### PR TITLE
feat(ui): design system primitives + light theme

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,7 +1,80 @@
+import { useState } from 'react';
+import {
+  AppShell,
+  Button,
+  Collapsible,
+  Dialog,
+  Input,
+  KbdPill,
+  ScrollArea,
+  Textarea,
+} from '@kay-am/ui';
+
 export function App() {
+  const [collapsed, setCollapsed] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
   return (
-    <main className="flex min-h-screen items-center justify-center bg-background text-foreground">
-      <h1 className="text-2xl font-medium tracking-tight">kAY.am</h1>
-    </main>
+    <AppShell
+      header={
+        <div className="flex w-full items-center justify-between">
+          <span className="font-semibold tracking-tight">kAY.am</span>
+          <span className="text-xs text-muted-foreground">
+            press <KbdPill>⌘K</KbdPill> to focus
+          </span>
+        </div>
+      }
+      leftSidebar={
+        <ScrollArea className="h-full p-2">
+          <div className="text-xs uppercase text-muted-foreground">Workspaces</div>
+          <ul className="mt-2 space-y-1">
+            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">demo</li>
+            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">api-gateway</li>
+            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">design-system</li>
+          </ul>
+        </ScrollArea>
+      }
+      main={
+        <div className="flex h-full flex-col gap-4 p-6">
+          <h1 className="text-lg font-medium tracking-tight">design system smoke test</h1>
+          <div className="flex flex-wrap gap-2">
+            <Button>primary</Button>
+            <Button variant="secondary">secondary</Button>
+            <Button variant="ghost">ghost</Button>
+            <Button variant="danger">danger</Button>
+            <Button size="sm">small</Button>
+          </div>
+          <Input placeholder="type something" />
+          <Textarea placeholder="multiline input" />
+          <Collapsible
+            open={collapsed}
+            onOpenChange={setCollapsed}
+            trigger={<span>collapsible section</span>}
+          >
+            <p className="text-sm text-muted-foreground">hidden content revealed when expanded.</p>
+          </Collapsible>
+          <div>
+            <Button onClick={() => setDialogOpen(true)}>open dialog</Button>
+            <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} title="hello">
+              <p className="text-sm text-muted-foreground">
+                native html dialog with backdrop and esc-to-close.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setDialogOpen(false)}>
+                  cancel
+                </Button>
+                <Button onClick={() => setDialogOpen(false)}>ok</Button>
+              </div>
+            </Dialog>
+          </div>
+        </div>
+      }
+      rightSidebar={
+        <ScrollArea className="h-full p-2">
+          <div className="text-xs uppercase text-muted-foreground">Context</div>
+          <p className="mt-2 text-sm text-muted-foreground">slots will live here.</p>
+        </ScrollArea>
+      }
+    />
   );
 }

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -8,10 +8,27 @@
   --color-muted: oklch(0.96 0.005 270);
   --color-muted-foreground: oklch(0.45 0.01 270);
   --color-border: oklch(0.92 0.005 270);
+  --color-danger: oklch(0.55 0.2 25);
+  --color-danger-foreground: oklch(0.99 0 0);
+
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 14px;
+  --text-lg: 16px;
+
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
 }
 
 html,
 body,
 #root {
   height: 100%;
