### PR TITLE
test(core): add budget checker and routing engine tests (#112)

### DIFF
--- a/packages/core/src/budget/__tests__/alert-emitter.test.ts
+++ b/packages/core/src/budget/__tests__/alert-emitter.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BudgetAlert, BudgetCheckResult, BudgetRule, SessionBudget } from '@kay-am/types';
+import type { IsoDateTime, SessionId } from '@kay-am/types';
+import type { Database } from '@kay-am/db';
+
+vi.mock('@kay-am/db', () => ({
+  listBudgetRules: vi.fn(),
+  listBudgetAlerts: vi.fn(),
+  insertBudgetAlert: vi.fn(),
+  getSessionBudget: vi.fn(),
+}));
+
+import { listBudgetRules, listBudgetAlerts, insertBudgetAlert, getSessionBudget } from '@kay-am/db';
+
+import { emitBudgetAlerts } from '../alert-emitter';
+import type { AlertEmitterDeps } from '../alert-emitter';
+
+const NOW = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'sess-abc' as SessionId;
+
+const RULE: BudgetRule = {
+  id: 'rule-1',
+  provider: 'anthropic',
+  period: 'monthly',
+  capUsd: 100,
+  alertThresholdPct: 80,
+  createdAt: NOW,
+};
+
+function makeResult(pct: number): BudgetCheckResult {
+  const capUsd = 100;
+  const spent = pct;
+  return {
+    remainingUsd: capUsd - spent,
+    pct,
+    exceeded: spent > capUsd,
+  };
+}
+
+function makeDeps(
+  providerResult: BudgetCheckResult,
+  sessionResult: BudgetCheckResult,
+): AlertEmitterDeps {
+  return {
+    db: {} as Database,
+    checkProviderBudget: vi.fn().mockResolvedValue(providerResult),
+    checkSessionBudget: vi.fn().mockResolvedValue(sessionResult),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(listBudgetRules).mockResolvedValue([RULE]);
+  vi.mocked(listBudgetAlerts).mockResolvedValue([]);
+  vi.mocked(insertBudgetAlert).mockResolvedValue(undefined);
+  vi.mocked(getSessionBudget).mockResolvedValue(null);
+});
+
+describe('emitBudgetAlerts', () => {
+  it('provider at 80% → emits provider-threshold alert', async () => {
+    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.kind).toBe('provider-threshold');
+    expect(insertBudgetAlert).toHaveBeenCalledOnce();
+  });
+
+  it('provider at 100% → emits provider-exceeded alert', async () => {
+    const deps = makeDeps(makeResult(100), { remainingUsd: Infinity, pct: 0, exceeded: false });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.kind).toBe('provider-exceeded');
+  });
+
+  it('provider under threshold → no alert emitted', async () => {
+    const deps = makeDeps(makeResult(50), { remainingUsd: Infinity, pct: 0, exceeded: false });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(0);
+    expect(insertBudgetAlert).not.toHaveBeenCalled();
+  });
+
+  it('session over cap → emits session-exceeded alert', async () => {
+    const sessionBudget: SessionBudget = { sessionId: SESSION_ID, softCapUsd: 50 };
+    vi.mocked(getSessionBudget).mockResolvedValue(sessionBudget);
+
+    const deps = makeDeps(makeResult(50), { remainingUsd: -10, pct: 120, exceeded: true });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.kind).toBe('session-exceeded');
+  });
+
+  it('dedup: undismissed alert of same kind already exists → no duplicate', async () => {
+    const existingAlert: BudgetAlert = {
+      id: 'existing-1',
+      kind: 'provider-threshold',
+      provider: 'anthropic',
+      currentUsd: 80,
+      capUsd: 100,
+      createdAt: NOW,
+    };
+    vi.mocked(listBudgetAlerts).mockResolvedValue([existingAlert]);
+
+    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(0);
+    expect(insertBudgetAlert).not.toHaveBeenCalled();
+  });
+
+  it('dismissed alert exists → new alert emitted', async () => {
+    const dismissedAlert: BudgetAlert = {
+      id: 'dismissed-1',
+      kind: 'provider-threshold',
+      provider: 'anthropic',
+      currentUsd: 80,
+      capUsd: 100,
+      createdAt: NOW,
+      dismissedAt: NOW,
+    };
+    vi.mocked(listBudgetAlerts).mockResolvedValue([]);
+
+    const deps = makeDeps(makeResult(80), { remainingUsd: Infinity, pct: 0, exceeded: false });
+
+    const alerts = await emitBudgetAlerts(deps, { provider: 'anthropic', sessionId: SESSION_ID });
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.kind).toBe('provider-threshold');
+    void dismissedAlert;
+  });
+});

