### PR TITLE
feat(core): parallel conflict detection + merge strategy (#204)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,11 +115,18 @@ export {
   awaitMerge,
   onProgress,
   cancelGroup,
+  detectConflicts,
+  resolveConflicts,
+  ManualResolutionRequiredError,
   type SchedulerDeps,
   type SchedulerHandle,
   type SchedulerProgress,
   type MergeResult,
   type UnsubscribeFn,
+  type RunFileTouches,
+  type FileConflict,
+  type ResolvedConflict,
+  type ConflictResolutionInput,
 } from './scheduler';
 
 export {

--- a/packages/core/src/scheduler/__tests__/conflict.test.ts
+++ b/packages/core/src/scheduler/__tests__/conflict.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  detectConflicts,
+  ManualResolutionRequiredError,
+  resolveConflicts,
+  type FileConflict,
+  type RunFileTouches,
+} from '../conflict';
+import type { IsoDateTime, ProviderRunId } from '@kay-am/types';
+
+const runId = (id: string) => id as ProviderRunId;
+const iso = (s: string) => s as IsoDateTime;
+
+describe('detectConflicts', () => {
+  it('returns empty for disjoint touches', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['src/foo.ts', 'src/bar.ts'] },
+      { runId: runId('run-b'), files: ['src/baz.ts'] },
+    ];
+    expect(detectConflicts(touches)).toHaveLength(0);
+  });
+
+  it('detects single conflict between 2 runs', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['src/shared.ts'] },
+      { runId: runId('run-b'), files: ['src/shared.ts'] },
+    ];
+    const conflicts = detectConflicts(touches);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.file).toBe('src/shared.ts');
+    expect(conflicts[0]!.runIds).toContain(runId('run-a'));
+    expect(conflicts[0]!.runIds).toContain(runId('run-b'));
+  });
+
+  it('detects N conflicts across multiple files', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['a.ts', 'b.ts', 'c.ts'] },
+      { runId: runId('run-b'), files: ['a.ts', 'b.ts'] },
+      { runId: runId('run-c'), files: ['b.ts', 'd.ts'] },
+    ];
+    const conflicts = detectConflicts(touches);
+    const files = conflicts.map((c) => c.file).sort();
+    expect(files).toEqual(['a.ts', 'b.ts']);
+    const bConflict = conflicts.find((c) => c.file === 'b.ts')!;
+    expect(bConflict.runIds).toHaveLength(3);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(detectConflicts([])).toHaveLength(0);
+  });
+});
+
+describe('resolveConflicts — last_write_wins', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/shared.ts', runIds: [runId('run-a'), runId('run-b')] },
+  ];
+
+  it('picks run with later completedAt', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T11:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+    expect(result[0]!.reason).toBe('last_write_wins');
+  });
+
+  it('tie in completedAt → picks lower runId (deterministic)', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-a'));
+  });
+
+  it('skips non-completed runs when picking winner', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'failed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T09:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+  });
+
+  it('falls back to deterministic runId sort when no run is completed', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'failed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T11:00:00Z'), status: 'failed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-a'));
+  });
+
+  it('returns empty when no conflicts', async () => {
+    const result = await resolveConflicts({
+      conflicts: [],
+      runStatuses: [],
+      strategy: 'last_write_wins',
+    });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('resolveConflicts — manual', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/alpha.ts', runIds: [runId('run-a'), runId('run-b')] },
+    { file: 'src/beta.ts', runIds: [runId('run-a'), runId('run-c')] },
+  ];
+
+  it('resolves all conflicts when manualPicks complete', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [],
+      strategy: 'manual',
+      manualPicks: {
+        'src/alpha.ts': runId('run-a'),
+        'src/beta.ts': runId('run-c'),
+      },
+    });
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.file === 'src/alpha.ts')!.winnerRunId).toBe(runId('run-a'));
+    expect(result.find((r) => r.file === 'src/beta.ts')!.winnerRunId).toBe(runId('run-c'));
+    expect(result[0]!.reason).toBe('manual_pick');
+  });
+
+  it('throws ManualResolutionRequiredError for missing picks', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+        manualPicks: { 'src/alpha.ts': runId('run-a') },
+      }),
+    ).rejects.toThrow(ManualResolutionRequiredError);
+  });
+
+  it('ManualResolutionRequiredError includes unresolved file list', async () => {
+    try {
+      await resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+        manualPicks: {},
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManualResolutionRequiredError);
+      const e = err as ManualResolutionRequiredError;
+      expect(e.unresolvedFiles).toContain('src/alpha.ts');
+      expect(e.unresolvedFiles).toContain('src/beta.ts');
+    }
+  });
+
+  it('throws when manualPicks is absent', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+      }),
+    ).rejects.toThrow(ManualResolutionRequiredError);
+  });
+});
+
+describe('resolveConflicts — synthesizer_driven', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/shared.ts', runIds: [runId('run-a'), runId('run-b')] },
+  ];
+
+  it('calls synthesize per conflict and returns result', async () => {
+    const synthesize = vi.fn().mockResolvedValue(runId('run-b'));
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [],
+      strategy: 'synthesizer_driven',
+      synthesize,
+    });
+    expect(synthesize).toHaveBeenCalledOnce();
+    expect(synthesize).toHaveBeenCalledWith(conflicts[0]);
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+    expect(result[0]!.reason).toBe('synthesizer');
+  });
+
+  it('surfaces error when synthesize rejects', async () => {
+    const synthesize = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'synthesizer_driven',
+        synthesize,
+      }),
+    ).rejects.toThrow('provider unavailable');
+  });
+
+  it('throws when synthesize callback is absent', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'synthesizer_driven',
+      }),
+    ).rejects.toThrow('synthesizer_driven strategy requires a synthesize callback');
+  });
+});

