### PR TITLE
feat(desktop): tauri spawn command + event stream

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "@types/node": "^22.10.0",
     "@vitejs/plugin-react": "^4.3.4",
     "happy-dom": "^15.11.7",
     "tailwindcss": "^4.0.0",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod db;
 mod editor;
 mod providers;
 mod secrets;
+mod turn;
 mod worktree;
 
 pub use secrets::read as read_secret;
@@ -12,10 +13,12 @@ use std::sync::Mutex;
 pub fn run() {
   let database = db::open().expect("failed to open kay-am database");
   let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
+  let turn_registry = turn::TurnRegistry::new();
 
   tauri::Builder::default()
     .manage(database)
     .manage(provider_state)
+    .manage(turn_registry)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -39,6 +42,8 @@ pub fn run() {
       worktree::worktree_exists,
       providers::get_provider_status,
       providers::refresh_provider_status,
+      turn::turn_spawn,
+      turn::turn_cancel,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Read};
+use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TurnError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("turn registry mutex poisoned")]
+    Poisoned,
+    #[error("turn not found: {0}")]
+    NotFound(String),
+}
+
+impl Serialize for TurnError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl TurnError {
+    fn kind(&self) -> &'static str {
+        match self {
+            TurnError::Io(_) => "io",
+            TurnError::Poisoned => "poisoned",
+            TurnError::NotFound(_) => "not_found",
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct TurnRegistry(pub Arc<Mutex<HashMap<String, Arc<Mutex<Option<Child>>>>>>);
+
+impl TurnRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpawnArgs {
+    pub run_id: String,
+    pub model: String,
+    pub working_dir: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub binary: Option<String>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TurnEventPayload {
+    Line { line: String },
+    End {
+        exit_code: Option<i32>,
+        stderr: String,
+    },
+    Error { message: String },
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct TurnEventEnvelope {
+    #[serde(rename = "runId")]
+    pub run_id: String,
+    #[serde(flatten)]
+    pub event: TurnEventPayload,
+}
+
+const EVENT_NAME: &str = "turn_event";
+
+#[tauri::command]
+pub fn turn_spawn(
+    app: AppHandle,
+    state: State<'_, TurnRegistry>,
+    args: SpawnArgs,
+) -> Result<String, TurnError> {
+    let binary = args.binary.unwrap_or_else(|| "claude".to_string());
+    let mut child = Command::new(binary)
+        .arg("-p")
+        .arg(&args.prompt)
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--working-dir")
+        .arg(&args.working_dir)
+        .arg("--model")
+        .arg(&args.model)
+        .arg("--dangerously-skip-permissions")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TurnError::Io(std::io::Error::other("no stdout")))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| TurnError::Io(std::io::Error::other("no stderr")))?;
+
+    let slot = Arc::new(Mutex::new(Some(child)));
+    state
+        .0
+        .lock()
+        .map_err(|_| TurnError::Poisoned)?
+        .insert(args.run_id.clone(), Arc::clone(&slot));
+
+    let app_clone = app.clone();
+    let registry = Arc::clone(&state.0);
+    let run_id = args.run_id.clone();
+
+    thread::spawn(move || {
+        forward_lines(&app_clone, &run_id, stdout);
+        let stderr_buf = capture_stderr(stderr);
+        let exit_code = wait_and_remove(&slot, &registry, &run_id);
+        let _ = app_clone.emit(
+            EVENT_NAME,
+            TurnEventEnvelope {
+                run_id: run_id.clone(),
+                event: TurnEventPayload::End {
+                    exit_code,
+                    stderr: stderr_buf,
+                },
+            },
+        );
+    });
+
+    Ok(args.run_id)
+}
+
+#[tauri::command]
+pub fn turn_cancel(state: State<'_, TurnRegistry>, run_id: String) -> Result<(), TurnError> {
+    let map = state.0.lock().map_err(|_| TurnError::Poisoned)?;
+    let slot = map
+        .get(&run_id)
+        .cloned()
+        .ok_or_else(|| TurnError::NotFound(run_id.clone()))?;
+    drop(map);
+
+    if let Ok(mut guard) = slot.lock() {
+        if let Some(child) = guard.as_mut() {
+            let _ = child.kill();
+        }
+    }
+    Ok(())
+}
+
+fn forward_lines(app: &AppHandle, run_id: &str, stdout: ChildStdout) {
+    let reader = BufReader::new(stdout);
+    for line in reader.lines() {
+        match line {
+            Ok(line) => {
+                let _ = app.emit(
+                    EVENT_NAME,
+                    TurnEventEnvelope {
+                        run_id: run_id.to_string(),
+                        event: TurnEventPayload::Line { line },
+                    },
+                );
+            }
+            Err(err) => {
+                let _ = app.emit(
+                    EVENT_NAME,
+                    TurnEventEnvelope {
+                        run_id: run_id.to_string(),
+                        event: TurnEventPayload::Error {
+                            message: err.to_string(),
+                        },
+                    },
+                );
+                break;
+            }
+        }
+    }
+}
+
+fn capture_stderr(mut stderr: ChildStderr) -> String {
+    let mut buf = String::new();
+    let _ = stderr.read_to_string(&mut buf);
+    buf
+}
+
+fn wait_and_remove(
+    slot: &Arc<Mutex<Option<Child>>>,
+    registry: &Arc<Mutex<HashMap<String, Arc<Mutex<Option<Child>>>>>>,
+    run_id: &str,
+) -> Option<i32> {
+    let exit = {
+        let mut guard = slot.lock().ok()?;
+        let child = guard.as_mut()?;
+        child.wait().ok().and_then(|status| status.code())
+    };
+    if let Ok(mut map) = registry.lock() {
+        map.remove(run_id);
+    }
+    exit
+}

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -1,0 +1,114 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { parseStreamJsonLine } from '@kay-am/core';
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+const EVENT_NAME = 'turn_event';
+
+interface SpawnArgs {
+  readonly runId: ProviderRunId;
+  readonly model: string;
+  readonly workingDir: string;
+  readonly prompt: string;
+  readonly binary?: string;
+}
+
+type RawTurnEnvelope =
+  | { runId: string; type: 'line'; line: string }
+  | { runId: string; type: 'end'; exit_code: number | null; stderr: string }
+  | { runId: string; type: 'error'; message: string };
+
+export interface TurnTermination {
+  readonly exitCode: number | null;
+  readonly stderr: string;
+}
+
+export async function* runTurn(
+  args: SpawnArgs,
+  now: () => IsoDateTime = () => new Date().toISOString() as IsoDateTime,
+): AsyncIterable<TurnEvent> {
+  const ctx = { runId: args.runId, now };
+  const queue: TurnEvent[] = [];
+  let resolver: ((value: IteratorResult<TurnEvent>) => void) | null = null;
+  let rejector: ((err: unknown) => void) | null = null;
+  let ended = false;
+  let error: unknown = null;
+
+  const flush = () => {
+    if (!resolver) return;
+    if (queue.length > 0) {
+      const value = queue.shift()!;
+      const r = resolver;
+      resolver = null;
+      r({ value, done: false });
+      return;
+    }
+    if (ended) {
+      const r = resolver;
+      resolver = null;
+      if (error) {
+        const rej = rejector;
+        rejector = null;
+        rej?.(error);
+      } else {
+        r({ value: undefined, done: true });
+      }
+    }
+  };
+
+  const unlisten: UnlistenFn = await listen<RawTurnEnvelope>(EVENT_NAME, (event) => {
+    if (event.payload.runId !== args.runId) return;
+
+    switch (event.payload.type) {
+      case 'line':
+        for (const ev of parseStreamJsonLine(event.payload.line, ctx)) {
+          queue.push(ev);
+        }
+        flush();
+        break;
+      case 'end':
+        ended = true;
+        flush();
+        break;
+      case 'error':
+        error = new Error(event.payload.message);
+        ended = true;
+        flush();
+        break;
+    }
+  });
+
+  await invoke<string>('turn_spawn', { args });
+
+  try {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (ended) {
+        if (error) throw error;
+        return;
+      }
+      const value = await new Promise<IteratorResult<TurnEvent>>((resolve, reject) => {
+        resolver = resolve;
+        rejector = reject;
+      });
+      if (value.done) return;
+      yield value.value;
+    }
+  } finally {
+    unlisten();
+    if (!ended) {
+      try {
+        await invoke('turn_cancel', { runId: args.runId });
+      } catch {
+        // best-effort cancellation
+      }
+    }
+  }
+}
+
+export async function cancelTurn(runId: ProviderRunId): Promise<void> {
+  await invoke('turn_cancel', { runId });
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -4,7 +4,7 @@
     "noEmit": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src"]
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.10.0",
     "better-sqlite3": "^11.7.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "lib": ["ES2022"],
-    "types": []
+    "types": ["node"]
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,13 +61,16 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))
       '@tauri-apps/cli':
         specifier: ^2.1.0
         version: 2.11.1
       '@testing-library/react':
         specifier: ^16.1.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -76,7 +79,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0))
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))
       happy-dom:
         specifier: ^15.11.7
         version: 15.11.7
