### PR TITLE
feat(core): telemetry recorder

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,9 +14,12 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@kay-am/db": "workspace:*",
     "@kay-am/types": "workspace:*"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "better-sqlite3": "^11.7.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,10 @@ export {
 } from './worktree';
 
 export { IllegalSessionTransitionError, sessionReducer, type SessionEvent } from './session';
+
+export {
+  TelemetryRecorder,
+  type RecordSummarizerInput,
+  type RecordTurnInput,
+  type TelemetryRecorderDeps,
+} from './telemetry';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -1,0 +1,6 @@
+export {
+  TelemetryRecorder,
+  type RecordSummarizerInput,
+  type RecordTurnInput,
+  type TelemetryRecorderDeps,
+} from './recorder';

--- a/packages/core/src/telemetry/recorder.test.ts
+++ b/packages/core/src/telemetry/recorder.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { migrate, type Database as DbInterface } from '@kay-am/db';
+import type {
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderRunId,
+  ProviderUsage,
+  SessionId,
+  TelemetryRecordId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { TelemetryRecorder } from './recorder';
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+const fakeAdapter: ProviderAdapter = {
+  id: 'anthropic',
+  capabilities: {
+    streaming: true,
+    toolUse: true,
+    fileEdits: true,
+    contextWindow: 200_000,
+    defaultModel: 'claude-opus-4-7',
+    availableModels: ['claude-opus-4-7'],
+  },
+  async detect() {
+    return { kind: 'available', binary: 'claude', version: '0.0.0' };
+  },
+  spawn() {
+    throw new Error('not used in tests');
+  },
+  cost(usage: ProviderUsage) {
+    return usage.inputTokens * 0.000003 + usage.outputTokens * 0.000015;
+  },
+};
+
+async function seedSession(
+  db: DbInterface,
+  workspaceId: WorkspaceId,
+  sessionId: SessionId,
+): Promise<void> {
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'demo', `/tmp/${workspaceId}`, 0, 0],
+  );
+  await db.execute(
+    `INSERT INTO sessions
+       (id, workspace_id, goal, state_kind, state_payload, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [sessionId, workspaceId, 'demo', 'idle', '{"lastActivityAt":"2026-05-07T00:00:00Z"}', 0, 0],
+  );
+  await db.execute(
+    `INSERT INTO provider_runs
+       (id, session_id, provider, model, status_kind, status_payload, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ['run_1', sessionId, 'anthropic', 'claude-opus-4-7', 'succeeded', '{}', 0],
+  );
+}
+
+let counter = 0;
+const newId = (): TelemetryRecordId => `tel_${++counter}` as TelemetryRecordId;
+const now = (): IsoDateTime => '2026-05-07T00:00:00.000Z' as IsoDateTime;
+
+describe('TelemetryRecorder', () => {
+  it('records a turn and computes cost via the adapter', async () => {
+    counter = 0;
+    const db = makeDb();
+    await migrate(db);
+    await seedSession(db, 'ws_1' as WorkspaceId, 'sess_1' as SessionId);
+
+    const recorder = new TelemetryRecorder({ db, adapter: fakeAdapter, newId, now });
+    const usage: ProviderUsage = {
+      inputTokens: 1000,
+      outputTokens: 500,
+      cachedInputTokens: 0,
+      estimatedCostUsd: 0,
+    };
+    const record = await recorder.recordTurn({
+      runId: 'run_1' as ProviderRunId,
+      sessionId: 'sess_1' as SessionId,
+      model: 'claude-opus-4-7',
+      usage,
+    });
+
+    expect(record.kind).toBe('turn');
+    expect(record.estimatedCostUsd).toBeCloseTo(0.0105);
+  });
+
+  it('aggregates per session, workspace and provider', async () => {
+    counter = 0;
+    const db = makeDb();
+    await migrate(db);
+    await seedSession(db, 'ws_2' as WorkspaceId, 'sess_2' as SessionId);
+
+    const recorder = new TelemetryRecorder({ db, adapter: fakeAdapter, newId, now });
+    const usage = {
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedInputTokens: 0,
+      estimatedCostUsd: 0,
+    } satisfies ProviderUsage;
+
+    await recorder.recordTurn({
+      runId: 'run_1' as ProviderRunId,
+      sessionId: 'sess_2' as SessionId,
+      model: 'claude-opus-4-7',
+      usage,
+    });
+    await recorder.recordSummarizer({
+      runId: 'run_1' as ProviderRunId,
+      sessionId: 'sess_2' as SessionId,
+      model: 'claude-haiku-4-5',
+      usage,
+      costUsd: 0.00002,
+    });
+
+    const session = await recorder.sessionSummary('sess_2' as SessionId);
+    expect(session.recordCount).toBe(2);
+    expect(session.inputTokens).toBe(200);
+    expect(session.outputTokens).toBe(100);
+
+    const workspace = await recorder.workspaceSummary('ws_2' as WorkspaceId);
+    expect(workspace.recordCount).toBe(2);
+
+    const provider = await recorder.providerSummary('anthropic');
+    expect(provider.recordCount).toBe(2);
+  });
+});

