### PR TITLE
feat(desktop): context panel with editable slots (#23)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
-import { AppShell, KbdPill, ScrollArea } from '@kay-am/ui';
+import { AppShell, KbdPill } from '@kay-am/ui';
 import { ChatView } from './components/chat/ChatView';
+import { ContextPanel } from './components/ContextPanel';
 import { SessionsSidebar } from './components/SessionsSidebar';
 import { TelemetryPill } from './components/TelemetryPill';
 import { WorkspaceSelector } from './components/WorkspaceSelector';
@@ -56,10 +57,18 @@ export function App() {
         )
       }
       rightSidebar={
-        <ScrollArea className="h-full p-2">
-          <div className="text-xs uppercase text-muted-foreground">context</div>
-          <p className="mt-2 text-sm text-muted-foreground">slots will live here.</p>
-        </ScrollArea>
+        currentSession ? (
+          <ContextPanel session={currentSession} />
+        ) : (
+          <div className="p-3">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              context
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              select a session to view its slots.
+            </p>
+          </div>
+        )
       }
     />
   );

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { ScrollArea, Textarea, cn } from '@kay-am/ui';
+import { SLOT_KEYS, SLOT_LABELS, type SlotKey } from '@kay-am/core';
+import type { ContextSlot, Session } from '@kay-am/types';
+import { useAppStore, useSessionSlots } from '../store';
+
+interface ContextPanelProps {
+  session: Session;
+}
+
+type SummarizerStatus = 'idle' | 'running' | 'error';
+
+export function ContextPanel({ session }: ContextPanelProps) {
+  const slots = useSessionSlots(session.id);
+  const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
+  const toggleSessionSlot = useAppStore((s) => s.toggleSessionSlot);
+
+  // summarizer not yet implemented (#8) — placeholder until wired
+  const summarizerStatus: SummarizerStatus = 'idle';
+  const summarizerLastUpdate: string | null = null;
+
+  const slotsByKey = new Map<string, ContextSlot>(slots.map((s) => [s.key, s]));
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-3 p-3">
+        <header className="flex items-center justify-between">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            context
+          </span>
+          <SummarizerBadge status={summarizerStatus} lastUpdate={summarizerLastUpdate} />
+        </header>
+
+        <ul className="flex flex-col gap-3">
+          {SLOT_KEYS.map((key) => {
+            const slot = slotsByKey.get(key);
+            return (
+              <SlotRow
+                key={key}
+                slotKey={key}
+                slot={slot}
+                onCommit={(value) => void upsertSessionSlot(session.id, key, value)}
+                onToggle={(enabled) => void toggleSessionSlot(session.id, key, enabled)}
+              />
+            );
+          })}
+        </ul>
+      </div>
+    </ScrollArea>
+  );
+}
+
+interface SlotRowProps {
+  slotKey: SlotKey;
+  slot: ContextSlot | undefined;
+  onCommit: (value: string) => void;
+  onToggle: (enabled: boolean) => void;
+}
+
+function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
+  const enabled = slot?.enabled ?? true;
+  const value = slot?.value ?? '';
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+
+  useEffect(() => {
+    if (!editing) setDraft(value);
+  }, [value, editing]);
+
+  const commit = () => {
+    setEditing(false);
+    if (draft !== value) onCommit(draft);
+  };
+
+  return (
+    <li className="flex flex-col gap-1">
+      <div className="flex items-center justify-between gap-2">
+        <label className="text-xs font-medium text-muted-foreground">{SLOT_LABELS[slotKey]}</label>
+        <button
+          type="button"
+          onClick={() => onToggle(!enabled)}
+          className={cn(
+            'rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+            enabled
+              ? 'border-primary/30 bg-primary/10 text-primary'
+              : 'border-border bg-muted text-muted-foreground',
+          )}
+          aria-pressed={enabled}
+        >
+          {enabled ? 'on' : 'off'}
+        </button>
+      </div>
+
+      {editing ? (
+        <Textarea
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              setDraft(value);
+              setEditing(false);
+            }
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              commit();
+            }
+          }}
+          className="min-h-12 text-xs"
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => setEditing(true)}
+          className={cn(
+            'whitespace-pre-wrap rounded-md border border-transparent px-2 py-1.5 text-left text-xs hover:border-border hover:bg-muted/40',
+            !enabled && 'opacity-60',
+          )}
+        >
+          {value.length > 0 ? (
+            value
+          ) : (
+            <span className="italic text-muted-foreground">empty — click to edit</span>
+          )}
+        </button>
+      )}
+    </li>
+  );
+}
+
+function SummarizerBadge({
+  status,
+  lastUpdate,
+}: {
+  status: SummarizerStatus;
+  lastUpdate: string | null;
+}) {
+  const styles: Record<SummarizerStatus, string> = {
+    idle: 'bg-muted text-muted-foreground',
+    running: 'bg-primary/10 text-primary',
+    error: 'bg-danger/10 text-danger',
+  };
+  const label = status === 'idle' ? 'summarizer idle' : status;
+  const tooltip = lastUpdate ? `last update: ${lastUpdate}` : 'summarizer not yet wired';
+  return (
+    <span
+      title={tooltip}
+      className={cn('rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wide', styles[status])}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -8,6 +8,7 @@ export {
   useCurrentSession,
   useCurrentWorkspace,
   useProviderAvailable,
+  useSessionSlots,
   useSessions,
   useWorkspaces,
 } from './selectors';

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import type { Session, Workspace } from '@kay-am/types';
+import type { ContextSlot, Session, SessionId, Workspace } from '@kay-am/types';
 import { useAppStore, type AppState } from './store';
 
 export const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
@@ -15,3 +15,8 @@ export const useCurrentWorkspace = (): Workspace | null => useAppStore(selectCur
 export const useSessions = (): ReadonlyArray<Session> => useAppStore(selectSessions);
 export const useCurrentSession = (): Session | null => useAppStore(selectCurrentSession);
 export const useProviderAvailable = (): boolean => useAppStore(selectProviderAvailable);
+
+const EMPTY_SLOTS: ReadonlyArray<ContextSlot> = [];
+
+export const useSessionSlots = (sessionId: SessionId | null): ReadonlyArray<ContextSlot> =>
+  useAppStore((s) => (sessionId ? (s.sessionSlots[sessionId] ?? EMPTY_SLOTS) : EMPTY_SLOTS));

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { sessionReducer } from '@kay-am/core';
+import { sessionReducer, type SlotKey } from '@kay-am/core';
 import {
   getSetting,
   insertMessage,
@@ -7,6 +7,7 @@ import {
   insertSession,
   insertTelemetry,
   insertWorkspace,
+  listContextSlotsForSession,
   listMessagesForSession,
   listSessionsForWorkspace,
   listTelemetryForSession,
@@ -16,9 +17,11 @@ import {
   summarizeWorkspaceTelemetry,
   updateProviderRunStatus,
   updateSessionState,
+  upsertContextSlot,
   type TelemetrySummary,
 } from '@kay-am/db';
 import type {
+  ContextSlot,
   IsoDateTime,
   Message,
   MessageId,
@@ -55,6 +58,7 @@ export interface AppState {
   readonly sessionWorktrees: Readonly<Record<string, string>>;
   readonly sessionTelemetry: Readonly<Record<string, ReadonlyArray<TelemetryRecord>>>;
   readonly workspaceSummary: TelemetrySummary | null;
+  readonly sessionSlots: Readonly<Record<string, ReadonlyArray<ContextSlot>>>;
 }
 
 export interface AppActions {
@@ -80,6 +84,9 @@ export interface AppActions {
   endSession(sessionId: SessionId): Promise<void>;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
   loadSessionTelemetry(sessionId: SessionId): Promise<void>;
+  loadSessionSlots(sessionId: SessionId): Promise<void>;
+  upsertSessionSlot(sessionId: SessionId, key: SlotKey, value: string): Promise<void>;
+  toggleSessionSlot(sessionId: SessionId, key: SlotKey, enabled: boolean): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -99,7 +106,19 @@ const initialState: AppState = {
   sessionWorktrees: {},
   sessionTelemetry: {},
   workspaceSummary: null,
+  sessionSlots: {},
 };
+
+function mergeSlots(
+  existing: ReadonlyArray<ContextSlot>,
+  next: ContextSlot,
+): ReadonlyArray<ContextSlot> {
+  const idx = existing.findIndex((s) => s.key === next.key);
+  if (idx === -1) return [...existing, next];
+  const copy = existing.slice();
+  copy[idx] = next;
+  return copy;
+}
 
 function messageToTurnEvent(message: Message): TurnEvent | null {
   if (message.role !== 'assistant') return null;
@@ -159,10 +178,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setCurrentSession: async (id) => {
     set({ currentSessionId: id, sessionSummary: null });
     if (id) {
-      const [messages, summary, telemetry] = await Promise.all([
+      const [messages, summary, telemetry, slots] = await Promise.all([
         listMessagesForSession(tauriDatabase, id),
         summarizeSessionTelemetry(tauriDatabase, id),
         listTelemetryForSession(tauriDatabase, id),
+        listContextSlotsForSession(tauriDatabase, id),
       ]);
       const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
       set((state) => ({
@@ -170,6 +190,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         messages: { ...state.messages, [id]: messages },
         transcripts: { ...state.transcripts, [id]: events },
         sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
+        sessionSlots: { ...state.sessionSlots, [id]: slots },
       }));
     }
   },
@@ -411,6 +432,39 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const records = await listTelemetryForSession(tauriDatabase, sessionId);
     set((state) => ({
       sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: records },
+    }));
+  },
+
+  loadSessionSlots: async (sessionId) => {
+    const slots = await listContextSlotsForSession(tauriDatabase, sessionId);
+    set((state) => ({
+      sessionSlots: { ...state.sessionSlots, [sessionId]: slots },
+    }));
+  },
+
+  upsertSessionSlot: async (sessionId, key, value) => {
+    const existing = get().sessionSlots[sessionId] ?? [];
+    const prev = existing.find((s) => s.key === key);
+    const next: ContextSlot = { key, value, enabled: prev?.enabled ?? true };
+    await upsertContextSlot(tauriDatabase, sessionId, next);
+    set((state) => ({
+      sessionSlots: {
+        ...state.sessionSlots,
+        [sessionId]: mergeSlots(state.sessionSlots[sessionId] ?? [], next),
+      },
+    }));
+  },
+
+  toggleSessionSlot: async (sessionId, key, enabled) => {
+    const existing = get().sessionSlots[sessionId] ?? [];
+    const prev = existing.find((s) => s.key === key);
+    const next: ContextSlot = { key, value: prev?.value ?? '', enabled };
+    await upsertContextSlot(tauriDatabase, sessionId, next);
+    set((state) => ({
+      sessionSlots: {
+        ...state.sessionSlots,
+        [sessionId]: mergeSlots(state.sessionSlots[sessionId] ?? [], next),
+      },
     }));
   },
 

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -5,5 +5,6 @@ export {
   isSlotKey,
   serializeSlots,
   SLOT_KEYS,
+  SLOT_LABELS,
   type SlotKey,
 } from './slots';

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -12,7 +12,7 @@ export type SlotKey = (typeof SLOT_KEYS)[number];
 
 const SLOT_KEY_SET = new Set<string>(SLOT_KEYS);
 
-const SLOT_LABELS: Record<SlotKey, string> = {
+export const SLOT_LABELS: Record<SlotKey, string> = {
   goal: 'goal',
   files_touched: 'files touched',
   decisions: 'decisions',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export {
   ContextEngine,
   InvalidSlotKeyError,
   SLOT_KEYS,
+  SLOT_LABELS,
   assertSlotKey,
   isSlotKey,
   serializeSlots,


### PR DESCRIPTION
## Summary
- right sidebar now renders the 5 synthetic context slots; edit-on-click → commit-on-blur (or cmd/ctrl+enter), esc cancels
- per-slot enabled toggle persists through `upsertContextSlot`
- summarizer status badge wired as ui placeholder (`idle`) until #8 lands the haiku client

## Implementation
- expose `SLOT_LABELS` from `@kay-am/core` for ui labels
- add `sessionSlots` state + `loadSessionSlots` / `upsertSessionSlot` / `toggleSessionSlot` actions to the zustand store
- load slots eagerly on `setCurrentSession` alongside messages/telemetry
- new `ContextPanel` component swapped into the `App` right sidebar; placeholder copy when no session is selected

## Acceptance
- [x] edits persist across reloads (round-trip through db)
- [x] empty slots render placeholder, not hidden
- [x] summarizer status renders (currently always `idle` until #8)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)