### PR TITLE
feat(desktop): providers panel + telemetry fix + v0.2 roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ coverage/
 
 # misc
 *.tsbuildinfo
+.claude/launch.json

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ kay-am/
 ### Prerequisites
 
 - **Node.js** ≥ 20 and **pnpm** ≥ 9
-- **Rust** toolchain (`rustup`) — required by Tauri 2; install from <https://rustup.rs>
+- **Rust** toolchain (`rustup`) — required by Tauri 2; install from <https://rustup.rs>. After installing, make sure `cargo` is on your shell `PATH` — `rustup` writes the env to `$HOME/.cargo/env`, which most shells don't auto-source. Either add `source "$HOME/.cargo/env"` to your `~/.zshrc` / `~/.bashrc`, or restart your terminal after install. Verify with `cargo --version` (Tauri shells out to `cargo metadata` and will fail with `os error 2` if it's missing).
 - Platform Tauri prereqs — see <https://v2.tauri.app/start/prerequisites/>
 - **Claude CLI** on `PATH` (`claude --version` should print a version) — used as the default provider
-- An **Anthropic API key** if you want to exercise the (upcoming) summarizer
+- An **Anthropic API key** if you want to exercise the summarizer (configurable from in-app settings, stored in the OS keychain)
 
 ### Quickstart
 
 ```bash
 pnpm install
-pnpm tauri:dev      # launches the desktop app in dev mode
+pnpm tauri:dev      # launches the desktop app in dev mode (root alias for the desktop workspace)
 ```
 
 Useful commands:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -167,6 +167,51 @@ After #1, #2, #3, #5, #6, #11, #12, #13, #17, #18, #20, #21, #22 (≈ 40% of v0.
 
 ---
 
