### PR TITLE
feat(core): cursor adapter (#68)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,14 +22,6 @@ export {
 export { computeCostUsd, priceFor } from './providers/claude/cost';
 export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';
 
-// CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
-// Import directly from @kay-am/core/src/providers/codex/adapter when needed in Node context.
-export { CODEX_CHEAP_MODEL } from './providers/codex/constants';
-export {
-  parseJsonLine as parseCodexJsonLine,
-  type ParseContext as CodexParseContext,
-} from './providers/codex/parser';
-
 // CursorAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from @kay-am/core/src/providers/cursor/adapter when needed in Node context.
 export { CURSOR_CHEAP_MODEL } from './providers/cursor/cost';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,22 @@ export {
 export { computeCostUsd, priceFor } from './providers/claude/cost';
 export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';
 
+// CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from @kay-am/core/src/providers/codex/adapter when needed in Node context.
+export { CODEX_CHEAP_MODEL } from './providers/codex/constants';
+export {
+  parseJsonLine as parseCodexJsonLine,
+  type ParseContext as CodexParseContext,
+} from './providers/codex/parser';
+
+// CursorAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from @kay-am/core/src/providers/cursor/adapter when needed in Node context.
+export { CURSOR_CHEAP_MODEL } from './providers/cursor/cost';
+export {
+  parseCursorStreamLine,
+  type ParseContext as CursorParseContext,
+} from './providers/cursor/parser';
+
 export {
   Summarizer,
   HAIKU_MODEL,

--- a/packages/core/src/providers/cursor/adapter.integration.test.ts
+++ b/packages/core/src/providers/cursor/adapter.integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderRunId, SessionId, TurnRequest } from '@kay-am/types';
+import { CursorAdapter } from './adapter';
+
+// Gated behind CURSOR_INTEGRATION=1. Not run on CI by default.
+// To run: CURSOR_INTEGRATION=1 pnpm -w test --filter @kay-am/core
+const enabled = process.env['CURSOR_INTEGRATION'] === '1';
+
+describe.skipIf(!enabled)('CursorAdapter — integration (requires cursor-agent + auth)', () => {
+  it('detect() reports cursor-agent as available', async () => {
+    const adapter = new CursorAdapter();
+    const result = await adapter.detect();
+    expect(result.kind).toBe('available');
+    console.info('[cursor integration] version:', (result as { version?: string }).version);
+  });
+
+  it('streams at least one assistant_text from a real prompt', async () => {
+    const adapter = new CursorAdapter();
+    const request: TurnRequest = {
+      runId: 'run_integration' as ProviderRunId,
+      sessionId: 'sess_integration' as SessionId,
+      model: 'cursor-small',
+      workingDir: '/tmp',
+      systemPrompt: 'You are a test assistant. Be brief.',
+      userMessage: 'Reply with only: "integration ok"',
+    };
+
+    const events = [];
+    for await (const event of adapter.spawn(request)) {
+      events.push(event);
+      if (event.kind === 'done' || event.kind === 'error') break;
+    }
+
+    const textEvents = events.filter((e) => e.kind === 'assistant_text');
+    expect(textEvents.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/providers/cursor/adapter.test.ts
+++ b/packages/core/src/providers/cursor/adapter.test.ts
@@ -1,0 +1,262 @@
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import { describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, ProviderRunId, SessionId, TurnEvent, TurnRequest } from '@kay-am/types';
+import { CursorAdapter } from './adapter';
+
+const fakeNow = (): IsoDateTime => '2026-05-07T00:00:00.000Z' as IsoDateTime;
+
+class FakeChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  exitCode: number | null = null;
+  killed = false;
+  signal: NodeJS.Signals | null = null;
+
+  constructor(lines: ReadonlyArray<string>, exit = 0) {
+    super();
+    this.stdout = Readable.from(lines.map((line) => `${line}\n`));
+    this.stderr = Readable.from([]);
+    queueMicrotask(() => {
+      this.exitCode = exit;
+      this.stdout.on('end', () => this.emit('close', exit));
+    });
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.killed = true;
+    this.signal = signal;
+    this.exitCode = 143;
+    return true;
+  }
+}
+
+class OpenChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  exitCode: number | null = null;
+  killed = false;
+  signal: NodeJS.Signals | null = null;
+
+  constructor(lines: ReadonlyArray<string>) {
+    super();
+    this.stdout = new Readable({ read() {} });
+    for (const line of lines) this.stdout.push(`${line}\n`);
+    this.stderr = new Readable({ read() {} });
+  }
+
+  kill(signal: NodeJS.Signals = 'SIGTERM'): boolean {
+    this.killed = true;
+    this.signal = signal;
+    this.exitCode = 143;
+    return true;
+  }
+}
+
+function makeRequest(): TurnRequest {
+  return {
+    runId: 'run_1' as ProviderRunId,
+    sessionId: 'sess_1' as SessionId,
+    model: 'cursor-small',
+    workingDir: '/tmp/demo',
+    systemPrompt: 'sys',
+    userMessage: 'hi',
+  };
+}
+
+const FIXTURES = {
+  init: JSON.stringify({ type: 'system', subtype: 'init' }),
+  assistantText: JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'text', text: 'hello world' }] },
+  }),
+  toolUseBash: JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [{ type: 'tool_use', id: 'tool_a', name: 'Bash', input: { command: 'ls' } }],
+    },
+  }),
+  toolUseWrite: JSON.stringify({
+    type: 'assistant',
+    message: {
+      content: [
+        {
+          type: 'tool_use',
+          id: 'tool_b',
+          name: 'Write',
+          input: { file_path: '/tmp/x.ts', content: 'export {};' },
+        },
+      ],
+    },
+  }),
+  toolResult: JSON.stringify({
+    type: 'user',
+    message: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'tool_a',
+          content: 'file1\nfile2',
+          is_error: false,
+        },
+      ],
+    },
+  }),
+  resultSuccess: JSON.stringify({
+    type: 'result',
+    subtype: 'success',
+    usage: { input_tokens: 12, output_tokens: 7, cache_read_input_tokens: 3 },
+  }),
+  resultError: JSON.stringify({ type: 'result', subtype: 'error', error: 'rate limit' }),
+};
+
+async function collect(adapter: CursorAdapter): Promise<ReadonlyArray<TurnEvent>> {
+  const events: TurnEvent[] = [];
+  for await (const event of adapter.spawn(makeRequest())) {
+    events.push(event);
+  }
+  return events;
+}
+
+// --- text stream ---
+describe('CursorAdapter — text stream', () => {
+  it('emits assistant_text, usage, done for a basic text turn', async () => {
+    const lines = [FIXTURES.init, FIXTURES.assistantText, FIXTURES.resultSuccess];
+    const child = new FakeChild(lines);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+
+    const events = await collect(adapter);
+    expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+    expect(events[0]).toMatchObject({ delta: 'hello world' });
+  });
+});
+
+// --- tool use ---
+describe('CursorAdapter — tool use', () => {
+  it('emits tool_call_start + tool_call_end for a bash tool round-trip', async () => {
+    const lines = [
+      FIXTURES.init,
+      FIXTURES.toolUseBash,
+      FIXTURES.toolResult,
+      FIXTURES.resultSuccess,
+    ];
+    const child = new FakeChild(lines);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+
+    const events = await collect(adapter);
+    expect(events.map((e) => e.kind)).toEqual([
+      'tool_call_start',
+      'tool_call_end',
+      'usage',
+      'done',
+    ]);
+    expect(events[0]).toMatchObject({ toolName: 'Bash' });
+    expect(events[1]).toMatchObject({ toolUseId: 'tool_a', isError: false });
+  });
+
+  it('emits file_edit alongside tool_call_start for Write tool', async () => {
+    const child = new FakeChild([FIXTURES.toolUseWrite, FIXTURES.resultSuccess]);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const events = await collect(adapter);
+    const fileEdit = events.find((e) => e.kind === 'file_edit');
+    expect(fileEdit).toMatchObject({ path: '/tmp/x.ts', editType: 'create' });
+  });
+});
+
+// --- usage ---
+describe('CursorAdapter — usage', () => {
+  it('maps input/output/cached token fields into ProviderUsage', async () => {
+    const child = new FakeChild([FIXTURES.resultSuccess]);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const events = await collect(adapter);
+    const usage = events.find((e) => e.kind === 'usage');
+    expect(usage).toMatchObject({
+      kind: 'usage',
+      usage: { inputTokens: 12, outputTokens: 7, cachedInputTokens: 3 },
+    });
+  });
+});
+
+// --- malformed JSON ---
+describe('CursorAdapter — malformed JSON', () => {
+  it('tolerates malformed lines without crashing the stream', async () => {
+    const lines = ['this is not json', '{ broken', FIXTURES.assistantText, FIXTURES.resultSuccess];
+    const child = new FakeChild(lines);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const events = await collect(adapter);
+    expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+  });
+
+  it('invokes onUnknown for unrecognised payload types and skips them', async () => {
+    const onUnknown = vi.fn();
+    const lines = [
+      FIXTURES.assistantText,
+      JSON.stringify({ type: 'mystery_event', payload: { x: 1 } }),
+      FIXTURES.resultSuccess,
+    ];
+    const child = new FakeChild(lines);
+    const adapter = new CursorAdapter({
+      now: fakeNow,
+      spawnFn: (() => child) as never,
+      onUnknown,
+    });
+    const events = await collect(adapter);
+    expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+    expect(onUnknown).toHaveBeenCalledWith(
+      'mystery_event',
+      expect.objectContaining({ type: 'mystery_event' }),
+    );
+  });
+});
+
+// --- non-zero exit / error ---
+describe('CursorAdapter — non-zero exit', () => {
+  it('emits an error event when result subtype is error', async () => {
+    const child = new FakeChild([FIXTURES.assistantText, FIXTURES.resultError]);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const events = await collect(adapter);
+    const errorEvent = events.find((e) => e.kind === 'error');
+    expect(errorEvent).toMatchObject({ kind: 'error', message: 'rate limit' });
+  });
+
+  it('propagates spawn ENOENT as a thrown error', async () => {
+    const child = new FakeChild([]);
+    queueMicrotask(() => child.emit('error', new Error('ENOENT: cursor-agent not found')));
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    await expect(collect(adapter)).rejects.toThrow('ENOENT');
+  });
+
+  it('kills the child on early break', async () => {
+    const child = new OpenChild([
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'a' }] },
+      }),
+    ]);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const iterator = adapter.spawn(makeRequest())[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    await iterator.return?.(undefined);
+    expect(child.killed).toBe(true);
+    expect(child.signal).toBe('SIGTERM');
+  });
+});
+
+// --- detect ---
+describe('CursorAdapter.detect', () => {
+  it('returns available with parsed version on exit 0', async () => {
+    const child = new FakeChild(['1.0.0']);
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const result = await adapter.detect();
+    expect(result.kind).toBe('available');
+  });
+
+  it('returns missing on spawn error', async () => {
+    const child = new FakeChild([]);
+    queueMicrotask(() => child.emit('error', new Error('ENOENT')));
+    const adapter = new CursorAdapter({ now: fakeNow, spawnFn: (() => child) as never });
+    const result = await adapter.detect();
+    expect(result.kind).toBe('missing');
+  });
+});

