### PR TITLE
feat(desktop): sessions sidebar + new session dialog

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,13 +1,15 @@
 import { useEffect } from 'react';
 import { AppShell, KbdPill, ScrollArea } from '@kay-am/ui';
+import { SessionsSidebar } from './components/SessionsSidebar';
 import { WorkspaceSelector } from './components/WorkspaceSelector';
-import { useAppStore, useCurrentWorkspace, useProviderAvailable } from './store';
+import { useAppStore, useCurrentSession, useCurrentWorkspace, useProviderAvailable } from './store';
 
 export function App() {
   const hydrate = useAppStore((s) => s.hydrate);
   const hydrated = useAppStore((s) => s.hydrated);
   const error = useAppStore((s) => s.error);
-  const current = useCurrentWorkspace();
+  const currentWorkspace = useCurrentWorkspace();
+  const currentSession = useCurrentSession();
   const providerAvailable = useProviderAvailable();
 
   useEffect(() => {
@@ -30,25 +32,24 @@ export function App() {
           </span>
         </div>
       }
-      leftSidebar={
-        <ScrollArea className="h-full p-2">
-          <div className="text-xs uppercase text-muted-foreground">sessions</div>
-          <p className="mt-2 text-xs text-muted-foreground">
-            {current ? 'no sessions yet — coming in #20' : 'pick a workspace to begin'}
-          </p>
-        </ScrollArea>
-      }
+      leftSidebar={<SessionsSidebar />}
       main={
         <div className="flex h-full flex-col gap-4 p-6">
           {!hydrated ? (
             <p className="text-sm text-muted-foreground">loading…</p>
           ) : error ? (
             <p className="text-sm text-danger">init error: {error}</p>
-          ) : current ? (
+          ) : currentSession ? (
             <>
-              <h1 className="text-lg font-medium tracking-tight">{current.name}</h1>
-              <p className="text-sm text-muted-foreground">{current.rootPath}</p>
+              <h1 className="text-lg font-medium tracking-tight">{currentSession.goal}</h1>
+              <p className="text-xs text-muted-foreground">
+                state: {currentSession.state.kind} · chat view in #21
+              </p>
             </>
+          ) : currentWorkspace ? (
+            <p className="text-sm text-muted-foreground">
+              create a session from the sidebar to begin.
+            </p>
           ) : (
             <p className="text-sm text-muted-foreground">
               no workspace selected. open the dropdown to add one.

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Button, Dialog, Input, Textarea } from '@kay-am/ui';
+import type { WorkspaceId } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+interface NewSessionDialogProps {
+  open: boolean;
+  onClose: () => void;
+  workspaceId: WorkspaceId;
+}
+
+export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialogProps) {
+  const createSession = useAppStore((s) => s.createSession);
+  const [goal, setGoal] = useState('');
+  const [prefix, setPrefix] = useState('kay');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const reset = () => {
+    setGoal('');
+    setPrefix('kay');
+    setError(null);
+  };
+
+  const onCreate = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      await createSession({ workspaceId, goal, branchPrefix: prefix });
+      reset();
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} title="new session">
+      <div className="flex flex-col gap-3">
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          goal
+          <Textarea
+            value={goal}
+            placeholder="refactor auth domain"
+            onChange={(e) => setGoal(e.target.value)}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+          branch prefix
+          <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} placeholder="kay" />
+        </label>
+        {error ? <p className="text-xs text-danger">{error}</p> : null}
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" onClick={onClose}>
+          cancel
+        </Button>
+        <Button onClick={onCreate} disabled={goal.trim().length === 0 || busy}>
+          {busy ? 'creating…' : 'create'}
+        </Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/SessionsSidebar.tsx
+++ b/apps/desktop/src/components/SessionsSidebar.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Button, ScrollArea, cn } from '@kay-am/ui';
+import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessions } from '../store';
+import { NewSessionDialog } from './NewSessionDialog';
+import { StatusBadge } from './StatusBadge';
+
+export function SessionsSidebar() {
+  const workspace = useCurrentWorkspace();
+  const sessions = useSessions();
+  const current = useCurrentSession();
+  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border px-3 py-2">
+        <span className="text-xs uppercase text-muted-foreground">sessions</span>
+        <Button variant="ghost" size="sm" disabled={!workspace} onClick={() => setDialogOpen(true)}>
+          + new
+        </Button>
+      </div>
+
+      {!workspace ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">pick a workspace to begin</p>
+      ) : (
+        <ScrollArea className="flex-1">
+          {sessions.length === 0 ? (
+            <p className="px-3 py-2 text-xs text-muted-foreground">no sessions yet</p>
+          ) : (
+            <ul className="py-1">
+              {sessions.map((session) => (
+                <li key={session.id}>
+                  <button
+                    type="button"
+                    onClick={() => void setCurrentSession(session.id)}
+                    className={cn(
+                      'flex w-full flex-col gap-1 px-3 py-2 text-left text-sm hover:bg-muted',
+                      session.id === current?.id && 'bg-muted',
+                    )}
+                  >
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="line-clamp-1 flex-1">{session.goal}</span>
+                      <StatusBadge state={session.state} />
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </ScrollArea>
+      )}
+
+      {workspace ? (
+        <NewSessionDialog
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+          workspaceId={workspace.id}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/StatusBadge.tsx
+++ b/apps/desktop/src/components/StatusBadge.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@kay-am/ui';
+import type { SessionState } from '@kay-am/types';
+
+const TONE: Record<SessionState['kind'], string> = {
+  draft: 'bg-muted text-muted-foreground',
+  starting: 'bg-primary/10 text-primary',
+  idle: 'bg-muted text-foreground',
+  running: 'bg-primary/15 text-primary',
+  error: 'bg-danger/10 text-danger',
+  ended: 'bg-muted text-muted-foreground',
+};
+
+export function StatusBadge({ state, className }: { state: SessionState; className?: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+        TONE[state.kind],
+        className,
+      )}
+    >
+      {state.kind}
+    </span>
+  );
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import {
   getSetting,
+  insertSession,
   insertWorkspace,
   listSessionsForWorkspace,
   listWorkspaces,
@@ -8,10 +9,18 @@ import {
   summarizeSessionTelemetry,
   type TelemetrySummary,
 } from '@kay-am/db';
-import type { IsoDateTime, Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  Session,
+  SessionId,
+  SessionState,
+  Workspace,
+  WorkspaceId,
+} from '@kay-am/types';
 import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
 import { validateGitRepo } from '../repo';
+import { createWorktree, type CreatedWorktree } from '../worktree';
 
 export interface AppState {
   readonly workspaces: ReadonlyArray<Workspace>;
@@ -35,6 +44,11 @@ export interface AppActions {
   saveSetting(key: string, value: string): Promise<void>;
   refreshProviderStatus(status: ProviderStatus): void;
   addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
+  createSession(input: {
+    workspaceId: WorkspaceId;
+    goal: string;
+    branchPrefix?: string;
+  }): Promise<{ session: Session; worktree: CreatedWorktree }>;
 }
 
 type AppStore = AppState & AppActions;
@@ -113,6 +127,41 @@ export const useAppStore = create<AppStore>((set) => ({
 
   refreshProviderStatus: (status) => {
     set({ providerStatus: status });
+  },
+
+  createSession: async ({ workspaceId, goal, branchPrefix }) => {
+    const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
+    if (!workspace) throw new Error(`workspace not found: ${workspaceId}`);
+
+    const prefix = branchPrefix?.trim() || 'kay';
+    const slugSeed = goal.trim().length > 0 ? goal : `session-${Date.now()}`;
+    const worktree = await createWorktree({
+      repoPath: workspace.rootPath,
+      branchPrefix: prefix,
+      slug: slugSeed,
+    });
+
+    const now = new Date().toISOString() as IsoDateTime;
+    const initialState: SessionState = { kind: 'draft' };
+    const session: Session = {
+      id: crypto.randomUUID() as SessionId,
+      workspaceId,
+      goal: goal.trim() || worktree.slug,
+      state: initialState,
+      contextSlots: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    await insertSession(tauriDatabase, session);
+
+    set((state) => ({
+      sessions:
+        state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
+      currentSessionId: session.id,
+      sessionSummary: null,
+    }));
+
+    return { session, worktree };
   },
 
   addWorkspace: async ({ rootPath, name }) => {


### PR DESCRIPTION
## Summary
Sidebar lists sessions of the current workspace; a 'new session' dialog walks the user through creating one.

- `createSession` action in zustand:
  1. resolve workspace from db
  2. `worktree_create` (slug derived from goal)
  3. insert a session row in `draft` state
  4. prepend to sessions, focus the new session
- `StatusBadge` renders `SessionState.kind` with per-kind tone (draft/starting/idle/running/error/ended).
- `NewSessionDialog` captures goal + branch prefix override and surfaces `createWorktree` errors inline.
- `SessionsSidebar` replaces the placeholder list. Header shows `+ new` (disabled with no workspace).
- `App.tsx` wires the sidebar in; main panel reflects the selected session.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: pick a workspace, create a session — worktree appears at `<repo>/../<repo>-kay-<slug>` with branch `kay/<slug>`
- [ ] Manual: create with empty goal → button disabled
- [ ] Manual: create twice with the same goal → second `createWorktree` returns `reused: true` (no failure)

Closes #20