### PR TITLE
feat(db): m011 parallel_phases migration

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -65,3 +65,10 @@ export {
   deleteWorktreesForSession,
   type SessionWorktree,
 } from './queries/session-worktrees';
+export {
+  insertGroup,
+  listGroupsForSession,
+  getGroupById,
+  deleteGroup,
+  updateGroupCompletedAt,
+} from './queries/parallel-phases';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -7,6 +7,7 @@ import { m006Skills } from './m006-skills';
 import { m007Phases } from './m007-phases';
 import { m008Permissions } from './m008-permissions';
 import { m009SessionWorktrees } from './m009-session-worktrees';
+import { m011ParallelPhases } from './m011-parallel-phases';
 
 export interface Migration {
   readonly version: number;
@@ -23,4 +24,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 7, sql: m007Phases },
   { version: 8, sql: m008Permissions },
   { version: 9, sql: m009SessionWorktrees },
+  { version: 11, sql: m011ParallelPhases },
 ];

--- a/packages/db/src/migrations/m011-parallel-phases.ts
+++ b/packages/db/src/migrations/m011-parallel-phases.ts
@@ -1,0 +1,17 @@
+export const m011ParallelPhases = /* sql */ `
+ALTER TABLE session_phase_runs ADD COLUMN group_id TEXT;
+ALTER TABLE session_phase_runs ADD COLUMN parallel_index INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS parallel_phase_groups (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  ordinal INTEGER NOT NULL,
+  merge_strategy TEXT NOT NULL CHECK (merge_strategy IN ('last_write_wins', 'manual', 'synthesizer_driven')),
+  created_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_parallel_phase_groups_session ON parallel_phase_groups(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_phase_runs_group ON session_phase_runs(group_id);
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import type {
   IsoDateTime,
+  ParallelPhaseGroup,
+  ParallelPhaseGroupId,
   PhaseDefinition,
   PhaseDefinitionId,
   PhaseRun,
@@ -34,6 +36,13 @@ import {
   listWorktreesForSession,
   deleteWorktreesForSession,
 } from '../queries/session-worktrees';
+import {
+  insertGroup,
+  listGroupsForSession,
+  getGroupById,
+  deleteGroup,
+  updateGroupCompletedAt,
+} from '../queries/parallel-phases';
 
 const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
@@ -276,5 +285,158 @@ describe('migrate', () => {
     await deleteWorktreesForSession(db, session.id);
     const afterDelete = await listWorktreesForSession(db, session.id);
     expect(afterDelete).toHaveLength(0);
+  });
+
+  it('round-trips parallel_phase_groups: insert, list, get, update, delete', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_ppg' as WorkspaceId,
+      name: 'ppg-test',
+      rootPath: '/tmp/ppg-test',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+
+    const session: Session = {
+      id: 'sess_ppg' as SessionId,
+      workspaceId: workspace.id,
+      goal: 'parallel phase group test',
+      state: { kind: 'draft' },
+      contextSlots: [],
+      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertSession(db, session);
+
+    const group1: ParallelPhaseGroup = {
+      id: 'ppg_1' as ParallelPhaseGroupId,
+      sessionId: session.id,
+      ordinal: 0,
+      mergeStrategy: 'last_write_wins',
+      createdAt: now(),
+      completedAt: null,
+    };
+
+    const group2: ParallelPhaseGroup = {
+      id: 'ppg_2' as ParallelPhaseGroupId,
+      sessionId: session.id,
+      ordinal: 1,
+      mergeStrategy: 'manual',
+      createdAt: now(),
+      completedAt: null,
+    };
+
+    await insertGroup(db, group1);
+    await insertGroup(db, group2);
+
+    const groups = await listGroupsForSession(db, session.id);
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.ordinal).toBe(0);
+    expect(groups[0]!.mergeStrategy).toBe('last_write_wins');
+    expect(groups[1]!.ordinal).toBe(1);
+    expect(groups[1]!.mergeStrategy).toBe('manual');
+
+    const fetched = await getGroupById(db, group1.id);
+    expect(fetched).not.toBeNull();
+    if (!fetched) throw new Error('fetched should not be null');
+    expect(fetched.id).toBe(group1.id);
+    expect(fetched.mergeStrategy).toBe('last_write_wins');
+    expect(fetched.completedAt).toBeNull();
+
+    const completedAt = now();
+    await updateGroupCompletedAt(db, group1.id, completedAt);
+    const updated = await getGroupById(db, group1.id);
+    expect(updated).not.toBeNull();
+    if (!updated) throw new Error('updated should not be null');
+    expect(updated.completedAt).toBe(completedAt);
+
+    await deleteGroup(db, group1.id);
+    const afterDelete = await listGroupsForSession(db, session.id);
+    expect(afterDelete).toHaveLength(1);
+    expect(afterDelete[0]!.id).toBe(group2.id);
+  });
+
+  it('backward-compat: sequential phases without group_id still work', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+
+    const workspace: Workspace = {
+      id: 'ws_seq' as WorkspaceId,
+      name: 'seq-test',
+      rootPath: '/tmp/seq-test',
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertWorkspace(db, workspace);
+
+    const session: Session = {
+      id: 'sess_seq' as SessionId,
+      workspaceId: workspace.id,
+      goal: 'sequential phases test',
+      state: { kind: 'draft' },
+      contextSlots: [],
+      providerPreference: DEFAULT_SESSION_PROVIDER_PREFERENCE,
+      createdAt: now(),
+      updatedAt: now(),
+    };
+    await insertSession(db, session);
+
+    const def1: PhaseDefinition = {
+      id: 'pdef_seq_1' as PhaseDefinitionId,
+      templateId: 'pt_seq' as PhaseTemplateId,
+      ordinal: 0,
+      name: 'Phase 1',
+      promptPrefix: 'First phase',
+    };
+
+    const def2: PhaseDefinition = {
+      id: 'pdef_seq_2' as PhaseDefinitionId,
+      templateId: 'pt_seq' as PhaseTemplateId,
+      ordinal: 1,
+      name: 'Phase 2',
+      promptPrefix: 'Second phase',
+    };
+
+    const template: PhaseTemplate = {
+      id: 'pt_seq' as PhaseTemplateId,
+      workspaceId: workspace.id,
+      name: 'Sequential Workflow',
+      description: 'Sequential phases without groups',
+      definitions: [def1, def2],
+      createdAt: now(),
+      updatedAt: now(),
+    };
+
+    await upsertPhaseTemplate(db, template);
+
+    const run1: PhaseRun = {
+      id: 'pr_seq_1' as PhaseRunId,
+      sessionId: session.id,
+      phaseDefinitionId: def1.id,
+      ordinal: 0,
+      name: 'Phase 1',
+      status: 'completed',
+    };
+
+    const run2: PhaseRun = {
+      id: 'pr_seq_2' as PhaseRunId,
+      sessionId: session.id,
+      phaseDefinitionId: def2.id,
+      ordinal: 1,
+      name: 'Phase 2',
+      status: 'completed',
+    };
+
+    await insertPhaseRun(db, run1);
+    await insertPhaseRun(db, run2);
+
+    const runs = await listPhaseRunsForSession(db, session.id);
+    expect(runs).toHaveLength(2);
+    expect(runs[0]!.ordinal).toBe(0);
+    expect(runs[1]!.ordinal).toBe(1);
   });
 });

--- a/packages/db/src/queries/parallel-phases.ts
+++ b/packages/db/src/queries/parallel-phases.ts
@@ -1,0 +1,83 @@
+import type {
+  IsoDateTime,
+  ParallelMergeStrategy,
+  ParallelPhaseGroup,
+  ParallelPhaseGroupId,
+  SessionId,
+} from '@kay-am/types';
+import type { Database } from '../client';
+
+interface ParallelPhaseGroupRow {
+  id: string;
+  session_id: string;
+  ordinal: number;
+  merge_strategy: string;
+  created_at: number;
+  completed_at: number | null;
+}
+
+function toDomain(row: ParallelPhaseGroupRow): ParallelPhaseGroup {
+  return {
+    id: row.id as ParallelPhaseGroupId,
+    sessionId: row.session_id as SessionId,
+    ordinal: row.ordinal,
+    mergeStrategy: row.merge_strategy as ParallelMergeStrategy,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    completedAt: row.completed_at
+      ? (new Date(row.completed_at).toISOString() as IsoDateTime)
+      : null,
+  };
+}
+
+export async function insertGroup(db: Database, group: ParallelPhaseGroup): Promise<void> {
+  await db.execute(
+    `INSERT INTO parallel_phase_groups
+      (id, session_id, ordinal, merge_strategy, created_at, completed_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      group.id,
+      group.sessionId,
+      group.ordinal,
+      group.mergeStrategy,
+      new Date(group.createdAt).getTime(),
+      group.completedAt ? new Date(group.completedAt).getTime() : null,
+    ],
+  );
+}
+
+export async function listGroupsForSession(
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<ParallelPhaseGroup>> {
+  const rows = await db.select<ParallelPhaseGroupRow>(
+    'SELECT * FROM parallel_phase_groups WHERE session_id = ? ORDER BY ordinal ASC',
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}
+
+export async function getGroupById(
+  db: Database,
+  groupId: ParallelPhaseGroupId,
+): Promise<ParallelPhaseGroup | null> {
+  const rows = await db.select<ParallelPhaseGroupRow>(
+    'SELECT * FROM parallel_phase_groups WHERE id = ? LIMIT 1',
+    [groupId],
+  );
+  return rows.length > 0 ? toDomain(rows[0]!) : null;
+}
+
+export async function deleteGroup(db: Database, groupId: ParallelPhaseGroupId): Promise<void> {
+  await db.execute('DELETE FROM parallel_phase_groups WHERE id = ?', [groupId]);
+}
+
+export async function updateGroupCompletedAt(
+  db: Database,
+  groupId: ParallelPhaseGroupId,
+  completedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute('UPDATE parallel_phase_groups SET completed_at = ? WHERE id = ?', [
+    new Date(completedAt).getTime(),
+    groupId,
+  ]);
+}


### PR DESCRIPTION
## summary

Migration m011 extends the DB schema to support parallel phase execution:

- adds `group_id` and `parallel_index` columns to `session_phase_runs` table
- creates `parallel_phase_groups` table with ordinal, merge_strategy (last_write_wins|manual|synthesizer_driven), and timestamps
- adds indexes on `session_id` and `group_id`
- ensures backward-compat: sequential phases without group_id still work

## test plan

- [x] migration applies cleanly on fresh DB
- [x] migration is idempotent
- [x] queries roundtrip: insert group → list → get → update completed_at → delete
- [x] backward-compat: sequential phases without group_id function normally

## depends on

closes #202