### PR TITLE
feat(core): permission engine, matcher, audit recorder, claude flags + tests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,3 +94,17 @@ export {
 } from './phases';
 // PhaseRegistry (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/phases/registry in Node/Tauri command contexts.
+
+export {
+  PermissionEngine,
+  type PermissionEngineDeps,
+  parseToolPattern,
+  parseArgsMatcher,
+  formatToolPattern,
+  type ToolMatcher,
+  buildClaudeFlags,
+  type ClaudeFlagSet,
+  PermissionAuditRecorder,
+  type AuditRecorderDeps,
+  type AuditQuery,
+} from './permissions';

--- a/packages/core/src/permissions/audit.test.ts
+++ b/packages/core/src/permissions/audit.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  PermissionAuditEntry,
+  PermissionDecision,
+  PermissionRequest,
+  PermissionRequestId,
+  PermissionRuleId,
+  SessionId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { PermissionAuditRecorder, type AuditQuery } from './audit';
+
+const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+const SESSION = 'session-1' as SessionId;
+const WS = 'ws-1' as WorkspaceId;
+
+function makeEntry(id: string): PermissionAuditEntry {
+  const request: PermissionRequest = {
+    id: id as PermissionRequestId,
+    runId: 'run-1' as never,
+    toolUseId: 'tool-use-1',
+    toolName: 'Edit',
+    input: {},
+    at: AT,
+  };
+  const decision: PermissionDecision = {
+    requestId: id as PermissionRequestId,
+    decision: 'allow',
+    ruleId: null,
+    decidedBy: 'default',
+    at: AT,
+  };
+  return { request, decision };
+}
+
+function makeInMemoryDeps() {
+  const store: PermissionAuditEntry[] = [];
+  return {
+    deps: {
+      insert: async (entry: PermissionAuditEntry) => {
+        store.push(entry);
+      },
+      list: async (_q: AuditQuery) => [...store] as ReadonlyArray<PermissionAuditEntry>,
+      clear: async (_scope: { sessionId?: SessionId; workspaceId?: WorkspaceId }) => {
+        store.splice(0, store.length);
+      },
+    },
+    store,
+  };
+}
+
+describe('PermissionAuditRecorder', () => {
+  it('record → query round-trip via in-memory deps', async () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    const entry = makeEntry('req-1');
+    await recorder.record(entry);
+
+    const results = await recorder.query({});
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(entry);
+  });
+
+  it('clear without scope throws', async () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    expect(() => recorder.clear({})).toThrow('clear scope required: sessionId or workspaceId');
+  });
+
+  it('clear without scope throws even with undefined values', () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    expect(() => recorder.clear({ sessionId: undefined, workspaceId: undefined })).toThrow(
+      'clear scope required: sessionId or workspaceId',
+    );
+  });
+
+  it('clear with sessionId only succeeds', async () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    await recorder.record(makeEntry('req-1'));
+    await expect(recorder.clear({ sessionId: SESSION })).resolves.toBeUndefined();
+  });
+
+  it('clear with workspaceId only succeeds', async () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    await recorder.record(makeEntry('req-1'));
+    await expect(recorder.clear({ workspaceId: WS })).resolves.toBeUndefined();
+  });
+
+  it('record multiple entries → query returns all', async () => {
+    const { deps } = makeInMemoryDeps();
+    const recorder = new PermissionAuditRecorder(deps);
+
+    await recorder.record(makeEntry('req-1'));
+    await recorder.record(makeEntry('req-2'));
+    await recorder.record(makeEntry('req-3'));
+
+    const results = await recorder.query({});
+    expect(results).toHaveLength(3);
+  });
+});

