### PR TITLE
feat(desktop): add provider spend breakdown in telemetry pill (#110)

### DIFF
--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@kay-am/ui';
 import type { TelemetryRecord } from '@kay-am/types';
 import { useAppStore } from '../store';
+import type { ProviderSpendEntry } from '../store';
 
 const EMPTY_TELEMETRY: ReadonlyArray<TelemetryRecord> = [];
 
@@ -15,21 +16,43 @@ const formatTokens = (n: number): string =>
 
 type SortKey = 'time' | 'cost';
 
-interface ProviderBreakdown {
-  readonly provider: string;
-  readonly cost: number;
+function spendColor(pct: number): string {
+  if (pct >= 1) return 'bg-red-500';
+  if (pct >= 0.8) return 'bg-yellow-500';
+  return 'bg-green-500';
 }
 
-function buildProviderBreakdown(
-  records: ReadonlyArray<TelemetryRecord>,
-): ReadonlyArray<ProviderBreakdown> {
-  const map = new Map<string, number>();
-  for (const r of records) {
-    map.set(r.provider, (map.get(r.provider) ?? 0) + r.estimatedCostUsd);
-  }
-  return Array.from(map.entries())
-    .map(([provider, cost]) => ({ provider, cost }))
-    .sort((a, b) => b.cost - a.cost);
+function spendTextColor(pct: number, hasCap: boolean): string {
+  if (!hasCap) return 'text-foreground';
+  if (pct >= 1) return 'text-red-600';
+  if (pct >= 0.8) return 'text-yellow-600';
+  return 'text-green-700';
+}
+
+function ProviderSpendRow({ entry }: { entry: ProviderSpendEntry }) {
+  const label = entry.provider === 'anthropic' ? 'claude' : entry.provider;
+  const hasCap = entry.capUsd !== null;
+  const pctClamped = Math.min(entry.pct, 1);
+
+  return (
+    <li className="flex flex-col gap-0.5 py-1">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium capitalize">{label}</span>
+        <span className={cn('font-mono text-xs', spendTextColor(entry.pct, hasCap))}>
+          {formatCost(entry.spentUsd)}
+          {hasCap ? ` / ${formatCost(entry.capUsd!)}` : null}
+        </span>
+      </div>
+      {hasCap ? (
+        <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className={cn('h-full rounded-full transition-all', spendColor(entry.pct))}
+            style={{ width: `${pctClamped * 100}%` }}
+          />
+        </div>
+      ) : null}
+    </li>
+  );
 }
 
 export function TelemetryPill() {
@@ -39,6 +62,7 @@ export function TelemetryPill() {
   const sessionTelemetry = useAppStore((s) =>
     currentSessionId ? (s.sessionTelemetry[currentSessionId] ?? EMPTY_TELEMETRY) : EMPTY_TELEMETRY,
   );
+  const providerSpendBreakdown = useAppStore((s) => s.providerSpendBreakdown);
 
   const [open, setOpen] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>('time');
@@ -69,11 +93,7 @@ export function TelemetryPill() {
     .filter((r) => r.kind === 'summarizer')
     .reduce((sum, r) => sum + r.estimatedCostUsd, 0);
 
-  const providerBreakdown = useMemo(
-    () => buildProviderBreakdown(sessionTelemetry),
-    [sessionTelemetry],
-  );
-  const hasMultipleProviders = providerBreakdown.length >= 2;
+  const hasMultipleProviders = providerSpendBreakdown.length >= 2;
 
   const sessionCost = sessionSummary?.estimatedCostUsd ?? 0;
   const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
@@ -125,19 +145,20 @@ export function TelemetryPill() {
                 <dd className="text-right font-medium">{formatCost(summarizerCost)}</dd>
               </>
             ) : null}
-            {hasMultipleProviders
-              ? providerBreakdown.map(({ provider, cost }) => (
-                  <>
-                    <dt key={`dt-${provider}`} className="text-muted-foreground">
-                      via {provider === 'anthropic' ? 'claude' : provider}
-                    </dt>
-                    <dd key={`dd-${provider}`} className="text-right font-medium">
-                      {formatCost(cost)}
-                    </dd>
-                  </>
-                ))
-              : null}
           </dl>
+
+          {providerSpendBreakdown.length > 0 ? (
+            <div className="mt-2 border-b border-border pb-2">
+              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                by provider
+              </p>
+              <ul className="flex flex-col divide-y divide-border">
+                {providerSpendBreakdown.map((entry) => (
+                  <ProviderSpendRow key={entry.provider} entry={entry} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
 
           <div className="mt-2 max-h-64 overflow-y-auto">
             {sorted.length === 0 ? (

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -3,6 +3,7 @@ export {
   type AppActions,
   type AppState,
   type BootPhase,
+  type ProviderSpendEntry,
   type SummarizerSessionStatus,
 } from './store';
 export {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -16,10 +16,12 @@ import {
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
   summarizeWorkspaceTelemetry,
+  summarizeWorkspaceProviderTelemetry,
   updateProviderRunStatus,
   updateSessionState,
   upsertContextSlot,
   type TelemetrySummary,
+  type ProviderTelemetrySummary,
 } from '@kay-am/db';
 import type {
   BudgetRule,
@@ -100,12 +102,20 @@ export interface AppState {
   readonly summarizerStatus: Readonly<Record<string, SummarizerSessionStatus>>;
   readonly budgetRules: ReadonlyArray<BudgetRule>;
   readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
+  readonly providerSpendBreakdown: ReadonlyArray<ProviderSpendEntry>;
 }
 
 export interface SummarizerSessionStatus {
   readonly status: 'idle' | 'running' | 'error';
   readonly lastUpdate: IsoDateTime | null;
   readonly error: string | null;
+}
+
+export interface ProviderSpendEntry {
+  readonly provider: ProviderTelemetrySummary['provider'];
+  readonly spentUsd: number;
+  readonly capUsd: number | null;
+  readonly pct: number;
 }
 
 export interface AppActions {
@@ -145,6 +155,7 @@ export interface AppActions {
   deleteBudgetRule(id: string): Promise<void>;
   loadSessionBudget(sessionId: SessionId): Promise<void>;
   setSessionBudget(sessionId: SessionId, softCapUsd: number): Promise<void>;
+  refreshProviderSpendBreakdown(workspaceId: WorkspaceId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -173,7 +184,20 @@ const initialState: AppState = {
   summarizerStatus: {},
   budgetRules: [],
   sessionBudgets: {},
+  providerSpendBreakdown: [],
 };
+
+function buildProviderSpendBreakdown(
+  providerSummaries: ReadonlyArray<ProviderTelemetrySummary>,
+  budgetRules: ReadonlyArray<BudgetRule>,
+): ReadonlyArray<ProviderSpendEntry> {
+  return providerSummaries.map((s) => {
+    const rule = budgetRules.find((r) => r.provider === s.provider) ?? null;
+    const capUsd = rule?.capUsd ?? null;
+    const pct = capUsd !== null && capUsd > 0 ? s.estimatedCostUsd / capUsd : 0;
+    return { provider: s.provider, spentUsd: s.estimatedCostUsd, capUsd, pct };
+  });
+}
 
 function mergeSlots(
   existing: ReadonlyArray<ContextSlot>,
@@ -272,11 +296,14 @@ async function runSummarizer(
     };
     await insertTelemetry(tauriDatabase, record);
 
-    const [sessionSummary, workspaceSummary, telemetry] = await Promise.all([
-      summarizeSessionTelemetry(tauriDatabase, sessionId),
-      summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
-      listTelemetryForSession(tauriDatabase, sessionId),
-    ]);
+    const [sessionSummary, workspaceSummary, telemetry, providerSummaries, budgetRules] =
+      await Promise.all([
+        summarizeSessionTelemetry(tauriDatabase, sessionId),
+        summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
+        listTelemetryForSession(tauriDatabase, sessionId),
+        summarizeWorkspaceProviderTelemetry(tauriDatabase, session.workspaceId),
+        invokeBudgetRuleList(),
+      ]);
     set((state) => ({
       sessionSummary,
       workspaceSummary,
@@ -285,6 +312,7 @@ async function runSummarizer(
         ...state.summarizerStatus,
         [sessionId]: { status: 'idle', lastUpdate: now(), error: null },
       },
+      providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
     }));
   } catch (err) {
     // never log api key — only the error message
@@ -387,11 +415,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
       workspaceSummary: null,
     });
     if (id) {
-      const [sessions, workspaceSummary] = await Promise.all([
+      const [sessions, workspaceSummary, providerSummaries, budgetRules] = await Promise.all([
         listSessionsForWorkspace(tauriDatabase, id),
         summarizeWorkspaceTelemetry(tauriDatabase, id),
+        summarizeWorkspaceProviderTelemetry(tauriDatabase, id),
+        invokeBudgetRuleList(),
       ]);
-      set({ sessions, workspaceSummary });
+      set({
+        sessions,
+        workspaceSummary,
+        providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
+      });
+    } else {
+      set({ providerSpendBreakdown: [] });
     }
     await dbSetSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID, id ?? '');
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, '');
@@ -647,11 +683,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
           }));
           const session = get().sessions.find((s) => s.id === sessionId);
           if (session) {
-            const [sessSummary, wsSummary] = await Promise.all([
+            const [sessSummary, wsSummary, providerSummaries, budgetRules] = await Promise.all([
               summarizeSessionTelemetry(tauriDatabase, sessionId),
               summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
+              summarizeWorkspaceProviderTelemetry(tauriDatabase, session.workspaceId),
+              invokeBudgetRuleList(),
             ]);
-            set({ sessionSummary: sessSummary, workspaceSummary: wsSummary });
+            set({
+              sessionSummary: sessSummary,
+              workspaceSummary: wsSummary,
+              providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
+            });
           }
         }
 
@@ -723,8 +765,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   refreshWorkspaceSummary: async (workspaceId) => {
-    const summary = await summarizeWorkspaceTelemetry(tauriDatabase, workspaceId);
-    set({ workspaceSummary: summary });
+    const [summary, providerSummaries, budgetRules] = await Promise.all([
+      summarizeWorkspaceTelemetry(tauriDatabase, workspaceId),
+      summarizeWorkspaceProviderTelemetry(tauriDatabase, workspaceId),
+      invokeBudgetRuleList(),
+    ]);
+    set({
+      workspaceSummary: summary,
+      providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
+    });
   },
 
   loadSessionTelemetry: async (sessionId) => {
@@ -856,5 +905,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
     await insertWorkspace(tauriDatabase, workspace);
     set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
     return workspace;
+  },
+
+  refreshProviderSpendBreakdown: async (workspaceId) => {
+    const [providerSummaries, budgetRules] = await Promise.all([
+      summarizeWorkspaceProviderTelemetry(tauriDatabase, workspaceId),
+      invokeBudgetRuleList(),
+    ]);
+    set({ providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules) });
   },
 }));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -25,7 +25,9 @@ export {
   summarizeSessionTelemetry,
   summarizeWorkspaceTelemetry,
   summarizeProviderTelemetry,
+  summarizeWorkspaceProviderTelemetry,
   type TelemetrySummary,
+  type ProviderTelemetrySummary,
 } from './queries/telemetry';
 export { getSetting, setSetting } from './queries/settings';
 export {

--- a/packages/db/src/queries/telemetry.ts
+++ b/packages/db/src/queries/telemetry.ts
@@ -134,3 +134,29 @@ export async function summarizeProviderTelemetry(
   );
   return toSummary(rows[0]);
 }
+
+export interface ProviderTelemetrySummary {
+  readonly provider: ProviderName;
+  readonly estimatedCostUsd: number;
+}
+
+interface ProviderSummaryRow {
+  provider: ProviderName;
+  cost: number | null;
+}
+
+export async function summarizeWorkspaceProviderTelemetry(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<ReadonlyArray<ProviderTelemetrySummary>> {
+  const rows = await db.select<ProviderSummaryRow>(
+    `SELECT t.provider, COALESCE(SUM(t.estimated_cost_usd), 0) AS cost
+       FROM telemetry_records t
+       INNER JOIN sessions s ON s.id = t.session_id
+      WHERE s.workspace_id = ?
+      GROUP BY t.provider
+      ORDER BY cost DESC`,
+    [workspaceId],
+  );
+  return rows.map((r) => ({ provider: r.provider, estimatedCostUsd: r.cost ?? 0 }));
+}


### PR DESCRIPTION
Closes #110

## Summary
- Add `summarizeWorkspaceProviderTelemetry` DB query — groups telemetry by provider across all sessions in a workspace
- Add `ProviderSpendEntry` type and `providerSpendBreakdown` field to store, refreshed on workspace change and after every turn/summarizer
- Extend `TelemetryPill` expanded panel with a "by provider" section: spend, optional cap, progress bar, color-coded green/yellow/red thresholds (< 80% / 80–99% / ≥ 100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)