### PR TITLE
feat(core): claude provider adapter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,3 +29,12 @@ export {
   type ContextEngineDeps,
   type SlotKey,
 } from './context';
+
+export {
+  ClaudeAdapter,
+  computeCostUsd,
+  parseStreamJsonLine,
+  priceFor,
+  type ClaudeAdapterDeps,
+  type ParseContext,
+} from './providers/claude';

--- a/packages/core/src/providers/claude/adapter.test.ts
+++ b/packages/core/src/providers/claude/adapter.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId, SessionId, TurnEvent, TurnRequest } from '@kay-am/types';
+import { ClaudeAdapter } from './adapter';
+
+const fakeNow = (): IsoDateTime => '2026-05-07T00:00:00.000Z' as IsoDateTime;
+
+class FakeChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  exitCode: number | null = null;
+  killed = false;
+  signal: NodeJS.Signals | null = null;
+
+  constructor(lines: ReadonlyArray<string>, exit = 0) {
+    super();
+    this.stdout = Readable.from(lines.map((line) => `${line}\n`));
+    this.stderr = Readable.from([]);
+    queueMicrotask(() => {
+      this.exitCode = exit;
+      this.stdout.on('end', () => this.emit('close', exit));
+    });
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.killed = true;
+    this.signal = signal;
+    this.exitCode = 143;
+    return true;
+  }
+}
+
+class OpenChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  exitCode: number | null = null;
+  killed = false;
+  signal: NodeJS.Signals | null = null;
+
+  constructor(lines: ReadonlyArray<string>) {
+    super();
+    this.stdout = new Readable({ read() {} });
+    for (const line of lines) this.stdout.push(`${line}\n`);
+    this.stderr = new Readable({ read() {} });
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.killed = true;
+    this.signal = signal;
+    this.exitCode = 143;
+    return true;
+  }
+}
+
+function makeOpenChild(lines: ReadonlyArray<string>): OpenChild {
+  return new OpenChild(lines);
+}
+
+function makeRequest(): TurnRequest {
+  return {
+    runId: 'run_1' as ProviderRunId,
+    sessionId: 'sess_1' as SessionId,
+    model: 'claude-opus-4-7',
+    workingDir: '/tmp/demo',
+    systemPrompt: 'sys',
+    userMessage: 'hi',
+  };
+}
+
+describe('ClaudeAdapter.spawn', () => {
+  it('emits parsed TurnEvents end-to-end', async () => {
+    const lines = [
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello' }] },
+      }),
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        usage: { input_tokens: 5, output_tokens: 3 },
+      }),
+    ];
+    const child = new FakeChild(lines);
+    const adapter = new ClaudeAdapter({
+      now: fakeNow,
+      spawnFn: (() => child) as never,
+    });
+
+    const collected: TurnEvent[] = [];
+    for await (const event of adapter.spawn(makeRequest())) {
+      collected.push(event);
+    }
+
+    expect(collected.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+    expect(collected[0]).toMatchObject({ delta: 'hello' });
+  });
+
+  it('kills the child on early break', async () => {
+    const child = makeOpenChild([
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'a' }] },
+      }),
+    ]);
+    const adapter = new ClaudeAdapter({
+      now: fakeNow,
+      spawnFn: (() => child) as never,
+    });
+
+    const iterator = adapter.spawn(makeRequest())[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    await iterator.return?.(undefined);
+    expect(child.killed).toBe(true);
+    expect(child.signal).toBe('SIGTERM');
+  });
+});
+
+describe('ClaudeAdapter.detect', () => {
+  it('returns available with parsed version on exit 0', async () => {
+    const child = new FakeChild(['1.0.0']);
+    const adapter = new ClaudeAdapter({
+      now: fakeNow,
+      spawnFn: (() => child) as never,
+    });
+    const result = await adapter.detect();
+    expect(result.kind).toBe('available');
+  });
+
+  it('returns missing on spawn error', async () => {
+    const child = new FakeChild([]);
+    queueMicrotask(() => child.emit('error', new Error('ENOENT')));
+    const adapter = new ClaudeAdapter({
+      now: fakeNow,
+      spawnFn: (() => child) as never,
+    });
+    const result = await adapter.detect();
+    expect(result.kind).toBe('missing');
+  });
+});

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -1,0 +1,187 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type {
+  DetectResult,
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderCapabilities,
+  ProviderUsage,
+  TurnEvent,
+  TurnRequest,
+} from '@kay-am/types';
+import { computeCostUsd } from './cost';
+import { parseStreamJsonLine } from './parser';
+
+const CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  toolUse: true,
+  fileEdits: true,
+  contextWindow: 1_000_000,
+  defaultModel: 'claude-opus-4-7',
+  availableModels: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+};
+
+export interface ClaudeAdapterDeps {
+  readonly binary?: string;
+  readonly now?: () => IsoDateTime;
+  readonly spawnFn?: typeof spawn;
+}
+
+export class ClaudeAdapter implements ProviderAdapter {
+  readonly id = 'anthropic' as const;
+  readonly capabilities = CAPABILITIES;
+
+  private readonly binary: string;
+  private readonly now: () => IsoDateTime;
+  private readonly spawnFn: typeof spawn;
+
+  constructor(deps: ClaudeAdapterDeps = {}) {
+    this.binary = deps.binary ?? 'claude';
+    this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
+    this.spawnFn = deps.spawnFn ?? spawn;
+  }
+
+  async detect(): Promise<DetectResult> {
+    return new Promise((resolve) => {
+      const child = this.spawnFn(this.binary, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.on('error', (err) => {
+        resolve({
+          kind: 'missing',
+          binary: this.binary,
+          reason: err.message,
+        });
+      });
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({
+            kind: 'available',
+            binary: this.binary,
+            version: stdout.trim(),
+          });
+        } else {
+          resolve({
+            kind: 'missing',
+            binary: this.binary,
+            reason: `exited with code ${code}`,
+          });
+        }
+      });
+    });
+  }
+
+  cost(usage: ProviderUsage, model: string): number {
+    return computeCostUsd(usage, model);
+  }
+
+  spawn(request: TurnRequest): AsyncIterable<TurnEvent> {
+    return spawnClaude(this.binary, this.spawnFn, this.now, request);
+  }
+}
+
+async function* spawnClaude(
+  binary: string,
+  spawnFn: typeof spawn,
+  now: () => IsoDateTime,
+  request: TurnRequest,
+): AsyncIterable<TurnEvent> {
+  const prompt = `${request.systemPrompt}\n\n${request.userMessage}`.trim();
+  const args = [
+    '-p',
+    prompt,
+    '--output-format',
+    'stream-json',
+    '--working-dir',
+    request.workingDir,
+    '--model',
+    request.model,
+    '--dangerously-skip-permissions',
+  ];
+
+  const child: ChildProcess = spawnFn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (!child.stdout) {
+    throw new Error('claude CLI started without stdout');
+  }
+
+  const queue: TurnEvent[] = [];
+  let resolver: ((value: IteratorResult<TurnEvent>) => void) | null = null;
+  let rejector: ((err: unknown) => void) | null = null;
+  let ended = false;
+  let error: unknown = null;
+
+  const ctx = { runId: request.runId, now };
+
+  const flush = () => {
+    if (resolver && queue.length > 0) {
+      const value = queue.shift()!;
+      const r = resolver;
+      resolver = null;
+      r({ value, done: false });
+    } else if (resolver && ended) {
+      const r = resolver;
+      resolver = null;
+      if (error) {
+        const rej = rejector;
+        rejector = null;
+        rej?.(error);
+      } else {
+        r({ value: undefined, done: true });
+      }
+    }
+  };
+
+  const lineReader = createInterface({ input: child.stdout });
+
+  lineReader.on('line', (line) => {
+    const events = parseStreamJsonLine(line, ctx);
+    for (const event of events) queue.push(event);
+    flush();
+  });
+
+  lineReader.on('close', () => {
+    ended = true;
+    flush();
+  });
+
+  child.on('error', (err) => {
+    error = err;
+    ended = true;
+    flush();
+  });
+
+  child.stderr?.on('data', () => {
+    // captured but not surfaced as TurnEvent for v0.1
+  });
+
+  try {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (ended) {
+        if (error) throw error;
+        return;
+      }
+      const value = await new Promise<IteratorResult<TurnEvent>>((resolve, reject) => {
+        resolver = resolve;
+        rejector = reject;
+      });
+      if (value.done) return;
+      yield value.value;
+    }
+  } finally {
+    if (!child.killed && child.exitCode === null) {
+      child.kill('SIGTERM');
+    }
+    lineReader.close();
+  }
+}

