### PR TITLE
feat(desktop): provider cli detection on startup

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,16 +1,21 @@
 mod db;
 mod editor;
+mod providers;
 mod secrets;
 mod worktree;
 
 pub use secrets::read as read_secret;
 
+use std::sync::Mutex;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   let database = db::open().expect("failed to open kay-am database");
+  let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
 
   tauri::Builder::default()
     .manage(database)
+    .manage(provider_state)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -32,6 +37,8 @@ pub fn run() {
       worktree::worktree_remove,
       worktree::worktree_list,
       worktree::worktree_exists,
+      providers::get_provider_status,
+      providers::refresh_provider_status,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -1,0 +1,124 @@
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::State;
+
+const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ProviderStatus {
+    pub id: String,
+    pub binary: String,
+    pub available: bool,
+    pub version: Option<String>,
+    pub error: Option<String>,
+}
+
+pub struct ProviderState(pub Mutex<ProviderStatus>);
+
+pub fn detect_claude() -> ProviderStatus {
+    detect_binary("anthropic", "claude")
+}
+
+fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
+    let mut child = match Command::new(binary)
+        .arg("--version")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(err) => {
+            return ProviderStatus {
+                id: id.to_string(),
+                binary: binary.to_string(),
+                available: false,
+                version: None,
+                error: Some(err.to_string()),
+            };
+        }
+    };
+
+    let deadline = Instant::now() + DETECT_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = child
+                    .stdout
+                    .take()
+                    .map(read_to_string)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if status.success() {
+                    return ProviderStatus {
+                        id: id.to_string(),
+                        binary: binary.to_string(),
+                        available: true,
+                        version: Some(stdout),
+                        error: None,
+                    };
+                } else {
+                    return ProviderStatus {
+                        id: id.to_string(),
+                        binary: binary.to_string(),
+                        available: false,
+                        version: None,
+                        error: Some(format!("exited with code {}", status.code().unwrap_or(-1))),
+                    };
+                }
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    return ProviderStatus {
+                        id: id.to_string(),
+                        binary: binary.to_string(),
+                        available: false,
+                        version: None,
+                        error: Some("detection timed out".to_string()),
+                    };
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(err) => {
+                return ProviderStatus {
+                    id: id.to_string(),
+                    binary: binary.to_string(),
+                    available: false,
+                    version: None,
+                    error: Some(err.to_string()),
+                };
+            }
+        }
+    }
+}
+
+fn read_to_string<R: std::io::Read>(mut reader: R) -> String {
+    let mut buf = String::new();
+    let _ = reader.read_to_string(&mut buf);
+    buf
+}
+
+#[tauri::command]
+pub fn get_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
+    state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
+        id: "anthropic".to_string(),
+        binary: "claude".to_string(),
+        available: false,
+        version: None,
+        error: Some("status mutex poisoned".to_string()),
+    })
+}
+
+#[tauri::command]
+pub fn refresh_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
+    let next = detect_claude();
+    if let Ok(mut current) = state.0.lock() {
+        *current = next.clone();
+    }
+    next
+}

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -1,0 +1,17 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface ProviderStatus {
+  readonly id: string;
+  readonly binary: string;
+  readonly available: boolean;
+  readonly version: string | null;
+  readonly error: string | null;
+}
+
+export async function getProviderStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('get_provider_status');
+}
+
+export async function refreshProviderStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('refresh_provider_status');
+}


### PR DESCRIPTION
## Summary
Detect installed provider CLIs at app boot and expose to the frontend.

- `providers.rs` runs `claude --version` with a 2s deadline, capturing stdout (version) or the failure mode (binary missing, non-zero exit, hung process killed by deadline).
- Status held in `ProviderState(Mutex<ProviderStatus>)`. Computed once on boot in `lib.rs::run` so the first frame can show an install banner without waiting on a roundtrip.
- Tauri commands `get_provider_status` (instant, cached) and `refresh_provider_status` (re-detects + updates the cache).
- Frontend wrapper in `apps/desktop/src/providers.ts`.

## Test plan
- [x] `cargo check` clean
- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [ ] Manual: with `claude` installed → `available: true`, version populated
- [ ] Manual: rename `claude` binary off path → `available: false`, error: ENOENT

Closes #15