### PR TITLE
feat(types): define provider adapter contract

### DIFF
--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -5,12 +5,38 @@ Shared TypeScript types for the kAY.am monorepo. Zero runtime code — types onl
 ## Usage
 
 ```ts
-import type { WorkspaceId, TaskStatus } from '@kay-am/types';
+import type { WorkspaceId, Session, ProviderAdapter } from '@kay-am/types';
 ```
 
-## Public API
+## Public surface
 
-See `src/index.ts` for the full type surface.
+### Branded IDs
+
+`WorkspaceId`, `SessionId`, `MessageId`, `ProviderRunId`, `TelemetryRecordId`, `IsoDateTime`. Pass `string` through `as` once at the boundary; everywhere else the brand prevents accidental mixing.
+
+### Domain entities
+
+- `Workspace` — registered repo on disk.
+- `Session` + `SessionState` — goal-scoped conversation. State is a discriminated union (`draft` / `starting` / `idle` / `running` / `error` / `ended`).
+- `ContextSlot` — fixed key/value used by the synthetic context engine.
+- `Message` + `MessageRole` — chat turn record.
+- `ProviderRun` + `ProviderRunStatus` — one execution of a provider CLI inside a session.
+- `TelemetryRecord` — per-run token + cost snapshot.
+
+### Provider adapter contract
+
+The shape every provider implementation must satisfy. Lives in this package so `@kay-am/core` and `apps/desktop` can depend on it without depending on each other.
+
+- `ProviderAdapter` — `id`, `capabilities`, `detect()`, `spawn(request)`, `cost(usage, model)`.
+- `TurnRequest` — input handed to `spawn`.
+- `TurnEvent` — discriminated union the adapter yields:
+  - `assistant_text` — incremental text delta
+  - `tool_call_start` / `tool_call_end` — tool invocation lifecycle
+  - `file_edit` — file mutation observed in the worktree
+  - `usage` — token + cost snapshot
+  - `error` — recoverable provider error
+  - `done` — terminal event
+- `ProviderCapabilities`, `ProviderUsage`, `DetectResult` — supporting shapes.
 
 ## Conventions
 

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,0 +1,68 @@
+import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
+import type { ProviderName } from './provider';
+
+export interface ProviderCapabilities {
+  readonly streaming: boolean;
+  readonly toolUse: boolean;
+  readonly fileEdits: boolean;
+  readonly contextWindow: number;
+  readonly defaultModel: string;
+  readonly availableModels: ReadonlyArray<string>;
+}
+
+export interface ProviderUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly estimatedCostUsd: number;
+}
+
+export type DetectResult =
+  | { kind: 'available'; binary: string; version: string }
+  | { kind: 'missing'; binary: string; reason: string };
+
+export interface TurnRequest {
+  readonly runId: ProviderRunId;
+  readonly sessionId: SessionId;
+  readonly model: string;
+  readonly workingDir: string;
+  readonly systemPrompt: string;
+  readonly userMessage: string;
+}
+
+export type TurnEvent =
+  | { kind: 'assistant_text'; runId: ProviderRunId; delta: string; at: IsoDateTime }
+  | {
+      kind: 'tool_call_start';
+      runId: ProviderRunId;
+      toolUseId: string;
+      toolName: string;
+      input: unknown;
+      at: IsoDateTime;
+    }
+  | {
+      kind: 'tool_call_end';
+      runId: ProviderRunId;
+      toolUseId: string;
+      output: unknown;
+      isError: boolean;
+      at: IsoDateTime;
+    }
+  | {
+      kind: 'file_edit';
+      runId: ProviderRunId;
+      path: string;
+      editType: 'create' | 'modify' | 'delete';
+      at: IsoDateTime;
+    }
+  | { kind: 'usage'; runId: ProviderRunId; usage: ProviderUsage; at: IsoDateTime }
+  | { kind: 'error'; runId: ProviderRunId; message: string; at: IsoDateTime }
+  | { kind: 'done'; runId: ProviderRunId; at: IsoDateTime };
+
+export interface ProviderAdapter {
+  readonly id: ProviderName;
+  readonly capabilities: ProviderCapabilities;
+  detect(): Promise<DetectResult>;
+  spawn(request: TurnRequest): AsyncIterable<TurnEvent>;
+  cost(usage: ProviderUsage, model: string): number;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,4 +9,12 @@ export type {
 export type { ContextSlot, Session, SessionState, Workspace } from './workspace';
 export type { Message, MessageRole } from './message';
 export type { ProviderName, ProviderRun, ProviderRunStatus } from './provider';
+export type {
+  DetectResult,
+  ProviderAdapter,
+  ProviderCapabilities,
+  ProviderUsage,
+  TurnEvent,
+  TurnRequest,
+} from './adapter';
 export type { TelemetryRecord } from './telemetry';


### PR DESCRIPTION
## Summary
- New `adapter.ts` in `@kay-am/types`:
  - `ProviderAdapter` interface (`id`, `capabilities`, `detect`, `spawn`, `cost`)
  - `TurnRequest` and `TurnEvent` (discriminated: `assistant_text` / `tool_call_start` / `tool_call_end` / `file_edit` / `usage` / `error` / `done`)
  - `ProviderCapabilities`, `ProviderUsage`, `DetectResult`
- Re-exported from package root.
- README updated with the full public surface.

The contract lives in `@kay-am/types` so `@kay-am/core` and `apps/desktop` depend on the shape, not on each other.

## Test plan
- [x] `pnpm --filter @kay-am/types typecheck` clean
- [x] `pnpm --filter @kay-am/types build` clean
- [x] No runtime code

Closes #2