--- a/packages/core/src/providers/claude/cost.test.ts
+++ b/packages/core/src/providers/claude/cost.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderUsage } from '@kay-am/types';
+import { computeCostUsd } from './cost';
+
+const usage: ProviderUsage = {
+  inputTokens: 1_000_000,
+  outputTokens: 1_000_000,
+  cachedInputTokens: 0,
+  estimatedCostUsd: 0,
+};
+
+describe('computeCostUsd', () => {
+  it('opus pricing', () => {
+    expect(computeCostUsd(usage, 'claude-opus-4-7')).toBeCloseTo(15 + 75);
+  });
+
+  it('sonnet pricing', () => {
+    expect(computeCostUsd(usage, 'claude-sonnet-4-6')).toBeCloseTo(3 + 15);
+  });
+
+  it('haiku pricing', () => {
+    expect(computeCostUsd(usage, 'claude-haiku-4-5')).toBeCloseTo(1 + 5);
+  });
+
+  it('unknown model falls back to sonnet pricing', () => {
+    expect(computeCostUsd(usage, 'claude-vapor-9-9')).toBeCloseTo(3 + 15);
+  });
+
+  it('cached tokens are billed at the discounted rate', () => {
+    const partial: ProviderUsage = {
+      inputTokens: 2_000_000,
+      outputTokens: 0,
+      cachedInputTokens: 1_000_000,
+      estimatedCostUsd: 0,
+    };
+    // sonnet: 1M billable @ $3 + 1M cached @ $0.3
+    expect(computeCostUsd(partial, 'claude-sonnet-4-6')).toBeCloseTo(3 + 0.3);
+  });
+});

