### PR TITLE
feat(db): sqlite schema + migration runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "better-sqlite3",
       "esbuild",
       "lefthook"
     ]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "noEmit": true,
     "lib": ["ES2022"],
     "types": []
   },
-  "include": ["src"],
-  "references": [{ "path": "../types" }]
+  "include": ["src"]
 }

--- a/packages/db/CONVENTIONS.md
+++ b/packages/db/CONVENTIONS.md
@@ -20,8 +20,8 @@ SQLite schema, migrations, and queries for kAY.am. Runs locally on the user's ma
 This is **local-only** persistence. No data leaves the user's machine.
 
 - DB file lives at `~/.kay-am/data.db` (or platform-equivalent app data dir).
-- API keys NEVER stored here — use OS keyring via Tauri keyring plugin.
-- No conversation content stored. Sessions store metadata only (titles, status, timestamps, provider used, cost summary).
+- API keys NEVER stored here — use OS keyring via the desktop secret store.
+- Conversation history (messages, slots, runs, telemetry) is stored locally so kAY.am owns the conversation across providers. Nothing transmitted.
 - User can wipe the DB by deleting the file. Reset = clean slate.
 
 ## Schema rules
@@ -36,10 +36,10 @@ This is **local-only** persistence. No data leaves the user's machine.
 
 ## Migrations
 
-- Sequential, numbered: `001_initial.sql`, `002_add_provider_usage.sql`, etc.
+- Sequential, numbered: `m001-initial.ts`, `m002-...ts`, etc. SQL is exported as a template-literal string so the same source ships through `tauri-plugin-sql` at runtime and through `better-sqlite3` in tests.
 - Each migration is idempotent (`CREATE TABLE IF NOT EXISTS`, conditional column adds).
 - Never edit a migration after it has shipped — add a new one.
-- Migration runner verifies version against schema_version table; refuses to start on mismatch.
+- The runner records applied versions in `schema_version` and skips them on re-run.
 
 ## Query patterns
 
@@ -64,17 +64,23 @@ This is **local-only** persistence. No data leaves the user's machine.
 
 ```
 src/
-├── index.ts              # public API
-├── client.ts             # database client wrapper
+├── index.ts              # public API (re-exports)
+├── client.ts             # Database interface
 ├── migrations/
-│   ├── 001_initial.sql
-│   ├── 002_*.sql
-│   └── runner.ts
+│   ├── index.ts          # ordered list
+│   ├── m001-initial.ts   # SQL as exported string
+│   ├── runner.ts         # migrate(db, migrations?) → MigrateResult
+│   └── runner.test.ts
 ├── queries/
 │   ├── workspace.ts
-│   ├── task.ts
-│   ├── provider.ts
-│   └── usage.ts
-└── shared/
-    └── errors.ts
+│   ├── session.ts
+│   ├── message.ts
+│   ├── context-slot.ts
+│   ├── provider-run.ts
+│   ├── telemetry.ts
+│   └── settings.ts
+├── shared/
+│   └── errors.ts
+└── test-helpers/
+    └── test-db.ts        # better-sqlite3 adapter (devDep, tests only)
 ```

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,8 @@
     "@kay-am/types": "workspace:*"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "better-sqlite3": "^11.7.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"
   }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,5 @@
