### PR TITLE
feat(core): add skill markdown parser

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,7 +49,12 @@ export {
   type ParseContext as CursorParseContext,
 } from './providers/cursor/parser';
 
-export { parseSlashCommand } from './skills';
+export {
+  SkillParseError,
+  parseSkillMarkdown,
+  parseSlashCommand,
+  serializeSkillMarkdown,
+} from './skills';
 
 // CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/providers/codex/adapter in Node contexts.

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,1 +1,2 @@
 export { parseSlashCommand } from './slash';
+export { SkillParseError, parseSkillMarkdown, serializeSkillMarkdown } from './parser';

--- a/packages/core/src/skills/parser.test.ts
+++ b/packages/core/src/skills/parser.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest';
+import { SkillParseError, parseSkillMarkdown, serializeSkillMarkdown } from './parser';
+
+const HAPPY_PATH = `---
+name: my-skill
+description: Does something useful
+args: [arg1, arg2]
+scripts: [setup.sh]
+---
+
+# My Skill
+
+This is the body.
+`;
+
+describe('parseSkillMarkdown', () => {
+  it('parses happy path correctly', () => {
+    const result = parseSkillMarkdown(HAPPY_PATH);
+    expect(result.frontmatter.name).toBe('my-skill');
+    expect(result.frontmatter.description).toBe('Does something useful');
+    expect(result.frontmatter.args).toEqual(['arg1', 'arg2']);
+    expect(result.frontmatter.scripts).toEqual(['setup.sh']);
+    expect(result.body).toBe('# My Skill\n\nThis is the body.\n');
+  });
+
+  it('throws when frontmatter delimiters are missing', () => {
+    expect(() => parseSkillMarkdown('name: foo\ndescription: bar\n')).toThrow(SkillParseError);
+    expect(() => parseSkillMarkdown('name: foo\ndescription: bar\n')).toThrow(
+      'missing or malformed frontmatter delimiters',
+    );
+  });
+
+  it('throws when name is missing', () => {
+    const raw = `---
+description: some desc
+---
+
+body
+`;
+    expect(() => parseSkillMarkdown(raw)).toThrow(SkillParseError);
+    expect(() => parseSkillMarkdown(raw)).toThrow('"name"');
+  });
+
+  it('throws when name does not match kebab-case pattern', () => {
+    const raw = `---
+name: MySkill
+description: some desc
+---
+
+body
+`;
+    expect(() => parseSkillMarkdown(raw)).toThrow(SkillParseError);
+    expect(() => parseSkillMarkdown(raw)).toThrow('"name" must match');
+  });
+
+  it('throws when description is missing', () => {
+    const raw = `---
+name: my-skill
+---
+
+body
+`;
+    expect(() => parseSkillMarkdown(raw)).toThrow(SkillParseError);
+    expect(() => parseSkillMarkdown(raw)).toThrow('"description"');
+  });
+
+  it('parses inline args list', () => {
+    const raw = `---
+name: my-skill
+description: desc
+args: [a, b, c]
+---
+
+body
+`;
+    const { frontmatter } = parseSkillMarkdown(raw);
+    expect(frontmatter.args).toEqual(['a', 'b', 'c']);
+  });
+
+  it('parses block args list', () => {
+    const raw = `---
+name: my-skill
+description: desc
+args:
+- alpha
+- beta
+---
+
+body
+`;
+    const { frontmatter } = parseSkillMarkdown(raw);
+    expect(frontmatter.args).toEqual(['alpha', 'beta']);
+  });
+
+  it('defaults args and scripts to empty arrays when absent', () => {
+    const raw = `---
+name: my-skill
+description: desc
+---
+
+body
+`;
+    const { frontmatter } = parseSkillMarkdown(raw);
+    expect(frontmatter.args).toEqual([]);
+    expect(frontmatter.scripts).toEqual([]);
+  });
+
+  it('preserves body internal whitespace', () => {
+    const raw = `---
+name: my-skill
+description: desc
+---
+
+line1
+
+  indented
+
+line3
+`;
+    const { body } = parseSkillMarkdown(raw);
+    expect(body).toBe('line1\n\n  indented\n\nline3\n');
+  });
+
+  it('trims leading newlines from body only', () => {
+    const raw = `---
+name: my-skill
+description: desc
+---
+
+
+  leading blank lines stripped
+`;
+    const { body } = parseSkillMarkdown(raw);
+    expect(body).toBe('  leading blank lines stripped\n');
+  });
+});
+
+describe('serializeSkillMarkdown', () => {
+  it('serialize → parse round-trip identity', () => {
+    const frontmatter = {
+      name: 'my-skill',
+      description: 'Does something useful',
+      args: ['arg1', 'arg2'] as const,
+      scripts: ['setup.sh'] as const,
+    };
+    const body = '# My Skill\n\nThis is the body.\n';
+    const serialized = serializeSkillMarkdown(frontmatter, body);
+    const parsed = parseSkillMarkdown(serialized);
+    expect(parsed.frontmatter.name).toBe(frontmatter.name);
+    expect(parsed.frontmatter.description).toBe(frontmatter.description);
+    expect(parsed.frontmatter.args).toEqual(frontmatter.args);
+    expect(parsed.frontmatter.scripts).toEqual(frontmatter.scripts);
+    expect(parsed.body).toBe(body);
+  });
+
+  it('skips empty args and scripts lines', () => {
+    const serialized = serializeSkillMarkdown(
+      { name: 'my-skill', description: 'desc', args: [], scripts: [] },
+      'body',
+    );
+    expect(serialized).not.toContain('args:');
+    expect(serialized).not.toContain('scripts:');
+  });
+
+  it('emits canonical form', () => {
+    const serialized = serializeSkillMarkdown(
+      { name: 'my-skill', description: 'desc', args: ['x'], scripts: ['run.sh'] },
+      'body content',
+    );
+    expect(serialized).toBe(
+      '---\nname: my-skill\ndescription: desc\nargs: [x]\nscripts: [run.sh]\n---\n\nbody content',
+    );
+  });
+});

