### PR TITLE
feat(desktop): add session soft cap in new-session dialog (#107)

### DIFF
--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
-import type { ProviderId, SessionProviderPreference, WorkspaceId } from '@kay-am/types';
+import type { ProviderId, SessionId, SessionProviderPreference, WorkspaceId } from '@kay-am/types';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
 import { useAppStore } from '../store';
 
@@ -34,11 +34,13 @@ export function NewSessionDialog({
 }: NewSessionDialogProps) {
   const createSession = useAppStore((s) => s.createSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
+  const setSessionBudget = useAppStore((s) => s.setSessionBudget);
   const providers = useAppStore((s) => s.providers);
   const settingKey = settingBranchPrefix(workspaceId);
   const storedPrefix = useAppStore((s) => s.settings[settingKey]);
   const [goal, setGoal] = useState('');
   const [prefix, setPrefix] = useState(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
+  const [softCapRaw, setSoftCapRaw] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -59,6 +61,7 @@ export function NewSessionDialog({
   const reset = () => {
     setGoal('');
     setPrefix(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
+    setSoftCapRaw('');
     setError(null);
   };
 
@@ -70,7 +73,16 @@ export function NewSessionDialog({
         defaultProvider: selectedProvider,
         allowTurnOverride: true,
       };
-      await createSession({ workspaceId, goal, branchPrefix: prefix, providerPreference });
+      const { session } = await createSession({
+        workspaceId,
+        goal,
+        branchPrefix: prefix,
+        providerPreference,
+      });
+      const parsedCap = parseFloat(softCapRaw);
+      if (softCapRaw.trim().length > 0 && !isNaN(parsedCap) && parsedCap > 0) {
+        await setSessionBudget(session.id as SessionId, parsedCap);
+      }
       reset();
       onClose();
     } catch (err) {
@@ -113,6 +125,17 @@ export function NewSessionDialog({
 
       <Field label="branch prefix" hint="branch name will be `<prefix>/<slug>`.">
         <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} placeholder="kay" />
+      </Field>
+
+      <Field label="soft cap (usd)" hint="optional spend limit. session is flagged when exceeded.">
+        <Input
+          value={softCapRaw}
+          onChange={(e) => setSoftCapRaw(e.target.value)}
+          placeholder="e.g. 5.00"
+          type="number"
+          min="0"
+          step="0.01"
+        />
       </Field>
 
       <Field label="provider">

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import { FolderOpen, FolderPlus, Plus } from 'lucide-react';
-import type { ProviderId, Session, Workspace } from '@kay-am/types';
+import type { ProviderId, Session, SessionId, Workspace } from '@kay-am/types';
 import {
   useAppStore,
   useCurrentSession,
@@ -175,6 +175,47 @@ interface SessionRowProps {
 function SessionRow({ session, isActive, onClick }: SessionRowProps) {
   const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id] ?? null);
   const providerId = session.providerPreference.defaultProvider;
+  const budget = useAppStore((s) => s.sessionBudgets[session.id as SessionId] ?? null);
+  const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
+  const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
+  const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const budgetLoaded = useRef(false);
+
+  const [editingCap, setEditingCap] = useState(false);
+  const [capDraft, setCapDraft] = useState('');
+
+  useEffect(() => {
+    if (!budgetLoaded.current) {
+      budgetLoaded.current = true;
+      void loadSessionBudget(session.id as SessionId);
+    }
+  }, [session.id, loadSessionBudget]);
+
+  const spent = isActive ? (spentUsd ?? 0) : 0;
+  const cap = budget?.softCapUsd ?? null;
+  const pct = cap !== null && cap > 0 ? spent / cap : null;
+
+  const barColor =
+    pct === null ? '' : pct >= 1 ? 'bg-red-500' : pct >= 0.8 ? 'bg-yellow-400' : 'bg-green-500';
+
+  const onCapClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setCapDraft(cap !== null ? String(cap) : '');
+    setEditingCap(true);
+  };
+
+  const onCapSave = async () => {
+    const parsed = parseFloat(capDraft);
+    if (!isNaN(parsed) && parsed > 0) {
+      await setSessionBudget(session.id as SessionId, parsed);
+    }
+    setEditingCap(false);
+  };
+
+  const onCapKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') void onCapSave();
+    if (e.key === 'Escape') setEditingCap(false);
+  };
 
   return (
     <li className="group">
@@ -210,6 +251,47 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
             <StatusBadge state={session.state} />
           </div>
         </button>
+
+        {cap !== null && (
+          <div className="flex flex-col gap-0.5 pl-3.5">
+            <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className={cn('h-full rounded-full transition-all', barColor)}
+                style={{ width: `${Math.min((pct ?? 0) * 100, 100)}%` }}
+              />
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] text-muted-foreground">
+                ${spent.toFixed(2)} /{' '}
+                {editingCap ? null : (
+                  <button
+                    type="button"
+                    className="text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+                    onClick={onCapClick}
+                    title="click to edit cap"
+                  >
+                    ${cap.toFixed(2)}
+                  </button>
+                )}
+              </span>
+              {editingCap && (
+                <input
+                  autoFocus
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={capDraft}
+                  onChange={(e) => setCapDraft(e.target.value)}
+                  onBlur={() => void onCapSave()}
+                  onKeyDown={onCapKeyDown}
+                  onClick={(e) => e.stopPropagation()}
+                  className="ml-1 w-16 rounded border border-border bg-background px-1 py-0 text-[10px] outline-none focus:ring-1 focus:ring-primary"
+                />
+              )}
+            </div>
+          </div>
+        )}
+
         <div
           className={cn(
             'flex justify-end opacity-0 transition-opacity',

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -30,6 +30,7 @@ import type {
   ProviderRun,
   ProviderRunId,
   Session,
+  SessionBudget,
   SessionId,
   SessionProviderPreference,
   SessionState,
@@ -42,6 +43,7 @@ import type {
 } from '@kay-am/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
 import { computeCostUsd } from '@kay-am/core';
+import { invokeSessionBudgetGet, invokeSessionBudgetSet } from '../budget';
 import { runDbMigrations, tauriDatabase } from '../db';
 import {
   buildProviderList,
@@ -97,6 +99,7 @@ export interface AppState {
   readonly sessionSlots: Readonly<Record<string, ReadonlyArray<ContextSlot>>>;
   readonly summarizerStatus: Readonly<Record<string, SummarizerSessionStatus>>;
   readonly budgetRules: ReadonlyArray<BudgetRule>;
+  readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
 }
 
 export interface SummarizerSessionStatus {
@@ -140,6 +143,8 @@ export interface AppActions {
   loadBudgetRules(): Promise<void>;
   saveBudgetRule(rule: Omit<BudgetRule, 'id' | 'createdAt'>): Promise<void>;
   deleteBudgetRule(id: string): Promise<void>;
+  loadSessionBudget(sessionId: SessionId): Promise<void>;
+  setSessionBudget(sessionId: SessionId, softCapUsd: number): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -167,6 +172,7 @@ const initialState: AppState = {
   sessionSlots: {},
   summarizerStatus: {},
   budgetRules: [],
+  sessionBudgets: {},
 };
 
 function mergeSlots(
@@ -812,6 +818,23 @@ export const useAppStore = create<AppStore>((set, get) => ({
   deleteBudgetRule: async (id) => {
     await invokeBudgetRuleDelete(id);
     set((state) => ({ budgetRules: state.budgetRules.filter((r) => r.id !== id) }));
+  },
+
+  loadSessionBudget: async (sessionId) => {
+    const budget = await invokeSessionBudgetGet(sessionId);
+    if (budget !== null) {
+      set((state) => ({
+        sessionBudgets: { ...state.sessionBudgets, [sessionId]: budget },
+      }));
+    }
+  },
+
+  setSessionBudget: async (sessionId, softCapUsd) => {
+    await invokeSessionBudgetSet(sessionId, softCapUsd);
+    const budget: SessionBudget = { sessionId, softCapUsd };
+    set((state) => ({
+      sessionBudgets: { ...state.sessionBudgets, [sessionId]: budget },
+    }));
   },
 
   addWorkspace: async ({ rootPath, name }) => {


### PR DESCRIPTION
Closes #107

## Summary

- adds optional "soft cap (USD)" field to new-session dialog; persists via `invokeSessionBudgetSet` after session creation
- shows a mini progress bar + `$X.XX / $Y.YY` label in the sidebar session row when a cap is set; color-coded green < 80%, yellow 80–99%, red ≥ 100%
- cap amount is click-to-edit inline (enter to save, escape to cancel) via `invokeSessionBudgetSet`
- store additions: `sessionBudgets` record, `loadSessionBudget`, `setSessionBudget` actions

## Test plan

- [ ] create session with soft cap → row shows progress bar at $0.00 / $X.XX (green)
- [ ] after spend reaches 80% threshold → bar turns yellow
- [ ] at/over cap → bar turns red
- [ ] click cap amount in sidebar → inline input appears, save with enter
- [ ] create session without soft cap → no progress bar shown
- [ ] typecheck passes: `pnpm typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)