### PR TITLE
feat(core): worktree manager

### DIFF
--- a/packages/core/src/worktree/git.ts
+++ b/packages/core/src/worktree/git.ts
@@ -1,0 +1,27 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const exec = promisify(execFile);
+
+export class GitError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr?: string,
+  ) {
+    super(message);
+    this.name = 'GitError';
+  }
+}
+
+export async function git(
+  cwd: string,
+  args: ReadonlyArray<string>,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    const result = await exec('git', [...args], { cwd });
+    return { stdout: result.stdout, stderr: result.stderr };
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & { stderr?: string };
+    throw new GitError(`git ${args.join(' ')} failed: ${error.message}`.trim(), error.stderr);
+  }
+}

--- a/packages/core/src/worktree/index.ts
+++ b/packages/core/src/worktree/index.ts
@@ -2,10 +2,10 @@ export {
   createWorktree,
   listWorktrees,
   removeWorktree,
-  sanitizeSlug,
-  GitError,
   WorktreeError,
   type CreatedWorktree,
   type CreateWorktreeOptions,
   type WorktreeInfo,
-} from './worktree';
+} from './manager';
+export { sanitizeSlug } from './slug';
+export { GitError } from './git';

--- a/packages/core/src/worktree/manager.test.ts
+++ b/packages/core/src/worktree/manager.test.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm, writeFile, realpath } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { git } from './git';
+import { createWorktree, listWorktrees, removeWorktree, WorktreeError } from './manager';
+
+async function initRepo(): Promise<string> {
+  const dir = await realpath(await mkdtemp(path.join(tmpdir(), 'kayam-wt-')));
+  const repo = path.join(dir, 'demo');
+  await git(dir, ['init', '--initial-branch=main', repo]);
+  await git(repo, ['config', 'user.email', 'test@example.com']);
+  await git(repo, ['config', 'user.name', 'Test']);
+  await writeFile(path.join(repo, 'README.md'), '# demo\n');
+  await git(repo, ['add', '.']);
+  await git(repo, ['commit', '-m', 'init']);
+  return repo;
+}
+
+describe('worktree manager', () => {
+  let repoPath = '';
+
+  beforeEach(async () => {
+    repoPath = await initRepo();
+  });
+
+  afterEach(async () => {
+    if (repoPath) {
+      await rm(path.dirname(repoPath), { recursive: true, force: true });
+    }
+  });
+
+  it('create + list + remove round-trip', async () => {
+    const created = await createWorktree({
+      repoPath,
+      branchPrefix: 'kay',
+      slug: 'first session',
+    });
+
+    expect(created.slug).toBe('first-session');
+    expect(created.branchName).toBe('kay/first-session');
+    expect(created.worktreePath).toBe(path.join(path.dirname(repoPath), 'demo-kay-first-session'));
+
+    const before = await listWorktrees(repoPath);
+    expect(before.some((w) => w.path === created.worktreePath)).toBe(true);
+
+    await removeWorktree(repoPath, created.worktreePath);
+    const after = await listWorktrees(repoPath);
+    expect(after.some((w) => w.path === created.worktreePath)).toBe(false);
+  });
+
+  it('rejects when the repo has uncommitted changes', async () => {
+    await writeFile(path.join(repoPath, 'dirty.txt'), 'work in progress');
+    await expect(
+      createWorktree({ repoPath, branchPrefix: 'kay', slug: 'dirty' }),
+    ).rejects.toBeInstanceOf(WorktreeError);
+  });
+
+  it('rejects when the branch already exists', async () => {
+    await git(repoPath, ['branch', 'kay/taken']);
+    await expect(
+      createWorktree({ repoPath, branchPrefix: 'kay', slug: 'taken' }),
+    ).rejects.toBeInstanceOf(WorktreeError);
+  });
+
+  it('honors a custom parent dir', async () => {
+    const custom = await realpath(await mkdtemp(path.join(tmpdir(), 'kayam-wt-parent-')));
+    const created = await createWorktree({
+      repoPath,
+      branchPrefix: 'kay',
+      slug: 'custom',
+      parentDir: custom,
+    });
+    expect(created.worktreePath.startsWith(custom)).toBe(true);
+    await removeWorktree(repoPath, created.worktreePath);
+    await rm(custom, { recursive: true, force: true });
+  });
+});