--- a/packages/core/src/providers/claude/cost.ts
+++ b/packages/core/src/providers/claude/cost.ts
@@ -1,0 +1,41 @@
+import type { ProviderUsage } from '@kay-am/types';
+
+interface ModelPrice {
+  readonly inputPerMtok: number;
+  readonly outputPerMtok: number;
+  readonly cachedInputPerMtok: number;
+}
+
+const PRICES: Record<string, ModelPrice> = {
+  'claude-opus-4-7': {
+    inputPerMtok: 15,
+    outputPerMtok: 75,
+    cachedInputPerMtok: 1.5,
+  },
+  'claude-sonnet-4-6': {
+    inputPerMtok: 3,
+    outputPerMtok: 15,
+    cachedInputPerMtok: 0.3,
+  },
+  'claude-haiku-4-5': {
+    inputPerMtok: 1,
+    outputPerMtok: 5,
+    cachedInputPerMtok: 0.1,
+  },
+};
+
+const FALLBACK: ModelPrice = PRICES['claude-sonnet-4-6']!;
+
+export function priceFor(model: string): ModelPrice {
+  return PRICES[model] ?? FALLBACK;
+}
+
+export function computeCostUsd(usage: ProviderUsage, model: string): number {
+  const price = priceFor(model);
+  const billableInput = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+  return (
+    (billableInput * price.inputPerMtok) / 1_000_000 +
+    (usage.cachedInputTokens * price.cachedInputPerMtok) / 1_000_000 +
+    (usage.outputTokens * price.outputPerMtok) / 1_000_000
+  );
+}

--- a/packages/core/src/providers/claude/index.ts
+++ b/packages/core/src/providers/claude/index.ts
@@ -1,0 +1,3 @@
+export { ClaudeAdapter, type ClaudeAdapterDeps } from './adapter';
+export { computeCostUsd, priceFor } from './cost';
+export { parseStreamJsonLine, type ParseContext } from './parser';