@@ -88,10 +91,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.6.0)(happy-dom@15.11.7)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/core:
     dependencies:
@@ -105,6 +108,9 @@ importers:
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
       better-sqlite3:
         specifier: ^11.7.0
         version: 11.10.0
@@ -113,7 +119,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@25.6.0)(happy-dom@15.11.7)(lightningcss@1.32.0)
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/db:
     dependencies:
@@ -1555,6 +1561,12 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
+  '@types/node@22.19.17':
+    resolution:
+      {
+        integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==,
+      }
+
   '@types/node@25.6.0':
     resolution:
       {
@@ -2873,6 +2885,12 @@ packages:
     engines: { node: '>=14.17' }
     hasBin: true
 
+  undici-types@6.21.0:
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
+
   undici-types@7.19.2:
     resolution:
       {
@@ -3633,12 +3651,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.4
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.4
 
-  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.2.4
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@tauri-apps/api@2.11.0': {}
 
@@ -3761,11 +3779,15 @@ snapshots:
 
   '@types/better-sqlite3@7.6.13':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
 
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@25.6.0':
     dependencies:
@@ -3779,7 +3801,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -3787,7 +3809,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3797,6 +3819,14 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
     dependencies:
@@ -4491,6 +4521,8 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@7.19.2: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -4500,6 +4532,24 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
+
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vite-node@2.1.9(@types/node@25.6.0)(lightningcss@1.32.0):
     dependencies:
@@ -4519,6 +4569,16 @@ snapshots:
       - supports-color
       - terser
 
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.3
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+
   vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
@@ -4529,7 +4589,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@6.4.2(@types/node@25.6.0)(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4538,10 +4598,46 @@ snapshots:
       rollup: 4.60.3
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 22.19.17
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
+
+  vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@2.1.9(@types/node@25.6.0)(happy-dom@15.11.7)(lightningcss@1.32.0):
     dependencies:


### PR DESCRIPTION
## Summary
End-to-end turn execution path: frontend kicks off a turn, Rust spawns the claude CLI, raw stdout lines stream to the frontend over Tauri events, JS parses them through `@kay-am/core`'s `parseStreamJsonLine` into a typed `AsyncIterable<TurnEvent>`.

- `turn_spawn(args)` (Rust) — starts the subprocess, registers it behind `Arc<Mutex<Option<Child>>>`, forwards each stdout line as a `turn_event` envelope (`line | end | error`). Returns the `runId` immediately so multiple turns can run concurrently across sessions.
- `turn_cancel(runId)` (Rust) — looks up the registered child and sends `kill`, yielding the same termination event from the background thread.
- Final `end` event carries the exit code and captured stderr so the caller can surface non-zero exits.
- `apps/desktop/src/turn.ts` wraps `invoke` + `listen` into a `runTurn` AsyncIterable that yields parsed `TurnEvent`s and cancels the process if the iterator ends early.
- `@types/node` added to `apps/desktop` and `@kay-am/core` so node: imports resolve consistently across the workspace; core's tsconfig switches `types` from `[]` to `['node']`.

### Note on parsing location
The issue mentions emitting "parsed `TurnEvent`s" from Rust. We forward raw lines and parse in JS instead, because the parser already lives in `@kay-am/core` (one source of truth per provider). The shape consumers see at the AsyncIterable boundary is identical.

## Test plan
- [x] `cargo check` clean
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: two concurrent turns interleave correctly
- [ ] Manual: `turn_cancel` mid-stream kills the process

Closes #13