### PR TITLE
feat(types): parallel phase domain types (#201)

### DIFF
--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -7,6 +7,8 @@ export type SkillId = string & { readonly __brand: 'SkillId' };
 export type PhaseTemplateId = string & { readonly __brand: 'PhaseTemplateId' };
 export type PhaseDefinitionId = string & { readonly __brand: 'PhaseDefinitionId' };
 export type PhaseRunId = string & { readonly __brand: 'PhaseRunId' };
+export type ParallelPhaseGroupId = string & { readonly __brand: 'ParallelPhaseGroupId' };
+export type ParallelPhaseRunId = string & { readonly __brand: 'ParallelPhaseRunId' };
 
 export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,6 +3,8 @@ export type {
   MessageId,
   PermissionRequestId,
   PermissionRuleId,
+  ParallelPhaseGroupId,
+  ParallelPhaseRunId,
   PhaseDefinitionId,
   PhaseRunId,
   PhaseTemplateId,
@@ -48,6 +50,9 @@ export type {
 } from './budget';
 export type { TelemetrySummary, TelemetryPeriodSummary } from './telemetry-period';
 export type {
+  ParallelMergeStrategy,
+  ParallelPhaseGroup,
+  ParallelPhaseRun,
   PhaseDefinition,
   PhaseRun,
   PhaseRunStatus,

--- a/packages/types/src/phase.ts
+++ b/packages/types/src/phase.ts
@@ -1,5 +1,7 @@
 import type {
   IsoDateTime,
+  ParallelPhaseGroupId,
+  ParallelPhaseRunId,
   PhaseDefinitionId,
   PhaseRunId,
   PhaseTemplateId,
@@ -11,6 +13,8 @@ import type { ProviderId } from './provider-registry';
 
 export type PhaseRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 
+export type ParallelMergeStrategy = 'last_write_wins' | 'manual' | 'synthesizer_driven';
+
 export type PhaseDefinition = Readonly<{
   id: PhaseDefinitionId;
   templateId: PhaseTemplateId;
@@ -19,6 +23,7 @@ export type PhaseDefinition = Readonly<{
   promptPrefix: string;
   providerOverride?: ProviderId;
   modelOverride?: string;
+  parallelGroup?: number;
 }>;
 
 export type PhaseTemplate = Readonly<{
@@ -50,3 +55,25 @@ export type PhaseTransition = Readonly<{
   carryForwardContext: string;
   at: IsoDateTime;
 }>;
+
+export interface ParallelPhaseGroup {
+  readonly id: ParallelPhaseGroupId;
+  readonly sessionId: SessionId;
+  readonly ordinal: number;
+  readonly mergeStrategy: ParallelMergeStrategy;
+  readonly createdAt: IsoDateTime;
+  readonly completedAt: IsoDateTime | null;
+}
+
+export interface ParallelPhaseRun {
+  readonly id: ParallelPhaseRunId;
+  readonly groupId: ParallelPhaseGroupId;
+  readonly phaseDefinitionId: PhaseDefinitionId;
+  readonly parallelIndex: number;
+  readonly runId: ProviderRunId;
+  readonly status: PhaseRunStatus;
+  readonly worktreePath: string;
+  readonly outputSummary: string | null;
+  readonly startedAt: IsoDateTime;
+  readonly completedAt: IsoDateTime | null;
+}


### PR DESCRIPTION
## Summary

Introduce parallel phase execution domain model for v0.7. Extends `PhaseDefinition` with optional `parallelGroup` field (phases with same group value execute concurrently before sync point). New types:
- `ParallelPhaseGroup` — logical group container with merge strategy
- `ParallelPhaseRun` — individual phase run within group
- `ParallelMergeStrategy` — union type (`'last_write_wins' | 'manual' | 'synthesizer_driven'`)
- Branded ids: `ParallelPhaseGroupId`, `ParallelPhaseRunId`

Backward-compatible: absent `parallelGroup` preserves sequential behavior.

## Verification

- TypeScript strict mode: pass (types package)
- No `any` types
- Named exports only
- Barrel updated
- Closes #201

🤖 Generated with Claude Code