### PR TITLE
feat(db,core,desktop): permission audit retry queue (m010)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -96,6 +96,10 @@ pub fn run() {
       permissions::permission_audit_insert,
       permissions::permission_audit_list,
       permissions::permission_audit_clear,
+      permissions::permission_audit_retry_enqueue,
+      permissions::permission_audit_retry_drain,
+      permissions::permission_audit_retry_update,
+      permissions::permission_audit_retry_delete,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/permissions.rs
+++ b/apps/desktop/src-tauri/src/permissions.rs
@@ -562,6 +562,109 @@ pub fn permission_audit_clear(
 }
 
 // ---------------------------------------------------------------------------
+// Commands — permission audit retry queue (#196)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuditRetryRow {
+    pub id: String,
+    #[serde(rename = "payloadJson")]
+    pub payload_json: String,
+    pub attempts: i64,
+    #[serde(rename = "lastError")]
+    pub last_error: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: i64,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuditRetryEnqueueInput {
+    pub id: String,
+    #[serde(rename = "payloadJson")]
+    pub payload_json: String,
+}
+
+#[tauri::command]
+pub fn permission_audit_retry_enqueue(
+    state: State<'_, Db>,
+    input: AuditRetryEnqueueInput,
+) -> Result<(), PermissionError> {
+    let conn = state.0.lock().map_err(|_| PermissionError::Poisoned)?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    conn.execute(
+        "INSERT INTO permission_audit_retry (id, payload_json, attempts, last_error, created_at, updated_at)
+         VALUES (?1, ?2, 0, NULL, ?3, ?4)
+         ON CONFLICT(id) DO NOTHING",
+        rusqlite::params![input.id, input.payload_json, now_ms, now_ms],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn permission_audit_retry_drain(
+    state: State<'_, Db>,
+    limit: i64,
+) -> Result<Vec<AuditRetryRow>, PermissionError> {
+    let conn = state.0.lock().map_err(|_| PermissionError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, payload_json, attempts, last_error, created_at, updated_at
+         FROM permission_audit_retry
+         ORDER BY created_at ASC
+         LIMIT ?1",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![limit], |row| {
+        Ok(AuditRetryRow {
+            id: row.get(0)?,
+            payload_json: row.get(1)?,
+            attempts: row.get(2)?,
+            last_error: row.get(3)?,
+            created_at: row.get(4)?,
+            updated_at: row.get(5)?,
+        })
+    })?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(PermissionError::Db)
+}
+
+#[tauri::command]
+pub fn permission_audit_retry_update(
+    state: State<'_, Db>,
+    id: String,
+    attempts: i64,
+    last_error: String,
+) -> Result<(), PermissionError> {
+    let conn = state.0.lock().map_err(|_| PermissionError::Poisoned)?;
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    conn.execute(
+        "UPDATE permission_audit_retry SET attempts = ?1, last_error = ?2, updated_at = ?3 WHERE id = ?4",
+        rusqlite::params![attempts, last_error, now_ms, id],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn permission_audit_retry_delete(
+    state: State<'_, Db>,
+    id: String,
+) -> Result<(), PermissionError> {
+    let conn = state.0.lock().map_err(|_| PermissionError::Poisoned)?;
+    conn.execute(
+        "DELETE FROM permission_audit_retry WHERE id = ?1",
+        rusqlite::params![id],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Utilities (mirrors phases.rs — kept independent per module)
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/src/permissions.ts
+++ b/apps/desktop/src/permissions.ts
@@ -224,6 +224,62 @@ export async function invokePermissionAuditClear(scope: PermissionAuditClearScop
 }
 
 // ---------------------------------------------------------------------------
+// Permission audit retry queue (#196)
+// ---------------------------------------------------------------------------
+
+interface RawAuditRetryRow {
+  readonly id: string;
+  readonly payloadJson: string;
+  readonly attempts: number;
+  readonly lastError: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+export interface AuditRetryEntry {
+  readonly id: string;
+  readonly payloadJson: string;
+  readonly attempts: number;
+  readonly lastError: string | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+}
+
+function rowToAuditRetryEntry(row: RawAuditRetryRow): AuditRetryEntry {
+  return {
+    id: row.id,
+    payloadJson: row.payloadJson,
+    attempts: row.attempts,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function invokeAuditRetryEnqueue(id: string, payloadJson: string): Promise<void> {
+  return invoke<void>('permission_audit_retry_enqueue', { input: { id, payloadJson } });
+}
+
+export async function invokeAuditRetryDrain(
+  limit: number,
+): Promise<ReadonlyArray<AuditRetryEntry>> {
+  const rows = await invoke<RawAuditRetryRow[]>('permission_audit_retry_drain', { limit });
+  return rows.map(rowToAuditRetryEntry);
+}
+
+export async function invokeAuditRetryUpdate(
+  id: string,
+  attempts: number,
+  lastError: string,
+): Promise<void> {
+  return invoke<void>('permission_audit_retry_update', { id, attempts, lastError });
+}
+
+export async function invokeAuditRetryDelete(id: string): Promise<void> {
+  return invoke<void>('permission_audit_retry_delete', { id });
+}
+
+// ---------------------------------------------------------------------------
 // Effective rules hook — for preflight banner
 // ---------------------------------------------------------------------------
 

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, Session, SessionId, TurnEvent, WorkspaceId } from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before store import
+// ---------------------------------------------------------------------------
+
+const runTurnSpy = vi.fn();
+const cancelTurnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  runTurn: (args: unknown) => runTurnSpy(args),
+  cancelTurn: cancelTurnSpy,
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+const permissionRuleListSpy = vi.fn();
+const permissionAuditInsertSpy = vi.fn();
+const auditRetryEnqueueSpy = vi.fn();
+const auditRetryDrainSpy = vi.fn();
+const auditRetryUpdateSpy = vi.fn();
+const auditRetryDeleteSpy = vi.fn();
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: (args: unknown) => permissionRuleListSpy(args),
+  invokePermissionAuditInsert: (args: unknown) => permissionAuditInsertSpy(args),
+  invokeAuditRetryEnqueue: (id: string, payload: string) => auditRetryEnqueueSpy(id, payload),
+  invokeAuditRetryDrain: (limit: number) => auditRetryDrainSpy(limit),
+  invokeAuditRetryUpdate: (id: string, attempts: number, err: string) =>
+    auditRetryUpdateSpy(id, attempts, err),
+  invokeAuditRetryDelete: (id: string) => auditRetryDeleteSpy(id),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: vi.fn(),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+vi.mock('../providerPricing', () => ({
+  parseProviderPricingConfig: vi.fn(() => null),
+  getCodexPriceOverride: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const NOW: IsoDateTime = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+
+function buildSession(): Session {
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'test',
+    state: { kind: 'idle', lastActivityAt: NOW },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function makeRetryEntry(overrides: { id?: string; payloadJson?: string; attempts?: number }) {
+  return {
+    id: overrides.id ?? 'retry-1',
+    payloadJson:
+      overrides.payloadJson ??
+      JSON.stringify({
+        id: 'req-1',
+        runId: 'run-1',
+        sessionId: SESSION_ID,
+        toolUseId: 'tu-1',
+        toolName: 'Edit',
+        inputJson: '{}',
+        decision: 'allow',
+        decidedBy: 'engine',
+        requestedAt: NOW,
+        decidedAt: NOW,
+      }),
+    attempts: overrides.attempts ?? 0,
+    lastError: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+async function* emptyStream(): AsyncIterable<TurnEvent> {
+  // intentionally empty
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('audit retry queue — sendTurn enqueue on failure', () => {
+  beforeEach(() => {
+    runTurnSpy.mockReset();
+    cancelTurnSpy.mockReset();
+    permissionRuleListSpy.mockReset();
+    permissionAuditInsertSpy.mockReset();
+    auditRetryEnqueueSpy.mockReset();
+    auditRetryDrainSpy.mockReset();
+    auditRetryUpdateSpy.mockReset();
+    auditRetryDeleteSpy.mockReset();
+
+    permissionRuleListSpy.mockResolvedValue([]);
+    auditRetryEnqueueSpy.mockResolvedValue(undefined);
+    auditRetryDrainSpy.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function importStore() {
+    const mod = await import('./store');
+    return mod.useAppStore;
+  }
+
+  function setupSession(useAppStore: Awaited<ReturnType<typeof importStore>>) {
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: {
+        anthropic: { state: 'connected', identity: 'test' },
+        cursor: { state: 'connected', identity: 'test' },
+        codex: { state: 'connected', identity: 'test' },
+      } as never,
+      workspaces: [
+        {
+          id: WORKSPACE_ID,
+          name: 'ws',
+          rootPath: '/tmp',
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+    });
+  }
+
+  it('enqueues to retry queue when audit insert fails', async () => {
+    permissionAuditInsertSpy.mockRejectedValue(new Error('db locked'));
+
+    async function* toolStream(): AsyncIterable<TurnEvent> {
+      yield {
+        kind: 'tool_call_start',
+        toolUseId: 'tu-1',
+        toolName: 'Edit',
+        input: { path: '/tmp/x' },
+        at: NOW,
+      } as TurnEvent;
+    }
+    runTurnSpy.mockImplementation(() => toolStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
+
+    expect(permissionAuditInsertSpy).toHaveBeenCalledTimes(1);
+    expect(auditRetryEnqueueSpy).toHaveBeenCalledTimes(1);
+    const [enqueuedId, enqueuedPayload] = auditRetryEnqueueSpy.mock.calls[0] as [string, string];
+    expect(typeof enqueuedId).toBe('string');
+    const parsed = JSON.parse(enqueuedPayload) as Record<string, unknown>;
+    expect(parsed.toolName).toBe('Edit');
+    // No rules → engine defaults to deny; decision value is whatever the engine decides.
+    expect(typeof parsed.decision).toBe('string');
+  });
+
+  it('does NOT enqueue when audit insert succeeds', async () => {
+    permissionAuditInsertSpy.mockResolvedValue({});
+
+    async function* toolStream(): AsyncIterable<TurnEvent> {
+      yield {
+        kind: 'tool_call_start',
+        toolUseId: 'tu-2',
+        toolName: 'Read',
+        input: {},
+        at: NOW,
+      } as TurnEvent;
+    }
+    runTurnSpy.mockImplementation(() => toolStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
+
+    expect(auditRetryEnqueueSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('audit retry queue — drain worker (happy path)', () => {
+  beforeEach(() => {
+    runTurnSpy.mockImplementation(() => emptyStream());
+    permissionRuleListSpy.mockResolvedValue([]);
+    auditRetryEnqueueSpy.mockResolvedValue(undefined);
+    auditRetryUpdateSpy.mockResolvedValue(undefined);
+    auditRetryDeleteSpy.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    auditRetryDrainSpy.mockReset();
+    auditRetryDeleteSpy.mockReset();
+    auditRetryUpdateSpy.mockReset();
+    permissionAuditInsertSpy.mockReset();
+  });
+
+  async function runHydrate() {
+    const { runDbMigrations } = await import('../db');
+    (runDbMigrations as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+    const { getSetting } = await import('@kay-am/db');
+    (getSetting as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const { getProviderStatus, getCursorStatus, getCodexStatus, checkProviderAuth } =
+      await import('../providers');
+    (getProviderStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'connected',
+      identity: 'test',
+    });
+    (getCursorStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'connected',
+      identity: 'test',
+    });
+    (getCodexStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'connected',
+      identity: 'test',
+    });
+    (checkProviderAuth as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'connected',
+      identity: 'test',
+    });
+
+    const mod = await import('./store');
+    await mod.useAppStore.getState().hydrate();
+    // Drain is fired with void — yield microtask so it can settle.
+    await Promise.resolve();
+  }
+
+  it('drain happy path: retries insert, deletes on success', async () => {
+    const entry = makeRetryEntry({ id: 'retry-happy', attempts: 2 });
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockResolvedValue({});
+
+    await runHydrate();
+
+    expect(auditRetryDrainSpy).toHaveBeenCalledWith(50);
+    expect(permissionAuditInsertSpy).toHaveBeenCalledTimes(1);
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-happy');
+    expect(auditRetryUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('drain failure path: increments attempts when insert still fails', async () => {
+    const entry = makeRetryEntry({ id: 'retry-fail', attempts: 3 });
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockRejectedValue(new Error('still locked'));
+
+    await runHydrate();
+
+    expect(auditRetryUpdateSpy).toHaveBeenCalledWith('retry-fail', 4, 'still locked');
+    expect(auditRetryDeleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('max-attempts boundary: deletes entry at attempt 10', async () => {
+    const entry = makeRetryEntry({ id: 'retry-max', attempts: 9 });
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockRejectedValue(new Error('permanent failure'));
+
+    await runHydrate();
+
+    // At attempts=9, nextAttempts=10 >= MAX(10) → delete, not update
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-max');
+    expect(auditRetryUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('drain skips rows with invalid JSON payload (deletes them)', async () => {
+    const entry = makeRetryEntry({ id: 'retry-bad-json', payloadJson: 'not-json' });
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+
+    await runHydrate();
+
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-bad-json');
+    expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -30,6 +30,10 @@ const permissionAuditInsertSpy = vi.fn();
 vi.mock('../permissions', () => ({
   invokePermissionRuleList: (args: unknown) => permissionRuleListSpy(args),
   invokePermissionAuditInsert: (args: unknown) => permissionAuditInsertSpy(args),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
   useEffectivePermissionRules: () => [],
 }));
 
@@ -51,6 +55,7 @@ vi.mock('@kay-am/db', () => ({
   insertMessage: vi.fn(),
   insertProviderRun: vi.fn(),
   insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
   insertTelemetry: vi.fn(),
   insertWorkspace: vi.fn(),
   listContextSlotsForSession: vi.fn(async () => []),
@@ -58,6 +63,8 @@ vi.mock('@kay-am/db', () => ({
   listSessionsForWorkspace: vi.fn(async () => []),
   listTelemetryForSession: vi.fn(async () => []),
   listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: vi.fn(),
   setSetting: vi.fn(),
   summarizeSessionTelemetry: vi.fn(async () => null),
   summarizeWorkspaceTelemetry: vi.fn(async () => null),

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -110,7 +110,16 @@ import {
   resolveSkillInvocation,
   type SkillUpsertArgs,
 } from '../skills';
-import { invokePermissionRuleList, invokePermissionAuditInsert } from '../permissions';
+import {
+  invokePermissionRuleList,
+  invokePermissionAuditInsert,
+  invokeAuditRetryEnqueue,
+  invokeAuditRetryDrain,
+  invokeAuditRetryUpdate,
+  invokeAuditRetryDelete,
+  type AuditRetryEntry,
+  type PermissionAuditInsertPayload,
+} from '../permissions';
 import {
   invokePhaseTemplateList,
   invokePhaseTemplateUpsert,
@@ -400,6 +409,49 @@ async function runSummarizer(
   }
 }
 
+const AUDIT_RETRY_MAX_ATTEMPTS = 10;
+const AUDIT_RETRY_DRAIN_BATCH = 50;
+
+async function drainAuditRetryQueue(): Promise<void> {
+  let entries: ReadonlyArray<AuditRetryEntry>;
+  try {
+    entries = await invokeAuditRetryDrain(AUDIT_RETRY_DRAIN_BATCH);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    let payload: PermissionAuditInsertPayload;
+    try {
+      payload = JSON.parse(entry.payloadJson) as PermissionAuditInsertPayload;
+    } catch {
+      await invokeAuditRetryDelete(entry.id).catch(() => undefined);
+      continue;
+    }
+
+    try {
+      await invokePermissionAuditInsert(payload);
+      await invokeAuditRetryDelete(entry.id);
+    } catch (err) {
+      const nextAttempts = entry.attempts + 1;
+      const errMsg = err instanceof Error ? err.message : String(err);
+
+      if (nextAttempts >= AUDIT_RETRY_MAX_ATTEMPTS) {
+        // TODO (@ak): emit alert via existing alert mechanism once one is in place (#196 max-attempts).
+        // No app-level non-blocking alert API exists yet; log to console as a
+        // discoverability measure until the alert system is wired.
+        console.error(
+          `permission audit retry exhausted (${AUDIT_RETRY_MAX_ATTEMPTS} attempts) for entry ${entry.id}; dropping`,
+          errMsg,
+        );
+        await invokeAuditRetryDelete(entry.id).catch(() => undefined);
+      } else {
+        await invokeAuditRetryUpdate(entry.id, nextAttempts, errMsg).catch(() => undefined);
+      }
+    }
+  }
+}
+
 export const useAppStore = create<AppStore>((set, get) => ({
   ...initialState,
 
@@ -470,6 +522,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
 
       set({ bootPhase: 'ready', hydrated: true });
+
+      // Drain audit retry queue after boot — non-blocking, best-effort.
+      void drainAuditRetryQueue();
     } catch (err) {
       set({
         bootPhase: 'error',
@@ -1000,34 +1055,44 @@ export const useAppStore = create<AppStore>((set, get) => ({
         if (event.kind === 'assistant_text') assistantText += event.delta;
 
         if (provider === 'anthropic' && event.kind === 'tool_call_start') {
+          const engine = new PermissionEngine();
+          const auditRequestId = crypto.randomUUID() as PermissionRequestId;
+          const request: PermissionRequest = {
+            id: auditRequestId,
+            runId,
+            toolUseId: event.toolUseId,
+            toolName: event.toolName,
+            input: event.input,
+            at: event.at,
+          };
+          const decision = engine.decide(request, effectiveRules, {
+            sessionId,
+            workspaceId: session.workspaceId,
+          });
+          const auditPayload: PermissionAuditInsertPayload = {
+            id: auditRequestId,
+            runId,
+            sessionId,
+            toolUseId: event.toolUseId,
+            toolName: event.toolName,
+            inputJson: JSON.stringify(event.input),
+            decision: decision.decision,
+            ...(decision.ruleId != null && { ruleId: decision.ruleId }),
+            decidedBy: decision.decidedBy,
+            requestedAt: event.at,
+            decidedAt: decision.at,
+          };
           try {
-            const engine = new PermissionEngine();
-            const request: PermissionRequest = {
-              id: crypto.randomUUID() as PermissionRequestId,
-              runId,
-              toolUseId: event.toolUseId,
-              toolName: event.toolName,
-              input: event.input,
-              at: event.at,
-            };
-            const decision = engine.decide(request, effectiveRules, {
-              sessionId,
-              workspaceId: session.workspaceId,
-            });
-            await invokePermissionAuditInsert({
-              runId,
-              sessionId,
-              toolUseId: event.toolUseId,
-              toolName: event.toolName,
-              inputJson: JSON.stringify(event.input),
-              decision: decision.decision,
-              ...(decision.ruleId != null && { ruleId: decision.ruleId }),
-              decidedBy: decision.decidedBy,
-              requestedAt: event.at,
-              decidedAt: decision.at,
-            });
-          } catch (err) {
-            console.error('permission audit insert failed', err);
+            await invokePermissionAuditInsert(auditPayload);
+          } catch {
+            // Insert failed — persist to retry queue so the audit trail is
+            // not silently dropped. JS single-threaded event loop makes the
+            // sequential await sufficient as a single-writer guard.
+            try {
+              await invokeAuditRetryEnqueue(auditRequestId, JSON.stringify(auditPayload));
+            } catch (enqueueErr) {
+              console.error('permission audit retry enqueue failed', enqueueErr);
+            }
           }
         }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -65,3 +65,10 @@ export {
   deleteWorktreesForSession,
   type SessionWorktree,
 } from './queries/session-worktrees';
+export {
+  enqueueAuditRetry,
+  drainOldest,
+  updateAuditRetryAttempts,
+  deleteAuditRetry,
+  type AuditRetryRow,
+} from './queries/permission-audit-retry';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -7,6 +7,7 @@ import { m006Skills } from './m006-skills';
 import { m007Phases } from './m007-phases';
 import { m008Permissions } from './m008-permissions';
 import { m009SessionWorktrees } from './m009-session-worktrees';
+import { m010PermissionAuditRetry } from './m010-permission-audit-retry';
 
 export interface Migration {
   readonly version: number;
@@ -23,4 +24,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 7, sql: m007Phases },
   { version: 8, sql: m008Permissions },
   { version: 9, sql: m009SessionWorktrees },
+  { version: 10, sql: m010PermissionAuditRetry },
 ];

--- a/packages/db/src/migrations/m010-permission-audit-retry.ts
+++ b/packages/db/src/migrations/m010-permission-audit-retry.ts
@@ -1,0 +1,11 @@
+export const m010PermissionAuditRetry = /* sql */ `
+CREATE TABLE IF NOT EXISTS permission_audit_retry (
+  id TEXT PRIMARY KEY,
+  payload_json TEXT NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_permission_audit_retry_created ON permission_audit_retry(created_at);
+`;

--- a/packages/db/src/queries/permission-audit-retry.test.ts
+++ b/packages/db/src/queries/permission-audit-retry.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from '../migrations/runner';
+import {
+  enqueueAuditRetry,
+  drainOldest,
+  updateAuditRetryAttempts,
+  deleteAuditRetry,
+} from './permission-audit-retry';
+
+async function makeDb() {
+  const db = makeTestDatabase();
+  await migrate(db);
+  return db;
+}
+
+describe('permission_audit_retry queries', () => {
+  it('enqueue inserts a row readable by drainOldest', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    await enqueueAuditRetry(db, 'entry-1', '{"foo":"bar"}', now);
+    const rows = await drainOldest(db, 10);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.id).toBe('entry-1');
+    expect(rows[0]!.payload_json).toBe('{"foo":"bar"}');
+    expect(rows[0]!.attempts).toBe(0);
+    expect(rows[0]!.last_error).toBeNull();
+  });
+
+  it('drainOldest returns rows ordered by created_at ascending', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    await enqueueAuditRetry(db, 'entry-b', '{"b":1}', now + 10);
+    await enqueueAuditRetry(db, 'entry-a', '{"a":1}', now);
+    await enqueueAuditRetry(db, 'entry-c', '{"c":1}', now + 20);
+
+    const rows = await drainOldest(db, 10);
+    expect(rows.map((r) => r.id)).toEqual(['entry-a', 'entry-b', 'entry-c']);
+  });
+
+  it('drainOldest respects limit', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    for (let i = 0; i < 5; i++) {
+      await enqueueAuditRetry(db, `entry-${i}`, `{"i":${i}}`, now + i);
+    }
+    const rows = await drainOldest(db, 3);
+    expect(rows).toHaveLength(3);
+  });
+
+  it('enqueue is idempotent on conflict (ON CONFLICT DO NOTHING)', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    await enqueueAuditRetry(db, 'dup-1', 'first', now);
+    await enqueueAuditRetry(db, 'dup-1', 'second', now + 100);
+
+    const rows = await drainOldest(db, 10);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.payload_json).toBe('first');
+  });
+
+  it('updateAuditRetryAttempts increments attempts and sets last_error', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    await enqueueAuditRetry(db, 'upd-1', '{}', now);
+    await updateAuditRetryAttempts(db, 'upd-1', 3, 'disk full', now + 1000);
+
+    const rows = await drainOldest(db, 10);
+    expect(rows[0]!.attempts).toBe(3);
+    expect(rows[0]!.last_error).toBe('disk full');
+  });
+
+  it('deleteAuditRetry removes the row', async () => {
+    const db = await makeDb();
+    const now = Date.now();
+
+    await enqueueAuditRetry(db, 'del-1', '{}', now);
+    await deleteAuditRetry(db, 'del-1');
+
+    const rows = await drainOldest(db, 10);
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/db/src/queries/permission-audit-retry.ts
+++ b/packages/db/src/queries/permission-audit-retry.ts
@@ -1,0 +1,56 @@
+import type { Database } from '../client';
+
+export interface AuditRetryRow {
+  readonly id: string;
+  readonly payload_json: string;
+  readonly attempts: number;
+  readonly last_error: string | null;
+  readonly created_at: number;
+  readonly updated_at: number;
+}
+
+export async function enqueueAuditRetry(
+  db: Database,
+  id: string,
+  payloadJson: string,
+  nowMs: number,
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO permission_audit_retry (id, payload_json, attempts, last_error, created_at, updated_at)
+     VALUES (?, ?, 0, NULL, ?, ?)
+     ON CONFLICT(id) DO NOTHING`,
+    [id, payloadJson, nowMs, nowMs],
+  );
+}
+
+export async function drainOldest(
+  db: Database,
+  limit: number,
+): Promise<ReadonlyArray<AuditRetryRow>> {
+  return db.select<AuditRetryRow>(
+    `SELECT id, payload_json, attempts, last_error, created_at, updated_at
+     FROM permission_audit_retry
+     ORDER BY created_at ASC
+     LIMIT ?`,
+    [limit],
+  );
+}
+
+export async function updateAuditRetryAttempts(
+  db: Database,
+  id: string,
+  attempts: number,
+  lastError: string,
+  nowMs: number,
+): Promise<void> {
+  await db.execute(
+    `UPDATE permission_audit_retry
+     SET attempts = ?, last_error = ?, updated_at = ?
+     WHERE id = ?`,
+    [attempts, lastError, nowMs, id],
+  );
+}
+
+export async function deleteAuditRetry(db: Database, id: string): Promise<void> {
+  await db.execute(`DELETE FROM permission_audit_retry WHERE id = ?`, [id]);
+}


### PR DESCRIPTION
Closes #196

## Why

`invokePermissionAuditInsert` in the turn event loop was wrapped in try/catch-and-continue — a tool-call proceeded even on audit failure, silently dropping the entry from the audit trail. v0.7 parallel scheduler will amplify audit volume; even transient SQLite contention would cause undetected data loss, breaking the local-first audit promise made in v0.6. This closes the leak before I1 wires the parallel scheduler.

## Decision: queue vs strict-fail

Blocking the turn on audit failure is wrong — the audit is a side-effect of the decision, not a gate. Strict-fail would degrade UX for a bookkeeping concern. A persistent retry queue gives eventual-consistency: failure is persisted across crashes, retried on next boot, and dropped only after 10 attempts (with a `console.error` TODO for a proper alert — no non-blocking app-level alert API exists yet).

## Alert mechanism for max-attempts

No existing non-blocking alert API is in place. On exhaustion the worker calls `console.error` and a `TODO (@ak)` comment points to #196 for wiring the alert once the system exists.

## What changed

- **m010 migration** — `permission_audit_retry(id, payload_json, attempts, last_error, created_at, updated_at)` + index
- **`@kay-am/db` queries** — `enqueueAuditRetry`, `drainOldest`, `updateAuditRetryAttempts`, `deleteAuditRetry`
- **Rust** — 4 Tauri commands (`permission_audit_retry_{enqueue,drain,update,delete}`) registered in `invoke_handler`
- **`apps/desktop/src/permissions.ts`** — TS bridge fns + `AuditRetryEntry` type
- **`store.ts`** — on insert failure → `invokeAuditRetryEnqueue`; `drainAuditRetryQueue()` fires on hydrate (non-blocking `void`); sequential `await` = single-writer pattern
- **Tests** — query roundtrip (6), drain happy/fail/max-attempts/bad-JSON (4), enqueue-on-failure + no-enqueue-on-success (2); all 23 desktop + 13 db tests green

## Test plan

- [ ] `pnpm --filter @kay-am/db test` — 13 tests green
- [ ] `pnpm --filter @kay-am/desktop typecheck` — clean
- [ ] `pnpm --filter @kay-am/desktop test` — 23 tests green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)