### PR TITLE
feat(desktop): secret store via keyring

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,3 +21,5 @@ serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.11.1" }
 tauri-plugin-log = "2"
+keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
+thiserror = "2"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,7 @@
+mod secrets;
+
+pub use secrets::read as read_secret;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
@@ -11,6 +15,10 @@ pub fn run() {
       }
       Ok(())
     })
+    .invoke_handler(tauri::generate_handler![
+      secrets::secret_set,
+      secrets::secret_delete,
+    ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -1,0 +1,43 @@
+use keyring::Entry;
+use thiserror::Error;
+
+const SERVICE: &str = "am.kay.desktop";
+
+#[derive(Debug, Error)]
+pub enum SecretError {
+    #[error("keyring backend error: {0}")]
+    Backend(#[from] keyring::Error),
+}
+
+impl serde::Serialize for SecretError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+fn entry(key: &str) -> Result<Entry, SecretError> {
+    Ok(Entry::new(SERVICE, key)?)
+}
+
+pub fn read(key: &str) -> Result<Option<String>, SecretError> {
+    match entry(key)?.get_password() {
+        Ok(value) => Ok(Some(value)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[tauri::command]
+pub fn secret_set(key: String, value: String) -> Result<(), SecretError> {
+    entry(&key)?.set_password(&value)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn secret_delete(key: String) -> Result<(), SecretError> {
+    match entry(&key)?.delete_credential() {
+        Ok(()) => Ok(()),
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}

--- a/apps/desktop/src/secrets.ts
+++ b/apps/desktop/src/secrets.ts
@@ -1,0 +1,9 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export async function setSecret(key: string, value: string): Promise<void> {
+  await invoke('secret_set', { key, value });
+}
+
+export async function deleteSecret(key: string): Promise<void> {
+  await invoke('secret_delete', { key });
+}


### PR DESCRIPTION
## Summary
- `secret_set(key, value)` and `secret_delete(key)` Tauri commands writing to the OS keychain (macOS Keychain, Linux Secret Service, Windows Credential Manager) via the `keyring` crate.
- Internal `secrets::read` accessor (re-exported as `read_secret`) so future summarizer code can fetch the key directly from Rust — frontend has no read path.
- Service identifier: `am.kay.desktop`.
- Frontend wrapper: `apps/desktop/src/secrets.ts`.

## Test plan
- [x] `cargo check` clean
- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [ ] Manual on macOS: `security find-generic-password -s am.kay.desktop -a <key>` shows the entry after `secret_set`

Closes #14