### PR TITLE
feat(desktop): detect cursor + codex binaries

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -14,12 +14,16 @@ use std::sync::Mutex;
 pub fn run() {
   let database = db::open().expect("failed to open kay-am database");
   let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
+  let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
+  let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
   let turn_registry = turn::TurnRegistry::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
     .manage(database)
     .manage(provider_state)
+    .manage(cursor_state)
+    .manage(codex_state)
     .manage(turn_registry)
     .setup(|app| {
       if cfg!(debug_assertions) {
@@ -46,6 +50,10 @@ pub fn run() {
       worktree::worktree_exists,
       providers::get_provider_status,
       providers::refresh_provider_status,
+      providers::get_cursor_status,
+      providers::refresh_cursor_status,
+      providers::get_codex_status,
+      providers::refresh_codex_status,
       turn::turn_spawn,
       turn::turn_cancel,
       repo::validate_git_repo,

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -19,8 +19,20 @@ pub struct ProviderStatus {
 
 pub struct ProviderState(pub Mutex<ProviderStatus>);
 
+pub struct CursorState(pub Mutex<ProviderStatus>);
+
+pub struct CodexState(pub Mutex<ProviderStatus>);
+
 pub fn detect_claude() -> ProviderStatus {
     detect_binary("anthropic", "claude")
+}
+
+pub fn detect_cursor() -> ProviderStatus {
+    detect_binary("cursor", "cursor-agent")
+}
+
+pub fn detect_codex() -> ProviderStatus {
+    detect_binary("codex", "codex")
 }
 
 fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
@@ -117,6 +129,46 @@ pub fn get_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
 #[tauri::command]
 pub fn refresh_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
     let next = detect_claude();
+    if let Ok(mut current) = state.0.lock() {
+        *current = next.clone();
+    }
+    next
+}
+
+#[tauri::command]
+pub fn get_cursor_status(state: State<'_, CursorState>) -> ProviderStatus {
+    state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
+        id: "cursor".to_string(),
+        binary: "cursor-agent".to_string(),
+        available: false,
+        version: None,
+        error: Some("status mutex poisoned".to_string()),
+    })
+}
+
+#[tauri::command]
+pub fn refresh_cursor_status(state: State<'_, CursorState>) -> ProviderStatus {
+    let next = detect_cursor();
+    if let Ok(mut current) = state.0.lock() {
+        *current = next.clone();
+    }
+    next
+}
+
+#[tauri::command]
+pub fn get_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
+    state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
+        id: "codex".to_string(),
+        binary: "codex".to_string(),
+        available: false,
+        version: None,
+        error: Some("status mutex poisoned".to_string()),
+    })
+}
+
+#[tauri::command]
+pub fn refresh_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
+    let next = detect_codex();
     if let Ok(mut current) = state.0.lock() {
         *current = next.clone();
     }

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -54,6 +54,22 @@ export async function refreshProviderStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('refresh_provider_status');
 }
 
+export async function getCursorStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('get_cursor_status');
+}
+
+export async function refreshCursorStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('refresh_cursor_status');
+}
+
+export async function getCodexStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('get_codex_status');
+}
+
+export async function refreshCodexStatus(): Promise<ProviderStatus> {
+  return invoke<ProviderStatus>('refresh_codex_status');
+}
+
 function claudeInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
   const id: ProviderId = 'anthropic';
   const base = {
@@ -78,25 +94,62 @@ function claudeInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
   };
 }
 
