### PR TITLE
feat(types): session provider preference types

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -36,6 +36,7 @@ import type {
   Workspace,
   WorkspaceId,
 } from '@kay-am/types';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
 import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
 import {
@@ -423,6 +424,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       goal: goal.trim() || worktree.slug,
       state: initialState,
       contextSlots: [],
+      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
       createdAt: now,
       updatedAt: now,
     };

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { IsoDateTime, Session, SessionId, Workspace, WorkspaceId } from '@kay-am/types';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrate } from './runner';
 import { migrations } from './index';
@@ -63,6 +64,7 @@ describe('migrate', () => {
       goal: 'refactor auth',
       state: { kind: 'idle', lastActivityAt: now() },
       contextSlots: [],
+      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
       createdAt: now(),
       updatedAt: now(),
     };

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -1,4 +1,5 @@
 import type { IsoDateTime, Session, SessionId, SessionState, WorkspaceId } from '@kay-am/types';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
 import type { Database } from '../client';
 
 interface SessionRow {
@@ -23,6 +24,7 @@ function toDomain(row: SessionRow, contextSlots: Session['contextSlots']): Sessi
     goal: row.goal,
     state: toState(row.state_kind, row.state_payload),
     contextSlots,
+    providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
   };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,3 +25,5 @@ export type {
   ProviderId,
   ProviderRegistryCapabilities,
 } from './provider-registry';
+export type { SessionProviderPreference, TurnProviderOverride } from './provider-preference';
+export { DEFAULT_SESSION_PROVIDER_PREFERENCE } from './provider-preference';

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -1,4 +1,5 @@
 import type { IsoDateTime, MessageId, SessionId } from './ids';
+import type { TurnProviderOverride } from './provider-preference';
 
 export type MessageRole = 'user' | 'assistant' | 'system';
 
@@ -8,4 +9,5 @@ export type Message = Readonly<{
   role: MessageRole;
   content: string;
   createdAt: IsoDateTime;
+  providerOverride?: TurnProviderOverride;
 }>;

--- a/packages/types/src/provider-preference.ts
+++ b/packages/types/src/provider-preference.ts
@@ -1,0 +1,17 @@
+import type { ProviderId } from './provider-registry';
+
+export interface SessionProviderPreference {
+  readonly defaultProvider: ProviderId;
+  readonly defaultModel?: string;
+  readonly allowTurnOverride: boolean;
+}
+
+export interface TurnProviderOverride {
+  readonly providerId: ProviderId;
+  readonly model?: string;
+}
+
+export const DEFAULT_SESSION_PROVIDER_PREFERENCE: SessionProviderPreference = {
+  defaultProvider: 'anthropic',
+  allowTurnOverride: true,
+};

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -1,4 +1,5 @@
 import type { IsoDateTime, ProviderRunId, SessionId, WorkspaceId } from './ids';
+import type { SessionProviderPreference } from './provider-preference';
 
 export type Workspace = Readonly<{
   id: WorkspaceId;
@@ -28,6 +29,7 @@ export type Session = Readonly<{
   goal: string;
   state: SessionState;
   contextSlots: ReadonlyArray<ContextSlot>;
+  providerPreference: SessionProviderPreference;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }>;


### PR DESCRIPTION
## Summary

- Add `SessionProviderPreference` and `TurnProviderOverride` interfaces to `@kay-am/types` in new `provider-preference.ts`
- Export `DEFAULT_SESSION_PROVIDER_PREFERENCE` constant (`{ defaultProvider: 'anthropic', allowTurnOverride: true }`)
- Extend `Session` with required `providerPreference: SessionProviderPreference` field
- Extend `Message` with optional `providerOverride?: TurnProviderOverride` field
- Update `db/queries/session.ts` `toDomain` to spread default (backward-compat for existing DB rows)
- Update `store.ts` `createSession` and `db` migration test to include the default

Closes #67

## Test plan

- [ ] `pnpm typecheck` passes (verified locally with `tsc --noEmit` across all packages)
- [ ] Lefthook pre-commit (prettier + commitlint) passed on commit
- [ ] No behavioral change for existing callers — `toDomain` returns default, `createSession` spreads default