### PR TITLE
feat(core): phase context propagator and registry

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,3 +84,13 @@ export {
   type SummarizerResult,
   type SummarizerUsage,
 } from './summarizer';
+
+export {
+  buildPhasePrompt,
+  isPhaseSequenceComplete,
+  nextPhase,
+  PhaseContextPropagator,
+  type PhaseContextPropagatorDeps,
+} from './phases';
+// PhaseRegistry (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/phases/registry in Node/Tauri command contexts.

--- a/packages/core/src/phases/index.ts
+++ b/packages/core/src/phases/index.ts
@@ -1,1 +1,4 @@
 export { buildPhasePrompt, isPhaseSequenceComplete, nextPhase } from './sequencer';
+export { PhaseContextPropagator, type PhaseContextPropagatorDeps } from './propagator';
+// registry.ts (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/phases/registry in Node/Tauri command contexts.

--- a/packages/core/src/phases/propagator.test.ts
+++ b/packages/core/src/phases/propagator.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { ContextSlot, IsoDateTime } from '@kay-am/types';
+import { PhaseContextPropagator } from './propagator';
+
+const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+
+function makeSummarizer(summary: string) {
+  return {
+    async summarizePhaseOutput(_text: string): Promise<string> {
+      return summary;
+    },
+  };
+}
+
+const SLOTS: ReadonlyArray<ContextSlot> = [{ key: 'goal', value: 'refactor auth', enabled: true }];
+
+describe('PhaseContextPropagator.buildTransition', () => {
+  it('combines summary and serialized slots in carryForwardContext', async () => {
+    const propagator = new PhaseContextPropagator({ summarizer: makeSummarizer('phase summary') });
+    const result = await propagator.buildTransition({
+      fromOrdinal: 0,
+      toOrdinal: 1,
+      completedPhaseOutput: 'raw output',
+      existingSlots: SLOTS,
+      at: AT,
+    });
+
+    expect(result.fromOrdinal).toBe(0);
+    expect(result.toOrdinal).toBe(1);
+    expect(result.at).toBe(AT);
+    expect(result.carryForwardContext).toContain('phase summary');
+    expect(result.carryForwardContext).toContain('refactor auth');
+  });
+
+  it('empty summary → slots text present without a leading double-newline', async () => {
+    const propagator = new PhaseContextPropagator({ summarizer: makeSummarizer('') });
+    const result = await propagator.buildTransition({
+      fromOrdinal: 1,
+      toOrdinal: 2,
+      completedPhaseOutput: 'output',
+      existingSlots: SLOTS,
+      at: AT,
+    });
+
+    expect(result.carryForwardContext).not.toMatch(/^\n\n/);
+    expect(result.carryForwardContext).toContain('refactor auth');
+  });
+
+  it('no slots → summary joined with serialized slot headers', async () => {
+    const propagator = new PhaseContextPropagator({ summarizer: makeSummarizer('only summary') });
+    const result = await propagator.buildTransition({
+      fromOrdinal: 0,
+      toOrdinal: 1,
+      completedPhaseOutput: 'output',
+      existingSlots: [],
+      at: AT,
+    });
+
+    expect(result.carryForwardContext).toContain('only summary');
+  });
+
+  it('empty summary and no slots → carryForwardContext contains only slot headers', async () => {
+    const propagator = new PhaseContextPropagator({ summarizer: makeSummarizer('') });
+    const result = await propagator.buildTransition({
+      fromOrdinal: 0,
+      toOrdinal: 1,
+      completedPhaseOutput: '',
+      existingSlots: [],
+      at: AT,
+    });
+
+    expect(result.carryForwardContext).not.toMatch(/^\n\n/);
+    expect(result.carryForwardContext.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/phases/propagator.ts
+++ b/packages/core/src/phases/propagator.ts
@@ -1,0 +1,29 @@
+import type { ContextSlot, IsoDateTime, PhaseTransition } from '@kay-am/types';
+import { serializeSlots } from '../context';
+
+export interface PhaseContextPropagatorDeps {
+  readonly summarizer: { summarizePhaseOutput(text: string): Promise<string> };
+}
+
+export class PhaseContextPropagator {
+  constructor(private readonly deps: PhaseContextPropagatorDeps) {}
+  async buildTransition(input: {
+    fromOrdinal: number;
+    toOrdinal: number;
+    completedPhaseOutput: string;
+    existingSlots: ReadonlyArray<ContextSlot>;
+    at: IsoDateTime;
+  }): Promise<PhaseTransition> {
+    const summary = await this.deps.summarizer.summarizePhaseOutput(input.completedPhaseOutput);
+    const slotsText = serializeSlots(input.existingSlots);
+    const carryForwardContext = [summary, slotsText]
+      .filter((s) => s.trim().length > 0)
+      .join('\n\n');
+    return {
+      fromOrdinal: input.fromOrdinal,
+      toOrdinal: input.toOrdinal,
+      carryForwardContext,
+      at: input.at,
+    };
+  }
+}

--- a/packages/core/src/phases/registry.test.ts
+++ b/packages/core/src/phases/registry.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import type {
+  IsoDateTime,
+  PhaseDefinitionId,
+  PhaseTemplate,
+  PhaseTemplateId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { migrate, insertWorkspace, type Database as DbInterface } from '@kay-am/db';
+import { PhaseRegistry, PhaseRegistryError } from './registry';
+
+const WORKSPACE_ID = 'ws_test' as WorkspaceId;
+const FIXED_NOW = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql: string) {
+      db.exec(sql);
+    },
+    async execute(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+async function makeSeededDb(): Promise<DbInterface> {
+  const db = makeDb();
+  await migrate(db);
+  await insertWorkspace(db, {
+    id: WORKSPACE_ID,
+    name: 'test',
+    rootPath: '/fake/root',
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+  });
+  return db;
+}
+
+function makeTemplate(overrides: Partial<PhaseTemplate> = {}): PhaseTemplate {
+  return {
+    id: 'pt_001' as PhaseTemplateId,
+    workspaceId: WORKSPACE_ID,
+    name: 'My Template',
+    description: 'desc',
+    definitions: [
+      {
+        id: 'pd_001' as PhaseDefinitionId,
+        templateId: 'pt_001' as PhaseTemplateId,
+        ordinal: 0,
+        name: 'Phase One',
+        promptPrefix: 'do phase one',
+      },
+      {
+        id: 'pd_002' as PhaseDefinitionId,
+        templateId: 'pt_001' as PhaseTemplateId,
+        ordinal: 1,
+        name: 'Phase Two',
+        promptPrefix: 'do phase two',
+      },
+    ],
+    createdAt: FIXED_NOW,
+    updatedAt: FIXED_NOW,
+    ...overrides,
+  };
+}
+
+describe('PhaseRegistry validation', () => {
+  it('throws when template name is empty', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    await expect(registry.upsert(makeTemplate({ name: '   ' }))).rejects.toThrow(
+      PhaseRegistryError,
+    );
+    await expect(registry.upsert(makeTemplate({ name: '   ' }))).rejects.toThrow(
+      'template name required',
+    );
+  });
+
+  it('throws when ordinals have a gap', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate({
+      definitions: [
+        {
+          id: 'pd_001' as PhaseDefinitionId,
+          templateId: 'pt_001' as PhaseTemplateId,
+          ordinal: 0,
+          name: 'Phase One',
+          promptPrefix: '',
+        },
+        {
+          id: 'pd_002' as PhaseDefinitionId,
+          templateId: 'pt_001' as PhaseTemplateId,
+          ordinal: 2,
+          name: 'Phase Three',
+          promptPrefix: '',
+        },
+      ],
+    });
+    await expect(registry.upsert(template)).rejects.toThrow(PhaseRegistryError);
+    await expect(registry.upsert(template)).rejects.toThrow('ordinals must be contiguous');
+  });
+
+  it('throws when a definition has an empty name', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate({
+      definitions: [
+        {
+          id: 'pd_001' as PhaseDefinitionId,
+          templateId: 'pt_001' as PhaseTemplateId,
+          ordinal: 0,
+          name: '  ',
+          promptPrefix: '',
+        },
+      ],
+    });
+    await expect(registry.upsert(template)).rejects.toThrow(PhaseRegistryError);
+    await expect(registry.upsert(template)).rejects.toThrow('has empty name');
+  });
+
+  it('throws on duplicate definition names', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate({
+      definitions: [
+        {
+          id: 'pd_001' as PhaseDefinitionId,
+          templateId: 'pt_001' as PhaseTemplateId,
+          ordinal: 0,
+          name: 'Same',
+          promptPrefix: '',
+        },
+        {
+          id: 'pd_002' as PhaseDefinitionId,
+          templateId: 'pt_001' as PhaseTemplateId,
+          ordinal: 1,
+          name: 'Same',
+          promptPrefix: '',
+        },
+      ],
+    });
+    await expect(registry.upsert(template)).rejects.toThrow(PhaseRegistryError);
+    await expect(registry.upsert(template)).rejects.toThrow('duplicate definition name');
+  });
+});
+
+describe('PhaseRegistry happy path', () => {
+  it('upsert → list returns template', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate();
+
+    const returned = await registry.upsert(template);
+    expect(returned.id).toBe(template.id);
+    expect(returned.name).toBe(template.name);
+
+    const list = await registry.list(WORKSPACE_ID);
+    expect(list).toHaveLength(1);
+    expect(list[0]?.id).toBe(template.id);
+  });
+
+  it('get returns template by id', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate();
+    await registry.upsert(template);
+
+    const found = await registry.get(template.id);
+    expect(found).not.toBeNull();
+    expect(found?.name).toBe('My Template');
+    expect(found?.definitions).toHaveLength(2);
+  });
+
+  it('get returns null for unknown id', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+
+    const found = await registry.get('pt_unknown' as PhaseTemplateId);
+    expect(found).toBeNull();
+  });
+
+  it('delete removes template', async () => {
+    const db = await makeSeededDb();
+    const registry = new PhaseRegistry({ db });
+    const template = makeTemplate();
+    await registry.upsert(template);
+
+    await registry.delete(template.id);
+    const list = await registry.list(WORKSPACE_ID);
+    expect(list).toHaveLength(0);
+  });
+});