-function placeholder(id: ProviderId, binary: string): ProviderInfo {
-  return {
+function cursorInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+  const id: ProviderId = 'cursor';
+  const base = {
     id,
     label: PROVIDER_LABEL[id],
-    binary,
+    binary: status?.binary ?? 'cursor-agent',
     capabilities: EMPTY_CAPABILITIES,
     identity: null,
-    connection: 'coming-soon',
-    version: null,
-    error: null,
     docsUrl: PROVIDER_DOCS[id],
     trackingIssueUrl: TRACKING_ISSUES[id],
   };
+  if (!status || !status.available) {
+    return { ...base, connection: 'missing', version: null, error: status?.error ?? null };
+  }
+  return { ...base, connection: 'installed_disconnected', version: status.version, error: null };
 }
 
-export function buildProviderList(claude: ProviderStatus | null): ReadonlyArray<ProviderInfo> {
+function codexInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+  const id: ProviderId = 'codex';
+  const base = {
+    id,
+    label: PROVIDER_LABEL[id],
+    binary: status?.binary ?? 'codex',
+    capabilities: EMPTY_CAPABILITIES,
+    identity: null,
+    docsUrl: PROVIDER_DOCS[id],
+    trackingIssueUrl: TRACKING_ISSUES[id],
+  };
+  if (!status || !status.available) {
+    return { ...base, connection: 'missing', version: null, error: status?.error ?? null };
+  }
+  return { ...base, connection: 'installed_disconnected', version: status.version, error: null };
+}
+
+export interface ProviderStatuses {
+  readonly anthropic: ProviderStatus | null;
+  readonly cursor: ProviderStatus | null;
+  readonly codex: ProviderStatus | null;
+}
+
+export function buildProviderList(statuses: ProviderStatuses): ReadonlyArray<ProviderInfo>;
+export function buildProviderList(anthropic: ProviderStatus | null): ReadonlyArray<ProviderInfo>;
+export function buildProviderList(
+  arg: ProviderStatus | null | ProviderStatuses,
+): ReadonlyArray<ProviderInfo> {
+  if (arg === null || (typeof arg === 'object' && 'available' in arg)) {
+    return [
+      claudeInfoFromStatus(arg as ProviderStatus | null),
+      cursorInfoFromStatus(null),
+      codexInfoFromStatus(null),
+    ];
+  }
+  const { anthropic, cursor, codex } = arg as ProviderStatuses;
   return [
-    claudeInfoFromStatus(claude),
-    placeholder('cursor', 'cursor-agent'),
-    placeholder('codex', 'codex'),
+    claudeInfoFromStatus(anthropic),
+    cursorInfoFromStatus(cursor),
+    codexInfoFromStatus(codex),
   ];
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -40,9 +40,12 @@ import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
 import {
   buildProviderList,
+  getCursorStatus,
+  getCodexStatus,
   getProviderStatus,
   type ProviderInfo,
   type ProviderStatus,
+  type ProviderStatuses,
 } from '../providers';
 import { validateGitRepo } from '../repo';
 import { ANTHROPIC_API_KEY_SECRET, getSecret, hasSecret } from '../secrets';
@@ -72,6 +75,8 @@ export interface AppState {
   readonly settings: Readonly<Record<string, string>>;
   readonly sessionSummary: TelemetrySummary | null;
   readonly providerStatus: ProviderStatus | null;
+  readonly cursorStatus: ProviderStatus | null;
+  readonly codexStatus: ProviderStatus | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
@@ -132,7 +137,9 @@ const initialState: AppState = {
   settings: {},
   sessionSummary: null,
   providerStatus: null,
-  providers: buildProviderList(null),
+  cursorStatus: null,
+  codexStatus: null,
+  providers: buildProviderList({ anthropic: null, cursor: null, codex: null }),
   hydrated: false,
   bootPhase: 'pending',
   apiKeyPresent: false,
@@ -296,8 +303,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
 
       set({ bootPhase: 'detecting-cli' });
-      const providerStatus = await getProviderStatus();
-      set({ providerStatus, providers: buildProviderList(providerStatus) });
+      const [providerStatus, cursorStatus, codexStatus] = await Promise.all([
+        getProviderStatus(),
+        getCursorStatus(),
+        getCodexStatus(),
+      ]);
+      const statuses: ProviderStatuses = {
+        anthropic: providerStatus,
+        cursor: cursorStatus,
+        codex: codexStatus,
+      };
+      set({ providerStatus, cursorStatus, codexStatus, providers: buildProviderList(statuses) });
 
       set({ bootPhase: 'loading-workspaces' });
       const workspaces = await listWorkspaces(tauriDatabase);
@@ -395,12 +411,28 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   refreshProviderStatus: (status) => {
-    set({ providerStatus: status, providers: buildProviderList(status) });
+    set((state) => {
+      const statuses: ProviderStatuses = {
+        anthropic: status,
+        cursor: state.cursorStatus,
+        codex: state.codexStatus,
+      };
+      return { providerStatus: status, providers: buildProviderList(statuses) };
+    });
   },
 
   refreshProviders: async () => {
-    const status = await getProviderStatus();
-    set({ providerStatus: status, providers: buildProviderList(status) });
+    const [providerStatus, cursorStatus, codexStatus] = await Promise.all([
+      getProviderStatus(),
+      getCursorStatus(),
+      getCodexStatus(),
+    ]);
+    const statuses: ProviderStatuses = {
+      anthropic: providerStatus,
+      cursor: cursorStatus,
+      codex: codexStatus,
+    };
+    set({ providerStatus, cursorStatus, codexStatus, providers: buildProviderList(statuses) });
   },
 
   createSession: async ({ workspaceId, goal, branchPrefix }) => {


### PR DESCRIPTION
## Summary

- Adds `detect_cursor` / `detect_codex` Rust fns in `providers.rs` using existing `detect_binary` helper; mirrors the claude pattern exactly
- Registers 4 new Tauri commands: `get_cursor_status`, `refresh_cursor_status`, `get_codex_status`, `refresh_codex_status` with dedicated `CursorState` / `CodexState` mutexes
- Updates `buildProviderList` to accept `ProviderStatuses` (overloaded — legacy `ProviderStatus | null` sig preserved for safety)
- `hydrate()` fetches all 3 statuses in parallel via `Promise.all`; store now holds `cursorStatus` + `codexStatus`
- cursor/codex show `installed_disconnected` when binary present, `missing` when not — drops `coming-soon` for these two

## Test plan

- [ ] `cargo check` passes (verified locally)
- [ ] `pnpm typecheck` passes (verified locally)
- [ ] `pnpm build` passes (verified locally)
- [ ] Boot app — provider panel shows cursor/codex as missing if binaries absent
- [ ] Install `cursor-agent` binary → restart → panel shows `installed_disconnected`

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)