### PR TITLE
feat(desktop): add budget alert toasts and alert center (#109)

### DIFF
--- a/apps/desktop/src-tauri/src/budget.rs
+++ b/apps/desktop/src-tauri/src/budget.rs
@@ -236,6 +236,198 @@ fn ymd_to_epoch_ms(year: i64, month: u32, day: u32) -> i64 {
     days * 86400 * 1000
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EmitAlertsInput {
+    pub provider: String,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+}
+
+#[tauri::command]
+pub fn budget_emit_alerts(
+    state: State<'_, Db>,
+    input: EmitAlertsInput,
+) -> Result<Vec<BudgetAlert>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let now = iso_now();
+    let period = "monthly";
+    let provider = &input.provider;
+    let session_id = &input.session_id;
+
+    // --- provider budget check ---
+    let provider_rule: Option<(String, f64, f64)> = {
+        let mut stmt = conn.prepare(
+            "SELECT id, cap_usd, alert_threshold_pct FROM budget_rules WHERE provider = ?1 AND period = ?2 LIMIT 1",
+        )?;
+        let mut rows = stmt.query_map(rusqlite::params![provider, period], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, f64>(1)?, row.get::<_, f64>(2)?))
+        })?;
+        match rows.next() {
+            Some(r) => Some(r.map_err(DbError::Sqlite)?),
+            None => None,
+        }
+    };
+
+    let (start_ms, end_ms) = current_month_window_ms();
+
+    let mut created: Vec<BudgetAlert> = Vec::new();
+
+    if let Some((_rule_id, cap_usd, threshold_pct)) = provider_rule {
+        let spent: f64 = conn.query_row(
+            "SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM telemetry_records
+              WHERE provider = ?1 AND recorded_at >= ?2 AND recorded_at <= ?3",
+            rusqlite::params![provider, start_ms, end_ms],
+            |row| row.get(0),
+        )?;
+
+        let pct = if cap_usd > 0.0 { (spent / cap_usd) * 100.0 } else { 0.0 };
+
+        let alert_kind: Option<&str> = if pct >= 100.0 {
+            Some("provider-exceeded")
+        } else if pct >= threshold_pct {
+            Some("provider-threshold")
+        } else {
+            None
+        };
+
+        if let Some(kind) = alert_kind {
+            let already: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM budget_alerts WHERE kind = ?1 AND provider = ?2 AND dismissed_at IS NULL",
+                rusqlite::params![kind, provider],
+                |row| row.get(0),
+            )?;
+            if already == 0 {
+                let id = uuid_v4();
+                conn.execute(
+                    "INSERT INTO budget_alerts (id, kind, provider, session_id, current_usd, cap_usd, created_at, dismissed_at)
+                     VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, NULL)",
+                    rusqlite::params![id, kind, provider, spent, cap_usd, now],
+                )?;
+                created.push(BudgetAlert {
+                    id,
+                    kind: kind.to_string(),
+                    provider: Some(provider.clone()),
+                    session_id: None,
+                    current_usd: spent,
+                    cap_usd,
+                    created_at: now.clone(),
+                    dismissed_at: None,
+                });
+            }
+        }
+    }
+
+    // --- session budget check ---
+    let session_cap: Option<f64> = {
+        let mut stmt = conn.prepare("SELECT soft_cap_usd FROM session_budgets WHERE session_id = ?1 LIMIT 1")?;
+        let mut rows = stmt.query_map(rusqlite::params![session_id], |row| row.get(0))?;
+        match rows.next() {
+            Some(r) => Some(r.map_err(DbError::Sqlite)?),
+            None => None,
+        }
+    };
+
+    if let Some(cap_usd) = session_cap {
+        let spent: f64 = conn.query_row(
+            "SELECT COALESCE(SUM(estimated_cost_usd), 0) FROM telemetry_records WHERE session_id = ?1",
+            rusqlite::params![session_id],
+            |row| row.get(0),
+        )?;
+
+        let pct = if cap_usd > 0.0 { (spent / cap_usd) * 100.0 } else { 0.0 };
+
+        let alert_kind: Option<&str> = if pct >= 100.0 {
+            Some("session-exceeded")
+        } else if pct >= 80.0 {
+            Some("session-threshold")
+        } else {
+            None
+        };
+
+        if let Some(kind) = alert_kind {
+            let already: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM budget_alerts WHERE kind = ?1 AND session_id = ?2 AND dismissed_at IS NULL",
+                rusqlite::params![kind, session_id],
+                |row| row.get(0),
+            )?;
+            if already == 0 {
+                let id = uuid_v4();
+                conn.execute(
+                    "INSERT INTO budget_alerts (id, kind, provider, session_id, current_usd, cap_usd, created_at, dismissed_at)
+                     VALUES (?1, ?2, NULL, ?3, ?4, ?5, ?6, NULL)",
+                    rusqlite::params![id, kind, session_id, spent, cap_usd, now],
+                )?;
+                created.push(BudgetAlert {
+                    id,
+                    kind: kind.to_string(),
+                    provider: None,
+                    session_id: Some(session_id.clone()),
+                    current_usd: spent,
+                    cap_usd,
+                    created_at: now.clone(),
+                    dismissed_at: None,
+                });
+            }
+        }
+    }
+
+    Ok(created)
+}
+
+fn uuid_v4() -> String {
+    use sha2::{Digest, Sha256};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
+    let pid = std::process::id();
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let input = format!("{}-{}-{}", t.as_nanos(), pid, seq);
+    let hash = Sha256::digest(input.as_bytes());
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-4{:01x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        hash[0], hash[1], hash[2], hash[3],
+        hash[4], hash[5],
+        hash[6] & 0x0f, hash[7],
+        (hash[8] & 0x3f) | 0x80, hash[9],
+        hash[10], hash[11], hash[12], hash[13], hash[14], hash[15],
+    )
+}
+
+fn iso_now() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    let (year, month, day, hour, min, sec) = epoch_secs_to_datetime(secs);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z", year, month, day, hour, min, sec)
+}
+
+fn epoch_secs_to_datetime(mut s: i64) -> (i64, u32, u32, u32, u32, u32) {
+    let sec = (s % 60) as u32;
+    s /= 60;
+    let min = (s % 60) as u32;
+    s /= 60;
+    let hour = (s % 24) as u32;
+    s /= 24;
+    let mut year: i64 = 1970;
+    loop {
+        let days = if is_leap_year(year) { 366 } else { 365 };
+        if s < days { break; }
+        s -= days;
+        year += 1;
+    }
+    let mut month: u32 = 1;
+    loop {
+        let d = days_in_month(year, month);
+        if s < d { break; }
+        s -= d;
+        month += 1;
+    }
+    let day = s as u32 + 1;
+    (year, month, day, hour, min, sec)
+}
+
 #[tauri::command]
 pub fn check_provider_budget(
     state: State<'_, Db>,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -70,6 +70,7 @@ pub fn run() {
       budget::session_budget_get,
       budget::budget_alerts_list,
       budget::budget_alert_dismiss,
+      budget::budget_emit_alerts,
       budget::check_provider_budget,
       budget::check_session_budget,
     ])

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { AppShell, Button, KbdPill } from '@kay-am/ui';
 import { Settings } from 'lucide-react';
 import type { SessionId } from '@kay-am/types';