--- a/packages/core/src/phases/registry.ts
+++ b/packages/core/src/phases/registry.ts
@@ -1,0 +1,61 @@
+import type { PhaseTemplate, PhaseTemplateId, WorkspaceId } from '@kay-am/types';
+import {
+  listPhaseTemplates as dbList,
+  getPhaseTemplate as dbGet,
+  upsertPhaseTemplate as dbUpsert,
+  deletePhaseTemplate as dbDelete,
+  type Database,
+} from '@kay-am/db';
+
+export class PhaseRegistryError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = 'PhaseRegistryError';
+  }
+}
+
+export interface PhaseRegistryDeps {
+  readonly db: Database;
+}
+
+export class PhaseRegistry {
+  constructor(private readonly deps: PhaseRegistryDeps) {}
+
+  list(workspaceId: WorkspaceId): Promise<ReadonlyArray<PhaseTemplate>> {
+    return dbList(this.deps.db, workspaceId);
+  }
+
+  get(id: PhaseTemplateId): Promise<PhaseTemplate | null> {
+    return dbGet(this.deps.db, id);
+  }
+
+  async upsert(template: PhaseTemplate): Promise<PhaseTemplate> {
+    this.validate(template);
+    await dbUpsert(this.deps.db, template);
+    return template;
+  }
+
+  delete(id: PhaseTemplateId): Promise<void> {
+    return dbDelete(this.deps.db, id);
+  }
+
+  private validate(template: PhaseTemplate): void {
+    if (template.name.trim().length === 0) throw new PhaseRegistryError('template name required');
+    const defs = template.definitions;
+    for (let i = 0; i < defs.length; i++) {
+      const def = defs[i]!;
+      if (def.ordinal !== i)
+        throw new PhaseRegistryError(
+          `ordinals must be contiguous starting at 0; got ${def.ordinal} at index ${i}`,
+        );
+      if (def.name.trim().length === 0)
+        throw new PhaseRegistryError(`definition at ordinal ${i} has empty name`);
+    }
+    const names = new Set<string>();
+    for (const d of defs) {
+      if (names.has(d.name))
+        throw new PhaseRegistryError(`duplicate definition name within template: ${d.name}`);
+      names.add(d.name);
+    }
+  }
+}

--- a/packages/types/src/phase.ts
+++ b/packages/types/src/phase.ts
@@ -47,6 +47,6 @@ export type PhaseRun = Readonly<{
 export type PhaseTransition = Readonly<{
   fromOrdinal: number;
   toOrdinal: number;
-  carryForwardContext: boolean;
+  carryForwardContext: string;
   at: IsoDateTime;
 }>;


### PR DESCRIPTION
## Summary

- Add `PhaseContextPropagator` (browser-safe) — builds `PhaseTransition` by summarizing completed phase output and serializing existing context slots into `carryForwardContext`
- Add `PhaseRegistry` (node-only) — CRUD wrapper over `@kay-am/db` phase-template queries with validation (empty name, non-contiguous ordinals, empty def names, duplicate def names)
- Fix `PhaseTransition.carryForwardContext` type from `boolean` → `string` (was mistyped; sequencer already expected `string`)

## Test plan

- [ ] `pnpm -w typecheck` — clean
- [ ] `pnpm -w test` — 257 passed, 4 skipped
- [ ] Propagator: fake summarizer, summary+slots combined, empty summary edge, empty slots edge
- [ ] Registry: all 4 validation error paths, happy-path list/get/delete with in-memory SQLite

Closes #153
Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)