### PR TITLE
feat(desktop): per-turn provider override

### DIFF
--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -15,6 +15,23 @@ const formatTokens = (n: number): string =>
 
 type SortKey = 'time' | 'cost';
 
+interface ProviderBreakdown {
+  readonly provider: string;
+  readonly cost: number;
+}
+
+function buildProviderBreakdown(
+  records: ReadonlyArray<TelemetryRecord>,
+): ReadonlyArray<ProviderBreakdown> {
+  const map = new Map<string, number>();
+  for (const r of records) {
+    map.set(r.provider, (map.get(r.provider) ?? 0) + r.estimatedCostUsd);
+  }
+  return Array.from(map.entries())
+    .map(([provider, cost]) => ({ provider, cost }))
+    .sort((a, b) => b.cost - a.cost);
+}
+
 export function TelemetryPill() {
   const sessionSummary = useAppStore((s) => s.sessionSummary);
   const workspaceSummary = useAppStore((s) => s.workspaceSummary);
@@ -51,6 +68,12 @@ export function TelemetryPill() {
   const summarizerCost = sessionTelemetry
     .filter((r) => r.kind === 'summarizer')
     .reduce((sum, r) => sum + r.estimatedCostUsd, 0);
+
+  const providerBreakdown = useMemo(
+    () => buildProviderBreakdown(sessionTelemetry),
+    [sessionTelemetry],
+  );
+  const hasMultipleProviders = providerBreakdown.length >= 2;
 
   const sessionCost = sessionSummary?.estimatedCostUsd ?? 0;
   const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
@@ -102,6 +125,18 @@ export function TelemetryPill() {
                 <dd className="text-right font-medium">{formatCost(summarizerCost)}</dd>
               </>
             ) : null}
+            {hasMultipleProviders
+              ? providerBreakdown.map(({ provider, cost }) => (
+                  <>
+                    <dt key={`dt-${provider}`} className="text-muted-foreground">
+                      via {provider === 'anthropic' ? 'claude' : provider}
+                    </dt>
+                    <dd key={`dd-${provider}`} className="text-right font-medium">
+                      {formatCost(cost)}
+                    </dd>
+                  </>
+                ))
+              : null}
           </dl>
 
           <div className="mt-2 max-h-64 overflow-y-auto">
@@ -122,6 +157,11 @@ export function TelemetryPill() {
                       >
                         {record.kind}
                       </span>
+                      {hasMultipleProviders ? (
+                        <span className="rounded bg-muted px-1 text-[10px] text-muted-foreground">
+                          {record.provider === 'anthropic' ? 'claude' : record.provider}
+                        </span>
+                      ) : null}
                       <span>
                         {formatTokens(record.inputTokens)}↓ / {formatTokens(record.outputTokens)}↑
                       </span>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useState, type KeyboardEvent } from 'react';
 import { Button, Textarea } from '@kay-am/ui';
-import type { Session } from '@kay-am/types';
+import type { ProviderId, Session, TurnProviderOverride } from '@kay-am/types';
 import { useAppStore } from '../../store';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
@@ -13,19 +13,34 @@ interface ChatInputProps {
 export function ChatInput({ session, providerDisconnected = false }: ChatInputProps) {
   const sendTurn = useAppStore((s) => s.sendTurn);
   const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
+  const connectedProviders = useAppStore((s) =>
+    s.providers.filter((p) => p.connection === 'connected'),
+  );
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
 
   const isRunning = RUNNING_KINDS.has(session.state.kind);
   const canSend = !isRunning && !providerDisconnected && value.trim().length > 0;
+  const allowOverride = session.providerPreference.allowTurnOverride;
+  const defaultProvider = session.providerPreference.defaultProvider;
+
+  const effectiveProvider: ProviderId = selectedProvider ?? defaultProvider;
 
   const onSend = async () => {
     const content = value.trim();
     if (!content || isRunning || providerDisconnected) return;
     setError(null);
     setValue('');
+
+    const override: TurnProviderOverride | undefined =
+      allowOverride && selectedProvider !== null && selectedProvider !== defaultProvider
+        ? { providerId: selectedProvider }
+        : undefined;
+
+    setSelectedProvider(null);
     try {
-      await sendTurn({ sessionId: session.id, content });
+      await sendTurn({ sessionId: session.id, content, override });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
@@ -39,6 +54,9 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   };
 
   const sendDisabledTitle = providerDisconnected ? 'sign in first' : undefined;
+  const overrideDisabledTitle = !allowOverride
+    ? 'override disabled in session settings'
+    : undefined;
 
   return (
     <div className="flex flex-col gap-2 border-t border-border p-3">
@@ -57,15 +75,36 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         rows={3}
       />
       {error ? <p className="text-xs text-danger">{error}</p> : null}
-      <div className="flex justify-end gap-2">
+      <div className="flex items-center justify-end gap-2">
         {isRunning ? (
           <Button variant="danger" onClick={() => void cancelCurrentTurn(session.id)}>
             cancel
           </Button>
         ) : (
-          <Button onClick={() => void onSend()} disabled={!canSend} title={sendDisabledTitle}>
-            send
-          </Button>
+          <>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <span>send via</span>
+              <select
+                disabled={!allowOverride || isRunning}
+                title={overrideDisabledTitle}
+                value={effectiveProvider}
+                onChange={(e) => setSelectedProvider(e.target.value as ProviderId)}
+                className="rounded border border-border bg-background px-1 py-0.5 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {connectedProviders.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.id === 'anthropic' ? 'claude' : p.id}
+                  </option>
+                ))}
+                {connectedProviders.every((p) => p.id !== defaultProvider) ? (
+                  <option value={defaultProvider}>{defaultProvider}</option>
+                ) : null}
+              </select>
+            </div>
+            <Button onClick={() => void onSend()} disabled={!canSend} title={sendDisabledTitle}>
+              send
+            </Button>
+          </>
         )}
       </div>
     </div>

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -35,6 +35,7 @@ import type {
   TelemetryRecord,
   TelemetryRecordId,
   TurnEvent,
+  TurnProviderOverride,
   Workspace,
   WorkspaceId,
 } from '@kay-am/types';
@@ -121,7 +122,11 @@ export interface AppActions {
   loadTranscript(sessionId: SessionId): Promise<void>;
   appendTurnEvent(sessionId: SessionId, event: TurnEvent): void;
   resetTranscript(sessionId: SessionId): void;
-  sendTurn(input: { sessionId: SessionId; content: string }): Promise<void>;
+  sendTurn(input: {
+    sessionId: SessionId;
+    content: string;
+    override?: TurnProviderOverride;
+  }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId): Promise<void>;
   endSession(sessionId: SessionId): Promise<void>;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
@@ -529,7 +534,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
-  sendTurn: async ({ sessionId, content }) => {
+  sendTurn: async ({ sessionId, content, override }) => {
     const before = get();
     const session = before.sessions.find((s) => s.id === sessionId);
     if (!session) throw new Error(`session not found: ${sessionId}`);
@@ -541,8 +546,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
 
     const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
-    const provider = session.providerPreference.defaultProvider;
-    const model = session.providerPreference.defaultModel ?? getDefaultTurnModel(provider);
+    const resolvedOverride =
+      session.providerPreference.allowTurnOverride && override != null ? override : undefined;
+    const provider = resolvedOverride?.providerId ?? session.providerPreference.defaultProvider;
+    const model =
+      resolvedOverride?.model ??
+      session.providerPreference.defaultModel ??
+      getDefaultTurnModel(provider);
 
     const authState = get().authResults?.[provider] ?? null;
     if (authState?.state === 'disconnected') {
@@ -562,6 +572,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       role: 'user',
       content,
       createdAt: now(),
+      ...(resolvedOverride !== undefined ? { providerOverride: resolvedOverride } : {}),
     };
     await insertMessage(tauriDatabase, userMessage);
 
@@ -584,6 +595,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     await updateSessionState(tauriDatabase, sessionId, nextState, now());
     applySessionUpdate(set, sessionId, nextState);
 
+    const providerInfo = get().providers.find((p) => p.id === provider);
+
     let assistantText = '';
     let lastError: unknown = null;
 
@@ -593,6 +606,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         model,
         workingDir,
         prompt: content,
+        binary: providerInfo?.binary,
       })) {
         get().appendTurnEvent(sessionId, event);
         if (event.kind === 'assistant_text') assistantText += event.delta;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -1,6 +1,7 @@
 import { m001Initial } from './m001-initial';
 import { m002TelemetryKind } from './m002-telemetry-kind';
 import { m003SessionProvider } from './m003-session-provider';
+import { m004TurnOverrides } from './m004-turn-overrides';
 
 export interface Migration {
   readonly version: number;
@@ -11,4 +12,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 1, sql: m001Initial },
   { version: 2, sql: m002TelemetryKind },
   { version: 3, sql: m003SessionProvider },
+  { version: 4, sql: m004TurnOverrides },
 ];

--- a/packages/db/src/migrations/m004-turn-overrides.ts
+++ b/packages/db/src/migrations/m004-turn-overrides.ts
@@ -1,0 +1,4 @@
+export const m004TurnOverrides = /* sql */ `
+ALTER TABLE messages ADD COLUMN provider_override_id TEXT NULL;
+ALTER TABLE messages ADD COLUMN provider_override_model TEXT NULL;
+`;

--- a/packages/db/src/queries/message.ts
+++ b/packages/db/src/queries/message.ts
@@ -1,4 +1,11 @@
-import type { IsoDateTime, Message, MessageId, MessageRole, SessionId } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  Message,
+  MessageId,
+  MessageRole,
+  SessionId,
+  TurnProviderOverride,
+} from '@kay-am/types';
 import type { Database } from '../client';
 
 interface MessageRow {
@@ -7,22 +14,43 @@ interface MessageRow {
   role: MessageRole;
   content: string;
   created_at: number;
+  provider_override_id: string | null;
+  provider_override_model: string | null;
 }
 
 function toDomain(row: MessageRow): Message {
+  const providerOverride: TurnProviderOverride | undefined =
+    row.provider_override_id != null
+      ? {
+          providerId: row.provider_override_id as TurnProviderOverride['providerId'],
+          model: row.provider_override_model ?? undefined,
+        }
+      : undefined;
+
   return {
     id: row.id as MessageId,
     sessionId: row.session_id as SessionId,
     role: row.role,
     content: row.content,
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    ...(providerOverride !== undefined ? { providerOverride } : {}),
   };
 }
 
 export async function insertMessage(db: Database, message: Message): Promise<void> {
   await db.execute(
-    'INSERT INTO messages (id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)',
-    [message.id, message.sessionId, message.role, message.content, Date.parse(message.createdAt)],
+    `INSERT INTO messages
+      (id, session_id, role, content, created_at, provider_override_id, provider_override_model)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [
+      message.id,
+      message.sessionId,
+      message.role,
+      message.content,
+      Date.parse(message.createdAt),
+      message.providerOverride?.providerId ?? null,
+      message.providerOverride?.model ?? null,
+    ],
   );
 }
 


### PR DESCRIPTION
## Summary

- Provider dropdown (`send via [claude ▾]`) added adjacent to send button in `ChatInput`; disabled with tooltip when `session.providerPreference.allowTurnOverride === false`
- `sendTurn` action extended with optional `override?: TurnProviderOverride`; when present and allowed, resolves provider binary from store's `providers` list and passes it to `turn_spawn`
- DB migration `m004-turn-overrides` adds `provider_override_id` and `provider_override_model` columns to `messages`; persisted on every user message insert
- `TelemetryPill` shows per-provider cost breakdown and per-record provider badge when ≥2 providers appear in session telemetry

## Rust-side gap (documented)

`turn_spawn` in `apps/desktop/src-tauri/src/turn.rs` spawns the binary passed via `SpawnArgs.binary` (already wired: TS now passes `providerInfo.binary` from the providers store). However, **the binary selection is correct only if the provider's CLI accepts the same `--model`, `--output-format stream-json`, and `--working-dir` flags as the `claude` CLI**. For `cursor` and `codex`, the CLI argument shapes differ — so sending a turn via an alternative provider will invoke the correct binary but the stream may not parse correctly until those adapters are fully wired. This is a pre-existing limitation, not introduced here; the TS-side routing is complete.

## Test plan

- [ ] Open session with `allowTurnOverride: true` (default) — dropdown shows connected providers, defaults to session's `defaultProvider`
- [ ] Change dropdown to another connected provider → send → `provider_override_id` persisted on message row, telemetry pill shows breakdown by provider
- [ ] Open session with `allowTurnOverride: false` — dropdown is disabled, tooltip reads "override disabled in session settings"
- [ ] Dropdown resets to session default after each send
- [ ] TelemetryPill: single-provider session shows no breakdown; multi-provider session shows per-provider cost rows and per-record provider badge

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)