### PR TITLE
feat(desktop): tauri worktree commands

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,3 +25,5 @@ keyring = { version = "3", features = ["apple-native", "linux-native", "windows-
 thiserror = "2"
 rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "5"
+regex = "1"
+sha2 = "0.10"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod db;
 mod editor;
 mod secrets;
+mod worktree;
 
 pub use secrets::read as read_secret;
 
@@ -27,6 +28,10 @@ pub fn run() {
       db::db_exec,
       db::db_execute,
       db::db_select,
+      worktree::worktree_create,
+      worktree::worktree_remove,
+      worktree::worktree_list,
+      worktree::worktree_exists,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -1,0 +1,253 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+const MAX_SLUG_LEN: usize = 40;
+
+#[derive(Debug, Error)]
+pub enum WorktreeError {
+    #[error("repository not found: {0}")]
+    RepoNotFound(String),
+    #[error("repository is dirty: {0}")]
+    Dirty(String),
+    #[error("git failed: {message}")]
+    Git { message: String },
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("invalid utf-8 in git output")]
+    InvalidUtf8,
+}
+
+impl Serialize for WorktreeError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl WorktreeError {
+    fn kind(&self) -> &'static str {
+        match self {
+            WorktreeError::RepoNotFound(_) => "repo_not_found",
+            WorktreeError::Dirty(_) => "dirty",
+            WorktreeError::Git { .. } => "git",
+            WorktreeError::Io(_) => "io",
+            WorktreeError::InvalidUtf8 => "invalid_utf8",
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct CreatedWorktree {
+    #[serde(rename = "worktreePath")]
+    pub worktree_path: String,
+    #[serde(rename = "branchName")]
+    pub branch_name: String,
+    pub slug: String,
+    pub reused: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorktreeInfo {
+    pub path: String,
+    pub branch: Option<String>,
+    pub head: String,
+    #[serde(rename = "isMain")]
+    pub is_main: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateArgs {
+    #[serde(rename = "repoPath")]
+    pub repo_path: String,
+    #[serde(rename = "branchPrefix")]
+    pub branch_prefix: String,
+    pub slug: String,
+    #[serde(rename = "parentDir")]
+    pub parent_dir: Option<String>,
+}
+
+pub fn sanitize_slug(input: &str) -> String {
+    let lowered = input.to_ascii_lowercase();
+    let alnum_dash = Regex::new(r"[^a-z0-9-]+").unwrap();
+    let collapsed_dashes = Regex::new(r"-+").unwrap();
+    let edge_dashes = Regex::new(r"^-+|-+$").unwrap();
+
+    let stage1 = alnum_dash.replace_all(&lowered, "-");
+    let stage2 = collapsed_dashes.replace_all(&stage1, "-");
+    let stage3 = edge_dashes.replace_all(&stage2, "");
+    let truncated: String = stage3.chars().take(MAX_SLUG_LEN).collect();
+    let trimmed = truncated.trim_end_matches('-').to_string();
+
+    if trimmed.is_empty() {
+        let mut hasher = Sha256::new();
+        hasher.update(input.as_bytes());
+        format!("{:x}", hasher.finalize()).chars().take(8).collect()
+    } else {
+        trimmed
+    }
+}
+
+#[tauri::command]
+pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeError> {
+    let repo_path = PathBuf::from(&args.repo_path);
+    if !repo_path.exists() {
+        return Err(WorktreeError::RepoNotFound(args.repo_path.clone()));
+    }
+
+    let slug = sanitize_slug(&args.slug);
+    let branch_name = format!("{}/{}", args.branch_prefix, slug);
+    let repo_name = repo_path
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| "repo".to_string());
+    let parent = args
+        .parent_dir
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            repo_path
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."))
+        });
+    let worktree_path = parent.join(format!("{repo_name}-{}-{slug}", args.branch_prefix));
+
+    if let Some(existing) = find_existing(&repo_path, &worktree_path)? {
+        return Ok(CreatedWorktree {
+            worktree_path: existing.path,
+            branch_name: existing.branch.unwrap_or(branch_name),
+            slug,
+            reused: true,
+        });
+    }
+
+    ensure_clean(&repo_path)?;
+    std::fs::create_dir_all(&parent)?;
+    git(
+        &repo_path,
+        &[
+            "worktree",
+            "add",
+            "-b",
+            &branch_name,
+            worktree_path.to_string_lossy().as_ref(),
+        ],
+    )?;
+
+    Ok(CreatedWorktree {
+        worktree_path: worktree_path.to_string_lossy().to_string(),
+        branch_name,
+        slug,
+        reused: false,
+    })
+}
+
+#[tauri::command]
+pub fn worktree_remove(repo_path: String, worktree_path: String) -> Result<(), WorktreeError> {
+    git(
+        Path::new(&repo_path),
+        &["worktree", "remove", "--force", &worktree_path],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn worktree_list(repo_path: String) -> Result<Vec<WorktreeInfo>, WorktreeError> {
+    let stdout = git(Path::new(&repo_path), &["worktree", "list", "--porcelain"])?;
+    Ok(parse_porcelain(&stdout))
+}
+
+#[tauri::command]
+pub fn worktree_exists(
+    repo_path: String,
+    branch_prefix: String,
+    slug: String,
+) -> Result<bool, WorktreeError> {
+    let entries = worktree_list(repo_path)?;
+    let target_branch = format!("{branch_prefix}/{}", sanitize_slug(&slug));
+    Ok(entries
+        .iter()
+        .any(|w| w.branch.as_deref() == Some(target_branch.as_str())))
+}
+
+fn find_existing(
+    repo_path: &Path,
+    worktree_path: &Path,
+) -> Result<Option<WorktreeInfo>, WorktreeError> {
+    let stdout = git(repo_path, &["worktree", "list", "--porcelain"])?;
+    let entries = parse_porcelain(&stdout);
+    Ok(entries
+        .into_iter()
+        .find(|w| Path::new(&w.path) == worktree_path))
+}
+
+fn ensure_clean(repo_path: &Path) -> Result<(), WorktreeError> {
+    let stdout = git(repo_path, &["status", "--porcelain"])?;
+    if !stdout.trim().is_empty() {
+        return Err(WorktreeError::Dirty(repo_path.to_string_lossy().into()));
+    }
+    Ok(())
+}
+
+fn git(cwd: &Path, args: &[&str]) -> Result<String, WorktreeError> {
+    let output = Command::new("git").args(args).current_dir(cwd).output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8(output.stderr).unwrap_or_default();
+        return Err(WorktreeError::Git {
+            message: format!("git {} failed: {stderr}", args.join(" ")).trim().to_string(),
+        });
+    }
+    String::from_utf8(output.stdout).map_err(|_| WorktreeError::InvalidUtf8)
+}
+
+fn parse_porcelain(stdout: &str) -> Vec<WorktreeInfo> {
+    let mut entries = Vec::new();
+    let mut is_first = true;
+
+    for block in stdout.split("\n\n") {
+        let block = block.trim();
+        if block.is_empty() {
+            continue;
+        }
+
+        let mut path = String::new();
+        let mut branch: Option<String> = None;
+        let mut head = String::new();
+
+        for line in block.lines() {
+            if let Some(rest) = line.strip_prefix("worktree ") {
+                path = rest.to_string();
+            } else if let Some(rest) = line.strip_prefix("HEAD ") {
+                head = rest.to_string();
+            } else if let Some(rest) = line.strip_prefix("branch ") {
+                branch = Some(rest.trim_start_matches("refs/heads/").to_string());
+            } else if line == "detached" {
+                branch = None;
+            }
+        }
+
+        if !path.is_empty() {
+            entries.push(WorktreeInfo {
+                path,
+                branch,
+                head,
+                is_main: is_first,
+            });
+            is_first = false;
+        }
+    }
+
+    entries
+}

--- a/apps/desktop/src/worktree.ts
+++ b/apps/desktop/src/worktree.ts
@@ -1,0 +1,42 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface CreatedWorktree {
+  readonly worktreePath: string;
+  readonly branchName: string;
+  readonly slug: string;
+  readonly reused: boolean;
+}
+
+export interface WorktreeInfo {
+  readonly path: string;
+  readonly branch: string | null;
+  readonly head: string;
+  readonly isMain: boolean;
+}
+
+export interface CreateWorktreeArgs {
+  readonly repoPath: string;
+  readonly branchPrefix: string;
+  readonly slug: string;
+  readonly parentDir?: string;
+}
+
+export async function createWorktree(args: CreateWorktreeArgs): Promise<CreatedWorktree> {
+  return invoke<CreatedWorktree>('worktree_create', { args });
+}
+
+export async function removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
+  await invoke('worktree_remove', { repoPath, worktreePath });
+}
+
+export async function listWorktrees(repoPath: string): Promise<ReadonlyArray<WorktreeInfo>> {
+  return invoke<ReadonlyArray<WorktreeInfo>>('worktree_list', { repoPath });
+}
+
+export async function worktreeExists(
+  repoPath: string,
+  branchPrefix: string,
+  slug: string,
+): Promise<boolean> {
+  return invoke<boolean>('worktree_exists', { repoPath, branchPrefix, slug });
+}


### PR DESCRIPTION
## Summary
Per-session sandbox plumbing accessible from JS.

- `worktree_create(args)`, `worktree_remove(repo, path)`, `worktree_list(repo)`, `worktree_exists(repo, prefix, slug)`.
- Slug sanitization mirrors `@kay-am/core` (lowercase, alnum + dash, collapsed runs, max 40, sha256 fallback) so slugs are stable across JS and Rust.
- **Idempotent create** — if a worktree at the same target path is already listed, returns its info with `reused: true` instead of failing. Caller can choose to surface this.
- Refuses to start when the repo is dirty.
- Errors serialize as `{ kind, message }` with stable `kind` values.

The TS worktree manager in `@kay-am/core` remains — it's the canonical testable implementation. `apps/desktop` runs through Rust because the WebView can't shell out.

## Test plan
- [x] `cargo check` clean
- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [ ] Manual: invoke `worktree_create` twice with same args → second returns `reused: true`

Closes #12