### PR TITLE
feat(desktop): "open in vscode" button on session

### DIFF
--- a/apps/desktop/src/components/OpenInEditorButton.tsx
+++ b/apps/desktop/src/components/OpenInEditorButton.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Button } from '@kay-am/ui';
+import type { ButtonProps } from '@kay-am/ui';
+import { openInEditor } from '../editor';
+
+interface OpenInEditorButtonProps extends Omit<ButtonProps, 'onClick' | 'children'> {
+  worktreePath: string | null;
+  label?: string;
+}
+
+export function OpenInEditorButton({
+  worktreePath,
+  label = 'open in vscode',
+  size = 'sm',
+  variant = 'ghost',
+  ...rest
+}: OpenInEditorButtonProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = async () => {
+    if (!worktreePath) return;
+    setError(null);
+    try {
+      await openInEditor(worktreePath);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const disabled = rest.disabled || worktreePath === null;
+  const tooltip =
+    worktreePath === null
+      ? 'session has no worktree (worktree paths are not yet persisted across restarts)'
+      : (error ?? undefined);
+
+  return (
+    <Button
+      {...rest}
+      size={size}
+      variant={variant}
+      disabled={disabled}
+      title={tooltip}
+      onClick={() => void onClick()}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/apps/desktop/src/components/SessionsSidebar.tsx
+++ b/apps/desktop/src/components/SessionsSidebar.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Button, ScrollArea, cn } from '@kay-am/ui';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessions } from '../store';
 import { NewSessionDialog } from './NewSessionDialog';
+import { OpenInEditorButton } from './OpenInEditorButton';
 import { StatusBadge } from './StatusBadge';
 
 export function SessionsSidebar() {
@@ -9,6 +10,7 @@ export function SessionsSidebar() {
   const sessions = useSessions();
   const current = useCurrentSession();
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const sessionWorktrees = useAppStore((s) => s.sessionWorktrees);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -28,23 +30,38 @@ export function SessionsSidebar() {
             <p className="px-3 py-2 text-xs text-muted-foreground">no sessions yet</p>
           ) : (
             <ul className="py-1">
-              {sessions.map((session) => (
-                <li key={session.id}>
-                  <button
-                    type="button"
-                    onClick={() => void setCurrentSession(session.id)}
-                    className={cn(
-                      'flex w-full flex-col gap-1 px-3 py-2 text-left text-sm hover:bg-muted',
-                      session.id === current?.id && 'bg-muted',
-                    )}
-                  >
-                    <span className="flex items-center justify-between gap-2">
-                      <span className="line-clamp-1 flex-1">{session.goal}</span>
-                      <StatusBadge state={session.state} />
-                    </span>
-                  </button>
-                </li>
-              ))}
+              {sessions.map((session) => {
+                const isCurrent = session.id === current?.id;
+                const worktreePath = sessionWorktrees[session.id] ?? null;
+                return (
+                  <li key={session.id} className="group">
+                    <div
+                      className={cn(
+                        'flex flex-col gap-1 px-3 py-2 text-left text-sm hover:bg-muted',
+                        isCurrent && 'bg-muted',
+                      )}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => void setCurrentSession(session.id)}
+                        className="flex w-full items-center justify-between gap-2"
+                      >
+                        <span className="line-clamp-1 flex-1">{session.goal}</span>
+                        <StatusBadge state={session.state} />
+                      </button>
+                      <div
+                        className={cn(
+                          'flex justify-end opacity-0 transition-opacity',
+                          (isCurrent || worktreePath !== null) && 'group-hover:opacity-100',
+                          isCurrent && 'opacity-100',
+                        )}
+                      >
+                        <OpenInEditorButton worktreePath={worktreePath} label="vscode" />
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
             </ul>
           )}
         </ScrollArea>


### PR DESCRIPTION
## Summary
Wires `open_in_editor` (from #16) into the session UI.

- `OpenInEditorButton` resolves the worktree path from `sessionWorktrees` state, surfaces tauri errors via `title`, and disables itself with a friendly tooltip when the session has no recorded worktree (e.g. after restart, until a future migration persists the path).
- Used in two places:
  - chat header (top-right of `ChatView`)
  - sessions sidebar row (visible on hover for non-current rows, always visible for the active row)

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: click 'vscode' on a fresh session → VS Code opens at the worktree path
- [ ] Manual: button is disabled with tooltip after app restart on a pre-existing session

Closes #28