### PR TITLE
feat(core): synthetic context engine

### DIFF
--- a/packages/core/src/context/engine.test.ts
+++ b/packages/core/src/context/engine.test.ts
@@ -1,0 +1,119 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+import { migrate, type Database as DbInterface } from '@kay-am/db';
+import type { SessionId, WorkspaceId } from '@kay-am/types';
+import { ContextEngine } from './engine';
+import { InvalidSlotKeyError, serializeSlots, SLOT_KEYS } from './slots';
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+async function seedSession(db: DbInterface, sessionId: SessionId): Promise<void> {
+  const workspaceId = 'ws_ctx' as WorkspaceId;
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'demo', '/tmp/demo', 0, 0],
+  );
+  await db.execute(
+    `INSERT INTO sessions
+       (id, workspace_id, goal, state_kind, state_payload, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [sessionId, workspaceId, 'demo', 'idle', '{"lastActivityAt":"2026-05-07T00:00:00Z"}', 0, 0],
+  );
+}
+
+describe('serializeSlots', () => {
+  it('emits every slot key with placeholder when missing', () => {
+    const out = serializeSlots([]);
+    for (const key of SLOT_KEYS) {
+      expect(out).toContain(`## ${key.replace(/_/g, ' ')}`);
+    }
+    expect(out.split('—').length - 1).toBe(SLOT_KEYS.length);
+  });
+
+  it('uses provided value when present', () => {
+    const out = serializeSlots([{ key: 'goal', value: 'refactor auth', enabled: true }]);
+    expect(out).toMatch(/## goal\nrefactor auth/);
+  });
+
+  it('order is stable regardless of input order', () => {
+    const a = serializeSlots([
+      { key: 'decisions', value: 'd', enabled: true },
+      { key: 'goal', value: 'g', enabled: true },
+    ]);
+    const b = serializeSlots([
+      { key: 'goal', value: 'g', enabled: true },
+      { key: 'decisions', value: 'd', enabled: true },
+    ]);
+    expect(a).toBe(b);
+  });
+
+  it('skips disabled slots', () => {
+    const out = serializeSlots([{ key: 'goal', value: 'hidden', enabled: false }]);
+    expect(out).not.toContain('hidden');
+    expect(out).toMatch(/## goal\n—/);
+  });
+});
+
+describe('ContextEngine', () => {
+  it('rejects unknown slot keys', async () => {
+    const db = makeDb();
+    await migrate(db);
+    await seedSession(db, 'sess_1' as SessionId);
+    const engine = new ContextEngine({ db });
+
+    await expect(engine.upsert('sess_1' as SessionId, 'unknown', 'x')).rejects.toBeInstanceOf(
+      InvalidSlotKeyError,
+    );
+  });
+
+  it('round-trips slots through the db', async () => {
+    const db = makeDb();
+    await migrate(db);
+    await seedSession(db, 'sess_2' as SessionId);
+    const engine = new ContextEngine({ db });
+
+    await engine.upsert('sess_2' as SessionId, 'goal', 'ship v0.1');
+    await engine.upsert('sess_2' as SessionId, 'decisions', 'use claude only');
+    await engine.upsert('sess_2' as SessionId, 'goal', 'ship v0.1 quickly');
+
+    const slots = await engine.load('sess_2' as SessionId);
+    const goal = slots.find((s) => s.key === 'goal');
+    const decisions = slots.find((s) => s.key === 'decisions');
+    expect(goal?.value).toBe('ship v0.1 quickly');
+    expect(decisions?.value).toBe('use claude only');
+
+    const serialized = await engine.serialize('sess_2' as SessionId);
+    expect(serialized).toContain('ship v0.1 quickly');
+    expect(serialized).toContain('use claude only');
+  });
+
+  it('toggles enabled', async () => {
+    const db = makeDb();
+    await migrate(db);
+    await seedSession(db, 'sess_3' as SessionId);
+    const engine = new ContextEngine({ db });
+
+    await engine.upsert('sess_3' as SessionId, 'goal', 'visible');
+    await engine.setEnabled('sess_3' as SessionId, 'goal', false);
+
+    const out = await engine.serialize('sess_3' as SessionId);
+    expect(out).not.toContain('visible');
+  });
+});

