### PR TITLE
feat(types): permission domain types

### DIFF
--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -5,6 +5,7 @@ import { m004TurnOverrides } from './m004-turn-overrides';
 import { m005BudgetTables } from './m005-budget-tables';
 import { m006Skills } from './m006-skills';
 import { m007Phases } from './m007-phases';
+import { m008Permissions } from './m008-permissions';
 
 export interface Migration {
   readonly version: number;
@@ -19,4 +20,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 5, sql: m005BudgetTables },
   { version: 6, sql: m006Skills },
   { version: 7, sql: m007Phases },
+  { version: 8, sql: m008Permissions },
 ];

--- a/packages/db/src/migrations/m008-permissions.ts
+++ b/packages/db/src/migrations/m008-permissions.ts
@@ -1,0 +1,37 @@
+export const m008Permissions = /* sql */ `
+CREATE TABLE IF NOT EXISTS permission_rules (
+  id TEXT PRIMARY KEY,
+  scope TEXT NOT NULL,
+  workspace_id TEXT,
+  session_id TEXT,
+  pattern_tool TEXT NOT NULL,
+  pattern_args_matcher TEXT,
+  decision TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_permission_rules_scope ON permission_rules(scope);
+CREATE INDEX IF NOT EXISTS idx_permission_rules_workspace_id ON permission_rules(workspace_id);
+CREATE INDEX IF NOT EXISTS idx_permission_rules_session_id ON permission_rules(session_id);
+
+CREATE TABLE IF NOT EXISTS permission_audit_log (
+  id TEXT PRIMARY KEY,
+  run_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  tool_use_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  input_json TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  rule_id TEXT,
+  decided_by TEXT NOT NULL,
+  requested_at TEXT NOT NULL,
+  decided_at TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+  FOREIGN KEY (rule_id) REFERENCES permission_rules(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_permission_audit_session_id ON permission_audit_log(session_id);
+CREATE INDEX IF NOT EXISTS idx_permission_audit_run_id ON permission_audit_log(run_id);
+`;

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -9,3 +9,6 @@ export type PhaseDefinitionId = string & { readonly __brand: 'PhaseDefinitionId'
 export type PhaseRunId = string & { readonly __brand: 'PhaseRunId' };
 
 export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };
+
+export type PermissionRuleId = string & { readonly __brand: 'PermissionRuleId' };
+export type PermissionRequestId = string & { readonly __brand: 'PermissionRequestId' };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,8 @@
 export type {
   IsoDateTime,
   MessageId,
+  PermissionRequestId,
+  PermissionRuleId,
   PhaseDefinitionId,
   PhaseRunId,
   PhaseTemplateId,
@@ -50,3 +52,14 @@ export type {
   PhaseTemplate,
   PhaseTransition,
 } from './phase';
+export type {
+  PermissionAuditEntry,
+  PermissionDecision,
+  PermissionDecisionKind,
+  PermissionDecisionOutcome,
+  PermissionDecisionSource,
+  PermissionRequest,
+  PermissionRule,
+  PermissionRulePattern,
+  PermissionRuleScope,
+} from './permission';

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -1,0 +1,55 @@
+import type {
+  IsoDateTime,
+  PermissionRequestId,
+  PermissionRuleId,
+  ProviderRunId,
+  SessionId,
+  WorkspaceId,
+} from './ids';
+
+export type PermissionRuleScope = 'workspace' | 'session' | 'global';
+
+export type PermissionDecisionKind = 'allow' | 'deny' | 'ask';
+
+export interface PermissionRulePattern {
+  readonly tool: string;
+  readonly argsMatcher?: string;
+}
+
+export interface PermissionRule {
+  readonly id: PermissionRuleId;
+  readonly scope: PermissionRuleScope;
+  readonly workspaceId?: WorkspaceId;
+  readonly sessionId?: SessionId;
+  readonly pattern: PermissionRulePattern;
+  readonly decision: PermissionDecisionKind;
+  readonly priority: number;
+  readonly createdAt: IsoDateTime;
+  readonly updatedAt: IsoDateTime;
+}
+
+export interface PermissionRequest {
+  readonly id: PermissionRequestId;
+  readonly runId: ProviderRunId;
+  readonly toolUseId: string;
+  readonly toolName: string;
+  readonly input: unknown;
+  readonly at: IsoDateTime;
+}
+
+export type PermissionDecisionOutcome = 'allow' | 'deny';
+
+export type PermissionDecisionSource = 'user' | 'rule' | 'default';
+
+export interface PermissionDecision {
+  readonly requestId: PermissionRequestId;
+  readonly decision: PermissionDecisionOutcome;
+  readonly ruleId: PermissionRuleId | null;
+  readonly decidedBy: PermissionDecisionSource;
+  readonly at: IsoDateTime;
+}
+
+export interface PermissionAuditEntry {
+  readonly request: PermissionRequest;
+  readonly decision: PermissionDecision;
+}


### PR DESCRIPTION
Adds the v0.6 permission proxy domain types to @kay-am/types: PermissionRule, PermissionRequest, PermissionDecision, PermissionAuditEntry, plus branded ids.

No runtime code; types only.

Closes #170