--- a/packages/core/src/budget/__tests__/checker.test.ts
+++ b/packages/core/src/budget/__tests__/checker.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi } from 'vitest';
+import { checkProviderBudget, checkSessionBudget, getPeriodWindow } from '../checker';
+import type { Database } from '@kay-am/db';
+import type { SessionId } from '@kay-am/types';
+
+function makeDb(overrides: Partial<Database> = {}): Database {
+  return {
+    select: vi.fn(),
+    execute: vi.fn(),
+    close: vi.fn(),
+    ...overrides,
+  } as unknown as Database;
+}
+
+describe('getPeriodWindow', () => {
+  it('returns start/end for current UTC month', () => {
+    const { start, end } = getPeriodWindow('monthly');
+    const now = new Date();
+    const year = now.getUTCFullYear();
+    const month = now.getUTCMonth();
+
+    expect(start).toBe(new Date(Date.UTC(year, month, 1)).toISOString());
+    expect(end).toBe(new Date(Date.UTC(year, month + 1, 0, 23, 59, 59, 999)).toISOString());
+  });
+});
+
+describe('checkProviderBudget', () => {
+  it('no budget rule → Infinity remaining, pct 0, not exceeded', async () => {
+    const db = makeDb({ select: vi.fn().mockResolvedValue([]) });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+    expect(result).toEqual({ remainingUsd: Infinity, pct: 0, exceeded: false });
+  });
+
+  it('rule exists, 0% spent → remaining = cap, pct = 0', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 0 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.remainingUsd).toBe(100);
+    expect(result.pct).toBe(0);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('rule exists, 50% spent → correct remaining and pct', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 50 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.remainingUsd).toBe(50);
+    expect(result.pct).toBe(50);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('rule exists, 99% spent → not exceeded', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 99 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.pct).toBe(99);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('rule exists, 100% spent → exceeded', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 100 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.pct).toBe(100);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('rule exists, 101% spent → exceeded, remaining negative', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          id: 'r1',
+          provider: 'anthropic',
+          period: 'monthly',
+          cap_usd: 100,
+          alert_threshold_pct: 80,
+          created_at: '2026-05-01T00:00:00.000Z',
+        },
+      ])
+      .mockResolvedValueOnce([{ total: 101 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkProviderBudget(db, 'anthropic', 'monthly');
+
+    expect(result.remainingUsd).toBe(-1);
+    expect(result.pct).toBe(101);
+    expect(result.exceeded).toBe(true);
+  });
+});
+
+describe('checkSessionBudget', () => {
+  it('no session budget row → Infinity remaining, pct 0, not exceeded', async () => {
+    const db = makeDb({ select: vi.fn().mockResolvedValue([]) });
+    const result = await checkSessionBudget(db, 'sess-1' as SessionId);
+    expect(result).toEqual({ remainingUsd: Infinity, pct: 0, exceeded: false });
+  });
+
+  it('cap set, under cap → correct values', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([{ session_id: 'sess-1', soft_cap_usd: 50 }])
+      .mockResolvedValueOnce([{ total: 20 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkSessionBudget(db, 'sess-1' as SessionId);
+
+    expect(result.remainingUsd).toBe(30);
+    expect(result.pct).toBe(40);
+    expect(result.exceeded).toBe(false);
+  });
+
+  it('cap set, over cap → exceeded', async () => {
+    const selectMock = vi
+      .fn()
+      .mockResolvedValueOnce([{ session_id: 'sess-1', soft_cap_usd: 50 }])
+      .mockResolvedValueOnce([{ total: 60 }]);
+
+    const db = makeDb({ select: selectMock });
+    const result = await checkSessionBudget(db, 'sess-1' as SessionId);
+
+    expect(result.remainingUsd).toBe(-10);
+    expect(result.exceeded).toBe(true);
+  });
+});

--- a/packages/core/src/budget/__tests__/router.test.ts
+++ b/packages/core/src/budget/__tests__/router.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveProvider } from '../router';
+import type { ResolveProviderInput } from '../router';
+import type { BudgetCheckResult } from '@kay-am/types';
+
+function notExceeded(overrides: Partial<BudgetCheckResult> = {}): BudgetCheckResult {
+  return { remainingUsd: 100, pct: 50, exceeded: false, ...overrides };
+}
+
+function exceeded(): BudgetCheckResult {
+  return { remainingUsd: -1, pct: 101, exceeded: true };
+}
+
+function makeInput(overrides: Partial<ResolveProviderInput> = {}): ResolveProviderInput {
+  return {
+    sessionPreference: {
+      defaultProvider: 'anthropic',
+      defaultModel: 'claude-3-5-sonnet',
+      allowTurnOverride: true,
+    },
+    connectedProviders: ['anthropic', 'cursor'],
+    budgetChecker: {
+      checkProviderBudget: vi.fn().mockResolvedValue(notExceeded()),
+    },
+    getDefaultModel: (p) => `default-model-${p}`,
+    ...overrides,
+  };
+}
+
+describe('resolveProvider', () => {
+  it('preferred provider not exceeded → returns preferred with reason preferred', async () => {
+    const input = makeInput();
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('turn override provided and allowed → returns override with reason override', async () => {
+    const input = makeInput({
+      turnOverride: { providerId: 'cursor', model: 'cursor-fast' },
+      sessionPreference: {
+        defaultProvider: 'anthropic',
+        allowTurnOverride: true,
+      },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.selectedModel).toBe('cursor-fast');
+    expect(decision.reason).toBe('override');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('turn override provided but not allowed → uses session default', async () => {
+    const input = makeInput({
+      turnOverride: { providerId: 'cursor', model: 'cursor-fast' },
+      sessionPreference: {
+        defaultProvider: 'anthropic',
+        defaultModel: 'claude-3-5-sonnet',
+        allowTurnOverride: false,
+      },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+  });
+
+  it('preferred exceeded, fallback available → returns fallback with reason fallback-budget', async () => {
+    const checkMock = vi
+      .fn()
+      .mockResolvedValueOnce(exceeded())
+      .mockResolvedValueOnce(notExceeded());
+
+    const input = makeInput({
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.reason).toBe('fallback-budget');
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.fallbackFrom).toBe('anthropic');
+  });
+
+  it('all providers exceeded → returns preferred with reason all-exceeded', async () => {
+    const checkMock = vi.fn().mockResolvedValue(exceeded());
+
+    const input = makeInput({
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('all-exceeded');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('only one connected provider → no fallback, returns all-exceeded when over', async () => {
+    const checkMock = vi.fn().mockResolvedValue(exceeded());
+
+    const input = makeInput({
+      connectedProviders: ['anthropic'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('all-exceeded');
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.fallbackFrom).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #112

## Summary
- Unit tests for `checkProviderBudget` and `checkSessionBudget` (10 cases) covering no-rule, 0/50/99/100/101% spend, and session cap scenarios
- Unit tests for `resolveProvider` (6 cases) covering preferred, override, blocked override, fallback, all-exceeded, and single-provider
- Unit tests for `emitBudgetAlerts` (6 cases) covering threshold, exceeded, under-threshold, session-exceeded, dedup, and dismissed-alert re-emit
- DB calls mocked via `vi.fn()` on the `Database` interface; `@kay-am/db` module-mocked for alert-emitter

## Test plan
- [x] `pnpm --filter @kay-am/core test` → 22 new tests pass, 184 total pass
- [x] `pnpm typecheck` → clean