### PR TITLE
feat(desktop): pre-flight auth check + callout

### DIFF
--- a/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
+++ b/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
@@ -1,0 +1,49 @@
+import { invoke } from '@tauri-apps/api/core';
+import { Button } from '@kay-am/ui';
+import type { ProviderId } from '@kay-am/types';
+
+const PROVIDER_LABEL: Record<ProviderId, string> = {
+  anthropic: 'claude',
+  cursor: 'cursor',
+  codex: 'codex',
+};
+
+async function providerAction(id: ProviderId, action: 'login' | 'logout'): Promise<void> {
+  return invoke('provider_action', { id, action });
+}
+
+interface AuthRequiredCalloutProps {
+  readonly providerId: ProviderId;
+  readonly identity?: string | null;
+  readonly onRefresh: () => void;
+}
+
+export function AuthRequiredCallout({ providerId, identity, onRefresh }: AuthRequiredCalloutProps) {
+  const label = PROVIDER_LABEL[providerId];
+
+  const onConnect = () => {
+    void providerAction(providerId, 'login');
+  };
+
+  return (
+    <div className="rounded-md border border-warning/40 bg-warning/5 px-3 py-3 text-sm">
+      <div className="flex items-start gap-2">
+        <span className="mt-0.5 text-warning">⚠</span>
+        <div className="flex-1">
+          <p className="font-medium text-foreground">{label} is not signed in.</p>
+          {identity ? (
+            <p className="mt-0.5 text-xs text-muted-foreground">last known identity: {identity}</p>
+          ) : null}
+          <div className="mt-2 flex gap-2">
+            <Button size="sm" onClick={onConnect}>
+              connect now ↗
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onRefresh}>
+              refresh status
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -5,18 +5,23 @@ import { useAppStore } from '../../store';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
-export function ChatInput({ session }: { session: Session }) {
+interface ChatInputProps {
+  readonly session: Session;
+  readonly providerDisconnected?: boolean;
+}
+
+export function ChatInput({ session, providerDisconnected = false }: ChatInputProps) {
   const sendTurn = useAppStore((s) => s.sendTurn);
   const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
 
   const isRunning = RUNNING_KINDS.has(session.state.kind);
-  const canSend = !isRunning && value.trim().length > 0;
+  const canSend = !isRunning && !providerDisconnected && value.trim().length > 0;
 
   const onSend = async () => {
     const content = value.trim();
-    if (!content || isRunning) return;
+    if (!content || isRunning || providerDisconnected) return;
     setError(null);
     setValue('');
     try {
@@ -33,6 +38,8 @@ export function ChatInput({ session }: { session: Session }) {
     }
   };
 
+  const sendDisabledTitle = providerDisconnected ? 'sign in first' : undefined;
+
   return (
     <div className="flex flex-col gap-2 border-t border-border p-3">
       <Textarea
@@ -42,9 +49,11 @@ export function ChatInput({ session }: { session: Session }) {
         placeholder={
           isRunning
             ? 'turn running… cancel to send another'
-            : 'message claude. shift+enter for newline.'
+            : providerDisconnected
+              ? 'sign in to send a message.'
+              : 'message claude. shift+enter for newline.'
         }
-        disabled={isRunning}
+        disabled={isRunning || providerDisconnected}
         rows={3}
       />
       {error ? <p className="text-xs text-danger">{error}</p> : null}
@@ -54,7 +63,7 @@ export function ChatInput({ session }: { session: Session }) {
             cancel
           </Button>
         ) : (
-          <Button onClick={() => void onSend()} disabled={!canSend}>
+          <Button onClick={() => void onSend()} disabled={!canSend} title={sendDisabledTitle}>
             send
           </Button>
         )}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -6,6 +6,7 @@ import { OpenInEditorButton } from '../OpenInEditorButton';
 import { ChatInput } from './ChatInput';
 import { reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
+import { AuthRequiredCallout } from './AuthRequiredCallout';
 
 interface ChatViewProps {
   session: Session;
@@ -17,8 +18,15 @@ export function ChatView({ session }: ChatViewProps) {
   const events = useTranscript(session.id);
   const items = useMemo(() => reduceTranscript(events), [events]);
   const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id] ?? null);
+  const authResults = useAppStore((s) => s.authResults);
+  const refreshProviders = useAppStore((s) => s.refreshProviders);
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState(true);
+
+  const provider = session.providerPreference.defaultProvider;
+  const providerAuthState = authResults?.[provider]?.state ?? null;
+  const providerIdentity = authResults?.[provider]?.identity ?? null;
+  const isProviderDisconnected = providerAuthState === 'disconnected';
 
   useEffect(() => {
     const el = scrollerRef.current;
@@ -53,12 +61,20 @@ export function ChatView({ session }: ChatViewProps) {
         className="relative flex-1 overflow-y-auto px-4 py-3"
       >
         {items.length === 0 ? (
-          <p className="text-sm text-muted-foreground">no turns yet — send a message.</p>
+          isProviderDisconnected ? (
+            <AuthRequiredCallout
+              providerId={provider}
+              identity={providerIdentity}
+              onRefresh={() => void refreshProviders()}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">no turns yet — send a message.</p>
+          )
         ) : (
           <ul className="flex flex-col gap-3">
             {items.map((item) => (
               <li key={item.key}>
-                <TranscriptCard item={item} />
+                <TranscriptCard item={item} onRefreshAuth={() => void refreshProviders()} />
               </li>
             ))}
           </ul>
@@ -82,7 +98,7 @@ export function ChatView({ session }: ChatViewProps) {
           session ended — no further turns. branch preserved.
         </div>
       ) : (
-        <ChatInput session={session} />
+        <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
       )}
     </div>
   );

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Collapsible, cn } from '@kay-am/ui';
 import { CopyButton } from './CopyButton';
 import type { TranscriptItem } from './transcript-items';
+import { AuthRequiredCallout } from './AuthRequiredCallout';
 
 const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
   create: 'bg-primary/10 text-primary',
@@ -9,7 +10,12 @@ const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
   delete: 'bg-danger/10 text-danger',
 };
 
-export function TranscriptCard({ item }: { item: TranscriptItem }) {
+interface TranscriptCardProps {
+  readonly item: TranscriptItem;
+  readonly onRefreshAuth?: () => void;
+}
+
+export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
   switch (item.kind) {
     case 'assistant_text':
       return <AssistantText text={item.text} />;
@@ -39,6 +45,14 @@ export function TranscriptCard({ item }: { item: TranscriptItem }) {
         <div className="rounded-md border border-danger/40 bg-danger/5 px-3 py-2 text-sm text-danger">
           {item.message}
         </div>
+      );
+    case 'auth_required':
+      return (
+        <AuthRequiredCallout
+          providerId={item.providerId}
+          identity={item.identity}
+          onRefresh={onRefreshAuth ?? (() => undefined)}
+        />
       );
     case 'done':
       return <hr className="border-border" />;

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -1,4 +1,5 @@
-import type { ProviderUsage, TurnEvent } from '@kay-am/types';
+import type { ProviderId, ProviderUsage, TurnEvent } from '@kay-am/types';
+import { decodeAuthRequiredMessage } from '../../turn';
 
 export type TranscriptItem =
   | { kind: 'assistant_text'; key: string; text: string }
@@ -15,6 +16,7 @@ export type TranscriptItem =
   | { kind: 'file_edit'; key: string; path: string; editType: 'create' | 'modify' | 'delete' }
   | { kind: 'usage'; key: string; usage: ProviderUsage }
   | { kind: 'error'; key: string; message: string }
+  | { kind: 'auth_required'; key: string; providerId: ProviderId; identity: string | null }
   | { kind: 'done'; key: string };
 
 export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArray<TranscriptItem> {
@@ -82,9 +84,20 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
       case 'usage':
         items.push({ kind: 'usage', key: `usage-${i}`, usage: event.usage });
         break;
-      case 'error':
-        items.push({ kind: 'error', key: `error-${i}`, message: event.message });
+      case 'error': {
+        const authPayload = decodeAuthRequiredMessage(event.message);
+        if (authPayload) {
+          items.push({
+            kind: 'auth_required',
+            key: `auth-${i}`,
+            providerId: authPayload.providerId,
+            identity: authPayload.identity,
+          });
+        } else {
+          items.push({ kind: 'error', key: `error-${i}`, message: event.message });
+        }
         break;
+      }
       case 'done':
         items.push({ kind: 'done', key: `done-${i}` });
         break;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -57,7 +57,7 @@ import {
   SETTING_LAST_SESSION_ID,
   SETTING_LAST_WORKSPACE_ID,
 } from '../settings';
-import { runTurn, cancelTurn } from '../turn';
+import { runTurn, cancelTurn, encodeAuthRequiredMessage, isAuthErrorMessage } from '../turn';
 import { createWorktree, removeWorktree, type CreatedWorktree } from '../worktree';
 
 export type BootPhase =
@@ -546,6 +546,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const provider = session.providerPreference.defaultProvider;
     const model = session.providerPreference.defaultModel ?? getDefaultTurnModel(provider);
 
+    const authState = get().authResults?.[provider] ?? null;
+    if (authState?.state === 'disconnected') {
+      const runId = crypto.randomUUID() as ProviderRunId;
+      get().appendTurnEvent(sessionId, {
+        kind: 'error',
+        runId,
+        message: encodeAuthRequiredMessage({ providerId: provider, identity: authState.identity }),
+        at: now(),
+      });
+      return;
+    }
+
     const userMessage: Message = {
       id: crypto.randomUUID() as MessageId,
       sessionId,
@@ -633,10 +645,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     } catch (err) {
       lastError = err;
-      const message = err instanceof Error ? err.message : String(err);
+      const rawMessage = err instanceof Error ? err.message : String(err);
+      const isAuthErr = isAuthErrorMessage(rawMessage);
+      const message = isAuthErr
+        ? encodeAuthRequiredMessage({
+            providerId: provider,
+            identity: get().authResults?.[provider]?.identity ?? null,
+          })
+        : rawMessage;
       const errorState: SessionState = {
         kind: 'error',
-        message,
+        message: rawMessage,
         failedAt: now(),
       };
       await updateSessionState(tauriDatabase, sessionId, errorState, now());
@@ -644,7 +663,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       await updateProviderRunStatus(tauriDatabase, runId, {
         kind: 'failed',
         finishedAt: now(),
-        error: message,
+        error: rawMessage,
       });
       get().appendTurnEvent(sessionId, {
         kind: 'error',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -10,6 +10,8 @@
   --color-border: oklch(0.92 0.005 270);
   --color-danger: oklch(0.55 0.2 25);
   --color-danger-foreground: oklch(0.99 0 0);
+  --color-warning: oklch(0.60 0.18 70);
+  --color-warning-foreground: oklch(0.99 0 0);
 
   --text-xs: 11px;
   --text-sm: 13px;

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -1,7 +1,45 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { parseStreamJsonLine } from '@kay-am/core';
-import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+import type { IsoDateTime, ProviderId, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+export const AUTH_REQUIRED_PREFIX = '__auth_required__:';
+
+export interface AuthRequiredPayload {
+  readonly providerId: ProviderId;
+  readonly identity: string | null;
+}
+
+export function encodeAuthRequiredMessage(payload: AuthRequiredPayload): string {
+  return `${AUTH_REQUIRED_PREFIX}${JSON.stringify(payload)}`;
+}
+
+export function decodeAuthRequiredMessage(message: string): AuthRequiredPayload | null {
+  if (!message.startsWith(AUTH_REQUIRED_PREFIX)) return null;
+  try {
+    return JSON.parse(message.slice(AUTH_REQUIRED_PREFIX.length)) as AuthRequiredPayload;
+  } catch {
+    return null;
+  }
+}
+
+const AUTH_ERROR_PATTERNS = [
+  /not authenticated/i,
+  /not logged in/i,
+  /auth required/i,
+  /authentication required/i,
+  /please log in/i,
+  /please sign in/i,
+  /unauthenticated/i,
+  /401/,
+  /unauthorized/i,
+  /login required/i,
+  /not signed in/i,
+];
+
+export function isAuthErrorMessage(text: string): boolean {
+  return AUTH_ERROR_PATTERNS.some((p) => p.test(text));
+}
 
 const EVENT_NAME = 'turn_event';
 


### PR DESCRIPTION
## Summary

- Pre-flight in `sendTurn`: checks `authResults` before spawning; if provider is `disconnected`, emits an `auth_required` TurnEvent (encoded in the `error` kind message) and skips spawn entirely
- Stderr mapping: known auth-error patterns (not authenticated, 401, not logged in, etc.) in turn pipeline catch block map to the same `auth_required` encoding as defense-in-depth
- `AuthRequiredCallout` component: renders provider label, last known identity, "connect now ↗" (via `provider_action` local stub), and "refresh status" buttons
- Transcript renderer: `auth_required` items decoded in `reduceTranscript` → render `AuthRequiredCallout` instead of default error block
- Boot / empty state: `ChatView` shows `AuthRequiredCallout` instead of "no turns yet" when provider is disconnected and transcript is empty
- Send button: disabled with `title="sign in first"` tooltip when provider disconnected; textarea placeholder updated accordingly
- `warning` CSS color token added to `styles.css` to match `danger` convention

## Test plan

- [ ] Disconnect claude (`claude logout`) → open app → existing session → callout visible, send button disabled with "sign in first" tooltip
- [ ] Click "connect now ↗" → `provider_action('anthropic', 'login')` invoked (terminal opens once #74 rust command lands)
- [ ] Click "refresh status" → `refreshProviders()` reruns auth check; on success callout disappears and send works
- [ ] If provider is `unknown` (not `disconnected`), send proceeds optimistically — no callout
- [ ] Auth-error stderr during turn (e.g. expired token mid-flight) maps to auth_required callout in transcript

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)