### PR TITLE
feat(desktop): provider auth state check (#73)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
       providers::refresh_cursor_status,
       providers::get_codex_status,
       providers::refresh_codex_status,
+      providers::check_provider_auth,
       turn::turn_spawn,
       turn::turn_cancel,
       repo::validate_git_repo,

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -2,10 +2,11 @@ use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use tauri::State;
 
 const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
+const AUTH_TIMEOUT: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, Serialize)]
@@ -22,6 +23,20 @@ pub struct ProviderState(pub Mutex<ProviderStatus>);
 pub struct CursorState(pub Mutex<ProviderStatus>);
 
 pub struct CodexState(pub Mutex<ProviderStatus>);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthStateKind {
+    Connected,
+    Disconnected,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AuthState {
+    pub state: AuthStateKind,
+    pub identity: Option<String>,
+}
 
 pub fn detect_claude() -> ProviderStatus {
     detect_binary("anthropic", "claude")
@@ -115,6 +130,161 @@ fn read_to_string<R: std::io::Read>(mut reader: R) -> String {
     buf
 }
 
+fn run_auth_command(args: &[&str]) -> Result<String, String> {
+    let (binary, rest) = args.split_first().ok_or_else(|| "empty command".to_string())?;
+    let mut child = Command::new(binary)
+        .args(rest)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| e.to_string())?;
+
+    let deadline = Instant::now() + AUTH_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let stdout = child
+                    .stdout
+                    .take()
+                    .map(read_to_string)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                let stderr = child
+                    .stderr
+                    .take()
+                    .map(read_to_string)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string();
+                if status.success() {
+                    return Ok(stdout);
+                } else {
+                    let msg = if stderr.is_empty() { stdout } else { stderr };
+                    return Err(msg);
+                }
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    return Err("auth check timed out".to_string());
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+}
+
+/// Extract a JSON string value for `key` from raw JSON text (no external deps).
+fn extract_json_string(json: &str, key: &str) -> Option<String> {
+    let needle = format!("\"{}\"", key);
+    let pos = json.find(&needle)?;
+    let after_key = &json[pos + needle.len()..];
+    let colon = after_key.find(':')? + 1;
+    let after_colon = after_key[colon..].trim_start();
+    if !after_colon.starts_with('"') {
+        return None;
+    }
+    let inner = &after_colon[1..];
+    let end = inner.find('"')?;
+    let value = &inner[..end];
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+/// Extract first email-like token from plain text output.
+fn extract_email(text: &str) -> Option<String> {
+    for word in text.split_whitespace() {
+        let w = word.trim_matches(|c: char| !c.is_alphanumeric() && c != '@' && c != '.');
+        if w.contains('@') && w.contains('.') {
+            return Some(w.to_string());
+        }
+    }
+    None
+}
+
+fn check_claude_auth() -> AuthState {
+    // `claude auth status` outputs JSON: {"loggedIn": bool, "authMethod": "...", ...}
+    match run_auth_command(&["claude", "auth", "status"]) {
+        Ok(output) => {
+            let logged_in =
+                output.contains("\"loggedIn\":true") || output.contains("\"loggedIn\": true");
+            if !logged_in {
+                return AuthState {
+                    state: AuthStateKind::Disconnected,
+                    identity: None,
+                };
+            }
+            let identity = extract_json_string(&output, "email")
+                .or_else(|| extract_json_string(&output, "username"))
+                .or_else(|| extract_json_string(&output, "accountName"));
+            AuthState {
+                state: AuthStateKind::Connected,
+                identity,
+            }
+        }
+        Err(_) => AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        },
+    }
+}
+
+fn check_cursor_auth() -> AuthState {
+    // `cursor-agent status` outputs plain text; "Not logged in" when unauthenticated
+    match run_auth_command(&["cursor-agent", "status"]) {
+        Ok(output) => {
+            let lower = output.to_lowercase();
+            if lower.contains("not logged in") || lower.contains("not authenticated") {
+                return AuthState {
+                    state: AuthStateKind::Disconnected,
+                    identity: None,
+                };
+            }
+            let identity = extract_email(&output)
+                .or_else(|| extract_json_string(&output, "email"))
+                .or_else(|| extract_json_string(&output, "username"));
+            AuthState {
+                state: AuthStateKind::Connected,
+                identity,
+            }
+        }
+        Err(_) => AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        },
+    }
+}
+
+fn check_codex_auth() -> AuthState {
+    match run_auth_command(&["codex", "auth", "status"]) {
+        Ok(output) => {
+            let lower = output.to_lowercase();
+            if lower.contains("not logged") || lower.contains("unauthenticated") {
+                return AuthState {
+                    state: AuthStateKind::Disconnected,
+                    identity: None,
+                };
+            }
+            let identity = extract_email(&output)
+                .or_else(|| extract_json_string(&output, "email"))
+                .or_else(|| extract_json_string(&output, "username"));
+            AuthState {
+                state: AuthStateKind::Connected,
+                identity,
+            }
+        }
+        Err(_) => AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        },
+    }
+}
+
 #[tauri::command]
 pub fn get_provider_status(state: State<'_, ProviderState>) -> ProviderStatus {
     state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
@@ -173,4 +343,17 @@ pub fn refresh_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
         *current = next.clone();
     }
     next