--- a/packages/core/src/context/engine.ts
+++ b/packages/core/src/context/engine.ts
@@ -1,0 +1,43 @@
+import { listContextSlotsForSession, upsertContextSlot, type Database } from '@kay-am/db';
+import type { ContextSlot, SessionId } from '@kay-am/types';
+import { assertSlotKey, serializeSlots, SLOT_KEYS, type SlotKey } from './slots';
+
+export interface ContextEngineDeps {
+  readonly db: Database;
+}
+
+export class ContextEngine {
+  constructor(private readonly deps: ContextEngineDeps) {}
+
+  load(sessionId: SessionId): Promise<ReadonlyArray<ContextSlot>> {
+    return listContextSlotsForSession(this.deps.db, sessionId);
+  }
+
+  async upsert(sessionId: SessionId, key: string, value: string): Promise<void> {
+    assertSlotKey(key);
+    await upsertContextSlot(this.deps.db, sessionId, {
+      key,
+      value,
+      enabled: true,
+    });
+  }
+
+  async setEnabled(sessionId: SessionId, key: SlotKey, enabled: boolean): Promise<void> {
+    const existing = await this.load(sessionId);
+    const slot = existing.find((s) => s.key === key);
+    await upsertContextSlot(this.deps.db, sessionId, {
+      key,
+      value: slot?.value ?? '',
+      enabled,
+    });
+  }
+
+  async serialize(sessionId: SessionId): Promise<string> {
+    const slots = await this.load(sessionId);
+    return serializeSlots(slots);
+  }
+
+  static get keys(): ReadonlyArray<SlotKey> {
+    return SLOT_KEYS;
+  }
+}

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -1,0 +1,9 @@
+export { ContextEngine, type ContextEngineDeps } from './engine';
+export {
+  assertSlotKey,
+  InvalidSlotKeyError,
+  isSlotKey,
+  serializeSlots,
+  SLOT_KEYS,
+  type SlotKey,
+} from './slots';

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -1,0 +1,55 @@
+import type { ContextSlot } from '@kay-am/types';
+
+export const SLOT_KEYS = [
+  'goal',
+  'files_touched',
+  'decisions',
+  'open_questions',
+  'last_output_summary',
+] as const;
+
+export type SlotKey = (typeof SLOT_KEYS)[number];
+
+const SLOT_KEY_SET = new Set<string>(SLOT_KEYS);
+
+const SLOT_LABELS: Record<SlotKey, string> = {
+  goal: 'goal',
+  files_touched: 'files touched',
+  decisions: 'decisions',
+  open_questions: 'open questions',
+  last_output_summary: 'last output summary',
+};
+
+const EMPTY_PLACEHOLDER = '—';
+
+export class InvalidSlotKeyError extends Error {
+  constructor(public readonly key: string) {
+    super(`unknown context slot key: ${key}`);
+    this.name = 'InvalidSlotKeyError';
+  }
+}
+
+export function isSlotKey(key: string): key is SlotKey {
+  return SLOT_KEY_SET.has(key);
+}
+
+export function assertSlotKey(key: string): asserts key is SlotKey {
+  if (!isSlotKey(key)) throw new InvalidSlotKeyError(key);
+}
+
+export function serializeSlots(slots: ReadonlyArray<ContextSlot>): string {
+  const byKey = new Map<SlotKey, ContextSlot>();
+  for (const slot of slots) {
+    if (isSlotKey(slot.key) && slot.enabled) {
+      byKey.set(slot.key, slot);
+    }
+  }
+
+  const sections = SLOT_KEYS.map((key) => {
+    const value = byKey.get(key)?.value.trim() ?? '';
+    const body = value.length > 0 ? value : EMPTY_PLACEHOLDER;
+    return `## ${SLOT_LABELS[key]}\n${body}`;
+  });
+
+  return sections.join('\n\n');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,3 +18,14 @@ export {
   type RecordTurnInput,
   type TelemetryRecorderDeps,
 } from './telemetry';
+
+export {
+  ContextEngine,
+  InvalidSlotKeyError,
+  SLOT_KEYS,
+  assertSlotKey,
+  isSlotKey,
+  serializeSlots,
+  type ContextEngineDeps,
+  type SlotKey,
+} from './context';


### PR DESCRIPTION
## Summary
Owns the structured slots that prefix every turn.

- Fixed slot keys: `goal`, `files_touched`, `decisions`, `open_questions`, `last_output_summary`. Validation rejects unknown keys at the upsert boundary.
- `serializeSlots` produces a deterministic markdown prefix — every key in canonical order, `'—'` placeholder when missing or disabled. Round-trip stable: serialize is a pure function of the canonical key order, not the input order.
- `ContextEngine` wraps the `@kay-am/db` `context_slots` queries with `load` / `upsert` / `setEnabled` / `serialize`.

## Test plan
- [x] `pnpm --filter @kay-am/core test` — 58 tests pass (7 new)
- [x] `pnpm turbo run typecheck test build` clean

Closes #7