### PR TITLE
feat(types): add skill domain types

### DIFF
--- a/packages/core/src/session/reducer.ts
+++ b/packages/core/src/session/reducer.ts
@@ -75,6 +75,7 @@ function applyTurnEvent(state: SessionState, turn: TurnEvent): SessionState {
     case 'tool_call_end':
     case 'file_edit':
     case 'usage':
+    case 'skill_invocation':
       return state;
     default: {
       const _exhaustive: never = turn;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -57,7 +57,14 @@ export type TurnEvent =
     }
   | { kind: 'usage'; runId: ProviderRunId; usage: ProviderUsage; at: IsoDateTime }
   | { kind: 'error'; runId: ProviderRunId; message: string; at: IsoDateTime }
-  | { kind: 'done'; runId: ProviderRunId; at: IsoDateTime };
+  | { kind: 'done'; runId: ProviderRunId; at: IsoDateTime }
+  | {
+      kind: 'skill_invocation';
+      runId: ProviderRunId;
+      skillName: string;
+      args: ReadonlyArray<string>;
+      at: IsoDateTime;
+    };
 
 export interface ProviderAdapter {
   readonly id: ProviderName;

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -3,5 +3,6 @@ export type SessionId = string & { readonly __brand: 'SessionId' };
 export type MessageId = string & { readonly __brand: 'MessageId' };
 export type ProviderRunId = string & { readonly __brand: 'ProviderRunId' };
 export type TelemetryRecordId = string & { readonly __brand: 'TelemetryRecordId' };
+export type SkillId = string & { readonly __brand: 'SkillId' };
 
 export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,7 @@ export type {
   MessageId,
   ProviderRunId,
   SessionId,
+  SkillId,
   TelemetryRecordId,
   WorkspaceId,
 } from './ids';
@@ -27,6 +28,7 @@ export type {
 } from './provider-registry';
 export type { SessionProviderPreference, TurnProviderOverride } from './provider-preference';
 export { DEFAULT_SESSION_PROVIDER_PREFERENCE } from './provider-preference';
+export type { Skill, SkillFrontmatter, SkillInvocation, SlashCommand } from './skill';
 export type {
   BudgetRule,
   BudgetPeriod,

--- a/packages/types/src/skill.ts
+++ b/packages/types/src/skill.ts
@@ -1,0 +1,31 @@
+import type { IsoDateTime, SkillId, WorkspaceId } from './ids';
+
+export interface SkillFrontmatter {
+  readonly name: string;
+  readonly description: string;
+  readonly args?: ReadonlyArray<string>;
+  readonly scripts?: ReadonlyArray<string>;
+}
+
+export interface Skill {
+  readonly id: SkillId;
+  readonly workspaceId: WorkspaceId;
+  readonly name: string;
+  readonly description: string;
+  readonly filePath: string;
+  readonly body: string;
+  readonly frontmatter: SkillFrontmatter;
+  readonly createdAt: IsoDateTime;
+  readonly updatedAt: IsoDateTime;
+}
+
+export interface SkillInvocation {
+  readonly skillId: SkillId;
+  readonly args: ReadonlyArray<string>;
+}
+
+export interface SlashCommand {
+  readonly name: string;
+  readonly args: ReadonlyArray<string>;
+  readonly raw: string;
+}


### PR DESCRIPTION
Defines core skill domain types per #126:

- SkillId branded string
- SkillFrontmatter with name, description, optional args and scripts
- Skill with full metadata including workspace, filepath, body, and timestamps
- SkillInvocation and SlashCommand types
- TurnEvent extended with skill_invocation variant

Typecheck passes. Session reducer updated to handle new event variant.

Closes #126