### PR TITLE
feat(desktop): zustand store + state wiring

### DIFF
--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -1,0 +1,13 @@
+export { useAppStore, type AppActions, type AppState } from './store';
+export {
+  selectCurrentSession,
+  selectCurrentWorkspace,
+  selectProviderAvailable,
+  selectSessions,
+  selectWorkspaces,
+  useCurrentSession,
+  useCurrentWorkspace,
+  useProviderAvailable,
+  useSessions,
+  useWorkspaces,
+} from './selectors';

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,0 +1,17 @@
+import type { Session, Workspace } from '@kay-am/types';
+import { useAppStore, type AppState } from './store';
+
+export const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
+export const selectCurrentWorkspace = (state: AppState): Workspace | null =>
+  state.workspaces.find((w) => w.id === state.currentWorkspaceId) ?? null;
+export const selectSessions = (state: AppState): ReadonlyArray<Session> => state.sessions;
+export const selectCurrentSession = (state: AppState): Session | null =>
+  state.sessions.find((s) => s.id === state.currentSessionId) ?? null;
+export const selectProviderAvailable = (state: AppState): boolean =>
+  state.providerStatus?.available === true;
+
+export const useWorkspaces = (): ReadonlyArray<Workspace> => useAppStore(selectWorkspaces);
+export const useCurrentWorkspace = (): Workspace | null => useAppStore(selectCurrentWorkspace);
+export const useSessions = (): ReadonlyArray<Session> => useAppStore(selectSessions);
+export const useCurrentSession = (): Session | null => useAppStore(selectCurrentSession);
+export const useProviderAvailable = (): boolean => useAppStore(selectProviderAvailable);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,0 +1,114 @@
+import { create } from 'zustand';
+import {
+  getSetting,
+  listSessionsForWorkspace,
+  listWorkspaces,
+  setSetting as dbSetSetting,
+  summarizeSessionTelemetry,
+  type TelemetrySummary,
+} from '@kay-am/db';
+import type { Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
+import { runDbMigrations, tauriDatabase } from '../db';
+import { getProviderStatus, type ProviderStatus } from '../providers';
+
+export interface AppState {
+  readonly workspaces: ReadonlyArray<Workspace>;
+  readonly currentWorkspaceId: WorkspaceId | null;
+  readonly sessions: ReadonlyArray<Session>;
+  readonly currentSessionId: SessionId | null;
+  readonly settings: Readonly<Record<string, string>>;
+  readonly sessionSummary: TelemetrySummary | null;
+  readonly providerStatus: ProviderStatus | null;
+  readonly hydrated: boolean;
+  readonly error: string | null;
+}
+
+export interface AppActions {
+  hydrate(): Promise<void>;
+  setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
+  setCurrentSession(id: SessionId | null): Promise<void>;
+  refreshSessions(workspaceId: WorkspaceId): Promise<void>;
+  refreshSessionSummary(sessionId: SessionId): Promise<void>;
+  loadSetting(key: string): Promise<string | null>;
+  saveSetting(key: string, value: string): Promise<void>;
+  refreshProviderStatus(status: ProviderStatus): void;
+}
+
+type AppStore = AppState & AppActions;
+
+const initialState: AppState = {
+  workspaces: [],
+  currentWorkspaceId: null,
+  sessions: [],
+  currentSessionId: null,
+  settings: {},
+  sessionSummary: null,
+  providerStatus: null,
+  hydrated: false,
+  error: null,
+};
+
+export const useAppStore = create<AppStore>((set) => ({
+  ...initialState,
+
+  hydrate: async () => {
+    try {
+      await runDbMigrations();
+      const [workspaces, providerStatus] = await Promise.all([
+        listWorkspaces(tauriDatabase),
+        getProviderStatus(),
+      ]);
+      set({ workspaces, providerStatus, hydrated: true, error: null });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : String(err), hydrated: true });
+    }
+  },
+
+  setCurrentWorkspace: async (id) => {
+    set({
+      currentWorkspaceId: id,
+      currentSessionId: null,
+      sessions: [],
+      sessionSummary: null,
+    });
+    if (id) {
+      const sessions = await listSessionsForWorkspace(tauriDatabase, id);
+      set({ sessions });
+    }
+  },
+
+  setCurrentSession: async (id) => {
+    set({ currentSessionId: id, sessionSummary: null });
+    if (id) {
+      const summary = await summarizeSessionTelemetry(tauriDatabase, id);
+      set({ sessionSummary: summary });
+    }
+  },
+
+  refreshSessions: async (workspaceId) => {
+    const sessions = await listSessionsForWorkspace(tauriDatabase, workspaceId);
+    set({ sessions });
+  },
+
+  refreshSessionSummary: async (sessionId) => {
+    const summary = await summarizeSessionTelemetry(tauriDatabase, sessionId);
+    set({ sessionSummary: summary });
+  },
+
+  loadSetting: async (key) => {
+    const value = await getSetting(tauriDatabase, key);
+    set((state) => ({
+      settings: value === null ? state.settings : { ...state.settings, [key]: value },
+    }));
+    return value;
+  },
+
+  saveSetting: async (key, value) => {
+    await dbSetSetting(tauriDatabase, key, value);
+    set((state) => ({ settings: { ...state.settings, [key]: value } }));
+  },
+
+  refreshProviderStatus: (status) => {
+    set({ providerStatus: status });
+  },
+}));


### PR DESCRIPTION
## Summary
Global state for the kAY.am UI, hydrated from SQLite at boot.

- `AppState` slices: `workspaces`, `sessions`, `currentWorkspaceId`, `currentSessionId`, `settings`, `sessionSummary`, `providerStatus`, `hydrated`, `error`.
- `AppActions` wrap `@kay-am/db` queries through the Tauri `Database` adapter and the providers status command:
  - `hydrate` runs migrations + loads workspaces + provider status
  - `setCurrentWorkspace` clears session-scoped state and refreshes the session list
  - `setCurrentSession` lazy-loads the telemetry summary
  - `refreshSessions` / `refreshSessionSummary` for explicit reloads
  - `loadSetting` / `saveSetting` round-trip through the `settings` table
  - `refreshProviderStatus` lets the boot path push the cached status from Rust into the store
- `selectors.ts` provides typed selectors and small `useX` hooks; UI code never reaches into the store shape directly.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: `useAppStore.getState().hydrate()` populates `workspaces` + `providerStatus` and flips `hydrated`

Closes #18