### PR TITLE
feat(desktop): add routing indicator on chat input (#108)

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -3,6 +3,7 @@ import { Button, Textarea } from '@kay-am/ui';
 import type { ProviderId, Session, TurnProviderOverride } from '@kay-am/types';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from '../../store';
+import { RoutingIndicator } from './RoutingIndicator';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -27,6 +28,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const defaultProvider = session.providerPreference.defaultProvider;
 
   const effectiveProvider: ProviderId = selectedProvider ?? defaultProvider;
+
+  const routingOverride: TurnProviderOverride | undefined =
+    allowOverride && selectedProvider !== null && selectedProvider !== defaultProvider
+      ? { providerId: selectedProvider }
+      : undefined;
+
+  const connectedProviderIds = connectedProviders.map((p) => p.id);
 
   const onSend = async () => {
     const content = value.trim();
@@ -62,6 +70,14 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   return (
     <div className="border-t border-border px-4 py-3">
       <div className="mx-auto flex max-w-3xl flex-col gap-2">
+        {!isRunning && !providerDisconnected ? (
+          <RoutingIndicator
+            sessionPreference={session.providerPreference}
+            turnOverride={routingOverride}
+            connectedProviders={connectedProviderIds}
+            onSendAnyway={value.trim().length > 0 ? () => void onSend() : undefined}
+          />
+        ) : null}
         <Textarea
           value={value}
           onChange={(e) => setValue(e.target.value)}

--- a/apps/desktop/src/components/chat/RoutingIndicator.tsx
+++ b/apps/desktop/src/components/chat/RoutingIndicator.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import type {
+  ProviderId,
+  RoutingDecision,
+  SessionProviderPreference,
+  TurnProviderOverride,
+} from '@kay-am/types';
+import { resolveProviderForTurn } from '../../routing';
+
+interface RoutingIndicatorProps {
+  readonly sessionPreference: SessionProviderPreference;
+  readonly turnOverride: TurnProviderOverride | undefined;
+  readonly connectedProviders: ReadonlyArray<ProviderId>;
+  readonly onSendAnyway?: () => void;
+}
+
+export function RoutingIndicator({
+  sessionPreference,
+  turnOverride,
+  connectedProviders,
+  onSendAnyway,
+}: RoutingIndicatorProps) {
+  const [decision, setDecision] = useState<RoutingDecision | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    resolveProviderForTurn(sessionPreference, turnOverride, [...connectedProviders]).then((d) => {
+      if (!cancelled) setDecision(d);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionPreference, turnOverride, connectedProviders]);
+
+  if (!decision) return null;
+
+  if (decision.reason === 'all-exceeded') {
+    return (
+      <div className="flex items-center gap-2 text-xs text-danger">
+        <span>all provider budgets exceeded</span>
+        {onSendAnyway ? (
+          <button type="button" onClick={onSendAnyway} className="underline hover:no-underline">
+            send anyway
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  const label = decision.selectedProvider === 'anthropic' ? 'claude' : decision.selectedProvider;
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      {decision.reason === 'fallback-budget' && decision.fallbackFrom ? (
+        <span className="text-warning">
+          ⚠ fallback: {label} / {decision.selectedModel} (budget exceeded for{' '}
+          {decision.fallbackFrom === 'anthropic' ? 'claude' : decision.fallbackFrom})
+        </span>
+      ) : (
+        <>
+          <span>
+            {label} / {decision.selectedModel}
+          </span>
+          {decision.reason === 'override' ? (
+            <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium text-accent-foreground">
+              override
+            </span>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #108

## Summary

- New `RoutingIndicator` component calls `resolveProviderForTurn()` reactively (re-runs on session preference or turn override change)
- Shows resolved provider + model above the chat textarea when not running/disconnected
- Override active → "override" badge
- Budget fallback → `⚠ fallback: [provider] / [model] (budget exceeded for [original])` in warning color
- All exceeded → blocking warning with optional "send anyway" button
- `ChatInput` wires it with existing `connectedProviders`, `session.providerPreference`, and computed `routingOverride`