### PR TITLE
feat(desktop): wire permission proxy into turn pipeline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Local-first AI workspace orchestrator. This roadmap tracks the path from bootstrap to v1.0. Each version is a GitHub milestone; issues are created only as they approach implementation.
 
-> **Status**: v0.4 complete. v0.6 next planned.
+> **Status**: v0.6 complete. v0.7 next planned.
 
 ## Architectural decisions (locked)
 
@@ -342,6 +342,61 @@ Skills: local registry of markdown + scripts, invocable via slash commands, exec
 #126 → #128 → #134 → #137
 #126 → #127 → #131
 #126 → #135 → #137
+```
+
+---
+
+## v0.6 issue index
+
+Permission proxy: tool-call interception via static rules + audit, removing `--dangerously-skip-permissions` for claude.
+
+### Foundation (parallelizable)
+
+- [#170 — feat(types): permission domain types](https://github.com/akhayam99/kay-am/issues/170)
+- [#171 — feat(db): m008 permissions migration](https://github.com/akhayam99/kay-am/issues/171) — depends on #170
+
+### Core layer
+
+- [#172 — feat(core): permission engine](https://github.com/akhayam99/kay-am/issues/172) — depends on #170
+- [#173 — feat(core): tool matcher patterns](https://github.com/akhayam99/kay-am/issues/173) — depends on #170
+- [#174 — feat(core): permission audit recorder](https://github.com/akhayam99/kay-am/issues/174) — depends on #171
+- [#175 — feat(core): permission rules → claude CLI flags](https://github.com/akhayam99/kay-am/issues/175) — depends on #173
+
+### Tauri commands
+
+- [#176 — feat(desktop): permission rule CRUD tauri commands](https://github.com/akhayam99/kay-am/issues/176) — depends on #171
+- [#177 — feat(desktop): permission audit log tauri commands](https://github.com/akhayam99/kay-am/issues/177) — depends on #174
+
+### UI
+
+- [#179 — feat(ui): permissions settings panel](https://github.com/akhayam99/kay-am/issues/179) — depends on #176
+- [#180 — feat(ui): permission audit log viewer](https://github.com/akhayam99/kay-am/issues/180) — depends on #177
+- [#181 — feat(ui): pre-flight permission summary in chat input](https://github.com/akhayam99/kay-am/issues/181) — depends on #175
+- [#182 — feat(ui): provider support indicator (cursor/codex limitation)](https://github.com/akhayam99/kay-am/issues/182) — depends on #176
+
+### Integration
+
+- [#178 — feat(desktop): wire permission flags into turn_spawn (rust)](https://github.com/akhayam99/kay-am/issues/178) — depends on #175
+- [#183 — feat(desktop): wire permission engine into sendTurn](https://github.com/akhayam99/kay-am/issues/183) — depends on #172, #175, #178
+- [#184 — feat(desktop): persist tool-call → audit on stream events](https://github.com/akhayam99/kay-am/issues/184) — depends on #174, #183
+- [#186 — test(core): permission engine + matcher contract tests](https://github.com/akhayam99/kay-am/issues/186) — depends on #172, #173, #175
+- [#187 — test(desktop): permission proxy integration smoke](https://github.com/akhayam99/kay-am/issues/187) — depends on #183
+- [#188 — feat(desktop): roadmap + docs update + integration glue](https://github.com/akhayam99/kay-am/issues/188) — depends on #183, #184, #186, #187
+
+### Stretch (deferred)
+
+- [#185 — feat(types/core): permission_request + permission_decision TurnEvent (MCP path)](https://github.com/akhayam99/kay-am/issues/185) → slipped to v0.7
+
+### Critical path
+
+```
+#170 → #171 → #176 → #179 → #183 → #188
+       #172 → #183
+       #173 → #175 → #178 → #183
+                  ↘ #181
+       #174 → #177 → #180
+                  ↘ #184 → #188
+       #186 + #187 → #188
 ```
 
 ---

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -43,8 +43,11 @@ impl TurnError {
     }
 }
 
+type ChildSlot = Arc<Mutex<Option<Child>>>;
+type ChildRegistry = Arc<Mutex<HashMap<String, ChildSlot>>>;
+
 #[derive(Default)]
-pub struct TurnRegistry(pub Arc<Mutex<HashMap<String, Arc<Mutex<Option<Child>>>>>>);
+pub struct TurnRegistry(pub ChildRegistry);
 
 impl TurnRegistry {
     pub fn new() -> Self {
@@ -61,6 +64,12 @@ pub struct SpawnArgs {
     pub prompt: String,
     #[serde(default)]
     pub binary: Option<String>,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub disallowed_tools: Vec<String>,
+    #[serde(default)]
+    pub permission_mode: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -91,7 +100,23 @@ pub fn turn_spawn(
     args: SpawnArgs,
 ) -> Result<String, TurnError> {
     let binary = args.binary.unwrap_or_else(|| "claude".to_string());
-    let mut child = Command::new(binary)
+    let permission_mode = args
+        .permission_mode
+        .clone()
+        .unwrap_or_else(|| "default".to_string());
+
+    if permission_mode == "bypassPermissions"
+        && args.allowed_tools.is_empty()
+        && args.disallowed_tools.is_empty()
+    {
+        eprintln!(
+            "[turn_spawn] permission_mode=bypassPermissions with no rules — \
+             relying on claude CLI native bypass; --dangerously-skip-permissions intentionally not set"
+        );
+    }
+
+    let mut command = Command::new(binary);
+    command
         .arg("-p")
         .arg(&args.prompt)
         .arg("--output-format")
@@ -100,7 +125,19 @@ pub fn turn_spawn(
         .arg(&args.working_dir)
         .arg("--model")
         .arg(&args.model)
-        .arg("--dangerously-skip-permissions")
+        .arg("--permission-mode")
+        .arg(&permission_mode);
+
+    if !args.allowed_tools.is_empty() {
+        command.arg("--allowedTools").arg(args.allowed_tools.join(","));
+    }
+    if !args.disallowed_tools.is_empty() {
+        command
+            .arg("--disallowedTools")
+            .arg(args.disallowed_tools.join(","));
+    }
+
+    let mut child = command
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -197,8 +234,8 @@ fn capture_stderr(mut stderr: ChildStderr) -> String {
 }
 
 fn wait_and_remove(
-    slot: &Arc<Mutex<Option<Child>>>,
-    registry: &Arc<Mutex<HashMap<String, Arc<Mutex<Option<Child>>>>>>,
+    slot: &ChildSlot,
+    registry: &ChildRegistry,
     run_id: &str,
 ) -> Option<i32> {
     let exit = {

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  PermissionRule,
+  PermissionRuleId,
+  ProviderRunId,
+  Session,
+  SessionId,
+  TurnEvent,
+  WorkspaceId,
+} from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — these MUST be hoisted before importing the store
+// ---------------------------------------------------------------------------
+
+const runTurnSpy = vi.fn();
+const cancelTurnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  runTurn: (args: unknown) => runTurnSpy(args),
+  cancelTurn: cancelTurnSpy,
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+const permissionRuleListSpy = vi.fn();
+const permissionAuditInsertSpy = vi.fn();
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: (args: unknown) => permissionRuleListSpy(args),
+  invokePermissionAuditInsert: (args: unknown) => permissionAuditInsertSpy(args),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [
+    { id: 'anthropic', binary: 'claude', connection: 'connected' },
+    { id: 'cursor', binary: 'cursor-agent', connection: 'connected' },
+  ],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({
+  resolveProviderForTurn: vi.fn(async (_pref, _override, _connected) => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+function buildSession(): Session {
+  const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'test',
+    state: { kind: 'idle', lastActivityAt: now },
+    contextSlots: [],
+    providerPreference: {
+      defaultProvider: 'anthropic',
+      allowTurnOverride: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildRule(overrides: Partial<PermissionRule>): PermissionRule {
+  const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+  return {
+    id: 'rule-1' as PermissionRuleId,
+    scope: 'session',
+    sessionId: SESSION_ID,
+    pattern: { tool: 'Edit' },
+    decision: 'allow',
+    priority: 100,
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+async function* emptyStream(): AsyncIterable<TurnEvent> {
+  // emit nothing — turn ends immediately
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendTurn — permission proxy integration', () => {
+  beforeEach(async () => {
+    runTurnSpy.mockReset();
+    cancelTurnSpy.mockReset();
+    permissionRuleListSpy.mockReset();
+    permissionAuditInsertSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+    permissionRuleListSpy.mockResolvedValue([]);
+    const routingMod = await import('../routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockReset();
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-3-5-sonnet-latest',
+      reason: 'preference',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function importStore() {
+    const mod = await import('./store');
+    return mod.useAppStore;
+  }
+
+  function setupSession(useAppStore: Awaited<ReturnType<typeof importStore>>) {
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: '/tmp/wt' },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: {
+        anthropic: { state: 'connected', identity: 'test' },
+        cursor: { state: 'connected', identity: 'test' },
+        codex: { state: 'connected', identity: 'test' },
+      } as never,
+      workspaces: [
+        {
+          id: WORKSPACE_ID,
+          name: 'ws',
+          rootPath: '/tmp',
+          createdAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+          updatedAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+        },
+      ],
+    });
+  }
+
+  it('forwards disallowedTools when a deny rule is configured (claude)', async () => {
+    permissionRuleListSpy.mockImplementation(async (args: { scope: string }) => {
+      if (args.scope === 'session') {
+        return [
+          buildRule({
+            decision: 'deny',
+            pattern: { tool: 'Bash', argsMatcher: 'rm:*' },
+          }),
+        ];
+      }
+      return [];
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hello' });
+
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.disallowedTools).toEqual(['Bash(rm:*)']);
+    expect(args.allowedTools).toEqual([]);
+    expect(args.permissionMode).toBe('default');
+  });
+
+  it('forwards allowedTools when an allow rule is configured (claude)', async () => {
+    permissionRuleListSpy.mockImplementation(async (args: { scope: string }) => {
+      if (args.scope === 'session') {
+        return [buildRule({ decision: 'allow', pattern: { tool: 'Edit' } })];
+      }
+      return [];
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.allowedTools).toEqual(['Edit']);
+    expect(args.disallowedTools).toEqual([]);
+  });
+
+  it('forwards empty tool lists with default mode when no rules exist (claude)', async () => {
+    permissionRuleListSpy.mockResolvedValue([]);
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.allowedTools).toEqual([]);
+    expect(args.disallowedTools).toEqual([]);
+    expect(args.permissionMode).toBe('default');
+    // regression guard: never carry the legacy bypass flag through the JS payload
+    expect(JSON.stringify(args)).not.toContain('dangerously-skip-permissions');
+  });
+
+  it('does NOT forward permission flags when provider is cursor', async () => {
+    const routingMod = await import('../routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      selectedProvider: 'cursor',
+      selectedModel: 'cursor-default',
+      reason: 'preference',
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args.allowedTools).toBeUndefined();
+    expect(args.disallowedTools).toBeUndefined();
+    expect(args.permissionMode).toBeUndefined();
+    expect(permissionRuleListSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -2,11 +2,14 @@ import { create } from 'zustand';
 import { invoke } from '@tauri-apps/api/core';
 import {
   PhaseContextPropagator,
+  PermissionEngine,
+  buildClaudeFlags,
   buildPhasePrompt,
   nextPhase,
   parseSlashCommand,
   sessionReducer,
   Summarizer,
+  type ClaudeFlagSet,
   type SlotKey,
 } from '@kay-am/core';
 import {
@@ -38,6 +41,9 @@ import type {
   IsoDateTime,
   Message,
   MessageId,
+  PermissionRequest,
+  PermissionRequestId,
+  PermissionRule,
   PhaseDefinition,
   PhaseRun,
   PhaseRunId,
@@ -99,6 +105,7 @@ import {
   resolveSkillInvocation,
   type SkillUpsertArgs,
 } from '../skills';
+import { invokePermissionRuleList, invokePermissionAuditInsert } from '../permissions';
 import {
   invokePhaseTemplateList,
   invokePhaseTemplateUpsert,
@@ -898,6 +905,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     const providerInfo = get().providers.find((p) => p.id === provider);
 
+    let claudeFlags: Partial<ClaudeFlagSet> = {};
+    let effectiveRules: ReadonlyArray<PermissionRule> = [];
+    if (provider === 'anthropic') {
+      try {
+        const [globalRules, workspaceRules, sessionRules] = await Promise.all([
+          invokePermissionRuleList({ scope: 'global' }),
+          invokePermissionRuleList({ scope: 'workspace', workspaceId: session.workspaceId }),
+          invokePermissionRuleList({ scope: 'session', sessionId }),
+        ]);
+        effectiveRules = [...globalRules, ...workspaceRules, ...sessionRules];
+        const flags = buildClaudeFlags({
+          rules: effectiveRules,
+          scope: { workspaceId: session.workspaceId, sessionId },
+        });
+        claudeFlags = {
+          allowedTools: flags.allowedTools,
+          disallowedTools: flags.disallowedTools,
+          permissionMode: flags.permissionMode,
+        };
+      } catch (err) {
+        console.error('permission rule load failed; falling back to empty rule set', err);
+        claudeFlags = { allowedTools: [], disallowedTools: [], permissionMode: 'default' };
+      }
+    }
+
     let assistantText = '';
     let lastError: unknown = null;
 
@@ -908,9 +940,42 @@ export const useAppStore = create<AppStore>((set, get) => ({
         workingDir,
         prompt: resolvedPrompt,
         binary: providerInfo?.binary,
+        ...claudeFlags,
       })) {
         get().appendTurnEvent(sessionId, event);
         if (event.kind === 'assistant_text') assistantText += event.delta;
+
+        if (provider === 'anthropic' && event.kind === 'tool_call_start') {
+          try {
+            const engine = new PermissionEngine();
+            const request: PermissionRequest = {
+              id: crypto.randomUUID() as PermissionRequestId,
+              runId,
+              toolUseId: event.toolUseId,
+              toolName: event.toolName,
+              input: event.input,
+              at: event.at,
+            };
+            const decision = engine.decide(request, effectiveRules, {
+              sessionId,
+              workspaceId: session.workspaceId,
+            });
+            await invokePermissionAuditInsert({
+              runId,
+              sessionId,
+              toolUseId: event.toolUseId,
+              toolName: event.toolName,
+              inputJson: JSON.stringify(event.input),
+              decision: decision.decision,
+              ...(decision.ruleId != null && { ruleId: decision.ruleId }),
+              decidedBy: decision.decidedBy,
+              requestedAt: event.at,
+              decidedAt: decision.at,
+            });
+          } catch (err) {
+            console.error('permission audit insert failed', err);
+          }
+        }
 
         if (event.kind === 'usage') {
           const cost = computeCostUsd(event.usage, model);

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -43,12 +43,22 @@ export function isAuthErrorMessage(text: string): boolean {
 
 const EVENT_NAME = 'turn_event';
 
+export type ClaudePermissionMode =
+  | 'default'
+  | 'acceptEdits'
+  | 'bypassPermissions'
+  | 'dontAsk'
+  | 'plan';
+
 interface SpawnArgs {
   readonly runId: ProviderRunId;
   readonly model: string;
   readonly workingDir: string;
   readonly prompt: string;
   readonly binary?: string;
+  readonly allowedTools?: ReadonlyArray<string>;
+  readonly disallowedTools?: ReadonlyArray<string>;
+  readonly permissionMode?: ClaudePermissionMode;
 }
 
 type RawTurnEnvelope =


### PR DESCRIPTION
Final v0.6 milestone PR. Removes `--dangerously-skip-permissions` from claude spawn; replaces with static rule-driven flag set + audit logging.

## Changes

- `turn.rs` SpawnArgs accepts allowed/disallowed/permission_mode; argv built dynamically.
- `turn.ts` mirrors new fields.
- `sendTurn` (provider=anthropic) loads effective rules across scopes, computes `ClaudeFlagSet`, forwards to `runTurn`; records audit entries on `tool_call_start`. Audit failures swallowed (console.error) so they cannot crash a turn.
- Smoke tests for allow/deny/no-rule + cursor regression guard. Includes explicit assertion that the JS-side payload never contains `dangerously-skip-permissions`.
- ROADMAP v0.6 issue index appended; status header bumped to `v0.6 complete. v0.7 next planned.`

## Verified

- No `--dangerously-skip-permissions` left in `apps/desktop/src-tauri/src/turn.rs` (only an `eprintln!` warning string referencing the legacy flag for context).
- `cargo check` + `cargo clippy -- -D warnings` clean (also fixed two pre-existing `type_complexity` warnings on the child registry).
- `pnpm -r typecheck` clean.
- `pnpm -r test --run` 296 + 4 passed.
- `pnpm --filter @kay-am/desktop build` succeeds.

## Notes

- The node-only `packages/core/src/providers/claude/adapter.ts` still hardcodes `--dangerously-skip-permissions`. It is NOT used by the desktop turn pipeline (which spawns directly via the rust `turn_spawn` command). Out of scope for v0.6 milestone closure; can be refactored in v0.7 alongside the MCP path (#185).

Closes #178
Closes #183
Closes #184
Closes #187
Closes #188