--- a/packages/core/src/scheduler/conflict.ts
+++ b/packages/core/src/scheduler/conflict.ts
@@ -1,0 +1,165 @@
+import type {
+  IsoDateTime,
+  ParallelMergeStrategy,
+  PhaseRunStatus,
+  ProviderRunId,
+} from '@kay-am/types';
+
+export interface RunFileTouches {
+  runId: ProviderRunId;
+  files: ReadonlyArray<string>;
+}
+
+export interface FileConflict {
+  file: string;
+  runIds: ReadonlyArray<ProviderRunId>;
+}
+
+export interface ResolvedConflict {
+  file: string;
+  winnerRunId: ProviderRunId;
+  reason: 'last_write_wins' | 'manual_pick' | 'synthesizer';
+}
+
+export interface ConflictResolutionInput {
+  conflicts: ReadonlyArray<FileConflict>;
+  runStatuses: ReadonlyArray<{
+    runId: ProviderRunId;
+    completedAt: IsoDateTime;
+    status: PhaseRunStatus;
+  }>;
+  strategy: ParallelMergeStrategy;
+  manualPicks?: Record<string, ProviderRunId>;
+  synthesize?: (conflict: FileConflict) => Promise<ProviderRunId>;
+}
+
+export class ManualResolutionRequiredError extends Error {
+  readonly unresolvedFiles: ReadonlyArray<string>;
+
+  constructor(unresolvedFiles: ReadonlyArray<string>) {
+    super(`manual resolution required for files: ${unresolvedFiles.join(', ')}`);
+    this.name = 'ManualResolutionRequiredError';
+    this.unresolvedFiles = unresolvedFiles;
+  }
+}
+
+export function detectConflicts(
+  touches: ReadonlyArray<RunFileTouches>,
+): ReadonlyArray<FileConflict> {
+  const fileToRuns = new Map<string, ProviderRunId[]>();
+
+  for (const { runId, files } of touches) {
+    for (const file of files) {
+      const existing = fileToRuns.get(file);
+      if (existing === undefined) {
+        fileToRuns.set(file, [runId]);
+      } else {
+        existing.push(runId);
+      }
+    }
+  }
+
+  const conflicts: FileConflict[] = [];
+  for (const [file, runIds] of fileToRuns) {
+    if (runIds.length >= 2) {
+      conflicts.push({ file, runIds });
+    }
+  }
+
+  return conflicts;
+}
+
+export async function resolveConflicts(
+  input: ConflictResolutionInput,
+): Promise<ReadonlyArray<ResolvedConflict>> {
+  const { conflicts, runStatuses, strategy, manualPicks, synthesize } = input;
+
+  if (conflicts.length === 0) {
+    return [];
+  }
+
+  if (strategy === 'last_write_wins') {
+    return resolveLastWriteWins(conflicts, runStatuses);
+  }
+
+  if (strategy === 'manual') {
+    return resolveManual(conflicts, manualPicks ?? {});
+  }
+
+  // synthesizer_driven
+  return resolveSynthesizer(conflicts, synthesize);
+}
+
+function resolveLastWriteWins(
+  conflicts: ReadonlyArray<FileConflict>,
+  runStatuses: ReadonlyArray<{
+    runId: ProviderRunId;
+    completedAt: IsoDateTime;
+    status: PhaseRunStatus;
+  }>,
+): ReadonlyArray<ResolvedConflict> {
+  const statusMap = new Map(runStatuses.map((r) => [r.runId, r]));
+
+  return conflicts.map((conflict) => {
+    const candidates = conflict.runIds
+      .map((runId) => statusMap.get(runId))
+      .filter(
+        (r): r is { runId: ProviderRunId; completedAt: IsoDateTime; status: PhaseRunStatus } =>
+          r !== undefined && r.status === 'completed',
+      );
+
+    if (candidates.length === 0) {
+      // No completed run — fall back to deterministic sort on runId
+      const sorted = [...conflict.runIds].sort();
+      return { file: conflict.file, winnerRunId: sorted[0]!, reason: 'last_write_wins' };
+    }
+
+    // Sort descending by completedAt, tie-break ascending by runId (deterministic)
+    candidates.sort((a, b) => {
+      const timeDiff = b.completedAt.localeCompare(a.completedAt);
+      if (timeDiff !== 0) return timeDiff;
+      return a.runId.localeCompare(b.runId);
+    });
+
+    return { file: conflict.file, winnerRunId: candidates[0]!.runId, reason: 'last_write_wins' };
+  });
+}
+
+function resolveManual(
+  conflicts: ReadonlyArray<FileConflict>,
+  manualPicks: Record<string, ProviderRunId>,
+): ReadonlyArray<ResolvedConflict> {
+  const unresolved: string[] = [];
+  const resolved: ResolvedConflict[] = [];
+
+  for (const conflict of conflicts) {
+    const pick = manualPicks[conflict.file];
+    if (pick === undefined) {
+      unresolved.push(conflict.file);
+    } else {
+      resolved.push({ file: conflict.file, winnerRunId: pick, reason: 'manual_pick' });
+    }
+  }
+
+  if (unresolved.length > 0) {
+    throw new ManualResolutionRequiredError(unresolved);
+  }
+
+  return resolved;
+}
+
+async function resolveSynthesizer(
+  conflicts: ReadonlyArray<FileConflict>,
+  synthesize: ((conflict: FileConflict) => Promise<ProviderRunId>) | undefined,
+): Promise<ReadonlyArray<ResolvedConflict>> {
+  if (synthesize === undefined) {
+    throw new Error('synthesizer_driven strategy requires a synthesize callback');
+  }
+
+  return Promise.all(
+    conflicts.map(async (conflict) => {
+      const winnerRunId = await synthesize(conflict);
+      return { file: conflict.file, winnerRunId, reason: 'synthesizer' as const };
+    }),
+  );
+}

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -8,6 +8,16 @@ import type {
   TurnEvent,
 } from '@kay-am/types';
 
