### PR TITLE
feat(desktop): open in vscode command

### DIFF
--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+use thiserror::Error;
+
+const DEFAULT_EDITOR: &str = "code";
+
+#[derive(Debug, Error)]
+pub enum EditorError {
+    #[error("editor binary '{0}' not found in PATH")]
+    NotFound(String),
+    #[error("failed to spawn editor '{binary}': {source}")]
+    Spawn {
+        binary: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+impl serde::Serialize for EditorError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[tauri::command]
+pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), EditorError> {
+    let binary = editor.unwrap_or_else(|| DEFAULT_EDITOR.to_string());
+
+    match Command::new(&binary).arg(&path).spawn() {
+        Ok(_) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Err(EditorError::NotFound(binary))
+        }
+        Err(source) => Err(EditorError::Spawn { binary, source }),
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod editor;
 mod secrets;
 
 pub use secrets::read as read_secret;
@@ -18,6 +19,7 @@ pub fn run() {
     .invoke_handler(tauri::generate_handler![
       secrets::secret_set,
       secrets::secret_delete,
+      editor::open_in_editor,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src/editor.ts
+++ b/apps/desktop/src/editor.ts
@@ -1,0 +1,5 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export async function openInEditor(path: string, editor?: string): Promise<void> {
+  await invoke('open_in_editor', { path, editor: editor ?? null });
+}


### PR DESCRIPTION
## Summary
- `open_in_editor(path, editor?)` Tauri command spawning the editor via `std::process`.
- Default binary `code`. The optional `editor` arg lets the future settings panel (#25) override it without changing the command surface.
- Returns a typed error to the frontend if the binary is missing or spawn fails.
- Frontend wrapper: `apps/desktop/src/editor.ts`.

## Test plan
- [x] `cargo check` clean
- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [ ] Manual: invoke `open_in_editor` with a workspace path; VS Code opens
- [ ] Manual: invoke with `editor: "nonexistent"`; error surfaces

Closes #16