+import { AlertCenter } from './components/AlertCenter';
 import { BootSplash } from './components/BootSplash';
 import { ChatView } from './components/chat/ChatView';
 import { ContextPanel } from './components/ContextPanel';
@@ -10,6 +11,7 @@ import { ProvidersChip } from './components/ProvidersChip';
 import { SettingsDialog } from './components/SettingsDialog';
 import { StatusBar } from './components/StatusBar';
 import { TelemetryPill } from './components/TelemetryPill';
+import { ToastProvider } from './components/Toast';
 import { WorkspacesSidebar } from './components/WorkspacesSidebar';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessionSlots } from './store';
 
@@ -79,7 +81,7 @@ export function App() {
   const rightSidebarCollapsed = !currentSession || !contextOpen;
 
   return (
-    <>
+    <ToastProvider>
       <AppShell
         header={
           <div className="flex w-full items-center gap-3">
@@ -87,6 +89,7 @@ export function App() {
             <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
               <ProvidersChip onOpenSettings={() => setSettingsOpen(true)} />
               <TelemetryPill />
+              <AlertCenter />
               <Button
                 variant="ghost"
                 size="sm"
@@ -130,7 +133,7 @@ export function App() {
           onClose={() => setEndOpen(false)}
         />
       ) : null}
-    </>
+    </ToastProvider>
   );
 }
 

--- a/apps/desktop/src/budget.ts
+++ b/apps/desktop/src/budget.ts
@@ -36,6 +36,13 @@ export async function invokeBudgetAlertDismiss(id: string): Promise<void> {
   return invoke<void>('budget_alert_dismiss', { id });
 }
 
+export async function invokeBudgetEmitAlerts(input: {
+  provider: ProviderName;
+  sessionId: string;
+}): Promise<BudgetAlert[]> {
+  return invoke<BudgetAlert[]>('budget_emit_alerts', { input });
+}
+
 export async function invokeCheckProviderBudget(
   provider: ProviderName,
   period: BudgetPeriod,

--- a/apps/desktop/src/components/AlertCenter.tsx
+++ b/apps/desktop/src/components/AlertCenter.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react';
+import { Bell, X } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import type { BudgetAlert, BudgetAlertKind } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+function alertLabel(alert: BudgetAlert): string {
+  const pct = alert.capUsd > 0 ? Math.round((alert.currentUsd / alert.capUsd) * 100) : 0;
+  if (alert.kind === 'provider-threshold') {
+    return `provider ${alert.provider ?? '?'} budget at ${pct}%`;
+  }
+  if (alert.kind === 'provider-exceeded') {
+    return `provider ${alert.provider ?? '?'} budget exceeded`;
+  }
+  if (alert.kind === 'session-threshold') {
+    return `session budget at ${pct}%`;
+  }
+  if (alert.kind === 'session-exceeded') {
+    return `session budget exceeded`;
+  }
+  return 'budget alert';
+}
+
+function alertKindBadge(kind: BudgetAlertKind): { label: string; className: string } {
+  if (kind === 'provider-exceeded' || kind === 'session-exceeded') {
+    return { label: 'exceeded', className: 'bg-danger/10 text-danger' };
+  }
+  return { label: 'threshold', className: 'bg-warning/10 text-warning' };
+}
+
+function formatTs(iso: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(iso));
+}
+
+export function AlertCenter() {
+  const budgetAlerts = useAppStore((s) => s.budgetAlerts);
+  const loadBudgetAlerts = useAppStore((s) => s.loadBudgetAlerts);
+  const dismissBudgetAlert = useAppStore((s) => s.dismissBudgetAlert);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    void loadBudgetAlerts();
+  }, [loadBudgetAlerts]);
+
+  const undismissed = budgetAlerts.filter((a) => a.dismissedAt == null);
+  const count = undismissed.length;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors',
+          open ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/60',
+        )}
+        aria-label={`alert center${count > 0 ? `, ${count} undismissed` : ''}`}
+        title="alert center"
+      >
+        <Bell size={13} aria-hidden />
+        {count > 0 && (
+          <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-warning text-[9px] font-bold leading-none text-warning-foreground">
+            {count > 9 ? '9+' : count}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} aria-hidden />
+          <div className="absolute right-0 top-full z-40 mt-1.5 w-80 overflow-hidden rounded-lg border border-border bg-background shadow-lg">
+            <div className="flex items-center justify-between border-b border-border-soft px-3 py-2">
+              <span className="text-xs font-semibold text-foreground">alerts</span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="close alert center"
+              >
+                <X size={13} aria-hidden />
+              </button>
+            </div>
+
+            {undismissed.length === 0 ? (
+              <p className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+                no active alerts
+              </p>
+            ) : (
+              <ul className="max-h-72 overflow-y-auto divide-y divide-border-soft">
+                {undismissed.map((alert) => {
+                  const badge = alertKindBadge(alert.kind);
+                  return (
+                    <li key={alert.id} className="flex items-start gap-2 px-3 py-2.5">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span
+                            className={cn(
+                              'rounded px-1 py-0.5 text-[10px] font-medium leading-none',
+                              badge.className,
+                            )}
+                          >
+                            {badge.label}
+                          </span>
+                          <span className="text-xs font-medium text-foreground">
+                            {alertLabel(alert)}
+                          </span>
+                        </div>
+                        <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+                          <span>
+                            ${alert.currentUsd.toFixed(2)} / ${alert.capUsd.toFixed(2)}
+                          </span>
+                          <span>·</span>
+                          <span>{formatTs(alert.createdAt)}</span>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        className="mt-0.5 shrink-0 text-[10px] text-muted-foreground underline-offset-2 hover:text-danger hover:underline"
+                        onClick={() => void dismissBudgetAlert(alert.id)}
+                      >
+                        dismiss
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/Toast.tsx
+++ b/apps/desktop/src/components/Toast.tsx
@@ -1,0 +1,117 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+
+export type ToastKind = 'warning' | 'error';
+
+export interface ToastItem {
+  readonly id: string;
+  readonly kind: ToastKind;
+  readonly message: string;
+}
+
+interface ToastContextValue {
+  showToast: (kind: ToastKind, message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const AUTO_DISMISS_MS = 5000;
+
+interface ToastProviderProps {
+  children: React.ReactNode;
+}
+
+export function ToastProvider({ children }: ToastProviderProps) {
+  const [toasts, setToasts] = useState<ReadonlyArray<ToastItem>>([]);
+
+  const showToast = useCallback((kind: ToastKind, message: string) => {
+    const id = crypto.randomUUID();
+    setToasts((prev) => [...prev, { id, kind, message }]);
+  }, []);
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <ToastStack toasts={toasts} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (ctx === null) throw new Error('useToast must be used inside ToastProvider');
+  return ctx;
+}
+
+interface ToastStackProps {
+  toasts: ReadonlyArray<ToastItem>;
+  onDismiss: (id: string) => void;
+}
+
+function ToastStack({ toasts, onDismiss }: ToastStackProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="pointer-events-none fixed right-4 top-4 z-50 flex flex-col gap-2"
+      role="region"
+      aria-label="notifications"
+      aria-live="polite"
+    >
+      {toasts.map((t) => (
+        <ToastCard key={t.id} toast={t} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+interface ToastCardProps {
+  toast: ToastItem;
+  onDismiss: (id: string) => void;
+}
+
+function ToastCard({ toast, onDismiss }: ToastCardProps) {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setVisible(true));
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      setTimeout(() => onDismiss(toast.id), 200);
+    }, AUTO_DISMISS_MS);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, [toast.id, onDismiss]);
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto flex max-w-xs items-start gap-2 rounded-lg border px-3 py-2.5 shadow-md transition-all duration-200',
+        visible ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0',
+        toast.kind === 'error'
+          ? 'border-danger/30 bg-background text-danger'
+          : 'border-warning/30 bg-background text-warning',
+      )}
+      role="alert"
+    >
+      <span className="flex-1 text-xs leading-snug">{toast.message}</span>
+      <button
+        type="button"
+        className="mt-0.5 shrink-0 opacity-60 hover:opacity-100"
+        onClick={() => onDismiss(toast.id)}
+        aria-label="dismiss notification"
+      >
+        <X size={12} aria-hidden />
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,9 +1,16 @@
 import { useState, type KeyboardEvent } from 'react';
 import { Button, Textarea } from '@kay-am/ui';
-import type { ProviderId, Session, TurnProviderOverride } from '@kay-am/types';
+import type {
+  BudgetAlert,
+  BudgetAlertKind,
+  ProviderId,
+  Session,
+  TurnProviderOverride,
+} from '@kay-am/types';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from '../../store';
 import { RoutingIndicator } from './RoutingIndicator';
+import { useToast, type ToastKind } from '../Toast';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -12,12 +19,31 @@ interface ChatInputProps {
   readonly providerDisconnected?: boolean;
 }
 
+function toastKindForAlert(kind: BudgetAlertKind): ToastKind {
+  return kind === 'provider-exceeded' || kind === 'session-exceeded' ? 'error' : 'warning';
+}
+
+function toastMessageForAlert(alert: BudgetAlert): string {
+  const pct = alert.capUsd > 0 ? Math.round((alert.currentUsd / alert.capUsd) * 100) : 0;
+  if (alert.kind === 'provider-threshold') {
+    return `provider ${alert.provider ?? '?'} budget at ${pct}%`;
+  }
+  if (alert.kind === 'provider-exceeded') {
+    return `provider ${alert.provider ?? '?'} budget exceeded`;
+  }
+  if (alert.kind === 'session-threshold') {
+    return `session budget at ${pct}%`;
+  }
+  return 'session budget exceeded';
+}
+
 export function ChatInput({ session, providerDisconnected = false }: ChatInputProps) {
   const sendTurn = useAppStore((s) => s.sendTurn);
   const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected')),
   );
+  const { showToast } = useToast();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
@@ -49,7 +75,16 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
     setSelectedProvider(null);
     try {
-      await sendTurn({ sessionId: session.id, content, override });
+      await sendTurn({
+        sessionId: session.id,
+        content,
+        override,
+        onNewAlerts: (alerts) => {
+          for (const alert of alerts) {
+            showToast(toastKindForAlert(alert.kind), toastMessageForAlert(alert));
+          }
+        },
+      });
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -6,6 +6,7 @@ export {
   type ProviderSpendEntry,
   type SummarizerSessionStatus,
 } from './store';
+
 export {
   selectCurrentSession,
   selectCurrentWorkspace,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -24,6 +24,7 @@ import {
   type ProviderTelemetrySummary,
 } from '@kay-am/db';
 import type {
+  BudgetAlert,
   BudgetRule,
   ContextSlot,
   IsoDateTime,
@@ -66,7 +67,13 @@ import {
 } from '../settings';
 import { runTurn, cancelTurn, encodeAuthRequiredMessage, isAuthErrorMessage } from '../turn';
 import { createWorktree, removeWorktree, type CreatedWorktree } from '../worktree';
-import { invokeBudgetRuleList, invokeBudgetRuleUpsert, invokeBudgetRuleDelete } from '../budget';
+import {
+  invokeBudgetRuleList,
+  invokeBudgetRuleUpsert,
+  invokeBudgetRuleDelete,
+  invokeBudgetAlertsList,
+  invokeBudgetAlertDismiss,
+} from '../budget';
 
 export type BootPhase =
   | 'pending'
@@ -103,6 +110,7 @@ export interface AppState {
   readonly budgetRules: ReadonlyArray<BudgetRule>;
   readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
   readonly providerSpendBreakdown: ReadonlyArray<ProviderSpendEntry>;
+  readonly budgetAlerts: ReadonlyArray<BudgetAlert>;
 }
 
 export interface SummarizerSessionStatus {
@@ -142,6 +150,7 @@ export interface AppActions {
     sessionId: SessionId;
     content: string;
     override?: TurnProviderOverride;
+    onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
   }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId): Promise<void>;
   endSession(sessionId: SessionId): Promise<void>;
@@ -156,6 +165,8 @@ export interface AppActions {
   loadSessionBudget(sessionId: SessionId): Promise<void>;
   setSessionBudget(sessionId: SessionId, softCapUsd: number): Promise<void>;
   refreshProviderSpendBreakdown(workspaceId: WorkspaceId): Promise<void>;
+  loadBudgetAlerts(): Promise<void>;
+  dismissBudgetAlert(id: string): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -185,6 +196,7 @@ const initialState: AppState = {
   budgetRules: [],
   sessionBudgets: {},
   providerSpendBreakdown: [],
+  budgetAlerts: [],
 };
 
 function buildProviderSpendBreakdown(
@@ -583,7 +595,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
-  sendTurn: async ({ sessionId, content, override }) => {
+  sendTurn: async ({ sessionId, content, override, onNewAlerts }) => {
     const before = get();
     const session = before.sessions.find((s) => s.id === sessionId);
     if (!session) throw new Error(`session not found: ${sessionId}`);
@@ -683,17 +695,23 @@ export const useAppStore = create<AppStore>((set, get) => ({
           }));
           const session = get().sessions.find((s) => s.id === sessionId);
           if (session) {
-            const [sessSummary, wsSummary, providerSummaries, budgetRules] = await Promise.all([
-              summarizeSessionTelemetry(tauriDatabase, sessionId),
-              summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
-              summarizeWorkspaceProviderTelemetry(tauriDatabase, session.workspaceId),
-              invokeBudgetRuleList(),
-            ]);
+            const [sessSummary, wsSummary, providerSummaries, budgetRules, freshAlerts] =
+              await Promise.all([
+                summarizeSessionTelemetry(tauriDatabase, sessionId),
+                summarizeWorkspaceTelemetry(tauriDatabase, session.workspaceId),
+                summarizeWorkspaceProviderTelemetry(tauriDatabase, session.workspaceId),
+                invokeBudgetRuleList(),
+                invokeBudgetAlertsList(),
+              ]);
+            const knownIds = new Set(get().budgetAlerts.map((a) => a.id));
+            const newAlerts = freshAlerts.filter((a) => !knownIds.has(a.id));
             set({
               sessionSummary: sessSummary,
               workspaceSummary: wsSummary,
               providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
+              budgetAlerts: freshAlerts,
             });
+            if (newAlerts.length > 0 && onNewAlerts) onNewAlerts(newAlerts);
           }
         }
 
@@ -913,5 +931,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
       invokeBudgetRuleList(),
     ]);
     set({ providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules) });
+  },
+
+  loadBudgetAlerts: async () => {
+    const alerts = await invokeBudgetAlertsList();
+    set({ budgetAlerts: alerts });
+  },
+
+  dismissBudgetAlert: async (id) => {
+    await invokeBudgetAlertDismiss(id);
+    set((state) => ({
+      budgetAlerts: state.budgetAlerts.map((a) =>
+        a.id === id ? { ...a, dismissedAt: new Date().toISOString() as IsoDateTime } : a,
+      ),
+    }));
   },
 }));


### PR DESCRIPTION
Closes #109

## Summary
- Toast notifications (top-right, auto-dismiss 5s, warning/error) shown after each turn when new budget alerts are emitted
- Alert center in header (bell icon + badge count) listing all undismissed alerts with dismiss per-item
- Store: `budgetAlerts`, `loadBudgetAlerts`, `dismissBudgetAlert` added; `sendTurn` accepts `onNewAlerts` callback for toast integration
- Rust: `budget_emit_alerts` Tauri command for server-side alert emission

## Test plan
- [ ] Set a budget rule with low cap, run a turn, verify warning toast appears
- [ ] Alert center badge shows count of undismissed alerts
- [ ] Dismiss button removes alert from list and clears badge
- [ ] Toast auto-dismisses after 5 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)