### PR TITLE
feat(desktop): parallel phase group CRUD tauri commands

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod budget;
 mod db;
 mod editor;
+mod parallel_phases;
 mod permissions;
 mod phases;
 mod providers;
@@ -89,6 +90,11 @@ pub fn run() {
       phases::phase_run_list_for_session,
       phases::phase_run_insert,
       phases::phase_run_update_status,
+      parallel_phases::parallel_phase_group_create,
+      parallel_phases::parallel_phase_group_list,
+      parallel_phases::parallel_phase_group_get,
+      parallel_phases::parallel_phase_group_delete,
+      parallel_phases::parallel_phase_group_update_completed_at,
       permissions::permission_rule_list,
       permissions::permission_rule_get,
       permissions::permission_rule_upsert,

--- a/apps/desktop/src-tauri/src/parallel_phases.rs
+++ b/apps/desktop/src-tauri/src/parallel_phases.rs
@@ -1,0 +1,372 @@
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::db::{Db, DbError};
+
+// ---------------------------------------------------------------------------
+// Structs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ParallelPhaseGroupRow {
+    pub id: String,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub ordinal: i64,
+    #[serde(rename = "mergeStrategy")]
+    pub merge_strategy: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    #[serde(rename = "completedAt")]
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ParallelPhaseGroupCreateInput {
+    pub id: Option<String>,
+    #[serde(rename = "sessionId")]
+    pub session_id: String,
+    pub ordinal: i64,
+    #[serde(rename = "mergeStrategy")]
+    pub merge_strategy: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParallelPhaseError {
+    #[error("db error: {0}")]
+    Db(#[from] rusqlite::Error),
+    #[error("db mutex poisoned")]
+    Poisoned,
+    #[error("parallel phase group not found: {0}")]
+    GroupNotFound(String),
+}
+
+impl Serialize for ParallelPhaseError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl ParallelPhaseError {
+    fn kind(&self) -> &'static str {
+        match self {
+            ParallelPhaseError::Db(_) => "db",
+            ParallelPhaseError::Poisoned => "poisoned",
+            ParallelPhaseError::GroupNotFound(_) => "group_not_found",
+        }
+    }
+}
+
+impl From<DbError> for ParallelPhaseError {
+    fn from(e: DbError) -> Self {
+        match e {
+            DbError::Sqlite(inner) => ParallelPhaseError::Db(inner),
+            DbError::Poisoned => ParallelPhaseError::Poisoned,
+            _ => ParallelPhaseError::Db(rusqlite::Error::InvalidQuery),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Parse ISO 8601 string → unix epoch ms.
+fn iso_to_epoch_ms(iso: &str) -> i64 {
+    let bytes = iso.as_bytes();
+    if bytes.len() < 19 {
+        return 0;
+    }
+    let year: i64 = parse_digits(bytes, 0, 4);
+    let month: u32 = parse_digits(bytes, 5, 2) as u32;
+    let day: u32 = parse_digits(bytes, 8, 2) as u32;
+    let hour: u32 = parse_digits(bytes, 11, 2) as u32;
+    let min: u32 = parse_digits(bytes, 14, 2) as u32;
+    let sec: u32 = parse_digits(bytes, 17, 2) as u32;
+
+    let ms: i64 = if bytes.len() > 19 && bytes[19] == b'.' {
+        parse_digits(bytes, 20, 3)
+    } else {
+        0
+    };
+
+    let epoch_secs = datetime_to_epoch_secs(year, month, day, hour, min, sec);
+    epoch_secs * 1000 + ms
+}
+
+fn parse_digits(bytes: &[u8], start: usize, len: usize) -> i64 {
+    let mut v: i64 = 0;
+    for i in start..start + len {
+        if i >= bytes.len() {
+            break;
+        }
+        let b = bytes[i];
+        if b.is_ascii_digit() {
+            v = v * 10 + (b - b'0') as i64;
+        }
+    }
+    v
+}
+
+fn datetime_to_epoch_secs(year: i64, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> i64 {
+    let mut days: i64 = 0;
+    for y in 1970..year {
+        days += if is_leap_year(y) { 366 } else { 365 };
+    }
+    for m in 1..month {
+        days += days_in_month(year, m);
+    }
+    days += (day as i64) - 1;
+    days * 86400 + (hour as i64) * 3600 + (min as i64) * 60 + (sec as i64)
+}
+
+/// Convert unix epoch ms → ISO 8601 string (UTC).
+fn epoch_ms_to_iso(ms: i64) -> String {
+    let secs = ms / 1000;
+    let (year, month, day, hour, min, sec) = epoch_secs_to_datetime(secs);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, min, sec
+    )
+}
+
+fn now_epoch_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}
+
+fn uuid_v4() -> String {
+    use sha2::{Digest, Sha256};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let t = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let pid = std::process::id();
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let input = format!("{}-{}-{}", t.as_nanos(), pid, seq);
+    let hash = Sha256::digest(input.as_bytes());
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-4{:01x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        hash[0], hash[1], hash[2], hash[3],
+        hash[4], hash[5],
+        hash[6] & 0x0f, hash[7],
+        (hash[8] & 0x3f) | 0x80, hash[9],
+        hash[10], hash[11], hash[12], hash[13], hash[14], hash[15],
+    )
+}
+
+fn is_leap_year(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+fn days_in_month(y: i64, m: u32) -> i64 {
+    match m {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => {
+            if is_leap_year(y) {
+                29
+            } else {
+                28
+            }
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn epoch_secs_to_datetime(mut s: i64) -> (i64, u32, u32, u32, u32, u32) {
+    let sec = (s % 60) as u32;
+    s /= 60;
+    let min = (s % 60) as u32;
+    s /= 60;
+    let hour = (s % 24) as u32;
+    s /= 24;
+    let mut year: i64 = 1970;
+    loop {
+        let days = if is_leap_year(year) { 366 } else { 365 };
+        if s < days {
+            break;
+        }
+        s -= days;
+        year += 1;
+    }
+    let mut month: u32 = 1;
+    loop {
+        let d = days_in_month(year, month);
+        if s < d {
+            break;
+        }
+        s -= d;
+        month += 1;
+    }
+    let day = s as u32 + 1;
+    (year, month, day, hour, min, sec)
+}
+
+fn row_to_group(row: &rusqlite::Row<'_>) -> Result<ParallelPhaseGroupRow, rusqlite::Error> {
+    let id: String = row.get(0)?;
+    let session_id: String = row.get(1)?;
+    let ordinal: i64 = row.get(2)?;
+    let merge_strategy: String = row.get(3)?;
+    let created_at_ms: i64 = row.get(4)?;
+    let completed_at_ms: Option<i64> = row.get(5)?;
+    Ok(ParallelPhaseGroupRow {
+        id,
+        session_id,
+        ordinal,
+        merge_strategy,
+        created_at: epoch_ms_to_iso(created_at_ms),
+        completed_at: completed_at_ms.map(epoch_ms_to_iso),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn parallel_phase_group_create(
+    state: State<'_, Db>,
+    input: ParallelPhaseGroupCreateInput,
+) -> Result<ParallelPhaseGroupRow, ParallelPhaseError> {
+    let conn = state.0.lock().map_err(|_| ParallelPhaseError::Poisoned)?;
+    let id = input.id.unwrap_or_else(uuid_v4);
+    let created_at_ms = input
+        .created_at
+        .as_deref()
+        .map(iso_to_epoch_ms)
+        .unwrap_or_else(now_epoch_ms);
+
+    conn.execute(
+        "INSERT INTO parallel_phase_groups
+           (id, session_id, ordinal, merge_strategy, created_at, completed_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, NULL)",
+        rusqlite::params![
+            id,
+            input.session_id,
+            input.ordinal,
+            input.merge_strategy,
+            created_at_ms,
+        ],
+    )?;
+
+    Ok(ParallelPhaseGroupRow {
+        id,
+        session_id: input.session_id,
+        ordinal: input.ordinal,
+        merge_strategy: input.merge_strategy,
+        created_at: epoch_ms_to_iso(created_at_ms),
+        completed_at: None,
+    })
+}
+
+#[tauri::command]
+pub fn parallel_phase_group_list(
+    state: State<'_, Db>,
+    session_id: String,
+) -> Result<Vec<ParallelPhaseGroupRow>, ParallelPhaseError> {
+    let conn = state.0.lock().map_err(|_| ParallelPhaseError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, session_id, ordinal, merge_strategy, created_at, completed_at
+         FROM parallel_phase_groups
+         WHERE session_id = ?1
+         ORDER BY ordinal ASC",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![session_id], row_to_group)?;
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(ParallelPhaseError::Db)
+}
+
+#[tauri::command]
+pub fn parallel_phase_group_get(
+    state: State<'_, Db>,
+    id: String,
+) -> Result<Option<ParallelPhaseGroupRow>, ParallelPhaseError> {
+    let conn = state.0.lock().map_err(|_| ParallelPhaseError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT id, session_id, ordinal, merge_strategy, created_at, completed_at
+         FROM parallel_phase_groups
+         WHERE id = ?1
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![id], row_to_group)?;
+    match rows.next() {
+        Some(r) => Ok(Some(r.map_err(ParallelPhaseError::Db)?)),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub fn parallel_phase_group_delete(
+    state: State<'_, Db>,
+    id: String,
+) -> Result<(), ParallelPhaseError> {
+    let conn = state.0.lock().map_err(|_| ParallelPhaseError::Poisoned)?;
+
+    let exists: bool = {
+        let mut stmt =
+            conn.prepare("SELECT 1 FROM parallel_phase_groups WHERE id = ?1 LIMIT 1")?;
+        let mut rows = stmt.query_map(rusqlite::params![id], |_| Ok(()))?;
+        rows.next().is_some()
+    };
+
+    if !exists {
+        return Err(ParallelPhaseError::GroupNotFound(id));
+    }
+
+    conn.execute(
+        "DELETE FROM parallel_phase_groups WHERE id = ?1",
+        rusqlite::params![id],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn parallel_phase_group_update_completed_at(
+    state: State<'_, Db>,
+    id: String,
+    completed_at: String,
+) -> Result<ParallelPhaseGroupRow, ParallelPhaseError> {
+    let conn = state.0.lock().map_err(|_| ParallelPhaseError::Poisoned)?;
+    let completed_at_ms = iso_to_epoch_ms(&completed_at);
+
+    let updated = conn.execute(
+        "UPDATE parallel_phase_groups SET completed_at = ?2 WHERE id = ?1",
+        rusqlite::params![id, completed_at_ms],
+    )?;
+
+    if updated == 0 {
+        return Err(ParallelPhaseError::GroupNotFound(id.clone()));
+    }
+
+    let mut stmt = conn.prepare(
+        "SELECT id, session_id, ordinal, merge_strategy, created_at, completed_at
+         FROM parallel_phase_groups
+         WHERE id = ?1
+         LIMIT 1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![id.clone()], row_to_group)?;
+    match rows.next() {
+        Some(r) => Ok(r.map_err(ParallelPhaseError::Db)?),
+        None => Err(ParallelPhaseError::GroupNotFound(id)),
+    }
+}

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -1,6 +1,9 @@
 import { invoke } from '@tauri-apps/api/core';
 import type {
   IsoDateTime,
+  ParallelMergeStrategy,
+  ParallelPhaseGroup,
+  ParallelPhaseGroupId,
   PhaseDefinition,
   PhaseDefinitionId,
   PhaseRun,
@@ -214,4 +217,82 @@ export async function invokePhaseRunUpdateStatus(
     },
   });
   return rowToPhaseRun(row);
+}
+
+// ---------------------------------------------------------------------------
+// Parallel phase group commands (#207)
+// ---------------------------------------------------------------------------
+
+interface RawParallelPhaseGroupRow {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly ordinal: number;
+  readonly mergeStrategy: string;
+  readonly createdAt: string;
+  readonly completedAt: string | null;
+}
+
+function rowToParallelPhaseGroup(row: RawParallelPhaseGroupRow): ParallelPhaseGroup {
+  return {
+    id: row.id as ParallelPhaseGroupId,
+    sessionId: row.sessionId as SessionId,
+    ordinal: row.ordinal,
+    mergeStrategy: row.mergeStrategy as ParallelMergeStrategy,
+    createdAt: row.createdAt as IsoDateTime,
+    completedAt: row.completedAt != null ? (row.completedAt as IsoDateTime) : null,
+  };
+}
+
+export interface ParallelPhaseGroupCreateArgs {
+  readonly id?: ParallelPhaseGroupId;
+  readonly sessionId: SessionId;
+  readonly ordinal: number;
+  readonly mergeStrategy: ParallelMergeStrategy;
+  readonly createdAt?: IsoDateTime;
+}
+
+export async function invokeParallelPhaseGroupCreate(
+  args: ParallelPhaseGroupCreateArgs,
+): Promise<ParallelPhaseGroup> {
+  const row = await invoke<RawParallelPhaseGroupRow>('parallel_phase_group_create', {
+    input: {
+      id: args.id ?? null,
+      sessionId: args.sessionId,
+      ordinal: args.ordinal,
+      mergeStrategy: args.mergeStrategy,
+      createdAt: args.createdAt ?? null,
+    },
+  });
+  return rowToParallelPhaseGroup(row);
+}
+
+export async function invokeParallelPhaseGroupList(
+  sessionId: SessionId,
+): Promise<ParallelPhaseGroup[]> {
+  const rows = await invoke<RawParallelPhaseGroupRow[]>('parallel_phase_group_list', {
+    sessionId,
+  });
+  return rows.map(rowToParallelPhaseGroup);
+}
+
+export async function invokeParallelPhaseGroupGet(
+  id: ParallelPhaseGroupId,
+): Promise<ParallelPhaseGroup | null> {
+  const row = await invoke<RawParallelPhaseGroupRow | null>('parallel_phase_group_get', { id });
+  return row != null ? rowToParallelPhaseGroup(row) : null;
+}
+
+export async function invokeParallelPhaseGroupDelete(id: ParallelPhaseGroupId): Promise<void> {
+  return invoke<void>('parallel_phase_group_delete', { id });
+}
+
+export async function invokeParallelPhaseGroupUpdateCompletedAt(
+  id: ParallelPhaseGroupId,
+  completedAt: IsoDateTime,
+): Promise<ParallelPhaseGroup> {
+  const row = await invoke<RawParallelPhaseGroupRow>('parallel_phase_group_update_completed_at', {
+    id,
+    completedAt,
+  });
+  return rowToParallelPhaseGroup(row);
 }


### PR DESCRIPTION
## Summary

- new Rust module `apps/desktop/src-tauri/src/parallel_phases.rs` with five commands: `parallel_phase_group_create`, `_list`, `_get`, `_delete`, `_update_completed_at`
- all five commands registered in `lib.rs` invoke handler
- `apps/desktop/src/phases.ts` extended with typed `invoke*` wrappers matching existing patterns

## Notes

- timestamps stored as unix epoch ms (INTEGER) matching m011 migration; bridge converts ISO ↔ ms in Rust helpers
- error type `ParallelPhaseError` mirrors `PhaseError` pattern: kind+message JSON, `GroupNotFound` variant
- `parallel_phase_group_delete` returns `GroupNotFound` when id is missing (consistent with `phase_template_delete`)

## Test plan

- [x] `pnpm --filter @kay-am/desktop typecheck` passes
- [x] `pnpm --filter @kay-am/desktop test` passes (23 tests)
- [x] `cargo check` passes

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)