### PR TITLE
feat(desktop): end-session flow + worktree cleanup

### DIFF
--- a/apps/desktop/src/components/EndSessionButton.tsx
+++ b/apps/desktop/src/components/EndSessionButton.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { Button, Dialog } from '@kay-am/ui';
+import type { Session } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+export function EndSessionButton({ session }: { session: Session }) {
+  const endSession = useAppStore((s) => s.endSession);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (session.state.kind === 'ended') return null;
+
+  const onConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await endSession(session.id);
+      setOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+        end session
+      </Button>
+      <Dialog open={open} onClose={() => setOpen(false)} title="end session?">
+        <p className="text-sm text-muted-foreground">
+          this removes the worktree directory at the session path. the branch is preserved for
+          manual merge.
+        </p>
+        {error ? <p className="text-xs text-danger">{error}</p> : null}
+        <div className="flex justify-end gap-2">
+          <Button variant="ghost" onClick={() => setOpen(false)} disabled={busy}>
+            cancel
+          </Button>
+          <Button variant="danger" onClick={() => void onConfirm()} disabled={busy}>
+            {busy ? 'ending…' : 'end'}
+          </Button>
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Session } from '@kay-am/types';
-import { useTranscript } from '../../store';
+import { useAppStore, useTranscript } from '../../store';
+import { EndSessionButton } from '../EndSessionButton';
+import { OpenInEditorButton } from '../OpenInEditorButton';
 import { ChatInput } from './ChatInput';
 import { reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
@@ -14,6 +16,7 @@ const PIN_TOLERANCE_PX = 32;
 export function ChatView({ session }: ChatViewProps) {
   const events = useTranscript(session.id);
   const items = useMemo(() => reduceTranscript(events), [events]);
+  const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id] ?? null);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState(true);
 
@@ -30,11 +33,19 @@ export function ChatView({ session }: ChatViewProps) {
     setPinned(distance < PIN_TOLERANCE_PX);
   };
 
+  const isEnded = session.state.kind === 'ended';
+
   return (
     <div className="flex h-full flex-col">
-      <div className="border-b border-border px-3 py-2">
-        <h1 className="text-sm font-semibold tracking-tight">{session.goal}</h1>
-        <p className="text-xs text-muted-foreground">state: {session.state.kind}</p>
+      <div className="flex items-start justify-between gap-3 border-b border-border px-3 py-2">
+        <div>
+          <h1 className="text-sm font-semibold tracking-tight">{session.goal}</h1>
+          <p className="text-xs text-muted-foreground">state: {session.state.kind}</p>
+        </div>
+        <div className="flex items-center gap-1">
+          <OpenInEditorButton worktreePath={worktreePath} />
+          <EndSessionButton session={session} />
+        </div>
       </div>
       <div
         ref={scrollerRef}
@@ -66,7 +77,13 @@ export function ChatView({ session }: ChatViewProps) {
           </button>
         ) : null}
       </div>
-      <ChatInput session={session} />
+      {isEnded ? (
+        <div className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
+          session ended — no further turns. branch preserved.
+        </div>
+      ) : (
+        <ChatInput session={session} />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -32,7 +32,7 @@ import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
 import { validateGitRepo } from '../repo';
 import { runTurn, cancelTurn } from '../turn';
-import { createWorktree, type CreatedWorktree } from '../worktree';
+import { createWorktree, removeWorktree, type CreatedWorktree } from '../worktree';
 
 export interface AppState {
   readonly workspaces: ReadonlyArray<Workspace>;
@@ -69,6 +69,7 @@ export interface AppActions {
   resetTranscript(sessionId: SessionId): void;
   sendTurn(input: { sessionId: SessionId; content: string }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId): Promise<void>;
+  endSession(sessionId: SessionId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -348,6 +349,37 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session || session.state.kind !== 'running') return;
     await cancelTurn(session.state.runId);
+  },
+
+  endSession: async (sessionId) => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) throw new Error(`session not found: ${sessionId}`);
+    if (session.state.kind === 'ended') return;
+    if (session.state.kind === 'running') {
+      await cancelTurn(session.state.runId);
+    }
+
+    const worktreePath = get().sessionWorktrees[sessionId];
+    const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    if (worktreePath && workspace) {
+      try {
+        await removeWorktree(workspace.rootPath, worktreePath);
+      } catch (err) {
+        // worktree may already be gone — surface as warning, continue ending
+        console.warn(`worktree_remove failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+    const ended: SessionState = sessionReducer(session.state, { kind: 'end', at: now() });
+    await updateSessionState(tauriDatabase, sessionId, ended, now());
+    applySessionUpdate(set, sessionId, ended);
+
+    set((state) => {
+      const nextWorktrees = { ...state.sessionWorktrees };
+      delete nextWorktrees[sessionId];
+      return { sessionWorktrees: nextWorktrees };
+    });
   },
 
   addWorkspace: async ({ rootPath, name }) => {


### PR DESCRIPTION
## Summary
End an active session: cancel any in-flight turn, remove the worktree directory, transition the session to `ended`, and lock the chat input.

- `endSession` action in zustand:
  - if state is `running`, call `cancelTurn(runId)` first
  - call `worktree_remove(repo, worktreePath)` (best-effort — failures are logged, the session still ends)
  - reduce session state through `sessionReducer({ kind: 'end' })` and persist via `updateSessionState`
  - drop the entry from `sessionWorktrees` so the open-in-vscode button disables itself
- `EndSessionButton` opens a destructive-style confirm dialog with copy clarifying the branch is preserved.
- ChatView header gains the button; once `ended`, the input is replaced with a muted footer line and no further turns can be sent.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: end an idle session — directory disappears, branch survives (`git branch --list 'kay/*'`)
- [ ] Manual: end a running session — turn cancels, then session ends

Closes #26