+export {
+  detectConflicts,
+  resolveConflicts,
+  ManualResolutionRequiredError,
+  type RunFileTouches,
+  type FileConflict,
+  type ResolvedConflict,
+  type ConflictResolutionInput,
+} from './conflict';
+
 export type UnsubscribeFn = () => void;
 
 export interface SchedulerDeps {


### PR DESCRIPTION
## Summary

- Pure `detectConflicts` fn: maps file paths → runs, returns only files touched by 2+ runs (no IO, browser-safe)
- `resolveConflicts` async dispatcher across three strategies: `last_write_wins`, `manual`, `synthesizer_driven`
- `ManualResolutionRequiredError` class with `unresolvedFiles: ReadonlyArray<string>` for UI to surface missing picks
- Dep-injected `synthesize` callback keeps synthesizer_driven testable and IO-free at the module level
- Tie-breaking: latest `completedAt` ISO string wins; identical timestamps → ascending `runId` lexicographic sort (deterministic)

## Test plan

- [ ] 16 unit tests pass (`detectConflicts` + all three strategy paths + error paths + edge cases)
- [ ] `pnpm typecheck` clean across all packages
- [ ] 0 conflicts (disjoint): empty result
- [ ] 1 conflict, 2 runs, last_write_wins: later completedAt wins
- [ ] Tied completedAt: deterministic by runId
- [ ] No completed runs: deterministic runId fallback
- [ ] manual strategy, all picks present: resolves cleanly
- [ ] manual strategy, missing pick: throws `ManualResolutionRequiredError` with file list
- [ ] synthesizer_driven: mock callback called per conflict, result surfaced
- [ ] synthesizer_driven, callback rejects: error propagated
- [ ] synthesizer_driven, no callback: throws

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)