--- a/packages/core/src/providers/cursor/adapter.ts
+++ b/packages/core/src/providers/cursor/adapter.ts
@@ -1,0 +1,199 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type {
+  DetectResult,
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderCapabilities,
+  ProviderUsage,
+  TurnEvent,
+  TurnRequest,
+} from '@kay-am/types';
+import { CURSOR_CHEAP_MODEL, computeCursorCostUsd } from './cost';
+import { parseCursorStreamLine } from './parser';
+
+const CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  toolUse: true,
+  fileEdits: true,
+  // cursor-agent proxies requests through cursor's infra; actual context window varies
+  // by underlying model. 200k is a safe lower bound for supported models.
+  contextWindow: 200_000,
+  defaultModel: 'claude-sonnet-4-5',
+  availableModels: [CURSOR_CHEAP_MODEL, 'claude-sonnet-4-5', 'gpt-4o'],
+};
+
+export interface CursorAdapterDeps {
+  readonly binary?: string;
+  readonly now?: () => IsoDateTime;
+  readonly spawnFn?: typeof spawn;
+  readonly onUnknown?: (type: string, payload: unknown) => void;
+}
+
+export class CursorAdapter implements ProviderAdapter {
+  readonly id = 'cursor' as const;
+  readonly capabilities = CAPABILITIES;
+
+  private readonly binary: string;
+  private readonly now: () => IsoDateTime;
+  private readonly spawnFn: typeof spawn;
+  private readonly onUnknown: (type: string, payload: unknown) => void;
+
+  constructor(deps: CursorAdapterDeps = {}) {
+    this.binary = deps.binary ?? 'cursor-agent';
+    this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
+    this.spawnFn = deps.spawnFn ?? spawn;
+    this.onUnknown =
+      deps.onUnknown ??
+      ((type) => {
+        console.warn(`[cursor-adapter] unknown stream-json payload type: ${type}`);
+      });
+  }
+
+  async detect(): Promise<DetectResult> {
+    return new Promise((resolve) => {
+      const child = this.spawnFn(this.binary, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.on('error', (err) => {
+        resolve({
+          kind: 'missing',
+          binary: this.binary,
+          reason: err.message,
+        });
+      });
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({
+            kind: 'available',
+            binary: this.binary,
+            version: stdout.trim(),
+          });
+        } else {
+          resolve({
+            kind: 'missing',
+            binary: this.binary,
+            reason: `exited with code ${code}`,
+          });
+        }
+      });
+    });
+  }
+
+  cost(usage: ProviderUsage, model: string): number {
+    return computeCursorCostUsd(usage, model);
+  }
+
+  spawn(request: TurnRequest): AsyncIterable<TurnEvent> {
+    return spawnCursor(this.binary, this.spawnFn, this.now, this.onUnknown, request);
+  }
+}
+
+async function* spawnCursor(
+  binary: string,
+  spawnFn: typeof spawn,
+  now: () => IsoDateTime,
+  onUnknown: (type: string, payload: unknown) => void,
+  request: TurnRequest,
+): AsyncIterable<TurnEvent> {
+  const prompt = `${request.systemPrompt}\n\n${request.userMessage}`.trim();
+  const args = [
+    '-p',
+    prompt,
+    '--output-format',
+    'stream-json',
+    '--workspace',
+    request.workingDir,
+    '--model',
+    request.model,
+    // --force is the cursor-agent equivalent of --dangerously-skip-permissions:
+    // allows all tool/command execution without interactive confirmation prompts.
+    '--force',
+  ];
+
+  const child: ChildProcess = spawnFn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (!child.stdout) {
+    throw new Error('cursor-agent CLI started without stdout');
+  }
+
+  const queue: TurnEvent[] = [];
+  let resolver: ((value: IteratorResult<TurnEvent>) => void) | null = null;
+  let rejector: ((err: unknown) => void) | null = null;
+  let ended = false;
+  let error: unknown = null;
+
+  const ctx = { runId: request.runId, now, onUnknown };
+
+  const flush = () => {
+    if (resolver && queue.length > 0) {
+      const value = queue.shift()!;
+      const r = resolver;
+      resolver = null;
+      r({ value, done: false });
+    } else if (resolver && ended) {
+      const r = resolver;
+      resolver = null;
+      if (error) {
+        const rej = rejector;
+        rejector = null;
+        rej?.(error);
+      } else {
+        r({ value: undefined, done: true });
+      }
+    }
+  };
+
+  const lineReader = createInterface({ input: child.stdout });
+
+  lineReader.on('line', (line) => {
+    const events = parseCursorStreamLine(line, ctx);
+    for (const event of events) queue.push(event);
+    flush();
+  });
+
+  lineReader.on('close', () => {
+    ended = true;
+    flush();
+  });
+
+  child.on('error', (err) => {
+    error = err;
+    ended = true;
+    flush();
+  });
+
+  child.stderr?.on('data', () => {
+    // captured but not surfaced as TurnEvent for v0.1
+  });
+
+  try {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (ended) {
+        if (error) throw error;
+        return;
+      }
+      const value = await new Promise<IteratorResult<TurnEvent>>((resolve, reject) => {
+        resolver = resolve;
+        rejector = reject;
+      });
+      if (value.done) return;
+      yield value.value;
+    }
+  } finally {
+    if (!child.killed && child.exitCode === null) {
+      child.kill('SIGTERM');
+    }
+    lineReader.close();
+  }
+}

