### PR TITLE
feat(desktop): tauri db commands

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,3 +23,5 @@ tauri = { version = "2.11.1" }
 tauri-plugin-log = "2"
 keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 thiserror = "2"
+rusqlite = { version = "0.32", features = ["bundled"] }
+dirs = "5"

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -1,0 +1,155 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use rusqlite::types::{Value, ValueRef};
+use rusqlite::{params_from_iter, Connection};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Number};
+use tauri::State;
+use thiserror::Error;
+
+const APP_DIR: &str = ".kay-am";
+const DB_FILE: &str = "data.db";
+
+#[derive(Debug, Error)]
+pub enum DbError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("home directory not available")]
+    NoHomeDir,
+    #[error("failed to create app directory: {0}")]
+    AppDir(#[from] std::io::Error),
+    #[error("connection mutex poisoned")]
+    Poisoned,
+}
+
+impl Serialize for DbError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl DbError {
+    fn kind(&self) -> &'static str {
+        match self {
+            DbError::Sqlite(_) => "sqlite",
+            DbError::NoHomeDir => "no_home_dir",
+            DbError::AppDir(_) => "app_dir",
+            DbError::Poisoned => "poisoned",
+        }
+    }
+}
+
+pub struct Db(pub Mutex<Connection>);
+
+pub fn open() -> Result<Db, DbError> {
+    let path = resolve_db_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let conn = Connection::open(&path)?;
+    conn.execute_batch("PRAGMA foreign_keys = ON; PRAGMA journal_mode = WAL;")?;
+    Ok(Db(Mutex::new(conn)))
+}
+
+fn resolve_db_path() -> Result<PathBuf, DbError> {
+    let home = dirs::home_dir().ok_or(DbError::NoHomeDir)?;
+    Ok(home.join(APP_DIR).join(DB_FILE))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum SqlParam {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+}
+
+impl SqlParam {
+    fn to_value(&self) -> Value {
+        match self {
+            SqlParam::Null => Value::Null,
+            SqlParam::Bool(b) => Value::Integer(if *b { 1 } else { 0 }),
+            SqlParam::Int(n) => Value::Integer(*n),
+            SqlParam::Float(f) => Value::Real(*f),
+            SqlParam::Text(s) => Value::Text(s.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecResult {
+    pub rows_affected: i64,
+}
+
+#[tauri::command]
+pub fn db_exec(state: State<'_, Db>, sql: String) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    conn.execute_batch(&sql)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn db_execute(
+    state: State<'_, Db>,
+    sql: String,
+    params: Option<Vec<SqlParam>>,
+) -> Result<ExecResult, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(&sql)?;
+    let bound = params.unwrap_or_default();
+    let values: Vec<Value> = bound.iter().map(SqlParam::to_value).collect();
+    let rows_affected = stmt.execute(params_from_iter(values.iter()))? as i64;
+    Ok(ExecResult { rows_affected })
+}
+
+#[tauri::command]
+pub fn db_select(
+    state: State<'_, Db>,
+    sql: String,
+    params: Option<Vec<SqlParam>>,
+) -> Result<Vec<Map<String, serde_json::Value>>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(&sql)?;
+    let bound = params.unwrap_or_default();
+    let values: Vec<Value> = bound.iter().map(SqlParam::to_value).collect();
+    let column_names: Vec<String> = stmt.column_names().into_iter().map(String::from).collect();
+
+    let mut rows = stmt.query(params_from_iter(values.iter()))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut record = Map::new();
+        for (idx, name) in column_names.iter().enumerate() {
+            record.insert(name.clone(), value_to_json(row.get_ref(idx)?));
+        }
+        out.push(record);
+    }
+    Ok(out)
+}
+
+fn value_to_json(value: ValueRef<'_>) -> serde_json::Value {
+    match value {
+        ValueRef::Null => serde_json::Value::Null,
+        ValueRef::Integer(n) => serde_json::Value::Number(Number::from(n)),
+        ValueRef::Real(f) => Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        ValueRef::Text(bytes) => serde_json::Value::String(
+            std::str::from_utf8(bytes)
+                .map(String::from)
+                .unwrap_or_default(),
+        ),
+        ValueRef::Blob(bytes) => serde_json::Value::String(format!("blob:{}", bytes.len())),
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod db;
 mod editor;
 mod secrets;
 
@@ -5,7 +6,10 @@ pub use secrets::read as read_secret;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+  let database = db::open().expect("failed to open kay-am database");
+
   tauri::Builder::default()
+    .manage(database)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -20,6 +24,9 @@ pub fn run() {
       secrets::secret_set,
       secrets::secret_delete,
       editor::open_in_editor,
+      db::db_exec,
+      db::db_execute,
+      db::db_select,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src/db.ts
+++ b/apps/desktop/src/db.ts
@@ -1,0 +1,24 @@
+import { invoke } from '@tauri-apps/api/core';
+import { migrate as runMigrations, type Database, type MigrateResult } from '@kay-am/db';
+
+export const tauriDatabase: Database = {
+  async exec(sql) {
+    await invoke('db_exec', { sql });
+  },
+  async execute(sql, params = []) {
+    return invoke<{ rowsAffected: number }>('db_execute', {
+      sql,
+      params: [...params],
+    });
+  },
+  async select(sql, params = []) {
+    return invoke<ReadonlyArray<Record<string, unknown>>>('db_select', {
+      sql,
+      params: [...params],
+    }) as unknown as Promise<ReadonlyArray<never>>;
+  },
+};
+
+export async function runDbMigrations(): Promise<MigrateResult> {
+  return runMigrations(tauriDatabase);
+}


### PR DESCRIPTION
## Summary
Persistence wired end-to-end with the `@kay-am/db` query helpers running through Tauri.

- New `db.rs` opens the SQLite file at `~/.kay-am/data.db` (parent dir created on first run) with foreign keys + WAL enabled.
- Three generic Tauri commands — `db_exec`, `db_execute`, `db_select` — back the `Database` interface from JS. Generic shape keeps schema knowledge in TS and avoids duplicating every query in Rust; permission-aware per-query commands are a v0.6 concern (permission proxy).
- Errors serialize as `{ kind, message }` with stable `kind` values so the frontend can branch on failure mode.
- Frontend adapter `apps/desktop/src/db.ts` exposes the `Database` interface plus `runDbMigrations` for the boot sequence (#27).

## Test plan
- [x] `cargo check` clean
- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [ ] Manual on `tauri:dev`: invoke `runDbMigrations()` returns `{ applied: [1, 2], skipped: [], currentVersion: 2 }` on first launch and `{ applied: [], skipped: [1, 2] }` on second

Closes #11