--- a/packages/core/src/telemetry/recorder.ts
+++ b/packages/core/src/telemetry/recorder.ts
@@ -1,0 +1,108 @@
+import {
+  insertTelemetry,
+  summarizeProviderTelemetry,
+  summarizeSessionTelemetry,
+  summarizeWorkspaceTelemetry,
+  type Database,
+  type TelemetrySummary,
+} from '@kay-am/db';
+import type {
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderName,
+  ProviderRunId,
+  ProviderUsage,
+  SessionId,
+  TelemetryKind,
+  TelemetryRecord,
+  TelemetryRecordId,
+  WorkspaceId,
+} from '@kay-am/types';
+
+export interface RecordTurnInput {
+  readonly runId: ProviderRunId;
+  readonly sessionId: SessionId;
+  readonly model: string;
+  readonly usage: ProviderUsage;
+}
+
+export interface RecordSummarizerInput {
+  readonly runId: ProviderRunId;
+  readonly sessionId: SessionId;
+  readonly model: string;
+  readonly usage: ProviderUsage;
+  readonly costUsd: number;
+}
+
+export interface TelemetryRecorderDeps {
+  readonly db: Database;
+  readonly adapter: ProviderAdapter;
+  readonly newId: () => TelemetryRecordId;
+  readonly now: () => IsoDateTime;
+}
+
+export class TelemetryRecorder {
+  constructor(private readonly deps: TelemetryRecorderDeps) {}
+
+  async recordTurn(input: RecordTurnInput): Promise<TelemetryRecord> {
+    const cost = this.deps.adapter.cost(input.usage, input.model);
+    return this.persist({
+      kind: 'turn',
+      runId: input.runId,
+      sessionId: input.sessionId,
+      provider: this.deps.adapter.id,
+      model: input.model,
+      usage: input.usage,
+      costUsd: cost,
+    });
+  }
+
+  async recordSummarizer(input: RecordSummarizerInput): Promise<TelemetryRecord> {
+    return this.persist({
+      kind: 'summarizer',
+      runId: input.runId,
+      sessionId: input.sessionId,
+      provider: this.deps.adapter.id,
+      model: input.model,
+      usage: input.usage,
+      costUsd: input.costUsd,
+    });
+  }
+
+  sessionSummary(sessionId: SessionId): Promise<TelemetrySummary> {
+    return summarizeSessionTelemetry(this.deps.db, sessionId);
+  }
+
+  workspaceSummary(workspaceId: WorkspaceId): Promise<TelemetrySummary> {
+    return summarizeWorkspaceTelemetry(this.deps.db, workspaceId);
+  }
+
+  providerSummary(provider: ProviderName): Promise<TelemetrySummary> {
+    return summarizeProviderTelemetry(this.deps.db, provider);
+  }
+
+  private async persist(args: {
+    kind: TelemetryKind;
+    runId: ProviderRunId;
+    sessionId: SessionId;
+    provider: ProviderName;
+    model: string;
+    usage: ProviderUsage;
+    costUsd: number;
+  }): Promise<TelemetryRecord> {
+    const record: TelemetryRecord = {
+      id: this.deps.newId(),
+      runId: args.runId,
+      sessionId: args.sessionId,
+      kind: args.kind,
+      provider: args.provider,
+      model: args.model,
+      inputTokens: args.usage.inputTokens,
+      outputTokens: args.usage.outputTokens,
+      estimatedCostUsd: args.costUsd,
+      recordedAt: this.deps.now(),
+    };
+    await insertTelemetry(this.deps.db, record);
+    return record;
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,7 +21,10 @@ export {
 } from './queries/provider-run';
 export {
   insertTelemetry,
+  listTelemetryForSession,
   summarizeSessionTelemetry,
-  type SessionTelemetrySummary,
+  summarizeWorkspaceTelemetry,
+  summarizeProviderTelemetry,
+  type TelemetrySummary,
 } from './queries/telemetry';
 export { getSetting, setSetting } from './queries/settings';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -1,8 +1,12 @@
 import { m001Initial } from './m001-initial';
+import { m002TelemetryKind } from './m002-telemetry-kind';
 
 export interface Migration {
   readonly version: number;
   readonly sql: string;
 }
 
-export const migrations: ReadonlyArray<Migration> = [{ version: 1, sql: m001Initial }];
+export const migrations: ReadonlyArray<Migration> = [
+  { version: 1, sql: m001Initial },
+  { version: 2, sql: m002TelemetryKind },
+];

--- a/packages/db/src/migrations/m002-telemetry-kind.ts
+++ b/packages/db/src/migrations/m002-telemetry-kind.ts
@@ -1,0 +1,5 @@
+export const m002TelemetryKind = /* sql */ `
+ALTER TABLE telemetry_records ADD COLUMN kind TEXT NOT NULL DEFAULT 'turn'
+  CHECK (kind IN ('turn','summarizer'));
+CREATE INDEX IF NOT EXISTS idx_telemetry_session_kind ON telemetry_records(session_id, kind);
+`;

--- a/packages/db/src/queries/telemetry.ts
+++ b/packages/db/src/queries/telemetry.ts
@@ -3,8 +3,10 @@ import type {
   ProviderName,
   ProviderRunId,
   SessionId,
+  TelemetryKind,
   TelemetryRecord,
   TelemetryRecordId,
+  WorkspaceId,
 } from '@kay-am/types';
 import type { Database } from '../client';
 
@@ -12,6 +14,7 @@ interface TelemetryRow {
   id: string;
   run_id: string;
   session_id: string;
+  kind: TelemetryKind;
   provider: ProviderName;
   model: string;
   input_tokens: number;
@@ -25,6 +28,7 @@ function toDomain(row: TelemetryRow): TelemetryRecord {
     id: row.id as TelemetryRecordId,
     runId: row.run_id as ProviderRunId,
     sessionId: row.session_id as SessionId,
+    kind: row.kind,
     provider: row.provider,
     model: row.model,
     inputTokens: row.input_tokens,
@@ -37,12 +41,13 @@ function toDomain(row: TelemetryRow): TelemetryRecord {
 export async function insertTelemetry(db: Database, record: TelemetryRecord): Promise<void> {
   await db.execute(
     `INSERT INTO telemetry_records
-      (id, run_id, session_id, provider, model, input_tokens, output_tokens, estimated_cost_usd, recorded_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, run_id, session_id, kind, provider, model, input_tokens, output_tokens, estimated_cost_usd, recorded_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       record.id,
       record.runId,
       record.sessionId,
+      record.kind,
       record.provider,
       record.model,
       record.inputTokens,
@@ -53,36 +58,79 @@ export async function insertTelemetry(db: Database, record: TelemetryRecord): Pr
   );
 }
 
-export interface SessionTelemetrySummary {
+export async function listTelemetryForSession(
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<TelemetryRecord>> {
+  const rows = await db.select<TelemetryRow>(
+    'SELECT * FROM telemetry_records WHERE session_id = ? ORDER BY recorded_at ASC',
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}
+
+export interface TelemetrySummary {
   readonly inputTokens: number;
   readonly outputTokens: number;
   readonly estimatedCostUsd: number;
   readonly recordCount: number;
 }
 
+interface SummaryRow {
+  input: number | null;
+  output: number | null;
+  cost: number | null;
+  count: number;
+}
+
+const SUMMARY_SELECT = `
+  COALESCE(SUM(input_tokens), 0) AS input,
+  COALESCE(SUM(output_tokens), 0) AS output,
+  COALESCE(SUM(estimated_cost_usd), 0) AS cost,
+  COUNT(*) AS count
+`;
+
+function toSummary(row: SummaryRow | undefined): TelemetrySummary {
+  return {
+    inputTokens: row?.input ?? 0,
+    outputTokens: row?.output ?? 0,
+    estimatedCostUsd: row?.cost ?? 0,
+    recordCount: row?.count ?? 0,
+  };
+}
+
 export async function summarizeSessionTelemetry(
   db: Database,
   sessionId: SessionId,
-): Promise<SessionTelemetrySummary> {
-  const rows = await db.select<{
-    input: number | null;
-    output: number | null;
-    cost: number | null;
-    count: number;
-  }>(
-    `SELECT
-       COALESCE(SUM(input_tokens), 0) AS input,
-       COALESCE(SUM(output_tokens), 0) AS output,
-       COALESCE(SUM(estimated_cost_usd), 0) AS cost,
-       COUNT(*) AS count
-     FROM telemetry_records WHERE session_id = ?`,
+): Promise<TelemetrySummary> {
+  const rows = await db.select<SummaryRow>(
+    `SELECT ${SUMMARY_SELECT} FROM telemetry_records WHERE session_id = ?`,
     [sessionId],
   );
-  const row = rows[0] ?? { input: 0, output: 0, cost: 0, count: 0 };
-  return {
-    inputTokens: row.input ?? 0,
-    outputTokens: row.output ?? 0,
-    estimatedCostUsd: row.cost ?? 0,
-    recordCount: row.count,
-  };
+  return toSummary(rows[0]);
+}
+
+export async function summarizeWorkspaceTelemetry(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<TelemetrySummary> {
+  const rows = await db.select<SummaryRow>(
+    `SELECT ${SUMMARY_SELECT}
+       FROM telemetry_records t
+       INNER JOIN sessions s ON s.id = t.session_id
+      WHERE s.workspace_id = ?`,
+    [workspaceId],
+  );
+  return toSummary(rows[0]);
+}
+
+export async function summarizeProviderTelemetry(
+  db: Database,
+  provider: ProviderName,
+): Promise<TelemetrySummary> {
+  const rows = await db.select<SummaryRow>(
+    `SELECT ${SUMMARY_SELECT} FROM telemetry_records WHERE provider = ?`,
+    [provider],
+  );
+  return toSummary(rows[0]);
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,4 +17,4 @@ export type {
   TurnEvent,
   TurnRequest,
 } from './adapter';
-export type { TelemetryRecord } from './telemetry';
+export type { TelemetryKind, TelemetryRecord } from './telemetry';

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,10 +1,13 @@
 import type { IsoDateTime, ProviderRunId, SessionId, TelemetryRecordId } from './ids';
 import type { ProviderName } from './provider';
 
+export type TelemetryKind = 'turn' | 'summarizer';
+
 export type TelemetryRecord = Readonly<{
   id: TelemetryRecordId;
   runId: ProviderRunId;
   sessionId: SessionId;
+  kind: TelemetryKind;
   provider: ProviderName;
   model: string;
   inputTokens: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,10 +95,19 @@ importers:
 
   packages/core:
     dependencies:
+      '@kay-am/db':
+        specifier: workspace:*
+        version: link:../db
       '@kay-am/types':
         specifier: workspace:*
         version: link:../types
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      better-sqlite3:
+        specifier: ^11.7.0
+        version: 11.10.0
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
End-to-end token + cost accounting for v0.1.

- Extend `TelemetryRecord` with `kind: 'turn' | 'summarizer'` in `@kay-am/types`.
- Migration `m002-telemetry-kind`: adds `kind` column (default `'turn'`) plus a `(session_id, kind)` index.
- `@kay-am/db`: `insertTelemetry` persists the new column; new `listTelemetryForSession`. Summary helpers split into per-session, per-workspace, per-provider variants returning a shared `TelemetrySummary` shape.
- `@kay-am/core`: `TelemetryRecorder` class — `recordTurn` computes cost via `adapter.cost(usage, model)`; `recordSummarizer` takes the cost from the caller (Haiku is billed in USD by Anthropic at v0.1 and the adapter abstraction is for the spawn-CLI providers). Aggregations expose session / workspace / provider summaries.
- Dependencies are injected (`db`, `adapter`, `newId`, `now`) so the recorder is testable without wall-clock or random IDs.
- Tests: cost-via-adapter on `recordTurn`, multi-record aggregation across all three summary scopes.

## Test plan
- [x] `pnpm --filter @kay-am/core test` — 51 tests pass
- [x] `pnpm --filter @kay-am/db test` — 4 tests pass
- [x] `pnpm turbo run typecheck test build` clean

Closes #10