--- a/packages/core/src/providers/claude/parser.test.ts
+++ b/packages/core/src/providers/claude/parser.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+import { parseStreamJsonLine, type ParseContext } from './parser';
+
+const at = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const ctx: ParseContext = {
+  runId: 'run_1' as ProviderRunId,
+  now: () => at,
+};
+
+function parse(line: string): ReadonlyArray<TurnEvent> {
+  return parseStreamJsonLine(line, ctx);
+}
+
+describe('parseStreamJsonLine', () => {
+  it('returns nothing for empty / blank lines', () => {
+    expect(parse('')).toEqual([]);
+    expect(parse('   ')).toEqual([]);
+  });
+
+  it('returns nothing for malformed json', () => {
+    expect(parse('{not json')).toEqual([]);
+  });
+
+  it('ignores system events', () => {
+    expect(parse(JSON.stringify({ type: 'system', subtype: 'init' }))).toEqual([]);
+  });
+
+  it('emits assistant_text for text content blocks', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      }),
+    );
+    expect(events).toEqual([{ kind: 'assistant_text', runId: ctx.runId, delta: 'hello', at }]);
+  });
+
+  it('emits tool_call_start for tool_use blocks', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 'tool_1',
+              name: 'Bash',
+              input: { command: 'ls' },
+            },
+          ],
+        },
+      }),
+    );
+    expect(events).toEqual([
+      {
+        kind: 'tool_call_start',
+        runId: ctx.runId,
+        toolUseId: 'tool_1',
+        toolName: 'Bash',
+        input: { command: 'ls' },
+        at,
+      },
+    ]);
+  });
+
+  it('also emits file_edit for Write tool', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 't',
+              name: 'Write',
+              input: { file_path: '/tmp/x.ts' },
+            },
+          ],
+        },
+      }),
+    );
+    expect(events.some((e) => e.kind === 'file_edit')).toBe(true);
+    const fileEdit = events.find((e) => e.kind === 'file_edit');
+    expect(fileEdit).toMatchObject({ path: '/tmp/x.ts', editType: 'create' });
+  });
+
+  it('emits modify for Edit tool', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              id: 't',
+              name: 'Edit',
+              input: { file_path: '/tmp/x.ts', old_string: 'a', new_string: 'b' },
+            },
+          ],
+        },
+      }),
+    );
+    const edit = events.find((e) => e.kind === 'file_edit');
+    expect(edit).toMatchObject({ path: '/tmp/x.ts', editType: 'modify' });
+  });
+
+  it('emits tool_call_end for user tool_result blocks', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'user',
+        message: {
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool_1',
+              content: 'output',
+              is_error: false,
+            },
+          ],
+        },
+      }),
+    );
+    expect(events[0]).toMatchObject({
+      kind: 'tool_call_end',
+      toolUseId: 'tool_1',
+      output: 'output',
+      isError: false,
+    });
+  });
+
+  it('emits usage + done from result success', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 2 },
+      }),
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      kind: 'usage',
+      usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 2 },
+    });
+    expect(events[1]).toMatchObject({ kind: 'done' });
+  });
+
+  it('emits error from result with error message', () => {
+    const events = parse(JSON.stringify({ type: 'result', subtype: 'error', error: 'rate limit' }));
+    const error = events.find((e) => e.kind === 'error');
+    expect(error).toMatchObject({ kind: 'error', message: 'rate limit' });
+  });
+});

