### PR TITLE
docs(repo): expand readme with development quickstart (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,19 +49,48 @@ kay-am/
 
 ## Development
 
+### Prerequisites
+
+- **Node.js** ≥ 20 and **pnpm** ≥ 9
+- **Rust** toolchain (`rustup`) — required by Tauri 2; install from <https://rustup.rs>
+- Platform Tauri prereqs — see <https://v2.tauri.app/start/prerequisites/>
+- **Claude CLI** on `PATH` (`claude --version` should print a version) — used as the default provider
+- An **Anthropic API key** if you want to exercise the (upcoming) summarizer
+
+### Quickstart
+
 ```bash
 pnpm install
-pnpm tauri:dev      # run desktop app in dev mode
-pnpm typecheck
-pnpm test
-pnpm build
+pnpm tauri:dev      # launches the desktop app in dev mode
 ```
 
-## Contributing
+Useful commands:
 
-See [CONVENTIONS.md](./CONVENTIONS.md) for monorepo conventions and [CLAUDE.md](./CLAUDE.md) for project rules.
+```bash
+pnpm typecheck      # tsc --noEmit across the monorepo (turbo)
+pnpm test           # vitest across packages
+pnpm build          # vite build (frontend only)
+pnpm lint           # placeholder; lint runs in CI
+```
 
-- Conventional commits (`type(scope): subject`).
+### Smoke test a session end-to-end
+
+1. Run `pnpm tauri:dev` and wait for the boot splash to reach _ready_.
+2. Open **settings** (top-right) → paste your **Anthropic API key**, set the **default editor binary** (e.g. `code`), save.
+3. From the workspace dropdown choose **add workspace…** and pick a local git repository (an existing one is fine — sessions run inside isolated git worktrees).
+4. From the left sidebar, click **+ new session**, give it a goal, accept the branch prefix.
+5. Type a message in the chat input → enter. You should see streamed assistant text, the cost meter ticking, and the `worktree-{slug}` directory created next to the repo.
+6. Use **end session** to close the worktree (the branch is preserved for manual merge).
+
+If the **claude cli missing** banner shows in the header, install the Claude CLI and reopen the app. If **api key missing** shows, click it to jump back into settings.
+
+## Roadmap & contributing
+
+- [ROADMAP.md](./ROADMAP.md) — milestones and the active issue list
+- [CONVENTIONS.md](./CONVENTIONS.md) — monorepo conventions
+- [CLAUDE.md](./CLAUDE.md) — project rules (also enforced via `lefthook` + `commitlint` on commit)
+
+- Conventional commits (`type(scope): subject`), all-lowercase subjects.
 - Branch protection on `main`. PR-only.
 - All changes in English.
 


### PR DESCRIPTION
## Summary
expands the **Development** section of the README now that v0.1 can demo a session end-to-end:

- prerequisites (Node + pnpm, Rust toolchain, Claude CLI, optional Anthropic API key)
- `pnpm install` + `pnpm tauri:dev` quickstart
- step-by-step smoke test that walks through settings → workspace → session → first turn → end session
- pointers to ROADMAP.md, CONVENTIONS.md, CLAUDE.md

## Acceptance
- [x] new contributor can clone → install → run → see a working session by following the README

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)