--- a/packages/core/src/skills/parser.ts
+++ b/packages/core/src/skills/parser.ts
@@ -1,0 +1,143 @@
+import type { SkillFrontmatter } from '@kay-am/types';
+
+export class SkillParseError extends Error {
+  constructor(reason: string) {
+    super(`SkillParseError: ${reason}`);
+    this.name = 'SkillParseError';
+  }
+}
+
+const NAME_RE = /^[a-z][a-z0-9-]*$/;
+const FRONTMATTER_RE = /^---[ \t]*\r?\n([\s\S]*?)\n---[ \t]*(\r?\n|$)/;
+
+function parseList(raw: string): ReadonlyArray<string> {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    const inner = trimmed.slice(1, trimmed.lastIndexOf(']'));
+    return inner
+      .split(',')
+      .map((s) => unquote(s.trim()))
+      .filter((s) => s.length > 0);
+  }
+  return trimmed
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith('- '))
+    .map((line) => unquote(line.slice(2).trim()));
+}
+
+function unquote(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseScalar(value: string): string {
+  return unquote(value.trim());
+}
+
+export function parseSkillMarkdown(raw: string): { frontmatter: SkillFrontmatter; body: string } {
+  const match = FRONTMATTER_RE.exec(raw);
+  if (match === null) {
+    throw new SkillParseError('missing or malformed frontmatter delimiters (expected --- ... ---)');
+  }
+
+  const frontmatterBlock = match[1] ?? '';
+  const afterDelimiter = raw.slice(match[0].length);
+  const body = afterDelimiter.replace(/^\n+/, '');
+
+  const fields: Record<string, string> = {};
+  const lines = frontmatterBlock.split('\n');
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+    if (line.trim() === '' || line.trimStart().startsWith('#')) {
+      i++;
+      continue;
+    }
+
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = line.slice(0, colonIdx).trim();
+    const rest = line.slice(colonIdx + 1);
+    const restTrimmed = rest.trim();
+
+    if (restTrimmed.startsWith('[') || restTrimmed !== '') {
+      fields[key] = restTrimmed;
+      i++;
+    } else {
+      const blockLines: string[] = [];
+      i++;
+      while (i < lines.length) {
+        const nextLine = lines[i] ?? '';
+        if (nextLine.trim() === '') break;
+        if (nextLine.trimStart().startsWith('- ')) {
+          blockLines.push(nextLine);
+          i++;
+        } else {
+          break;
+        }
+      }
+      fields[key] = blockLines.join('\n');
+    }
+  }
+
+  const rawName = fields['name'];
+  if (rawName === undefined || rawName.trim() === '') {
+    throw new SkillParseError('field "name" is required and must be non-empty');
+  }
+  const name = parseScalar(rawName);
+  if (!NAME_RE.test(name)) {
+    throw new SkillParseError(
+      `field "name" must match /^[a-z][a-z0-9-]*$/ (kebab-case), got: "${name}"`,
+    );
+  }
+
+  const rawDescription = fields['description'];
+  if (rawDescription === undefined || rawDescription.trim() === '') {
+    throw new SkillParseError('field "description" is required and must be non-empty');
+  }
+  const description = parseScalar(rawDescription);
+
+  const args: ReadonlyArray<string> =
+    fields['args'] !== undefined && fields['args'].trim() !== '' ? parseList(fields['args']) : [];
+
+  const scripts: ReadonlyArray<string> =
+    fields['scripts'] !== undefined && fields['scripts'].trim() !== ''
+      ? parseList(fields['scripts'])
+      : [];
+
+  const frontmatter: SkillFrontmatter = { name, description, args, scripts };
+  return { frontmatter, body };
+}
+
+export function serializeSkillMarkdown(frontmatter: SkillFrontmatter, body: string): string {
+  const lines: string[] = ['---'];
+  lines.push(`name: ${frontmatter.name}`);
+  lines.push(`description: ${frontmatter.description}`);
+
+  const args = frontmatter.args ?? [];
+  if (args.length > 0) {
+    lines.push(`args: [${args.join(', ')}]`);
+  }
+
+  const scripts = frontmatter.scripts ?? [];
+  if (scripts.length > 0) {
+    lines.push(`scripts: [${scripts.join(', ')}]`);
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push(body);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
Pure YAML-subset frontmatter parser/serializer for skill .md files. Exports parseSkillMarkdown, serializeSkillMarkdown, SkillParseError. Browser-safe, no deps.

Re-based version of #142 to resolve barrel conflict against #141.

Closes #129