### PR TITLE
feat(desktop): chat input + send turn

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,0 +1,64 @@
+import { useState, type KeyboardEvent } from 'react';
+import { Button, Textarea } from '@kay-am/ui';
+import type { Session } from '@kay-am/types';
+import { useAppStore } from '../../store';
+
+const RUNNING_KINDS = new Set(['starting', 'running']);
+
+export function ChatInput({ session }: { session: Session }) {
+  const sendTurn = useAppStore((s) => s.sendTurn);
+  const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
+  const [value, setValue] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const isRunning = RUNNING_KINDS.has(session.state.kind);
+  const canSend = !isRunning && value.trim().length > 0;
+
+  const onSend = async () => {
+    const content = value.trim();
+    if (!content || isRunning) return;
+    setError(null);
+    setValue('');
+    try {
+      await sendTurn({ sessionId: session.id, content });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      void onSend();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border p-3">
+      <Textarea
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={
+          isRunning
+            ? 'turn running… cancel to send another'
+            : 'message claude. shift+enter for newline.'
+        }
+        disabled={isRunning}
+        rows={3}
+      />
+      {error ? <p className="text-xs text-danger">{error}</p> : null}
+      <div className="flex justify-end gap-2">
+        {isRunning ? (
+          <Button variant="danger" onClick={() => void cancelCurrentTurn(session.id)}>
+            cancel
+          </Button>
+        ) : (
+          <Button onClick={() => void onSend()} disabled={!canSend}>
+            send
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Session } from '@kay-am/types';
 import { useTranscript } from '../../store';
+import { ChatInput } from './ChatInput';
 import { reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
 
@@ -65,6 +66,7 @@ export function ChatView({ session }: ChatViewProps) {
           </button>
         ) : null}
       </div>
+      <ChatInput session={session} />
     </div>
   );
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand';
+import { sessionReducer } from '@kay-am/core';
 import {
   getSetting,
+  insertMessage,
+  insertProviderRun,
   insertSession,
   insertWorkspace,
   listMessagesForSession,
@@ -8,11 +11,15 @@ import {
   listWorkspaces,
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
+  updateProviderRunStatus,
+  updateSessionState,
   type TelemetrySummary,
 } from '@kay-am/db';
 import type {
   IsoDateTime,
   Message,
+  MessageId,
+  ProviderRun,
   ProviderRunId,
   Session,
   SessionId,
@@ -24,6 +31,7 @@ import type {
 import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
 import { validateGitRepo } from '../repo';
+import { runTurn, cancelTurn } from '../turn';
 import { createWorktree, type CreatedWorktree } from '../worktree';
 
 export interface AppState {
@@ -38,6 +46,7 @@ export interface AppState {
   readonly error: string | null;
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
+  readonly sessionWorktrees: Readonly<Record<string, string>>;
 }
 
 export interface AppActions {
@@ -58,6 +67,8 @@ export interface AppActions {
   loadTranscript(sessionId: SessionId): Promise<void>;
   appendTurnEvent(sessionId: SessionId, event: TurnEvent): void;
   resetTranscript(sessionId: SessionId): void;
+  sendTurn(input: { sessionId: SessionId; content: string }): Promise<void>;
+  cancelCurrentTurn(sessionId: SessionId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -74,6 +85,7 @@ const initialState: AppState = {
   error: null,
   transcripts: {},
   messages: {},
+  sessionWorktrees: {},
 };
 
 function messageToTurnEvent(message: Message): TurnEvent | null {
@@ -86,7 +98,20 @@ function messageToTurnEvent(message: Message): TurnEvent | null {
   };
 }
 
-export const useAppStore = create<AppStore>((set) => ({
+const DEFAULT_MODEL = 'claude-opus-4-7';
+const DEFAULT_PREFIX = 'kay';
+
+type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
+
+function applySessionUpdate(set: SetFn, sessionId: SessionId, state: SessionState): void {
+  set((store) => ({
+    sessions: store.sessions.map((s) =>
+      s.id === sessionId ? { ...s, state, updatedAt: new Date().toISOString() as IsoDateTime } : s,
+    ),
+  }));
+}
+
+export const useAppStore = create<AppStore>((set, get) => ({
   ...initialState,
 
   hydrate: async () => {
@@ -186,6 +211,7 @@ export const useAppStore = create<AppStore>((set) => ({
         state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
       currentSessionId: session.id,
       sessionSummary: null,
+      sessionWorktrees: { ...state.sessionWorktrees, [session.id]: worktree.worktreePath },
     }));
 
     return { session, worktree };
@@ -213,6 +239,116 @@ export const useAppStore = create<AppStore>((set) => ({
     set((state) => ({
       transcripts: { ...state.transcripts, [sessionId]: [] },
     }));
+  },
+
+  sendTurn: async ({ sessionId, content }) => {
+    const before = get();
+    const session = before.sessions.find((s) => s.id === sessionId);
+    if (!session) throw new Error(`session not found: ${sessionId}`);
+    const workingDir = before.sessionWorktrees[sessionId];
+    if (!workingDir) {
+      throw new Error(
+        'session worktree not initialized — open a fresh session (worktree paths are not yet persisted across restarts)',
+      );
+    }
+
+    const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+    const userMessage: Message = {
+      id: crypto.randomUUID() as MessageId,
+      sessionId,
+      role: 'user',
+      content,
+      createdAt: now(),
+    };
+    await insertMessage(tauriDatabase, userMessage);
+
+    const runId = crypto.randomUUID() as ProviderRunId;
+    const run: ProviderRun = {
+      id: runId,
+      sessionId,
+      provider: 'anthropic',
+      model: DEFAULT_MODEL,
+      status: { kind: 'streaming', startedAt: now() },
+      createdAt: now(),
+    };
+    await insertProviderRun(tauriDatabase, run);
+
+    let nextState: SessionState = session.state;
+    if (nextState.kind === 'draft') {
+      nextState = sessionReducer(nextState, { kind: 'start', at: now() });
+    }
+    nextState = sessionReducer(nextState, { kind: 'send', runId, at: now() });
+    await updateSessionState(tauriDatabase, sessionId, nextState, now());
+    applySessionUpdate(set, sessionId, nextState);
+
+    let assistantText = '';
+    let lastError: unknown = null;
+
+    try {
+      for await (const event of runTurn({
+        runId,
+        model: DEFAULT_MODEL,
+        workingDir,
+        prompt: content,
+      })) {
+        get().appendTurnEvent(sessionId, event);
+        if (event.kind === 'assistant_text') assistantText += event.delta;
+
+        const current = get().sessions.find((s) => s.id === sessionId);
+        if (current) {
+          const reduced = sessionReducer(current.state, { kind: 'receive_event', event });
+          if (reduced !== current.state) {
+            await updateSessionState(tauriDatabase, sessionId, reduced, now());
+            applySessionUpdate(set, sessionId, reduced);
+          }
+        }
+      }
+      await updateProviderRunStatus(tauriDatabase, runId, {
+        kind: 'succeeded',
+        finishedAt: now(),
+      });
+    } catch (err) {
+      lastError = err;
+      const message = err instanceof Error ? err.message : String(err);
+      const errorState: SessionState = {
+        kind: 'error',
+        message,
+        failedAt: now(),
+      };
+      await updateSessionState(tauriDatabase, sessionId, errorState, now());
+      applySessionUpdate(set, sessionId, errorState);
+      await updateProviderRunStatus(tauriDatabase, runId, {
+        kind: 'failed',
+        finishedAt: now(),
+        error: message,
+      });
+      get().appendTurnEvent(sessionId, {
+        kind: 'error',
+        runId,
+        message,
+        at: now(),
+      });
+    }
+
+    if (assistantText.length > 0) {
+      const assistantMessage: Message = {
+        id: crypto.randomUUID() as MessageId,
+        sessionId,
+        role: 'assistant',
+        content: assistantText,
+        createdAt: now(),
+      };
+      await insertMessage(tauriDatabase, assistantMessage);
+    }
+
+    if (lastError) throw lastError;
+  },
+
+  cancelCurrentTurn: async (sessionId) => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session || session.state.kind !== 'running') return;
+    await cancelTurn(session.state.runId);
   },
 
   addWorkspace: async ({ rootPath, name }) => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -99,7 +99,6 @@ function messageToTurnEvent(message: Message): TurnEvent | null {
 }
 
 const DEFAULT_MODEL = 'claude-opus-4-7';
-const DEFAULT_PREFIX = 'kay';
 
 type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./node": {
+      "types": "./src/node.ts",
+      "default": "./src/node.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,3 @@
-export {
-  createWorktree,
-  listWorktrees,
-  removeWorktree,
-  sanitizeSlug,
-  GitError,
-  WorktreeError,
-  type CreatedWorktree,
-  type CreateWorktreeOptions,
-  type WorktreeInfo,
-} from './worktree';
-
 export { IllegalSessionTransitionError, sessionReducer, type SessionEvent } from './session';
 
 export {
@@ -30,11 +18,5 @@ export {
   type SlotKey,
 } from './context';
 
-export {
-  ClaudeAdapter,
-  computeCostUsd,
-  parseStreamJsonLine,
-  priceFor,
-  type ClaudeAdapterDeps,
-  type ParseContext,
-} from './providers/claude';
+export { computeCostUsd, priceFor } from './providers/claude/cost';
+export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -1,0 +1,13 @@
+export {
+  createWorktree,
+  listWorktrees,
+  removeWorktree,
+  sanitizeSlug,
+  GitError,
+  WorktreeError,
+  type CreatedWorktree,
+  type CreateWorktreeOptions,
+  type WorktreeInfo,
+} from './worktree';
+
+export { ClaudeAdapter, type ClaudeAdapterDeps } from './providers/claude';


### PR DESCRIPTION
## Summary
End-to-end turn flow: user types a message, kAY.am persists it, spawns the claude CLI through the existing Tauri pipeline, folds `TurnEvent`s back into chat + session state, and saves the assistant reply.

- `sendTurn` action in zustand:
  - persist user `Message`
  - insert `ProviderRun` (`streaming`) and reduce `SessionState` through `start` (if draft) → `send` (running)
  - resolve `workingDir` from the session's worktree (created at `createSession` time and tracked in `sessionWorktrees` runtime state; persistence across restarts will land with a future migration)
  - iterate `runTurn(...)`, reduce `receive_event` for each yielded event, persist transcript via `appendTurnEvent`
  - on `done` / `error` from the reducer, mirror to db
  - persist concatenated assistant text as one `Message`
- `cancelCurrentTurn` calls `cancelTurn(runId)` when state is running.
- `ChatInput` textarea: enter sends, shift+enter newline; send disabled while running, swapped for `cancel`.
- `ChatView` renders the input below the transcript.
- Spawn errors surface inline above the textarea AND as an error `TurnEvent` in the transcript.

### Repackaging `@kay-am/core`
The store needs `sessionReducer` (browser-safe) but importing from `@kay-am/core` was pulling in the worktree manager + `ClaudeAdapter`, both of which use `node:child_process`. Vite externalized the node modules but rollup failed because their named imports (`spawn`, `promisify`, etc.) are read at module load.

- `src/index.ts` now exports only browser-safe surface: `sessionReducer`, `ContextEngine`, `TelemetryRecorder`, the claude parser, cost helpers.
- `src/node.ts` (new exports subpath `@kay-am/core/node`) exports the node-only surface: worktree manager, `sanitizeSlug`, `ClaudeAdapter`.
- `core/index.ts` deep-imports from `claude/cost.ts` and `claude/parser.ts` to skip the providers/claude barrel that re-exports the adapter.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: create a session, type a message, hit enter — claude CLI streams back, assistant text accumulates, state goes running → idle, sidebar badge updates
- [ ] Manual: hit cancel mid-stream → state goes error, process dies

Closes #22