+}
+
+#[tauri::command]
+pub fn check_provider_auth(provider_id: String) -> AuthState {
+    match provider_id.as_str() {
+        "anthropic" => check_claude_auth(),
+        "cursor" => check_cursor_auth(),
+        "codex" => check_codex_auth(),
+        _ => AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        },
+    }
 }

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -5,6 +5,13 @@ import type {
   ProviderId,
 } from '@kay-am/types';
 
+export type AuthStateKind = 'connected' | 'disconnected' | 'unknown';
+
+export interface AuthState {
+  readonly state: AuthStateKind;
+  readonly identity: string | null;
+}
+
 export type { ProviderId, ProviderConnectionState };
 
 export interface ProviderStatus {
@@ -70,62 +77,81 @@ export async function refreshCodexStatus(): Promise<ProviderStatus> {
   return invoke<ProviderStatus>('refresh_codex_status');
 }
 
-function claudeInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+export async function checkProviderAuth(providerId: ProviderId): Promise<AuthState> {
+  return invoke<AuthState>('check_provider_auth', { providerId });
+}
+
+export type ProviderAuthResults = Readonly<Record<ProviderId, AuthState | null>>;
+
+function connectionFromDetectionAndAuth(
+  available: boolean,
+  detectionError: string | null,
+  auth: AuthState | null,
+): ProviderConnectionState {
+  if (!available) {
+    return detectionError ? 'error' : 'missing';
+  }
+  if (!auth || auth.state === 'unknown') return 'installed_disconnected';
+  if (auth.state === 'disconnected') return 'installed_disconnected';
+  return 'connected';
+}
+
+function claudeInfoFromStatus(status: ProviderStatus | null, auth: AuthState | null): ProviderInfo {
   const id: ProviderId = 'anthropic';
   const base = {
     id,
     label: PROVIDER_LABEL[id],
     binary: status?.binary ?? 'claude',
     capabilities: EMPTY_CAPABILITIES,
-    identity: null,
+    identity: auth?.identity ?? null,
     docsUrl: PROVIDER_DOCS[id],
   };
   if (!status) {
     return { ...base, connection: 'missing', version: null, error: null };
   }
-  if (status.available) {
-    return { ...base, connection: 'connected', version: status.version, error: null };
-  }
+  const connection = connectionFromDetectionAndAuth(status.available, status.error, auth);
   return {
     ...base,
-    connection: status.error ? 'error' : 'missing',
-    version: null,
-    error: status.error,
+    connection,
+    version: status.available ? status.version : null,
+    error: status.available ? null : status.error,
   };
 }
 
-function cursorInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+function cursorInfoFromStatus(status: ProviderStatus | null, auth: AuthState | null): ProviderInfo {
   const id: ProviderId = 'cursor';
   const base = {
     id,
     label: PROVIDER_LABEL[id],
     binary: status?.binary ?? 'cursor-agent',
     capabilities: EMPTY_CAPABILITIES,
-    identity: null,
+    identity: auth?.identity ?? null,
     docsUrl: PROVIDER_DOCS[id],
     trackingIssueUrl: TRACKING_ISSUES[id],
   };
   if (!status || !status.available) {
     return { ...base, connection: 'missing', version: null, error: status?.error ?? null };
   }
-  return { ...base, connection: 'installed_disconnected', version: status.version, error: null };
+  const connection = connectionFromDetectionAndAuth(status.available, status.error, auth);
+  return { ...base, connection, version: status.version, error: null };
 }
 
-function codexInfoFromStatus(status: ProviderStatus | null): ProviderInfo {
+function codexInfoFromStatus(status: ProviderStatus | null, auth: AuthState | null): ProviderInfo {
   const id: ProviderId = 'codex';
   const base = {
     id,
     label: PROVIDER_LABEL[id],
     binary: status?.binary ?? 'codex',
     capabilities: EMPTY_CAPABILITIES,
-    identity: null,
+    identity: auth?.identity ?? null,
     docsUrl: PROVIDER_DOCS[id],
     trackingIssueUrl: TRACKING_ISSUES[id],
   };
   if (!status || !status.available) {
     return { ...base, connection: 'missing', version: null, error: status?.error ?? null };
   }
-  return { ...base, connection: 'installed_disconnected', version: status.version, error: null };
+  const connection = connectionFromDetectionAndAuth(status.available, status.error, auth);
+  return { ...base, connection, version: status.version, error: null };
 }
 
 export interface ProviderStatuses {
@@ -134,22 +160,14 @@ export interface ProviderStatuses {
   readonly codex: ProviderStatus | null;
 }
 
-export function buildProviderList(statuses: ProviderStatuses): ReadonlyArray<ProviderInfo>;
-export function buildProviderList(anthropic: ProviderStatus | null): ReadonlyArray<ProviderInfo>;
 export function buildProviderList(
-  arg: ProviderStatus | null | ProviderStatuses,
+  statuses: ProviderStatuses,
+  auth?: ProviderAuthResults,
 ): ReadonlyArray<ProviderInfo> {
-  if (arg === null || (typeof arg === 'object' && 'available' in arg)) {
-    return [
-      claudeInfoFromStatus(arg as ProviderStatus | null),
-      cursorInfoFromStatus(null),
-      codexInfoFromStatus(null),
-    ];
-  }
-  const { anthropic, cursor, codex } = arg as ProviderStatuses;
+  const { anthropic, cursor, codex } = statuses;
   return [
-    claudeInfoFromStatus(anthropic),
-    cursorInfoFromStatus(cursor),
-    codexInfoFromStatus(codex),
+    claudeInfoFromStatus(anthropic, auth?.anthropic ?? null),
+    cursorInfoFromStatus(cursor, auth?.cursor ?? null),
+    codexInfoFromStatus(codex, auth?.codex ?? null),
   ];
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -41,9 +41,11 @@ import { computeCostUsd } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase } from '../db';
 import {
   buildProviderList,
+  checkProviderAuth,
   getCursorStatus,
   getCodexStatus,
   getProviderStatus,
+  type ProviderAuthResults,
   type ProviderInfo,
   type ProviderStatus,
   type ProviderStatuses,
@@ -78,6 +80,7 @@ export interface AppState {
   readonly providerStatus: ProviderStatus | null;
   readonly cursorStatus: ProviderStatus | null;
   readonly codexStatus: ProviderStatus | null;
+  readonly authResults: ProviderAuthResults | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
@@ -140,6 +143,7 @@ const initialState: AppState = {
   providerStatus: null,
   cursorStatus: null,
   codexStatus: null,
+  authResults: null,
   providers: buildProviderList({ anthropic: null, cursor: null, codex: null }),
   hydrated: false,
   bootPhase: 'pending',
@@ -316,6 +320,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
       };
       set({ providerStatus, cursorStatus, codexStatus, providers: buildProviderList(statuses) });
 
+      const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
+        checkProviderAuth('anthropic'),
+        checkProviderAuth('cursor'),
+        checkProviderAuth('codex'),
+      ]);
+      const authResults: ProviderAuthResults = {
+        anthropic: anthropicAuth,
+        cursor: cursorAuth,
+        codex: codexAuth,
+      };
+      set({ authResults, providers: buildProviderList(statuses, authResults) });
+
       set({ bootPhase: 'loading-workspaces' });
       const workspaces = await listWorkspaces(tauriDatabase);
       set({ workspaces });
@@ -418,7 +434,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         cursor: state.cursorStatus,
         codex: state.codexStatus,
       };
-      return { providerStatus: status, providers: buildProviderList(statuses) };
+      return {
+        providerStatus: status,
+        providers: buildProviderList(statuses, state.authResults ?? undefined),
+      };
     });
   },
 
