### PR TITLE
feat(ui): permissions settings panel + provider support indicator

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -53,6 +53,12 @@ export function App() {
   }, [hydrate]);
 
   useEffect(() => {
+    const handler = () => setSettingsOpen(true);
+    window.addEventListener('kayam:open-settings', handler);
+    return () => window.removeEventListener('kayam:open-settings', handler);
+  }, []);
+
+  useEffect(() => {
     if (!currentSession) {
       setContextOpen(false);
       setContextHydratedFor(null);

--- a/apps/desktop/src/components/PermissionsPanel.tsx
+++ b/apps/desktop/src/components/PermissionsPanel.tsx
@@ -1,0 +1,461 @@
+import { useEffect, useState } from 'react';
+import { Button, Input } from '@kay-am/ui';
+import type { PermissionDecisionKind, PermissionRule, PermissionRuleScope } from '@kay-am/types';
+import { formatToolPattern } from '@kay-am/core';
+import type { PermissionRuleId } from '@kay-am/types';
+import {
+  invokePermissionRuleList,
+  invokePermissionRuleUpsert,
+  invokePermissionRuleDelete,
+} from '../permissions';
+import { useCurrentSession, useCurrentWorkspace } from '../store';
+
+const TOOL_NAMES = [
+  'Bash',
+  'Edit',
+  'Write',
+  'MultiEdit',
+  'Read',
+  'Glob',
+  'Grep',
+  'NotebookEdit',
+  'WebFetch',
+  'WebSearch',
+  'Task',
+  'TodoWrite',
+];
+
+const DECISION_OPTIONS: PermissionDecisionKind[] = ['allow', 'deny', 'ask'];
+
+const DECISION_BADGE: Record<PermissionDecisionKind, string> = {
+  allow: 'bg-success/15 text-success',
+  deny: 'bg-danger/15 text-danger',
+  ask: 'bg-warning/15 text-warning',
+};
+
+type ScopeTab = PermissionRuleScope;
+
+interface RuleForm {
+  tool: string;
+  argsMatcher: string;
+  decision: PermissionDecisionKind;
+  priority: string;
+}
+
+const emptyForm = (): RuleForm => ({
+  tool: '',
+  argsMatcher: '',
+  decision: 'allow',
+  priority: '0',
+});
+
+function computePreview(form: RuleForm): string {
+  const tool = form.tool.trim();
+  if (!tool) return '';
+  const rendered = formatToolPattern({
+    tool,
+    ...(form.argsMatcher.trim() ? { argsMatcher: form.argsMatcher.trim() } : {}),
+  });
+  if (form.decision === 'allow') return `--allowedTools "${rendered}"`;
+  if (form.decision === 'deny') return `--disallowedTools "${rendered}"`;
+  return `(ask — no flag emitted for "${rendered}")`;
+}
+
+export function PermissionsPanel() {
+  const workspace = useCurrentWorkspace();
+  const session = useCurrentSession();
+
+  const [scope, setScope] = useState<ScopeTab>('global');
+  const [rules, setRules] = useState<ReadonlyArray<PermissionRule>>([]);
+  const [loading, setLoading] = useState(false);
+  const [editingRule, setEditingRule] = useState<PermissionRule | 'new' | null>(null);
+  const [form, setForm] = useState<RuleForm>(emptyForm());
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [pendingDeleteId, setPendingDeleteId] = useState<PermissionRuleId | null>(null);
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+
+  const showNonClaudeBanner =
+    scope === 'session' &&
+    session !== null &&
+    session.providerPreference.defaultProvider !== 'anthropic' &&
+    !bannerDismissed;
+
+  const canLoadScope =
+    scope === 'global' ||
+    (scope === 'workspace' && workspace !== null) ||
+    (scope === 'session' && session !== null);
+
+  const loadRules = async () => {
+    if (!canLoadScope) {
+      setRules([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const list = await invokePermissionRuleList({
+        scope,
+        ...(scope === 'workspace' && workspace ? { workspaceId: workspace.id } : {}),
+        ...(scope === 'session' && session ? { sessionId: session.id } : {}),
+      });
+      setRules(list);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadRules();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, workspace?.id, session?.id]);
+
+  const openNew = () => {
+    setEditingRule('new');
+    setForm(emptyForm());
+    setFormError(null);
+  };
+
+  const openEdit = (rule: PermissionRule) => {
+    setEditingRule(rule);
+    setForm({
+      tool: rule.pattern.tool,
+      argsMatcher: rule.pattern.argsMatcher ?? '',
+      decision: rule.decision,
+      priority: String(rule.priority),
+    });
+    setFormError(null);
+  };
+
+  const cancelEdit = () => {
+    setEditingRule(null);
+    setFormError(null);
+  };
+
+  const onSave = async () => {
+    const tool = form.tool.trim();
+    if (!tool) {
+      setFormError('tool pattern is required');
+      return;
+    }
+    const priority = parseInt(form.priority, 10);
+    if (isNaN(priority)) {
+      setFormError('priority must be an integer');
+      return;
+    }
+    setSaving(true);
+    setFormError(null);
+    try {
+      const existingId = editingRule !== 'new' && editingRule ? editingRule.id : undefined;
+      await invokePermissionRuleUpsert({
+        ...(existingId ? { id: existingId } : {}),
+        scope,
+        ...(scope === 'workspace' && workspace ? { workspaceId: workspace.id } : {}),
+        ...(scope === 'session' && session ? { sessionId: session.id } : {}),
+        patternTool: tool,
+        ...(form.argsMatcher.trim() ? { patternArgsMatcher: form.argsMatcher.trim() } : {}),
+        decision: form.decision,
+        priority,
+      });
+      setEditingRule(null);
+      await loadRules();
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onDeleteConfirm = async (id: PermissionRuleId) => {
+    await invokePermissionRuleDelete(id);
+    setPendingDeleteId(null);
+    await loadRules();
+  };
+
+  if (editingRule !== null) {
+    return (
+      <RuleEditor
+        form={form}
+        onChange={setForm}
+        onSave={() => void onSave()}
+        onCancel={cancelEdit}
+        saving={saving}
+        error={formError}
+        isNew={editingRule === 'new'}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <div className="text-xs font-semibold text-foreground">permission rules</div>
+        {canLoadScope && (
+          <Button variant="ghost" size="sm" onClick={openNew}>
+            add rule
+          </Button>
+        )}
+      </div>
+
+      <ScopeTabs
+        current={scope}
+        onChange={(s) => {
+          setScope(s);
+          setBannerDismissed(false);
+        }}
+      />
+
+      {showNonClaudeBanner && (
+        <div className="flex items-start justify-between gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-[11px] text-warning">
+          <span>
+            permission proxy is currently claude-only. rules saved here will not affect cursor/codex
+            turns until v0.7.
+          </span>
+          <button
+            type="button"
+            className="shrink-0 underline hover:opacity-80"
+            onClick={() => setBannerDismissed(true)}
+          >
+            dismiss
+          </button>
+        </div>
+      )}
+
+      {scope === 'workspace' && !workspace && (
+        <p className="text-[11px] text-muted-foreground">
+          select a workspace to manage workspace rules.
+        </p>
+      )}
+      {scope === 'session' && !session && (
+        <p className="text-[11px] text-muted-foreground">
+          select a session to manage session rules.
+        </p>
+      )}
+
+      {canLoadScope && !loading && rules.length === 0 && (
+        <p className="text-[11px] text-muted-foreground">
+          no rules for this scope. add one to control which tools claude can use.
+        </p>
+      )}
+
+      {canLoadScope && rules.length > 0 && (
+        <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
+          {rules.map((rule) => (
+            <RuleRow
+              key={rule.id}
+              rule={rule}
+              onEdit={() => openEdit(rule)}
+              onDelete={() => setPendingDeleteId(rule.id)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {pendingDeleteId !== null && (
+        <DeleteConfirm
+          onConfirm={() => void onDeleteConfirm(pendingDeleteId)}
+          onCancel={() => setPendingDeleteId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ScopeTabs({ current, onChange }: { current: ScopeTab; onChange: (s: ScopeTab) => void }) {
+  const tabs: ScopeTab[] = ['global', 'workspace', 'session'];
+  return (
+    <div className="flex gap-1">
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          type="button"
+          className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+            current === tab
+              ? 'bg-foreground text-background'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => onChange(tab)}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function RuleRow({
+  rule,
+  onEdit,
+  onDelete,
+}: {
+  rule: PermissionRule;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const rendered = formatToolPattern(rule.pattern);
+  return (
+    <li className="flex items-center gap-3 px-3 py-2.5 text-xs">
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="font-mono font-medium">{rendered}</span>
+        <span className="text-[10px] text-muted-foreground">priority {rule.priority}</span>
+      </div>
+      <span
+        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${DECISION_BADGE[rule.decision]}`}
+      >
+        {rule.decision}
+      </span>
+      <button
+        type="button"
+        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-foreground"
+        onClick={onEdit}
+      >
+        edit
+      </button>
+      <button
+        type="button"
+        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-danger"
+        onClick={onDelete}
+      >
+        delete
+      </button>
+    </li>
+  );
+}
+
+function DeleteConfirm({ onConfirm, onCancel }: { onConfirm: () => void; onCancel: () => void }) {
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-md border border-danger/30 bg-danger/5 px-3 py-2.5 text-[11px]">
+      <span className="text-foreground">delete this rule?</span>
+      <div className="flex gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          cancel
+        </Button>
+        <Button size="sm" onClick={onConfirm}>
+          delete
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RuleEditor({
+  form,
+  onChange,
+  onSave,
+  onCancel,
+  saving,
+  error,
+  isNew,
+}: {
+  form: RuleForm;
+  onChange: (f: RuleForm) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  error: string | null;
+  isNew: boolean;
+}) {
+  const preview = computePreview(form);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const suggestions = TOOL_NAMES.filter((t) =>
+    t.toLowerCase().startsWith(form.tool.toLowerCase()),
+  ).filter((t) => t !== form.tool);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="text-xs font-semibold text-foreground">
+        {isNew ? 'add rule' : 'edit rule'}
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
+        <div className="relative flex flex-col gap-1.5">
+          <label className="text-[11px] font-semibold text-foreground">tool pattern</label>
+          <Input
+            value={form.tool}
+            onChange={(e) => {
+              onChange({ ...form, tool: e.target.value });
+              setShowSuggestions(true);
+            }}
+            onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+            onFocus={() => setShowSuggestions(true)}
+            placeholder="Bash"
+          />
+          {showSuggestions && suggestions.length > 0 && (
+            <ul className="absolute left-0 right-0 top-full z-10 mt-0.5 overflow-hidden rounded-md border border-border-soft bg-background shadow-md">
+              {suggestions.map((s) => (
+                <li key={s}>
+                  <button
+                    type="button"
+                    className="w-full px-3 py-1.5 text-left text-xs hover:bg-muted"
+                    onMouseDown={() => {
+                      onChange({ ...form, tool: s });
+                      setShowSuggestions(false);
+                    }}
+                  >
+                    {s}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label className="text-[11px] font-semibold text-foreground">
+            args matcher <span className="font-normal text-muted-foreground">(optional)</span>
+          </label>
+          <Input
+            value={form.argsMatcher}
+            onChange={(e) => onChange({ ...form, argsMatcher: e.target.value })}
+            placeholder="git:* or /path/to/file"
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <div className="flex flex-1 flex-col gap-1.5">
+            <label className="text-[11px] font-semibold text-foreground">decision</label>
+            <select
+              className="w-full rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              value={form.decision}
+              onChange={(e) =>
+                onChange({ ...form, decision: e.target.value as PermissionDecisionKind })
+              }
+            >
+              {DECISION_OPTIONS.map((d) => (
+                <option key={d} value={d}>
+                  {d}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-1 flex-col gap-1.5">
+            <label className="text-[11px] font-semibold text-foreground">priority</label>
+            <Input
+              type="number"
+              step="1"
+              placeholder="0"
+              value={form.priority}
+              onChange={(e) => onChange({ ...form, priority: e.target.value })}
+            />
+          </div>
+        </div>
+
+        {preview && (
+          <div className="rounded bg-muted px-2.5 py-2 font-mono text-[10px] text-muted-foreground">
+            renders as: <span className="text-foreground">{preview}</span>
+          </div>
+        )}
+
+        {error && <p className="text-[11px] text-danger">{error}</p>}
+
+        <div className="flex items-center justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
+            cancel
+          </Button>
+          <Button size="sm" onClick={onSave} disabled={saving}>
+            {saving ? 'saving…' : 'save'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -82,6 +82,14 @@ function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =>
               {info.version}
             </span>
           ) : null}
+          {info.id !== 'anthropic' ? (
+            <span
+              className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              title="v0.7 will extend the permission proxy to cursor and codex. For now, these providers continue with their previous defaults."
+            >
+              permission proxy: not supported
+            </span>
+          ) : null}
         </div>
         <RowStatus info={info} />
       </div>

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button, Dialog, Input } from '@kay-am/ui';
 import { ProvidersPanel } from './ProvidersPanel';
 import { BudgetRulesPanel } from './BudgetRulesPanel';
+import { PermissionsPanel } from './PermissionsPanel';
 import { SkillsPanel } from './SkillsPanel';
 import { PhasesPanel } from './PhasesPanel';
 import {
@@ -100,6 +101,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           <PhasesPanel workspaceId={workspace.id} />
         </div>
       ) : null}
+
+      <div className="border-t border-border-soft pt-4">
+        <PermissionsPanel />
+      </div>
 
       <div className="flex flex-col gap-4 border-t border-border-soft pt-4">
         <Section label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -1,11 +1,20 @@
 import { useState } from 'react';
-import { GitBranch, FolderOpen, Cpu, PanelRightClose, PanelRightOpen, Square } from 'lucide-react';
+import {
+  GitBranch,
+  FolderOpen,
+  Cpu,
+  PanelRightClose,
+  PanelRightOpen,
+  Square,
+  ShieldCheck,
+} from 'lucide-react';
 import { Button, cn } from '@kay-am/ui';
 import type { PhaseRun, PhaseRunStatus, ProviderId, Session, SessionId } from '@kay-am/types';
 import { getDefaultTurnModel } from '@kay-am/core';
 import { openInEditor } from '../../editor';
 import { DEFAULT_EDITOR_BINARY, SETTING_EDITOR_BINARY } from '../../settings';
 import { useAppStore } from '../../store';
+import { PermissionAuditPanel } from './PermissionAuditPanel';
 
 interface ChatHeaderProps {
   session: Session;
@@ -39,6 +48,7 @@ export function ChatHeader({
   );
   const [copied, setCopied] = useState(false);
   const [openErr, setOpenErr] = useState<string | null>(null);
+  const [auditOpen, setAuditOpen] = useState(false);
 
   const provider = session.providerPreference.defaultProvider;
   const model = session.providerPreference.defaultModel ?? getDefaultTurnModel(provider);
@@ -121,6 +131,15 @@ export function ChatHeader({
         <Button
           variant="ghost"
           size="sm"
+          onClick={() => setAuditOpen((v) => !v)}
+          title="permission audit log"
+          aria-label="permission audit log"
+        >
+          <ShieldCheck size={14} aria-hidden />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={onToggleContext}
           title={contextOpen ? 'hide context panel' : 'show context panel'}
           aria-label={contextOpen ? 'hide context panel' : 'show context panel'}
@@ -128,6 +147,11 @@ export function ChatHeader({
           {contextOpen ? <PanelRightClose size={14} /> : <PanelRightOpen size={14} />}
         </Button>
       </div>
+      <PermissionAuditPanel
+        sessionId={session.id}
+        open={auditOpen}
+        onClose={() => setAuditOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,17 +1,22 @@
-import { useState, useRef, useCallback, type KeyboardEvent } from 'react';
+import { useState, useRef, useCallback, useMemo, type KeyboardEvent } from 'react';
 import { Button, Textarea } from '@kay-am/ui';
 import type {
   BudgetAlert,
   BudgetAlertKind,
+  PermissionRule,
   ProviderId,
   Session,
+  SessionId,
   TurnProviderOverride,
+  WorkspaceId,
 } from '@kay-am/types';
+import { buildClaudeFlags } from '@kay-am/core';
 import { useShallow } from 'zustand/react/shallow';
 import { useAppStore } from '../../store';
 import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
+import { useEffectivePermissionRules } from '../../permissions';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -47,6 +52,11 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected')),
   );
   const workspaceSkills = useAppStore(useShallow((s) => s.skills[session.workspaceId] ?? []));
+
+  const effectiveRules = useEffectivePermissionRules({
+    sessionId: session.id,
+    workspaceId: session.workspaceId,
+  });
   const { showToast } = useToast();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -140,6 +150,12 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             onSendAnyway={value.trim().length > 0 ? () => void onSend() : undefined}
           />
         ) : null}
+        <PreflightPill
+          provider={effectiveProvider}
+          rules={effectiveRules}
+          sessionId={session.id}
+          workspaceId={session.workspaceId}
+        />
         <div className="relative" ref={wrapperRef}>
           {showPopover && isSlashMode ? (
             <SlashCommandPopover
@@ -199,5 +215,63 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         </div>
       </div>
     </div>
+  );
+}
+
+function PreflightPill({
+  provider,
+  rules,
+  sessionId,
+  workspaceId,
+}: {
+  provider: ProviderId;
+  rules: ReadonlyArray<PermissionRule>;
+  sessionId: SessionId;
+  workspaceId: WorkspaceId;
+}) {
+  const flags = useMemo(
+    () =>
+      provider === 'anthropic'
+        ? buildClaudeFlags({ rules, scope: { sessionId, workspaceId } })
+        : null,
+    [provider, rules, sessionId, workspaceId],
+  );
+
+  const openSettings = () => {
+    window.dispatchEvent(new CustomEvent('kayam:open-settings'));
+  };
+
+  if (provider !== 'anthropic') {
+    return (
+      <button
+        type="button"
+        onClick={openSettings}
+        title="v0.7 will extend permission coverage to this provider."
+        className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted"
+      >
+        permission proxy: claude only
+      </button>
+    );
+  }
+
+  if (!flags) return null;
+
+  const { allowedTools, disallowedTools } = flags;
+  const tooltipLines = [
+    allowedTools.length > 0 ? `--allowedTools "${allowedTools.join(' ')}"` : null,
+    disallowedTools.length > 0 ? `--disallowedTools "${disallowedTools.join(' ')}"` : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return (
+    <button
+      type="button"
+      onClick={openSettings}
+      title={tooltipLines || 'no permission rules configured'}
+      className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted"
+    >
+      permissions: {allowedTools.length} allow / {disallowedTools.length} deny
+    </button>
   );
 }

--- a/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
+++ b/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Button } from '@kay-am/ui';
+import type { PermissionAuditEntry, ProviderRunId, SessionId } from '@kay-am/types';
+import { useAppStore } from '../../store';
+import { invokePermissionAuditList, invokePermissionAuditClear } from '../../permissions';
+import { useToast } from '../Toast';
+
+interface Props {
+  sessionId: SessionId;
+  open: boolean;
+  onClose: () => void;
+}
+
+const RUNNING_KINDS = new Set(['starting', 'running']);
+
+function formatTime(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
+function inputPreview(input: unknown): string {
+  const raw = typeof input === 'string' ? input : JSON.stringify(input);
+  return raw.length > 80 ? raw.slice(0, 80) + '…' : raw;
+}
+
+function groupByRunId(
+  entries: ReadonlyArray<PermissionAuditEntry>,
+): Map<ProviderRunId, ReadonlyArray<PermissionAuditEntry>> {
+  const map = new Map<ProviderRunId, PermissionAuditEntry[]>();
+  for (const e of entries) {
+    const runId = e.request.runId;
+    const bucket = map.get(runId) ?? [];
+    bucket.push(e);
+    map.set(runId, bucket);
+  }
+  return map as Map<ProviderRunId, ReadonlyArray<PermissionAuditEntry>>;
+}
+
+export function PermissionAuditPanel({ sessionId, open, onClose }: Props) {
+  const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId));
+  const isStreaming = RUNNING_KINDS.has(session?.state.kind ?? 'idle');
+  const { showToast } = useToast();
+
+  const [entries, setEntries] = useState<ReadonlyArray<PermissionAuditEntry>>([]);
+  const [loading, setLoading] = useState(false);
+  const [clearing, setClearing] = useState(false);
+  const [confirmClear, setConfirmClear] = useState(false);
+
+  const [filterTool, setFilterTool] = useState('');
+  const [filterDecision, setFilterDecision] = useState<'all' | 'allow' | 'deny'>('all');
+  const [filterFrom, setFilterFrom] = useState('');
+  const [filterTo, setFilterTo] = useState('');
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!open) return;
+    try {
+      const result = await invokePermissionAuditList({ sessionId, limit: 500 });
+      setEntries(result);
+    } catch {
+      // silent — panel will show stale data
+    }
+  }, [open, sessionId]);
+
+  useEffect(() => {
+    if (!open) {
+      setEntries([]);
+      setFilterTool('');
+      setFilterDecision('all');
+      setFilterFrom('');
+      setFilterTo('');
+      setConfirmClear(false);
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      return;
+    }
+
+    setLoading(true);
+    void fetch().finally(() => setLoading(false));
+
+    if (isStreaming) {
+      intervalRef.current = setInterval(() => void fetch(), 2000);
+    }
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [open, fetch, isStreaming]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (isStreaming && !intervalRef.current) {
+      intervalRef.current = setInterval(() => void fetch(), 2000);
+    } else if (!isStreaming && intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, [isStreaming, open, fetch]);
+
+  const onClear = async () => {
+    if (!confirmClear) {
+      setConfirmClear(true);
+      return;
+    }
+    setClearing(true);
+    try {
+      await invokePermissionAuditClear({ sessionId });
+      setEntries([]);
+      showToast('warning', 'audit log cleared for this session');
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'clear failed');
+    } finally {
+      setClearing(false);
+      setConfirmClear(false);
+    }
+  };
+
+  const filtered = entries.filter((e) => {
+    if (filterTool && !e.request.toolName.toLowerCase().includes(filterTool.toLowerCase()))
+      return false;
+    if (filterDecision !== 'all') {
+      const outcome = e.decision.decision;
+      if (filterDecision === 'allow' && outcome !== 'allow') return false;
+      if (filterDecision === 'deny' && outcome !== 'deny') return false;
+    }
+    if (filterFrom) {
+      const from = new Date(filterFrom).getTime();
+      if (new Date(e.request.at).getTime() < from) return false;
+    }
+    if (filterTo) {
+      const to = new Date(filterTo).getTime() + 86400000;
+      if (new Date(e.request.at).getTime() > to) return false;
+    }
+    return true;
+  });
+
+  const grouped = groupByRunId(filtered);
+  const runIds = [...grouped.keys()];
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-40" aria-hidden onClick={onClose} />
+      <div className="fixed right-0 top-0 z-50 flex h-full w-[480px] max-w-full flex-col border-l border-border bg-background shadow-xl">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <span className="text-sm font-semibold">permission audit log</span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="close audit panel"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-2.5">
+          <input
+            type="text"
+            placeholder="filter by tool…"
+            value={filterTool}
+            onChange={(e) => setFilterTool(e.target.value)}
+            className="h-7 w-36 rounded border border-border bg-background px-2 text-xs text-foreground placeholder:text-muted-foreground"
+          />
+          <select
+            value={filterDecision}
+            onChange={(e) => setFilterDecision(e.target.value as 'all' | 'allow' | 'deny')}
+            className="h-7 rounded border border-border bg-background px-1 text-xs text-foreground"
+          >
+            <option value="all">all decisions</option>
+            <option value="allow">allow only</option>
+            <option value="deny">deny only</option>
+          </select>
+          <input
+            type="date"
+            value={filterFrom}
+            onChange={(e) => setFilterFrom(e.target.value)}
+            className="h-7 rounded border border-border bg-background px-1 text-xs text-foreground"
+            title="from date"
+          />
+          <input
+            type="date"
+            value={filterTo}
+            onChange={(e) => setFilterTo(e.target.value)}
+            className="h-7 rounded border border-border bg-background px-1 text-xs text-foreground"
+            title="to date"
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {loading ? (
+            <p className="text-xs text-muted-foreground">loading…</p>
+          ) : runIds.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              no tool calls recorded for this session yet.
+            </p>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {runIds.map((runId) => {
+                const runEntries = grouped.get(runId)!;
+                const firstAt = runEntries[0]?.request.at ?? '';
+                return (
+                  <div key={runId} className="flex flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                        run
+                      </span>
+                      <span className="font-mono text-[10px] text-muted-foreground">
+                        {String(runId).slice(0, 12)}…
+                      </span>
+                      {firstAt ? (
+                        <span className="text-[10px] text-muted-foreground/60">
+                          {formatTime(firstAt)}
+                        </span>
+                      ) : null}
+                    </div>
+                    <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle">
+                      {runEntries.map((e) => (
+                        <AuditRow key={e.request.id} entry={e} />
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center justify-end border-t border-border px-4 py-2.5">
+          <Button variant="ghost" size="sm" onClick={() => void onClear()} disabled={clearing}>
+            {confirmClear ? 'confirm clear?' : clearing ? 'clearing…' : 'clear audit for session'}
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function AuditRow({ entry }: { entry: PermissionAuditEntry }) {
+  const isAllow = entry.decision.decision === 'allow';
+  const ruleLabel =
+    entry.decision.decidedBy === 'default'
+      ? 'default'
+      : entry.decision.ruleId
+        ? `rule:${String(entry.decision.ruleId).slice(0, 8)}`
+        : entry.decision.decidedBy;
+
+  return (
+    <li className="flex items-start gap-3 px-3 py-2 text-xs">
+      <span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
+        {formatTime(entry.request.at)}
+      </span>
+      <span className="min-w-0 flex-1 font-mono text-[11px]">
+        <span className="font-semibold">{entry.request.toolName}</span>
+        <span className="ml-1 text-muted-foreground">{inputPreview(entry.request.input)}</span>
+      </span>
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <span
+          className={
+            isAllow
+              ? 'rounded-full bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700'
+              : 'rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700'
+          }
+        >
+          {isAllow ? 'allow' : 'deny'}
+        </span>
+        <span className="text-[9px] text-muted-foreground/60">{ruleLabel}</span>
+      </div>
+    </li>
+  );
+}

--- a/apps/desktop/src/permissions.ts
+++ b/apps/desktop/src/permissions.ts
@@ -222,3 +222,50 @@ export async function invokePermissionAuditClear(scope: PermissionAuditClearScop
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// Effective rules hook — for preflight banner
+// ---------------------------------------------------------------------------
+
+import { useEffect, useRef, useState } from 'react';
+
+export function useEffectivePermissionRules(args: {
+  sessionId: SessionId | null;
+  workspaceId: WorkspaceId | null;
+  refreshKey?: number;
+}): ReadonlyArray<PermissionRule> {
+  const { sessionId, workspaceId, refreshKey = 0 } = args;
+  const [rules, setRules] = useState<ReadonlyArray<PermissionRule>>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!sessionId || !workspaceId) {
+      setRules([]);
+      return;
+    }
+
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const [global, workspace, session] = await Promise.all([
+          invokePermissionRuleList({ scope: 'global' }),
+          invokePermissionRuleList({ scope: 'workspace', workspaceId }),
+          invokePermissionRuleList({ scope: 'session', sessionId }),
+        ]);
+        if (!cancelled) setRules([...global, ...workspace, ...session]);
+      } catch {
+        // silent
+      }
+    };
+
+    void load();
+    timerRef.current = setInterval(() => void load(), 30000);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [sessionId, workspaceId, refreshKey]);
+
+  return rules;
+}


### PR DESCRIPTION
Settings UI for v0.6 permission proxy.

- PermissionsPanel: scope tabs (global/workspace/session), rule list, add/edit dialog with tool pattern autocomplete + claude flag preview, delete with confirmation
- Non-claude warning banner on session scope (dismissible, component state only)
- ProvidersPanel: cursor/codex rows show `permission proxy: not supported` badge with tooltip

Closes #179
Closes #182