### PR TITLE
feat(desktop): workspace selector + picker

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "@kay-am/types": "workspace:*",
     "@kay-am/ui": "workspace:*",
     "@tauri-apps/api": "^2.1.1",
+    "@tauri-apps/plugin-dialog": "^2.2.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
     "@tauri-apps/plugin-sql": "^2.2.0",
     "react": "^19.0.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -27,3 +27,4 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 dirs = "5"
 regex = "1"
 sha2 = "0.10"
+tauri-plugin-dialog = "2"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": ["main"],
-  "permissions": ["core:default"]
+  "permissions": ["core:default", "dialog:default"]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod db;
 mod editor;
 mod providers;
+mod repo;
 mod secrets;
 mod turn;
 mod worktree;
@@ -16,6 +17,7 @@ pub fn run() {
   let turn_registry = turn::TurnRegistry::new();
 
   tauri::Builder::default()
+    .plugin(tauri_plugin_dialog::init())
     .manage(database)
     .manage(provider_state)
     .manage(turn_registry)
@@ -44,6 +46,7 @@ pub fn run() {
       providers::refresh_provider_status,
       turn::turn_spawn,
       turn::turn_cancel,
+      repo::validate_git_repo,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/repo.rs
+++ b/apps/desktop/src-tauri/src/repo.rs
@@ -1,0 +1,55 @@
+use std::path::Path;
+use std::process::Command;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct GitRepoCheck {
+    #[serde(rename = "isRepo")]
+    pub is_repo: bool,
+    #[serde(rename = "rootPath")]
+    pub root_path: Option<String>,
+    pub error: Option<String>,
+}
+
+#[tauri::command]
+pub fn validate_git_repo(path: String) -> GitRepoCheck {
+    let candidate = Path::new(&path);
+    if !candidate.exists() {
+        return GitRepoCheck {
+            is_repo: false,
+            root_path: None,
+            error: Some(format!("path does not exist: {path}")),
+        };
+    }
+    let output = match Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(candidate)
+        .output()
+    {
+        Ok(out) => out,
+        Err(err) => {
+            return GitRepoCheck {
+                is_repo: false,
+                root_path: None,
+                error: Some(err.to_string()),
+            };
+        }
+    };
+    if !output.status.success() {
+        return GitRepoCheck {
+            is_repo: false,
+            root_path: None,
+            error: Some("not a git repository".to_string()),
+        };
+    }
+    let root = String::from_utf8(output.stdout)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    GitRepoCheck {
+        is_repo: true,
+        root_path: Some(root),
+        error: None,
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,77 +1,64 @@
-import { useState } from 'react';
-import {
-  AppShell,
-  Button,
-  Collapsible,
-  Dialog,
-  Input,
-  KbdPill,
-  ScrollArea,
-  Textarea,
-} from '@kay-am/ui';
+import { useEffect } from 'react';
+import { AppShell, KbdPill, ScrollArea } from '@kay-am/ui';
+import { WorkspaceSelector } from './components/WorkspaceSelector';
+import { useAppStore, useCurrentWorkspace, useProviderAvailable } from './store';
 
 export function App() {
-  const [collapsed, setCollapsed] = useState(true);
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const hydrate = useAppStore((s) => s.hydrate);
+  const hydrated = useAppStore((s) => s.hydrated);
+  const error = useAppStore((s) => s.error);
+  const current = useCurrentWorkspace();
+  const providerAvailable = useProviderAvailable();
+
+  useEffect(() => {
+    void hydrate();
+  }, [hydrate]);
 
   return (
     <AppShell
       header={
-        <div className="flex w-full items-center justify-between">
+        <div className="flex w-full items-center gap-3">
           <span className="font-semibold tracking-tight">kAY.am</span>
-          <span className="text-xs text-muted-foreground">
-            press <KbdPill>⌘K</KbdPill> to focus
+          <WorkspaceSelector />
+          <span className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            {!providerAvailable ? (
+              <span className="rounded-full bg-danger/10 px-2 py-0.5 text-danger">
+                claude cli missing
+              </span>
+            ) : null}
+            press <KbdPill>⌘K</KbdPill>
           </span>
         </div>
       }
       leftSidebar={
         <ScrollArea className="h-full p-2">
-          <div className="text-xs uppercase text-muted-foreground">Workspaces</div>
-          <ul className="mt-2 space-y-1">
-            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">demo</li>
-            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">api-gateway</li>
-            <li className="rounded-md px-2 py-1 text-sm hover:bg-muted">design-system</li>
-          </ul>
+          <div className="text-xs uppercase text-muted-foreground">sessions</div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            {current ? 'no sessions yet — coming in #20' : 'pick a workspace to begin'}
+          </p>
         </ScrollArea>
       }
       main={
         <div className="flex h-full flex-col gap-4 p-6">
-          <h1 className="text-lg font-medium tracking-tight">design system smoke test</h1>
-          <div className="flex flex-wrap gap-2">
-            <Button>primary</Button>
-            <Button variant="secondary">secondary</Button>
-            <Button variant="ghost">ghost</Button>
-            <Button variant="danger">danger</Button>
-            <Button size="sm">small</Button>
-          </div>
-          <Input placeholder="type something" />
-          <Textarea placeholder="multiline input" />
-          <Collapsible
-            open={collapsed}
-            onOpenChange={setCollapsed}
-            trigger={<span>collapsible section</span>}
-          >
-            <p className="text-sm text-muted-foreground">hidden content revealed when expanded.</p>
-          </Collapsible>
-          <div>
-            <Button onClick={() => setDialogOpen(true)}>open dialog</Button>
-            <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} title="hello">
-              <p className="text-sm text-muted-foreground">
-                native html dialog with backdrop and esc-to-close.
-              </p>
-              <div className="flex justify-end gap-2">
-                <Button variant="ghost" onClick={() => setDialogOpen(false)}>
-                  cancel
-                </Button>
-                <Button onClick={() => setDialogOpen(false)}>ok</Button>
-              </div>
-            </Dialog>
-          </div>
+          {!hydrated ? (
+            <p className="text-sm text-muted-foreground">loading…</p>
+          ) : error ? (
+            <p className="text-sm text-danger">init error: {error}</p>
+          ) : current ? (
+            <>
+              <h1 className="text-lg font-medium tracking-tight">{current.name}</h1>
+              <p className="text-sm text-muted-foreground">{current.rootPath}</p>
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              no workspace selected. open the dropdown to add one.
+            </p>
+          )}
         </div>
       }
       rightSidebar={
         <ScrollArea className="h-full p-2">
-          <div className="text-xs uppercase text-muted-foreground">Context</div>
+          <div className="text-xs uppercase text-muted-foreground">context</div>
           <p className="mt-2 text-sm text-muted-foreground">slots will live here.</p>
         </ScrollArea>
       }

--- a/apps/desktop/src/components/WorkspaceSelector.tsx
+++ b/apps/desktop/src/components/WorkspaceSelector.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import { open as openDialog } from '@tauri-apps/plugin-dialog';
+import { Button, Dialog, Input } from '@kay-am/ui';
+import { useAppStore } from '../store';
+import { useCurrentWorkspace, useWorkspaces } from '../store';
+
+export function WorkspaceSelector() {
+  const workspaces = useWorkspaces();
+  const current = useCurrentWorkspace();
+  const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
+  const addWorkspace = useAppStore((s) => s.addWorkspace);
+
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [path, setPath] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onClick = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onClick);
+    return () => window.removeEventListener('mousedown', onClick);
+  }, [menuOpen]);
+
+  const onPick = async () => {
+    const picked = await openDialog({ directory: true, multiple: false });
+    if (typeof picked === 'string') {
+      setPath(picked);
+      setError(null);
+    }
+  };
+
+  const onAdd = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const ws = await addWorkspace({ rootPath: path });
+      await setCurrentWorkspace(ws.id);
+      setDialogOpen(false);
+      setPath('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <Button variant="secondary" size="sm" onClick={() => setMenuOpen((v) => !v)}>
+        {current?.name ?? 'select workspace'}
+        <span aria-hidden className="ml-1 text-muted-foreground">
+          ▾
+        </span>
+      </Button>
+
+      {menuOpen ? (
+        <div className="absolute left-0 top-9 z-10 w-64 rounded-md border border-border bg-background py-1 shadow-lg">
+          {workspaces.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">no workspaces yet</div>
+          ) : (
+            <ul className="max-h-64 overflow-y-auto">
+              {workspaces.map((ws) => (
+                <li key={ws.id}>
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between px-3 py-1.5 text-sm hover:bg-muted"
+                    onClick={() => {
+                      void setCurrentWorkspace(ws.id);
+                      setMenuOpen(false);
+                    }}
+                  >
+                    <span className="truncate">{ws.name}</span>
+                    {ws.id === current?.id ? (
+                      <span aria-hidden className="text-muted-foreground">
+                        ✓
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="border-t border-border" />
+          <button
+            type="button"
+            className="flex w-full items-center px-3 py-1.5 text-sm hover:bg-muted"
+            onClick={() => {
+              setMenuOpen(false);
+              setDialogOpen(true);
+            }}
+          >
+            + add workspace
+          </button>
+        </div>
+      ) : null}
+
+      <Dialog open={dialogOpen} onClose={() => setDialogOpen(false)} title="add workspace">
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Input
+              value={path}
+              placeholder="/path/to/repo"
+              onChange={(e) => setPath(e.target.value)}
+            />
+            <Button variant="secondary" onClick={onPick}>
+              browse
+            </Button>
+          </div>
+          {error ? <p className="text-xs text-danger">{error}</p> : null}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setDialogOpen(false)}>
+            cancel
+          </Button>
+          <Button onClick={onAdd} disabled={path.length === 0 || busy}>
+            {busy ? 'adding…' : 'add'}
+          </Button>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/desktop/src/repo.ts
+++ b/apps/desktop/src/repo.ts
@@ -1,0 +1,11 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface GitRepoCheck {
+  readonly isRepo: boolean;
+  readonly rootPath: string | null;
+  readonly error: string | null;
+}
+
+export async function validateGitRepo(path: string): Promise<GitRepoCheck> {
+  return invoke<GitRepoCheck>('validate_git_repo', { path });
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,15 +1,17 @@
 import { create } from 'zustand';
 import {
   getSetting,
+  insertWorkspace,
   listSessionsForWorkspace,
   listWorkspaces,
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
   type TelemetrySummary,
 } from '@kay-am/db';
-import type { Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
+import type { IsoDateTime, Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
 import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
+import { validateGitRepo } from '../repo';
 
 export interface AppState {
   readonly workspaces: ReadonlyArray<Workspace>;
@@ -32,6 +34,7 @@ export interface AppActions {
   loadSetting(key: string): Promise<string | null>;
   saveSetting(key: string, value: string): Promise<void>;
   refreshProviderStatus(status: ProviderStatus): void;
+  addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
 }
 
 type AppStore = AppState & AppActions;
@@ -110,5 +113,26 @@ export const useAppStore = create<AppStore>((set) => ({
 
   refreshProviderStatus: (status) => {
     set({ providerStatus: status });
+  },
+
+  addWorkspace: async ({ rootPath, name }) => {
+    const check = await validateGitRepo(rootPath);
+    if (!check.isRepo || !check.rootPath) {
+      throw new Error(check.error ?? 'not a git repository');
+    }
+    const resolvedRoot = check.rootPath;
+    const inferredName =
+      name?.trim() || resolvedRoot.split('/').filter(Boolean).at(-1) || 'workspace';
+    const now = new Date().toISOString() as IsoDateTime;
+    const workspace: Workspace = {
+      id: crypto.randomUUID() as WorkspaceId,
+      name: inferredName,
+      rootPath: resolvedRoot,
+      createdAt: now,
+      updatedAt: now,
+    };
+    await insertWorkspace(tauriDatabase, workspace);
+    set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
+    return workspace;
   },
 }));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.1.1
         version: 2.11.0
+      '@tauri-apps/plugin-dialog':
+        specifier: ^2.2.0
+        version: 2.7.1
       '@tauri-apps/plugin-shell':
         specifier: ^2.2.0
         version: 2.3.5
@@ -1427,6 +1430,12 @@ packages:
       }
     engines: { node: '>= 10' }
     hasBin: true
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution:
+      {
+        integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==,
+      }
 
   '@tauri-apps/plugin-shell@2.3.5':
     resolution:
@@ -3706,6 +3715,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.1
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.1
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
+
+  '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-shell@2.3.5':
     dependencies:


### PR DESCRIPTION
## Summary
Header dropdown lists registered workspaces; an 'add workspace' dialog walks the user through picking a directory and validating it as a git repo before persisting.

- Rust `validate_git_repo` runs `git rev-parse --show-toplevel` and returns `{ isRepo, rootPath, error }`. We resolve to the repo root even if the user picked a subdirectory.
- Native directory picker via `tauri-plugin-dialog` (capability `dialog:default` added).
- `addWorkspace` action in zustand: validate → insert via `@kay-am/db` → prepend.
- `WorkspaceSelector` component: secondary button + click-outside dropdown of workspaces, `+ add workspace` opens the dialog.
- `App.tsx` now hydrates on mount, renders the selector, and shows a 'claude cli missing' chip when detection failed.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: pick a non-git folder → friendly error in the dialog
- [ ] Manual: pick a git subdir → workspace persists with the repo root path

Closes #19