@@ -433,7 +452,23 @@ export const useAppStore = create<AppStore>((set, get) => ({
       cursor: cursorStatus,
       codex: codexStatus,
     };
-    set({ providerStatus, cursorStatus, codexStatus, providers: buildProviderList(statuses) });
+    const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
+      checkProviderAuth('anthropic'),
+      checkProviderAuth('cursor'),
+      checkProviderAuth('codex'),
+    ]);
+    const authResults: ProviderAuthResults = {
+      anthropic: anthropicAuth,
+      cursor: cursorAuth,
+      codex: codexAuth,
+    };
+    set({
+      providerStatus,
+      cursorStatus,
+      codexStatus,
+      authResults,
+      providers: buildProviderList(statuses, authResults),
+    });
   },
 
   createSession: async ({ workspaceId, goal, branchPrefix }) => {


### PR DESCRIPTION
## Summary

- add `check_provider_auth(provider_id: String) -> AuthState` tauri command with per-provider impl: claude uses `claude auth status` (JSON), cursor uses `cursor-agent status` (plain text), codex uses `codex auth status` (best-effort fallback to `unknown` if binary absent)
- `AuthState { state: AuthStateKind, identity: Option<String> }` with serde `rename_all = "lowercase"` so TS gets `"connected" | "disconnected" | "unknown"`
- 2s timeout per auth check, same polling pattern as binary detection; identity is best-effort (connected + identity: null if parse fails); command error → unknown
- ts `checkProviderAuth` invoke wrapper + `ProviderAuthResults` type in `providers.ts`; `buildProviderList` extended with optional `auth` param; per-provider connection derived from detection + auth (binary missing → `missing`; available + auth disconnected/unknown → `installed_disconnected`; available + auth connected → `connected`)
- `hydrate()` runs auth checks in parallel after detection and merges `authResults` into store; `refreshProviders` does the same; `refreshProviderStatus` passes existing auth through

## Deviations

- worktree base was `a66b500` (has #72, missing #84); switched to `feat/desktop-provider-auth-check` which had `a758528` as base — so #84 (`DEFAULT_SESSION_PROVIDER_PREFERENCE`) is included
- `cursor-agent status` exits non-zero when not logged in → returns `Err` → `unknown` state (conservative); verified "Not logged in" text path for success exit
- codex binary not present on dev machine; command falls back to `unknown` via `Err(_)` — no special handling needed
- prettier collapsed multi-line fn signatures on pre-commit hook — cosmetic only

## Test plan

- [ ] `cargo check` passes
- [ ] `pnpm --filter @kay-am/desktop run build` passes
- [ ] `pnpm -w typecheck` passes
- [ ] launch app: providers panel shows `connected` for claude (logged in) after hydration
- [ ] `cursor-agent`: not logged in → `installed_disconnected`; logged in → `connected`
- [ ] codex: binary missing → `missing`

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)