--- a/packages/core/src/providers/claude/parser.ts
+++ b/packages/core/src/providers/claude/parser.ts
@@ -1,0 +1,177 @@
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+export interface ParseContext {
+  readonly runId: ProviderRunId;
+  readonly now: () => IsoDateTime;
+}
+
+interface AssistantMessage {
+  readonly content?: ReadonlyArray<AssistantContentBlock>;
+}
+
+type AssistantContentBlock =
+  | { type: 'text'; text: string }
+  | {
+      type: 'tool_use';
+      id: string;
+      name: string;
+      input: unknown;
+    };
+
+interface ToolResultBlock {
+  readonly tool_use_id: string;
+  readonly content?: unknown;
+  readonly is_error?: boolean;
+}
+
+interface UserMessage {
+  readonly content?: ReadonlyArray<ToolResultBlock | { type: string }>;
+}
+
+interface UsagePayload {
+  readonly input_tokens?: number;
+  readonly output_tokens?: number;
+  readonly cache_read_input_tokens?: number;
+}
+
+const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  'Edit',
+  'MultiEdit',
+  'Write',
+  'NotebookEdit',
+]);
+
+function fileEditFromInput(
+  toolName: string,
+  input: unknown,
+): {
+  path: string;
+  editType: 'create' | 'modify' | 'delete';
+} | null {
+  if (!FILE_EDIT_TOOLS.has(toolName)) return null;
+  if (typeof input !== 'object' || input === null) return null;
+  const record = input as Record<string, unknown>;
+  const path = typeof record.file_path === 'string' ? record.file_path : null;
+  if (!path) return null;
+  const editType: 'create' | 'modify' | 'delete' = toolName === 'Write' ? 'create' : 'modify';
+  return { path, editType };
+}
+
+function isToolResultBlock(block: unknown): block is ToolResultBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'tool_use_id' in block &&
+    typeof (block as { tool_use_id: unknown }).tool_use_id === 'string'
+  );
+}
+
+export function parseStreamJsonLine(line: string, ctx: ParseContext): ReadonlyArray<TurnEvent> {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return [];
+
+  let payload: { type?: string } & Record<string, unknown>;
+  try {
+    payload = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  const at = ctx.now();
+
+  switch (payload.type) {
+    case 'assistant':
+      return parseAssistant(payload.message as AssistantMessage | undefined, ctx, at);
+
+    case 'user':
+      return parseUser(payload.message as UserMessage | undefined, ctx, at);
+
+    case 'result': {
+      const usage = (payload.usage as UsagePayload | undefined) ?? {};
+      const events: TurnEvent[] = [];
+      if (typeof usage.input_tokens === 'number' || typeof usage.output_tokens === 'number') {
+        events.push({
+          kind: 'usage',
+          runId: ctx.runId,
+          usage: {
+            inputTokens: usage.input_tokens ?? 0,
+            outputTokens: usage.output_tokens ?? 0,
+            cachedInputTokens: usage.cache_read_input_tokens ?? 0,
+            estimatedCostUsd: 0,
+          },
+          at,
+        });
+      }
+      const subtype = payload.subtype as string | undefined;
+      if (subtype === 'success') {
+        events.push({ kind: 'done', runId: ctx.runId, at });
+      } else if (typeof payload.error === 'string') {
+        events.push({ kind: 'error', runId: ctx.runId, message: payload.error, at });
+      } else {
+        events.push({ kind: 'done', runId: ctx.runId, at });
+      }
+      return events;
+    }
+
+    case 'system':
+    default:
+      return [];
+  }
+}
+
+function parseAssistant(
+  message: AssistantMessage | undefined,
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  const blocks = message?.content ?? [];
+  const events: TurnEvent[] = [];
+
+  for (const block of blocks) {
+    if (block.type === 'text' && block.text.length > 0) {
+      events.push({ kind: 'assistant_text', runId: ctx.runId, delta: block.text, at });
+    } else if (block.type === 'tool_use') {
+      events.push({
+        kind: 'tool_call_start',
+        runId: ctx.runId,
+        toolUseId: block.id,
+        toolName: block.name,
+        input: block.input,
+        at,
+      });
+      const edit = fileEditFromInput(block.name, block.input);
+      if (edit) {
+        events.push({
+          kind: 'file_edit',
+          runId: ctx.runId,
+          path: edit.path,
+          editType: edit.editType,
+          at,
+        });
+      }
+    }
+  }
+  return events;
+}
+
+function parseUser(
+  message: UserMessage | undefined,
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  const blocks = message?.content ?? [];
+  const events: TurnEvent[] = [];
+  for (const block of blocks) {
+    if (isToolResultBlock(block)) {
+      events.push({
+        kind: 'tool_call_end',
+        runId: ctx.runId,
+        toolUseId: block.tool_use_id,
+        output: block.content ?? null,
+        isError: block.is_error === true,
+        at,
+      });
+    }
+  }
+  return events;
+}


### PR DESCRIPTION
## Summary
`ProviderAdapter` implementation backed by the headless `claude` CLI.

- `ClaudeAdapter` spawns `claude -p <prompt> --output-format stream-json --working-dir <path> --model <model> --dangerously-skip-permissions` and yields `TurnEvent`s.
- Stream-JSON parser maps:
  - `assistant.text` → `assistant_text`
  - `assistant.tool_use` → `tool_call_start` (+ `file_edit` when the tool is one of `Edit` / `MultiEdit` / `Write` / `NotebookEdit`)
  - `user.tool_result` → `tool_call_end`
  - `result(success)` → `usage` + `done`
  - `result(error)` → `error`
  Unknown / `system` events are silently dropped.
- **Backpressure**: events buffer in memory but the AsyncIterable only produces at the consumer's pace via a single-slot resolver. The child stays in its own io loop and TS doesn't try to drain.
- **Early termination**: the async generator's `finally` sends `SIGTERM` to the child if it is still running.
- `detect()` parses `claude --version` exit code, returning `available` / `missing`.
- `cost()` uses a per-model price table (Opus / Sonnet / Haiku), with cached input billed at the discounted rate. Unknown models fall back to Sonnet pricing.

## Test plan
- [x] `pnpm --filter @kay-am/core test` — 77 tests pass (parser + cost + adapter spawn + detect + early-kill)
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: `claude --version` available; spawn against a real claude install

Closes #6