### PR TITLE
feat(desktop): telemetry pill + breakdown

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { AppShell, KbdPill, ScrollArea } from '@kay-am/ui';
 import { ChatView } from './components/chat/ChatView';
 import { SessionsSidebar } from './components/SessionsSidebar';
+import { TelemetryPill } from './components/TelemetryPill';
 import { WorkspaceSelector } from './components/WorkspaceSelector';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useProviderAvailable } from './store';
 
@@ -23,14 +24,17 @@ export function App() {
         <div className="flex w-full items-center gap-3">
           <span className="font-semibold tracking-tight">kAY.am</span>
           <WorkspaceSelector />
-          <span className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
             {!providerAvailable ? (
               <span className="rounded-full bg-danger/10 px-2 py-0.5 text-danger">
                 claude cli missing
               </span>
             ) : null}
-            press <KbdPill>⌘K</KbdPill>
-          </span>
+            <TelemetryPill />
+            <span>
+              press <KbdPill>⌘K</KbdPill>
+            </span>
+          </div>
         </div>
       }
       leftSidebar={<SessionsSidebar />}

--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@kay-am/ui';
+import { useAppStore } from '../store';
+
+const formatCost = (usd: number): string => `$${usd.toFixed(4)}`;
+const formatTokens = (n: number): string =>
+  n >= 1_000_000
+    ? `${(n / 1_000_000).toFixed(2)}M`
+    : n >= 1_000
+      ? `${(n / 1_000).toFixed(1)}k`
+      : `${n}`;
+
+type SortKey = 'time' | 'cost';
+
+export function TelemetryPill() {
+  const sessionSummary = useAppStore((s) => s.sessionSummary);
+  const workspaceSummary = useAppStore((s) => s.workspaceSummary);
+  const currentSessionId = useAppStore((s) => s.currentSessionId);
+  const sessionTelemetry = useAppStore((s) =>
+    currentSessionId ? (s.sessionTelemetry[currentSessionId] ?? []) : [],
+  );
+
+  const [open, setOpen] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>('time');
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onClick);
+    return () => window.removeEventListener('mousedown', onClick);
+  }, [open]);
+
+  const sorted = useMemo(() => {
+    const copy = [...sessionTelemetry];
+    if (sortKey === 'cost') {
+      copy.sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd);
+    } else {
+      copy.sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt));
+    }
+    return copy;
+  }, [sessionTelemetry, sortKey]);
+
+  const summarizerCost = sessionTelemetry
+    .filter((r) => r.kind === 'summarizer')
+    .reduce((sum, r) => sum + r.estimatedCostUsd, 0);
+
+  const sessionCost = sessionSummary?.estimatedCostUsd ?? 0;
+  const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-2 rounded-full border border-border bg-muted px-2 py-0.5 text-xs hover:bg-muted/70"
+      >
+        <span className="font-medium">{formatCost(sessionCost)}</span>
+        <span className="text-muted-foreground">session</span>
+        <span aria-hidden className="text-muted-foreground">
+          ·
+        </span>
+        <span className="font-medium">{formatCost(workspaceCost)}</span>
+        <span className="text-muted-foreground">total</span>
+      </button>
+
+      {open ? (
+        <div className="absolute right-0 top-7 z-10 w-80 rounded-md border border-border bg-background p-3 text-xs shadow-lg">
+          <div className="mb-2 flex items-center justify-between">
+            <span className="font-semibold uppercase tracking-wide text-muted-foreground">
+              breakdown
+            </span>
+            <div className="flex gap-1">
+              <SortChip
+                active={sortKey === 'time'}
+                onClick={() => setSortKey('time')}
+                label="time"
+              />
+              <SortChip
+                active={sortKey === 'cost'}
+                onClick={() => setSortKey('cost')}
+                label="cost"
+              />
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-2 gap-x-3 gap-y-1 border-b border-border pb-2">
+            <dt className="text-muted-foreground">session</dt>
+            <dd className="text-right font-medium">{formatCost(sessionCost)}</dd>
+            <dt className="text-muted-foreground">workspace</dt>
+            <dd className="text-right font-medium">{formatCost(workspaceCost)}</dd>
+            {summarizerCost > 0 ? (
+              <>
+                <dt className="text-muted-foreground">summarizer</dt>
+                <dd className="text-right font-medium">{formatCost(summarizerCost)}</dd>
+              </>
+            ) : null}
+          </dl>
+
+          <div className="mt-2 max-h-64 overflow-y-auto">
+            {sorted.length === 0 ? (
+              <p className="py-2 text-muted-foreground">no recorded turns yet.</p>
+            ) : (
+              <ul className="flex flex-col gap-1">
+                {sorted.map((record) => (
+                  <li key={record.id} className="flex items-center justify-between gap-2 py-0.5">
+                    <span className="flex items-center gap-1 text-muted-foreground">
+                      <span
+                        className={cn(
+                          'rounded px-1 text-[10px] uppercase',
+                          record.kind === 'summarizer'
+                            ? 'bg-muted text-muted-foreground'
+                            : 'bg-primary/10 text-primary',
+                        )}
+                      >
+                        {record.kind}
+                      </span>
+                      <span>
+                        {formatTokens(record.inputTokens)}↓ / {formatTokens(record.outputTokens)}↑
+                      </span>
+                    </span>
+                    <span className="font-mono">{formatCost(record.estimatedCostUsd)}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SortChip({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+        active ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -5,12 +5,15 @@ import {
   insertMessage,
   insertProviderRun,
   insertSession,
+  insertTelemetry,
   insertWorkspace,
   listMessagesForSession,
   listSessionsForWorkspace,
+  listTelemetryForSession,
   listWorkspaces,
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
+  summarizeWorkspaceTelemetry,
   updateProviderRunStatus,
   updateSessionState,
   type TelemetrySummary,
@@ -24,10 +27,13 @@ import type {
   Session,
   SessionId,
   SessionState,
+  TelemetryRecord,
+  TelemetryRecordId,
   TurnEvent,
   Workspace,
   WorkspaceId,
 } from '@kay-am/types';
+import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
 import { validateGitRepo } from '../repo';
@@ -47,6 +53,8 @@ export interface AppState {
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
   readonly sessionWorktrees: Readonly<Record<string, string>>;
+  readonly sessionTelemetry: Readonly<Record<string, ReadonlyArray<TelemetryRecord>>>;
+  readonly workspaceSummary: TelemetrySummary | null;
 }
 
 export interface AppActions {
@@ -70,6 +78,8 @@ export interface AppActions {
   sendTurn(input: { sessionId: SessionId; content: string }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId): Promise<void>;
   endSession(sessionId: SessionId): Promise<void>;
+  refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
+  loadSessionTelemetry(sessionId: SessionId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -87,6 +97,8 @@ const initialState: AppState = {
   transcripts: {},
   messages: {},
   sessionWorktrees: {},
+  sessionTelemetry: {},
+  workspaceSummary: null,
 };
 
 function messageToTurnEvent(message: Message): TurnEvent | null {
@@ -133,23 +145,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
       currentSessionId: null,
       sessions: [],
       sessionSummary: null,
+      workspaceSummary: null,
     });
     if (id) {
-      const sessions = await listSessionsForWorkspace(tauriDatabase, id);
-      set({ sessions });
+      const [sessions, workspaceSummary] = await Promise.all([
+        listSessionsForWorkspace(tauriDatabase, id),
+        summarizeWorkspaceTelemetry(tauriDatabase, id),
+      ]);
+      set({ sessions, workspaceSummary });
     }
   },
 
   setCurrentSession: async (id) => {
     set({ currentSessionId: id, sessionSummary: null });
     if (id) {
-      const messages = await listMessagesForSession(tauriDatabase, id);
+      const [messages, summary, telemetry] = await Promise.all([
+        listMessagesForSession(tauriDatabase, id),
+        summarizeSessionTelemetry(tauriDatabase, id),
+        listTelemetryForSession(tauriDatabase, id),
+      ]);
       const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
-      const summary = await summarizeSessionTelemetry(tauriDatabase, id);
       set((state) => ({
         sessionSummary: summary,
         messages: { ...state.messages, [id]: messages },
         transcripts: { ...state.transcripts, [id]: events },
+        sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
       }));
     }
   },
@@ -295,6 +315,37 @@ export const useAppStore = create<AppStore>((set, get) => ({
         get().appendTurnEvent(sessionId, event);
         if (event.kind === 'assistant_text') assistantText += event.delta;
 
+        if (event.kind === 'usage') {
+          const cost = computeCostUsd(event.usage, DEFAULT_MODEL);
+          const record: TelemetryRecord = {
+            id: crypto.randomUUID() as TelemetryRecordId,
+            runId,
+            sessionId,
+            kind: 'turn',
+            provider: 'anthropic',
+            model: DEFAULT_MODEL,
+            inputTokens: event.usage.inputTokens,
+            outputTokens: event.usage.outputTokens,
+            estimatedCostUsd: cost,
+            recordedAt: now(),
+          };
+          await insertTelemetry(tauriDatabase, record);
+          set((state) => ({
+            sessionTelemetry: {
+              ...state.sessionTelemetry,
+              [sessionId]: [...(state.sessionTelemetry[sessionId] ?? []), record],
+            },
+          }));
+          const session = get().sessions.find((s) => s.id === sessionId);
+          if (session) {
+            const [sessSummary, wsSummary] = await Promise.all([
+              summarizeSessionTelemetry(tauriDatabase, sessionId),
+              summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
+            ]);
+            set({ sessionSummary: sessSummary, workspaceSummary: wsSummary });
+          }
+        }
+
         const current = get().sessions.find((s) => s.id === sessionId);
         if (current) {
           const reduced = sessionReducer(current.state, { kind: 'receive_event', event });
@@ -349,6 +400,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session || session.state.kind !== 'running') return;
     await cancelTurn(session.state.runId);
+  },
+
+  refreshWorkspaceSummary: async (workspaceId) => {
+    const summary = await summarizeWorkspaceTelemetry(tauriDatabase, workspaceId);
+    set({ workspaceSummary: summary });
+  },
+
+  loadSessionTelemetry: async (sessionId) => {
+    const records = await listTelemetryForSession(tauriDatabase, sessionId);
+    set((state) => ({
+      sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: records },
+    }));
   },
 
   endSession: async (sessionId) => {


### PR DESCRIPTION
## Summary
Real-time spend visibility in the header.

- `sendTurn` now records a `TelemetryRecord` on every `usage` `TurnEvent`, computing cost via `@kay-am/core`'s `computeCostUsd` with the session's model. The record is inserted into `telemetry_records` and pushed into `sessionTelemetry` state, then both summaries (session + workspace) are recomputed so the pill updates mid-stream.
- New zustand state: `sessionTelemetry` (per-session record array) + `workspaceSummary`. New actions: `refreshWorkspaceSummary`, `loadSessionTelemetry`. `setCurrentWorkspace` hydrates `workspaceSummary`; `setCurrentSession` hydrates `sessionTelemetry`.
- `TelemetryPill` renders a sticky pill showing session + workspace cost (`$0.0123`, 4 decimals). Click opens a click-outside popover with:
  - aggregated session / workspace / summarizer subtotals
  - per-record list with kind chip (turn / summarizer), in/out token counts, cost
  - sort toggle: by time (default) or by cost
- App.tsx wires the pill into the header.

## Test plan
- [x] `pnpm turbo run typecheck test build` clean
- [ ] Manual: send a turn — pill updates as the `usage` event arrives mid-stream
- [ ] Manual: switch session — pill snaps to the new session's totals while workspace stays cumulative

Closes #24