### PR TITLE
feat(core): provider registry unified factory (#70)

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { sessionReducer, Summarizer, type SlotKey } from '@kay-am/core';
+import { sessionReducer, Summarizer, getDefaultTurnModel, type SlotKey } from '@kay-am/core';
 import {
   getSetting,
   insertMessage,
@@ -174,8 +174,6 @@ function messageToTurnEvent(message: Message): TurnEvent | null {
     at: message.createdAt,
   };
 }
-
-const DEFAULT_MODEL = 'claude-opus-4-7';
 
 type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
 
@@ -510,6 +508,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
 
     const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+    const provider = session.providerPreference.defaultProvider;
+    const model = session.providerPreference.defaultModel ?? getDefaultTurnModel(provider);
 
     const userMessage: Message = {
       id: crypto.randomUUID() as MessageId,
@@ -524,8 +524,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const run: ProviderRun = {
       id: runId,
       sessionId,
-      provider: 'anthropic',
-      model: DEFAULT_MODEL,
+      provider,
+      model,
       status: { kind: 'streaming', startedAt: now() },
       createdAt: now(),
     };
@@ -545,7 +545,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       for await (const event of runTurn({
         runId,
-        model: DEFAULT_MODEL,
+        model,
         workingDir,
         prompt: content,
       })) {
@@ -553,14 +553,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
         if (event.kind === 'assistant_text') assistantText += event.delta;
 
         if (event.kind === 'usage') {
-          const cost = computeCostUsd(event.usage, DEFAULT_MODEL);
+          const cost = computeCostUsd(event.usage, model);
           const record: TelemetryRecord = {
             id: crypto.randomUUID() as TelemetryRecordId,
             runId,
             sessionId,
             kind: 'turn',
-            provider: 'anthropic',
-            model: DEFAULT_MODEL,
+            provider,
+            model,
             inputTokens: event.usage.inputTokens,
             outputTokens: event.usage.outputTokens,
             estimatedCostUsd: cost,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,14 @@ export {
 export { computeCostUsd, priceFor } from './providers/claude/cost';
 export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';
 
+// registry.ts (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from @kay-am/core/src/providers/registry when needed in Node context.
+export {
+  PROVIDER_CAPABILITIES,
+  getCapabilities,
+  getDefaultTurnModel,
+} from './providers/capabilities';
+
 // CursorAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from @kay-am/core/src/providers/cursor/adapter when needed in Node context.
 export { CURSOR_CHEAP_MODEL } from './providers/cursor/cost';

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,0 +1,44 @@
+import type { ProviderId, ProviderRegistryCapabilities } from '@kay-am/types';
+import { CURSOR_CHEAP_MODEL } from './cursor/cost';
+import { CODEX_CHEAP_MODEL } from './codex/constants';
+
+export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistryCapabilities>> = {
+  anthropic: {
+    models: [
+      { id: 'claude-opus-4-7', tier: 'turn', contextWindow: 1_000_000 },
+      { id: 'claude-sonnet-4-6', tier: 'turn', contextWindow: 200_000 },
+      { id: 'claude-haiku-4-5', tier: 'cheap', contextWindow: 200_000 },
+    ],
+    supportsTools: true,
+    supportsStream: true,
+    supportsCheapModel: true,
+  },
+  cursor: {
+    models: [
+      { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
+      { id: 'gpt-4o', tier: 'turn', contextWindow: 128_000 },
+      { id: CURSOR_CHEAP_MODEL, tier: 'cheap', contextWindow: 32_000 },
+    ],
+    supportsTools: true,
+    supportsStream: true,
+    supportsCheapModel: true,
+  },
+  codex: {
+    models: [
+      { id: 'codex-latest', tier: 'turn', contextWindow: 128_000 },
+      { id: CODEX_CHEAP_MODEL, tier: 'cheap', contextWindow: 128_000 },
+    ],
+    supportsTools: true,
+    supportsStream: true,
+    supportsCheapModel: true,
+  },
+};
+
+export function getCapabilities(id: ProviderId): ProviderRegistryCapabilities {
+  return PROVIDER_CAPABILITIES[id];
+}
+
+export function getDefaultTurnModel(id: ProviderId): string {
+  const caps = PROVIDER_CAPABILITIES[id];
+  return caps.models.find((m) => m.tier === 'turn')?.id ?? caps.models[0]!.id;
+}

--- a/packages/core/src/providers/registry.test.ts
+++ b/packages/core/src/providers/registry.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { ClaudeAdapter } from './claude/adapter';
+import { CursorAdapter } from './cursor/adapter';
+import { CodexAdapter } from './codex/adapter';
+import {
+  UnknownProviderError,
+  createProvider,
+  getCapabilities,
+  listSupportedProviders,
+} from './registry';
+
+describe('listSupportedProviders', () => {
+  it('returns all three provider ids', () => {
+    expect(listSupportedProviders()).toEqual(['anthropic', 'cursor', 'codex']);
+  });
+
+  it('result is readonly array', () => {
+    const result = listSupportedProviders();
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+describe('createProvider', () => {
+  it('returns ClaudeAdapter for anthropic', () => {
+    const adapter = createProvider('anthropic');
+    expect(adapter).toBeInstanceOf(ClaudeAdapter);
+    expect(adapter.id).toBe('anthropic');
+  });
+
+  it('returns CursorAdapter for cursor', () => {
+    const adapter = createProvider('cursor');
+    expect(adapter).toBeInstanceOf(CursorAdapter);
+    expect(adapter.id).toBe('cursor');
+  });
+
+  it('returns CodexAdapter for codex', () => {
+    const adapter = createProvider('codex');
+    expect(adapter).toBeInstanceOf(CodexAdapter);
+    expect(adapter.id).toBe('codex');
+  });
+
+  it('passes deps through to adapter', () => {
+    const binary = '/custom/claude-bin';
+    const adapter = createProvider('anthropic', { binary });
+    expect(adapter).toBeInstanceOf(ClaudeAdapter);
+  });
+
+  it('throws UnknownProviderError for unknown id', () => {
+    expect(() => createProvider('unknown' as never)).toThrow(UnknownProviderError);
+    expect(() => createProvider('unknown' as never)).toThrow('unknown provider: unknown');
+  });
+});
+
+describe('getCapabilities', () => {
+  it('returns anthropic capabilities with correct flags', () => {
+    const caps = getCapabilities('anthropic');
+    expect(caps.supportsTools).toBe(true);
+    expect(caps.supportsStream).toBe(true);
+    expect(caps.supportsCheapModel).toBe(true);
+    expect(caps.models.length).toBeGreaterThan(0);
+  });
+
+  it('anthropic has a cheap-tier model', () => {
+    const caps = getCapabilities('anthropic');
+    expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
+  });
+
+  it('cursor capabilities have models', () => {
+    const caps = getCapabilities('cursor');
+    expect(caps.models.length).toBeGreaterThan(0);
+    expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
+  });
+
+  it('codex capabilities have models', () => {
+    const caps = getCapabilities('codex');
+    expect(caps.models.length).toBeGreaterThan(0);
+    expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
+  });
+
+  it('all models have required fields', () => {
+    for (const id of listSupportedProviders()) {
+      const caps = getCapabilities(id);
+      for (const model of caps.models) {
+        expect(typeof model.id).toBe('string');
+        expect(['turn', 'cheap']).toContain(model.tier);
+        expect(typeof model.contextWindow).toBe('number');
+        expect(model.contextWindow).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/packages/core/src/providers/registry.ts
+++ b/packages/core/src/providers/registry.ts
@@ -1,0 +1,50 @@
+import { spawn } from 'node:child_process';
+import type {
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderId,
+  ProviderRegistryCapabilities,
+} from '@kay-am/types';
+import { ClaudeAdapter } from './claude/adapter';
+import { CursorAdapter } from './cursor/adapter';
+import { CodexAdapter } from './codex/adapter';
+import { PROVIDER_CAPABILITIES } from './capabilities';
+
+export type { ProviderRegistryCapabilities };
+
+export interface ProviderDeps {
+  readonly binary?: string;
+  readonly now?: () => IsoDateTime;
+  readonly spawnFn?: typeof spawn;
+  readonly onUnknown?: (type: string, payload: unknown) => void;
+}
+
+export class UnknownProviderError extends Error {
+  constructor(id: string) {
+    super(`unknown provider: ${id}`);
+    this.name = 'UnknownProviderError';
+  }
+}
+
+export function createProvider(id: ProviderId, deps: ProviderDeps = {}): ProviderAdapter {
+  switch (id) {
+    case 'anthropic':
+      return new ClaudeAdapter(deps);
+    case 'cursor':
+      return new CursorAdapter(deps);
+    case 'codex':
+      return new CodexAdapter(deps);
+    default: {
+      const _exhaustive: never = id;
+      throw new UnknownProviderError(_exhaustive);
+    }
+  }
+}
+
+export function listSupportedProviders(): ReadonlyArray<ProviderId> {
+  return ['anthropic', 'cursor', 'codex'];
+}
+
+export function getCapabilities(id: ProviderId): ProviderRegistryCapabilities {
+  return PROVIDER_CAPABILITIES[id];
+}


### PR DESCRIPTION
## Summary

- Adds `packages/core/src/providers/capabilities.ts` — browser-safe module with `PROVIDER_CAPABILITIES` record, `getCapabilities(id)`, and `getDefaultTurnModel(id)` (first `turn`-tier model for a given `ProviderId`). Exported from `@kay-am/core` barrel.
- Adds `packages/core/src/providers/registry.ts` — Node-only factory module (uses `node:child_process` via adapter imports). Exports `createProvider(id, deps)`, `listSupportedProviders()`, `getCapabilities(id)`, and `UnknownProviderError`. Intentionally NOT in the browser barrel per existing pattern for cursor/codex adapters.
- Adds `registry.test.ts` — 12 unit tests covering correct adapter instance per id, `UnknownProviderError` on unknown id, and capabilities shape validation for all three providers.
- Wires turn pipeline in `apps/desktop/src/store/store.ts`: `sendTurn` now reads `session.providerPreference.defaultProvider` + `session.providerPreference.defaultModel` (falling back to `getDefaultTurnModel`) instead of hardcoded `'anthropic'` / `'claude-opus-4-7'`. Removes dead `DEFAULT_MODEL` constant.

## Deviations

**Turn spawning is Rust-side, not TS-side.** The desktop frontend calls Tauri `turn_spawn` command (in `apps/desktop/src/turn.ts`) which passes `model` and `binary` to Rust. The TS adapters (`ClaudeAdapter`, `CursorAdapter`, `CodexAdapter`) are **not** called during turn execution in the browser context — they exist in `packages/core` for direct Node/Rust-adjacent use. The registry (`createProvider`) is not called in `sendTurn`; the session preference only affects telemetry recording and model selection passed to Rust. Full cursor/codex routing through the registry will be activated by #74/#75/#76 UI work + the Rust-side `turn_spawn` command accepting a `providerId` param.

## Test plan

- [x] `pnpm -w typecheck` — all 5 packages pass
- [x] `pnpm -w test` — 153 tests pass (12 new in `registry.test.ts`)
- [x] `pnpm -w lint` — no violations
- [ ] Manual: create session, send turn — should use `claude-opus-4-7` as before (no behavioral change since `DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider = 'anthropic'`)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)