### PR TITLE
refactor(core): summarizer uses active provider cli (#71)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ These are the non-negotiable choices that frame all of v0.1 and constrain later 
 
 1. **Provider integration via headless CLI spawn** — `claude -p "<prompt>" --output-format stream-json --working-dir <worktree> --dangerously-skip-permissions`. The user's existing subscription (Claude Max, Cursor Pro, ChatGPT Pro) is consumed via the official provider CLI. Anthropic / OpenAI / Cursor SDKs are explicitly NOT used in v0.1 — they require per-token billing and would defeat the "spend less" mission.
 2. **kAY.am owns the conversation** — history lives in our SQLite, not in `~/.claude/projects/`. Every turn is reconstructed from the synthetic context plus the new user message; we never rely on `--resume`. This is what makes context portable across providers.
-3. **Synthetic context = hybrid structured slots** — fixed slots (`goal`, `files_touched`, `decisions`, `open_questions`, `last_output_summary`), editable by hand at any time, auto-updated post-turn by a cheap summarizer (Claude Haiku via Anthropic API at token cost — pennies per session).
+3. **Synthetic context = hybrid structured slots** — fixed slots (`goal`, `files_touched`, `decisions`, `open_questions`, `last_output_summary`), editable by hand at any time, auto-updated post-turn by a cheap summarizer (active provider's cheap-tier model via CLI — no separate API key required, runs against the user's existing subscription).
 4. **Isolation = git worktree per session** — branch prefix configurable per workspace (default `kay`). Worktree is the sandbox that makes `--dangerously-skip-permissions` acceptable in v0.1.
 5. **Provider scope, phased** — v0.1 ships with Claude only behind a stable adapter interface; v0.2 adds Cursor + Codex together to stress-test the contract on two new adapters at once.
 6. **Permission model v0.1** — `--dangerously-skip-permissions` ON, contained by the worktree sandbox. Permission proxy (intercept tool-calls → UI approve/deny) lands in v0.6 once we know what real usage demands.
@@ -33,7 +33,7 @@ Full design spec: see the conversation that produced this roadmap. Architectural
 - Auto worktree creation on session start, cleanup on end (branch preserved)
 - Provider CLI detection at boot
 - Chat UI with stream-rendered TurnEvents (assistant text, tool-use cards, file edit cards, usage)
-- Synthetic context engine + Haiku summarizer (auto slot update post-turn)
+- Synthetic context engine + cheap-tier summarizer via active provider CLI (auto slot update post-turn)
 - Telemetry: per-turn / per-session / per-workspace token + USD cost
 - Persistence of workspaces, sessions, messages, slots, telemetry, settings
 - Open-in-VS-Code button on session

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod editor;
 mod providers;
 mod repo;
 mod secrets;
+mod summarize;
 mod turn;
 mod worktree;
 
@@ -58,6 +59,7 @@ pub fn run() {
       providers::provider_action,
       turn::turn_spawn,
       turn::turn_cancel,
+      summarize::summarize_session,
       repo::validate_git_repo,
     ])
     .run(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -1,0 +1,105 @@
+use std::process::{Command, Stdio};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SummarizeError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("unknown provider: {0}")]
+    UnknownProvider(String),
+}
+
+impl Serialize for SummarizeError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl SummarizeError {
+    fn kind(&self) -> &'static str {
+        match self {
+            SummarizeError::Io(_) => "io",
+            SummarizeError::UnknownProvider(_) => "unknown_provider",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SummarizeArgs {
+    pub provider_id: String,
+    pub model: String,
+    pub binary: String,
+    pub user_message: String,
+    pub system_prompt: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SummarizeResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+}
+
+#[tauri::command]
+pub fn summarize_session(args: SummarizeArgs) -> Result<SummarizeResult, SummarizeError> {
+    let cli_args = build_cli_args(&args)?;
+
+    let output = Command::new(&args.binary)
+        .args(&cli_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+
+    Ok(SummarizeResult {
+        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        exit_code: output.status.code(),
+    })
+}
+
+fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {
+    match args.provider_id.as_str() {
+        "anthropic" => Ok(vec![
+            "-p".to_string(),
+            args.user_message.clone(),
+            "--model".to_string(),
+            args.model.clone(),
+            "--system-prompt".to_string(),
+            args.system_prompt.clone(),
+            "--output-format".to_string(),
+            "json".to_string(),
+            "--no-session-persistence".to_string(),
+        ]),
+        "cursor" => Ok(vec![
+            "-p".to_string(),
+            format!("{}\n\n{}", args.system_prompt, args.user_message),
+            "--model".to_string(),
+            args.model.clone(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+            "--force".to_string(),
+        ]),
+        "codex" => Ok(vec![
+            "exec".to_string(),
+            "--json".to_string(),
+            "--model".to_string(),
+            args.model.clone(),
+            "--".to_string(),
+            format!("{}\n\n{}", args.system_prompt, args.user_message),
+        ]),
+        other => Err(SummarizeError::UnknownProvider(other.to_string())),
+    }
+}

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, Input } from '@kay-am/ui';
 import { ProvidersPanel } from './ProvidersPanel';
-import { ANTHROPIC_API_KEY_SECRET, deleteSecret, hasSecret, setSecret } from '../secrets';
 import {
   DEFAULT_BRANCH_PREFIX,
   DEFAULT_EDITOR_BINARY,
@@ -21,10 +20,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const workspace = useCurrentWorkspace();
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
-  const refreshApiKeyPresence = useAppStore((s) => s.refreshApiKeyPresence);
 
-  const [apiKeySet, setApiKeySet] = useState<boolean | null>(null);
-  const [apiKeyDraft, setApiKeyDraft] = useState('');
   const [editorBinary, setEditorBinary] = useState(DEFAULT_EDITOR_BINARY);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [saveState, setSaveState] = useState<SaveState>('idle');
@@ -34,8 +30,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     if (!open) return;
     setSaveState('idle');
     setError(null);
-    setApiKeyDraft('');
-    void hasSecret(ANTHROPIC_API_KEY_SECRET).then(setApiKeySet);
     void loadSetting(SETTING_EDITOR_BINARY).then((v) =>
       setEditorBinary(v ?? DEFAULT_EDITOR_BINARY),
     );
@@ -50,12 +44,6 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     setSaveState('saving');
     setError(null);
     try {
-      if (apiKeyDraft.trim().length > 0) {
-        await setSecret(ANTHROPIC_API_KEY_SECRET, apiKeyDraft.trim());
-        setApiKeySet(true);
-        setApiKeyDraft('');
-        await refreshApiKeyPresence();
-      }
       await saveSetting(SETTING_EDITOR_BINARY, editorBinary.trim() || DEFAULT_EDITOR_BINARY);
       if (workspace) {
         await saveSetting(
@@ -70,51 +58,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }
   };
 
-  const onClearKey = async () => {
-    setError(null);
-    try {
-      await deleteSecret(ANTHROPIC_API_KEY_SECRET);
-      setApiKeySet(false);
-      await refreshApiKeyPresence();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  };
-
   return (
     <Dialog open={open} onClose={onClose} title="settings" className="min-w-96">
       <div className="flex flex-col gap-4">
         <ProvidersPanel />
-
-        <Section
-          label="anthropic api key (summarizer only)"
-          help={
-            apiKeySet === null
-              ? 'checking keychain…'
-              : apiKeySet
-                ? 'key present in keychain (write-only) — used by post-turn summarizer (Haiku). Removed in v0.2 (#71).'
-                : 'optional. enables auto context-slot updates via Haiku (~$0.0015/turn). slots stay editable by hand without it.'
-          }
-        >
-          <div className="flex gap-2">
-            <Input
-              type="password"
-              autoComplete="off"
-              placeholder={apiKeySet ? '•••••••• (replace)' : 'sk-ant-…'}
-              value={apiKeyDraft}
-              onChange={(e) => setApiKeyDraft(e.target.value)}
-            />
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => void onClearKey()}
-              disabled={apiKeySet !== true}
-              title="remove key from keychain"
-            >
-              clear
-            </Button>
-          </div>
-        </Section>
 
         <Section label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>
           <Input

--- a/apps/desktop/src/secrets.ts
+++ b/apps/desktop/src/secrets.ts
@@ -15,5 +15,3 @@ export async function hasSecret(key: string): Promise<boolean> {
 export async function getSecret(key: string): Promise<string | null> {
   return await invoke<string | null>('secret_get', { key });
 }
-
-export const ANTHROPIC_API_KEY_SECRET = 'anthropic_api_key';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -51,7 +51,6 @@ import {
   type ProviderStatuses,
 } from '../providers';
 import { validateGitRepo } from '../repo';
-import { ANTHROPIC_API_KEY_SECRET, getSecret, hasSecret } from '../secrets';
 import {
   SETTING_EDITOR_BINARY,
   SETTING_LAST_SESSION_ID,
@@ -84,7 +83,6 @@ export interface AppState {
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
-  readonly apiKeyPresent: boolean;
   readonly error: string | null;
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
@@ -125,7 +123,6 @@ export interface AppActions {
   endSession(sessionId: SessionId): Promise<void>;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
   loadSessionTelemetry(sessionId: SessionId): Promise<void>;
-  refreshApiKeyPresence(): Promise<void>;
   loadSessionSlots(sessionId: SessionId): Promise<void>;
   upsertSessionSlot(sessionId: SessionId, key: SlotKey, value: string): Promise<void>;
   toggleSessionSlot(sessionId: SessionId, key: SlotKey, enabled: boolean): Promise<void>;
@@ -147,7 +144,6 @@ const initialState: AppState = {
   providers: buildProviderList({ anthropic: null, cursor: null, codex: null }),
   hydrated: false,
   bootPhase: 'pending',
-  apiKeyPresent: false,
   error: null,
   transcripts: {},
   messages: {},
@@ -195,7 +191,6 @@ async function runSummarizer(
   sessionId: SessionId,
   turnInput: string,
   turnOutput: string,
-  apiKey: string,
 ): Promise<void> {
   const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
   set((state) => ({
@@ -209,7 +204,8 @@ async function runSummarizer(
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session) return;
 
-    const summarizer = new Summarizer({ apiKey });
+    const providerId = session.providerPreference.defaultProvider;
+    const summarizer = new Summarizer({ providerId });
     const prevSlots = get().sessionSlots[sessionId] ?? [];
     const result = await summarizer.summarize({ prevSlots, turnInput, turnOutput });
 
@@ -232,7 +228,7 @@ async function runSummarizer(
     await insertProviderRun(tauriDatabase, {
       id: summarizerRunId,
       sessionId,
-      provider: 'anthropic',
+      provider: providerId,
       model: result.model,
       status: { kind: 'streaming', startedAt },
       createdAt: startedAt,
@@ -246,7 +242,7 @@ async function runSummarizer(
       runId: summarizerRunId,
       sessionId,
       kind: 'summarizer',
-      provider: 'anthropic',
+      provider: providerId,
       model: result.model,
       inputTokens: result.usage.inputTokens,
       outputTokens: result.usage.outputTokens,
@@ -291,18 +287,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
       await runDbMigrations();
 
       set({ bootPhase: 'loading-settings' });
-      const [editorBinary, lastWorkspaceRaw, lastSessionRaw, apiKeyPresent] = await Promise.all([
+      const [editorBinary, lastWorkspaceRaw, lastSessionRaw] = await Promise.all([
         getSetting(tauriDatabase, SETTING_EDITOR_BINARY),
         getSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID),
         getSetting(tauriDatabase, SETTING_LAST_SESSION_ID),
-        hasSecret(ANTHROPIC_API_KEY_SECRET),
       ]);
       set((state) => {
         const next = { ...state.settings };
         if (editorBinary !== null) next[SETTING_EDITOR_BINARY] = editorBinary;
         if (lastWorkspaceRaw !== null) next[SETTING_LAST_WORKSPACE_ID] = lastWorkspaceRaw;
         if (lastSessionRaw !== null) next[SETTING_LAST_SESSION_ID] = lastSessionRaw;
-        return { settings: next, apiKeyPresent };
+        return { settings: next };
       });
 
       set({ bootPhase: 'detecting-cli' });
@@ -685,10 +680,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
 
     if (!lastError && assistantText.length > 0) {
-      const apiKey = await getSecret(ANTHROPIC_API_KEY_SECRET);
-      if (apiKey) {
-        void runSummarizer(set, get, sessionId, content, assistantText, apiKey);
-      }
+      void runSummarizer(set, get, sessionId, content, assistantText);
     }
 
     if (lastError) throw lastError;
@@ -710,11 +702,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set((state) => ({
       sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: records },
     }));
-  },
-
-  refreshApiKeyPresence: async () => {
-    const present = await hasSecret(ANTHROPIC_API_KEY_SECRET);
-    set({ apiKeyPresent: present });
   },
 
   loadSessionSlots: async (sessionId) => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { invoke } from '@tauri-apps/api/core';
 import { sessionReducer, Summarizer, getDefaultTurnModel, type SlotKey } from '@kay-am/core';
 import {
   getSetting,
@@ -205,7 +206,7 @@ async function runSummarizer(
     if (!session) return;
 
     const providerId = session.providerPreference.defaultProvider;
-    const summarizer = new Summarizer({ providerId });
+    const summarizer = new Summarizer({ providerId, invokeFn: invoke });
     const prevSlots = get().sessionSlots[sessionId] ?? [];
     const result = await summarizer.summarize({ prevSlots, turnInput, turnOutput });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,8 @@ export {
   type ParseContext as CodexParseContext,
 } from './providers/codex/parser';
 
+// SummarizerCli (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/summarizer/cli in Node/test contexts.
 export {
   Summarizer,
   SummarizerParseError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,9 +48,8 @@ export {
 
 export {
   Summarizer,
-  HAIKU_MODEL,
-  SummarizerHttpError,
   SummarizerParseError,
+  SummarizerSpawnError,
   type ContextSlotDelta,
   type ContextSlotDeltaUpsert,
   type SummarizeInput,

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -1,29 +1,8 @@
+import { spawn } from 'node:child_process';
 import type { ContextSlot, ProviderId } from '@kay-am/types';
+import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
-import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
-
-export type { SlotKey };
-
-function getCheapModel(providerId: ProviderId): string {
-  const caps = PROVIDER_CAPABILITIES[providerId];
-  return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
-}
-
-function getDefaultBinary(providerId: ProviderId): string {
-  switch (providerId) {
-    case 'anthropic':
-      return 'claude';
-    case 'cursor':
-      return 'cursor-agent';
-    case 'codex':
-      return 'codex';
-    default: {
-      const _exhaustive: never = providerId;
-      throw new Error(`unknown provider: ${_exhaustive}`);
-    }
-  }
-}
 
 export type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
 
@@ -50,12 +29,10 @@ export interface SummarizerResult {
   readonly model: string;
 }
 
-type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
-
 export interface SummarizerDeps {
   readonly providerId: ProviderId;
   readonly binary?: string;
-  readonly invokeFn: InvokeFn;
+  readonly spawnFn?: typeof spawn;
 }
 
 export class SummarizerSpawnError extends Error {
@@ -78,12 +55,6 @@ export class SummarizerParseError extends Error {
   }
 }
 
-interface SummarizeCommandResult {
-  readonly stdout: string;
-  readonly stderr: string;
-  readonly exitCode: number | null;
-}
-
 const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session.
 
 There are exactly five slots, each with a stable key:
@@ -99,39 +70,23 @@ The schema is:
 Only include slots that should change. Omit slots that stay the same. Never invent new keys.
 If nothing should change, return { "upserts": [] }.`;
 
-export class Summarizer {
-  private readonly providerId: ProviderId;
-  private readonly binary: string;
-  private readonly model: string;
-  private readonly invokeFn: InvokeFn;
+function getCheapModel(providerId: ProviderId): string {
+  const caps = PROVIDER_CAPABILITIES[providerId];
+  return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
+}
 
-  constructor(deps: SummarizerDeps) {
-    this.providerId = deps.providerId;
-    this.binary = deps.binary ?? getDefaultBinary(deps.providerId);
-    this.model = getCheapModel(deps.providerId);
-    this.invokeFn = deps.invokeFn;
-  }
-
-  async summarize(input: SummarizeInput): Promise<SummarizerResult> {
-    const userMessage = buildUserPrompt(input);
-
-    const result = await this.invokeFn<SummarizeCommandResult>('summarize_session', {
-      args: {
-        providerId: this.providerId,
-        model: this.model,
-        binary: this.binary,
-        userMessage,
-        systemPrompt: SYSTEM_PROMPT,
-      },
-    });
-
-    if ((result.exitCode ?? 0) !== 0) {
-      throw new SummarizerSpawnError(result.exitCode, result.stderr);
+function getDefaultBinary(providerId: ProviderId): string {
+  switch (providerId) {
+    case 'anthropic':
+      return 'claude';
+    case 'cursor':
+      return 'cursor-agent';
+    case 'codex':
+      return 'codex';
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
     }
-
-    const { text, usage } = extractTextAndUsage(this.providerId, result.stdout, this.model);
-    const delta = parseDelta(text);
-    return { delta, usage, model: this.model };
   }
 }
 
@@ -142,19 +97,105 @@ interface ClaudeJsonResult {
     readonly output_tokens?: number;
     readonly cache_read_input_tokens?: number;
   };
+  readonly model?: string;
   readonly subtype?: string;
   readonly is_error?: boolean;
 }
 
-function extractTextAndUsage(
-  providerId: ProviderId,
-  stdout: string,
-  model: string,
-): { text: string; usage: SummarizerUsage } {
-  if (providerId === 'anthropic') {
-    return extractClaudeJsonOutput(stdout, model);
+export class Summarizer {
+  private readonly providerId: ProviderId;
+  private readonly binary: string;
+  private readonly model: string;
+  private readonly spawnFn: typeof spawn;
+
+  constructor(deps: SummarizerDeps) {
+    this.providerId = deps.providerId;
+    this.binary = deps.binary ?? getDefaultBinary(deps.providerId);
+    this.model = getCheapModel(deps.providerId);
+    this.spawnFn = deps.spawnFn ?? spawn;
   }
-  return { text: stdout.trim(), usage: zeroUsage() };
+
+  async summarize(input: SummarizeInput): Promise<SummarizerResult> {
+    const userMessage = buildUserPrompt(input);
+    const { stdout, stderr, exitCode } = await this.spawnCli(userMessage);
+
+    if (exitCode !== 0) {
+      throw new SummarizerSpawnError(exitCode, stderr);
+    }
+
+    const { text, usage } = this.extractTextAndUsage(stdout);
+    const delta = parseDelta(text);
+
+    return { delta, usage, model: this.model };
+  }
+
+  private spawnCli(
+    userMessage: string,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+    return new Promise((resolve, reject) => {
+      const args = buildCliArgs(this.providerId, this.model, SYSTEM_PROMPT, userMessage);
+      const child = this.spawnFn(this.binary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', (err) => reject(err));
+      child.on('close', (code) => resolve({ stdout, stderr, exitCode: code }));
+    });
+  }
+
+  private extractTextAndUsage(stdout: string): { text: string; usage: SummarizerUsage } {
+    if (this.providerId === 'anthropic') {
+      return extractClaudeJsonOutput(stdout, this.model);
+    }
+    return { text: stdout.trim(), usage: zeroUsage() };
+  }
+}
+
+function buildCliArgs(
+  providerId: ProviderId,
+  model: string,
+  systemPrompt: string,
+  userMessage: string,
+): string[] {
+  switch (providerId) {
+    case 'anthropic':
+      return [
+        '-p',
+        userMessage,
+        '--model',
+        model,
+        '--system-prompt',
+        systemPrompt,
+        '--output-format',
+        'json',
+        '--no-session-persistence',
+      ];
+    case 'cursor':
+      return [
+        '-p',
+        `${systemPrompt}\n\n${userMessage}`,
+        '--model',
+        model,
+        '--output-format',
+        'stream-json',
+        '--force',
+      ];
+    case 'codex':
+      return ['exec', '--json', '--model', model, '--', `${systemPrompt}\n\n${userMessage}`];
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
+    }
+  }
 }
 
 function extractClaudeJsonOutput(

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -2,7 +2,7 @@ import { type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
-import { Summarizer, SummarizerParseError, SummarizerSpawnError } from './client';
+import { Summarizer, SummarizerParseError, SummarizerSpawnError } from './cli';
 
 interface MockChild extends EventEmitter {
   stdout: Readable;

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -1,77 +1,132 @@
+import { type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
-import { HAIKU_MODEL, Summarizer, SummarizerHttpError, SummarizerParseError } from './client';
+import { Summarizer, SummarizerParseError, SummarizerSpawnError } from './client';
 
-function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
-  return new Response(JSON.stringify(body), {
-    status: 200,
-    headers: { 'content-type': 'application/json' },
-    ...init,
-  });
+interface MockChild extends EventEmitter {
+  stdout: Readable;
+  stderr: Readable;
+  killed: boolean;
+  exitCode: number | null;
+  kill(signal?: NodeJS.Signals | string): boolean;
 }
 
-interface Usage {
-  input_tokens: number;
-  output_tokens: number;
-  cache_read_input_tokens?: number;
-}
-
-function makeAnthropicReply(text: string, usage: Usage = { input_tokens: 100, output_tokens: 20 }) {
-  return {
-    content: [{ type: 'text', text }],
-    usage,
-    model: HAIKU_MODEL,
+function makeMockSpawn(
+  stdoutData: string,
+  stderrData: string = '',
+  exitCode: number = 0,
+): { spawnFn: typeof import('node:child_process').spawn; child: MockChild } {
+  const child = new EventEmitter() as MockChild;
+  child.stdout = new Readable({ read() {} });
+  child.stderr = new Readable({ read() {} });
+  child.killed = false;
+  child.exitCode = null;
+  child.kill = () => {
+    child.killed = true;
+    return true;
   };
+
+  const spawnFn = vi.fn().mockImplementation(() => {
+    // Push data first, then null to end the stream, then emit close after stream drains
+    setImmediate(() => {
+      if (stdoutData) child.stdout.push(stdoutData);
+      child.stdout.push(null);
+      if (stderrData) child.stderr.push(stderrData);
+      child.stderr.push(null);
+      // close after stream ends so data is fully buffered before the promise resolves
+      setImmediate(() => child.emit('close', exitCode));
+    });
+    return child as unknown as ChildProcess;
+  }) as unknown as typeof import('node:child_process').spawn;
+
+  return { spawnFn, child };
 }
 
-describe('Summarizer', () => {
-  it('rejects construction without an api key', () => {
-    expect(() => new Summarizer({ apiKey: '' })).toThrow(/api key/);
-    expect(() => new Summarizer({ apiKey: '   ' })).toThrow(/api key/);
+function makeClaudeJsonOutput(text: string, inputTokens = 100, outputTokens = 20): string {
+  return JSON.stringify({
+    result: text,
+    usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+    subtype: 'success',
+    is_error: false,
+  });
+}
+
+describe('Summarizer (CLI-based)', () => {
+  it('spawns claude CLI with correct args for anthropic provider', async () => {
+    const { spawnFn } = makeMockSpawn(makeClaudeJsonOutput(JSON.stringify({ upserts: [] })));
+    const summarizer = new Summarizer({ providerId: 'anthropic', spawnFn });
+
+    await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    const [binary, args] = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      string[],
+    ];
+    expect(binary).toBe('claude');
+    expect(args).toContain('-p');
+    expect(args).toContain('--model');
+    expect(args).toContain('claude-haiku-4-5');
+    expect(args).toContain('--system-prompt');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('json');
+    expect(args).toContain('--no-session-persistence');
   });
 
-  it('sends the expected request shape to the anthropic api', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(makeAnthropicReply(JSON.stringify({ upserts: [] }))),
-    );
-    const summarizer = new Summarizer({ apiKey: 'sk-ant-test', fetchFn });
+  it('spawns cursor-agent CLI with correct args for cursor provider', async () => {
+    const { spawnFn } = makeMockSpawn(JSON.stringify({ upserts: [] }));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
-    await summarizer.summarize({
-      prevSlots: [],
-      turnInput: 'do the thing',
-      turnOutput: 'did the thing',
+    await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    const [binary, args] = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      string[],
+    ];
+    expect(binary).toBe('cursor-agent');
+    expect(args).toContain('-p');
+    expect(args).toContain('--model');
+    expect(args).toContain('cursor-small');
+    expect(args).toContain('--force');
+  });
+
+  it('spawns codex CLI with correct args for codex provider', async () => {
+    const { spawnFn } = makeMockSpawn(JSON.stringify({ upserts: [] }));
+    const summarizer = new Summarizer({ providerId: 'codex', spawnFn });
+
+    await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    const [binary, args] = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      string[],
+    ];
+    expect(binary).toBe('codex');
+    expect(args[0]).toBe('exec');
+    expect(args).toContain('--model');
+    expect(args).toContain('codex-mini-latest');
+  });
+
+  it('respects custom binary override', async () => {
+    const { spawnFn } = makeMockSpawn(makeClaudeJsonOutput(JSON.stringify({ upserts: [] })));
+    const summarizer = new Summarizer({
+      providerId: 'anthropic',
+      binary: '/custom/claude',
+      spawnFn,
     });
 
-    expect(fetchFn).toHaveBeenCalledTimes(1);
-    const call = fetchFn.mock.calls[0]!;
-    const url = call[0];
-    const init = call[1] as RequestInit;
-    expect(url).toBe('https://api.anthropic.com/v1/messages');
-    expect(init.method).toBe('POST');
-    const headers = init.headers as Record<string, string>;
-    expect(headers['x-api-key']).toBe('sk-ant-test');
-    expect(headers['anthropic-version']).toBe('2023-06-01');
-    const body = JSON.parse(init.body as string);
-    expect(body.model).toBe(HAIKU_MODEL);
-    expect(body.system).toContain('exactly five slots');
-    expect(body.messages[0].content).toContain('do the thing');
-    expect(body.messages[0].content).toContain('did the thing');
+    await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    const [binary] = (spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string[]];
+    expect(binary).toBe('/custom/claude');
   });
 
-  it('parses a valid delta and returns normalized usage + cost', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(
-        makeAnthropicReply(
-          JSON.stringify({
-            upserts: [
-              { key: 'goal', value: 'refactor auth' },
-              { key: 'decisions', value: '- use jwt\n- 24h ttl' },
-            ],
-          }),
-          { input_tokens: 1_000_000, output_tokens: 500_000, cache_read_input_tokens: 0 },
-        ),
-      ),
+  it('parses a valid delta from anthropic json output', async () => {
+    const delta = { upserts: [{ key: 'goal', value: 'refactor auth' }] };
+    const { spawnFn } = makeMockSpawn(
+      makeClaudeJsonOutput(JSON.stringify(delta), 1_000_000, 500_000),
     );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const summarizer = new Summarizer({ providerId: 'anthropic', spawnFn });
 
     const result = await summarizer.summarize({
       prevSlots: [],
@@ -79,110 +134,125 @@ describe('Summarizer', () => {
       turnOutput: 'jwt 24h',
     });
 
-    expect(result.delta.upserts).toEqual([
-      { key: 'goal', value: 'refactor auth' },
-      { key: 'decisions', value: '- use jwt\n- 24h ttl' },
-    ]);
+    expect(result.delta.upserts).toEqual([{ key: 'goal', value: 'refactor auth' }]);
     expect(result.usage.inputTokens).toBe(1_000_000);
     expect(result.usage.outputTokens).toBe(500_000);
-    // haiku pricing: $1 / MTok in, $5 / MTok out → 1 + 2.5 = 3.5
-    expect(result.usage.estimatedCostUsd).toBeCloseTo(3.5);
-    expect(result.model).toBe(HAIKU_MODEL);
+    expect(result.usage.estimatedCostUsd).toBeGreaterThan(0);
+    expect(result.model).toBe('claude-haiku-4-5');
+  });
+
+  it('parses plain json text from cursor provider', async () => {
+    const delta = { upserts: [{ key: 'decisions', value: 'use sqlite' }] };
+    const { spawnFn } = makeMockSpawn(JSON.stringify(delta));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
+    const result = await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    expect(result.delta.upserts).toEqual([{ key: 'decisions', value: 'use sqlite' }]);
+    expect(result.usage.inputTokens).toBe(0);
+    expect(result.usage.estimatedCostUsd).toBe(0);
   });
 
   it('strips ```json code fences before parsing', async () => {
     const fenced = '```json\n{ "upserts": [{"key": "goal", "value": "x"}] }\n```';
-    const fetchFn = vi.fn<typeof fetch>(async () => jsonResponse(makeAnthropicReply(fenced)));
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
-    const result = await summarizer.summarize({
-      prevSlots: [],
-      turnInput: 'a',
-      turnOutput: 'b',
-    });
+    const { spawnFn } = makeMockSpawn(fenced);
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
+    const result = await summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' });
     expect(result.delta.upserts).toEqual([{ key: 'goal', value: 'x' }]);
   });
 
   it('drops upsert entries with unknown slot keys', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(
-        makeAnthropicReply(
-          JSON.stringify({
-            upserts: [
-              { key: 'goal', value: 'ok' },
-              { key: 'mystery_slot', value: 'nope' },
-              { key: 'decisions', value: 'keep' },
-            ],
-          }),
-        ),
-      ),
-    );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
-    const result = await summarizer.summarize({
-      prevSlots: [],
-      turnInput: 'a',
-      turnOutput: 'b',
-    });
+    const delta = {
+      upserts: [
+        { key: 'goal', value: 'ok' },
+        { key: 'mystery_slot', value: 'nope' },
+        { key: 'decisions', value: 'keep' },
+      ],
+    };
+    const { spawnFn } = makeMockSpawn(JSON.stringify(delta));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
+    const result = await summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' });
     expect(result.delta.upserts.map((u) => u.key)).toEqual(['goal', 'decisions']);
   });
 
   it('throws SummarizerParseError on non-json response', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(makeAnthropicReply('hello, not json')),
-    );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const { spawnFn } = makeMockSpawn('hello, not json');
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
     await expect(
       summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' }),
     ).rejects.toBeInstanceOf(SummarizerParseError);
   });
 
   it('throws SummarizerParseError when upserts is missing', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(makeAnthropicReply(JSON.stringify({ other: 'shape' }))),
-    );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const { spawnFn } = makeMockSpawn(JSON.stringify({ other: 'shape' }));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
     await expect(
       summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' }),
     ).rejects.toBeInstanceOf(SummarizerParseError);
   });
 
-  it('throws SummarizerHttpError on non-2xx response', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () => new Response('rate limited', { status: 429 }));
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+  it('throws SummarizerSpawnError on non-zero exit code', async () => {
+    const { spawnFn } = makeMockSpawn('', 'rate limited', 1);
+    const summarizer = new Summarizer({ providerId: 'anthropic', spawnFn });
+
     const err = await summarizer
       .summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' })
       .catch((e) => e);
-    expect(err).toBeInstanceOf(SummarizerHttpError);
-    expect((err as SummarizerHttpError).status).toBe(429);
-    expect((err as SummarizerHttpError).body).toBe('rate limited');
+    expect(err).toBeInstanceOf(SummarizerSpawnError);
+    expect((err as SummarizerSpawnError).exitCode).toBe(1);
+    expect((err as SummarizerSpawnError).stderr).toBe('rate limited');
   });
 
-  it('does not log or expose the api key on errors', async () => {
-    const apiKey = 'sk-ant-very-secret';
-    const fetchFn = vi.fn<typeof fetch>(async () => new Response('boom', { status: 500 }));
-    const summarizer = new Summarizer({ apiKey, fetchFn });
-    let captured: SummarizerHttpError | null = null;
-    try {
-      await summarizer.summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' });
-    } catch (e) {
-      captured = e as SummarizerHttpError;
-    }
-    expect(captured).not.toBeNull();
-    expect(captured!.message).not.toContain(apiKey);
-    expect(captured!.body).not.toContain(apiKey);
-  });
+  it('includes previous slot values in the prompt', async () => {
+    const { spawnFn } = makeMockSpawn(makeClaudeJsonOutput(JSON.stringify({ upserts: [] })));
+    const summarizer = new Summarizer({ providerId: 'anthropic', spawnFn });
 
-  it('includes previous slot values in the prompt body', async () => {
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      jsonResponse(makeAnthropicReply(JSON.stringify({ upserts: [] }))),
-    );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
     await summarizer.summarize({
       prevSlots: [{ key: 'goal', value: 'auth refactor', enabled: true }],
       turnInput: 'q',
       turnOutput: 'a',
     });
-    const init = fetchFn.mock.calls[0]![1] as RequestInit;
-    const body = JSON.parse(init.body as string);
-    expect(body.messages[0].content).toContain('goal: auth refactor');
+
+    const args = ((spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string[]])[1];
+    const promptArg = args[args.indexOf('-p') + 1];
+    expect(promptArg).toContain('goal: auth refactor');
+  });
+
+  it('includes system prompt in cursor prompt arg (no --system-prompt flag)', async () => {
+    const { spawnFn } = makeMockSpawn(JSON.stringify({ upserts: [] }));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
+
+    await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+
+    const args = ((spawnFn as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string[]])[1];
+    expect(args).not.toContain('--system-prompt');
+    const promptArg = args[args.indexOf('-p') + 1];
+    expect(promptArg).toContain('exactly five slots');
+  });
+
+  it('returns zero usage for codex provider', async () => {
+    const { spawnFn } = makeMockSpawn(JSON.stringify({ upserts: [] }));
+    const summarizer = new Summarizer({ providerId: 'codex', spawnFn });
+
+    const result = await summarizer.summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' });
+    expect(result.usage.inputTokens).toBe(0);
+    expect(result.usage.outputTokens).toBe(0);
+    expect(result.usage.estimatedCostUsd).toBe(0);
+  });
+
+  it('falls back to raw stdout as text if claude json output lacks result field', async () => {
+    const rawText = JSON.stringify({ upserts: [{ key: 'goal', value: 'fallback' }] });
+    const claudeJsonMissingResult = JSON.stringify({ subtype: 'success', usage: {} });
+    const { spawnFn } = makeMockSpawn(claudeJsonMissingResult + '\n' + rawText);
+    const summarizer = new Summarizer({ providerId: 'anthropic', spawnFn });
+
+    const err = await summarizer
+      .summarize({ prevSlots: [], turnInput: 'a', turnOutput: 'b' })
+      .catch((e) => e);
+    expect(err).toBeInstanceOf(SummarizerParseError);
   });
 });

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import type { ContextSlot, IsoDateTime, ProviderId } from '@kay-am/types';
+import type { ContextSlot, ProviderId } from '@kay-am/types';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
@@ -32,9 +32,7 @@ export interface SummarizerResult {
 export interface SummarizerDeps {
   readonly providerId: ProviderId;
   readonly binary?: string;
-  readonly now?: () => IsoDateTime;
   readonly spawnFn?: typeof spawn;
-  readonly maxTokens?: number;
 }
 
 export class SummarizerSpawnError extends Error {

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,11 +1,8 @@
-import type { ContextSlot, IsoDateTime } from '@kay-am/types';
+import { spawn } from 'node:child_process';
+import type { ContextSlot, IsoDateTime, ProviderId } from '@kay-am/types';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { computeCostUsd } from '../providers/claude/cost';
-
-export const HAIKU_MODEL = 'claude-haiku-4-5';
-const ANTHROPIC_MESSAGES_URL = 'https://api.anthropic.com/v1/messages';
-const ANTHROPIC_API_VERSION = '2023-06-01';
-const DEFAULT_MAX_TOKENS = 512;
+import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 
 export type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
 
@@ -33,20 +30,20 @@ export interface SummarizerResult {
 }
 
 export interface SummarizerDeps {
-  readonly apiKey: string;
-  readonly model?: string;
-  readonly fetchFn?: typeof fetch;
+  readonly providerId: ProviderId;
+  readonly binary?: string;
   readonly now?: () => IsoDateTime;
+  readonly spawnFn?: typeof spawn;
   readonly maxTokens?: number;
 }
 
-export class SummarizerHttpError extends Error {
+export class SummarizerSpawnError extends Error {
   constructor(
-    public readonly status: number,
-    public readonly body: string,
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
   ) {
-    super(`anthropic api error: ${status}`);
-    this.name = 'SummarizerHttpError';
+    super(`summarizer cli exited with code ${exitCode ?? 'null'}`);
+    this.name = 'SummarizerSpawnError';
   }
 }
 
@@ -58,16 +55,6 @@ export class SummarizerParseError extends Error {
     super(message);
     this.name = 'SummarizerParseError';
   }
-}
-
-interface AnthropicMessageResponse {
-  readonly content?: ReadonlyArray<{ type: string; text?: string }>;
-  readonly usage?: {
-    readonly input_tokens?: number;
-    readonly output_tokens?: number;
-    readonly cache_read_input_tokens?: number;
-  };
-  readonly model?: string;
 }
 
 const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session.
@@ -85,68 +72,160 @@ The schema is:
 Only include slots that should change. Omit slots that stay the same. Never invent new keys.
 If nothing should change, return { "upserts": [] }.`;
 
+function getCheapModel(providerId: ProviderId): string {
+  const caps = PROVIDER_CAPABILITIES[providerId];
+  return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
+}
+
+function getDefaultBinary(providerId: ProviderId): string {
+  switch (providerId) {
+    case 'anthropic':
+      return 'claude';
+    case 'cursor':
+      return 'cursor-agent';
+    case 'codex':
+      return 'codex';
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
+    }
+  }
+}
+
+interface ClaudeJsonResult {
+  readonly result?: string;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+  };
+  readonly model?: string;
+  readonly subtype?: string;
+  readonly is_error?: boolean;
+}
+
 export class Summarizer {
-  private readonly apiKey: string;
+  private readonly providerId: ProviderId;
+  private readonly binary: string;
   private readonly model: string;
-  private readonly fetchFn: typeof fetch;
-  private readonly maxTokens: number;
+  private readonly spawnFn: typeof spawn;
 
   constructor(deps: SummarizerDeps) {
-    if (!deps.apiKey || deps.apiKey.trim().length === 0) {
-      throw new Error('summarizer requires an anthropic api key');
-    }
-    this.apiKey = deps.apiKey;
-    this.model = deps.model ?? HAIKU_MODEL;
-    this.fetchFn = deps.fetchFn ?? fetch;
-    this.maxTokens = deps.maxTokens ?? DEFAULT_MAX_TOKENS;
+    this.providerId = deps.providerId;
+    this.binary = deps.binary ?? getDefaultBinary(deps.providerId);
+    this.model = getCheapModel(deps.providerId);
+    this.spawnFn = deps.spawnFn ?? spawn;
   }
 
   async summarize(input: SummarizeInput): Promise<SummarizerResult> {
     const userMessage = buildUserPrompt(input);
+    const { stdout, stderr, exitCode } = await this.spawnCli(userMessage);
 
-    const response = await this.fetchFn(ANTHROPIC_MESSAGES_URL, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-api-key': this.apiKey,
-        'anthropic-version': ANTHROPIC_API_VERSION,
-      },
-      body: JSON.stringify({
-        model: this.model,
-        max_tokens: this.maxTokens,
-        system: SYSTEM_PROMPT,
-        messages: [{ role: 'user', content: userMessage }],
-      }),
-    });
-
-    if (!response.ok) {
-      const body = await safeReadText(response);
-      throw new SummarizerHttpError(response.status, body);
+    if (exitCode !== 0) {
+      throw new SummarizerSpawnError(exitCode, stderr);
     }
 
-    const payload = (await response.json()) as AnthropicMessageResponse;
-    const text = (payload.content ?? [])
-      .filter((block) => block.type === 'text')
-      .map((block) => block.text ?? '')
-      .join('')
-      .trim();
-
+    const { text, usage } = this.extractTextAndUsage(stdout);
     const delta = parseDelta(text);
-    const usage = this.normalizeUsage(payload);
 
-    return { delta, usage, model: payload.model ?? this.model };
+    return { delta, usage, model: this.model };
   }
 
-  private normalizeUsage(payload: AnthropicMessageResponse): SummarizerUsage {
-    const inputTokens = payload.usage?.input_tokens ?? 0;
-    const outputTokens = payload.usage?.output_tokens ?? 0;
-    const cachedInputTokens = payload.usage?.cache_read_input_tokens ?? 0;
-    const estimatedCostUsd = computeCostUsd(
-      { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd: 0 },
-      this.model,
-    );
-    return { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd };
+  private spawnCli(
+    userMessage: string,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+    return new Promise((resolve, reject) => {
+      const args = buildCliArgs(this.providerId, this.model, SYSTEM_PROMPT, userMessage);
+      const child = this.spawnFn(this.binary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', (err) => reject(err));
+      child.on('close', (code) => resolve({ stdout, stderr, exitCode: code }));
+    });
   }
+
+  private extractTextAndUsage(stdout: string): { text: string; usage: SummarizerUsage } {
+    if (this.providerId === 'anthropic') {
+      return extractClaudeJsonOutput(stdout, this.model);
+    }
+    return { text: stdout.trim(), usage: zeroUsage() };
+  }
+}
+
+function buildCliArgs(
+  providerId: ProviderId,
+  model: string,
+  systemPrompt: string,
+  userMessage: string,
+): string[] {
+  switch (providerId) {
+    case 'anthropic':
+      return [
+        '-p',
+        userMessage,
+        '--model',
+        model,
+        '--system-prompt',
+        systemPrompt,
+        '--output-format',
+        'json',
+        '--no-session-persistence',
+      ];
+    case 'cursor':
+      return [
+        '-p',
+        `${systemPrompt}\n\n${userMessage}`,
+        '--model',
+        model,
+        '--output-format',
+        'stream-json',
+        '--force',
+      ];
+    case 'codex':
+      return ['exec', '--json', '--model', model, '--', `${systemPrompt}\n\n${userMessage}`];
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
+    }
+  }
+}
+
+function extractClaudeJsonOutput(
+  stdout: string,
+  model: string,
+): { text: string; usage: SummarizerUsage } {
+  const trimmed = stdout.trim();
+  let parsed: ClaudeJsonResult;
+  try {
+    parsed = JSON.parse(trimmed) as ClaudeJsonResult;
+  } catch {
+    return { text: trimmed, usage: zeroUsage() };
+  }
+
+  const text = parsed.result ?? '';
+  const rawUsage = parsed.usage ?? {};
+  const inputTokens = rawUsage.input_tokens ?? 0;
+  const outputTokens = rawUsage.output_tokens ?? 0;
+  const cachedInputTokens = rawUsage.cache_read_input_tokens ?? 0;
+  const estimatedCostUsd = computeCostUsd(
+    { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd: 0 },
+    model,
+  );
+  return { text, usage: { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd } };
+}
+
+function zeroUsage(): SummarizerUsage {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 };
 }
 
 function buildUserPrompt(input: SummarizeInput): string {
@@ -206,12 +285,4 @@ function parseDelta(raw: string): ContextSlotDelta {
 function stripCodeFences(raw: string): string {
   const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(raw.trim());
   return (fenced?.[1] ?? raw).trim();
-}
-
-async function safeReadText(response: Response): Promise<string> {
-  try {
-    return await response.text();
-  } catch {
-    return '';
-  }
 }

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -1,8 +1,7 @@
 export {
   Summarizer,
-  HAIKU_MODEL,
   SummarizerParseError,
-  SummarizerHttpError,
+  SummarizerSpawnError,
   type ContextSlotDelta,
   type ContextSlotDeltaUpsert,
   type SummarizeInput,

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -1,3 +1,5 @@
+// SummarizerCli (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/summarizer/cli in Node/test contexts.
 export {
   Summarizer,
   SummarizerParseError,

--- a/packages/core/src/summarizer/round-trip.test.ts
+++ b/packages/core/src/summarizer/round-trip.test.ts
@@ -1,10 +1,13 @@
+import { type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import Database from 'better-sqlite3';
 import { describe, expect, it, vi } from 'vitest';
 import { migrate, type Database as DbInterface } from '@kay-am/db';
 import type { SessionId, WorkspaceId } from '@kay-am/types';
 import { ContextEngine } from '../context/engine';
 import { SLOT_KEYS } from '../context/slots';
-import { HAIKU_MODEL, Summarizer } from './client';
+import { Summarizer } from './client';
 
 function makeDb(): DbInterface {
   const db = new Database(':memory:');
@@ -39,15 +42,28 @@ async function seedSession(db: DbInterface, sessionId: SessionId): Promise<void>
   );
 }
 
-function fakeAnthropicReply(upserts: ReadonlyArray<{ key: string; value: string }>) {
-  return new Response(
-    JSON.stringify({
-      content: [{ type: 'text', text: JSON.stringify({ upserts }) }],
-      usage: { input_tokens: 100, output_tokens: 20 },
-      model: HAIKU_MODEL,
-    }),
-    { status: 200, headers: { 'content-type': 'application/json' } },
-  );
+function makeMockSpawnWithOutput(text: string): typeof import('node:child_process').spawn {
+  return vi.fn().mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+      stderr: Readable;
+      killed: boolean;
+      exitCode: number | null;
+      kill: () => boolean;
+    };
+    child.stdout = new Readable({ read() {} });
+    child.stderr = new Readable({ read() {} });
+    child.killed = false;
+    child.exitCode = null;
+    child.kill = () => true;
+    setImmediate(() => {
+      child.stdout.push(text);
+      child.stdout.push(null);
+      child.stderr.push(null);
+      setImmediate(() => child.emit('close', 0));
+    });
+    return child as unknown as ChildProcess;
+  }) as unknown as typeof import('node:child_process').spawn;
 }
 
 async function applyDelta(
@@ -69,8 +85,8 @@ describe('synthetic context engine round-trip', () => {
     const engine = new ContextEngine({ db });
 
     const fakeUpserts = SLOT_KEYS.map((key) => ({ key, value: `seeded ${key}` }));
-    const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply(fakeUpserts));
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const spawnFn = makeMockSpawnWithOutput(JSON.stringify({ upserts: fakeUpserts }));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
     const before = await engine.load(sessionId);
     expect(before).toHaveLength(0);
@@ -99,13 +115,15 @@ describe('synthetic context engine round-trip', () => {
     await engine.upsert(sessionId, 'goal', 'original goal');
     await engine.upsert(sessionId, 'decisions', 'original decision');
 
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      fakeAnthropicReply([
-        { key: 'goal', value: 'updated goal' },
-        { key: 'open_questions', value: 'how to test?' },
-      ]),
+    const spawnFn = makeMockSpawnWithOutput(
+      JSON.stringify({
+        upserts: [
+          { key: 'goal', value: 'updated goal' },
+          { key: 'open_questions', value: 'how to test?' },
+        ],
+      }),
     );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
     const before = await engine.load(sessionId);
     const result = await summarizer.summarize({
@@ -133,8 +151,8 @@ describe('synthetic context engine round-trip', () => {
       await engine.upsert(sessionId, key, `pre-${key}`);
     }
 
-    const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply([]));
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const spawnFn = makeMockSpawnWithOutput(JSON.stringify({ upserts: [] }));
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
     const before = await engine.load(sessionId);
     const result = await summarizer.summarize({
@@ -156,13 +174,11 @@ describe('synthetic context engine round-trip', () => {
     await seedSession(db, sessionId);
     const engine = new ContextEngine({ db });
 
-    const summarizerWith = (upserts: ReadonlyArray<{ key: string; value: string }>) => {
-      const fetchFn = vi.fn<typeof fetch>(async () => fakeAnthropicReply(upserts));
-      return new Summarizer({ apiKey: 'sk', fetchFn });
-    };
-
     for (let i = 0; i < 5; i += 1) {
-      const summarizer = summarizerWith([{ key: 'goal', value: `iteration ${i}` }]);
+      const spawnFn = makeMockSpawnWithOutput(
+        JSON.stringify({ upserts: [{ key: 'goal', value: `iteration ${i}` }] }),
+      );
+      const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
       const slots = await engine.load(sessionId);
       const result = await summarizer.summarize({
         prevSlots: slots,
@@ -186,10 +202,10 @@ describe('synthetic context engine round-trip', () => {
     const engine = new ContextEngine({ db });
 
     const huge = 'x'.repeat(50_000);
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      fakeAnthropicReply([{ key: 'last_output_summary', value: huge }]),
+    const spawnFn = makeMockSpawnWithOutput(
+      JSON.stringify({ upserts: [{ key: 'last_output_summary', value: huge }] }),
     );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
     const result = await summarizer.summarize({
       prevSlots: [],
@@ -210,13 +226,15 @@ describe('synthetic context engine round-trip', () => {
     await seedSession(db, sessionId);
     const engine = new ContextEngine({ db });
 
-    const fetchFn = vi.fn<typeof fetch>(async () =>
-      fakeAnthropicReply([
-        { key: 'goal', value: 'ok' },
-        { key: 'mystery_slot', value: 'should be dropped' },
-      ]),
+    const spawnFn = makeMockSpawnWithOutput(
+      JSON.stringify({
+        upserts: [
+          { key: 'goal', value: 'ok' },
+          { key: 'mystery_slot', value: 'should be dropped' },
+        ],
+      }),
     );
-    const summarizer = new Summarizer({ apiKey: 'sk', fetchFn });
+    const summarizer = new Summarizer({ providerId: 'cursor', spawnFn });
 
     const result = await summarizer.summarize({
       prevSlots: [],

--- a/packages/core/src/summarizer/round-trip.test.ts
+++ b/packages/core/src/summarizer/round-trip.test.ts
@@ -7,7 +7,7 @@ import { migrate, type Database as DbInterface } from '@kay-am/db';
 import type { SessionId, WorkspaceId } from '@kay-am/types';
 import { ContextEngine } from '../context/engine';
 import { SLOT_KEYS } from '../context/slots';
-import { Summarizer } from './client';
+import { Summarizer } from './cli';
 
 function makeDb(): DbInterface {
   const db = new Database(':memory:');


### PR DESCRIPTION
## Summary

- Drop direct `api.anthropic.com` HTTP call from `Summarizer` — no more `ANTHROPIC_API_KEY` dependency
- Summarizer now spawns the active session provider's cheap-tier CLI model (`claude-haiku-4-5`, `cursor-small`, `codex-mini-latest`) using `spawnFn`
- `SummarizerDeps.providerId: ProviderId` replaces `apiKey: string`; cheap model resolved from `PROVIDER_CAPABILITIES` matrix
- `SummarizerHttpError` removed; `SummarizerSpawnError` added (carries `exitCode` + `stderr`)
- `ANTHROPIC_API_KEY_SECRET` constant removed from `secrets.ts`
- `apiKeyPresent` field + `refreshApiKeyPresence` action removed from store
- API key section removed from `SettingsDialog.tsx` (only the api-key block; structure unchanged)
- `runSummarizer` now derives `providerId` from `session.providerPreference.defaultProvider`
- ROADMAP architectural decision #3 updated: drops "Haiku via Anthropic API" exception
- Tests rewritten with mock-CLI spawn fixtures (no fetch mocks)

## Trade-offs accepted

- +~500ms latency post-turn from CLI spawn. Documented in issue.
- +1 call against subscription cap per turn (summarizer call). Documented in issue.

## Test plan

- [ ] `pnpm -w typecheck` passes (5/5 packages)
- [ ] `pnpm -w test` passes (158 tests, 4 skipped integration)
- [ ] Zero references to `ANTHROPIC_API_KEY` in repo (except GitHub issue URL in ROADMAP)
- [ ] SettingsDialog no longer shows API key field; other sections unchanged

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)