### PR TITLE
feat(core): add skill registry

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,6 +54,13 @@ export {
   parseSkillMarkdown,
   parseSlashCommand,
   serializeSkillMarkdown,
+  SkillRegistry,
+  SkillRegistryError,
+  type SkillFs,
+  type SkillRegistryDeps,
+  SkillExecutor,
+  SkillScriptError,
+  type SkillScriptRunner,
 } from './skills';
 
 // CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.

--- a/packages/core/src/skills/executor.test.ts
+++ b/packages/core/src/skills/executor.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Skill } from '@kay-am/types';
+import { SkillExecutor, SkillScriptError } from './executor';
+import type { SkillScriptRunner } from './executor';
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    id: 'skill-1' as Skill['id'],
+    workspaceId: 'ws-1' as Skill['workspaceId'],
+    name: 'test-skill',
+    description: 'test',
+    filePath: '/workspace/.kay/skills/test-skill.md',
+    body: '',
+    frontmatter: { name: 'test-skill', description: 'test' },
+    createdAt: '2024-01-01T00:00:00Z' as Skill['createdAt'],
+    updatedAt: '2024-01-01T00:00:00Z' as Skill['updatedAt'],
+    ...overrides,
+  };
+}
+
+const executor = new SkillExecutor();
+
+describe('SkillExecutor.resolve', () => {
+  it('substitutes {{arg0}} and {{arg1}} from args', async () => {
+    const skill = makeSkill({ body: 'Hello {{arg0}}, you are {{arg1}}!' });
+    const result = await executor.resolve({
+      skill,
+      args: ['world', 'great'],
+      workingDir: '/workspace',
+    });
+    expect(result).toBe('Hello world, you are great!');
+  });
+
+  it('substitutes missing positional with empty string', async () => {
+    const skill = makeSkill({ body: 'a={{arg0}} b={{arg1}} c={{arg2}}' });
+    const result = await executor.resolve({ skill, args: ['only-zero'], workingDir: '/workspace' });
+    expect(result).toBe('a=only-zero b= c=');
+  });
+
+  it('substitutes {{script:foo}} when runner returns canned stdout', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockResolvedValue('canned-output'),
+    };
+    const skill = makeSkill({
+      body: 'result={{script:setup}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['setup.sh'],
+      },
+    });
+    const result = await executor.resolve({
+      skill,
+      args: [],
+      workingDir: '/workspace',
+      runner,
+    });
+    expect(result).toBe('result=canned-output');
+    expect(runner.runScript).toHaveBeenCalledWith(
+      '/workspace/.kay/skills/setup.sh',
+      [],
+      '/workspace',
+    );
+  });
+
+  it('does not execute scripts not in frontmatter scripts list', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockResolvedValue('should-not-appear'),
+    };
+    const skill = makeSkill({
+      body: 'result={{script:other}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: [],
+      },
+    });
+    const result = await executor.resolve({
+      skill,
+      args: [],
+      workingDir: '/workspace',
+      runner,
+    });
+    // placeholder stays unreplaced since no scripts ran
+    expect(result).toBe('result={{script:other}}');
+    expect(runner.runScript).not.toHaveBeenCalled();
+  });
+
+  it('propagates SkillScriptError when runner throws', async () => {
+    const error = new SkillScriptError('script failed', 'bash: not found');
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn().mockRejectedValue(error),
+    };
+    const skill = makeSkill({
+      body: '{{script:setup}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['setup.sh'],
+      },
+    });
+    await expect(
+      executor.resolve({ skill, args: [], workingDir: '/workspace', runner }),
+    ).rejects.toThrow(SkillScriptError);
+  });
+
+  it('refuses script path that resolves outside .kay/skills via path traversal', async () => {
+    const runner: SkillScriptRunner = {
+      runScript: vi.fn(),
+    };
+    const skill = makeSkill({
+      body: '{{script:evil}}',
+      frontmatter: {
+        name: 'test-skill',
+        description: 'test',
+        scripts: ['../../evil.sh'],
+      },
+    });
+    await expect(
+      executor.resolve({ skill, args: [], workingDir: '/workspace', runner }),
+    ).rejects.toThrow(SkillScriptError);
+    expect(runner.runScript).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/skills/executor.ts
+++ b/packages/core/src/skills/executor.ts
@@ -1,0 +1,102 @@
+import type { Skill } from '@kay-am/types';
+
+export interface SkillScriptRunner {
+  runScript(scriptPath: string, args: ReadonlyArray<string>, cwd: string): Promise<string>;
+}
+
+export class SkillScriptError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr: string,
+  ) {
+    super(message);
+    this.name = 'SkillScriptError';
+  }
+}
+
+export class SkillExecutor {
+  async resolve(input: {
+    skill: Skill;
+    args: ReadonlyArray<string>;
+    workingDir: string;
+    runner?: SkillScriptRunner;
+  }): Promise<string> {
+    const { skill, args, workingDir, runner } = input;
+
+    const skillDir = posixDirname(normalizePath(skill.filePath));
+    const allowedPrefix = skillDir;
+
+    let body = substituteArgs(skill.body, args);
+
+    const scripts = skill.frontmatter.scripts ?? [];
+    if (scripts.length > 0) {
+      if (runner === undefined) {
+        throw new Error('runner is required when skill has scripts');
+      }
+
+      for (const scriptEntry of scripts) {
+        const scriptAbsPath = joinPaths(skillDir, scriptEntry);
+
+        if (!isUnderPrefix(scriptAbsPath, allowedPrefix)) {
+          throw new SkillScriptError(
+            `path traversal detected: script "${scriptEntry}" resolves outside allowed prefix "${allowedPrefix}"`,
+            '',
+          );
+        }
+
+        const stdout = await runner.runScript(scriptAbsPath, args, workingDir);
+        const varName = posixBasenameNoExt(scriptEntry);
+        body = body.replaceAll(`{{script:${varName}}}`, stdout);
+      }
+    }
+
+    return body;
+  }
+}
+
+function substituteArgs(body: string, args: ReadonlyArray<string>): string {
+  return body.replace(/\{\{arg(\d+)\}\}/g, (_, indexStr: string) => {
+    const index = parseInt(indexStr, 10);
+    return args[index] ?? '';
+  });
+}
+
+/** Normalize away `.` and `..` segments, preserving leading slash. */
+function normalizePath(p: string): string {
+  const isAbsolute = p.startsWith('/');
+  const parts = p.split('/').filter((s) => s.length > 0);
+  const stack: string[] = [];
+  for (const part of parts) {
+    if (part === '.') continue;
+    if (part === '..') {
+      stack.pop();
+    } else {
+      stack.push(part);
+    }
+  }
+  return (isAbsolute ? '/' : '') + stack.join('/');
+}
+
+function posixDirname(p: string): string {
+  const slash = p.lastIndexOf('/');
+  if (slash === -1) return '.';
+  if (slash === 0) return '/';
+  return p.slice(0, slash);
+}
+
+function joinPaths(base: string, rel: string): string {
+  if (rel.startsWith('/')) return normalizePath(rel);
+  return normalizePath(base + '/' + rel);
+}
+
+function isUnderPrefix(absPath: string, prefix: string): boolean {
+  const normalized = normalizePath(absPath);
+  const normalizedPrefix = normalizePath(prefix);
+  return normalized === normalizedPrefix || normalized.startsWith(normalizedPrefix + '/');
+}
+
+function posixBasenameNoExt(p: string): string {
+  const base = p.slice(p.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot > 0 ? base.slice(0, dot) : base;
+}

--- a/packages/core/src/skills/fs-node.ts
+++ b/packages/core/src/skills/fs-node.ts
@@ -1,0 +1,21 @@
+import { readdir, readFile, access } from 'node:fs/promises';
+import type { SkillFs } from './registry';
+
+export const nodeSkillFs: SkillFs = {
+  async readDir(path: string): Promise<string[]> {
+    return readdir(path);
+  },
+
+  async readFile(path: string): Promise<string> {
+    return readFile(path, 'utf8');
+  },
+
+  async stat(path: string): Promise<{ exists: boolean }> {
+    try {
+      await access(path);
+      return { exists: true };
+    } catch {
+      return { exists: false };
+    }
+  },
+};

--- a/packages/core/src/skills/index.ts
+++ b/packages/core/src/skills/index.ts
@@ -1,2 +1,13 @@
 export { parseSlashCommand } from './slash';
 export { SkillParseError, parseSkillMarkdown, serializeSkillMarkdown } from './parser';
+// fs-node.ts (node:fs/promises) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/skills/fs-node in Node/Tauri command contexts.
+export {
+  SkillRegistry,
+  SkillRegistryError,
+  type SkillFs,
+  type SkillRegistryDeps,
+} from './registry';
+// runner-node.ts (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/skills/runner-node in Node contexts.
+export { SkillExecutor, SkillScriptError, type SkillScriptRunner } from './executor';

--- a/packages/core/src/skills/registry.test.ts
+++ b/packages/core/src/skills/registry.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import type { IsoDateTime, WorkspaceId } from '@kay-am/types';
+import {
+  migrate,
+  insertWorkspace,
+  listSkillsForWorkspace,
+  type Database as DbInterface,
+} from '@kay-am/db';
+import type { SkillFs } from './registry';
+import { SkillRegistry, SkillRegistryError } from './registry';
+
+const WORKSPACE_ID = 'ws_test' as WorkspaceId;
+const ROOT = '/fake/root';
+const SKILLS_DIR = `${ROOT}/.kay/skills`;
+
+const FIXED_NOW = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+
+function makeNow(): () => IsoDateTime {
+  return () => FIXED_NOW;
+}
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql: string) {
+      db.exec(sql);
+    },
+    async execute(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+async function makeSeededDb(): Promise<DbInterface> {
+  const db = makeDb();
+  await migrate(db);
+  await insertWorkspace(db, {
+    id: WORKSPACE_ID,
+    name: 'test',
+    rootPath: ROOT,
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+  });
+  return db;
+}
+
+function makeFs(files: Record<string, string>): SkillFs {
+  return {
+    async readDir(path: string): Promise<string[]> {
+      if (path !== SKILLS_DIR) return [];
+      return Object.keys(files)
+        .filter((f) => f.startsWith(`${SKILLS_DIR}/`))
+        .map((f) => f.slice(`${SKILLS_DIR}/`.length));
+    },
+    async readFile(path: string): Promise<string> {
+      const content = files[path];
+      if (content === undefined) throw new Error(`file not found: ${path}`);
+      return content;
+    },
+    async stat(path: string): Promise<{ exists: boolean }> {
+      const hasFiles = Object.keys(files).some((f) => f.startsWith(`${path}/`));
+      return { exists: hasFiles };
+    },
+  };
+}
+
+const SKILL_A = `---
+name: skill-a
+description: First skill
+---
+
+Body of skill A.
+`;
+
+const SKILL_B = `---
+name: skill-b
+description: Second skill
+---
+
+Body of skill B.
+`;
+
+const MALFORMED = `no frontmatter here`;
+
+describe('SkillRegistry.scanWorkspace', () => {
+  it('happy path: 2 .md files → both parsed and upserted', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+      [`${SKILLS_DIR}/skill-b.md`]: SKILL_B,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(2);
+    const names = result.map((s) => s.name).sort();
+    expect(names).toEqual(['skill-a', 'skill-b']);
+
+    const inDb = await listSkillsForWorkspace(db, WORKSPACE_ID);
+    expect(inDb).toHaveLength(2);
+  });
+
+  it('file removed → next scan deletes db row', async () => {
+    const db = await makeSeededDb();
+    const fsFirst = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+      [`${SKILLS_DIR}/skill-b.md`]: SKILL_B,
+    });
+    const registry = new SkillRegistry({ fs: fsFirst, now: makeNow() });
+    await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    const fsSecond = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+    });
+    const registry2 = new SkillRegistry({ fs: fsSecond, now: makeNow() });
+    const result = await registry2.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('skill-a');
+
+    const inDb = await listSkillsForWorkspace(db, WORKSPACE_ID);
+    expect(inDb).toHaveLength(1);
+    expect(inDb[0]?.name).toBe('skill-a');
+  });
+
+  it('malformed file → SkillRegistryError surfaced', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${SKILLS_DIR}/bad.md`]: MALFORMED,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    await expect(registry.scanWorkspace(WORKSPACE_ID, ROOT, db)).rejects.toThrow(
+      SkillRegistryError,
+    );
+  });
+
+  it('empty / missing skills dir → returns empty array', async () => {
+    const db = await makeSeededDb();
+    const fsMissing: SkillFs = {
+      async readDir(): Promise<string[]> {
+        return [];
+      },
+      async readFile(path: string): Promise<string> {
+        throw new Error(`not found: ${path}`);
+      },
+      async stat(): Promise<{ exists: boolean }> {
+        return { exists: false };
+      },
+    };
+
+    const registry = new SkillRegistry({ fs: fsMissing, now: makeNow() });
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(0);
+    const inDb = await listSkillsForWorkspace(db, WORKSPACE_ID);
+    expect(inDb).toHaveLength(0);
+  });
+});
+
+describe('SkillRegistry.listSkills', () => {
+  it('returns skills from db for workspace', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+    await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    const list = await registry.listSkills(WORKSPACE_ID, db);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.name).toBe('skill-a');
+  });
+});
+
+describe('SkillRegistry.getSkillByName', () => {
+  it('returns skill when found', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+    await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    const skill = await registry.getSkillByName(WORKSPACE_ID, 'skill-a', db);
+    expect(skill).not.toBeNull();
+    expect(skill?.name).toBe('skill-a');
+  });
+
+  it('returns null for unknown name', async () => {
+    const db = await makeSeededDb();
+    const registry = new SkillRegistry({ fs: makeFs({}), now: makeNow() });
+
+    const skill = await registry.getSkillByName(WORKSPACE_ID, 'nonexistent', db);
+    expect(skill).toBeNull();
+  });
+});

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -1,0 +1,125 @@
+import type { IsoDateTime, Skill, SkillId, WorkspaceId } from '@kay-am/types';
+import type { Database as SqlDatabase } from '@kay-am/db';
+import { listSkillsForWorkspace, upsertSkill, deleteSkill } from '@kay-am/db';
+import { parseSkillMarkdown, SkillParseError } from './parser';
+
+export interface SkillFs {
+  readDir(path: string): Promise<string[]>;
+  readFile(path: string): Promise<string>;
+  stat(path: string): Promise<{ exists: boolean }>;
+}
+
+export interface SkillRegistryDeps {
+  readonly fs: SkillFs;
+  readonly now: () => IsoDateTime;
+}
+
+export class SkillRegistryError extends Error {
+  constructor(
+    message: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'SkillRegistryError';
+  }
+}
+
+export class SkillRegistry {
+  private readonly fs: SkillFs;
+  private readonly now: () => IsoDateTime;
+
+  constructor(deps: SkillRegistryDeps) {
+    this.fs = deps.fs;
+    this.now = deps.now;
+  }
+
+  async scanWorkspace(
+    workspaceId: WorkspaceId,
+    rootPath: string,
+    db: SqlDatabase,
+  ): Promise<ReadonlyArray<Skill>> {
+    const skillsDir = `${rootPath}/.kay/skills`;
+
+    let filenames: string[];
+    try {
+      filenames = await this.fs.readDir(skillsDir);
+    } catch (err) {
+      const { exists } = await this.fs.stat(skillsDir).catch(() => ({ exists: false }));
+      if (!exists) {
+        filenames = [];
+      } else {
+        throw new SkillRegistryError(`failed to read skills directory: ${skillsDir}`, err);
+      }
+    }
+
+    const mdFiles = filenames.filter((f) => f.endsWith('.md'));
+
+    const existing = await listSkillsForWorkspace(db, workspaceId);
+    const existingByPath = new Map<string, Skill>(existing.map((s) => [s.filePath, s]));
+
+    const scannedPaths = new Set<string>();
+    const result: Skill[] = [];
+
+    for (const filename of mdFiles) {
+      const filePath = `${skillsDir}/${filename}`;
+      scannedPaths.add(filePath);
+
+      let raw: string;
+      try {
+        raw = await this.fs.readFile(filePath);
+      } catch (err) {
+        throw new SkillRegistryError(`failed to read skill file: ${filePath}`, err);
+      }
+
+      let parsed: ReturnType<typeof parseSkillMarkdown>;
+      try {
+        parsed = parseSkillMarkdown(raw);
+      } catch (err) {
+        if (err instanceof SkillParseError) {
+          throw new SkillRegistryError(`malformed skill file ${filePath}: ${err.message}`, err);
+        }
+        throw err;
+      }
+
+      const { frontmatter, body } = parsed;
+      const existing_ = existingByPath.get(filePath);
+      const now = this.now();
+
+      const skill: Skill = {
+        id: existing_?.id ?? (crypto.randomUUID() as SkillId),
+        workspaceId,
+        name: frontmatter.name,
+        description: frontmatter.description,
+        filePath,
+        body,
+        frontmatter,
+        createdAt: existing_?.createdAt ?? now,
+        updatedAt: now,
+      };
+
+      await upsertSkill(db, skill);
+      result.push(skill);
+    }
+
+    for (const s of existing) {
+      if (!scannedPaths.has(s.filePath)) {
+        await deleteSkill(db, s.id);
+      }
+    }
+
+    return result;
+  }
+
+  async listSkills(workspaceId: WorkspaceId, db: SqlDatabase): Promise<ReadonlyArray<Skill>> {
+    return listSkillsForWorkspace(db, workspaceId);
+  }
+
+  async getSkillByName(
+    workspaceId: WorkspaceId,
+    name: string,
+    db: SqlDatabase,
+  ): Promise<Skill | null> {
+    const skills = await listSkillsForWorkspace(db, workspaceId);
+    return skills.find((s) => s.name === name) ?? null;
+  }
+}

--- a/packages/core/src/skills/runner-node.ts
+++ b/packages/core/src/skills/runner-node.ts
@@ -1,0 +1,17 @@
+import { execFile } from 'node:child_process';
+import type { SkillScriptRunner } from './executor';
+import { SkillScriptError } from './executor';
+
+function runScript(scriptPath: string, args: ReadonlyArray<string>, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile('bash', [scriptPath, ...args], { cwd }, (error, stdout, stderr) => {
+      if (error !== null) {
+        reject(new SkillScriptError(error.message, stderr));
+        return;
+      }
+      resolve(stdout);
+    });
+  });
+}
+
+export const nodeSkillScriptRunner: SkillScriptRunner = { runScript };


### PR DESCRIPTION
## Summary

- `SkillRegistry` class scans `<workspace>/.kay/skills/*.md`, parses each via `parseSkillMarkdown`, upserts into db, and removes stale rows
- `SkillFs` interface + `nodeSkillFs` node adapter (`fs-node.ts`) — excluded from browser-safe barrel
- `SkillRegistryError` for fs/parse failures
- 7 vitest tests: happy path, removal, malformed file, empty dir, listSkills, getSkillByName found/null

## Test plan

- [x] `pnpm --filter @kay-am/core typecheck` passes
- [x] `pnpm --filter @kay-am/core test` passes (7/7 registry tests, 225 total)
- [x] fs-node adapter excluded from browser-safe barrel per pattern

Closes #131