--- a/packages/core/src/permissions/audit.ts
+++ b/packages/core/src/permissions/audit.ts
@@ -1,0 +1,34 @@
+import type { IsoDateTime, PermissionAuditEntry, SessionId, WorkspaceId } from '@kay-am/types';
+
+export interface AuditQuery {
+  readonly sessionId?: SessionId;
+  readonly workspaceId?: WorkspaceId;
+  readonly fromAt?: IsoDateTime;
+  readonly toAt?: IsoDateTime;
+  readonly limit?: number;
+}
+
+export interface AuditRecorderDeps {
+  readonly insert: (entry: PermissionAuditEntry) => Promise<void>;
+  readonly list: (q: AuditQuery) => Promise<ReadonlyArray<PermissionAuditEntry>>;
+  readonly clear: (scope: { sessionId?: SessionId; workspaceId?: WorkspaceId }) => Promise<void>;
+}
+
+export class PermissionAuditRecorder {
+  constructor(private readonly deps: AuditRecorderDeps) {}
+
+  record(entry: PermissionAuditEntry): Promise<void> {
+    return this.deps.insert(entry);
+  }
+
+  query(q: AuditQuery): Promise<ReadonlyArray<PermissionAuditEntry>> {
+    return this.deps.list(q);
+  }
+
+  clear(scope: { sessionId?: SessionId; workspaceId?: WorkspaceId }): Promise<void> {
+    if (!scope.sessionId && !scope.workspaceId) {
+      throw new Error('clear scope required: sessionId or workspaceId');
+    }
+    return this.deps.clear(scope);
+  }
+}

--- a/packages/core/src/permissions/claude-flags.test.ts
+++ b/packages/core/src/permissions/claude-flags.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  PermissionRule,
+  PermissionRuleId,
+  SessionId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { buildClaudeFlags } from './claude-flags';
+
+const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+const SESSION = 'session-1' as SessionId;
+const WS = 'ws-1' as WorkspaceId;
+const SCOPE = { sessionId: SESSION, workspaceId: WS };
+
+function makeRule(
+  overrides: Partial<PermissionRule> & Pick<PermissionRule, 'id' | 'decision'>,
+): PermissionRule {
+  return {
+    scope: 'global',
+    pattern: { tool: '*' },
+    priority: 0,
+    createdAt: AT,
+    updatedAt: AT,
+    ...overrides,
+  };
+}
+
+describe('buildClaudeFlags', () => {
+  it('allow-Edit-only set', () => {
+    const rules: PermissionRule[] = [
+      makeRule({ id: 'r1' as PermissionRuleId, decision: 'allow', pattern: { tool: 'Edit' } }),
+    ];
+    expect(buildClaudeFlags({ rules, scope: SCOPE })).toMatchInlineSnapshot(`
+      {
+        "allowedTools": [
+          "Edit",
+        ],
+        "disallowedTools": [],
+        "permissionMode": "default",
+      }
+    `);
+  });
+
+  it('deny rm + allow everything else', () => {
+    const rules: PermissionRule[] = [
+      makeRule({
+        id: 'r1' as PermissionRuleId,
+        decision: 'deny',
+        pattern: { tool: 'Bash', argsMatcher: 'rm:*' },
+        priority: 10,
+      }),
+      makeRule({
+        id: 'r2' as PermissionRuleId,
+        decision: 'allow',
+        pattern: { tool: '*' },
+        priority: 0,
+      }),
+    ];
+    expect(buildClaudeFlags({ rules, scope: SCOPE })).toMatchInlineSnapshot(`
+      {
+        "allowedTools": [
+          "*",
+        ],
+        "disallowedTools": [
+          "Bash(rm:*)",
+        ],
+        "permissionMode": "default",
+      }
+    `);
+  });
+
+  it('mixed scopes — both rendered, session deny alongside workspace allow', () => {
+    const rules: PermissionRule[] = [
+      makeRule({
+        id: 'ws-allow' as PermissionRuleId,
+        scope: 'workspace',
+        workspaceId: WS,
+        decision: 'allow',
+        pattern: { tool: 'Edit' },
+        priority: 5,
+      }),
+      makeRule({
+        id: 'session-deny' as PermissionRuleId,
+        scope: 'session',
+        sessionId: SESSION,
+        decision: 'deny',
+        pattern: { tool: 'Edit' },
+        priority: 5,
+      }),
+    ];
+    expect(buildClaudeFlags({ rules, scope: SCOPE })).toMatchInlineSnapshot(`
+      {
+        "allowedTools": [
+          "Edit",
+        ],
+        "disallowedTools": [
+          "Edit",
+        ],
+        "permissionMode": "default",
+      }
+    `);
+  });
+
+  it('always permissionMode: default', () => {
+    const result = buildClaudeFlags({ rules: [], scope: SCOPE });
+    expect(result.permissionMode).toBe('default');
+  });
+
+  it('ask rules do not appear in either list', () => {
+    const rules: PermissionRule[] = [
+      makeRule({ id: 'r1' as PermissionRuleId, decision: 'ask', pattern: { tool: 'Bash' } }),
+    ];
+    const result = buildClaudeFlags({ rules, scope: SCOPE });
+    expect(result.allowedTools).toHaveLength(0);
+    expect(result.disallowedTools).toHaveLength(0);
+  });
+
+  it('de-duplication: same pattern appears only once per list', () => {
+    const rules: PermissionRule[] = [
+      makeRule({
+        id: 'r1' as PermissionRuleId,
+        decision: 'allow',
+        pattern: { tool: 'Edit' },
+        priority: 2,
+      }),
+      makeRule({
+        id: 'r2' as PermissionRuleId,
+        decision: 'allow',
+        pattern: { tool: 'Edit' },
+        priority: 1,
+      }),
+    ];
+    const result = buildClaudeFlags({ rules, scope: SCOPE });
+    expect(result.allowedTools).toEqual(['Edit']);
+  });
+
+  it('rules outside scope are excluded', () => {
+    const rules: PermissionRule[] = [
+      makeRule({
+        id: 'r1' as PermissionRuleId,
+        scope: 'session',
+        sessionId: 'other-session' as SessionId,
+        decision: 'allow',
+        pattern: { tool: 'Edit' },
+      }),
+    ];
+    const result = buildClaudeFlags({ rules, scope: SCOPE });
+    expect(result.allowedTools).toHaveLength(0);
+  });
+});