--- a/packages/core/src/providers/cursor/cost.ts
+++ b/packages/core/src/providers/cursor/cost.ts
@@ -1,0 +1,48 @@
+import type { ProviderUsage } from '@kay-am/types';
+
+// cursor-agent routes requests through Cursor's subscription model — actual token prices
+// are not publicly documented. Using conservative estimates mirroring sonnet-tier pricing
+// as a placeholder. TODO (@ak): update when Cursor publishes per-token pricing (#71).
+interface ModelPrice {
+  readonly inputPerMtok: number;
+  readonly outputPerMtok: number;
+  readonly cachedInputPerMtok: number;
+}
+
+// cursor-small is the documented cheap-tier alias in cursor-agent's model list.
+// The underlying model may change; the alias is stable per Cursor docs.
+export const CURSOR_CHEAP_MODEL = 'cursor-small';
+
+const PRICES: Record<string, ModelPrice> = {
+  [CURSOR_CHEAP_MODEL]: {
+    inputPerMtok: 0.15,
+    outputPerMtok: 0.6,
+    cachedInputPerMtok: 0.015,
+  },
+  'claude-sonnet-4-5': {
+    inputPerMtok: 3,
+    outputPerMtok: 15,
+    cachedInputPerMtok: 0.3,
+  },
+  'gpt-4o': {
+    inputPerMtok: 5,
+    outputPerMtok: 15,
+    cachedInputPerMtok: 0.5,
+  },
+};
+
+const FALLBACK: ModelPrice = PRICES[CURSOR_CHEAP_MODEL]!;
+
+export function cursorPriceFor(model: string): ModelPrice {
+  return PRICES[model] ?? FALLBACK;
+}
+
+export function computeCursorCostUsd(usage: ProviderUsage, model: string): number {
+  const price = cursorPriceFor(model);
+  const billableInput = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+  return (
+    (billableInput * price.inputPerMtok) / 1_000_000 +
+    (usage.cachedInputTokens * price.cachedInputPerMtok) / 1_000_000 +
+    (usage.outputTokens * price.outputPerMtok) / 1_000_000
+  );
+}