--- a/packages/core/src/worktree/manager.ts
+++ b/packages/core/src/worktree/manager.ts
@@ -1,0 +1,104 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { git, GitError } from './git';
+import { sanitizeSlug } from './slug';
+
+export class WorktreeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WorktreeError';
+  }
+}
+
+export interface CreateWorktreeOptions {
+  readonly repoPath: string;
+  readonly branchPrefix: string;
+  readonly slug: string;
+  readonly parentDir?: string;
+}
+
+export interface CreatedWorktree {
+  readonly worktreePath: string;
+  readonly branchName: string;
+  readonly slug: string;
+}
+
+export interface WorktreeInfo {
+  readonly path: string;
+  readonly branch: string | null;
+  readonly head: string;
+  readonly isMain: boolean;
+}
+
+export async function createWorktree(opts: CreateWorktreeOptions): Promise<CreatedWorktree> {
+  const slug = sanitizeSlug(opts.slug);
+  const branchName = `${opts.branchPrefix}/${slug}`;
+  const repoName = path.basename(opts.repoPath);
+  const parent = opts.parentDir ?? path.dirname(opts.repoPath);
+  const worktreePath = path.join(parent, `${repoName}-${opts.branchPrefix}-${slug}`);
+
+  await ensureClean(opts.repoPath);
+  await ensureBranchAvailable(opts.repoPath, branchName);
+
+  await mkdir(parent, { recursive: true });
+  await git(opts.repoPath, ['worktree', 'add', '-b', branchName, worktreePath]);
+
+  return { worktreePath, branchName, slug };
+}
+
+export async function removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+  await git(repoPath, ['worktree', 'remove', '--force', worktreePath]);
+}
+
+export async function listWorktrees(repoPath: string): Promise<ReadonlyArray<WorktreeInfo>> {
+  const { stdout } = await git(repoPath, ['worktree', 'list', '--porcelain']);
+  return parsePorcelain(stdout);
+}
+
+async function ensureClean(repoPath: string): Promise<void> {
+  const { stdout } = await git(repoPath, ['status', '--porcelain']);
+  if (stdout.trim().length > 0) {
+    throw new WorktreeError(`repository is dirty: ${repoPath}`);
+  }
+}
+
+async function ensureBranchAvailable(repoPath: string, branchName: string): Promise<void> {
+  try {
+    await git(repoPath, ['show-ref', '--verify', '--quiet', `refs/heads/${branchName}`]);
+  } catch (err) {
+    if (err instanceof GitError) return;
+    throw err;
+  }
+  throw new WorktreeError(`branch already exists: ${branchName}`);
+}
+
+function parsePorcelain(stdout: string): ReadonlyArray<WorktreeInfo> {
+  const blocks = stdout.split(/\n\n+/).filter((block) => block.trim().length > 0);
+  const entries: WorktreeInfo[] = [];
+  let isFirst = true;
+
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    let worktreePath = '';
+    let branch: string | null = null;
+    let head = '';
+
+    for (const line of lines) {
+      if (line.startsWith('worktree ')) worktreePath = line.slice('worktree '.length);
+      else if (line.startsWith('HEAD ')) head = line.slice('HEAD '.length);
+      else if (line.startsWith('branch ')) {
+        const ref = line.slice('branch '.length);
+        branch = ref.replace(/^refs\/heads\//, '');
+      } else if (line === 'detached') {
+        branch = null;
+      }
+    }
+
+    if (worktreePath.length > 0) {
+      entries.push({ path: worktreePath, branch, head, isMain: isFirst });
+      isFirst = false;
+    }
+  }
+
+  return entries;
+}

--- a/packages/core/src/worktree/slug.test.ts
+++ b/packages/core/src/worktree/slug.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSlug } from './slug';
+
+describe('sanitizeSlug', () => {
+  it('lowercases and keeps a-z 0-9 and hyphens', () => {
+    expect(sanitizeSlug('Refactor Auth Domain')).toBe('refactor-auth-domain');
+  });
+
+  it('collapses runs of separators', () => {
+    expect(sanitizeSlug('a---b__c  d')).toBe('a-b-c-d');
+  });
+
+  it('strips leading and trailing hyphens', () => {
+    expect(sanitizeSlug('---hi---')).toBe('hi');
+  });
+
+  it('truncates to max 40 chars without trailing hyphen', () => {
+    const long = 'a'.repeat(60);
+    expect(sanitizeSlug(long)).toHaveLength(40);
+  });
+
+  it('falls back to a stable hash for empty input', () => {
+    expect(sanitizeSlug('')).toMatch(/^[a-f0-9]{8}$/);
+    expect(sanitizeSlug('!!!')).toMatch(/^[a-f0-9]{8}$/);
+  });
+});

--- a/packages/core/src/worktree/slug.ts
+++ b/packages/core/src/worktree/slug.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'node:crypto';
+
+const MAX_SLUG_LENGTH = 40;
+
+export function sanitizeSlug(input: string): string {
+  const cleaned = input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SLUG_LENGTH)
+    .replace(/-+$/, '');
+
+  if (cleaned.length === 0) {
+    return createHash('sha256').update(input).digest('hex').slice(0, 8);
+  }
+  return cleaned;
+}


### PR DESCRIPTION
## Summary
- Pure node/git plumbing for the per-session sandbox in `@kay-am/core`.
- `createWorktree({ repoPath, branchPrefix, slug, parentDir? })` → `{ worktreePath, branchName, slug }`. Default parent is the repo's parent dir. Layout: `<parent>/<repo>-<prefix>-<slug>`.
- `removeWorktree(repoPath, worktreePath)`.
- `listWorktrees(repoPath)` — parses `git worktree list --porcelain`.
- `sanitizeSlug(input)` — lowercases, normalizes separators, caps to 40 chars, falls back to a stable 8-char SHA when the input has no usable characters.
- Refuses to start when the repo is dirty or the target branch already exists.
- Tests cover slug edge cases plus full create / list / remove cycles on temp repos, plus dirty-repo + branch-conflict failures, plus a custom parent dir.

## Test plan
- [x] `pnpm --filter @kay-am/core test` — 9 tests pass
- [x] `pnpm turbo run typecheck test build` clean

Closes #5