### PR TITLE
feat(desktop): provider connect/disconnect (#74)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ pub fn run() {
       providers::get_codex_status,
       providers::refresh_codex_status,
       providers::check_provider_auth,
+      providers::provider_action,
       turn::turn_spawn,
       turn::turn_cancel,
       repo::validate_git_repo,

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -345,6 +345,82 @@ pub fn refresh_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
     next
 }
 
+fn provider_login_command(provider_id: &str) -> Option<String> {
+    match provider_id {
+        "anthropic" => Some("claude /login".to_string()),
+        "cursor" => Some("cursor login".to_string()),
+        "codex" => Some("codex login".to_string()),
+        _ => None,
+    }
+}
+
+fn provider_logout_command(provider_id: &str) -> Option<String> {
+    match provider_id {
+        "anthropic" => Some("claude /logout".to_string()),
+        "cursor" => Some("cursor logout".to_string()),
+        "codex" => Some("codex logout".to_string()),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn spawn_in_terminal(command: &str) -> Result<(), String> {
+    // osascript ensures the terminal window opens and the command runs even if Terminal is already open
+    let script = format!(
+        "tell application \"Terminal\" to do script \"{}\"",
+        command.replace('\\', "\\\\").replace('"', "\\\"")
+    );
+    Command::new("osascript")
+        .args(["-e", &script])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_in_terminal(command: &str) -> Result<(), String> {
+    let terminals: &[(&str, &[&str])] = &[
+        ("gnome-terminal", &["--", "bash", "-c"]),
+        ("konsole", &["-e", "bash", "-c"]),
+        ("xterm", &["-e", "bash", "-c"]),
+    ];
+    for (term, base_args) in terminals {
+        let mut args: Vec<&str> = base_args.to_vec();
+        let cmd_with_pause = format!("{}; read -p 'press enter to close'", command);
+        args.push(&cmd_with_pause);
+        if Command::new(term).args(&args).spawn().is_ok() {
+            return Ok(());
+        }
+    }
+    Err("no supported terminal emulator found (tried gnome-terminal, konsole, xterm)".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn spawn_in_terminal(command: &str) -> Result<(), String> {
+    Command::new("cmd")
+        .args(["/c", "start", "cmd", "/k", command])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn spawn_in_terminal(_command: &str) -> Result<(), String> {
+    Err("unsupported platform".to_string())
+}
+
+#[tauri::command]
+pub fn provider_action(provider_id: String, action: String) -> Result<(), String> {
+    let command = match action.as_str() {
+        "login" => provider_login_command(&provider_id),
+        "logout" => provider_logout_command(&provider_id),
+        _ => return Err(format!("unknown action: {}", action)),
+    }
+    .ok_or_else(|| format!("unknown provider: {}", provider_id))?;
+
+    spawn_in_terminal(&command)
+}
+
 #[tauri::command]
 pub fn check_provider_auth(provider_id: String) -> AuthState {
     match provider_id.as_str() {

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Button, cn } from '@kay-am/ui';
 import type { ProviderConnectionState, ProviderInfo } from '../providers';
+import { providerAction } from '../providers';
+import type { ProviderId } from '../providers';
 import { useAppStore } from '../store';
 
 const STATE_LABEL: Record<ProviderConnectionState, string> = {
@@ -49,7 +51,7 @@ export function ProvidersPanel() {
       </div>
       <ul className="flex flex-col divide-y divide-border rounded border border-border">
         {providers.map((p) => (
-          <ProviderRow key={p.id} info={p} />
+          <ProviderRow key={p.id} info={p} onRefresh={onRefresh} />
         ))}
       </ul>
       <p className="text-[11px] text-muted-foreground">
@@ -60,7 +62,7 @@ export function ProvidersPanel() {
   );
 }
 
-function ProviderRow({ info }: { info: ProviderInfo }) {
+function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
   const placeholder = info.connection === 'coming-soon';
   return (
     <li
@@ -83,12 +85,23 @@ function ProviderRow({ info }: { info: ProviderInfo }) {
           {info.error ? <span className="text-danger"> — {info.error}</span> : null}
         </div>
       </div>
-      <RowActions info={info} />
+      <RowActions info={info} onRefresh={onRefresh} />
     </li>
   );
 }
 
-function RowActions({ info }: { info: ProviderInfo }) {
+function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
+  const [pending, setPending] = useState<'login' | 'logout' | null>(null);
+
+  const onAction = async (action: 'login' | 'logout') => {
+    setPending(action);
+    try {
+      await providerAction(info.id as ProviderId, action);
+    } catch {
+      // terminal launch failed — fall through to show note anyway
+    }
+  };
+
   if (info.connection === 'coming-soon') {
     return info.trackingIssueUrl ? (
       <a
@@ -101,17 +114,73 @@ function RowActions({ info }: { info: ProviderInfo }) {
       </a>
     ) : null;
   }
-  if (info.connection === 'connected') {
-    return null;
+
+  if (info.connection === 'missing') {
+    return (
+      <a
+        href={info.docsUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="text-[11px] text-primary underline hover:opacity-80"
+      >
+        install ↗
+      </a>
+    );
   }
-  return (
-    <a
-      href={info.docsUrl}
-      target="_blank"
-      rel="noreferrer"
-      className="text-[11px] text-primary underline hover:opacity-80"
-    >
-      install ↗
-    </a>
-  );
+
+  if (info.connection === 'error') {
+    return (
+      <Button variant="ghost" size="sm" onClick={() => void onRefresh()}>
+        retry
+      </Button>
+    );
+  }
+
+  if (info.connection === 'installed_disconnected') {
+    return (
+      <div className="flex flex-col items-end gap-0.5">
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={pending === 'login'}
+          onClick={() => void onAction('login')}
+        >
+          connect
+        </Button>
+        {pending === 'login' ? (
+          <span className="text-[10px] text-muted-foreground">
+            complete in terminal, then{' '}
+            <button className="underline hover:text-foreground" onClick={() => void onRefresh()}>
+              refresh ↻
+            </button>
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (info.connection === 'connected') {
+    return (
+      <div className="flex flex-col items-end gap-0.5">
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={pending === 'logout'}
+          onClick={() => void onAction('logout')}
+        >
+          disconnect
+        </Button>
+        {pending === 'logout' ? (
+          <span className="text-[10px] text-muted-foreground">
+            complete in terminal, then{' '}
+            <button className="underline hover:text-foreground" onClick={() => void onRefresh()}>
+              refresh ↻
+            </button>
+          </span>
+        ) : null}
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -81,6 +81,15 @@ export async function checkProviderAuth(providerId: ProviderId): Promise<AuthSta
   return invoke<AuthState>('check_provider_auth', { providerId });
 }
 
+export type ProviderAction = 'login' | 'logout';
+
+export async function providerAction(
+  providerId: ProviderId,
+  action: ProviderAction,
+): Promise<void> {
+  return invoke<void>('provider_action', { providerId, action });
+}
+
 export type ProviderAuthResults = Readonly<Record<ProviderId, AuthState | null>>;
 
 function connectionFromDetectionAndAuth(


### PR DESCRIPTION
## Summary

- Adds `provider_action(id, action)` Tauri command that spawns the provider's login/logout command in an OS-native terminal (osascript on macOS, gnome-terminal/konsole/xterm on Linux, cmd on Windows)
- Exports `providerAction` TS invoke wrapper from `apps/desktop/src/providers.ts` (available for #79 to import)
- Updates `ProvidersPanel` with per-state CTAs: `connect` (installed_disconnected), `disconnect` (connected), `retry` (error), `install ↗` (missing), `track ↗` (coming-soon)
- After CTA click: inline note "complete in terminal, then refresh ↻" appears

## Provider commands

| provider | login | logout |
|---|---|---|
| anthropic | `claude /login` | `claude /logout` |
| cursor | `cursor login` | `cursor logout` |
| codex | `codex login` | `codex logout` |

## Test plan

- [ ] `cargo check` passes (verified)
- [ ] `pnpm -w build` passes (verified)
- [ ] Click "connect" on disconnected provider → Terminal.app opens with login command
- [ ] Click "disconnect" on connected provider → Terminal.app opens with logout command
- [ ] After completing flow + clicking refresh → connection state flips

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)