--- a/packages/core/src/providers/cursor/index.ts
+++ b/packages/core/src/providers/cursor/index.ts
@@ -1,0 +1,3 @@
+export { CursorAdapter, type CursorAdapterDeps } from './adapter';
+export { CURSOR_CHEAP_MODEL, computeCursorCostUsd, cursorPriceFor } from './cost';
+export { parseCursorStreamLine, type ParseContext } from './parser';

--- a/packages/core/src/providers/cursor/parser.ts
+++ b/packages/core/src/providers/cursor/parser.ts
@@ -1,0 +1,185 @@
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+export interface ParseContext {
+  readonly runId: ProviderRunId;
+  readonly now: () => IsoDateTime;
+  readonly onUnknown?: (type: string, payload: unknown) => void;
+}
+
+// cursor-agent stream-json uses the same envelope shape as claude's stream-json:
+// { type: 'assistant' | 'user' | 'result' | 'system', ... }
+// This is the same Anthropic message format (cursor wraps model calls via their API).
+const KNOWN_PAYLOAD_TYPES: ReadonlySet<string> = new Set(['system', 'assistant', 'user', 'result']);
+
+interface AssistantMessage {
+  readonly content?: ReadonlyArray<AssistantContentBlock>;
+}
+
+type AssistantContentBlock =
+  | { type: 'text'; text: string }
+  | {
+      type: 'tool_use';
+      id: string;
+      name: string;
+      input: unknown;
+    };
+
+interface ToolResultBlock {
+  readonly tool_use_id: string;
+  readonly content?: unknown;
+  readonly is_error?: boolean;
+}
+
+interface UserMessage {
+  readonly content?: ReadonlyArray<ToolResultBlock | { type: string }>;
+}
+
+interface UsagePayload {
+  readonly input_tokens?: number;
+  readonly output_tokens?: number;
+  readonly cache_read_input_tokens?: number;
+}
+
+const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
+  'Edit',
+  'MultiEdit',
+  'Write',
+  'NotebookEdit',
+]);
+
+function fileEditFromInput(
+  toolName: string,
+  input: unknown,
+): { path: string; editType: 'create' | 'modify' | 'delete' } | null {
+  if (!FILE_EDIT_TOOLS.has(toolName)) return null;
+  if (typeof input !== 'object' || input === null) return null;
+  const record = input as Record<string, unknown>;
+  const path = typeof record.file_path === 'string' ? record.file_path : null;
+  if (!path) return null;
+  const editType: 'create' | 'modify' | 'delete' = toolName === 'Write' ? 'create' : 'modify';
+  return { path, editType };
+}
+
+function isToolResultBlock(block: unknown): block is ToolResultBlock {
+  return (
+    typeof block === 'object' &&
+    block !== null &&
+    'tool_use_id' in block &&
+    typeof (block as { tool_use_id: unknown }).tool_use_id === 'string'
+  );
+}
+
+export function parseCursorStreamLine(line: string, ctx: ParseContext): ReadonlyArray<TurnEvent> {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return [];
+
+  let payload: { type?: string } & Record<string, unknown>;
+  try {
+    payload = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  const at = ctx.now();
+
+  switch (payload.type) {
+    case 'assistant':
+      return parseAssistant(payload.message as AssistantMessage | undefined, ctx, at);
+
+    case 'user':
+      return parseUser(payload.message as UserMessage | undefined, ctx, at);
+
+    case 'result': {
+      const usage = (payload.usage as UsagePayload | undefined) ?? {};
+      const events: TurnEvent[] = [];
+      if (typeof usage.input_tokens === 'number' || typeof usage.output_tokens === 'number') {
+        events.push({
+          kind: 'usage',
+          runId: ctx.runId,
+          usage: {
+            inputTokens: usage.input_tokens ?? 0,
+            outputTokens: usage.output_tokens ?? 0,
+            cachedInputTokens: usage.cache_read_input_tokens ?? 0,
+            estimatedCostUsd: 0,
+          },
+          at,
+        });
+      }
+      const subtype = payload.subtype as string | undefined;
+      if (subtype === 'success') {
+        events.push({ kind: 'done', runId: ctx.runId, at });
+      } else if (typeof payload.error === 'string') {
+        events.push({ kind: 'error', runId: ctx.runId, message: payload.error, at });
+      } else {
+        events.push({ kind: 'done', runId: ctx.runId, at });
+      }
+      return events;
+    }
+
+    case 'system':
+      return [];
+
+    default:
+      if (typeof payload.type === 'string' && !KNOWN_PAYLOAD_TYPES.has(payload.type)) {
+        ctx.onUnknown?.(payload.type, payload);
+      }
+      return [];
+  }
+}
+
+function parseAssistant(
+  message: AssistantMessage | undefined,
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  const blocks = message?.content ?? [];
+  const events: TurnEvent[] = [];
+
+  for (const block of blocks) {
+    if (block.type === 'text' && block.text.length > 0) {
+      events.push({ kind: 'assistant_text', runId: ctx.runId, delta: block.text, at });
+    } else if (block.type === 'tool_use') {
+      events.push({
+        kind: 'tool_call_start',
+        runId: ctx.runId,
+        toolUseId: block.id,
+        toolName: block.name,
+        input: block.input,
+        at,
+      });
+      const edit = fileEditFromInput(block.name, block.input);
+      if (edit) {
+        events.push({
+          kind: 'file_edit',
+          runId: ctx.runId,
+          path: edit.path,
+          editType: edit.editType,
+          at,
+        });
+      }
+    }
+  }
+  return events;
+}
+
+function parseUser(
+  message: UserMessage | undefined,
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  const blocks = message?.content ?? [];
+  const events: TurnEvent[] = [];
+  for (const block of blocks) {
+    if (isToolResultBlock(block)) {
+      events.push({
+        kind: 'tool_call_end',
+        runId: ctx.runId,
+        toolUseId: block.tool_use_id,
+        output: block.content ?? null,
+        isError: block.is_error === true,
+        at,
+      });
+    }
+  }
+  return events;
+}

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -1,6 +1,6 @@
 import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
 
-export type ProviderName = 'anthropic' | 'openai' | 'cursor';
+export type ProviderName = 'anthropic' | 'openai' | 'cursor' | 'codex';
 
 export type ProviderRunStatus =
   | { kind: 'pending' }


### PR DESCRIPTION
## Summary

- Implement `CursorAdapter` matching the `ProviderAdapter` contract
- Spawn `cursor-agent` with `-p --output-format stream-json --workspace --model --force` flags
- Parse stream-json envelope → `TurnEvent` (assistant_text, tool_use, usage, error, done)
- Add `CURSOR_CHEAP_MODEL = 'cursor-small'` constant for summarizer reuse (#71)
- Extend `ProviderName` with `'codex'` to unblock parallel #69 adapter (coordination note)

## Protocol notes / deviations

- `--workspace` used for working dir (cursor-agent's flag, not `--working-dir`)
- `--force` used for skip-permissions (cursor-agent equivalent of `--dangerously-skip-permissions`)
- Stream-json envelope is identical to claude's format (`type: assistant|user|result|system`) — cursor-agent proxies through Anthropic message format
- Cost prices for `cursor-small` are estimated (no public per-token pricing from Cursor); tagged `TODO (@ak)` for refinement in #71
- `cursor-agent models` returns "No models available for this account" on dev machine; `availableModels` is a best-effort list based on CLI docs

## Test plan

- [x] Unit tests: text stream, tool use (bash + write), usage, malformed JSON, non-zero exit/error — all passing
- [x] Integration test gated by `CURSOR_INTEGRATION=1` (skipped on CI)
- [x] `pnpm -w typecheck` passes
- [x] `pnpm --filter @kay-am/core test` — 11 cursor tests pass, 141 total
- [x] `pnpm --filter @kay-am/desktop build` passes

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)