+## v0.2 issue index
+
+Cursor + Codex adapters, summarizer refactor (drop API-key path → use active-provider CLI), provider connection UX.
+
+### Foundation (parallelizable)
+
+- [#66 — feat(types): provider registry + capability matrix types](https://github.com/akhayam99/kay-am/issues/66)
+- [#67 — feat(types): session provider preference types](https://github.com/akhayam99/kay-am/issues/67) — depends on #66
+
+### Core layer
+
+- [#68 — feat(core): cursor adapter (CLI spawn + stream parse)](https://github.com/akhayam99/kay-am/issues/68) — depends on #66
+- [#69 — feat(core): codex adapter (CLI spawn + stream parse)](https://github.com/akhayam99/kay-am/issues/69) — depends on #66
+- [#70 — feat(core): provider registry (unified factory)](https://github.com/akhayam99/kay-am/issues/70) — depends on #66, #68, #69
+- [#71 — refactor(core): summarizer uses active-provider CLI (drop ANTHROPIC_API_KEY)](https://github.com/akhayam99/kay-am/issues/71) — depends on #70
+
+### Tauri commands
+
+- [#72 — feat(desktop): detect cursor + codex binaries (rust)](https://github.com/akhayam99/kay-am/issues/72)
+- [#73 — feat(desktop): provider auth state check (rust)](https://github.com/akhayam99/kay-am/issues/73) — depends on #72
+- [#74 — feat(desktop): provider connect (open external terminal with login command)](https://github.com/akhayam99/kay-am/issues/74) — depends on #72
+
+### UI
+
+- [#75 — feat(desktop): provider panel in Settings (detect/install/connect/logout)](https://github.com/akhayam99/kay-am/issues/75) — depends on #72, #73, #74
+- [#76 — feat(desktop): per-session provider preference picker](https://github.com/akhayam99/kay-am/issues/76) — depends on #67, #70, #75
+- [#77 — feat(desktop): per-turn provider override](https://github.com/akhayam99/kay-am/issues/77) — depends on #76
+- [#79 — feat(desktop): pre-flight auth check + guided error on turn](https://github.com/akhayam99/kay-am/issues/79) — depends on #73, #75
+
+### Docs
+
+- [#78 — docs(repo): provider integration guide](https://github.com/akhayam99/kay-am/issues/78) — depends on #74, #75
+
+### Critical path
+
+```
+#66 → #68 → #70 → #71  →  summarizer migrated, anthropic-key gone
+       ↘ #69 ↗
+#66 → #67 → #76 → #77  →  per-session + per-turn provider choice
+#72 → #73 → #75
+        ↘ #74 ↗
+```
+
+---
+
 ## How to read this roadmap
 
 - One issue ≈ 1–4 hours of focused implementation work.

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -13,13 +13,13 @@ name = "kay_am_desktop_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2.6.1" }
+tauri-build = { version = "2.6.1", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.11.1" }
+tauri = { version = "2.11.1", features = [] }
 tauri-plugin-log = "2"
 keyring = { version = "3", features = ["apple-native", "linux-native", "windows-native"] }
 thiserror = "2"

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,21 +3,20 @@ import { AppShell, Button, KbdPill } from '@kay-am/ui';
 import { BootSplash } from './components/BootSplash';
 import { ChatView } from './components/chat/ChatView';
 import { ContextPanel } from './components/ContextPanel';
+import { ProvidersChip } from './components/ProvidersChip';
 import { SessionsSidebar } from './components/SessionsSidebar';
 import { SettingsDialog } from './components/SettingsDialog';
 import { TelemetryPill } from './components/TelemetryPill';
 import { WorkspaceSelector } from './components/WorkspaceSelector';
-import { useAppStore, useCurrentSession, useCurrentWorkspace, useProviderAvailable } from './store';
+import { useAppStore, useCurrentSession, useCurrentWorkspace } from './store';
 
 export function App() {
   const hydrate = useAppStore((s) => s.hydrate);
   const hydrated = useAppStore((s) => s.hydrated);
   const bootPhase = useAppStore((s) => s.bootPhase);
   const error = useAppStore((s) => s.error);
-  const apiKeyPresent = useAppStore((s) => s.apiKeyPresent);
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
-  const providerAvailable = useProviderAvailable();
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
@@ -36,21 +35,7 @@ export function App() {
             <span className="font-semibold tracking-tight">kAY.am</span>
             <WorkspaceSelector />
             <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
-              {!providerAvailable ? (
-                <span className="rounded-full bg-danger/10 px-2 py-0.5 text-danger">
-                  claude cli missing
-                </span>
-              ) : null}
-              {!apiKeyPresent ? (
-                <button
-                  type="button"
-                  onClick={() => setSettingsOpen(true)}
-                  className="rounded-full bg-danger/10 px-2 py-0.5 text-danger hover:bg-danger/20"
-                  title="open settings to add your anthropic api key"
-                >
-                  api key missing
-                </button>
-              ) : null}
+              <ProvidersChip onOpenSettings={() => setSettingsOpen(true)} />
               <TelemetryPill />
               <Button
                 variant="ghost"

--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@kay-am/ui';
+import { useAppStore } from '../store';
+
+interface ProvidersChipProps {
+  onOpenSettings: () => void;
+}
+
+export function ProvidersChip({ onOpenSettings }: ProvidersChipProps) {
+  const providers = useAppStore((s) => s.providers);
+  const active = providers.filter((p) => p.state !== 'coming-soon');
+  const connected = active.filter((p) => p.state === 'connected').length;
+  const total = active.length;
+  const allOk = total > 0 && connected === total;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpenSettings}
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border border-border px-2 py-0.5 text-xs hover:bg-muted',
+        allOk ? 'text-muted-foreground' : 'text-danger',
+      )}
+      title="open settings → providers"
+    >
+      <span
+        aria-hidden
+        className={cn('inline-block h-1.5 w-1.5 rounded-full', allOk ? 'bg-primary' : 'bg-danger')}
+      />
+      <span>
+        {connected}/{total} providers
+      </span>
+    </button>
+  );
+}

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Button, cn } from '@kay-am/ui';
+import type { ProviderConnectionState, ProviderInfo } from '../providers';
+import { useAppStore } from '../store';
+
+const STATE_LABEL: Record<ProviderConnectionState, string> = {
+  connected: 'connected',
+  missing: 'not installed',
+  error: 'error',
+  'coming-soon': 'integration in v0.2',
+};
+
+const STATE_DOT: Record<ProviderConnectionState, string> = {
+  connected: 'bg-primary',
+  missing: 'bg-danger',
+  error: 'bg-danger',
+  'coming-soon': 'bg-muted-foreground/40',
+};
+
+export function ProvidersPanel() {
+  const providers = useAppStore((s) => s.providers);
+  const refreshProviders = useAppStore((s) => s.refreshProviders);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const onRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await refreshProviders();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-medium text-muted-foreground">providers</div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void onRefresh()}
+          disabled={refreshing}
+          title="re-detect installed CLIs"
+        >
+          {refreshing ? 'refreshing…' : 'refresh'}
+        </Button>
+      </div>
+      <ul className="flex flex-col divide-y divide-border rounded border border-border">
+        {providers.map((p) => (
+          <ProviderRow key={p.id} info={p} />
+        ))}
+      </ul>
+      <p className="text-[11px] text-muted-foreground">
+        kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run{' '}
+        <code className="rounded bg-muted px-1">claude</code> in a terminal once).
+      </p>
+    </div>
+  );
+}
+
+function ProviderRow({ info }: { info: ProviderInfo }) {
+  const placeholder = info.state === 'coming-soon';
+  return (
+    <li
+      className={cn('flex items-center gap-3 px-3 py-2 text-xs', placeholder ? 'opacity-60' : '')}
+    >
+      <span
+        aria-hidden
+        className={cn('inline-block h-2 w-2 rounded-full', STATE_DOT[info.state])}
+      />
+      <div className="flex flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{info.label}</span>
+          <code className="text-[10px] text-muted-foreground">{info.binary}</code>
+          {info.version ? (
+            <span className="text-[10px] text-muted-foreground">{info.version}</span>
+          ) : null}
+        </div>
+        <div className="text-[11px] text-muted-foreground">
+          {STATE_LABEL[info.state]}
+          {info.error ? <span className="text-danger"> — {info.error}</span> : null}
+        </div>
+      </div>
+      <RowActions info={info} />
+    </li>
+  );
+}
+
+function RowActions({ info }: { info: ProviderInfo }) {
+  if (info.state === 'coming-soon') {
+    return info.trackingIssueUrl ? (
+      <a
+        href={info.trackingIssueUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="text-[11px] text-muted-foreground underline hover:text-foreground"
+      >
+        track ↗
+      </a>
+    ) : null;
+  }
+  if (info.state === 'connected') {
+    return null;
+  }
+  return (
+    <a
+      href={info.docsUrl}
+      target="_blank"
+      rel="noreferrer"
+      className="text-[11px] text-primary underline hover:opacity-80"
+    >
+      install ↗
+    </a>
+  );
+}

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, Input } from '@kay-am/ui';
+import { ProvidersPanel } from './ProvidersPanel';
 import { ANTHROPIC_API_KEY_SECRET, deleteSecret, hasSecret, setSecret } from '../secrets';
 import {
   DEFAULT_BRANCH_PREFIX,
@@ -80,19 +81,19 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }
   };
 
-  const summarizerHint = 'needs summarizer client (#8) — wired once available';
-
   return (
     <Dialog open={open} onClose={onClose} title="settings" className="min-w-96">
       <div className="flex flex-col gap-4">
+        <ProvidersPanel />
+
         <Section
-          label="anthropic api key"
+          label="anthropic api key (summarizer only)"
           help={
             apiKeySet === null
               ? 'checking keychain…'
               : apiKeySet
-                ? 'key present in keychain (write-only)'
-                : 'no key stored yet'
+                ? 'key present in keychain (write-only) — used by post-turn summarizer (Haiku). Removed in v0.2 (#71).'
+                : 'optional. enables auto context-slot updates via Haiku (~$0.0015/turn). slots stay editable by hand without it.'
           }
         >
           <div className="flex gap-2">
@@ -139,12 +140,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             placeholder={DEFAULT_BRANCH_PREFIX}
             disabled={!workspace}
           />
-        </Section>
-
-        <Section label="test summarizer" help={summarizerHint}>
-          <Button variant="ghost" size="sm" disabled title={summarizerHint}>
-            run test
-          </Button>
         </Section>
 
         {error ? <p className="text-xs text-danger">{error}</p> : null}

--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@kay-am/ui';
+import type { TelemetryRecord } from '@kay-am/types';
 import { useAppStore } from '../store';
+
+const EMPTY_TELEMETRY: ReadonlyArray<TelemetryRecord> = [];
 
 const formatCost = (usd: number): string => `$${usd.toFixed(4)}`;
 const formatTokens = (n: number): string =>
@@ -17,7 +20,7 @@ export function TelemetryPill() {
   const workspaceSummary = useAppStore((s) => s.workspaceSummary);
   const currentSessionId = useAppStore((s) => s.currentSessionId);
   const sessionTelemetry = useAppStore((s) =>
-    currentSessionId ? (s.sessionTelemetry[currentSessionId] ?? []) : [],
+    currentSessionId ? (s.sessionTelemetry[currentSessionId] ?? EMPTY_TELEMETRY) : EMPTY_TELEMETRY,
   );
 
   const [open, setOpen] = useState(false);

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 
+export type ProviderId = 'anthropic' | 'cursor' | 'codex';
+
 export interface ProviderStatus {
   readonly id: string;
   readonly binary: string;
@@ -8,10 +10,83 @@ export interface ProviderStatus {
   readonly error: string | null;
 }
 
+export type ProviderConnectionState = 'connected' | 'missing' | 'error' | 'coming-soon';
+
+export interface ProviderInfo {
+  readonly id: ProviderId;
+  readonly label: string;
+  readonly binary: string;
+  readonly state: ProviderConnectionState;
+  readonly version: string | null;
+  readonly error: string | null;
+  readonly docsUrl: string;
+  readonly trackingIssueUrl?: string;
+}
+
+const PROVIDER_LABEL: Record<ProviderId, string> = {
+  anthropic: 'claude',
+  cursor: 'cursor',
+  codex: 'codex',
+};
+
+const PROVIDER_DOCS: Record<ProviderId, string> = {
+  anthropic: 'https://docs.claude.com/en/docs/claude-code/overview',
+  cursor: 'https://docs.cursor.com/cli',
+  codex: 'https://github.com/openai/codex',
+};
+
+const TRACKING_ISSUES: Partial<Record<ProviderId, string>> = {
+  cursor: 'https://github.com/akhayam99/kay-am/issues/68',
+  codex: 'https://github.com/akhayam99/kay-am/issues/69',
+};
+
 export async function getProviderStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('get_provider_status');
 }
 
 export async function refreshProviderStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('refresh_provider_status');
+}
+
+function claudeInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+  const id: ProviderId = 'anthropic';
+  const base = {
+    id,
+    label: PROVIDER_LABEL[id],
+    binary: status?.binary ?? 'claude',
+    docsUrl: PROVIDER_DOCS[id],
+  };
+  if (!status) {
+    return { ...base, state: 'missing', version: null, error: null };
+  }
+  if (status.available) {
+    return { ...base, state: 'connected', version: status.version, error: null };
+  }
+  return {
+    ...base,
+    state: status.error ? 'error' : 'missing',
+    version: null,
+    error: status.error,
+  };
+}
+
+function placeholder(id: ProviderId, binary: string): ProviderInfo {
+  return {
+    id,
+    label: PROVIDER_LABEL[id],
+    binary,
+    state: 'coming-soon',
+    version: null,
+    error: null,
+    docsUrl: PROVIDER_DOCS[id],
+    trackingIssueUrl: TRACKING_ISSUES[id],
+  };
+}
+
+export function buildProviderList(claude: ProviderStatus | null): ReadonlyArray<ProviderInfo> {
+  return [
+    claudeInfoFromStatus(claude),
+    placeholder('cursor', 'cursor-agent'),
+    placeholder('codex', 'codex'),
+  ];
 }

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -8,12 +8,10 @@ export {
 export {
   selectCurrentSession,
   selectCurrentWorkspace,
-  selectProviderAvailable,
   selectSessions,
   selectWorkspaces,
   useCurrentSession,
   useCurrentWorkspace,
-  useProviderAvailable,
   useSessionSlots,
   useSessions,
   useSummarizerStatus,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -7,14 +7,10 @@ export const selectCurrentWorkspace = (state: AppState): Workspace | null =>
 export const selectSessions = (state: AppState): ReadonlyArray<Session> => state.sessions;
 export const selectCurrentSession = (state: AppState): Session | null =>
   state.sessions.find((s) => s.id === state.currentSessionId) ?? null;
-export const selectProviderAvailable = (state: AppState): boolean =>
-  state.providerStatus?.available === true;
-
 export const useWorkspaces = (): ReadonlyArray<Workspace> => useAppStore(selectWorkspaces);
 export const useCurrentWorkspace = (): Workspace | null => useAppStore(selectCurrentWorkspace);
 export const useSessions = (): ReadonlyArray<Session> => useAppStore(selectSessions);
 export const useCurrentSession = (): Session | null => useAppStore(selectCurrentSession);
-export const useProviderAvailable = (): boolean => useAppStore(selectProviderAvailable);
 
 const EMPTY_SLOTS: ReadonlyArray<ContextSlot> = [];
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -38,7 +38,12 @@ import type {
 } from '@kay-am/types';
 import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
-import { getProviderStatus, type ProviderStatus } from '../providers';
+import {
+  buildProviderList,
+  getProviderStatus,
+  type ProviderInfo,
+  type ProviderStatus,
+} from '../providers';
 import { validateGitRepo } from '../repo';
 import { ANTHROPIC_API_KEY_SECRET, getSecret, hasSecret } from '../secrets';
 import {
@@ -67,6 +72,7 @@ export interface AppState {
   readonly settings: Readonly<Record<string, string>>;
   readonly sessionSummary: TelemetrySummary | null;
   readonly providerStatus: ProviderStatus | null;
+  readonly providers: ReadonlyArray<ProviderInfo>;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
   readonly apiKeyPresent: boolean;
@@ -95,6 +101,7 @@ export interface AppActions {
   loadSetting(key: string): Promise<string | null>;
   saveSetting(key: string, value: string): Promise<void>;
   refreshProviderStatus(status: ProviderStatus): void;
+  refreshProviders(): Promise<void>;
   addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
   createSession(input: {
     workspaceId: WorkspaceId;
@@ -125,6 +132,7 @@ const initialState: AppState = {
   settings: {},
   sessionSummary: null,
   providerStatus: null,
+  providers: buildProviderList(null),
   hydrated: false,
   bootPhase: 'pending',
   apiKeyPresent: false,
@@ -289,7 +297,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       set({ bootPhase: 'detecting-cli' });
       const providerStatus = await getProviderStatus();
-      set({ providerStatus });
+      set({ providerStatus, providers: buildProviderList(providerStatus) });
 
       set({ bootPhase: 'loading-workspaces' });
       const workspaces = await listWorkspaces(tauriDatabase);
@@ -387,7 +395,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   refreshProviderStatus: (status) => {
-    set({ providerStatus: status });
+    set({ providerStatus: status, providers: buildProviderList(status) });
+  },
+
+  refreshProviders: async () => {
+    const status = await getProviderStatus();
+    set({ providerStatus: status, providers: buildProviderList(status) });
   },
 
   createSession: async ({ workspaceId, goal, branchPrefix }) => {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "turbo run test",
+    "tauri:dev": "pnpm --filter @kay-am/desktop tauri:dev",
+    "tauri:build": "pnpm --filter @kay-am/desktop tauri:build",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "prepare": "lefthook install"


### PR DESCRIPTION
## Summary

Bundles four threads landed in this branch:

- **fix(desktop)** — `<TelemetryPill>` selector returned a fresh `[]` literal each snapshot → `useSyncExternalStore` infinite loop → component crashed → no error boundary → React unmounted entire tree → blank window. Cached empty array.
- **feat(desktop)** — multi-provider panel scaffolded. Header pills `claude cli missing` + `api key missing` replaced by a single `N/M providers` chip. Settings → providers section shows claude (live, with rust detection + install link if missing) and cursor + codex as `coming-soon` placeholders linking to v0.2 tracking issues (#68, #69). API key field reframed as "summarizer only" with note about removal in #71.
- **chore(repo)** — root `tauri:dev` / `tauri:build` aliases (carried from original branch scope) + readme cargo path note.
- **docs(repo)** — v0.2 issue index added to ROADMAP. 14 issues curated covering cursor + codex adapters, provider registry, summarizer refactor (drop ANTHROPIC_API_KEY), provider connection UX, pre-flight auth check (#66–#79).

## Test plan

- [ ] `pnpm tauri:dev` opens without blank window (telemetry pill no longer crashes mount)
- [ ] header chip shows `1/1 providers` green when claude CLI is installed + on PATH
- [ ] header chip shows `0/1 providers` red + danger color when claude binary is missing
- [ ] click chip → settings opens at top → providers section visible
- [ ] cursor + codex rows are greyed, show `track ↗` link to GitHub issues #68 and #69
- [ ] click `refresh` → re-runs claude detection
- [ ] api key field still saves to keychain (no behavioral regression for summarizer)
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)