### PR TITLE
feat(types): define core domain types

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,6 +10,7 @@
     }
   },
   "scripts": {
+    "build": "tsc -b",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -1,0 +1,7 @@
+export type WorkspaceId = string & { readonly __brand: 'WorkspaceId' };
+export type SessionId = string & { readonly __brand: 'SessionId' };
+export type MessageId = string & { readonly __brand: 'MessageId' };
+export type ProviderRunId = string & { readonly __brand: 'ProviderRunId' };
+export type TelemetryRecordId = string & { readonly __brand: 'TelemetryRecordId' };
+
+export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,1 +1,12 @@
-export type {};
+export type {
+  IsoDateTime,
+  MessageId,
+  ProviderRunId,
+  SessionId,
+  TelemetryRecordId,
+  WorkspaceId,
+} from './ids';
+export type { ContextSlot, Session, SessionState, Workspace } from './workspace';
+export type { Message, MessageRole } from './message';
+export type { ProviderName, ProviderRun, ProviderRunStatus } from './provider';
+export type { TelemetryRecord } from './telemetry';

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -1,0 +1,11 @@
+import type { IsoDateTime, MessageId, SessionId } from './ids';
+
+export type MessageRole = 'user' | 'assistant' | 'system';
+
+export type Message = Readonly<{
+  id: MessageId;
+  sessionId: SessionId;
+  role: MessageRole;
+  content: string;
+  createdAt: IsoDateTime;
+}>;

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -1,0 +1,19 @@
+import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
+
+export type ProviderName = 'anthropic' | 'openai' | 'cursor';
+
+export type ProviderRunStatus =
+  | { kind: 'pending' }
+  | { kind: 'streaming'; startedAt: IsoDateTime }
+  | { kind: 'succeeded'; finishedAt: IsoDateTime }
+  | { kind: 'failed'; finishedAt: IsoDateTime; error: string }
+  | { kind: 'cancelled'; finishedAt: IsoDateTime };
+
+export type ProviderRun = Readonly<{
+  id: ProviderRunId;
+  sessionId: SessionId;
+  provider: ProviderName;
+  model: string;
+  status: ProviderRunStatus;
+  createdAt: IsoDateTime;
+}>;

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,0 +1,14 @@
+import type { IsoDateTime, ProviderRunId, SessionId, TelemetryRecordId } from './ids';
+import type { ProviderName } from './provider';
+
+export type TelemetryRecord = Readonly<{
+  id: TelemetryRecordId;
+  runId: ProviderRunId;
+  sessionId: SessionId;
+  provider: ProviderName;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  estimatedCostUsd: number;
+  recordedAt: IsoDateTime;
+}>;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -1,0 +1,33 @@
+import type { IsoDateTime, ProviderRunId, SessionId, WorkspaceId } from './ids';
+
+export type Workspace = Readonly<{
+  id: WorkspaceId;
+  name: string;
+  rootPath: string;
+  createdAt: IsoDateTime;
+  updatedAt: IsoDateTime;
+}>;
+
+export type ContextSlot = Readonly<{
+  key: string;
+  value: string;
+  enabled: boolean;
+}>;
+
+export type SessionState =
+  | { kind: 'draft' }
+  | { kind: 'starting'; startedAt: IsoDateTime }
+  | { kind: 'idle'; lastActivityAt: IsoDateTime }
+  | { kind: 'running'; runId: ProviderRunId; startedAt: IsoDateTime }
+  | { kind: 'error'; message: string; failedAt: IsoDateTime }
+  | { kind: 'ended'; endedAt: IsoDateTime };
+
+export type Session = Readonly<{
+  id: SessionId;
+  workspaceId: WorkspaceId;
+  goal: string;
+  state: SessionState;
+  contextSlots: ReadonlyArray<ContextSlot>;
+  createdAt: IsoDateTime;
+  updatedAt: IsoDateTime;
+}>;


### PR DESCRIPTION
## Summary
- Branded ID types (`WorkspaceId`, `SessionId`, `MessageId`, `ProviderRunId`, `TelemetryRecordId`) plus `IsoDateTime`.
- Domain entities: `Workspace`, `Session`, `ContextSlot`, `Message`, `ProviderRun`, `TelemetryRecord`.
- `SessionState` discriminated union (draft / starting / idle / running / error / ended).
- One file per domain per `packages/types/CONVENTIONS.md`.

## Test plan
- [x] `pnpm --filter @kay-am/types build` clean
- [x] `pnpm --filter @kay-am/types typecheck` clean
- [x] No runtime code, types only

Closes #1