### PR TITLE
fix(desktop): drop project-references from tsconfig

### DIFF
--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -6,11 +6,5 @@
     "jsx": "react-jsx",
     "types": ["vite/client"]
   },
-  "include": ["src"],
-  "references": [
-    { "path": "../../packages/types" },
-    { "path": "../../packages/core" },
-    { "path": "../../packages/db" },
-    { "path": "../../packages/ui" }
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
Main was red after #38 merged: CI hit `TS6305: Output file '.../packages/ui/dist/index.d.ts' has not been built from source`. Locally green because previous `tsc -b` builds had populated `packages/*/dist`; CI starts clean and tries to typecheck desktop before any package builds.

Fix: drop the `references` array from `apps/desktop/tsconfig.json`. Each workspace package exposes `"types": "./src/index.ts"` via package.json `exports`, so TS resolves cross-package imports through pnpm symlinks straight to source — no composite build needed.

## Test plan
- [x] `rm -rf packages/*/dist apps/desktop/dist && pnpm turbo run typecheck --force` clean
- [ ] Main CI green after merge