### PR TITLE
feat(core): add slash command parser

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,8 @@ export {
   type ParseContext as CursorParseContext,
 } from './providers/cursor/parser';
 
+export { parseSlashCommand } from './skills';
+
 // CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/providers/codex/adapter in Node contexts.
 export { CODEX_CHEAP_MODEL } from './providers/codex/constants';

--- a/packages/core/src/skills/__tests__/slash.test.ts
+++ b/packages/core/src/skills/__tests__/slash.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { parseSlashCommand } from '../slash';
+
+describe('parseSlashCommand', () => {
+  it('returns null for empty input', () => {
+    expect(parseSlashCommand('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only input', () => {
+    expect(parseSlashCommand('   \n  \n')).toBeNull();
+  });
+
+  it('returns null for bare slash', () => {
+    expect(parseSlashCommand('/')).toBeNull();
+  });
+
+  it('returns null for input not starting with slash', () => {
+    expect(parseSlashCommand('hello world')).toBeNull();
+  });
+
+  it('returns null for bad name starting with digit', () => {
+    expect(parseSlashCommand('/123bad')).toBeNull();
+  });
+
+  it('returns null for bad name with uppercase', () => {
+    expect(parseSlashCommand('/Foo')).toBeNull();
+  });
+
+  it('parses /foo with no args', () => {
+    const result = parseSlashCommand('/foo');
+    expect(result).toEqual({ name: 'foo', args: [], raw: '/foo' });
+  });
+
+  it('parses /foo with two positional args', () => {
+    const result = parseSlashCommand('/foo arg1 arg2');
+    expect(result).toEqual({ name: 'foo', args: ['arg1', 'arg2'], raw: '/foo arg1 arg2' });
+  });
+
+  it('parses /foo bar baz mixed', () => {
+    const result = parseSlashCommand('/foo bar baz');
+    expect(result).toEqual({ name: 'foo', args: ['bar', 'baz'], raw: '/foo bar baz' });
+  });
+
+  it('preserves double-quoted arg as single token', () => {
+    const result = parseSlashCommand('/foo "with spaces"');
+    expect(result).toEqual({ name: 'foo', args: ['with spaces'], raw: '/foo "with spaces"' });
+  });
+
+  it('preserves single-quoted arg as single token', () => {
+    const result = parseSlashCommand("/foo 'single quotes'");
+    expect(result).toEqual({ name: 'foo', args: ['single quotes'], raw: "/foo 'single quotes'" });
+  });
+
+  it('handles mixed quoted and unquoted args', () => {
+    const result = parseSlashCommand('/foo bar "quoted value" baz');
+    expect(result).toEqual({
+      name: 'foo',
+      args: ['bar', 'quoted value', 'baz'],
+      raw: '/foo bar "quoted value" baz',
+    });
+  });
+
+  it('trims leading whitespace before the slash', () => {
+    const result = parseSlashCommand('   /foo bar');
+    expect(result).toEqual({ name: 'foo', args: ['bar'], raw: '/foo bar' });
+  });
+
+  it('considers only first non-empty line for multi-line input', () => {
+    const result = parseSlashCommand('/foo arg1\nignored line\n/bar ignored');
+    expect(result).toEqual({ name: 'foo', args: ['arg1'], raw: '/foo arg1' });
+  });
+
+  it('skips leading blank lines to find first non-empty line', () => {
+    const result = parseSlashCommand('\n\n/foo bar');
+    expect(result).toEqual({ name: 'foo', args: ['bar'], raw: '/foo bar' });
+  });
+
+  it('returns null when first non-empty line is not a slash command', () => {
+    const result = parseSlashCommand('not a command\n/foo bar');
+    expect(result).toBeNull();
+  });
+
+  it('raw field matches original first non-empty line after trim', () => {
+    const result = parseSlashCommand('  /my-cmd  x y  ');
+    expect(result?.raw).toBe('/my-cmd  x y');
+  });
+
+  it('parses name with hyphens', () => {
+    const result = parseSlashCommand('/my-command');
+    expect(result).toEqual({ name: 'my-command', args: [], raw: '/my-command' });
+  });
+
+  it('parses name with digits after first char', () => {
+    const result = parseSlashCommand('/foo2bar');
+    expect(result).toEqual({ name: 'foo2bar', args: [], raw: '/foo2bar' });
+  });
+});

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,0 +1,1 @@
+export { parseSlashCommand } from './slash';

--- a/packages/core/src/skills/slash.ts
+++ b/packages/core/src/skills/slash.ts
@@ -1,0 +1,61 @@
+import type { SlashCommand } from '@kay-am/types';
+
+const NAME_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+function tokenize(argsStr: string): ReadonlyArray<string> {
+  const tokens: string[] = [];
+  let i = 0;
+  const s = argsStr.trim();
+
+  while (i < s.length) {
+    if (s[i] === ' ' || s[i] === '\t') {
+      i++;
+      continue;
+    }
+
+    if (s[i] === '"' || s[i] === "'") {
+      const quote = s[i];
+      i++;
+      let token = '';
+      while (i < s.length && s[i] !== quote) {
+        token += s[i];
+        i++;
+      }
+      i++; // skip closing quote
+      tokens.push(token);
+    } else {
+      let token = '';
+      while (i < s.length && s[i] !== ' ' && s[i] !== '\t') {
+        token += s[i];
+        i++;
+      }
+      tokens.push(token);
+    }
+  }
+
+  return tokens;
+}
+
+export function parseSlashCommand(input: string): SlashCommand | null {
+  const lines = input.split('\n');
+  const firstNonEmpty = lines.find((l) => l.trim().length > 0);
+
+  if (firstNonEmpty === undefined) return null;
+
+  const trimmed = firstNonEmpty.trim();
+
+  if (!trimmed.startsWith('/')) return null;
+
+  const rest = trimmed.slice(1);
+  if (rest.length === 0) return null;
+
+  const spaceIdx = rest.search(/[\s]/);
+  const name = spaceIdx === -1 ? rest : rest.slice(0, spaceIdx);
+
+  if (!NAME_PATTERN.test(name)) return null;
+
+  const argsStr = spaceIdx === -1 ? '' : rest.slice(spaceIdx);
+  const args = argsStr.trim().length === 0 ? [] : tokenize(argsStr);
+
+  return { name, args, raw: trimmed };
+}


### PR DESCRIPTION
## What

Pure `parseSlashCommand(input: string): SlashCommand | null` function in `packages/core/src/skills/slash.ts`.

## Behavior

- Trims leading whitespace before checking for `/`
- Multi-line: only first non-empty line considered for the slash command
- Name must match `/^[a-z][a-z0-9-]*$/`
- Args tokenized on whitespace; quoted strings (single or double) collapsed to single arg, quotes stripped
- `raw` = trimmed first non-empty line
- Returns `null` for empty, whitespace-only, bare `/`, bad name, or non-slash input

## Files changed

- `packages/core/src/skills/slash.ts` — impl
- `packages/core/src/skills/index.ts` — sub-barrel
- `packages/core/src/skills/__tests__/slash.test.ts` — 19 test cases
- `packages/core/src/index.ts` — barrel re-export

## Test plan

- [x] `pnpm --filter @kay-am/core typecheck` — clean
- [x] `pnpm --filter @kay-am/core test` — 19/19 slash tests pass, 199 total pass

Closes #128