### PR TITLE
feat(db): add skills table migration and queries

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -41,3 +41,10 @@ export {
   dismissBudgetAlert,
   type ListBudgetAlertsOptions,
 } from './queries/budget';
+export {
+  listSkillsForWorkspace,
+  getSkillById,
+  upsertSkill,
+  deleteSkill,
+  deleteSkillsForWorkspace,
+} from './queries/skill';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -3,6 +3,7 @@ import { m002TelemetryKind } from './m002-telemetry-kind';
 import { m003SessionProvider } from './m003-session-provider';
 import { m004TurnOverrides } from './m004-turn-overrides';
 import { m005BudgetTables } from './m005-budget-tables';
+import { m006Skills } from './m006-skills';
 
 export interface Migration {
   readonly version: number;
@@ -15,4 +16,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 3, sql: m003SessionProvider },
   { version: 4, sql: m004TurnOverrides },
   { version: 5, sql: m005BudgetTables },
+  { version: 6, sql: m006Skills },
 ];

--- a/packages/db/src/migrations/m006-skills.ts
+++ b/packages/db/src/migrations/m006-skills.ts
@@ -1,0 +1,16 @@
+export const m006Skills = /* sql */ `
+CREATE TABLE IF NOT EXISTS skills (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  body TEXT NOT NULL,
+  frontmatter_json TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  UNIQUE(workspace_id, name)
+);
+CREATE INDEX IF NOT EXISTS idx_skills_workspace_id ON skills(workspace_id);
+`;

--- a/packages/db/src/queries/skill.ts
+++ b/packages/db/src/queries/skill.ts
@@ -1,0 +1,81 @@
+import type { IsoDateTime, Skill, SkillFrontmatter, SkillId, WorkspaceId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface SkillRow {
+  id: string;
+  workspace_id: string;
+  name: string;
+  description: string;
+  file_path: string;
+  body: string;
+  frontmatter_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function toSkill(row: SkillRow): Skill {
+  return {
+    id: row.id as SkillId,
+    workspaceId: row.workspace_id as WorkspaceId,
+    name: row.name,
+    description: row.description,
+    filePath: row.file_path,
+    body: row.body,
+    frontmatter: JSON.parse(row.frontmatter_json) as SkillFrontmatter,
+    createdAt: row.created_at as IsoDateTime,
+    updatedAt: row.updated_at as IsoDateTime,
+  };
+}
+
+export async function listSkillsForWorkspace(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<ReadonlyArray<Skill>> {
+  const rows = await db.select<SkillRow>(
+    'SELECT * FROM skills WHERE workspace_id = ? ORDER BY created_at ASC',
+    [workspaceId],
+  );
+  return rows.map(toSkill);
+}
+
+export async function getSkillById(db: Database, skillId: SkillId): Promise<Skill | null> {
+  const rows = await db.select<SkillRow>('SELECT * FROM skills WHERE id = ?', [skillId]);
+  return rows[0] ? toSkill(rows[0]) : null;
+}
+
+export async function upsertSkill(db: Database, skill: Skill): Promise<void> {
+  await db.execute(
+    `INSERT INTO skills
+      (id, workspace_id, name, description, file_path, body, frontmatter_json, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       name = excluded.name,
+       description = excluded.description,
+       file_path = excluded.file_path,
+       body = excluded.body,
+       frontmatter_json = excluded.frontmatter_json,
+       updated_at = excluded.updated_at`,
+    [
+      skill.id,
+      skill.workspaceId,
+      skill.name,
+      skill.description,
+      skill.filePath,
+      skill.body,
+      JSON.stringify(skill.frontmatter),
+      skill.createdAt,
+      skill.updatedAt,
+    ],
+  );
+}
+
+export async function deleteSkill(db: Database, skillId: SkillId): Promise<void> {
+  await db.execute('DELETE FROM skills WHERE id = ?', [skillId]);
+}
+
+export async function deleteSkillsForWorkspace(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<void> {
+  await db.execute('DELETE FROM skills WHERE workspace_id = ?', [workspaceId]);
+}


### PR DESCRIPTION
## Summary
- Create m006-skills migration with skills table (id, workspace_id, name, description, file_path, body, frontmatter_json, timestamps)
- Add skill query functions: listSkillsForWorkspace, getSkillById, upsertSkill, deleteSkill, deleteSkillsForWorkspace
- Handles frontmatter JSON serialization/deserialization
- Export queries from db package barrel

Closes #127