### PR TITLE
feat(core): summarizer client (anthropic haiku) (#8) + round-trip tests (#30)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -35,6 +35,7 @@ pub fn run() {
       secrets::secret_set,
       secrets::secret_delete,
       secrets::secret_has,
+      secrets::secret_get,
       editor::open_in_editor,
       db::db_exec,
       db::db_execute,

--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -46,3 +46,8 @@ pub fn secret_delete(key: String) -> Result<(), SecretError> {
 pub fn secret_has(key: String) -> Result<bool, SecretError> {
     Ok(read(&key)?.is_some())
 }
+
+#[tauri::command]
+pub fn secret_get(key: String) -> Result<Option<String>, SecretError> {
+    read(&key)
+}

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -2,22 +2,19 @@ import { useEffect, useState } from 'react';
 import { ScrollArea, Textarea, cn } from '@kay-am/ui';
 import { SLOT_KEYS, SLOT_LABELS, type SlotKey } from '@kay-am/core';
 import type { ContextSlot, Session } from '@kay-am/types';
-import { useAppStore, useSessionSlots } from '../store';
+import { useAppStore, useSessionSlots, useSummarizerStatus } from '../store';
 
 interface ContextPanelProps {
   session: Session;
 }
 
-type SummarizerStatus = 'idle' | 'running' | 'error';
+type SummarizerStatusKind = 'idle' | 'running' | 'error';
 
 export function ContextPanel({ session }: ContextPanelProps) {
   const slots = useSessionSlots(session.id);
+  const summarizer = useSummarizerStatus(session.id);
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
   const toggleSessionSlot = useAppStore((s) => s.toggleSessionSlot);
-
-  // summarizer not yet implemented (#8) — placeholder until wired
-  const summarizerStatus: SummarizerStatus = 'idle';
-  const summarizerLastUpdate: string | null = null;
 
   const slotsByKey = new Map<string, ContextSlot>(slots.map((s) => [s.key, s]));
 
@@ -28,7 +25,11 @@ export function ContextPanel({ session }: ContextPanelProps) {
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             context
           </span>
-          <SummarizerBadge status={summarizerStatus} lastUpdate={summarizerLastUpdate} />
+          <SummarizerBadge
+            status={summarizer.status}
+            lastUpdate={summarizer.lastUpdate}
+            error={summarizer.error}
+          />
         </header>
 
         <ul className="flex flex-col gap-3">
@@ -133,23 +134,34 @@ function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
 function SummarizerBadge({
   status,
   lastUpdate,
+  error,
 }: {
-  status: SummarizerStatus;
+  status: SummarizerStatusKind;
   lastUpdate: string | null;
+  error: string | null;
 }) {
-  const styles: Record<SummarizerStatus, string> = {
+  const styles: Record<SummarizerStatusKind, string> = {
     idle: 'bg-muted text-muted-foreground',
     running: 'bg-primary/10 text-primary',
     error: 'bg-danger/10 text-danger',
   };
-  const label = status === 'idle' ? 'summarizer idle' : status;
-  const tooltip = lastUpdate ? `last update: ${lastUpdate}` : 'summarizer not yet wired';
+  const labels: Record<SummarizerStatusKind, string> = {
+    idle: 'summarizer idle',
+    running: 'summarizing…',
+    error: 'summarizer error',
+  };
+  const tooltip =
+    status === 'error' && error
+      ? `last error: ${error}`
+      : lastUpdate
+        ? `last update: ${lastUpdate}`
+        : 'no summarizer run yet — runs after each turn when an api key is set';
   return (
     <span
       title={tooltip}
       className={cn('rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wide', styles[status])}
     >
-      {label}
+      {labels[status]}
     </span>
   );
 }

--- a/apps/desktop/src/secrets.ts
+++ b/apps/desktop/src/secrets.ts
@@ -12,4 +12,8 @@ export async function hasSecret(key: string): Promise<boolean> {
   return await invoke<boolean>('secret_has', { key });
 }
 
+export async function getSecret(key: string): Promise<string | null> {
+  return await invoke<string | null>('secret_get', { key });
+}
+
 export const ANTHROPIC_API_KEY_SECRET = 'anthropic_api_key';

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -1,4 +1,10 @@
-export { useAppStore, type AppActions, type AppState, type BootPhase } from './store';
+export {
+  useAppStore,
+  type AppActions,
+  type AppState,
+  type BootPhase,
+  type SummarizerSessionStatus,
+} from './store';
 export {
   selectCurrentSession,
   selectCurrentWorkspace,
@@ -10,6 +16,7 @@ export {
   useProviderAvailable,
   useSessionSlots,
   useSessions,
+  useSummarizerStatus,
   useWorkspaces,
 } from './selectors';
 export { selectTranscript, useTranscript } from './transcript';

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,5 +1,5 @@
 import type { ContextSlot, Session, SessionId, Workspace } from '@kay-am/types';
-import { useAppStore, type AppState } from './store';
+import { useAppStore, type AppState, type SummarizerSessionStatus } from './store';
 
 export const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
 export const selectCurrentWorkspace = (state: AppState): Workspace | null =>
@@ -20,3 +20,8 @@ const EMPTY_SLOTS: ReadonlyArray<ContextSlot> = [];
 
 export const useSessionSlots = (sessionId: SessionId | null): ReadonlyArray<ContextSlot> =>
   useAppStore((s) => (sessionId ? (s.sessionSlots[sessionId] ?? EMPTY_SLOTS) : EMPTY_SLOTS));
+
+const IDLE_STATUS: SummarizerSessionStatus = { status: 'idle', lastUpdate: null, error: null };
+
+export const useSummarizerStatus = (sessionId: SessionId | null): SummarizerSessionStatus =>
+  useAppStore((s) => (sessionId ? (s.summarizerStatus[sessionId] ?? IDLE_STATUS) : IDLE_STATUS));

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { sessionReducer, type SlotKey } from '@kay-am/core';
+import { sessionReducer, Summarizer, type SlotKey } from '@kay-am/core';
 import {
   getSetting,
   insertMessage,
@@ -40,7 +40,7 @@ import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
 import { getProviderStatus, type ProviderStatus } from '../providers';
 import { validateGitRepo } from '../repo';
-import { ANTHROPIC_API_KEY_SECRET, hasSecret } from '../secrets';
+import { ANTHROPIC_API_KEY_SECRET, getSecret, hasSecret } from '../secrets';
 import {
   SETTING_EDITOR_BINARY,
   SETTING_LAST_SESSION_ID,
@@ -77,6 +77,13 @@ export interface AppState {
   readonly sessionTelemetry: Readonly<Record<string, ReadonlyArray<TelemetryRecord>>>;
   readonly workspaceSummary: TelemetrySummary | null;
   readonly sessionSlots: Readonly<Record<string, ReadonlyArray<ContextSlot>>>;
+  readonly summarizerStatus: Readonly<Record<string, SummarizerSessionStatus>>;
+}
+
+export interface SummarizerSessionStatus {
+  readonly status: 'idle' | 'running' | 'error';
+  readonly lastUpdate: IsoDateTime | null;
+  readonly error: string | null;
 }
 
 export interface AppActions {
@@ -128,6 +135,7 @@ const initialState: AppState = {
   sessionTelemetry: {},
   workspaceSummary: null,
   sessionSlots: {},
+  summarizerStatus: {},
 };
 
 function mergeSlots(
@@ -161,6 +169,99 @@ function applySessionUpdate(set: SetFn, sessionId: SessionId, state: SessionStat
       s.id === sessionId ? { ...s, state, updatedAt: new Date().toISOString() as IsoDateTime } : s,
     ),
   }));
+}
+
+async function runSummarizer(
+  set: SetFn,
+  get: () => AppStore,
+  sessionId: SessionId,
+  turnInput: string,
+  turnOutput: string,
+  apiKey: string,
+): Promise<void> {
+  const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+  set((state) => ({
+    summarizerStatus: {
+      ...state.summarizerStatus,
+      [sessionId]: { status: 'running', lastUpdate: null, error: null },
+    },
+  }));
+
+  try {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+
+    const summarizer = new Summarizer({ apiKey });
+    const prevSlots = get().sessionSlots[sessionId] ?? [];
+    const result = await summarizer.summarize({ prevSlots, turnInput, turnOutput });
+
+    for (const upsert of result.delta.upserts) {
+      const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
+      const next: ContextSlot = {
+        key: upsert.key,
+        value: upsert.value,
+        enabled: existing?.enabled ?? true,
+      };
+      await upsertContextSlot(tauriDatabase, sessionId, next);
+    }
+    const refreshed = await listContextSlotsForSession(tauriDatabase, sessionId);
+    set((state) => ({
+      sessionSlots: { ...state.sessionSlots, [sessionId]: refreshed },
+    }));
+
+    const summarizerRunId = crypto.randomUUID() as ProviderRunId;
+    const startedAt = now();
+    await insertProviderRun(tauriDatabase, {
+      id: summarizerRunId,
+      sessionId,
+      provider: 'anthropic',
+      model: result.model,
+      status: { kind: 'streaming', startedAt },
+      createdAt: startedAt,
+    });
+    await updateProviderRunStatus(tauriDatabase, summarizerRunId, {
+      kind: 'succeeded',
+      finishedAt: now(),
+    });
+    const record: TelemetryRecord = {
+      id: crypto.randomUUID() as TelemetryRecordId,
+      runId: summarizerRunId,
+      sessionId,
+      kind: 'summarizer',
+      provider: 'anthropic',
+      model: result.model,
+      inputTokens: result.usage.inputTokens,
+      outputTokens: result.usage.outputTokens,
+      estimatedCostUsd: result.usage.estimatedCostUsd,
+      recordedAt: now(),
+    };
+    await insertTelemetry(tauriDatabase, record);
+
+    const [sessionSummary, workspaceSummary, telemetry] = await Promise.all([
+      summarizeSessionTelemetry(tauriDatabase, sessionId),
+      summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
+      listTelemetryForSession(tauriDatabase, sessionId),
+    ]);
+    set((state) => ({
+      sessionSummary,
+      workspaceSummary,
+      sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: telemetry },
+      summarizerStatus: {
+        ...state.summarizerStatus,
+        [sessionId]: { status: 'idle', lastUpdate: now(), error: null },
+      },
+    }));
+  } catch (err) {
+    // never log api key — only the error message
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[summarizer] failed for session ${sessionId}: ${message}`);
+    set((state) => ({
+      summarizerStatus: {
+        ...state.summarizerStatus,
+        [sessionId]: { status: 'error', lastUpdate: now(), error: message },
+      },
+    }));
+  }
 }
 
 export const useAppStore = create<AppStore>((set, get) => ({
@@ -480,6 +581,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
         createdAt: now(),
       };
       await insertMessage(tauriDatabase, assistantMessage);
+    }
+
+    if (!lastError && assistantText.length > 0) {
+      const apiKey = await getSecret(ANTHROPIC_API_KEY_SECRET);
+      if (apiKey) {
+        void runSummarizer(set, get, sessionId, content, assistantText, apiKey);
+      }
     }
 
     if (lastError) throw lastError;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,3 +21,16 @@ export {
 
 export { computeCostUsd, priceFor } from './providers/claude/cost';
 export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';
+
+export {
+  Summarizer,
+  HAIKU_MODEL,
+  SummarizerHttpError,
+  SummarizerParseError,
+  type ContextSlotDelta,
+  type ContextSlotDeltaUpsert,
+  type SummarizeInput,
+  type SummarizerDeps,
+  type SummarizerResult,
+  type SummarizerUsage,
+} from './summarizer';

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+import { HAIKU_MODEL, Summarizer, SummarizerHttpError, SummarizerParseError } from './client';
+
+function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  });
+}
+
+interface Usage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens?: number;
+}
+
+function makeAnthropicReply(text: string, usage: Usage = { input_tokens: 100, output_tokens: 20 }) {
+  return {
+    content: [{ type: 'text', text }],
+    usage,
+    model: HAIKU_MODEL,
+  };
+}
+
+describe('Summarizer', () => {
+  it('rejects construction without an api key', () => {
+    expect(() => new Summarizer({ apiKey: '' })).toThrow(/api key/);
+    expect(() => new Summarizer({ apiKey: '   ' })).toThrow(/api key/);
+  });
+
+  it('sends the expected request shape to the anthropic api', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(makeAnthropicReply(JSON.stringify({ upserts: [] }))),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk-ant-test', fetchFn });
+
+    await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'do the thing',
+      turnOutput: 'did the thing',
+    });
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const call = fetchFn.mock.calls[0]!;
+    const url = call[0];
+    const init = call[1] as RequestInit;
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-test');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe(HAIKU_MODEL);
+    expect(body.system).toContain('exactly five slots');
+    expect(body.messages[0].content).toContain('do the thing');
+    expect(body.messages[0].content).toContain('did the thing');
+  });
+
+  it('parses a valid delta and returns normalized usage + cost', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(
+        makeAnthropicReply(
+          JSON.stringify({
+            upserts: [
+              { key: 'goal', value: 'refactor auth' },
+              { key: 'decisions', value: '- use jwt\n- 24h ttl' },
+            ],
+          }),
+          { input_tokens: 1_000_000, output_tokens: 500_000, cache_read_input_tokens: 0 },
+        ),
+      ),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const result = await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'plan auth',
+      turnOutput: 'jwt 24h',
+    });
+
+    expect(result.delta.upserts).toEqual([
+      { key: 'goal', value: 'refactor auth' },
+      { key: 'decisions', value: '- use jwt\n- 24h ttl' },
+    ]);
+    expect(result.usage.inputTokens).toBe(1_000_000);
+    expect(result.usage.outputTokens).toBe(500_000);
+    // haiku pricing: $1 / MTok in, $5 / MTok out → 1 + 2.5 = 3.5
+    expect(result.usage.estimatedCostUsd).toBeCloseTo(3.5);
+    expect(result.model).toBe(HAIKU_MODEL);
+  });
+
+  it('strips ```json code fences before parsing', async () => {
+    const fenced = '```json\n{ "upserts": [{"key": "goal", "value": "x"}] }\n```';
+    const fetchFn = vi.fn<typeof fetch>(async () => jsonResponse(makeAnthropicReply(fenced)));
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const result = await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'a',
+      turnOutput: 'b',
+    });
+    expect(result.delta.upserts).toEqual([{ key: 'goal', value: 'x' }]);
+  });
+
+  it('drops upsert entries with unknown slot keys', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(
+        makeAnthropicReply(
+          JSON.stringify({
+            upserts: [
+              { key: 'goal', value: 'ok' },
+              { key: 'mystery_slot', value: 'nope' },
+              { key: 'decisions', value: 'keep' },
+            ],
+          }),
+        ),
+      ),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const result = await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'a',
+      turnOutput: 'b',
+    });
+    expect(result.delta.upserts.map((u) => u.key)).toEqual(['goal', 'decisions']);
+  });
+
+  it('throws SummarizerParseError on non-json response', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(makeAnthropicReply('hello, not json')),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    await expect(
+      summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' }),
+    ).rejects.toBeInstanceOf(SummarizerParseError);
+  });
+
+  it('throws SummarizerParseError when upserts is missing', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(makeAnthropicReply(JSON.stringify({ other: 'shape' }))),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    await expect(
+      summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' }),
+    ).rejects.toBeInstanceOf(SummarizerParseError);
+  });
+
+  it('throws SummarizerHttpError on non-2xx response', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => new Response('rate limited', { status: 429 }));
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const err = await summarizer
+      .summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(SummarizerHttpError);
+    expect((err as SummarizerHttpError).status).toBe(429);
+    expect((err as SummarizerHttpError).body).toBe('rate limited');
+  });
+
+  it('does not log or expose the api key on errors', async () => {
+    const apiKey = 'sk-ant-very-secret';
+    const fetchFn = vi.fn<typeof fetch>(async () => new Response('boom', { status: 500 }));
+    const summarizer = new Summarizer({ apiKey, fetchFn });
+    let captured: SummarizerHttpError | null = null;
+    try {
+      await summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' });
+    } catch (e) {
+      captured = e as SummarizerHttpError;
+    }
+    expect(captured).not.toBeNull();
+    expect(captured!.message).not.toContain(apiKey);
+    expect(captured!.body).not.toContain(apiKey);
+  });
+
+  it('includes previous slot values in the prompt body', async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      jsonResponse(makeAnthropicReply(JSON.stringify({ upserts: [] }))),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    await summarizer.summarize({
+      prevSlots: [{ key: 'goal', value: 'auth refactor', enabled: true }],
+      turnInput: 'q',
+      turnOutput: 'a',
+    });
+    const init = fetchFn.mock.calls[0]![1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.messages[0].content).toContain('goal: auth refactor');
+  });
+});

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,0 +1,217 @@
+import type { ContextSlot, IsoDateTime } from '@kay-am/types';
+import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
+import { computeCostUsd } from '../providers/claude/cost';
+
+export const HAIKU_MODEL = 'claude-haiku-4-5';
+const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_API_VERSION = '2023-06-01';
+const DEFAULT_MAX_TOKENS = 512;
+
+export type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
+
+export type ContextSlotDelta = Readonly<{
+  upserts: ReadonlyArray<ContextSlotDeltaUpsert>;
+}>;
+
+export interface SummarizerUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly estimatedCostUsd: number;
+}
+
+export interface SummarizeInput {
+  readonly prevSlots: ReadonlyArray<ContextSlot>;
+  readonly turnInput: string;
+  readonly turnOutput: string;
+}
+
+export interface SummarizerResult {
+  readonly delta: ContextSlotDelta;
+  readonly usage: SummarizerUsage;
+  readonly model: string;
+}
+
+export interface SummarizerDeps {
+  readonly apiKey: string;
+  readonly model?: string;
+  readonly fetchFn?: typeof fetch;
+  readonly now?: () => IsoDateTime;
+  readonly maxTokens?: number;
+}
+
+export class SummarizerHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string,
+  ) {
+    super(`anthropic api error: ${status}`);
+    this.name = 'SummarizerHttpError';
+  }
+}
+
+export class SummarizerParseError extends Error {
+  constructor(
+    message: string,
+    public readonly raw: string,
+  ) {
+    super(message);
+    this.name = 'SummarizerParseError';
+  }
+}
+
+interface AnthropicMessageResponse {
+  readonly content?: ReadonlyArray<{ type: string; text?: string }>;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+  };
+  readonly model?: string;
+}
+
+const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session.
+
+There are exactly five slots, each with a stable key:
+${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
+
+You will receive the previous slot values plus the most recent user turn and assistant turn.
+Decide which slots, if any, should change. Keep values terse: a sentence or short bullet list per slot.
+
+You MUST respond with a single JSON object and nothing else. No prose, no markdown, no code fences.
+The schema is:
+{ "upserts": [ { "key": "<one of the five keys>", "value": "<new slot value>" } ] }
+
+Only include slots that should change. Omit slots that stay the same. Never invent new keys.
+If nothing should change, return { "upserts": [] }.`;
+
+export class Summarizer {
+  private readonly apiKey: string;
+  private readonly model: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly maxTokens: number;
+
+  constructor(deps: SummarizerDeps) {
+    if (!deps.apiKey || deps.apiKey.trim().length === 0) {
+      throw new Error('summarizer requires an anthropic api key');
+    }
+    this.apiKey = deps.apiKey;
+    this.model = deps.model ?? HAIKU_MODEL;
+    this.fetchFn = deps.fetchFn ?? fetch;
+    this.maxTokens = deps.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  async summarize(input: SummarizeInput): Promise<SummarizerResult> {
+    const userMessage = buildUserPrompt(input);
+
+    const response = await this.fetchFn(ANTHROPIC_MESSAGES_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': ANTHROPIC_API_VERSION,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: this.maxTokens,
+        system: SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: userMessage }],
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await safeReadText(response);
+      throw new SummarizerHttpError(response.status, body);
+    }
+
+    const payload = (await response.json()) as AnthropicMessageResponse;
+    const text = (payload.content ?? [])
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('')
+      .trim();
+
+    const delta = parseDelta(text);
+    const usage = this.normalizeUsage(payload);
+
+    return { delta, usage, model: payload.model ?? this.model };
+  }
+
+  private normalizeUsage(payload: AnthropicMessageResponse): SummarizerUsage {
+    const inputTokens = payload.usage?.input_tokens ?? 0;
+    const outputTokens = payload.usage?.output_tokens ?? 0;
+    const cachedInputTokens = payload.usage?.cache_read_input_tokens ?? 0;
+    const estimatedCostUsd = computeCostUsd(
+      { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd: 0 },
+      this.model,
+    );
+    return { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd };
+  }
+}
+
+function buildUserPrompt(input: SummarizeInput): string {
+  const slotLines = SLOT_KEYS.map((key) => {
+    const slot = input.prevSlots.find((s) => s.key === key);
+    const value = slot?.enabled ? slot.value || '(empty)' : '(empty)';
+    return `${key}: ${value}`;
+  }).join('\n');
+
+  return [
+    'Current slot values:',
+    slotLines,
+    '',
+    'User turn:',
+    input.turnInput,
+    '',
+    'Assistant turn:',
+    input.turnOutput,
+    '',
+    'Return the JSON object now.',
+  ].join('\n');
+}
+
+function parseDelta(raw: string): ContextSlotDelta {
+  const stripped = stripCodeFences(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (err) {
+    throw new SummarizerParseError(
+      `summarizer response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      raw,
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || !('upserts' in parsed)) {
+    throw new SummarizerParseError('summarizer response missing "upserts" array', raw);
+  }
+  const candidate = (parsed as { upserts: unknown }).upserts;
+  if (!Array.isArray(candidate)) {
+    throw new SummarizerParseError('summarizer "upserts" was not an array', raw);
+  }
+
+  const upserts: ContextSlotDeltaUpsert[] = [];
+  for (const entry of candidate) {
+    if (typeof entry !== 'object' || entry === null) continue;
+    const e = entry as Record<string, unknown>;
+    const key = e.key;
+    const value = e.value;
+    if (typeof key !== 'string' || !isSlotKey(key)) continue;
+    if (typeof value !== 'string') continue;
+    upserts.push({ key, value });
+  }
+  return { upserts };
+}
+
+function stripCodeFences(raw: string): string {
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(raw.trim());
+  return (fenced?.[1] ?? raw).trim();
+}
+
+async function safeReadText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -1,0 +1,12 @@
+export {
+  Summarizer,
+  HAIKU_MODEL,
+  SummarizerParseError,
+  SummarizerHttpError,
+  type ContextSlotDelta,
+  type ContextSlotDeltaUpsert,
+  type SummarizeInput,
+  type SummarizerDeps,
+  type SummarizerResult,
+  type SummarizerUsage,
+} from './client';