--- a/packages/core/src/permissions/claude-flags.ts
+++ b/packages/core/src/permissions/claude-flags.ts
@@ -1,0 +1,59 @@
+import type { PermissionRule, PermissionRuleScope, SessionId, WorkspaceId } from '@kay-am/types';
+import { formatToolPattern } from './matcher';
+
+export interface ClaudeFlagSet {
+  readonly allowedTools: ReadonlyArray<string>;
+  readonly disallowedTools: ReadonlyArray<string>;
+  readonly permissionMode: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
+}
+
+const SCOPE_RANK: Record<PermissionRuleScope, number> = {
+  session: 2,
+  workspace: 1,
+  global: 0,
+};
+
+function isApplicable(
+  rule: PermissionRule,
+  scope: { workspaceId: WorkspaceId; sessionId: SessionId },
+): boolean {
+  if (rule.scope === 'global') return true;
+  if (rule.scope === 'session') return rule.sessionId === scope.sessionId;
+  if (rule.scope === 'workspace') return rule.workspaceId === scope.workspaceId;
+  return false;
+}
+
+export function buildClaudeFlags(input: {
+  readonly rules: ReadonlyArray<PermissionRule>;
+  readonly scope: { workspaceId: WorkspaceId; sessionId: SessionId };
+}): ClaudeFlagSet {
+  const applicable = input.rules.filter((r) => isApplicable(r, input.scope));
+
+  const sorted = [...applicable].sort((a, b) => {
+    if (b.priority !== a.priority) return b.priority - a.priority;
+    return SCOPE_RANK[b.scope] - SCOPE_RANK[a.scope];
+  });
+
+  const allowedSet = new Set<string>();
+  const disallowedSet = new Set<string>();
+  const allowedTools: string[] = [];
+  const disallowedTools: string[] = [];
+
+  for (const rule of sorted) {
+    if (rule.decision === 'ask') continue;
+    const rendered = formatToolPattern(rule.pattern);
+    if (rule.decision === 'allow') {
+      if (!allowedSet.has(rendered)) {
+        allowedSet.add(rendered);
+        allowedTools.push(rendered);
+      }
+    } else {
+      if (!disallowedSet.has(rendered)) {
+        disallowedSet.add(rendered);
+        disallowedTools.push(rendered);
+      }
+    }
+  }
+
+  return { allowedTools, disallowedTools, permissionMode: 'default' };
+}

