### PR TITLE
feat(desktop): add slash command autocomplete and skill manager

### DIFF
--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, Dialog, Input } from '@kay-am/ui';
 import { ProvidersPanel } from './ProvidersPanel';
 import { BudgetRulesPanel } from './BudgetRulesPanel';
+import { SkillsPanel } from './SkillsPanel';
 import {
   DEFAULT_BRANCH_PREFIX,
   DEFAULT_EDITOR_BINARY,
@@ -86,6 +87,12 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       <div className="border-t border-border-soft pt-4">
         <BudgetRulesPanel />
       </div>
+
+      {workspace ? (
+        <div className="border-t border-border-soft pt-4">
+          <SkillsPanel workspaceId={workspace.id} />
+        </div>
+      ) : null}
 
       <div className="flex flex-col gap-4 border-t border-border-soft pt-4">
         <Section label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>

--- a/apps/desktop/src/components/SkillsPanel.tsx
+++ b/apps/desktop/src/components/SkillsPanel.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useState } from 'react';
+import { Button, Input, Textarea } from '@kay-am/ui';
+import type { Skill, SkillFrontmatter, WorkspaceId } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+interface SkillsPanelProps {
+  readonly workspaceId: WorkspaceId;
+}
+
+interface EditorForm {
+  name: string;
+  description: string;
+  args: string;
+  scripts: string;
+  body: string;
+}
+
+const emptyForm = (): EditorForm => ({
+  name: '',
+  description: '',
+  args: '',
+  scripts: '',
+  body: '',
+});
+
+function skillToForm(skill: Skill): EditorForm {
+  return {
+    name: skill.name,
+    description: skill.description,
+    args: skill.frontmatter.args?.join(', ') ?? '',
+    scripts: skill.frontmatter.scripts?.join(', ') ?? '',
+    body: skill.body,
+  };
+}
+
+const KEBAB_RE = /^[a-z][a-z0-9-]*$/;
+
+function validateName(
+  name: string,
+  existing: ReadonlyArray<Skill>,
+  editingId?: string,
+): string | null {
+  if (!name.trim()) return 'name is required';
+  if (!KEBAB_RE.test(name)) return 'name must be kebab-case (lowercase letters, numbers, hyphens)';
+  const collision = existing.find((s) => s.name === name && s.id !== editingId);
+  if (collision) return 'name already in use';
+  return null;
+}
+
+function parseChips(raw: string): ReadonlyArray<string> {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function SkillsPanel({ workspaceId }: SkillsPanelProps) {
+  const skills = useAppStore((s) => s.skills[workspaceId] ?? []);
+  const loadSkills = useAppStore((s) => s.loadSkills);
+  const saveSkill = useAppStore((s) => s.saveSkill);
+  const deleteSkill = useAppStore((s) => s.deleteSkill);
+  const rescanSkills = useAppStore((s) => s.rescanSkills);
+
+  const [editingSkill, setEditingSkill] = useState<Skill | null | 'new'>(null);
+  const [form, setForm] = useState<EditorForm>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [rescanning, setRescanning] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void loadSkills(workspaceId);
+  }, [loadSkills, workspaceId]);
+
+  const openNew = () => {
+    setEditingSkill('new');
+    setForm(emptyForm());
+    setFormError(null);
+  };
+
+  const openEdit = (skill: Skill) => {
+    setEditingSkill(skill);
+    setForm(skillToForm(skill));
+    setFormError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingSkill(null);
+    setFormError(null);
+  };
+
+  const onSave = async () => {
+    const nameErr = validateName(
+      form.name,
+      skills,
+      editingSkill !== 'new' && editingSkill ? editingSkill.id : undefined,
+    );
+    if (nameErr) {
+      setFormError(nameErr);
+      return;
+    }
+
+    const frontmatter: SkillFrontmatter = {
+      name: form.name,
+      description: form.description,
+      ...(parseChips(form.args).length > 0 ? { args: parseChips(form.args) } : {}),
+      ...(parseChips(form.scripts).length > 0 ? { scripts: parseChips(form.scripts) } : {}),
+    };
+
+    setSaving(true);
+    setFormError(null);
+    try {
+      await saveSkill({
+        workspaceId,
+        name: form.name,
+        description: form.description,
+        frontmatter,
+        body: form.body,
+        filePath: editingSkill !== 'new' && editingSkill ? editingSkill.filePath : undefined,
+      });
+      setEditingSkill(null);
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDelete = async (skill: Skill) => {
+    await deleteSkill(skill.id, workspaceId);
+  };
+
+  const onRescan = async () => {
+    setRescanning(true);
+    try {
+      await rescanSkills(workspaceId);
+    } finally {
+      setRescanning(false);
+    }
+  };
+
+  if (editingSkill !== null) {
+    return (
+      <SkillEditor
+        form={form}
+        onChange={setForm}
+        onSave={() => void onSave()}
+        onCancel={cancelEdit}
+        saving={saving}
+        error={formError}
+        isNew={editingSkill === 'new'}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-foreground">skills</div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={() => void onRescan()} disabled={rescanning}>
+            {rescanning ? 'rescanning…' : 'rescan'}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={openNew}>
+            new skill
+          </Button>
+        </div>
+      </div>
+
+      {skills.length === 0 ? (
+        <p className="text-[11px] text-muted-foreground">
+          no skills for this workspace. create one or rescan the workspace directory.
+        </p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
+          {skills.map((skill) => (
+            <SkillRow
+              key={skill.id}
+              skill={skill}
+              onEdit={() => openEdit(skill)}
+              onDelete={() => void onDelete(skill)}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function SkillRow({
+  skill,
+  onEdit,
+  onDelete,
+}: {
+  skill: Skill;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <li className="flex items-start gap-3 px-3 py-2.5 text-xs">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="font-medium">/{skill.name}</span>
+        {skill.description ? (
+          <span className="text-[11px] text-muted-foreground">{skill.description}</span>
+        ) : null}
+        <span className="truncate text-[10px] text-muted-foreground/60">{skill.filePath}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <button
+          type="button"
+          className="text-[11px] text-muted-foreground underline hover:text-foreground"
+          onClick={onEdit}
+        >
+          edit
+        </button>
+        <button
+          type="button"
+          className="text-[11px] text-muted-foreground underline hover:text-danger"
+          onClick={onDelete}
+        >
+          delete
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function SkillEditor({
+  form,
+  onChange,
+  onSave,
+  onCancel,
+  saving,
+  error,
+  isNew,
+}: {
+  form: EditorForm;
+  onChange: (f: EditorForm) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+  isNew: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-xs font-semibold text-foreground">
+        {isNew ? 'new skill' : 'edit skill'}
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-semibold text-foreground">name</label>
+          <Input
+            value={form.name}
+            onChange={(e) => onChange({ ...form, name: e.target.value })}
+            placeholder="my-skill"
+          />
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-semibold text-foreground">description</label>
+          <Input
+            value={form.description}
+            onChange={(e) => onChange({ ...form, description: e.target.value })}
+            placeholder="what this skill does"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <div className="flex flex-1 flex-col gap-1.5">
+            <label className="text-[11px] font-semibold text-foreground">
+              args (comma-separated)
+            </label>
+            <Input
+              value={form.args}
+              onChange={(e) => onChange({ ...form, args: e.target.value })}
+              placeholder="arg1, arg2"
+            />
+          </div>
+          <div className="flex flex-1 flex-col gap-1.5">
+            <label className="text-[11px] font-semibold text-foreground">
+              scripts (comma-separated)
+            </label>
+            <Input
+              value={form.scripts}
+              onChange={(e) => onChange({ ...form, scripts: e.target.value })}
+              placeholder="./script.sh"
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-semibold text-foreground">body</label>
+          <Textarea
+            value={form.body}
+            onChange={(e) => onChange({ ...form, body: e.target.value })}
+            placeholder="skill prompt body…"
+            rows={6}
+            className="font-mono text-xs"
+          />
+        </div>
+
+        {error ? <p className="text-[11px] text-danger">{error}</p> : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
+            cancel
+          </Button>
+          <Button size="sm" onClick={onSave} disabled={saving}>
+            {saving ? 'saving…' : 'save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, type KeyboardEvent } from 'react';
+import { useState, useRef, useCallback, type KeyboardEvent } from 'react';
 import { Button, Textarea } from '@kay-am/ui';
 import type {
   BudgetAlert,
@@ -11,8 +11,11 @@ import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from '../../store';
 import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
+import { SlashCommandPopover } from './SlashCommandPopover';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
+
+const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
 
 interface ChatInputProps {
   readonly session: Session;
@@ -43,10 +46,16 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected')),
   );
+  const workspaceSkills = useAppStore(useShallow((s) => s.skills[session.workspaceId] ?? []));
   const { showToast } = useToast();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
+  const [showPopover, setShowPopover] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
+  const isSlashMode = slashQuery !== null;
 
   const isRunning = RUNNING_KINDS.has(session.state.kind);
   const canSend = !isRunning && !providerDisconnected && value.trim().length > 0;
@@ -61,6 +70,17 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
       : undefined;
 
   const connectedProviderIds = connectedProviders.map((p) => p.id);
+
+  const onValueChange = (next: string) => {
+    setValue(next);
+    setShowPopover(SLASH_MODE_RE.test(next));
+  };
+
+  const onSkillSelect = useCallback((name: string) => {
+    setValue(`/${name} `);
+    setShowPopover(false);
+    wrapperRef.current?.querySelector('textarea')?.focus();
+  }, []);
 
   const onSend = async () => {
     const content = value.trim();
@@ -91,7 +111,14 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   };
 
   const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === 'Enter' && !event.shiftKey) {
+    if (
+      showPopover &&
+      (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'Tab')
+    ) {
+      event.preventDefault();
+      return;
+    }
+    if (event.key === 'Enter' && !event.shiftKey && !showPopover) {
       event.preventDefault();
       void onSend();
     }
@@ -113,20 +140,30 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             onSendAnyway={value.trim().length > 0 ? () => void onSend() : undefined}
           />
         ) : null}
-        <Textarea
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={
-            isRunning
-              ? 'turn running… cancel to send another'
-              : providerDisconnected
-                ? 'sign in to send a message.'
-                : 'message claude. shift+enter for newline.'
-          }
-          disabled={isRunning || providerDisconnected}
-          rows={3}
-        />
+        <div className="relative" ref={wrapperRef}>
+          {showPopover && isSlashMode ? (
+            <SlashCommandPopover
+              items={workspaceSkills}
+              query={slashQuery}
+              onSelect={onSkillSelect}
+              onDismiss={() => setShowPopover(false)}
+            />
+          ) : null}
+          <Textarea
+            value={value}
+            onChange={(e) => onValueChange(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={
+              isRunning
+                ? 'turn running… cancel to send another'
+                : providerDisconnected
+                  ? 'sign in to send a message.'
+                  : 'message claude. shift+enter for newline.'
+            }
+            disabled={isRunning || providerDisconnected}
+            rows={3}
+          />
+        </div>
         {error ? <p className="text-xs text-danger">{error}</p> : null}
         <div className="flex items-center justify-end gap-2">
           {isRunning ? (

--- a/apps/desktop/src/components/chat/SlashCommandPopover.tsx
+++ b/apps/desktop/src/components/chat/SlashCommandPopover.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface SkillItem {
+  readonly name: string;
+  readonly description: string;
+}
+
+interface SlashCommandPopoverProps {
+  readonly items: ReadonlyArray<SkillItem>;
+  readonly query: string;
+  readonly onSelect: (name: string) => void;
+  readonly onDismiss: () => void;
+}
+
+function fuzzyMatch(name: string, query: string): boolean {
+  return name.toLowerCase().includes(query.toLowerCase());
+}
+
+export function SlashCommandPopover({
+  items,
+  query,
+  onSelect,
+  onDismiss,
+}: SlashCommandPopoverProps) {
+  const filtered = items.filter((item) => fuzzyMatch(item.name, query));
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+      } else if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        const item = filtered[activeIndex];
+        if (item) onSelect(item.name);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onDismiss();
+      }
+    };
+    window.addEventListener('keydown', handler, { capture: true });
+    return () => window.removeEventListener('keydown', handler, { capture: true });
+  }, [filtered, activeIndex, onSelect, onDismiss]);
+
+  useEffect(() => {
+    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-background shadow-md">
+      {filtered.length === 0 ? (
+        <p className="px-3 py-2 text-[11px] text-muted-foreground">
+          no skills — create one in settings
+        </p>
+      ) : (
+        <ul ref={listRef} className="max-h-48 overflow-y-auto py-1">
+          {filtered.map((item, i) => (
+            <li
+              key={item.name}
+              className={`flex cursor-pointer flex-col gap-0.5 px-3 py-2 ${
+                i === activeIndex ? 'bg-accent' : 'hover:bg-accent/50'
+              }`}
+              onMouseEnter={() => setActiveIndex(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(item.name);
+              }}
+            >
+              <span className="text-xs font-medium text-foreground">/{item.name}</span>
+              {item.description ? (
+                <span className="text-[11px] text-muted-foreground">{item.description}</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -37,6 +37,8 @@ import type {
   SessionId,
   SessionProviderPreference,
   SessionState,
+  Skill,
+  SkillId,
   TelemetryRecord,
   TelemetryRecordId,
   TurnEvent,
@@ -75,6 +77,13 @@ import {
   invokeBudgetAlertsList,
   invokeBudgetAlertDismiss,
 } from '../budget';
+import {
+  invokeSkillList,
+  invokeSkillUpsert,
+  invokeSkillDelete,
+  invokeSkillRescan,
+  type SkillUpsertArgs,
+} from '../skills';
 
 export type BootPhase =
   | 'pending'
@@ -112,6 +121,7 @@ export interface AppState {
   readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
   readonly providerSpendBreakdown: ReadonlyArray<ProviderSpendEntry>;
   readonly budgetAlerts: ReadonlyArray<BudgetAlert>;
+  readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
 }
 
 export interface SummarizerSessionStatus {
@@ -168,6 +178,10 @@ export interface AppActions {
   refreshProviderSpendBreakdown(workspaceId: WorkspaceId): Promise<void>;
   loadBudgetAlerts(): Promise<void>;
   dismissBudgetAlert(id: string): Promise<void>;
+  loadSkills(workspaceId: WorkspaceId): Promise<void>;
+  saveSkill(input: SkillUpsertArgs): Promise<void>;
+  deleteSkill(skillId: SkillId, workspaceId: WorkspaceId): Promise<void>;
+  rescanSkills(workspaceId: WorkspaceId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -198,6 +212,7 @@ const initialState: AppState = {
   sessionBudgets: {},
   providerSpendBreakdown: [],
   budgetAlerts: [],
+  skills: {},
 };
 
 function buildProviderSpendBreakdown(
@@ -428,17 +443,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
       workspaceSummary: null,
     });
     if (id) {
-      const [sessions, workspaceSummary, providerSummaries, budgetRules] = await Promise.all([
-        listSessionsForWorkspace(tauriDatabase, id),
-        summarizeWorkspaceTelemetry(tauriDatabase, id),
-        summarizeWorkspaceProviderTelemetry(tauriDatabase, id),
-        invokeBudgetRuleList(),
-      ]);
-      set({
+      const [sessions, workspaceSummary, providerSummaries, budgetRules, skills] =
+        await Promise.all([
+          listSessionsForWorkspace(tauriDatabase, id),
+          summarizeWorkspaceTelemetry(tauriDatabase, id),
+          summarizeWorkspaceProviderTelemetry(tauriDatabase, id),
+          invokeBudgetRuleList(),
+          invokeSkillList(id),
+        ]);
+      set((state) => ({
         sessions,
         workspaceSummary,
         providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
-      });
+        skills: { ...state.skills, [id]: skills },
+      }));
     } else {
       set({ providerSpendBreakdown: [] });
     }
@@ -966,5 +984,27 @@ export const useAppStore = create<AppStore>((set, get) => ({
         a.id === id ? { ...a, dismissedAt: new Date().toISOString() as IsoDateTime } : a,
       ),
     }));
+  },
+
+  loadSkills: async (workspaceId) => {
+    const skills = await invokeSkillList(workspaceId);
+    set((state) => ({ skills: { ...state.skills, [workspaceId]: skills } }));
+  },
+
+  saveSkill: async (input) => {
+    await invokeSkillUpsert(input);
+    const skills = await invokeSkillList(input.workspaceId);
+    set((state) => ({ skills: { ...state.skills, [input.workspaceId]: skills } }));
+  },
+
+  deleteSkill: async (skillId, workspaceId) => {
+    await invokeSkillDelete(skillId);
+    const skills = await invokeSkillList(workspaceId);
+    set((state) => ({ skills: { ...state.skills, [workspaceId]: skills } }));
+  },
+
+  rescanSkills: async (workspaceId) => {
+    const skills = await invokeSkillRescan(workspaceId);
+    set((state) => ({ skills: { ...state.skills, [workspaceId]: skills } }));
   },
 }));


### PR DESCRIPTION
Implements slash command popover in chat input and a skill management panel in settings.

## Changes

- **store**: added `skills` state keyed by `WorkspaceId`; `loadSkills`, `saveSkill`, `deleteSkill`, `rescanSkills` actions; `setCurrentWorkspace` now pre-fetches skills
- **SlashCommandPopover**: keyboard-navigable list (↑↓/Enter/Tab/Esc), case-insensitive substring filter, empty state
- **ChatInput**: detects `/[a-z0-9-]*` at line start → shows popover; arrow/tab keys forwarded to popover; Enter blocked while popover open; on select fills `/<name> ` and refocuses textarea
- **SkillsPanel**: list + inline editor (name kebab-case validation, uniqueness check, args/scripts as comma chips, mono body textarea, rescan button)
- **SettingsDialog**: added Skills section above editor/branch settings, gated on workspace selection

Closes #134
Closes #136