--- a/packages/core/src/summarizer/round-trip.test.ts
+++ b/packages/core/src/summarizer/round-trip.test.ts
@@ -1,0 +1,233 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it, vi } from 'vitest';
+import { migrate, type Database as DbInterface } from '@kay-am/db';
+import type { SessionId, WorkspaceId } from '@kay-am/types';
+import { ContextEngine } from '../context/engine';
+import { SLOT_KEYS } from '../context/slots';
+import { HAIKU_MODEL, Summarizer } from './client';
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+async function seedSession(db: DbInterface, sessionId: SessionId): Promise<void> {
+  const workspaceId = 'ws_round' as WorkspaceId;
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [workspaceId, 'demo', '/tmp/demo', 0, 0],
+  );
+  await db.execute(
+    `INSERT INTO sessions
+       (id, workspace_id, goal, state_kind, state_payload, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [sessionId, workspaceId, 'demo', 'idle', '{"lastActivityAt":"2026-05-07T00:00:00Z"}', 0, 0],
+  );
+}
+
+function fakeAnthropicReply(upserts: ReadonlyArray<{ key: string; value: string }>) {
+  return new Response(
+    JSON.stringify({
+      content: [{ type: 'text', text: JSON.stringify({ upserts }) }],
+      usage: { input_tokens: 100, output_tokens: 20 },
+      model: HAIKU_MODEL,
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+async function applyDelta(
+  engine: ContextEngine,
+  sessionId: SessionId,
+  upserts: ReadonlyArray<{ key: string; value: string }>,
+): Promise<void> {
+  for (const upsert of upserts) {
+    await engine.upsert(sessionId, upsert.key, upsert.value);
+  }
+}
+
+describe('synthetic context engine round-trip', () => {
+  it('all 5 slots empty → summarizer fills them all', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_empty' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const fakeUpserts = SLOT_KEYS.map((key) => ({ key, value: `seeded ${key}` }));
+    const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply(fakeUpserts));
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const before = await engine.load(sessionId);
+    expect(before).toHaveLength(0);
+
+    const result = await summarizer.summarize({
+      prevSlots: before,
+      turnInput: 'kick off',
+      turnOutput: 'ack',
+    });
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    expect(after.map((s) => s.key).sort()).toEqual([...SLOT_KEYS].sort());
+    for (const slot of after) {
+      expect(slot.value).toBe(`seeded ${slot.key}`);
+    }
+  });
+
+  it('partial state → summarizer updates some, leaves others alone', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_partial' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    await engine.upsert(sessionId, 'goal', 'original goal');
+    await engine.upsert(sessionId, 'decisions', 'original decision');
+
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      fakeAnthropicReply([
+        { key: 'goal', value: 'updated goal' },
+        { key: 'open_questions', value: 'how to test?' },
+      ]),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const before = await engine.load(sessionId);
+    const result = await summarizer.summarize({
+      prevSlots: before,
+      turnInput: 'q',
+      turnOutput: 'a',
+    });
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    const byKey = new Map(after.map((s) => [s.key, s.value]));
+    expect(byKey.get('goal')).toBe('updated goal');
+    expect(byKey.get('decisions')).toBe('original decision');
+    expect(byKey.get('open_questions')).toBe('how to test?');
+  });
+
+  it('full state → empty delta keeps slots untouched', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_full' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    for (const key of SLOT_KEYS) {
+      await engine.upsert(sessionId, key, `pre-${key}`);
+    }
+
+    const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply([]));
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const before = await engine.load(sessionId);
+    const result = await summarizer.summarize({
+      prevSlots: before,
+      turnInput: 'noop',
+      turnOutput: 'noop',
+    });
+    expect(result.delta.upserts).toEqual([]);
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    expect(after.map((s) => s.value).sort()).toEqual(SLOT_KEYS.map((k) => `pre-${k}`).sort());
+  });
+
+  it('preserves stable keys (no key drift after multiple round-trips)', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_drift' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const summarizerWith = (upserts: ReadonlyArray<{ key: string; value: string }>) => {
+      const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply(upserts));
+      return new Summarizer({ apiKey: 'sk', fetchFn });
+    };
+
+    for (let i = 0; i < 5; i += 1) {
+      const summarizer = summarizerWith([{ key: 'goal', value: `iteration ${i}` }]);
+      const slots = await engine.load(sessionId);
+      const result = await summarizer.summarize({
+        prevSlots: slots,
+        turnInput: `q${i}`,
+        turnOutput: `a${i}`,
+      });
+      await applyDelta(engine, sessionId, result.delta.upserts);
+    }
+
+    const after = await engine.load(sessionId);
+    expect(after).toHaveLength(1);
+    expect(after[0]?.key).toBe('goal');
+    expect(after[0]?.value).toBe('iteration 4');
+  });
+
+  it('handles oversize values without truncation', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_huge' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const huge = 'x'.repeat(50_000);
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      fakeAnthropicReply([{ key: 'last_output_summary', value: huge }]),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const result = await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'q',
+      turnOutput: 'a',
+    });
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    const slot = after.find((s) => s.key === 'last_output_summary');
+    expect(slot?.value.length).toBe(50_000);
+  });
+
+  it('drops summarizer-suggested keys outside the known set', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_unknown_key' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const fetchFn = vi.fn<typeof fetch>(async () =>
+      fakeAnthropicReply([
+        { key: 'goal', value: 'ok' },
+        { key: 'mystery_slot', value: 'should be dropped' },
+      ]),
+    );
+    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+
+    const result = await summarizer.summarize({
+      prevSlots: [],
+      turnInput: 'q',
+      turnOutput: 'a',
+    });
+
+    expect(result.delta.upserts.map((u) => u.key)).toEqual(['goal']);
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    expect(after.map((s) => s.key)).toEqual(['goal']);
+  });
+});


### PR DESCRIPTION
## Summary
new `Summarizer` in `@kay-am/core` that posts the previous slots + last user/assistant turn to the Anthropic Messages API against `claude-haiku-4-5`, parses a strict-JSON response into a typed `ContextSlotDelta`, and reports normalized usage + USD cost. graceful degradation on parse errors and non-2xx responses; the api key is never exposed in error messages or bodies.

closes both #8 (the client itself) and #30 (round-trip suite over `ContextEngine`).

## Coverage
- **client.test.ts** — 10 tests: request shape, valid/invalid responses, code-fence stripping, unknown-key drops, http error surface, api-key safety
- **round-trip.test.ts** — 6 tests: empty / partial / full slot states, oversize values, no key drift across iterations, summarizer-suggested unknown keys are dropped before write

## Desktop integration
- new `secret_get` tauri command (read-only mirror of `secret_set`) so the store can pull the api key from the keychain when running the summarizer; the key is never logged
- `sendTurn` now fires `runSummarizer` in the background after a successful turn — applies the delta via `upsertContextSlot`, reloads `sessionSlots`, and records a `summarizer`-kind telemetry row tied to a fresh `provider_run`
- new `summarizerStatus` state slice (idle / running / error per session) and `useSummarizerStatus` selector
- `ContextPanel` summarizer badge now reflects real state with an error tooltip; the `#8 placeholder` copy is gone

## Acceptance — #8
- [x] receives `(prevSlots, turnInput, turnOutput)` → returns delta
- [x] api key sourced from os keychain (write-only set, read by request only, never logged)
- [x] unit tested with stub fetch

## Acceptance — #30
- [x] round-trip preserves stable keys
- [x] edge cases (oversize, empty) handled

Closes #8
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)