### PR TITLE
feat(db,core,desktop): persist session worktrees in m009 table

### DIFF
--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -35,7 +35,7 @@ export function StatusBar({ onEndSession, onOpenTelemetry }: StatusBarProps) {
     session ? (s.sessionTelemetry[session.id] ?? null) : null,
   );
   const worktreePath = useAppStore((s) =>
-    session ? (s.sessionWorktrees[session.id] ?? null) : null,
+    session ? ((s.sessionWorktrees[session.id] ?? [])[0] ?? null) : null,
   );
   const editorBinary = useAppStore(
     (s) => s.settings[SETTING_EDITOR_BINARY] ?? DEFAULT_EDITOR_BINARY,

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -173,7 +173,7 @@ interface SessionRowProps {
 }
 
 function SessionRow({ session, isActive, onClick }: SessionRowProps) {
-  const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id] ?? null);
+  const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const providerId = session.providerPreference.defaultProvider;
   const budget = useAppStore((s) => s.sessionBudgets[session.id as SessionId] ?? null);
   const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -19,7 +19,7 @@ const PIN_TOLERANCE_PX = 32;
 export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }: ChatViewProps) {
   const events = useTranscript(session.id);
   const items = useMemo(() => reduceTranscript(events), [events]);
-  const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id] ?? null);
+  const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const authResults = useAppStore((s) => s.authResults);
   const refreshProviders = useAppStore((s) => s.refreshProviders);
   const scrollerRef = useRef<HTMLDivElement>(null);

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -199,7 +199,7 @@ describe('sendTurn — permission proxy integration', () => {
   function setupSession(useAppStore: Awaited<ReturnType<typeof importStore>>) {
     useAppStore.setState({
       sessions: [buildSession()],
-      sessionWorktrees: { [SESSION_ID]: '/tmp/wt' },
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
       providers: [
         {
           id: 'anthropic',

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -17,6 +17,7 @@ import {
   insertMessage,
   insertProviderRun,
   insertSession,
+  insertSessionWorktree,
   insertTelemetry,
   insertWorkspace,
   listContextSlotsForSession,
@@ -24,6 +25,8 @@ import {
   listSessionsForWorkspace,
   listTelemetryForSession,
   listWorkspaces,
+  listWorktreesForSession,
+  deleteWorktreesForSession,
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
   summarizeWorkspaceTelemetry,
@@ -143,7 +146,7 @@ export interface AppState {
   readonly error: string | null;
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
-  readonly sessionWorktrees: Readonly<Record<string, string>>;
+  readonly sessionWorktrees: Readonly<Record<string, ReadonlyArray<string>>>;
   readonly sessionTelemetry: Readonly<Record<string, ReadonlyArray<TelemetryRecord>>>;
   readonly workspaceSummary: TelemetrySummary | null;
   readonly sessionSlots: Readonly<Record<string, ReadonlyArray<ContextSlot>>>;
@@ -515,8 +518,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
           invokeSkillList(id),
           invokePhaseTemplateList(id),
         ]);
+      const worktreeRows = await Promise.all(
+        sessions.map((s) => listWorktreesForSession(tauriDatabase, s.id)),
+      );
+      const sessionWorktrees: Record<string, ReadonlyArray<string>> = {};
+      for (let i = 0; i < sessions.length; i++) {
+        const s = sessions[i]!;
+        const rows = worktreeRows[i]!;
+        if (rows.length > 0) {
+          sessionWorktrees[s.id] = rows.map((r) => r.worktreePath);
+        }
+      }
       set((state) => ({
         sessions,
+        sessionWorktrees,
         workspaceSummary,
         providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
         skills: { ...state.skills, [id]: skills },
@@ -656,13 +671,24 @@ export const useAppStore = create<AppStore>((set, get) => ({
       updatedAt: now,
     };
     await insertSession(tauriDatabase, session);
+    await insertSessionWorktree(tauriDatabase, {
+      id: crypto.randomUUID(),
+      sessionId: session.id,
+      worktreePath: worktree.worktreePath,
+      branch: worktree.branchName,
+      parallelIndex: 0,
+      createdAt: Date.now(),
+    });
 
     set((state) => ({
       sessions:
         state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
       currentSessionId: session.id,
       sessionSummary: null,
-      sessionWorktrees: { ...state.sessionWorktrees, [session.id]: worktree.worktreePath },
+      sessionWorktrees: {
+        ...state.sessionWorktrees,
+        [session.id]: [worktree.worktreePath],
+      },
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
 
@@ -697,10 +723,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const before = get();
     const session = before.sessions.find((s) => s.id === sessionId);
     if (!session) throw new Error(`session not found: ${sessionId}`);
-    const workingDir = before.sessionWorktrees[sessionId];
+    const workingDir = (before.sessionWorktrees[sessionId] ?? [])[0] ?? null;
     if (!workingDir) {
       throw new Error(
-        'session worktree not initialized — open a fresh session (worktree paths are not yet persisted across restarts)',
+        'session worktree not initialized — restart the app to reload persisted worktree paths',
       );
     }
 
@@ -1195,16 +1221,21 @@ export const useAppStore = create<AppStore>((set, get) => ({
       await cancelTurn(session.state.runId);
     }
 
-    const worktreePath = get().sessionWorktrees[sessionId];
+    const worktreePaths = get().sessionWorktrees[sessionId] ?? [];
     const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
-    if (worktreePath && workspace) {
-      try {
-        await removeWorktree(workspace.rootPath, worktreePath);
-      } catch (err) {
-        // worktree may already be gone — surface as warning, continue ending
-        console.warn(`worktree_remove failed: ${err instanceof Error ? err.message : String(err)}`);
+    if (workspace) {
+      for (const worktreePath of worktreePaths) {
+        try {
+          await removeWorktree(workspace.rootPath, worktreePath);
+        } catch (err) {
+          // worktree may already be gone — surface as warning, continue ending
+          console.warn(
+            `worktree_remove failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
     }
+    await deleteWorktreesForSession(tauriDatabase, sessionId);
 
     const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
     const ended: SessionState = sessionReducer(session.state, { kind: 'end', at: now() });

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -170,7 +170,7 @@ describe('setCurrentWorkspace — session-scoped state cleanup', () => {
       messages: { [SESSION_IDLE]: [] },
       sessionTelemetry: { [SESSION_IDLE]: [] },
       sessionSlots: { [SESSION_IDLE]: [] },
-      sessionWorktrees: { [SESSION_IDLE]: '/tmp/wt' },
+      sessionWorktrees: { [SESSION_IDLE]: ['/tmp/wt'] },
       sessionPhaseRuns: { [SESSION_IDLE]: [] },
       sessionBudgets: { [SESSION_IDLE]: { softCapUsd: 10 } as never },
       summarizerStatus: { [SESSION_IDLE]: { status: 'idle', lastUpdate: null, error: null } },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -59,3 +59,9 @@ export {
   insertPhaseRun,
   updatePhaseRunStatus,
 } from './queries/phase-runs';
+export {
+  insertSessionWorktree,
+  listWorktreesForSession,
+  deleteWorktreesForSession,
+  type SessionWorktree,
+} from './queries/session-worktrees';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -6,6 +6,7 @@ import { m005BudgetTables } from './m005-budget-tables';
 import { m006Skills } from './m006-skills';
 import { m007Phases } from './m007-phases';
 import { m008Permissions } from './m008-permissions';
+import { m009SessionWorktrees } from './m009-session-worktrees';
 
 export interface Migration {
   readonly version: number;
@@ -21,4 +22,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 6, sql: m006Skills },
   { version: 7, sql: m007Phases },
   { version: 8, sql: m008Permissions },
+  { version: 9, sql: m009SessionWorktrees },
 ];

--- a/packages/db/src/migrations/m009-session-worktrees.ts
+++ b/packages/db/src/migrations/m009-session-worktrees.ts
@@ -1,0 +1,12 @@
+export const m009SessionWorktrees = /* sql */ `
+CREATE TABLE IF NOT EXISTS session_worktrees (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  worktree_path TEXT NOT NULL,
+  branch TEXT NOT NULL,
+  parallel_index INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_session_worktrees_session_id ON session_worktrees(session_id);
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -29,6 +29,11 @@ import {
   insertPhaseRun,
   updatePhaseRunStatus,
 } from '../queries/phase-runs';
+import {
+  insertSessionWorktree,
+  listWorktreesForSession,
+  deleteWorktreesForSession,
+} from '../queries/session-worktrees';
 
 const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
@@ -217,5 +222,59 @@ describe('migrate', () => {
     await deletePhaseTemplate(db, template.id);
     const deleted = await getPhaseTemplate(db, template.id);
     expect(deleted).toBeNull();
+  });
+
+  it('round-trips session_worktrees: insert, list, delete', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_wt' as WorkspaceId,
+      name: 'wt-test',
+      rootPath: '/tmp/wt-test',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+
+    const session: Session = {
+      id: 'sess_wt' as SessionId,
+      workspaceId: workspace.id,
+      goal: 'worktree test',
+      state: { kind: 'draft' },
+      contextSlots: [],
+      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertSession(db, session);
+
+    await insertSessionWorktree(db, {
+      id: 'wt_1',
+      sessionId: session.id,
+      worktreePath: '/tmp/worktrees/wt_1',
+      branch: 'kay/feat-1',
+      parallelIndex: 0,
+      createdAt: Date.now(),
+    });
+    await insertSessionWorktree(db, {
+      id: 'wt_2',
+      sessionId: session.id,
+      worktreePath: '/tmp/worktrees/wt_2',
+      branch: 'kay/feat-2',
+      parallelIndex: 1,
+      createdAt: Date.now(),
+    });
+
+    const rows = await listWorktreesForSession(db, session.id);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.worktreePath).toBe('/tmp/worktrees/wt_1');
+    expect(rows[0]!.parallelIndex).toBe(0);
+    expect(rows[1]!.worktreePath).toBe('/tmp/worktrees/wt_2');
+    expect(rows[1]!.parallelIndex).toBe(1);
+
+    await deleteWorktreesForSession(db, session.id);
+    const afterDelete = await listWorktreesForSession(db, session.id);
+    expect(afterDelete).toHaveLength(0);
   });
 });

--- a/packages/db/src/queries/session-worktrees.ts
+++ b/packages/db/src/queries/session-worktrees.ts
@@ -1,0 +1,65 @@
+import type { SessionId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface SessionWorktreeRow {
+  id: string;
+  session_id: string;
+  worktree_path: string;
+  branch: string;
+  parallel_index: number;
+  created_at: number;
+}
+
+export interface SessionWorktree {
+  readonly id: string;
+  readonly sessionId: SessionId;
+  readonly worktreePath: string;
+  readonly branch: string;
+  readonly parallelIndex: number;
+  readonly createdAt: number;
+}
+
+function toDomain(row: SessionWorktreeRow): SessionWorktree {
+  return {
+    id: row.id,
+    sessionId: row.session_id as SessionId,
+    worktreePath: row.worktree_path,
+    branch: row.branch,
+    parallelIndex: row.parallel_index,
+    createdAt: row.created_at,
+  };
+}
+
+export async function insertSessionWorktree(
+  db: Database,
+  worktree: SessionWorktree,
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO session_worktrees
+      (id, session_id, worktree_path, branch, parallel_index, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      worktree.id,
+      worktree.sessionId,
+      worktree.worktreePath,
+      worktree.branch,
+      worktree.parallelIndex,
+      worktree.createdAt,
+    ],
+  );
+}
+
+export async function listWorktreesForSession(
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<SessionWorktree>> {
+  const rows = await db.select<SessionWorktreeRow>(
+    'SELECT * FROM session_worktrees WHERE session_id = ? ORDER BY parallel_index ASC',
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}
+
+export async function deleteWorktreesForSession(db: Database, sessionId: SessionId): Promise<void> {
+  await db.execute('DELETE FROM session_worktrees WHERE session_id = ?', [sessionId]);
+}


### PR DESCRIPTION
Closes #195

## Summary

- `m009-session-worktrees`: new migration adding `session_worktrees(id, session_id FK→sessions ON DELETE CASCADE, worktree_path, branch, parallel_index DEFAULT 0, created_at)` with index on `session_id`
- New query file `packages/db/src/queries/session-worktrees.ts`: `insertSessionWorktree`, `listWorktreesForSession`, `deleteWorktreesForSession`
- Store type: `sessionWorktrees` promoted from `Record<SessionId, string>` → `Record<SessionId, ReadonlyArray<string>>` — API ready for N>1 parallel, N=1 in practice until C3
- `createSession`: persists worktree row at `parallel_index=0` immediately after creation
- `setCurrentWorkspace`: hydrates `sessionWorktrees` from DB for all workspace sessions on switch/boot (fixes restart regression)
- `endSession`: calls `deleteWorktreesForSession` + iterates all paths for `removeWorktree`
- UI read sites (WorkspacesSidebar, StatusBar, ChatView): read `[0]` from array — no UX change

## Test plan

- [ ] `pnpm --filter @kay-am/db test` — 7 tests pass (includes new session_worktrees roundtrip)
- [ ] `pnpm --filter @kay-am/desktop typecheck` — clean
- [ ] `pnpm --filter @kay-am/desktop test` — 7 tests pass (store tests updated to array shape)
- [ ] Manual: create session → restart app → session worktree path still visible in StatusBar / ChatHeader
- [ ] Manual: end session → row deleted from `session_worktrees`, worktree removed from disk

🤖 Generated with [Claude Code](https://claude.com/claude-code)