### PR TITLE
feat(desktop): chat view with stream renderer

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { AppShell, KbdPill, ScrollArea } from '@kay-am/ui';
+import { ChatView } from './components/chat/ChatView';
 import { SessionsSidebar } from './components/SessionsSidebar';
 import { WorkspaceSelector } from './components/WorkspaceSelector';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useProviderAvailable } from './store';
@@ -34,28 +35,21 @@ export function App() {
       }
       leftSidebar={<SessionsSidebar />}
       main={
-        <div className="flex h-full flex-col gap-4 p-6">
-          {!hydrated ? (
-            <p className="text-sm text-muted-foreground">loading…</p>
-          ) : error ? (
-            <p className="text-sm text-danger">init error: {error}</p>
-          ) : currentSession ? (
-            <>
-              <h1 className="text-lg font-medium tracking-tight">{currentSession.goal}</h1>
-              <p className="text-xs text-muted-foreground">
-                state: {currentSession.state.kind} · chat view in #21
-              </p>
-            </>
-          ) : currentWorkspace ? (
+        !hydrated ? (
+          <p className="p-6 text-sm text-muted-foreground">loading…</p>
+        ) : error ? (
+          <p className="p-6 text-sm text-danger">init error: {error}</p>
+        ) : currentSession ? (
+          <ChatView session={currentSession} />
+        ) : (
+          <div className="flex h-full flex-col p-6">
             <p className="text-sm text-muted-foreground">
-              create a session from the sidebar to begin.
+              {currentWorkspace
+                ? 'create a session from the sidebar to begin.'
+                : 'no workspace selected. open the dropdown to add one.'}
             </p>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              no workspace selected. open the dropdown to add one.
-            </p>
-          )}
-        </div>
+          </div>
+        )
       }
       rightSidebar={
         <ScrollArea className="h-full p-2">

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Session } from '@kay-am/types';
+import { useTranscript } from '../../store';
+import { reduceTranscript } from './transcript-items';
+import { TranscriptCard } from './TranscriptCards';
+
+interface ChatViewProps {
+  session: Session;
+}
+
+const PIN_TOLERANCE_PX = 32;
+
+export function ChatView({ session }: ChatViewProps) {
+  const events = useTranscript(session.id);
+  const items = useMemo(() => reduceTranscript(events), [events]);
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [pinned, setPinned] = useState(true);
+
+  useEffect(() => {
+    const el = scrollerRef.current;
+    if (!el || !pinned) return;
+    el.scrollTop = el.scrollHeight;
+  }, [items, pinned]);
+
+  const onScroll = () => {
+    const el = scrollerRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setPinned(distance < PIN_TOLERANCE_PX);
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border px-3 py-2">
+        <h1 className="text-sm font-semibold tracking-tight">{session.goal}</h1>
+        <p className="text-xs text-muted-foreground">state: {session.state.kind}</p>
+      </div>
+      <div
+        ref={scrollerRef}
+        onScroll={onScroll}
+        className="relative flex-1 overflow-y-auto px-4 py-3"
+      >
+        {items.length === 0 ? (
+          <p className="text-sm text-muted-foreground">no turns yet — send a message.</p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {items.map((item) => (
+              <li key={item.key}>
+                <TranscriptCard item={item} />
+              </li>
+            ))}
+          </ul>
+        )}
+        {!pinned ? (
+          <button
+            type="button"
+            className="sticky bottom-2 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background px-3 py-1 text-xs shadow"
+            onClick={() => {
+              setPinned(true);
+              const el = scrollerRef.current;
+              if (el) el.scrollTop = el.scrollHeight;
+            }}
+          >
+            jump to latest
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/CopyButton.tsx
+++ b/apps/desktop/src/components/chat/CopyButton.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { Button } from '@kay-am/ui';
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // clipboard API not available
+    }
+  };
+
+  return (
+    <Button variant="ghost" size="sm" onClick={onCopy} aria-label="copy">
+      {copied ? 'copied' : 'copy'}
+    </Button>
+  );
+}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { Collapsible, cn } from '@kay-am/ui';
+import { CopyButton } from './CopyButton';
+import type { TranscriptItem } from './transcript-items';
+
+const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
+  create: 'bg-primary/10 text-primary',
+  modify: 'bg-muted text-foreground',
+  delete: 'bg-danger/10 text-danger',
+};
+
+export function TranscriptCard({ item }: { item: TranscriptItem }) {
+  switch (item.kind) {
+    case 'assistant_text':
+      return <AssistantText text={item.text} />;
+    case 'tool_call':
+      return <ToolCall item={item} />;
+    case 'file_edit':
+      return (
+        <div
+          className={cn(
+            'inline-flex w-fit items-center gap-2 rounded-md border border-border px-2 py-1 text-xs',
+            EDIT_TONE[item.editType],
+          )}
+        >
+          <span className="font-medium uppercase tracking-wide">{item.editType}</span>
+          <code className="font-mono">{item.path}</code>
+        </div>
+      );
+    case 'usage':
+      return (
+        <p className="text-xs text-muted-foreground">
+          {item.usage.inputTokens} in / {item.usage.outputTokens} out tokens
+          {item.usage.cachedInputTokens > 0 ? ` · ${item.usage.cachedInputTokens} cached` : ''}
+        </p>
+      );
+    case 'error':
+      return (
+        <div className="rounded-md border border-danger/40 bg-danger/5 px-3 py-2 text-sm text-danger">
+          {item.message}
+        </div>
+      );
+    case 'done':
+      return <hr className="border-border" />;
+  }
+}
+
+function AssistantText({ text }: { text: string }) {
+  return (
+    <div className="group relative rounded-lg border border-border bg-background px-3 py-2">
+      <div className="absolute right-1 top-1 opacity-0 transition-opacity group-hover:opacity-100">
+        <CopyButton text={text} />
+      </div>
+      <p className="whitespace-pre-wrap text-sm text-foreground">{text}</p>
+    </div>
+  );
+}
+
+function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' }> }) {
+  const [open, setOpen] = useState(false);
+  const tone = item.isError ? 'border-danger/40 bg-danger/5' : 'border-border bg-muted';
+  return (
+    <div className={cn('rounded-md border px-2 py-1.5', tone)}>
+      <Collapsible
+        open={open}
+        onOpenChange={setOpen}
+        trigger={
+          <span className="flex items-center gap-2 text-xs font-medium">
+            <span className="rounded bg-background px-1.5 py-0.5 font-mono text-[10px] uppercase">
+              tool
+            </span>
+            {item.toolName}
+            {!item.ended ? (
+              <span className="text-muted-foreground">…</span>
+            ) : item.isError ? (
+              <span className="text-danger">error</span>
+            ) : null}
+          </span>
+        }
+      >
+        <pre className="overflow-x-auto rounded bg-background p-2 text-[11px] text-muted-foreground">
+          input: {JSON.stringify(item.input, null, 2)}
+        </pre>
+        {item.ended ? (
+          <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-[11px] text-muted-foreground">
+            output: {JSON.stringify(item.output, null, 2)}
+          </pre>
+        ) : null}
+      </Collapsible>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -1,0 +1,96 @@
+import type { ProviderUsage, TurnEvent } from '@kay-am/types';
+
+export type TranscriptItem =
+  | { kind: 'assistant_text'; key: string; text: string }
+  | {
+      kind: 'tool_call';
+      key: string;
+      toolUseId: string;
+      toolName: string;
+      input: unknown;
+      output: unknown;
+      isError: boolean;
+      ended: boolean;
+    }
+  | { kind: 'file_edit'; key: string; path: string; editType: 'create' | 'modify' | 'delete' }
+  | { kind: 'usage'; key: string; usage: ProviderUsage }
+  | { kind: 'error'; key: string; message: string }
+  | { kind: 'done'; key: string };
+
+export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArray<TranscriptItem> {
+  const items: TranscriptItem[] = [];
+  const callIndex = new Map<string, number>();
+  let textBuffer = '';
+  let textKey: string | null = null;
+
+  const flushText = () => {
+    if (textBuffer.length > 0 && textKey) {
+      items.push({ kind: 'assistant_text', key: textKey, text: textBuffer });
+    }
+    textBuffer = '';
+    textKey = null;
+  };
+
+  for (let i = 0; i < events.length; i += 1) {
+    const event = events[i]!;
+    if (event.kind === 'assistant_text') {
+      if (textKey === null) textKey = `text-${i}`;
+      textBuffer += event.delta;
+      continue;
+    }
+    flushText();
+
+    switch (event.kind) {
+      case 'tool_call_start': {
+        const key = `tool-${event.toolUseId}`;
+        callIndex.set(event.toolUseId, items.length);
+        items.push({
+          kind: 'tool_call',
+          key,
+          toolUseId: event.toolUseId,
+          toolName: event.toolName,
+          input: event.input,
+          output: null,
+          isError: false,
+          ended: false,
+        });
+        break;
+      }
+      case 'tool_call_end': {
+        const idx = callIndex.get(event.toolUseId);
+        if (idx !== undefined) {
+          const existing = items[idx];
+          if (existing && existing.kind === 'tool_call') {
+            items[idx] = {
+              ...existing,
+              output: event.output,
+              isError: event.isError,
+              ended: true,
+            };
+          }
+        }
+        break;
+      }
+      case 'file_edit':
+        items.push({
+          kind: 'file_edit',
+          key: `edit-${i}`,
+          path: event.path,
+          editType: event.editType,
+        });
+        break;
+      case 'usage':
+        items.push({ kind: 'usage', key: `usage-${i}`, usage: event.usage });
+        break;
+      case 'error':
+        items.push({ kind: 'error', key: `error-${i}`, message: event.message });
+        break;
+      case 'done':
+        items.push({ kind: 'done', key: `done-${i}` });
+        break;
+    }
+  }
+
+  flushText();
+  return items;
+}

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -11,3 +11,4 @@ export {
   useSessions,
   useWorkspaces,
 } from './selectors';
+export { selectTranscript, useTranscript } from './transcript';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -3,6 +3,7 @@ import {
   getSetting,
   insertSession,
   insertWorkspace,
+  listMessagesForSession,
   listSessionsForWorkspace,
   listWorkspaces,
   setSetting as dbSetSetting,
@@ -11,9 +12,12 @@ import {
 } from '@kay-am/db';
 import type {
   IsoDateTime,
+  Message,
+  ProviderRunId,
   Session,
   SessionId,
   SessionState,
+  TurnEvent,
   Workspace,
   WorkspaceId,
 } from '@kay-am/types';
@@ -32,6 +36,8 @@ export interface AppState {
   readonly providerStatus: ProviderStatus | null;
   readonly hydrated: boolean;
   readonly error: string | null;
+  readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
+  readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
 }
 
 export interface AppActions {
@@ -49,6 +55,9 @@ export interface AppActions {
     goal: string;
     branchPrefix?: string;
   }): Promise<{ session: Session; worktree: CreatedWorktree }>;
+  loadTranscript(sessionId: SessionId): Promise<void>;
+  appendTurnEvent(sessionId: SessionId, event: TurnEvent): void;
+  resetTranscript(sessionId: SessionId): void;
 }
 
 type AppStore = AppState & AppActions;
@@ -63,7 +72,19 @@ const initialState: AppState = {
   providerStatus: null,
   hydrated: false,
   error: null,
+  transcripts: {},
+  messages: {},
 };
+
+function messageToTurnEvent(message: Message): TurnEvent | null {
+  if (message.role !== 'assistant') return null;
+  return {
+    kind: 'assistant_text',
+    runId: 'history' as ProviderRunId,
+    delta: message.content,
+    at: message.createdAt,
+  };
+}
 
 export const useAppStore = create<AppStore>((set) => ({
   ...initialState,
@@ -97,8 +118,14 @@ export const useAppStore = create<AppStore>((set) => ({
   setCurrentSession: async (id) => {
     set({ currentSessionId: id, sessionSummary: null });
     if (id) {
+      const messages = await listMessagesForSession(tauriDatabase, id);
+      const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
       const summary = await summarizeSessionTelemetry(tauriDatabase, id);
-      set({ sessionSummary: summary });
+      set((state) => ({
+        sessionSummary: summary,
+        messages: { ...state.messages, [id]: messages },
+        transcripts: { ...state.transcripts, [id]: events },
+      }));
     }
   },
 
@@ -162,6 +189,30 @@ export const useAppStore = create<AppStore>((set) => ({
     }));
 
     return { session, worktree };
+  },
+
+  loadTranscript: async (sessionId) => {
+    const messages = await listMessagesForSession(tauriDatabase, sessionId);
+    const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
+    set((state) => ({
+      messages: { ...state.messages, [sessionId]: messages },
+      transcripts: { ...state.transcripts, [sessionId]: events },
+    }));
+  },
+
+  appendTurnEvent: (sessionId, event) => {
+    set((state) => {
+      const existing = state.transcripts[sessionId] ?? [];
+      return {
+        transcripts: { ...state.transcripts, [sessionId]: [...existing, event] },
+      };
+    });
+  },
+
+  resetTranscript: (sessionId) => {
+    set((state) => ({
+      transcripts: { ...state.transcripts, [sessionId]: [] },
+    }));
   },
 
   addWorkspace: async ({ rootPath, name }) => {

--- a/apps/desktop/src/store/transcript.ts
+++ b/apps/desktop/src/store/transcript.ts
@@ -1,0 +1,13 @@
+import type { SessionId, TurnEvent } from '@kay-am/types';
+import { useAppStore, type AppState } from './store';
+
+const EMPTY: ReadonlyArray<TurnEvent> = [];
+
+export const selectTranscript =
+  (sessionId: SessionId | null) =>
+  (state: AppState): ReadonlyArray<TurnEvent> =>
+    sessionId ? (state.transcripts[sessionId] ?? EMPTY) : EMPTY;
+
+export function useTranscript(sessionId: SessionId | null): ReadonlyArray<TurnEvent> {
+  return useAppStore(selectTranscript(sessionId));
+}


### PR DESCRIPTION
## Summary
Main panel renders the live `TurnEvent` stream (and rehydrated history) as structured cards.

- `transcripts` + `messages` slices in zustand, keyed by session id. `setCurrentSession` rehydrates messages from db (assistant rows projected back as `assistant_text` events under a synthetic `'history'` runId). `appendTurnEvent` lets the spawn pipeline (#22) push live events.
- `reduceTranscript` folds raw events into displayable items: text deltas merge into one card, `tool_call_start`/`end` pair by `toolUseId` into one collapsible card, `file_edit` / `usage` / `error` / `done` each render their own card.
- `TranscriptCard` picks the renderer per item kind. Tool calls show JSON in/out when expanded. Assistant text gets a copy button on hover. File edits render as small chips with tone per edit type.
- `ChatView` autoscrolls when the user is pinned to the bottom (within 32px tolerance). Scrolling up unpins; a 'jump to latest' pill restores it.
- `App.tsx` hands the current session to `ChatView`.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: append events programmatically — text deltas merge; tool_call_start/end fold into one card; file_edit chip shows path
- [ ] Manual: scroll up mid-stream — pinned flips false, 'jump to latest' returns

Closes #21