### PR TITLE
feat(desktop): add skill invocation card in transcript

### DIFF
--- a/apps/desktop/src/components/chat/SkillInvocationCard.tsx
+++ b/apps/desktop/src/components/chat/SkillInvocationCard.tsx
@@ -1,0 +1,24 @@
+import type { TranscriptItem } from './transcript-items';
+
+interface SkillInvocationCardProps {
+  readonly item: Extract<TranscriptItem, { kind: 'skill_invocation' }>;
+}
+
+export function SkillInvocationCard({ item }: SkillInvocationCardProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-l-2 border-primary/40 pl-3 py-1">
+      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        skill
+      </span>
+      <span className="text-xs font-medium text-foreground">{item.skillName}</span>
+      {item.args.map((arg, idx) => (
+        <span
+          key={idx}
+          className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-secondary-foreground"
+        >
+          {arg}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -3,6 +3,7 @@ import { Collapsible, cn } from '@kay-am/ui';
 import { CopyButton } from './CopyButton';
 import type { TranscriptItem } from './transcript-items';
 import { AuthRequiredCallout } from './AuthRequiredCallout';
+import { SkillInvocationCard } from './SkillInvocationCard';
 
 const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
   create: 'bg-primary/10 text-primary',
@@ -54,6 +55,8 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
           onRefresh={onRefreshAuth ?? (() => undefined)}
         />
       );
+    case 'skill_invocation':
+      return <SkillInvocationCard item={item} />;
     case 'done':
       return <hr className="border-border" />;
   }

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -17,6 +17,7 @@ export type TranscriptItem =
   | { kind: 'usage'; key: string; usage: ProviderUsage }
   | { kind: 'error'; key: string; message: string }
   | { kind: 'auth_required'; key: string; providerId: ProviderId; identity: string | null }
+  | { kind: 'skill_invocation'; key: string; skillName: string; args: ReadonlyArray<string> }
   | { kind: 'done'; key: string };
 
 export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArray<TranscriptItem> {
@@ -98,6 +99,14 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
         }
         break;
       }
+      case 'skill_invocation':
+        items.push({
+          kind: 'skill_invocation',
+          key: `skill-${i}`,
+          skillName: event.skillName,
+          args: event.args,
+        });
+        break;
       case 'done':
         items.push({ kind: 'done', key: `done-${i}` });
         break;


### PR DESCRIPTION
## Summary

- Adds `skill_invocation` variant to `TranscriptItem` discriminated union in `transcript-items.ts`
- Handles `skill_invocation` `TurnEvent` in `reduceTranscript`, mapping it to the new item kind
- New `SkillInvocationCard` component renders: skill name badge (`bg-muted`), arg chips (`bg-secondary`), left border accent to distinguish from other cards
- Wires `SkillInvocationCard` into the `TranscriptCard` switch

## Test plan

- [ ] Trigger a skill invocation in a chat session and verify the card renders with skill name and args
- [ ] Confirm card is visually distinct from `assistant_text`, `tool_call`, and `error` cards
- [ ] Typecheck passes (`pnpm --filter @kay-am/desktop typecheck`)

Closes #135