--- a/packages/core/src/permissions/engine.test.ts
+++ b/packages/core/src/permissions/engine.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  PermissionRequest,
+  PermissionRule,
+  PermissionRuleId,
+  PermissionRequestId,
+  SessionId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { PermissionEngine } from './engine';
+
+const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
+const SESSION_A = 'session-a' as SessionId;
+const SESSION_B = 'session-b' as SessionId;
+const WS_A = 'ws-a' as WorkspaceId;
+const WS_B = 'ws-b' as WorkspaceId;
+const CTX = { sessionId: SESSION_A, workspaceId: WS_A };
+
+function makeRequest(toolName: string, input: unknown = {}): PermissionRequest {
+  return {
+    id: 'req-1' as PermissionRequestId,
+    runId: 'run-1' as never,
+    toolUseId: 'tool-use-1',
+    toolName,
+    input,
+    at: AT,
+  };
+}
+
+function makeRule(
+  overrides: Partial<PermissionRule> & Pick<PermissionRule, 'id' | 'decision'>,
+): PermissionRule {
+  return {
+    scope: 'global',
+    pattern: { tool: '*' },
+    priority: 0,
+    createdAt: AT,
+    updatedAt: AT,
+    ...overrides,
+  };
+}
+
+describe('PermissionEngine.decide', () => {
+  const engine = new PermissionEngine();
+
+  it('no match → deny by default', () => {
+    const result = engine.decide(makeRequest('Edit'), [], CTX);
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBeNull();
+    expect(result.decidedBy).toBe('default');
+    expect(result.requestId).toBe('req-1');
+    expect(result.at).toBe(AT);
+  });
+
+  it('no match → allow when defaultDecision=allow', () => {
+    const e = new PermissionEngine({ defaultDecision: 'allow' });
+    const result = e.decide(makeRequest('Edit'), [], CTX);
+    expect(result.decision).toBe('allow');
+    expect(result.decidedBy).toBe('default');
+  });
+
+  it('ruleId set when rule matched, decidedBy=rule', () => {
+    const rule = makeRule({
+      id: 'rule-x' as PermissionRuleId,
+      decision: 'allow',
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [rule], CTX);
+    expect(result.ruleId).toBe('rule-x');
+    expect(result.decidedBy).toBe('rule');
+  });
+
+  it('session scope wins over global at equal priority', () => {
+    const globalAllow = makeRule({
+      id: 'global-allow' as PermissionRuleId,
+      scope: 'global',
+      decision: 'allow',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const sessionDeny = makeRule({
+      id: 'session-deny' as PermissionRuleId,
+      scope: 'session',
+      sessionId: SESSION_A,
+      decision: 'deny',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [globalAllow, sessionDeny], CTX);
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBe('session-deny');
+  });
+
+  it('workspace scope wins over global at equal priority', () => {
+    const globalAllow = makeRule({
+      id: 'global-allow' as PermissionRuleId,
+      scope: 'global',
+      decision: 'allow',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const wsDeny = makeRule({
+      id: 'ws-deny' as PermissionRuleId,
+      scope: 'workspace',
+      workspaceId: WS_A,
+      decision: 'deny',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [globalAllow, wsDeny], CTX);
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBe('ws-deny');
+  });
+
+  it('session scope wins over workspace scope', () => {
+    const wsAllow = makeRule({
+      id: 'ws-allow' as PermissionRuleId,
+      scope: 'workspace',
+      workspaceId: WS_A,
+      decision: 'allow',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const sessionDeny = makeRule({
+      id: 'session-deny' as PermissionRuleId,
+      scope: 'session',
+      sessionId: SESSION_A,
+      decision: 'deny',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [wsAllow, sessionDeny], CTX);
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBe('session-deny');
+  });
+
+  it('higher priority wins regardless of scope', () => {
+    const sessionDeny = makeRule({
+      id: 'session-deny' as PermissionRuleId,
+      scope: 'session',
+      sessionId: SESSION_A,
+      decision: 'deny',
+      priority: 1,
+      pattern: { tool: 'Edit' },
+    });
+    const globalAllow = makeRule({
+      id: 'global-allow' as PermissionRuleId,
+      scope: 'global',
+      decision: 'allow',
+      priority: 10,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [sessionDeny, globalAllow], CTX);
+    expect(result.decision).toBe('allow');
+    expect(result.ruleId).toBe('global-allow');
+  });
+
+  it('deny beats allow at equal precedence', () => {
+    const allow = makeRule({
+      id: 'allow-rule' as PermissionRuleId,
+      scope: 'global',
+      decision: 'allow',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const deny = makeRule({
+      id: 'deny-rule' as PermissionRuleId,
+      scope: 'global',
+      decision: 'deny',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [allow, deny], CTX);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('ask treated as deny at engine level', () => {
+    const ask = makeRule({
+      id: 'ask-rule' as PermissionRuleId,
+      scope: 'global',
+      decision: 'ask',
+      priority: 5,
+      pattern: { tool: 'Bash' },
+    });
+    const result = engine.decide(makeRequest('Bash', { command: 'ls' }), [ask], CTX);
+    expect(result.decision).toBe('deny');
+  });
+
+  it('rules for other sessions/workspaces are excluded', () => {
+    const otherSession = makeRule({
+      id: 'other-session' as PermissionRuleId,
+      scope: 'session',
+      sessionId: SESSION_B,
+      decision: 'allow',
+      priority: 100,
+      pattern: { tool: 'Edit' },
+    });
+    const otherWs = makeRule({
+      id: 'other-ws' as PermissionRuleId,
+      scope: 'workspace',
+      workspaceId: WS_B,
+      decision: 'allow',
+      priority: 100,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [otherSession, otherWs], CTX);
+    expect(result.decision).toBe('deny');
+    expect(result.ruleId).toBeNull();
+  });
+
+  it('specificity: concrete tool beats glob at equal priority+scope', () => {
+    const glob = makeRule({
+      id: 'glob-deny' as PermissionRuleId,
+      scope: 'global',
+      decision: 'deny',
+      priority: 5,
+      pattern: { tool: '*' },
+    });
+    const specific = makeRule({
+      id: 'specific-allow' as PermissionRuleId,
+      scope: 'global',
+      decision: 'allow',
+      priority: 5,
+      pattern: { tool: 'Edit' },
+    });
+    const result = engine.decide(makeRequest('Edit'), [glob, specific], CTX);
+    expect(result.decision).toBe('allow');
+    expect(result.ruleId).toBe('specific-allow');
+  });
+});

--- a/packages/core/src/permissions/engine.ts
+++ b/packages/core/src/permissions/engine.ts
@@ -1,0 +1,91 @@
+import type {
+  PermissionDecision,
+  PermissionDecisionOutcome,
+  PermissionRequest,
+  PermissionRule,
+  PermissionRuleScope,
+  SessionId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { formatToolPattern, parseToolPattern } from './matcher';
+
+export interface PermissionEngineDeps {
+  readonly defaultDecision?: 'allow' | 'deny';
+}
+
+const SCOPE_RANK: Record<PermissionRuleScope, number> = {
+  session: 2,
+  workspace: 1,
+  global: 0,
+};
+
+function isApplicable(
+  rule: PermissionRule,
+  context: { sessionId: SessionId; workspaceId: WorkspaceId },
+): boolean {
+  if (rule.scope === 'global') return true;
+  if (rule.scope === 'session') return rule.sessionId === context.sessionId;
+  if (rule.scope === 'workspace') return rule.workspaceId === context.workspaceId;
+  return false;
+}
+
+function isSpecific(rule: PermissionRule): boolean {
+  const pattern = formatToolPattern(rule.pattern);
+  return !pattern.includes('*');
+}
+
+export class PermissionEngine {
+  private readonly defaultDecision: 'allow' | 'deny';
+
+  constructor(deps?: PermissionEngineDeps) {
+    this.defaultDecision = deps?.defaultDecision ?? 'deny';
+  }
+
+  decide(
+    request: PermissionRequest,
+    rules: ReadonlyArray<PermissionRule>,
+    context: { sessionId: SessionId; workspaceId: WorkspaceId },
+  ): PermissionDecision {
+    const applicable = rules.filter((r) => isApplicable(r, context));
+
+    const matched = applicable.filter((r) => {
+      const matcher = parseToolPattern(formatToolPattern(r.pattern));
+      return matcher.matches(request.toolName, request.input);
+    });
+
+    if (matched.length === 0) {
+      return {
+        requestId: request.id,
+        decision: this.defaultDecision,
+        ruleId: null,
+        decidedBy: 'default',
+        at: request.at,
+      };
+    }
+
+    // Sort: priority desc, scope desc, specificity desc, deny-wins on ties
+    const sorted = [...matched].sort((a, b) => {
+      if (b.priority !== a.priority) return b.priority - a.priority;
+      const scopeDiff = SCOPE_RANK[b.scope] - SCOPE_RANK[a.scope];
+      if (scopeDiff !== 0) return scopeDiff;
+      const aSpec = isSpecific(a) ? 1 : 0;
+      const bSpec = isSpecific(b) ? 1 : 0;
+      if (bSpec !== aSpec) return bSpec - aSpec;
+      // equal precedence: deny/ask wins over allow
+      const denyRank = (d: string) => (d === 'deny' || d === 'ask' ? 1 : 0);
+      return denyRank(b.decision) - denyRank(a.decision);
+    });
+
+    // sorted is guaranteed non-empty (matched.length > 0)
+    const winner = sorted[0] as PermissionRule;
+    const outcome: PermissionDecisionOutcome = winner.decision === 'allow' ? 'allow' : 'deny';
+
+    return {
+      requestId: request.id,
+      decision: outcome,
+      ruleId: winner.id,
+      decidedBy: 'rule',
+      at: request.at,
+    };
+  }
+}

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -1,0 +1,4 @@
+export { PermissionEngine, type PermissionEngineDeps } from './engine';
+export { formatToolPattern, parseArgsMatcher, parseToolPattern, type ToolMatcher } from './matcher';
+export { buildClaudeFlags, type ClaudeFlagSet } from './claude-flags';
+export { PermissionAuditRecorder, type AuditRecorderDeps, type AuditQuery } from './audit';

--- a/packages/core/src/permissions/matcher.test.ts
+++ b/packages/core/src/permissions/matcher.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { formatToolPattern, parseToolPattern } from './matcher';
+import type { PermissionRulePattern } from '@kay-am/types';
+
+describe('parseToolPattern', () => {
+  it('bare tool name matches any args', () => {
+    const m = parseToolPattern('Edit');
+    expect(m.matches('Edit', { file_path: '/any/path' })).toBe(true);
+    expect(m.matches('Edit', {})).toBe(true);
+    expect(m.matches('Bash', {})).toBe(false);
+  });
+
+  it('wildcard * matches any tool and args', () => {
+    const m = parseToolPattern('*');
+    expect(m.matches('Edit', {})).toBe(true);
+    expect(m.matches('Bash', { command: 'ls' })).toBe(true);
+    expect(m.matches('AnythingElse', null)).toBe(true);
+  });
+
+  it('Bash(git:*) matches command with git: prefix (claude colon notation)', () => {
+    // In claude --allowedTools syntax, Bash(git:*) means the Bash command arg
+    // starts with "git:" — the colon is literal in the pattern.
+    const m = parseToolPattern('Bash(git:*)');
+    expect(m.matches('Bash', { command: 'git:status' })).toBe(true);
+    expect(m.matches('Bash', { command: 'git:commit' })).toBe(true);
+    expect(m.matches('Bash', { command: 'ls -la' })).toBe(false);
+    expect(m.matches('Edit', { command: 'git:status' })).toBe(false);
+  });
+
+  it('Bash(git *) matches space-separated git commands', () => {
+    const m = parseToolPattern('Bash(git *)');
+    expect(m.matches('Bash', { command: 'git status' })).toBe(true);
+    expect(m.matches('Bash', { command: 'git commit' })).toBe(true);
+    expect(m.matches('Bash', { command: 'ls -la' })).toBe(false);
+  });
+
+  it('Edit(/abs/**) matches file_path under /abs/', () => {
+    const m = parseToolPattern('Edit(/abs/**)');
+    expect(m.matches('Edit', { file_path: '/abs/foo/bar' })).toBe(true);
+    expect(m.matches('Edit', { file_path: '/abs/' })).toBe(true);
+    expect(m.matches('Edit', { file_path: '/other/foo' })).toBe(false);
+  });
+
+  it('single segment * does not cross : or /', () => {
+    const m = parseToolPattern('Bash(git *)');
+    expect(m.matches('Bash', { command: 'git status' })).toBe(true);
+    // the * should not match across : (per claude convention)
+    const m2 = parseToolPattern('Bash(git:*)');
+    expect(m2.matches('Bash', { command: 'git:foo:bar' })).toBe(false);
+  });
+
+  it('regex metachar escape: literal dot in path', () => {
+    const m = parseToolPattern('Edit(/foo.bar/*)');
+    expect(m.matches('Edit', { file_path: '/foo.bar/baz' })).toBe(true);
+    // dot is literal, not wildcard
+    expect(m.matches('Edit', { file_path: '/fooXbar/baz' })).toBe(false);
+  });
+
+  it('** glob matches across segments', () => {
+    const m = parseToolPattern('Edit(/src/**)');
+    expect(m.matches('Edit', { file_path: '/src/a/b/c/d.ts' })).toBe(true);
+  });
+});
+
+describe('formatToolPattern round-trip', () => {
+  it('bare tool', () => {
+    const p: PermissionRulePattern = { tool: 'Edit' };
+    expect(formatToolPattern(p)).toBe('Edit');
+  });
+
+  it('tool with argsMatcher', () => {
+    const p: PermissionRulePattern = { tool: 'Bash', argsMatcher: 'git:*' };
+    expect(formatToolPattern(p)).toBe('Bash(git:*)');
+  });
+
+  it('wildcard', () => {
+    const p: PermissionRulePattern = { tool: '*' };
+    expect(formatToolPattern(p)).toBe('*');
+  });
+});

--- a/packages/core/src/permissions/matcher.ts
+++ b/packages/core/src/permissions/matcher.ts
@@ -1,0 +1,86 @@
+import type { PermissionRulePattern } from '@kay-am/types';
+
+export interface ToolMatcher {
+  matches(toolName: string, input: unknown): boolean;
+}
+
+// Regex metachars excluding * (handled separately as glob wildcard)
+const REGEX_METACHARS = /[.+?()[\]{}\^$|\\]/g;
+
+function globToRegex(glob: string): RegExp {
+  // Split on ** and * BEFORE escaping other metachars so we can handle them independently
+  // Strategy: walk char by char building pattern
+  let pattern = '';
+  let i = 0;
+  while (i < glob.length) {
+    const ch = glob[i];
+    if (ch === '*' && glob[i + 1] === '*') {
+      pattern += '.*';
+      i += 2;
+    } else if (ch === '*') {
+      pattern += '[^:/]*';
+      i += 1;
+    } else {
+      // escape regex metachar
+      pattern += ch!.replace(REGEX_METACHARS, '\\$&');
+      i += 1;
+    }
+  }
+  return new RegExp(`^${pattern}$`);
+}
+
+export function parseArgsMatcher(matcher: string): (input: unknown) => boolean {
+  if (!matcher) return () => true;
+  const re = globToRegex(matcher);
+  return (input: unknown) => {
+    const str = stringifyInput('', input);
+    return re.test(str);
+  };
+}
+
+function stringifyInput(toolName: string, input: unknown): string {
+  if (input === null || input === undefined) return '';
+  const obj = input as Record<string, unknown>;
+  if (toolName === 'Bash') {
+    return typeof obj['command'] === 'string' ? obj['command'] : JSON.stringify(input);
+  }
+  if (['Edit', 'Write', 'MultiEdit', 'NotebookEdit'].includes(toolName)) {
+    return typeof obj['file_path'] === 'string' ? obj['file_path'] : JSON.stringify(input);
+  }
+  return JSON.stringify(input);
+}
+
+export function parseToolPattern(pattern: string): ToolMatcher {
+  const parenIdx = pattern.indexOf('(');
+
+  if (parenIdx === -1) {
+    // bare tool name or wildcard `*`
+    const tool = pattern.trim();
+    if (tool === '*') {
+      return { matches: () => true };
+    }
+    return {
+      matches(toolName: string, _input: unknown): boolean {
+        return toolName === tool;
+      },
+    };
+  }
+
+  const tool = pattern.slice(0, parenIdx).trim();
+  const argsGlob = pattern.slice(parenIdx + 1, pattern.lastIndexOf(')'));
+
+  const argsRe = globToRegex(argsGlob);
+
+  return {
+    matches(toolName: string, input: unknown): boolean {
+      if (toolName !== tool) return false;
+      const str = stringifyInput(toolName, input);
+      return argsRe.test(str);
+    },
+  };
+}
+
+export function formatToolPattern(pattern: PermissionRulePattern): string {
+  if (!pattern.argsMatcher) return pattern.tool;
+  return `${pattern.tool}(${pattern.argsMatcher})`;
+}


### PR DESCRIPTION
Consolidated v0.6 permissions core layer.

- PermissionEngine + decision precedence (session > workspace > global, priority desc, deny-wins).
- ToolMatcher + claude --allowedTools-compatible pattern parser.
- buildClaudeFlags renders effective rules to claude CLI flag set.
- PermissionAuditRecorder with pluggable deps for browser-safe usage.
- Vitest coverage for engine, matcher, claude-flags, and audit.

Closes #172
Closes #173
Closes #174
Closes #175
Closes #186