+  font-size: 13px;
+}
+
+body {
+  font-feature-settings: "cv11", "ss01";
+  -webkit-font-smoothing: antialiased;
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -7,3 +7,100 @@ No business logic, no Tauri APIs, no data fetching. Light mode only for now.
 ## Conventions
 
 See [CONVENTIONS.md](./CONVENTIONS.md).
+
+## Primitives
+
+### Button
+
+```tsx
+import { Button } from '@kay-am/ui';
+
+<Button onClick={handleClick}>save</Button>
+<Button variant="secondary">cancel</Button>
+<Button variant="ghost" size="sm">…</Button>
+<Button variant="danger" disabled>delete</Button>
+```
+
+Variants: `primary` (default), `secondary`, `ghost`, `danger`. Sizes: `sm`, `md`.
+
+### Input
+
+```tsx
+import { Input } from '@kay-am/ui';
+
+<Input placeholder="search" value={q} onChange={(e) => setQ(e.target.value)} />;
+```
+
+### Textarea
+
+```tsx
+import { Textarea } from '@kay-am/ui';
+
+<Textarea rows={4} placeholder="goal" />;
+```
+
+### ScrollArea
+
+```tsx
+import { ScrollArea } from '@kay-am/ui';
+
+<ScrollArea className="h-64">{longList}</ScrollArea>;
+```
+
+### Collapsible
+
+```tsx
+import { Collapsible } from '@kay-am/ui';
+
+<Collapsible open={open} onOpenChange={setOpen} trigger="files touched">
+  <ul>{...}</ul>
+</Collapsible>
+```
+
+### Dialog
+
+Wraps native `<dialog>`. Esc closes; backdrop click does not.
+
+```tsx
+import { Dialog } from '@kay-am/ui';
+
+<Dialog open={open} onClose={close} title="confirm">
+  <p>are you sure?</p>
+  <Button onClick={confirm}>yes</Button>
+</Dialog>;
+```
+
+### KbdPill
+
+```tsx
+import { KbdPill } from '@kay-am/ui';
+
+press <KbdPill>⌘K</KbdPill> to open
+```
+
+### AppShell
+
+Three-pane layout: header on top, left sidebar, main, right sidebar. Each pane scrolls independently.
+
+```tsx
+import { AppShell } from '@kay-am/ui';
+
+<AppShell
+  header={<TopBar />}
+  leftSidebar={<Sessions />}
+  main={<Chat />}
+  rightSidebar={<Context />}
+/>;
+```
+
+## Helper
+
+### cn
+
+Class-merging helper. `clsx` + `tailwind-merge`.
+
+```tsx
+import { cn } from '@kay-am/ui';
+
+<span className={cn('text-sm', isActive && 'font-medium')} />;
+```

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+export interface AppShellProps {
+  header: ReactNode;
+  leftSidebar: ReactNode;
+  main: ReactNode;
+  rightSidebar: ReactNode;
+}
+
+export function AppShell({ header, leftSidebar, main, rightSidebar }: AppShellProps) {
+  return (
+    <div className="grid h-screen grid-rows-[auto_1fr] bg-background text-foreground">
+      <header className="flex h-9 items-center border-b border-border px-3 text-sm">
+        {header}
+      </header>
+      <div className="grid grid-cols-[260px_minmax(0,1fr)_320px] overflow-hidden">
+        <aside className="overflow-y-auto border-r border-border">{leftSidebar}</aside>
+        <main className="overflow-y-auto">{main}</main>
+        <aside className="overflow-y-auto border-l border-border">{rightSidebar}</aside>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,44 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonSize = 'sm' | 'md';
+
+export interface ButtonProps extends Omit<ComponentProps<'button'>, 'type'> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  type?: 'button' | 'submit' | 'reset';
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'bg-primary text-primary-foreground hover:bg-primary/90',
+  secondary: 'bg-muted text-foreground hover:bg-muted/70 border-border',
+  ghost: 'text-foreground hover:bg-muted',
+  danger: 'bg-danger text-danger-foreground hover:bg-danger/90',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-7 px-2.5 text-xs',
+  md: 'h-8 px-3 text-sm',
+};
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  type = 'button',
+  className,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cn(
+        'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        variantClasses[variant],
+        sizeClasses[size],
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/components/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react';
+import { cn } from '../cn';
+
+export interface CollapsibleProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trigger: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Collapsible({
+  open,
+  onOpenChange,
+  trigger,
+  children,
+  className,
+}: CollapsibleProps) {
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => onOpenChange(!open)}
+        className="flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+      >
+        <span className="flex-1 text-left">{trigger}</span>
+        <span
+          aria-hidden
+          className={cn('text-muted-foreground transition-transform', open && 'rotate-90')}
+        >
+          ›
+        </span>
+      </button>
+      {open ? <div className="px-2 py-1">{children}</div> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { cn } from '../cn';
+
+export interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  title?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Dialog({ open, onClose, title, children, className }: DialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+    const handleClose = () => onClose();
+    dialog.addEventListener('close', handleClose);
+    return () => dialog.removeEventListener('close', handleClose);
+  }, [onClose]);
+
+  return (
+    <dialog
+      ref={ref}
+      className={cn(
+        'rounded-lg border border-border bg-background p-0 text-foreground shadow-lg backdrop:bg-black/30',
+        className,
+      )}
+    >
+      <div className="flex min-w-72 flex-col gap-3 p-4">
+        {title ? <h2 className="text-sm font-semibold">{title}</h2> : null}
+        {children}
+      </div>
+    </dialog>
+  );
+}

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,0 +1,17 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type InputProps = ComponentProps<'input'>;
+
+export function Input({ className, type = 'text', ...rest }: InputProps) {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50',
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/components/KbdPill.tsx
+++ b/packages/ui/src/components/KbdPill.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type KbdPillProps = ComponentProps<'kbd'>;
+
+export function KbdPill({ className, ...rest }: KbdPillProps) {
+  return (
+    <kbd
+      className={cn(
+        'inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground',
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/components/ScrollArea.tsx
+++ b/packages/ui/src/components/ScrollArea.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type ScrollAreaProps = ComponentProps<'div'>;
+
+export function ScrollArea({ className, ...rest }: ScrollAreaProps) {
+  return (
+    <div
+      className={cn(
+        'overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin]',
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,0 +1,16 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type TextareaProps = ComponentProps<'textarea'>;
+
+export function Textarea({ className, ...rest }: TextareaProps) {
+  return (
+    <textarea
+      className={cn(
+        'min-h-16 w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50',
+        className,
+      )}
+      {...rest}
+    />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,17 @@
-export {};
+export { cn } from './cn';
+export { AppShell } from './components/AppShell';
+export type { AppShellProps } from './components/AppShell';
+export { Button } from './components/Button';
+export type { ButtonProps, ButtonSize, ButtonVariant } from './components/Button';
+export { Collapsible } from './components/Collapsible';
+export type { CollapsibleProps } from './components/Collapsible';
+export { Dialog } from './components/Dialog';
+export type { DialogProps } from './components/Dialog';
+export { Input } from './components/Input';
+export type { InputProps } from './components/Input';
+export { KbdPill } from './components/KbdPill';
+export type { KbdPillProps } from './components/KbdPill';
+export { ScrollArea } from './components/ScrollArea';
+export type { ScrollAreaProps } from './components/ScrollArea';
+export { Textarea } from './components/Textarea';
+export type { TextareaProps } from './components/Textarea';


### PR DESCRIPTION
## Summary
- Tokens: added `danger` colors, explicit `--text-*` (11/13/14/16) and `--radius-*`, 13px base, antialiasing.
- Primitives in `@kay-am/ui`: `Button` (4 variants × 2 sizes), `Input`, `Textarea`, `ScrollArea`, `Collapsible`, `Dialog` (native `<dialog>`), `KbdPill`, plus `AppShell` three-pane layout.
- `cn()` re-exported from package root.
- Package README documents each primitive with a minimal usage example.
- `apps/desktop/src/App.tsx` swapped to a smoke-test screen exercising every primitive in the AppShell.

## Test plan
- [x] `pnpm turbo run typecheck build test` clean
- [ ] `pnpm --filter @kay-am/desktop tauri:dev` shows three-pane layout with all primitives interactive

Closes #17