### PR TITLE
feat(types): provider registry + capability matrix (#66)

### DIFF
--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -7,8 +7,8 @@ interface ProvidersChipProps {
 
 export function ProvidersChip({ onOpenSettings }: ProvidersChipProps) {
   const providers = useAppStore((s) => s.providers);
-  const active = providers.filter((p) => p.state !== 'coming-soon');
-  const connected = active.filter((p) => p.state === 'connected').length;
+  const active = providers.filter((p) => p.connection !== 'coming-soon');
+  const connected = active.filter((p) => p.connection === 'connected').length;
   const total = active.length;
   const allOk = total > 0 && connected === total;
 

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../store';
 
 const STATE_LABEL: Record<ProviderConnectionState, string> = {
   connected: 'connected',
+  installed_disconnected: 'installed, not logged in',
   missing: 'not installed',
   error: 'error',
   'coming-soon': 'integration in v0.2',
@@ -12,6 +13,7 @@ const STATE_LABEL: Record<ProviderConnectionState, string> = {
 
 const STATE_DOT: Record<ProviderConnectionState, string> = {
   connected: 'bg-primary',
+  installed_disconnected: 'bg-warning',
   missing: 'bg-danger',
   error: 'bg-danger',
   'coming-soon': 'bg-muted-foreground/40',
@@ -59,14 +61,14 @@ export function ProvidersPanel() {
 }
 
 function ProviderRow({ info }: { info: ProviderInfo }) {
-  const placeholder = info.state === 'coming-soon';
+  const placeholder = info.connection === 'coming-soon';
   return (
     <li
       className={cn('flex items-center gap-3 px-3 py-2 text-xs', placeholder ? 'opacity-60' : '')}
     >
       <span
         aria-hidden
-        className={cn('inline-block h-2 w-2 rounded-full', STATE_DOT[info.state])}
+        className={cn('inline-block h-2 w-2 rounded-full', STATE_DOT[info.connection])}
       />
       <div className="flex flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
@@ -77,7 +79,7 @@ function ProviderRow({ info }: { info: ProviderInfo }) {
           ) : null}
         </div>
         <div className="text-[11px] text-muted-foreground">
-          {STATE_LABEL[info.state]}
+          {STATE_LABEL[info.connection]}
           {info.error ? <span className="text-danger"> — {info.error}</span> : null}
         </div>
       </div>
@@ -87,7 +89,7 @@ function ProviderRow({ info }: { info: ProviderInfo }) {
 }
 
 function RowActions({ info }: { info: ProviderInfo }) {
-  if (info.state === 'coming-soon') {
+  if (info.connection === 'coming-soon') {
     return info.trackingIssueUrl ? (
       <a
         href={info.trackingIssueUrl}
@@ -99,7 +101,7 @@ function RowActions({ info }: { info: ProviderInfo }) {
       </a>
     ) : null;
   }
-  if (info.state === 'connected') {
+  if (info.connection === 'connected') {
     return null;
   }
   return (

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -1,6 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
+import type {
+  ProviderConnectionState,
+  ProviderInfo as ProviderInfoBase,
+  ProviderId,
+} from '@kay-am/types';
 
-export type ProviderId = 'anthropic' | 'cursor' | 'codex';
+export type { ProviderId, ProviderConnectionState };
 
 export interface ProviderStatus {
   readonly id: string;
@@ -10,14 +15,8 @@ export interface ProviderStatus {
   readonly error: string | null;
 }
 
-export type ProviderConnectionState = 'connected' | 'missing' | 'error' | 'coming-soon';
-
-export interface ProviderInfo {
-  readonly id: ProviderId;
+export interface ProviderInfo extends ProviderInfoBase {
   readonly label: string;
-  readonly binary: string;
-  readonly state: ProviderConnectionState;
-  readonly version: string | null;
   readonly error: string | null;
   readonly docsUrl: string;
   readonly trackingIssueUrl?: string;
@@ -40,6 +39,13 @@ const TRACKING_ISSUES: Partial<Record<ProviderId, string>> = {
   codex: 'https://github.com/akhayam99/kay-am/issues/69',
 };
 
+const EMPTY_CAPABILITIES: ProviderInfoBase['capabilities'] = {
+  models: [],
+  supportsTools: false,
+  supportsStream: false,
+  supportsCheapModel: false,
+};
+
 export async function getProviderStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('get_provider_status');
 }
@@ -54,17 +60,19 @@ function claudeInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
     id,
     label: PROVIDER_LABEL[id],
     binary: status?.binary ?? 'claude',
+    capabilities: EMPTY_CAPABILITIES,
+    identity: null,
     docsUrl: PROVIDER_DOCS[id],
   };
   if (!status) {
-    return { ...base, state: 'missing', version: null, error: null };
+    return { ...base, connection: 'missing', version: null, error: null };
   }
   if (status.available) {
-    return { ...base, state: 'connected', version: status.version, error: null };
+    return { ...base, connection: 'connected', version: status.version, error: null };
   }
   return {
     ...base,
-    state: status.error ? 'error' : 'missing',
+    connection: status.error ? 'error' : 'missing',
     version: null,
     error: status.error,
   };
@@ -75,7 +83,9 @@ function placeholder(id: ProviderId, binary: string): ProviderInfo {
     id,
     label: PROVIDER_LABEL[id],
     binary,
-    state: 'coming-soon',
+    capabilities: EMPTY_CAPABILITIES,
+    identity: null,
+    connection: 'coming-soon',
     version: null,
     error: null,
     docsUrl: PROVIDER_DOCS[id],

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,10 @@ export type {
   TurnRequest,
 } from './adapter';
 export type { TelemetryKind, TelemetryRecord } from './telemetry';
+export type {
+  ModelTier,
+  ProviderConnectionState,
+  ProviderInfo,
+  ProviderId,
+  ProviderRegistryCapabilities,
+} from './provider-registry';

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -1,0 +1,30 @@
+export type ProviderId = 'anthropic' | 'cursor' | 'codex';
+
+export type ProviderConnectionState =
+  | 'connected'
+  | 'installed_disconnected'
+  | 'missing'
+  | 'error'
+  | 'coming-soon';
+
+export interface ModelTier {
+  readonly id: string;
+  readonly tier: 'turn' | 'cheap';
+  readonly contextWindow: number;
+}
+
+export interface ProviderRegistryCapabilities {
+  readonly models: ReadonlyArray<ModelTier>;
+  readonly supportsTools: boolean;
+  readonly supportsStream: boolean;
+  readonly supportsCheapModel: boolean;
+}
+
+export interface ProviderInfo {
+  readonly id: ProviderId;
+  readonly binary: string;
+  readonly capabilities: ProviderRegistryCapabilities;
+  readonly connection: ProviderConnectionState;
+  readonly version: string | null;
+  readonly identity: string | null;
+}


### PR DESCRIPTION
## Summary

- Add `packages/types/src/provider-registry.ts` with canonical contracts: `ProviderId`, `ProviderConnectionState` (5 states incl. `installed_disconnected`), `ModelTier`, `ProviderRegistryCapabilities`, `ProviderInfo`
- Re-export all new types from `@kay-am/types` index; named `ProviderRegistryCapabilities` to avoid collision with existing `ProviderCapabilities` from `adapter.ts`
- Extend desktop `ProviderInfo` to satisfy canonical `ProviderInfoBase` while adding UI-layer fields (`label`, `error`, `docsUrl`, `trackingIssueUrl`)
- Rename `state` → `connection` across desktop layer (`providers.ts`, `ProvidersPanel.tsx`, `ProvidersChip.tsx`); `STATE_LABEL`/`STATE_DOT` maps updated to cover `installed_disconnected`

## Test plan

- [ ] `pnpm -w typecheck` passes (5/5 packages)
- [ ] `pnpm -w lint` passes
- [ ] ProvidersPanel renders correctly (connected dot, error dot, coming-soon opacity)
- [ ] ProvidersChip count logic unchanged (filters `coming-soon`, counts `connected`)
- [ ] `buildProviderList(null)` returns anthropic as `missing`, cursor/codex as `coming-soon`

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)