### PR TITLE
feat(desktop): per-session provider picker

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -52,7 +52,7 @@ export function App() {
             </div>
           </div>
         }
-        leftSidebar={<SessionsSidebar />}
+        leftSidebar={<SessionsSidebar onOpenSettings={() => setSettingsOpen(true)} />}
         main={
           error ? (
             <p className="p-6 text-sm text-danger">init error: {error}</p>

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Button, Dialog, Input, Textarea } from '@kay-am/ui';
-import type { WorkspaceId } from '@kay-am/types';
+import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
+import type { ProviderId, SessionProviderPreference, WorkspaceId } from '@kay-am/types';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
 import { useAppStore } from '../store';
 
@@ -8,11 +8,33 @@ interface NewSessionDialogProps {
   open: boolean;
   onClose: () => void;
   workspaceId: WorkspaceId;
+  onOpenSettings: () => void;
 }
 
-export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialogProps) {
+const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+
+const PROVIDER_LABEL: Record<ProviderId, string> = {
+  anthropic: 'claude',
+  cursor: 'cursor',
+  codex: 'codex',
+};
+
+function pickDefaultProvider(connectedIds: ReadonlySet<ProviderId>): ProviderId {
+  for (const id of PROVIDER_ORDER) {
+    if (connectedIds.has(id)) return id;
+  }
+  return 'anthropic';
+}
+
+export function NewSessionDialog({
+  open,
+  onClose,
+  workspaceId,
+  onOpenSettings,
+}: NewSessionDialogProps) {
   const createSession = useAppStore((s) => s.createSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
+  const providers = useAppStore((s) => s.providers);
   const settingKey = settingBranchPrefix(workspaceId);
   const storedPrefix = useAppStore((s) => s.settings[settingKey]);
   const [goal, setGoal] = useState('');
@@ -20,12 +42,19 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
+  const [selectedProvider, setSelectedProvider] = useState<ProviderId>(() => {
+    const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
+    return pickDefaultProvider(ids);
+  });
+
   useEffect(() => {
     if (!open) return;
     void loadSetting(settingKey).then((value) => {
       setPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
-  }, [open, settingKey, loadSetting]);
+    const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
+    setSelectedProvider(pickDefaultProvider(ids));
+  }, [open, settingKey, loadSetting, providers]);
 
   const reset = () => {
     setGoal('');
@@ -37,7 +66,11 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
     setError(null);
     setBusy(true);
     try {
-      await createSession({ workspaceId, goal, branchPrefix: prefix });
+      const providerPreference: SessionProviderPreference = {
+        defaultProvider: selectedProvider,
+        allowTurnOverride: true,
+      };
+      await createSession({ workspaceId, goal, branchPrefix: prefix, providerPreference });
       reset();
       onClose();
     } catch (err) {
@@ -46,6 +79,10 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
       setBusy(false);
     }
   };
+
+  const connectedProviderIds = new Set(
+    providers.filter((p) => p.connection === 'connected').map((p) => p.id),
+  );
 
   return (
     <Dialog open={open} onClose={onClose} title="new session">
@@ -62,6 +99,53 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
           branch prefix
           <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} placeholder="kay" />
         </label>
+        <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+          provider
+          <ul className="flex flex-col divide-y divide-border rounded border border-border">
+            {PROVIDER_ORDER.map((id) => {
+              const connected = connectedProviderIds.has(id);
+              const disabled = !connected;
+              return (
+                <li
+                  key={id}
+                  className={cn('flex items-center gap-2 px-3 py-2', disabled ? 'opacity-50' : '')}
+                >
+                  <input
+                    type="radio"
+                    name="provider"
+                    id={`provider-${id}`}
+                    value={id}
+                    checked={selectedProvider === id}
+                    disabled={disabled}
+                    onChange={() => setSelectedProvider(id)}
+                    className="accent-primary"
+                  />
+                  <label
+                    htmlFor={`provider-${id}`}
+                    className={cn(
+                      'flex flex-1 items-center justify-between',
+                      disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                    )}
+                  >
+                    <span className="font-medium">{PROVIDER_LABEL[id]}</span>
+                    {!connected && (
+                      <button
+                        type="button"
+                        className="text-[11px] text-primary underline hover:opacity-80"
+                        onClick={() => {
+                          onClose();
+                          onOpenSettings();
+                        }}
+                      >
+                        connect in settings
+                      </button>
+                    )}
+                  </label>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
         {error ? <p className="text-xs text-danger">{error}</p> : null}
       </div>
       <div className="flex justify-end gap-2">

--- a/apps/desktop/src/components/SessionsSidebar.tsx
+++ b/apps/desktop/src/components/SessionsSidebar.tsx
@@ -1,11 +1,42 @@
 import { useState } from 'react';
 import { Button, ScrollArea, cn } from '@kay-am/ui';
+import type { ProviderId } from '@kay-am/types';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessions } from '../store';
 import { NewSessionDialog } from './NewSessionDialog';
 import { OpenInEditorButton } from './OpenInEditorButton';
 import { StatusBadge } from './StatusBadge';
 
-export function SessionsSidebar() {
+interface SessionsSidebarProps {
+  onOpenSettings: () => void;
+}
+
+const PROVIDER_CHIP_COLOR: Record<ProviderId, string> = {
+  anthropic: 'bg-orange-100 text-orange-700',
+  cursor: 'bg-blue-100 text-blue-700',
+  codex: 'bg-green-100 text-green-700',
+};
+
+const PROVIDER_SHORT: Record<ProviderId, string> = {
+  anthropic: 'cl',
+  cursor: 'cu',
+  codex: 'cx',
+};
+
+function ProviderChip({ providerId }: { providerId: ProviderId }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded px-1 py-0.5 text-[10px] font-medium leading-none',
+        PROVIDER_CHIP_COLOR[providerId],
+      )}
+      title={providerId}
+    >
+      {PROVIDER_SHORT[providerId]}
+    </span>
+  );
+}
+
+export function SessionsSidebar({ onOpenSettings }: SessionsSidebarProps) {
   const workspace = useCurrentWorkspace();
   const sessions = useSessions();
   const current = useCurrentSession();
@@ -47,7 +78,10 @@ export function SessionsSidebar() {
                         className="flex w-full items-center justify-between gap-2"
                       >
                         <span className="line-clamp-1 flex-1">{session.goal}</span>
-                        <StatusBadge state={session.state} />
+                        <div className="flex shrink-0 items-center gap-1">
+                          <ProviderChip providerId={session.providerPreference.defaultProvider} />
+                          <StatusBadge state={session.state} />
+                        </div>
                       </button>
                       <div
                         className={cn(
@@ -72,6 +106,7 @@ export function SessionsSidebar() {
           open={dialogOpen}
           onClose={() => setDialogOpen(false)}
           workspaceId={workspace.id}
+          onOpenSettings={onOpenSettings}
         />
       ) : null}
     </div>

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -29,6 +29,7 @@ import type {
   ProviderRunId,
   Session,
   SessionId,
+  SessionProviderPreference,
   SessionState,
   TelemetryRecord,
   TelemetryRecordId,
@@ -116,6 +117,7 @@ export interface AppActions {
     workspaceId: WorkspaceId;
     goal: string;
     branchPrefix?: string;
+    providerPreference?: SessionProviderPreference;
   }): Promise<{ session: Session; worktree: CreatedWorktree }>;
   loadTranscript(sessionId: SessionId): Promise<void>;
   appendTurnEvent(sessionId: SessionId, event: TurnEvent): void;
@@ -469,7 +471,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     });
   },
 
-  createSession: async ({ workspaceId, goal, branchPrefix }) => {
+  createSession: async ({ workspaceId, goal, branchPrefix, providerPreference }) => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) throw new Error(`workspace not found: ${workspaceId}`);
 
@@ -489,7 +491,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       goal: goal.trim() || worktree.slug,
       state: initialState,
       contextSlots: [],
-      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
+      providerPreference: providerPreference ?? DEFAULT_SESSION_PROVIDER_PREFERENCE,
       createdAt: now,
       updatedAt: now,
     };

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -1,5 +1,6 @@
 import { m001Initial } from './m001-initial';
 import { m002TelemetryKind } from './m002-telemetry-kind';
+import { m003SessionProvider } from './m003-session-provider';
 
 export interface Migration {
   readonly version: number;
@@ -9,4 +10,5 @@ export interface Migration {
 export const migrations: ReadonlyArray<Migration> = [
   { version: 1, sql: m001Initial },
   { version: 2, sql: m002TelemetryKind },
+  { version: 3, sql: m003SessionProvider },
 ];

--- a/packages/db/src/migrations/m003-session-provider.ts
+++ b/packages/db/src/migrations/m003-session-provider.ts
@@ -1,0 +1,4 @@
+export const m003SessionProvider = /* sql */ `
+ALTER TABLE sessions ADD COLUMN provider_default TEXT NOT NULL DEFAULT 'anthropic';
+ALTER TABLE sessions ADD COLUMN provider_allow_override INTEGER NOT NULL DEFAULT 1;
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -75,4 +75,34 @@ describe('migrate', () => {
     expect(fetched?.goal).toBe('refactor auth');
     expect(fetched?.state.kind).toBe('idle');
   });
+
+  it('round-trips session providerPreference columns', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_3' as WorkspaceId,
+      name: 'prov-test',
+      rootPath: '/tmp/demo3',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+
+    const session: Session = {
+      id: 'sess_2' as SessionId,
+      workspaceId: workspace.id,
+      goal: 'test provider pref',
+      state: { kind: 'draft' },
+      contextSlots: [],
+      providerPreference: { defaultProvider: 'cursor', allowTurnOverride: false },
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertSession(db, session);
+    const fetched = await getSessionById(db, session.id);
+
+    expect(fetched?.providerPreference.defaultProvider).toBe('cursor');
+    expect(fetched?.providerPreference.allowTurnOverride).toBe(false);
+  });
 });

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -1,5 +1,12 @@
-import type { IsoDateTime, Session, SessionId, SessionState, WorkspaceId } from '@kay-am/types';
-import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  ProviderId,
+  Session,
+  SessionId,
+  SessionProviderPreference,
+  SessionState,
+  WorkspaceId,
+} from '@kay-am/types';
 import type { Database } from '../client';
 
 interface SessionRow {
@@ -8,6 +15,8 @@ interface SessionRow {
   goal: string;
   state_kind: SessionState['kind'];
   state_payload: string;
+  provider_default: string;
+  provider_allow_override: number;
   created_at: number;
   updated_at: number;
 }
@@ -17,6 +26,18 @@ function toState(kind: SessionState['kind'], payload: string): SessionState {
   return { kind, ...data } as SessionState;
 }
 
+const VALID_PROVIDER_IDS: ReadonlySet<string> = new Set(['anthropic', 'cursor', 'codex']);
+
+function toProviderPreference(row: SessionRow): SessionProviderPreference {
+  const defaultProvider: ProviderId = VALID_PROVIDER_IDS.has(row.provider_default)
+    ? (row.provider_default as ProviderId)
+    : 'anthropic';
+  return {
+    defaultProvider,
+    allowTurnOverride: row.provider_allow_override !== 0,
+  };
+}
+
 function toDomain(row: SessionRow, contextSlots: Session['contextSlots']): Session {
   return {
     id: row.id as SessionId,
@@ -24,7 +45,7 @@ function toDomain(row: SessionRow, contextSlots: Session['contextSlots']): Sessi
     goal: row.goal,
     state: toState(row.state_kind, row.state_payload),
     contextSlots,
-    providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
+    providerPreference: toProviderPreference(row),
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
   };
@@ -39,14 +60,16 @@ export async function insertSession(db: Database, session: Session): Promise<voi
   const { kind, payload } = splitState(session.state);
   await db.execute(
     `INSERT INTO sessions
-      (id, workspace_id, goal, state_kind, state_payload, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      (id, workspace_id, goal, state_kind, state_payload, provider_default, provider_allow_override, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       session.id,
       session.workspaceId,
       session.goal,
       kind,
       payload,
+      session.providerPreference.defaultProvider,
+      session.providerPreference.allowTurnOverride ? 1 : 0,
       Date.parse(session.createdAt),
       Date.parse(session.updatedAt),
     ],


### PR DESCRIPTION
## Summary

- DB migration m003 adds `provider_default` (TEXT, DEFAULT 'anthropic') and `provider_allow_override` (INTEGER, DEFAULT 1) to `sessions` table — existing rows backfill to anthropic/override-on
- `packages/db/src/queries/session.ts` reads both columns into `Session.providerPreference`; insert writes them back
- `NewSessionDialog` gains a provider radio picker ordered anthropic > cursor > codex; disconnected providers are greyed with a "connect in settings" link that opens SettingsDialog
- `SessionsSidebar` shows a small colored chip (cl/cu/cx) next to each session row; `onOpenSettings` prop threaded from `App.tsx`
- `store.createSession` accepts optional `providerPreference`, falls back to `DEFAULT_SESSION_PROVIDER_PREFERENCE`
- Turn pipeline already reads `session.providerPreference.defaultProvider` (#70) — no change needed

## Test plan

- [ ] `pnpm -w test` passes (5 DB tests including new providerPreference roundtrip)
- [ ] `pnpm -w typecheck` passes
- [ ] open new session dialog — provider list shows with radio buttons; connected = selectable, disconnected = greyed + "connect in settings"
- [ ] create session with non-default provider — sidebar chip reflects choice
- [ ] existing sessions show 'cl' chip (backfilled to anthropic)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)