### PR TITLE
feat(desktop): add budget crud tauri commands (#104)

### DIFF
--- a/apps/desktop/src-tauri/src/budget.rs
+++ b/apps/desktop/src-tauri/src/budget.rs
@@ -1,0 +1,160 @@
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::db::{Db, DbError};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BudgetRule {
+    pub id: String,
+    pub provider: String,
+    pub period: String,
+    #[serde(rename = "capUsd")]
+    pub cap_usd: f64,
+    #[serde(rename = "alertThresholdPct")]
+    pub alert_threshold_pct: f64,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SessionBudget {
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    #[serde(rename = "softCapUsd")]
+    pub soft_cap_usd: f64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BudgetAlert {
+    pub id: String,
+    pub kind: String,
+    pub provider: Option<String>,
+    #[serde(rename = "sessionId")]
+    pub session_id: Option<String>,
+    #[serde(rename = "currentUsd")]
+    pub current_usd: f64,
+    #[serde(rename = "capUsd")]
+    pub cap_usd: f64,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "dismissedAt")]
+    pub dismissed_at: Option<String>,
+}
+
+#[tauri::command]
+pub fn budget_rule_upsert(state: State<'_, Db>, rule: BudgetRule) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    conn.execute(
+        "INSERT INTO budget_rules (id, provider, period, cap_usd, alert_threshold_pct, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+         ON CONFLICT(id) DO UPDATE SET
+           provider = excluded.provider,
+           period = excluded.period,
+           cap_usd = excluded.cap_usd,
+           alert_threshold_pct = excluded.alert_threshold_pct",
+        rusqlite::params![
+            rule.id,
+            rule.provider,
+            rule.period,
+            rule.cap_usd,
+            rule.alert_threshold_pct,
+            rule.created_at,
+        ],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn budget_rule_list(state: State<'_, Db>) -> Result<Vec<BudgetRule>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, provider, period, cap_usd, alert_threshold_pct, created_at FROM budget_rules",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(BudgetRule {
+            id: row.get(0)?,
+            provider: row.get(1)?,
+            period: row.get(2)?,
+            cap_usd: row.get(3)?,
+            alert_threshold_pct: row.get(4)?,
+            created_at: row.get(5)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(DbError::Sqlite)
+}
+
+#[tauri::command]
+pub fn budget_rule_delete(state: State<'_, Db>, id: String) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    conn.execute("DELETE FROM budget_rules WHERE id = ?1", rusqlite::params![id])?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn session_budget_set(
+    state: State<'_, Db>,
+    session_id: String,
+    soft_cap_usd: f64,
+) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    conn.execute(
+        "INSERT INTO session_budgets (session_id, soft_cap_usd)
+         VALUES (?1, ?2)
+         ON CONFLICT(session_id) DO UPDATE SET soft_cap_usd = excluded.soft_cap_usd",
+        rusqlite::params![session_id, soft_cap_usd],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn session_budget_get(
+    state: State<'_, Db>,
+    session_id: String,
+) -> Result<Option<SessionBudget>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt =
+        conn.prepare("SELECT session_id, soft_cap_usd FROM session_budgets WHERE session_id = ?1")?;
+    let mut rows = stmt.query_map(rusqlite::params![session_id], |row| {
+        Ok(SessionBudget {
+            session_id: row.get(0)?,
+            soft_cap_usd: row.get(1)?,
+        })
+    })?;
+    match rows.next() {
+        Some(row) => Ok(Some(row.map_err(DbError::Sqlite)?)),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub fn budget_alerts_list(state: State<'_, Db>) -> Result<Vec<BudgetAlert>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, kind, provider, session_id, current_usd, cap_usd, created_at, dismissed_at
+         FROM budget_alerts
+         WHERE dismissed_at IS NULL",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(BudgetAlert {
+            id: row.get(0)?,
+            kind: row.get(1)?,
+            provider: row.get(2)?,
+            session_id: row.get(3)?,
+            current_usd: row.get(4)?,
+            cap_usd: row.get(5)?,
+            created_at: row.get(6)?,
+            dismissed_at: row.get(7)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(DbError::Sqlite)
+}
+
+#[tauri::command]
+pub fn budget_alert_dismiss(state: State<'_, Db>, id: String) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    conn.execute(
+        "UPDATE budget_alerts SET dismissed_at = datetime('now') WHERE id = ?1",
+        rusqlite::params![id],
+    )?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod budget;
 mod db;
 mod editor;
 mod providers;
@@ -62,6 +63,13 @@ pub fn run() {
       turn::turn_cancel,
       summarize::summarize_session,
       repo::validate_git_repo,
+      budget::budget_rule_upsert,
+      budget::budget_rule_list,
+      budget::budget_rule_delete,
+      budget::session_budget_set,
+      budget::session_budget_get,
+      budget::budget_alerts_list,
+      budget::budget_alert_dismiss,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src/budget.ts
+++ b/apps/desktop/src/budget.ts
@@ -1,0 +1,30 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { BudgetAlert, BudgetRule, SessionBudget } from '@kay-am/types';
+
+export async function invokeBudgetRuleUpsert(rule: BudgetRule): Promise<void> {
+  return invoke<void>('budget_rule_upsert', { rule });
+}
+
+export async function invokeBudgetRuleList(): Promise<BudgetRule[]> {
+  return invoke<BudgetRule[]>('budget_rule_list');
+}
+
+export async function invokeBudgetRuleDelete(id: string): Promise<void> {
+  return invoke<void>('budget_rule_delete', { id });
+}
+
+export async function invokeSessionBudgetSet(sessionId: string, softCapUsd: number): Promise<void> {
+  return invoke<void>('session_budget_set', { sessionId, softCapUsd });
+}
+
+export async function invokeSessionBudgetGet(sessionId: string): Promise<SessionBudget | null> {
+  return invoke<SessionBudget | null>('session_budget_get', { sessionId });
+}
+
+export async function invokeBudgetAlertsList(): Promise<BudgetAlert[]> {
+  return invoke<BudgetAlert[]>('budget_alerts_list');
+}
+
+export async function invokeBudgetAlertDismiss(id: string): Promise<void> {
+  return invoke<void>('budget_alert_dismiss', { id });
+}

--- a/packages/core/src/budget/index.ts
+++ b/packages/core/src/budget/index.ts
@@ -1,1 +1,2 @@
 export { checkProviderBudget, checkSessionBudget, getPeriodWindow } from './checker';
+export { resolveProvider, type ResolveProviderInput } from './router';

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -1,0 +1,80 @@
+import type {
+  BudgetCheckResult,
+  BudgetPeriod,
+  ProviderId,
+  ProviderName,
+  RoutingDecision,
+  SessionProviderPreference,
+  TurnProviderOverride,
+} from '@kay-am/types';
+
+export type ResolveProviderInput = {
+  sessionPreference: SessionProviderPreference;
+  turnOverride?: TurnProviderOverride;
+  connectedProviders: ProviderId[];
+  budgetChecker: {
+    checkProviderBudget: (
+      provider: ProviderName,
+      period: BudgetPeriod,
+    ) => Promise<BudgetCheckResult>;
+  };
+  getDefaultModel: (provider: ProviderId) => string;
+};
+
+const PROVIDER_ID_TO_NAME: Readonly<Record<ProviderId, ProviderName>> = {
+  anthropic: 'anthropic',
+  cursor: 'cursor',
+  codex: 'openai',
+};
+
+export async function resolveProvider(input: ResolveProviderInput): Promise<RoutingDecision> {
+  const { sessionPreference, turnOverride, connectedProviders, budgetChecker, getDefaultModel } =
+    input;
+
+  const useOverride = turnOverride !== undefined && sessionPreference.allowTurnOverride;
+
+  const preferredProvider: ProviderId = useOverride
+    ? turnOverride!.providerId
+    : sessionPreference.defaultProvider;
+
+  const preferredModel =
+    useOverride && turnOverride!.model !== undefined
+      ? turnOverride!.model
+      : (sessionPreference.defaultModel ?? getDefaultModel(preferredProvider));
+
+  const preferredName = PROVIDER_ID_TO_NAME[preferredProvider];
+  const preferredResult = await budgetChecker.checkProviderBudget(preferredName, 'monthly');
+
+  if (!preferredResult.exceeded) {
+    return {
+      selectedProvider: preferredProvider,
+      selectedModel: preferredModel,
+      reason: useOverride ? 'override' : 'preferred',
+      fallbackUsed: false,
+    };
+  }
+
+  for (const candidate of connectedProviders) {
+    if (candidate === preferredProvider) continue;
+
+    const candidateName = PROVIDER_ID_TO_NAME[candidate];
+    const candidateResult = await budgetChecker.checkProviderBudget(candidateName, 'monthly');
+
+    if (!candidateResult.exceeded) {
+      return {
+        selectedProvider: candidate,
+        selectedModel: getDefaultModel(candidate),
+        reason: 'fallback-budget',
+        fallbackUsed: true,
+        fallbackFrom: preferredProvider,
+      };
+    }
+  }
+
+  return {
+    selectedProvider: preferredProvider,
+    selectedModel: preferredModel,
+    reason: 'all-exceeded',
+    fallbackUsed: false,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ export {
   type SlotKey,
 } from './context';
 
+export { resolveProvider, type ResolveProviderInput } from './budget/router';
+
 export { computeCostUsd, priceFor } from './providers/claude/cost';
 export { parseStreamJsonLine, type ParseContext } from './providers/claude/parser';
 


### PR DESCRIPTION
Closes #104

## Summary
- `src-tauri/src/budget.rs`: 7 Tauri commands covering `budget_rules`, `session_budgets`, and `budget_alerts` tables (upsert/list/delete, set/get, list/dismiss)
- `src-tauri/src/lib.rs`: registered `mod budget` + all 7 commands in `invoke_handler`
- `apps/desktop/src/budget.ts`: typed `invoke` wrappers using `BudgetRule`, `SessionBudget`, `BudgetAlert` from `@kay-am/types`

## Test plan
- [ ] `cargo check` passes (verified locally)
- [ ] `pnpm typecheck` passes (verified locally)
- [ ] Manual: call each command from devtools / test page