### PR TITLE
refactor(core): parametrize claude ts adapter permission flags (#198)

### DIFF
--- a/packages/core/src/providers/claude/adapter.test.ts
+++ b/packages/core/src/providers/claude/adapter.test.ts
@@ -1,7 +1,14 @@
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
-import type { IsoDateTime, ProviderRunId, SessionId, TurnEvent, TurnRequest } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  ProviderRunId,
+  SessionId,
+  TurnEvent,
+  TurnPermissionFlags,
+  TurnRequest,
+} from '@kay-am/types';
 import { ClaudeAdapter } from './adapter';
 
 const fakeNow = (): IsoDateTime => '2026-05-07T00:00:00.000Z' as IsoDateTime;
@@ -57,7 +64,7 @@ function makeOpenChild(lines: ReadonlyArray<string>): OpenChild {
   return new OpenChild(lines);
 }
 
-function makeRequest(): TurnRequest {
+function makeRequest(permissionFlags?: TurnPermissionFlags): TurnRequest {
   return {
     runId: 'run_1' as ProviderRunId,
     sessionId: 'sess_1' as SessionId,
@@ -65,6 +72,7 @@ function makeRequest(): TurnRequest {
     workingDir: '/tmp/demo',
     systemPrompt: 'sys',
     userMessage: 'hi',
+    permissionFlags,
   };
 }
 
@@ -138,5 +146,66 @@ describe('ClaudeAdapter.detect', () => {
     });
     const result = await adapter.detect();
     expect(result.kind).toBe('missing');
+  });
+});
+
+describe('spawnClaude — permission flags', () => {
+  function captureArgs(permissionFlags?: TurnPermissionFlags): string[] {
+    let capturedArgs: string[] = [];
+    const child = new FakeChild([]);
+    const spawnFn = (_binary: string, args: string[]) => {
+      capturedArgs = args;
+      return child;
+    };
+    const adapter = new ClaudeAdapter({
+      now: fakeNow,
+      spawnFn: spawnFn as never,
+    });
+    void (async () => {
+      for await (const _ of adapter.spawn(makeRequest(permissionFlags))) {
+        // drain
+      }
+    })();
+    return capturedArgs;
+  }
+
+  it('uses --permission-mode default and omits legacy bypass flag when no permissionFlags provided', () => {
+    const args = captureArgs();
+    expect(args).toContain('--permission-mode');
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('default');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+    expect(args).not.toContain('--allowedTools');
+    expect(args).not.toContain('--disallowedTools');
+  });
+
+  it('passes bypassPermissions mode without legacy bypass flag', () => {
+    const args = captureArgs({ mode: 'bypassPermissions' });
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('bypassPermissions');
+    expect(args).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('appends --allowedTools as comma-list when allowedTools non-empty', () => {
+    const args = captureArgs({ mode: 'default', allowedTools: ['Edit', 'Read'] });
+    expect(args).toContain('--allowedTools');
+    expect(args[args.indexOf('--allowedTools') + 1]).toBe('Edit,Read');
+    expect(args).not.toContain('--disallowedTools');
+  });
+
+  it('appends --disallowedTools as comma-list when disallowedTools non-empty', () => {
+    const args = captureArgs({ mode: 'default', disallowedTools: ['Bash(rm:*)'] });
+    expect(args).toContain('--disallowedTools');
+    expect(args[args.indexOf('--disallowedTools') + 1]).toBe('Bash(rm:*)');
+    expect(args).not.toContain('--allowedTools');
+  });
+
+  it('appends both tool lists when both provided', () => {
+    const args = captureArgs({
+      mode: 'plan',
+      allowedTools: ['Read'],
+      disallowedTools: ['Bash'],
+    });
+    expect(args[args.indexOf('--permission-mode') + 1]).toBe('plan');
+    expect(args[args.indexOf('--allowedTools') + 1]).toBe('Read');
+    expect(args[args.indexOf('--disallowedTools') + 1]).toBe('Bash');
   });
 });

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -99,6 +99,9 @@ async function* spawnClaude(
   request: TurnRequest,
 ): AsyncIterable<TurnEvent> {
   const prompt = `${request.systemPrompt}\n\n${request.userMessage}`.trim();
+  const flags = request.permissionFlags;
+  const mode = flags?.mode ?? 'default';
+
   const args = [
     '-p',
     prompt,
@@ -108,8 +111,19 @@ async function* spawnClaude(
     request.workingDir,
     '--model',
     request.model,
-    '--dangerously-skip-permissions',
+    '--permission-mode',
+    mode,
   ];
+
+  const allowedTools = flags?.allowedTools ?? [];
+  const disallowedTools = flags?.disallowedTools ?? [];
+
+  if (allowedTools.length > 0) {
+    args.push('--allowedTools', allowedTools.join(','));
+  }
+  if (disallowedTools.length > 0) {
+    args.push('--disallowedTools', disallowedTools.join(','));
+  }
 
   const child: ChildProcess = spawnFn(binary, args, {
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -21,6 +21,14 @@ export type DetectResult =
   | { kind: 'available'; binary: string; version: string }
   | { kind: 'missing'; binary: string; reason: string };
 
+export type PermissionMode = 'default' | 'bypassPermissions' | 'plan' | 'acceptEdits';
+
+export interface TurnPermissionFlags {
+  readonly mode: PermissionMode;
+  readonly allowedTools?: ReadonlyArray<string>;
+  readonly disallowedTools?: ReadonlyArray<string>;
+}
+
 export interface TurnRequest {
   readonly runId: ProviderRunId;
   readonly sessionId: SessionId;
@@ -28,6 +36,7 @@ export interface TurnRequest {
   readonly workingDir: string;
   readonly systemPrompt: string;
   readonly userMessage: string;
+  readonly permissionFlags?: TurnPermissionFlags;
 }
 
 export type TurnEvent =

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,10 +17,12 @@ export type { Message, MessageRole } from './message';
 export type { ProviderName, ProviderRun, ProviderRunStatus } from './provider';
 export type {
   DetectResult,
+  PermissionMode,
   ProviderAdapter,
   ProviderCapabilities,
   ProviderUsage,
   TurnEvent,
+  TurnPermissionFlags,
   TurnRequest,
 } from './adapter';
 export type { TelemetryKind, TelemetryRecord } from './telemetry';


### PR DESCRIPTION
## Summary

- Extend `TurnRequest` in `packages/types/src/adapter.ts` with optional `permissionFlags: TurnPermissionFlags` (new exported types: `PermissionMode`, `TurnPermissionFlags`)
- Drop hardcoded `--dangerously-skip-permissions` from `spawnClaude`; build args dynamically via `--permission-mode <mode>` (default `'default'`) + conditional `--allowedTools`/`--disallowedTools`, mirroring `turn.rs:118-138`
- Add 5 new tests covering: no-flags default, bypassPermissions mode, allowedTools, disallowedTools, both lists; regression guard for absent legacy flag

**Type owner decision**: `TurnRequest` (not `ClaudeAdapterDeps`) owns `permissionFlags` — it is per-turn data that varies per call, not adapter-level config. Matches the rust `SpawnArgs` shape.

Closes #198
Part 2 of #185 (deferred from v0.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)