### PR TITLE
feat(core): session lifecycle reducer

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,3 +9,5 @@ export {
   type CreateWorktreeOptions,
   type WorktreeInfo,
 } from './worktree';
+
+export { IllegalSessionTransitionError, sessionReducer, type SessionEvent } from './session';

--- a/packages/core/src/session/index.ts
+++ b/packages/core/src/session/index.ts
@@ -1,0 +1,1 @@
+export { IllegalSessionTransitionError, sessionReducer, type SessionEvent } from './reducer';

--- a/packages/core/src/session/reducer.test.ts
+++ b/packages/core/src/session/reducer.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId, SessionState, TurnEvent } from '@kay-am/types';
+import { IllegalSessionTransitionError, sessionReducer, type SessionEvent } from './reducer';
+
+const at = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const later = '2026-05-07T00:01:00.000Z' as IsoDateTime;
+const runId = 'run_1' as ProviderRunId;
+
+const draft: SessionState = { kind: 'draft' };
+const starting: SessionState = { kind: 'starting', startedAt: at };
+const idle: SessionState = { kind: 'idle', lastActivityAt: at };
+const running: SessionState = { kind: 'running', runId, startedAt: at };
+const errored: SessionState = { kind: 'error', message: 'boom', failedAt: at };
+const ended: SessionState = { kind: 'ended', endedAt: at };
+
+describe('sessionReducer — start', () => {
+  it('draft → starting', () => {
+    expect(sessionReducer(draft, { kind: 'start', at })).toEqual({
+      kind: 'starting',
+      startedAt: at,
+    });
+  });
+
+  it.each([starting, idle, running, errored, ended])('rejects from %s', (state) => {
+    expect(() => sessionReducer(state, { kind: 'start', at })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — send', () => {
+  it('starting → running', () => {
+    expect(sessionReducer(starting, { kind: 'send', runId, at: later })).toEqual({
+      kind: 'running',
+      runId,
+      startedAt: later,
+    });
+  });
+
+  it('idle → running', () => {
+    expect(sessionReducer(idle, { kind: 'send', runId, at: later })).toEqual({
+      kind: 'running',
+      runId,
+      startedAt: later,
+    });
+  });
+
+  it.each([draft, running, errored, ended])('rejects from %s', (state) => {
+    expect(() => sessionReducer(state, { kind: 'send', runId, at })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — receive_event', () => {
+  it('done → idle', () => {
+    const event: TurnEvent = { kind: 'done', runId, at: later };
+    expect(sessionReducer(running, { kind: 'receive_event', event })).toEqual({
+      kind: 'idle',
+      lastActivityAt: later,
+    });
+  });
+
+  it('error → error state', () => {
+    const event: TurnEvent = {
+      kind: 'error',
+      runId,
+      message: 'rate limit',
+      at: later,
+    };
+    expect(sessionReducer(running, { kind: 'receive_event', event })).toEqual({
+      kind: 'error',
+      message: 'rate limit',
+      failedAt: later,
+    });
+  });
+
+  it.each<TurnEvent>([
+    { kind: 'assistant_text', runId, delta: 'hi', at: later },
+    {
+      kind: 'usage',
+      runId,
+      usage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, estimatedCostUsd: 0 },
+      at: later,
+    },
+  ])('keeps running for %s', (event) => {
+    expect(sessionReducer(running, { kind: 'receive_event', event })).toEqual(running);
+  });
+
+  it.each([draft, starting, idle, errored, ended])('rejects from %s', (state) => {
+    const event: TurnEvent = { kind: 'done', runId, at: later };
+    expect(() => sessionReducer(state, { kind: 'receive_event', event })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — end', () => {
+  it.each([draft, starting, idle, running, errored])('%s → ended', (state) => {
+    expect(sessionReducer(state, { kind: 'end', at: later })).toEqual({
+      kind: 'ended',
+      endedAt: later,
+    });
+  });
+
+  it('rejects from ended (already terminal)', () => {
+    expect(() => sessionReducer(ended, { kind: 'end', at: later })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — error', () => {
+  it.each([draft, starting, idle, running, errored])('%s → error', (state) => {
+    expect(sessionReducer(state, { kind: 'error', message: 'x', at: later })).toEqual({
+      kind: 'error',
+      message: 'x',
+      failedAt: later,
+    });
+  });
+
+  it('rejects from ended', () => {
+    expect(() => sessionReducer(ended, { kind: 'error', message: 'x', at: later })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — retry', () => {
+  it('error → idle', () => {
+    expect(sessionReducer(errored, { kind: 'retry', at: later })).toEqual({
+      kind: 'idle',
+      lastActivityAt: later,
+    });
+  });
+
+  it.each([draft, starting, idle, running, ended])('rejects from %s', (state) => {
+    expect(() => sessionReducer(state, { kind: 'retry', at: later })).toThrow(
+      IllegalSessionTransitionError,
+    );
+  });
+});
+
+describe('sessionReducer — purity', () => {
+  it('does not mutate input state', () => {
+    const state: SessionState = { kind: 'draft' };
+    const event: SessionEvent = { kind: 'start', at };
+    const next = sessionReducer(state, event);
+    expect(state).toEqual({ kind: 'draft' });
+    expect(next).not.toBe(state);
+  });
+});

--- a/packages/core/src/session/reducer.ts
+++ b/packages/core/src/session/reducer.ts
@@ -1,0 +1,84 @@
+import type { IsoDateTime, ProviderRunId, SessionState, TurnEvent } from '@kay-am/types';
+
+export type SessionEvent =
+  | { kind: 'start'; at: IsoDateTime }
+  | { kind: 'send'; runId: ProviderRunId; at: IsoDateTime }
+  | { kind: 'receive_event'; event: TurnEvent }
+  | { kind: 'end'; at: IsoDateTime }
+  | { kind: 'error'; message: string; at: IsoDateTime }
+  | { kind: 'retry'; at: IsoDateTime };
+
+export class IllegalSessionTransitionError extends Error {
+  constructor(
+    public readonly state: SessionState,
+    public readonly event: SessionEvent,
+  ) {
+    super(`illegal transition: cannot apply ${event.kind} in state ${state.kind}`);
+    this.name = 'IllegalSessionTransitionError';
+  }
+}
+
+export function sessionReducer(state: SessionState, event: SessionEvent): SessionState {
+  switch (event.kind) {
+    case 'start':
+      if (state.kind !== 'draft') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return { kind: 'starting', startedAt: event.at };
+
+    case 'send':
+      if (state.kind !== 'starting' && state.kind !== 'idle') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return { kind: 'running', runId: event.runId, startedAt: event.at };
+
+    case 'receive_event': {
+      if (state.kind !== 'running') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return applyTurnEvent(state, event.event);
+    }
+
+    case 'end':
+      if (state.kind === 'ended') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return { kind: 'ended', endedAt: event.at };
+
+    case 'error':
+      if (state.kind === 'ended') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return { kind: 'error', message: event.message, failedAt: event.at };
+
+    case 'retry':
+      if (state.kind !== 'error') {
+        throw new IllegalSessionTransitionError(state, event);
+      }
+      return { kind: 'idle', lastActivityAt: event.at };
+
+    default: {
+      const _exhaustive: never = event;
+      throw new Error(`unhandled session event: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}
+
+function applyTurnEvent(state: SessionState, turn: TurnEvent): SessionState {
+  switch (turn.kind) {
+    case 'done':
+      return { kind: 'idle', lastActivityAt: turn.at };
+    case 'error':
+      return { kind: 'error', message: turn.message, failedAt: turn.at };
+    case 'assistant_text':
+    case 'tool_call_start':
+    case 'tool_call_end':
+    case 'file_edit':
+    case 'usage':
+      return state;
+    default: {
+      const _exhaustive: never = turn;
+      throw new Error(`unhandled turn event: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Pure state machine for `SessionState`: `sessionReducer(state, event) → state`. Exhaustive on `event` and `state` with `never` defaults.
- Events: `start`, `send`, `receive_event`, `end`, `error`, `retry`.
- `receive_event` folds a `TurnEvent` into the running session: `done` → `idle`, `error` → `error`, anything else leaves state unchanged.
- Illegal transitions throw `IllegalSessionTransitionError`. The reducer never mutates input.
- 40 tests cover every transition in the matrix plus the illegal-transition rejections per state.

## Test plan
- [x] `pnpm --filter @kay-am/core test` — 49 tests pass (40 new + 9 worktree)
- [x] `pnpm --filter @kay-am/core typecheck` clean

Closes #9