+export interface Database {
+  exec(sql: string): Promise<void>;
+  execute(sql: string, params?: ReadonlyArray<unknown>): Promise<{ rowsAffected: number }>;
+  select<T>(sql: string, params?: ReadonlyArray<unknown>): Promise<ReadonlyArray<T>>;
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,27 @@
-export {};
+export type { Database } from './client';
+
+export { migrate, type MigrateResult } from './migrations/runner';
+export { migrations, type Migration } from './migrations';
+
+export { NotFoundError, UniqueViolationError } from './shared/errors';
+
+export { insertWorkspace, getWorkspaceById, listWorkspaces } from './queries/workspace';
+export {
+  insertSession,
+  updateSessionState,
+  getSessionById,
+  listSessionsForWorkspace,
+} from './queries/session';
+export { insertMessage, listMessagesForSession } from './queries/message';
+export { upsertContextSlot, listContextSlotsForSession } from './queries/context-slot';
+export {
+  insertProviderRun,
+  updateProviderRunStatus,
+  getProviderRunById,
+} from './queries/provider-run';
+export {
+  insertTelemetry,
+  summarizeSessionTelemetry,
+  type SessionTelemetrySummary,
+} from './queries/telemetry';
+export { getSetting, setSetting } from './queries/settings';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -1,0 +1,8 @@
+import { m001Initial } from './m001-initial';
+
+export interface Migration {
+  readonly version: number;
+  readonly sql: string;
+}
+
+export const migrations: ReadonlyArray<Migration> = [{ version: 1, sql: m001Initial }];

--- a/packages/db/src/migrations/m001-initial.ts
+++ b/packages/db/src/migrations/m001-initial.ts
@@ -1,0 +1,75 @@
+export const m001Initial = /* sql */ `
+CREATE TABLE IF NOT EXISTS workspaces (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  root_path TEXT NOT NULL UNIQUE,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  goal TEXT NOT NULL,
+  state_kind TEXT NOT NULL CHECK (state_kind IN ('draft','starting','idle','running','error','ended')),
+  state_payload TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_sessions_workspace_id ON sessions(workspace_id);
+
+CREATE TABLE IF NOT EXISTS messages (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  role TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_messages_session_id ON messages(session_id);
+CREATE INDEX IF NOT EXISTS idx_messages_session_created ON messages(session_id, created_at);
+
+CREATE TABLE IF NOT EXISTS context_slots (
+  session_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+  PRIMARY KEY (session_id, key),
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS provider_runs (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('anthropic','openai','cursor')),
+  model TEXT NOT NULL,
+  status_kind TEXT NOT NULL CHECK (status_kind IN ('pending','streaming','succeeded','failed','cancelled')),
+  status_payload TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_provider_runs_session_id ON provider_runs(session_id);
+
+CREATE TABLE IF NOT EXISTS telemetry_records (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  model TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL,
+  output_tokens INTEGER NOT NULL,
+  estimated_cost_usd REAL NOT NULL,
+  recorded_at INTEGER NOT NULL,
+  FOREIGN KEY (run_id) REFERENCES provider_runs(id) ON DELETE CASCADE,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_telemetry_run_id ON telemetry_records(run_id);
+CREATE INDEX IF NOT EXISTS idx_telemetry_session_id ON telemetry_records(session_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from './runner';
+import { migrations } from './index';
+import { getWorkspaceById, insertWorkspace } from '../queries/workspace';
+import { getSessionById, insertSession } from '../queries/session';
+
+const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+describe('migrate', () => {
+  it('applies all migrations on a fresh db', async () => {
+    const db = makeTestDatabase();
+    const result = await migrate(db);
+    expect(result.applied).toEqual(migrations.map((m) => m.version));
+    expect(result.skipped).toEqual([]);
+    expect(result.currentVersion).toBe(migrations.at(-1)?.version);
+  });
+
+  it('is idempotent: re-running applies nothing', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    const second = await migrate(db);
+    expect(second.applied).toEqual([]);
+    expect(second.skipped).toEqual(migrations.map((m) => m.version));
+  });
+
+  it('round-trips a workspace through the schema', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_1' as WorkspaceId,
+      name: 'demo',
+      rootPath: '/tmp/demo',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+    const fetched = await getWorkspaceById(db, workspace.id);
+
+    expect(fetched).not.toBeNull();
+    expect(fetched?.name).toBe('demo');
+    expect(fetched?.rootPath).toBe('/tmp/demo');
+  });
+
+  it('round-trips a session with discriminated state', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_2' as WorkspaceId,
+      name: 'demo',
+      rootPath: '/tmp/demo2',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+
+    const session: Session = {
+      id: 'sess_1' as SessionId,
+      workspaceId: workspace.id,
+      goal: 'refactor auth',
+      state: { kind: 'idle', lastActivityAt: now() },
+      contextSlots: [],
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertSession(db, session);
+    const fetched = await getSessionById(db, session.id);
+
+    expect(fetched).not.toBeNull();
+    expect(fetched?.goal).toBe('refactor auth');
+    expect(fetched?.state.kind).toBe('idle');
+  });
+});

--- a/packages/db/src/migrations/runner.ts
+++ b/packages/db/src/migrations/runner.ts
@@ -1,0 +1,45 @@
+import type { Database } from '../client';
+import { migrations as defaultMigrations, type Migration } from './index';
+
+const ENSURE_VERSION_TABLE = `
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER PRIMARY KEY,
+  applied_at INTEGER NOT NULL
+);
+`;
+
+export interface MigrateResult {
+  readonly applied: ReadonlyArray<number>;
+  readonly skipped: ReadonlyArray<number>;
+  readonly currentVersion: number;
+}
+
+export async function migrate(
+  db: Database,
+  migrations: ReadonlyArray<Migration> = defaultMigrations,
+): Promise<MigrateResult> {
+  await db.exec(ENSURE_VERSION_TABLE);
+
+  const rows = await db.select<{ version: number }>('SELECT version FROM schema_version');
+  const applied = new Set(rows.map((row) => row.version));
+
+  const ordered = [...migrations].sort((a, b) => a.version - b.version);
+  const newlyApplied: number[] = [];
+  const skipped: number[] = [];
+
+  for (const migration of ordered) {
+    if (applied.has(migration.version)) {
+      skipped.push(migration.version);
+      continue;
+    }
+    await db.exec(migration.sql);
+    await db.execute('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)', [
+      migration.version,
+      Date.now(),
+    ]);
+    newlyApplied.push(migration.version);
+  }
+
+  const currentVersion = ordered.at(-1)?.version ?? 0;
+  return { applied: newlyApplied, skipped, currentVersion };
+}

--- a/packages/db/src/queries/context-slot.ts
+++ b/packages/db/src/queries/context-slot.ts
@@ -1,0 +1,43 @@
+import type { ContextSlot, SessionId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface ContextSlotRow {
+  session_id: string;
+  key: string;
+  value: string;
+  enabled: number;
+}
+
+function toDomain(row: ContextSlotRow): ContextSlot {
+  return {
+    key: row.key,
+    value: row.value,
+    enabled: row.enabled === 1,
+  };
+}
+
+export async function upsertContextSlot(
+  db: Database,
+  sessionId: SessionId,
+  slot: ContextSlot,
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO context_slots (session_id, key, value, enabled)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(session_id, key) DO UPDATE SET
+       value = excluded.value,
+       enabled = excluded.enabled`,
+    [sessionId, slot.key, slot.value, slot.enabled ? 1 : 0],
+  );
+}
+
+export async function listContextSlotsForSession(
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<ContextSlot>> {
+  const rows = await db.select<ContextSlotRow>(
+    'SELECT * FROM context_slots WHERE session_id = ? ORDER BY key',
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}

--- a/packages/db/src/queries/message.ts
+++ b/packages/db/src/queries/message.ts
@@ -1,0 +1,38 @@
+import type { IsoDateTime, Message, MessageId, MessageRole, SessionId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface MessageRow {
+  id: string;
+  session_id: string;
+  role: MessageRole;
+  content: string;
+  created_at: number;
+}
+
+function toDomain(row: MessageRow): Message {
+  return {
+    id: row.id as MessageId,
+    sessionId: row.session_id as SessionId,
+    role: row.role,
+    content: row.content,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function insertMessage(db: Database, message: Message): Promise<void> {
+  await db.execute(
+    'INSERT INTO messages (id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)',
+    [message.id, message.sessionId, message.role, message.content, Date.parse(message.createdAt)],
+  );
+}
+
+export async function listMessagesForSession(
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<Message>> {
+  const rows = await db.select<MessageRow>(
+    'SELECT * FROM messages WHERE session_id = ? ORDER BY created_at ASC',
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}

--- a/packages/db/src/queries/provider-run.ts
+++ b/packages/db/src/queries/provider-run.ts
@@ -1,0 +1,75 @@
+import type {
+  IsoDateTime,
+  ProviderName,
+  ProviderRun,
+  ProviderRunId,
+  ProviderRunStatus,
+  SessionId,
+} from '@kay-am/types';
+import type { Database } from '../client';
+
+interface ProviderRunRow {
+  id: string;
+  session_id: string;
+  provider: ProviderName;
+  model: string;
+  status_kind: ProviderRunStatus['kind'];
+  status_payload: string;
+  created_at: number;
+}
+
+function toStatus(kind: ProviderRunStatus['kind'], payload: string): ProviderRunStatus {
+  const data = JSON.parse(payload) as Record<string, unknown>;
+  return { kind, ...data } as ProviderRunStatus;
+}
+
+function splitStatus(status: ProviderRunStatus): {
+  kind: ProviderRunStatus['kind'];
+  payload: string;
+} {
+  const { kind, ...rest } = status;
+  return { kind, payload: JSON.stringify(rest) };
+}
+
+function toDomain(row: ProviderRunRow): ProviderRun {
+  return {
+    id: row.id as ProviderRunId,
+    sessionId: row.session_id as SessionId,
+    provider: row.provider,
+    model: row.model,
+    status: toStatus(row.status_kind, row.status_payload),
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function insertProviderRun(db: Database, run: ProviderRun): Promise<void> {
+  const { kind, payload } = splitStatus(run.status);
+  await db.execute(
+    `INSERT INTO provider_runs
+      (id, session_id, provider, model, status_kind, status_payload, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [run.id, run.sessionId, run.provider, run.model, kind, payload, Date.parse(run.createdAt)],
+  );
+}
+
+export async function updateProviderRunStatus(
+  db: Database,
+  id: ProviderRunId,
+  status: ProviderRunStatus,
+): Promise<void> {
+  const { kind, payload } = splitStatus(status);
+  await db.execute('UPDATE provider_runs SET status_kind = ?, status_payload = ? WHERE id = ?', [
+    kind,
+    payload,
+    id,
+  ]);
+}
+
+export async function getProviderRunById(
+  db: Database,
+  id: ProviderRunId,
+): Promise<ProviderRun | null> {
+  const rows = await db.select<ProviderRunRow>('SELECT * FROM provider_runs WHERE id = ?', [id]);
+  const row = rows[0];
+  return row ? toDomain(row) : null;
+}

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -1,0 +1,83 @@
+import type { IsoDateTime, Session, SessionId, SessionState, WorkspaceId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface SessionRow {
+  id: string;
+  workspace_id: string;
+  goal: string;
+  state_kind: SessionState['kind'];
+  state_payload: string;
+  created_at: number;
+  updated_at: number;
+}
+
+function toState(kind: SessionState['kind'], payload: string): SessionState {
+  const data = JSON.parse(payload) as Record<string, unknown>;
+  return { kind, ...data } as SessionState;
+}
+
+function toDomain(row: SessionRow, contextSlots: Session['contextSlots']): Session {
+  return {
+    id: row.id as SessionId,
+    workspaceId: row.workspace_id as WorkspaceId,
+    goal: row.goal,
+    state: toState(row.state_kind, row.state_payload),
+    contextSlots,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
+  };
+}
+
+function splitState(state: SessionState): { kind: SessionState['kind']; payload: string } {
+  const { kind, ...rest } = state;
+  return { kind, payload: JSON.stringify(rest) };
+}
+
+export async function insertSession(db: Database, session: Session): Promise<void> {
+  const { kind, payload } = splitState(session.state);
+  await db.execute(
+    `INSERT INTO sessions
+      (id, workspace_id, goal, state_kind, state_payload, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      session.id,
+      session.workspaceId,
+      session.goal,
+      kind,
+      payload,
+      Date.parse(session.createdAt),
+      Date.parse(session.updatedAt),
+    ],
+  );
+}
+
+export async function updateSessionState(
+  db: Database,
+  id: SessionId,
+  state: SessionState,
+  updatedAt: IsoDateTime,
+): Promise<void> {
+  const { kind, payload } = splitState(state);
+  await db.execute(
+    'UPDATE sessions SET state_kind = ?, state_payload = ?, updated_at = ? WHERE id = ?',
+    [kind, payload, Date.parse(updatedAt), id],
+  );
+}
+
+export async function getSessionById(db: Database, id: SessionId): Promise<Session | null> {
+  const rows = await db.select<SessionRow>('SELECT * FROM sessions WHERE id = ?', [id]);
+  const row = rows[0];
+  if (!row) return null;
+  return toDomain(row, []);
+}
+
+export async function listSessionsForWorkspace(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<ReadonlyArray<Session>> {
+  const rows = await db.select<SessionRow>(
+    'SELECT * FROM sessions WHERE workspace_id = ? ORDER BY updated_at DESC',
+    [workspaceId],
+  );
+  return rows.map((row) => toDomain(row, []));
+}

--- a/packages/db/src/queries/settings.ts
+++ b/packages/db/src/queries/settings.ts
@@ -1,0 +1,20 @@
+import type { Database } from '../client';
+
+interface SettingsRow {
+  key: string;
+  value: string;
+  updated_at: number;
+}
+
+export async function getSetting(db: Database, key: string): Promise<string | null> {
+  const rows = await db.select<SettingsRow>('SELECT * FROM settings WHERE key = ?', [key]);
+  return rows[0]?.value ?? null;
+}
+
+export async function setSetting(db: Database, key: string, value: string): Promise<void> {
+  await db.execute(
+    `INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+    [key, value, Date.now()],
+  );
+}

--- a/packages/db/src/queries/telemetry.ts
+++ b/packages/db/src/queries/telemetry.ts
@@ -1,0 +1,88 @@
+import type {
+  IsoDateTime,
+  ProviderName,
+  ProviderRunId,
+  SessionId,
+  TelemetryRecord,
+  TelemetryRecordId,
+} from '@kay-am/types';
+import type { Database } from '../client';
+
+interface TelemetryRow {
+  id: string;
+  run_id: string;
+  session_id: string;
+  provider: ProviderName;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  estimated_cost_usd: number;
+  recorded_at: number;
+}
+
+function toDomain(row: TelemetryRow): TelemetryRecord {
+  return {
+    id: row.id as TelemetryRecordId,
+    runId: row.run_id as ProviderRunId,
+    sessionId: row.session_id as SessionId,
+    provider: row.provider,
+    model: row.model,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    estimatedCostUsd: row.estimated_cost_usd,
+    recordedAt: new Date(row.recorded_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function insertTelemetry(db: Database, record: TelemetryRecord): Promise<void> {
+  await db.execute(
+    `INSERT INTO telemetry_records
+      (id, run_id, session_id, provider, model, input_tokens, output_tokens, estimated_cost_usd, recorded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      record.id,
+      record.runId,
+      record.sessionId,
+      record.provider,
+      record.model,
+      record.inputTokens,
+      record.outputTokens,
+      record.estimatedCostUsd,
+      Date.parse(record.recordedAt),
+    ],
+  );
+}
+
+export interface SessionTelemetrySummary {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly estimatedCostUsd: number;
+  readonly recordCount: number;
+}
+
+export async function summarizeSessionTelemetry(
+  db: Database,
+  sessionId: SessionId,
+): Promise<SessionTelemetrySummary> {
+  const rows = await db.select<{
+    input: number | null;
+    output: number | null;
+    cost: number | null;
+    count: number;
+  }>(
+    `SELECT
+       COALESCE(SUM(input_tokens), 0) AS input,
+       COALESCE(SUM(output_tokens), 0) AS output,
+       COALESCE(SUM(estimated_cost_usd), 0) AS cost,
+       COUNT(*) AS count
+     FROM telemetry_records WHERE session_id = ?`,
+    [sessionId],
+  );
+  const row = rows[0] ?? { input: 0, output: 0, cost: 0, count: 0 };
+  return {
+    inputTokens: row.input ?? 0,
+    outputTokens: row.output ?? 0,
+    estimatedCostUsd: row.cost ?? 0,
+    recordCount: row.count,
+  };
+}

--- a/packages/db/src/queries/workspace.ts
+++ b/packages/db/src/queries/workspace.ts
@@ -1,0 +1,40 @@
+import type { IsoDateTime, Workspace, WorkspaceId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface WorkspaceRow {
+  id: string;
+  name: string;
+  root_path: string;
+  created_at: number;
+  updated_at: number;
+}
+
+function toDomain(row: WorkspaceRow): Workspace {
+  return {
+    id: row.id as WorkspaceId,
+    name: row.name,
+    rootPath: row.root_path,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function insertWorkspace(db: Database, workspace: Workspace): Promise<void> {
+  const created = Date.parse(workspace.createdAt);
+  const updated = Date.parse(workspace.updatedAt);
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspace.id, workspace.name, workspace.rootPath, created, updated],
+  );
+}
+
+export async function getWorkspaceById(db: Database, id: WorkspaceId): Promise<Workspace | null> {
+  const rows = await db.select<WorkspaceRow>('SELECT * FROM workspaces WHERE id = ?', [id]);
+  const row = rows[0];
+  return row ? toDomain(row) : null;
+}
+
+export async function listWorkspaces(db: Database): Promise<ReadonlyArray<Workspace>> {
+  const rows = await db.select<WorkspaceRow>('SELECT * FROM workspaces ORDER BY created_at DESC');
+  return rows.map(toDomain);
+}

--- a/packages/db/src/shared/errors.ts
+++ b/packages/db/src/shared/errors.ts
@@ -1,0 +1,19 @@
+export class NotFoundError extends Error {
+  constructor(
+    public readonly entity: string,
+    public readonly id: string,
+  ) {
+    super(`${entity} not found: ${id}`);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class UniqueViolationError extends Error {
+  constructor(
+    public readonly entity: string,
+    public readonly field: string,
+  ) {
+    super(`unique constraint violated on ${entity}.${field}`);
+    this.name = 'UniqueViolationError';
+  }
+}

--- a/packages/db/src/test-helpers/test-db.ts
+++ b/packages/db/src/test-helpers/test-db.ts
@@ -1,0 +1,22 @@
+import Database from 'better-sqlite3';
+import type { Database as DatabaseInterface } from '../client';
+
+export function makeTestDatabase(filename = ':memory:'): DatabaseInterface {
+  const db = new Database(filename);
+  db.pragma('foreign_keys = ON');
+
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "noEmit": true,
     "lib": ["ES2022"],
     "types": []
   },
-  "include": ["src"],
-  "references": [{ "path": "../types" }]
+  "include": ["src"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,6 @@
     }
   },
   "scripts": {
-    "build": "tsc -b",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,12 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "noEmit": true
   },
   "include": ["src"]
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,15 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
+    "noEmit": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "types": []
   },
-  "include": ["src"],
-  "references": [{ "path": "../types" }]
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,12 @@ importers:
         specifier: workspace:*
         version: link:../types
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^11.7.0
+        version: 11.10.0
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1522,6 +1528,12 @@ packages:
         integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
       }
 
+  '@types/better-sqlite3@7.6.13':
+    resolution:
+      {
+        integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==,
+      }
+
   '@types/estree@1.0.8':
     resolution:
       {
@@ -1665,6 +1677,12 @@ packages:
       }
     engines: { node: '>=12' }
 
+  base64-js@1.5.1:
+    resolution:
+      {
+        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
+      }
+
   baseline-browser-mapping@2.10.27:
     resolution:
       {
@@ -1673,6 +1691,24 @@ packages:
     engines: { node: '>=6.0.0' }
     hasBin: true
 
+  better-sqlite3@11.10.0:
+    resolution:
+      {
+        integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==,
+      }
+
+  bindings@1.5.0:
+    resolution:
+      {
+        integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==,
+      }
+
+  bl@4.1.0:
+    resolution:
+      {
+        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
+      }
+
   browserslist@4.28.2:
     resolution:
       {
@@ -1680,6 +1716,12 @@ packages:
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
+
+  buffer@5.7.1:
+    resolution:
+      {
+        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
+      }
 
   cac@6.7.14:
     resolution:
@@ -1714,6 +1756,12 @@ packages:
         integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
       }
     engines: { node: '>= 16' }
+
+  chownr@1.1.4:
+    resolution:
+      {
+        integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==,
+      }
 
   cliui@8.0.1:
     resolution:
@@ -1817,12 +1865,26 @@ packages:
       supports-color:
         optional: true
 
+  decompress-response@6.0.0:
+    resolution:
+      {
+        integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==,
+      }
+    engines: { node: '>=10' }
+
   deep-eql@5.0.2:
     resolution:
       {
         integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
       }
     engines: { node: '>=6' }
+
+  deep-extend@0.6.0:
+    resolution:
+      {
+        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
+      }
+    engines: { node: '>=4.0.0' }
 
   dequal@2.0.3:
     resolution:
@@ -1861,6 +1923,12 @@ packages:
     resolution:
       {
         integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
+
+  end-of-stream@1.4.5:
+    resolution:
+      {
+        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
       }
 
   enhanced-resolve@5.21.0:
@@ -1931,6 +1999,13 @@ packages:
         integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
       }
 
+  expand-template@2.0.3:
+    resolution:
+      {
+        integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==,
+      }
+    engines: { node: '>=6' }
+
   expect-type@1.3.0:
     resolution:
       {
@@ -1962,6 +2037,18 @@ packages:
       picomatch:
         optional: true
 
+  file-uri-to-path@1.0.0:
+    resolution:
+      {
+        integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==,
+      }
+
+  fs-constants@1.0.0:
+    resolution:
+      {
+        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
+      }
+
   fsevents@2.3.3:
     resolution:
       {
@@ -1992,6 +2079,12 @@ packages:
     engines: { node: '>=18' }
     hasBin: true
 
+  github-from-package@0.0.0:
+    resolution:
+      {
+        integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
+      }
+
   global-directory@5.0.0:
     resolution:
       {
@@ -2012,6 +2105,12 @@ packages:
       }
     engines: { node: '>=18.0.0' }
 
+  ieee754@1.2.1:
+    resolution:
+      {
+        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
+      }
+
   import-fresh@3.3.1:
     resolution:
       {
@@ -2023,6 +2122,18 @@ packages:
     resolution:
       {
         integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
+      }
+
+  inherits@2.0.4:
+    resolution:
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
+
+  ini@1.3.8:
+    resolution:
+      {
+        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
       }
 
   ini@6.0.0:
@@ -2349,10 +2460,23 @@ packages:
       }
     engines: { node: '>=18' }
 
+  mimic-response@3.1.0:
+    resolution:
+      {
+        integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==,
+      }
+    engines: { node: '>=10' }
+
   minimist@1.2.8:
     resolution:
       {
         integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
+      }
+
+  mkdirp-classic@0.5.3:
+    resolution:
+      {
+        integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==,
       }
 
   ms@2.1.3:
@@ -2369,10 +2493,29 @@ packages:
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution:
+      {
+        integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==,
+      }
+
+  node-abi@3.92.0:
+    resolution:
+      {
+        integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==,
+      }
+    engines: { node: '>=10' }
+
   node-releases@2.0.38:
     resolution:
       {
         integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==,
+      }
+
+  once@1.4.0:
+    resolution:
+      {
+        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
       }
 
   parent-module@1.0.1:
@@ -2422,6 +2565,15 @@ packages:
       }
     engines: { node: ^10 || ^12 || >=14 }
 
+  prebuild-install@7.1.3:
+    resolution:
+      {
+        integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==,
+      }
+    engines: { node: '>=10' }
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@3.8.3:
     resolution:
       {
@@ -2436,6 +2588,19 @@ packages:
         integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
       }
     engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
+
+  pump@3.0.4:
+    resolution:
+      {
+        integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==,
+      }
+
+  rc@1.2.8:
+    resolution:
+      {
+        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
+      }
+    hasBin: true
 
   react-dom@19.2.6:
     resolution:
@@ -2464,6 +2629,13 @@ packages:
         integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==,
       }
     engines: { node: '>=0.10.0' }
+
+  readable-stream@3.6.2:
+    resolution:
+      {
+        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
+      }
+    engines: { node: '>= 6' }
 
   require-directory@2.1.1:
     resolution:
@@ -2501,6 +2673,12 @@ packages:
     engines: { node: '>=18.0.0', npm: '>=8.0.0' }
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution:
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
+
   scheduler@0.27.0:
     resolution:
       {
@@ -2526,6 +2704,18 @@ packages:
     resolution:
       {
         integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+      }
+
+  simple-concat@1.0.1:
+    resolution:
+      {
+        integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==,
+      }
+
+  simple-get@4.0.1:
+    resolution:
+      {
+        integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==,
       }
 
   source-map-js@1.2.1:
@@ -2554,12 +2744,25 @@ packages:
       }
     engines: { node: '>=8' }
 
+  string_decoder@1.3.0:
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
+
   strip-ansi@6.0.1:
     resolution:
       {
         integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
       }
     engines: { node: '>=8' }
+
+  strip-json-comments@2.0.1:
+    resolution:
+      {
+        integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==,
+      }
+    engines: { node: '>=0.10.0' }
 
   tailwind-merge@2.6.1:
     resolution:
@@ -2577,6 +2780,19 @@ packages:
     resolution:
       {
         integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
+      }
+    engines: { node: '>=6' }
+
+  tar-fs@2.1.4:
+    resolution:
+      {
+        integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==,
+      }
+
+  tar-stream@2.2.0:
+    resolution:
+      {
+        integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==,
       }
     engines: { node: '>=6' }
 
@@ -2627,6 +2843,12 @@ packages:
       }
     engines: { node: '>=14.0.0' }
 
+  tunnel-agent@0.6.0:
+    resolution:
+      {
+        integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
+      }
+
   turbo@2.9.9:
     resolution:
       {
@@ -2656,6 +2878,12 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   vite-node@2.1.9:
     resolution:
@@ -2798,6 +3026,12 @@ packages:
         integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
       }
     engines: { node: '>=10' }
+
+  wrappy@1.0.2:
+    resolution:
+      {
+        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
+      }
 
   y18n@5.0.8:
     resolution:
@@ -3516,6 +3750,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 25.6.0
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
@@ -3609,7 +3847,24 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.27: {}
+
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   browserslist@4.28.2:
     dependencies:
@@ -3618,6 +3873,11 @@ snapshots:
       electron-to-chromium: 1.5.351
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   cac@6.7.14: {}
 
@@ -3634,6 +3894,8 @@ snapshots:
       pathval: 2.0.1
 
   check-error@2.1.3: {}
+
+  chownr@1.1.4: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3691,7 +3953,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-eql@5.0.2: {}
+
+  deep-extend@0.6.0: {}
 
   dequal@2.0.3: {}
 
@@ -3706,6 +3974,10 @@ snapshots:
   electron-to-chromium@1.5.351: {}
 
   emoji-regex@8.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enhanced-resolve@5.21.0:
     dependencies:
@@ -3785,6 +4057,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3794,6 +4068,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-uri-to-path@1.0.0: {}
+
+  fs-constants@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -3810,6 +4088,8 @@ snapshots:
       - conventional-commits-filter
       - conventional-commits-parser
 
+  github-from-package@0.0.0: {}
+
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
@@ -3822,12 +4102,18 @@ snapshots:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
 
+  ieee754@1.2.1: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   import-meta-resolve@4.2.0: {}
+
+  inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   ini@6.0.0: {}
 
@@ -3965,13 +4251,27 @@ snapshots:
 
   meow@13.2.0: {}
 
+  mimic-response@3.1.0: {}
+
   minimist@1.2.8: {}
+
+  mkdirp-classic@0.5.3: {}
 
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
 
+  napi-build-utils@2.0.0: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.7.4
+
   node-releases@2.0.38: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   parent-module@1.0.1:
     dependencies:
@@ -3998,6 +4298,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prettier@3.8.3: {}
 
   pretty-format@27.5.1:
@@ -4005,6 +4320,18 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -4016,6 +4343,12 @@ snapshots:
   react-refresh@0.17.0: {}
 
   react@19.2.6: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   require-directory@2.1.1: {}
 
@@ -4056,6 +4389,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -4063,6 +4398,14 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
 
   source-map-js@1.2.1: {}
 
@@ -4076,15 +4419,36 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-json-comments@2.0.1: {}
 
   tailwind-merge@2.6.1: {}
 
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   tinybench@2.9.0: {}
 
@@ -4102,6 +4466,10 @@ snapshots:
   tinyrainbow@1.2.0: {}
 
   tinyspy@3.0.2: {}
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   turbo@2.9.9:
     optionalDependencies:
@@ -4121,6 +4489,8 @@ snapshots:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0):
     dependencies:
@@ -4214,6 +4584,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- `Database` interface (`exec` / `execute` / `select`) so the same query helpers run against `tauri-plugin-sql` at runtime and `better-sqlite3` in tests.
- Schema (migration `m001-initial`) covering: `workspaces`, `sessions`, `messages`, `context_slots`, `provider_runs`, `telemetry_records`, `settings`.
- SQL ships as a TS template-literal string (no `.sql` files) — same source for runtime and tests.
- `migrate()` runner records applied versions in `schema_version`, idempotent on re-run.
- Per-table query helpers in `queries/*` returning domain types from `@kay-am/types` (rows mapped here, never in UI).
- Typed errors in `shared/errors.ts`.
- `runner.test.ts` exercises: fresh apply, idempotent re-apply, workspace round-trip, session round-trip with discriminated state.

## Dependency justification
`better-sqlite3` (devDep, ~5M weekly downloads, MIT). Tests-only. Used because vitest's bundled Vite (5.4) does not transparently resolve Node 22's `node:sqlite`, and a real SQLite engine is the only honest way to verify the schema.

## Test plan
- [x] `pnpm --filter @kay-am/db typecheck` clean
- [x] `pnpm --filter @kay-am/db test` — 4 tests pass
- [x] `pnpm turbo run typecheck test build` clean

Closes #3