### PR TITLE
feat(core): add skill executor

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,13 @@ export {
   parseSkillMarkdown,
   parseSlashCommand,
   serializeSkillMarkdown,
+  SkillRegistry,
+  SkillRegistryError,
+  type SkillFs,
+  type SkillRegistryDeps,
+  SkillExecutor,
+  SkillScriptError,
+  type SkillScriptRunner,
 } from './skills';
 
 // CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.

--- a/packages/core/src/skills/executor.test.ts
+++ b/packages/core/src/skills/executor.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Skill } from '@kay-am/types';
+import { SkillExecutor, SkillScriptError } from './executor';
+import type { SkillScriptRunner } from './executor';
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    id: 'skill-1' as Skill['id'],
+    workspaceId: 'ws-1' as Skill['workspaceId'],
+    name: 'test-skill',
+    description: 'test',
+    filePath: '/workspace/.kay/skills/test-skill.md',
+    body: '',
+    frontmatter: { name: 'test-skill', description: 'test' },
+    createdAt: '2024-01-01T00:00:00Z' as Skill['createdAt'],
+    updatedAt: '2024-01-01T00:00:00Z' as Skill['updatedAt'],
+    ...overrides,
+  };
+}
+
+const executor = new SkillExecutor();
+
+describe('SkillExecutor.resolve', () => {
+  it('substitutes {{arg0}} and {{arg1}} from args', async () => {
+    const skill = makeSkill({ body: 'Hello {{arg0}}, you are {{arg1}}!' });
+    const result = await executor.resolve({
+      skill,
+      args: ['world', 'great'],
+      workingDir: '/workspace',
+    });
+    expect(result).toBe('Hello world, you are great!');
+  });
+
+  it('substitutes missing positional with empty string', async () => {
+    const skill = makeSkill({ body: 'a={{arg0}} b={{arg1}} c={{arg2}}' });
+    const result = await executor.resolve({ skill, args: ['only-zero'], workingDir: '/workspace' });
+    expect(result).toBe('a=only-zero b= c=');
+  });
+
+  it('substitutes {{script:foo}} when runner returns canned stdout', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockResolvedValue('canned-output'),
+    };
+    const skill = makeSkill({
+      body: 'result={{script:setup}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['setup.sh'],
+      },
+    });
+    const result = await executor.resolve({
+      skill,
+      args: [],
+      workingDir: '/workspace',
+      runner,
+    });
+    expect(result).toBe('result=canned-output');
+    expect(runner.runScript).toHaveBeenCalledWith(
+      '/workspace/.kay/skills/setup.sh',
+      [],
+      '/workspace',
+    );
+  });
+
+  it('does not execute scripts not in frontmatter scripts list', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockResolvedValue('should-not-appear'),
+    };
+    const skill = makeSkill({
+      body: 'result={{script:other}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: [],
+      },
+    });
+    const result = await executor.resolve({
+      skill,
+      args: [],
+      workingDir: '/workspace',
+      runner,
+    });
+    // placeholder stays unreplaced since no scripts ran
+    expect(result).toBe('result={{script:other}}');
+    expect(runner.runScript).not.toHaveBeenCalled();
+  });
+
+  it('propagates SkillScriptError when runner throws', async () => {
+    const error = new SkillScriptError('script failed', 'bash: not found');
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockRejectedValue(error),
+    };
+    const skill = makeSkill({
+      body: '{{script:setup}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['setup.sh'],
+      },
+    });
+    await expect(
+      executor.resolve({ skill, args: [], workingDir: '/workspace', runner }),
+    ).rejects.toThrow(SkillScriptError);
+  });
+
+  it('refuses script path that resolves outside .kay/skills via path traversal', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn(),
+    };
+    const skill = makeSkill({
+      body: '{{script:evil}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['../../evil.sh'],
+      },
+    });
+    await expect(
+      executor.resolve({ skill, args: [], workingDir: '/workspace', runner }),
+    ).rejects.toThrow(SkillScriptError);
+    expect(runner.runScript).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/skills/executor.ts
+++ b/packages/core/src/skills/executor.ts
@@ -1,0 +1,102 @@
+import type { Skill } from '@kay-am/types';
+
+export interface SkillScriptRunner {
+  runScript(scriptPath: string, args: ReadonlyArray<string>, cwd: string): Promise<string>;
+}
+
+export class SkillScriptError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = 'SkillScriptError';
+  }
+}
+
+export class SkillExecutor {
+  async resolve(input: {
+    skill: Skill;
+    args: ReadonlyArray<string>;
+    workingDir: string;
+    runner?: SkillScriptRunner;
+  }): Promise<string> {
+    const { skill, args, workingDir, runner } = input;
+
+    const skillDir = posixDirname(normalizePath(skill.filePath));
+    const allowedPrefix = skillDir;
+
+    let body = substituteArgs(skill.body, args);
+
+    const scripts = skill.frontmatter.scripts ?? [];
+    if (scripts.length > 0) {
+      if (runner === undefined) {
+        throw new Error('runner is required when skill has scripts');
+      }
+
+      for (const scriptEntry of scripts) {
+        const scriptAbsPath = joinPaths(skillDir, scriptEntry);
+
+        if (!isUnderPrefix(scriptAbsPath, allowedPrefix)) {
+          throw new SkillScriptError(
+            `path traversal detected: script "${scriptEntry}" resolves outside allowed prefix "${allowedPrefix}"`,
+            '',
+          );
+        }
+
+        const stdout = await runner.runScript(scriptAbsPath, args, workingDir);
+        const varName = posixBasenameNoExt(scriptEntry);
+        body = body.replaceAll(`{{script:${varName}}}`, stdout);
+      }
+    }
+
+    return body;
+  }
+}
+
+function substituteArgs(body: string, args: ReadonlyArray<string>): string {
+  return body.replace(/\{\{arg(\d+)\}\}/g, (_, indexStr: string) => {
+    const index = parseInt(indexStr, 10);
+    return args[index] ?? '';
+  });
+}
+
+/** Normalize away `.` and `..` segments, preserving leading slash. */
+function normalizePath(p: string): string {
+  const isAbsolute = p.startsWith('/');
+  const parts = p.split('/').filter((s) => s.length > 0);
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === '.') continue;
+    if (part === '..') {
+      stack.pop();
+    } else {
+      stack.push(part);
+    }
+  }
+  return (isAbsolute ? '/' : '') + stack.join('/');
+}
+
+function posixDirname(p: string): string {
+  const slash = p.lastIndexOf('/');
+  if (slash === -1) return '.';
+  if (slash === 0) return '/';
+  return p.slice(0, slash);
+}
+
+function joinPaths(base: string, rel: string): string {
+  if (rel.startsWith('/')) return normalizePath(rel);
+  return normalizePath(base + '/' + rel);
+}
+
+function isUnderPrefix(absPath: string, prefix: string): boolean {
+  const normalized = normalizePath(absPath);
+  const normalizedPrefix = normalizePath(prefix);
+  return normalized === normalizedPrefix || normalized.startsWith(normalizedPrefix + '/');
+}
+
+function posixBasenameNoExt(p: string): string {
+  const base = p.slice(p.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,2 +1,13 @@
 export { parseSlashCommand } from './slash';
 export { SkillParseError, parseSkillMarkdown, serializeSkillMarkdown } from './parser';
+// fs-node.ts (node:fs/promises) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/skills/fs-node in Node/Tauri command contexts.
+export {
+  SkillRegistry,
+  SkillRegistryError,
+  type SkillFs,
+  type SkillRegistryDeps,
+} from './registry';
+// runner-node.ts (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/skills/runner-node in Node contexts.
+export { SkillExecutor, SkillScriptError, type SkillScriptRunner } from './executor';

--- a/packages/core/src/skills/runner-node.ts
+++ b/packages/core/src/skills/runner-node.ts
@@ -1,0 +1,17 @@
+import { execFile } from 'node:child_process';
+import type { SkillScriptRunner } from './executor';
+import { SkillScriptError } from './executor';
+
+function runScript(scriptPath: string, args: ReadonlyArray<string>, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('bash', [scriptPath, ...args], { cwd }, (error, stdout, stderr) => {
+      if (error !== null) {
+        reject(new SkillScriptError(error.message, stderr));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+export const nodeSkillScriptRunner: SkillScriptRunner = { runScript };


### PR DESCRIPTION
## What

Add `SkillExecutor` to resolve a skill invocation into a final prompt string.

- Substitutes `{{argN}}` positional placeholders from `args` (missing → empty string, no throw).
- For each script in `skill.frontmatter.scripts`, resolves the path relative to `dirname(skill.filePath)`, guards against path traversal (refuses scripts outside the skill dir), invokes `runner.runScript`, and substitutes `{{script:<basename-no-ext>}}` in the body.
- `SkillScriptRunner` interface keeps the executor browser-safe; `nodeSkillScriptRunner` (node:child_process) lives in `runner-node.ts` and is excluded from the barrel.
- `SkillScriptError` carries `stderr` property.

## Files changed

- `packages/core/src/skills/executor.ts` — `SkillExecutor`, `SkillScriptRunner`, `SkillScriptError`
- `packages/core/src/skills/runner-node.ts` — Node-only `nodeSkillScriptRunner` (excluded from barrel)
- `packages/core/src/skills/executor.test.ts` — 6 tests covering all required cases
- `packages/core/src/skills/index.ts` — barrel updated
- `packages/core/src/index.ts` — root barrel updated

## Test plan

- [x] All 6 executor tests pass locally
- [x] `runner-node.ts` excluded from browser-safe barrel
- [x] Pre-existing `registry.test.ts` failure unrelated (missing `@kay-am/db` specifiers from unpublished #131 work)

Closes #130