### PR TITLE
feat(desktop): parallel phase run spawn batch tauri command

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -95,6 +95,7 @@ pub fn run() {
       parallel_phases::parallel_phase_group_get,
       parallel_phases::parallel_phase_group_delete,
       parallel_phases::parallel_phase_group_update_completed_at,
+      parallel_phases::parallel_phase_run_spawn,
       permissions::permission_rule_list,
       permissions::permission_rule_get,
       permissions::permission_rule_upsert,

--- a/apps/desktop/src-tauri/src/parallel_phases.rs
+++ b/apps/desktop/src-tauri/src/parallel_phases.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::db::{Db, DbError};
+use crate::turn::{spawn_one, SpawnOneArgs, TurnError, TurnRegistry};
 
 // ---------------------------------------------------------------------------
 // Structs
@@ -368,5 +369,125 @@ pub fn parallel_phase_group_update_completed_at(
     match rows.next() {
         Some(r) => Ok(r.map_err(ParallelPhaseError::Db)?),
         None => Err(ParallelPhaseError::GroupNotFound(id)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parallel run spawn
+// ---------------------------------------------------------------------------
+
+/// One run within a parallel phase — carries the per-process identity.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParallelRunSpec {
+    pub run_id: String,
+    /// Worktree path produced by C3 worktree helper.
+    pub working_dir: String,
+    /// Zero-based index among sibling runs in the group.
+    #[allow(dead_code)]
+    pub parallel_index: u32,
+}
+
+/// Arguments for spawning a batch of parallel runs in one invoke.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ParallelSpawnArgs {
+    /// Parallel phase group this batch belongs to (for tracing / audit).
+    #[allow(dead_code)]
+    pub group_id: String,
+    pub runs: Vec<ParallelRunSpec>,
+    #[serde(default)]
+    pub binary: Option<String>,
+    pub model: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub permission_mode: Option<String>,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    #[serde(default)]
+    pub disallowed_tools: Vec<String>,
+}
+
+/// Spawn N child processes concurrently (one per `ParallelRunSpec`).
+///
+/// Each child is registered in `TurnRegistry` with its own `run_id` and emits
+/// `turn_event` envelopes tagged with that `run_id`. Returns all launched
+/// `run_id`s once every child has been spawned (threads run independently).
+/// Cancelling a single `run_id` via `turn_cancel` does not affect siblings.
+#[tauri::command]
+pub fn parallel_phase_run_spawn(
+    app: AppHandle,
+    state: State<'_, TurnRegistry>,
+    args: ParallelSpawnArgs,
+) -> Result<Vec<String>, TurnError> {
+    let binary = args.binary.as_deref().unwrap_or("claude");
+    let permission_mode = args
+        .permission_mode
+        .as_deref()
+        .unwrap_or("default")
+        .to_string();
+
+    let mut run_ids: Vec<String> = Vec::with_capacity(args.runs.len());
+
+    for spec in &args.runs {
+        let run_id = spawn_one(
+            &app,
+            &state.0,
+            SpawnOneArgs {
+                run_id: &spec.run_id,
+                binary,
+                model: &args.model,
+                working_dir: &spec.working_dir,
+                prompt: &args.prompt,
+                permission_mode: &permission_mode,
+                allowed_tools: &args.allowed_tools,
+                disallowed_tools: &args.disallowed_tools,
+            },
+        )?;
+        run_ids.push(run_id);
+    }
+
+    Ok(run_ids)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parallel_spawn_args_defaults() {
+        let json = r#"{
+            "groupId": "g1",
+            "runs": [
+                {"runId": "r1", "workingDir": "/tmp/wt1", "parallelIndex": 0},
+                {"runId": "r2", "workingDir": "/tmp/wt2", "parallelIndex": 1}
+            ],
+            "model": "claude-3-opus",
+            "prompt": "do the thing"
+        }"#;
+        let parsed: ParallelSpawnArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.group_id, "g1");
+        assert_eq!(parsed.runs.len(), 2);
+        assert_eq!(parsed.runs[0].run_id, "r1");
+        assert_eq!(parsed.runs[1].parallel_index, 1);
+        assert!(parsed.binary.is_none());
+        assert!(parsed.permission_mode.is_none());
+        assert!(parsed.allowed_tools.is_empty());
+        assert!(parsed.disallowed_tools.is_empty());
+    }
+
+    #[test]
+    fn parallel_run_spec_fields() {
+        let spec = ParallelRunSpec {
+            run_id: "run-42".to_string(),
+            working_dir: "/worktrees/branch-p0".to_string(),
+            parallel_index: 0,
+        };
+        assert_eq!(spec.run_id, "run-42");
+        assert_eq!(spec.parallel_index, 0);
     }
 }

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -91,45 +91,57 @@ pub struct TurnEventEnvelope {
     pub event: TurnEventPayload,
 }
 
-const EVENT_NAME: &str = "turn_event";
+pub const EVENT_NAME: &str = "turn_event";
 
-#[tauri::command]
-pub fn turn_spawn(
-    app: AppHandle,
-    state: State<'_, TurnRegistry>,
-    args: SpawnArgs,
+/// Per-run spawn parameters used by both `turn_spawn` and `parallel_phase_run_spawn`.
+pub struct SpawnOneArgs<'a> {
+    pub run_id: &'a str,
+    pub binary: &'a str,
+    pub model: &'a str,
+    pub working_dir: &'a str,
+    pub prompt: &'a str,
+    pub permission_mode: &'a str,
+    pub allowed_tools: &'a [String],
+    pub disallowed_tools: &'a [String],
+}
+
+/// Spawns one child process, registers it in the registry, and starts the
+/// forwarding thread. Returns `run_id` on success.
+///
+/// Extracted so that `turn_spawn` (single run) and `parallel_phase_run_spawn`
+/// (N runs) share the same logic without copy-paste.
+pub(crate) fn spawn_one(
+    app: &AppHandle,
+    registry: &ChildRegistry,
+    args: SpawnOneArgs<'_>,
 ) -> Result<String, TurnError> {
-    let binary = args.binary.unwrap_or_else(|| "claude".to_string());
-    let permission_mode = args
-        .permission_mode
-        .clone()
-        .unwrap_or_else(|| "default".to_string());
-
-    if permission_mode == "bypassPermissions"
+    if args.permission_mode == "bypassPermissions"
         && args.allowed_tools.is_empty()
         && args.disallowed_tools.is_empty()
     {
         eprintln!(
-            "[turn_spawn] permission_mode=bypassPermissions with no rules — \
+            "[spawn_one] permission_mode=bypassPermissions with no rules — \
              relying on claude CLI native bypass; --dangerously-skip-permissions intentionally not set"
         );
     }
 
-    let mut command = Command::new(binary);
+    let mut command = Command::new(args.binary);
     command
         .arg("-p")
-        .arg(&args.prompt)
+        .arg(args.prompt)
         .arg("--output-format")
         .arg("stream-json")
         .arg("--working-dir")
-        .arg(&args.working_dir)
+        .arg(args.working_dir)
         .arg("--model")
-        .arg(&args.model)
+        .arg(args.model)
         .arg("--permission-mode")
-        .arg(&permission_mode);
+        .arg(args.permission_mode);
 
     if !args.allowed_tools.is_empty() {
-        command.arg("--allowedTools").arg(args.allowed_tools.join(","));
+        command
+            .arg("--allowedTools")
+            .arg(args.allowed_tools.join(","));
     }
     if !args.disallowed_tools.is_empty() {
         command
@@ -152,24 +164,23 @@ pub fn turn_spawn(
         .ok_or_else(|| TurnError::Io(std::io::Error::other("no stderr")))?;
 
     let slot = Arc::new(Mutex::new(Some(child)));
-    state
-        .0
+    registry
         .lock()
         .map_err(|_| TurnError::Poisoned)?
-        .insert(args.run_id.clone(), Arc::clone(&slot));
+        .insert(args.run_id.to_string(), Arc::clone(&slot));
 
     let app_clone = app.clone();
-    let registry = Arc::clone(&state.0);
-    let run_id = args.run_id.clone();
+    let registry_clone = Arc::clone(registry);
+    let run_id_owned = args.run_id.to_string();
 
     thread::spawn(move || {
-        forward_lines(&app_clone, &run_id, stdout);
+        forward_lines(&app_clone, &run_id_owned, stdout);
         let stderr_buf = capture_stderr(stderr);
-        let exit_code = wait_and_remove(&slot, &registry, &run_id);
+        let exit_code = wait_and_remove(&slot, &registry_clone, &run_id_owned);
         let _ = app_clone.emit(
             EVENT_NAME,
             TurnEventEnvelope {
-                run_id: run_id.clone(),
+                run_id: run_id_owned.clone(),
                 event: TurnEventPayload::End {
                     exit_code,
                     stderr: stderr_buf,
@@ -178,7 +189,36 @@ pub fn turn_spawn(
         );
     });
 
-    Ok(args.run_id)
+    Ok(args.run_id.to_string())
+}
+
+#[tauri::command]
+pub fn turn_spawn(
+    app: AppHandle,
+    state: State<'_, TurnRegistry>,
+    args: SpawnArgs,
+) -> Result<String, TurnError> {
+    let binary = args.binary.as_deref().unwrap_or("claude");
+    let permission_mode = args
+        .permission_mode
+        .as_deref()
+        .unwrap_or("default")
+        .to_string();
+
+    spawn_one(
+        &app,
+        &state.0,
+        SpawnOneArgs {
+            run_id: &args.run_id,
+            binary,
+            model: &args.model,
+            working_dir: &args.working_dir,
+            prompt: &args.prompt,
+            permission_mode: &permission_mode,
+            allowed_tools: &args.allowed_tools,
+            disallowed_tools: &args.disallowed_tools,
+        },
+    )
 }
 
 #[tauri::command]
@@ -247,4 +287,39 @@ fn wait_and_remove(
         map.remove(run_id);
     }
     exit
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn turn_registry_default_is_empty() {
+        let registry = TurnRegistry::new();
+        let map = registry.0.lock().unwrap();
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn spawn_one_args_fields_accessible() {
+        let allowed: Vec<String> = vec!["Bash".to_string()];
+        let disallowed: Vec<String> = vec![];
+        let args = SpawnOneArgs {
+            run_id: "run-1",
+            binary: "echo",
+            model: "claude-3",
+            working_dir: "/tmp",
+            prompt: "hello",
+            permission_mode: "default",
+            allowed_tools: &allowed,
+            disallowed_tools: &disallowed,
+        };
+        assert_eq!(args.run_id, "run-1");
+        assert_eq!(args.binary, "echo");
+        assert_eq!(args.allowed_tools, &["Bash".to_string()]);
+    }
 }

--- a/apps/desktop/src/__tests__/parallel-spawn.test.ts
+++ b/apps/desktop/src/__tests__/parallel-spawn.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks — factories must not reference outer-scope variables
+// (vi.mock is hoisted before variable initialization)
+// ---------------------------------------------------------------------------
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Subject under test (imported after mocks are registered)
+// ---------------------------------------------------------------------------
+
+import { invoke } from '@tauri-apps/api/core';
+import { invokeParallelPhaseRunSpawn, type ParallelSpawnArgs } from '../turn';
+
+const invokeMock = vi.mocked(invoke);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('invokeParallelPhaseRunSpawn', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it('calls parallel_phase_run_spawn with correct args and returns run ids', async () => {
+    const runIds = ['run-a', 'run-b'];
+    invokeMock.mockResolvedValueOnce(runIds);
+
+    const args: ParallelSpawnArgs = {
+      groupId: 'group-1',
+      runs: [
+        { runId: 'run-a' as never, workingDir: '/worktrees/wt-0', parallelIndex: 0 },
+        { runId: 'run-b' as never, workingDir: '/worktrees/wt-1', parallelIndex: 1 },
+      ],
+      model: 'claude-opus-4-5',
+      prompt: 'implement feature X',
+    };
+
+    const result = await invokeParallelPhaseRunSpawn(args);
+
+    expect(invokeMock).toHaveBeenCalledOnce();
+    expect(invokeMock).toHaveBeenCalledWith('parallel_phase_run_spawn', { args });
+    expect(result).toEqual(['run-a', 'run-b']);
+  });
+
+  it('forwards optional fields to invoke', async () => {
+    invokeMock.mockResolvedValueOnce(['run-c']);
+
+    const args: ParallelSpawnArgs = {
+      groupId: 'group-2',
+      runs: [{ runId: 'run-c' as never, workingDir: '/worktrees/wt-2', parallelIndex: 0 }],
+      model: 'claude-sonnet-4-6',
+      prompt: 'refactor module',
+      binary: 'claude-custom',
+      permissionMode: 'acceptEdits',
+      allowedTools: ['Bash', 'Edit'],
+      disallowedTools: ['WebSearch'],
+    };
+
+    const result = await invokeParallelPhaseRunSpawn(args);
+
+    expect(invokeMock).toHaveBeenCalledWith('parallel_phase_run_spawn', { args });
+    expect(result).toEqual(['run-c']);
+  });
+
+  it('returns empty array when runs is empty', async () => {
+    invokeMock.mockResolvedValueOnce([]);
+
+    const args: ParallelSpawnArgs = {
+      groupId: 'group-empty',
+      runs: [],
+      model: 'claude-haiku-3-5',
+      prompt: 'noop',
+    };
+
+    const result = await invokeParallelPhaseRunSpawn(args);
+
+    expect(result).toEqual([]);
+  });
+
+  it('propagates invoke errors', async () => {
+    invokeMock.mockRejectedValueOnce(new Error('tauri error'));
+
+    const args: ParallelSpawnArgs = {
+      groupId: 'group-err',
+      runs: [{ runId: 'run-x' as never, workingDir: '/tmp', parallelIndex: 0 }],
+      model: 'claude-opus-4-5',
+      prompt: 'fail',
+    };
+
+    await expect(invokeParallelPhaseRunSpawn(args)).rejects.toThrow('tauri error');
+  });
+});

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -160,3 +160,41 @@ export async function* runTurn(
 export async function cancelTurn(runId: ProviderRunId): Promise<void> {
   await invoke('turn_cancel', { runId });
 }
+
+// ---------------------------------------------------------------------------
+// Parallel phase run spawn
+// ---------------------------------------------------------------------------
+
+export interface ParallelRunSpec {
+  readonly runId: ProviderRunId;
+  /** Worktree path from C3 worktree helper. */
+  readonly workingDir: string;
+  readonly parallelIndex: number;
+}
+
+export interface ParallelSpawnArgs {
+  readonly groupId: string;
+  readonly runs: ReadonlyArray<ParallelRunSpec>;
+  readonly binary?: string;
+  readonly model: string;
+  readonly prompt: string;
+  readonly permissionMode?: ClaudePermissionMode;
+  readonly allowedTools?: ReadonlyArray<string>;
+  readonly disallowedTools?: ReadonlyArray<string>;
+}
+
+/**
+ * Spawn N child processes concurrently via a single Tauri invoke.
+ *
+ * Returns the launched `runId`s in the same order as `args.runs`.
+ * Each run emits `turn_event` envelopes tagged with its own `runId` — the
+ * existing `RawTurnEnvelope` listener already filters by `runId`, so no
+ * frontend changes are needed for multiplexing.
+ */
+export async function invokeParallelPhaseRunSpawn(
+  args: ParallelSpawnArgs,
+): Promise<ReadonlyArray<ProviderRunId>> {
+  return invoke<string[]>('parallel_phase_run_spawn', { args }).then(
+    (ids) => ids as ProviderRunId[],
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,11 +115,18 @@ export {
   awaitMerge,
   onProgress,
   cancelGroup,
+  detectConflicts,
+  resolveConflicts,
+  ManualResolutionRequiredError,
   type SchedulerDeps,
   type SchedulerHandle,
   type SchedulerProgress,
   type MergeResult,
   type UnsubscribeFn,
+  type RunFileTouches,
+  type FileConflict,
+  type ResolvedConflict,
+  type ConflictResolutionInput,
 } from './scheduler';
 
 export {

--- a/packages/core/src/scheduler/__tests__/conflict.test.ts
+++ b/packages/core/src/scheduler/__tests__/conflict.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  detectConflicts,
+  ManualResolutionRequiredError,
+  resolveConflicts,
+  type FileConflict,
+  type RunFileTouches,
+} from '../conflict';
+import type { IsoDateTime, ProviderRunId } from '@kay-am/types';
+
+const runId = (id: string) => id as ProviderRunId;
+const iso = (s: string) => s as IsoDateTime;
+
+describe('detectConflicts', () => {
+  it('returns empty for disjoint touches', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['src/foo.ts', 'src/bar.ts'] },
+      { runId: runId('run-b'), files: ['src/baz.ts'] },
+    ];
+    expect(detectConflicts(touches)).toHaveLength(0);
+  });
+
+  it('detects single conflict between 2 runs', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['src/shared.ts'] },
+      { runId: runId('run-b'), files: ['src/shared.ts'] },
+    ];
+    const conflicts = detectConflicts(touches);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.file).toBe('src/shared.ts');
+    expect(conflicts[0]!.runIds).toContain(runId('run-a'));
+    expect(conflicts[0]!.runIds).toContain(runId('run-b'));
+  });
+
+  it('detects N conflicts across multiple files', () => {
+    const touches: ReadonlyArray<RunFileTouches> = [
+      { runId: runId('run-a'), files: ['a.ts', 'b.ts', 'c.ts'] },
+      { runId: runId('run-b'), files: ['a.ts', 'b.ts'] },
+      { runId: runId('run-c'), files: ['b.ts', 'd.ts'] },
+    ];
+    const conflicts = detectConflicts(touches);
+    const files = conflicts.map((c) => c.file).sort();
+    expect(files).toEqual(['a.ts', 'b.ts']);
+    const bConflict = conflicts.find((c) => c.file === 'b.ts')!;
+    expect(bConflict.runIds).toHaveLength(3);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(detectConflicts([])).toHaveLength(0);
+  });
+});
+
+describe('resolveConflicts — last_write_wins', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/shared.ts', runIds: [runId('run-a'), runId('run-b')] },
+  ];
+
+  it('picks run with later completedAt', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T11:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+    expect(result[0]!.reason).toBe('last_write_wins');
+  });
+
+  it('tie in completedAt → picks lower runId (deterministic)', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-a'));
+  });
+
+  it('skips non-completed runs when picking winner', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'failed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T09:00:00Z'), status: 'completed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+  });
+
+  it('falls back to deterministic runId sort when no run is completed', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [
+        { runId: runId('run-a'), completedAt: iso('2024-01-01T10:00:00Z'), status: 'failed' },
+        { runId: runId('run-b'), completedAt: iso('2024-01-01T11:00:00Z'), status: 'failed' },
+      ],
+      strategy: 'last_write_wins',
+    });
+    expect(result[0]!.winnerRunId).toBe(runId('run-a'));
+  });
+
+  it('returns empty when no conflicts', async () => {
+    const result = await resolveConflicts({
+      conflicts: [],
+      runStatuses: [],
+      strategy: 'last_write_wins',
+    });
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('resolveConflicts — manual', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/alpha.ts', runIds: [runId('run-a'), runId('run-b')] },
+    { file: 'src/beta.ts', runIds: [runId('run-a'), runId('run-c')] },
+  ];
+
+  it('resolves all conflicts when manualPicks complete', async () => {
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [],
+      strategy: 'manual',
+      manualPicks: {
+        'src/alpha.ts': runId('run-a'),
+        'src/beta.ts': runId('run-c'),
+      },
+    });
+    expect(result).toHaveLength(2);
+    expect(result.find((r) => r.file === 'src/alpha.ts')!.winnerRunId).toBe(runId('run-a'));
+    expect(result.find((r) => r.file === 'src/beta.ts')!.winnerRunId).toBe(runId('run-c'));
+    expect(result[0]!.reason).toBe('manual_pick');
+  });
+
+  it('throws ManualResolutionRequiredError for missing picks', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+        manualPicks: { 'src/alpha.ts': runId('run-a') },
+      }),
+    ).rejects.toThrow(ManualResolutionRequiredError);
+  });
+
+  it('ManualResolutionRequiredError includes unresolved file list', async () => {
+    try {
+      await resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+        manualPicks: {},
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManualResolutionRequiredError);
+      const e = err as ManualResolutionRequiredError;
+      expect(e.unresolvedFiles).toContain('src/alpha.ts');
+      expect(e.unresolvedFiles).toContain('src/beta.ts');
+    }
+  });
+
+  it('throws when manualPicks is absent', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'manual',
+      }),
+    ).rejects.toThrow(ManualResolutionRequiredError);
+  });
+});
+
+describe('resolveConflicts — synthesizer_driven', () => {
+  const conflicts: ReadonlyArray<FileConflict> = [
+    { file: 'src/shared.ts', runIds: [runId('run-a'), runId('run-b')] },
+  ];
+
+  it('calls synthesize per conflict and returns result', async () => {
+    const synthesize = vi.fn().mockResolvedValue(runId('run-b'));
+    const result = await resolveConflicts({
+      conflicts,
+      runStatuses: [],
+      strategy: 'synthesizer_driven',
+      synthesize,
+    });
+    expect(synthesize).toHaveBeenCalledOnce();
+    expect(synthesize).toHaveBeenCalledWith(conflicts[0]);
+    expect(result[0]!.winnerRunId).toBe(runId('run-b'));
+    expect(result[0]!.reason).toBe('synthesizer');
+  });
+
+  it('surfaces error when synthesize rejects', async () => {
+    const synthesize = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'synthesizer_driven',
+        synthesize,
+      }),
+    ).rejects.toThrow('provider unavailable');
+  });
+
+  it('throws when synthesize callback is absent', async () => {
+    await expect(
+      resolveConflicts({
+        conflicts,
+        runStatuses: [],
+        strategy: 'synthesizer_driven',
+      }),
+    ).rejects.toThrow('synthesizer_driven strategy requires a synthesize callback');
+  });
+});

--- a/packages/core/src/scheduler/conflict.ts
+++ b/packages/core/src/scheduler/conflict.ts
@@ -1,0 +1,165 @@
+import type {
+  IsoDateTime,
+  ParallelMergeStrategy,
+  PhaseRunStatus,
+  ProviderRunId,
+} from '@kay-am/types';
+
+export interface RunFileTouches {
+  runId: ProviderRunId;
+  files: ReadonlyArray<string>;
+}
+
+export interface FileConflict {
+  file: string;
+  runIds: ReadonlyArray<ProviderRunId>;
+}
+
+export interface ResolvedConflict {
+  file: string;
+  winnerRunId: ProviderRunId;
+  reason: 'last_write_wins' | 'manual_pick' | 'synthesizer';
+}
+
+export interface ConflictResolutionInput {
+  conflicts: ReadonlyArray<FileConflict>;
+  runStatuses: ReadonlyArray<{
+    runId: ProviderRunId;
+    completedAt: IsoDateTime;
+    status: PhaseRunStatus;
+  }>;
+  strategy: ParallelMergeStrategy;
+  manualPicks?: Record<string, ProviderRunId>;
+  synthesize?: (conflict: FileConflict) => Promise<ProviderRunId>;
+}
+
+export class ManualResolutionRequiredError extends Error {
+  readonly unresolvedFiles: ReadonlyArray<string>;
+
+  constructor(unresolvedFiles: ReadonlyArray<string>) {
+    super(`manual resolution required for files: ${unresolvedFiles.join(', ')}`);
+    this.name = 'ManualResolutionRequiredError';
+    this.unresolvedFiles = unresolvedFiles;
+  }
+}
+
+export function detectConflicts(
+  touches: ReadonlyArray<RunFileTouches>,
+): ReadonlyArray<FileConflict> {
+  const fileToRuns = new Map<string, ProviderRunId[]>();
+
+  for (const { runId, files } of touches) {
+    for (const file of files) {
+      const existing = fileToRuns.get(file);
+      if (existing === undefined) {
+        fileToRuns.set(file, [runId]);
+      } else {
+        existing.push(runId);
+      }
+    }
+  }
+
+  const conflicts: FileConflict[] = [];
+  for (const [file, runIds] of fileToRuns) {
+    if (runIds.length >= 2) {
+      conflicts.push({ file, runIds });
+    }
+  }
+
+  return conflicts;
+}
+
+export async function resolveConflicts(
+  input: ConflictResolutionInput,
+): Promise<ReadonlyArray<ResolvedConflict>> {
+  const { conflicts, runStatuses, strategy, manualPicks, synthesize } = input;
+
+  if (conflicts.length === 0) {
+    return [];
+  }
+
+  if (strategy === 'last_write_wins') {
+    return resolveLastWriteWins(conflicts, runStatuses);
+  }
+
+  if (strategy === 'manual') {
+    return resolveManual(conflicts, manualPicks ?? {});
+  }
+
+  // synthesizer_driven
+  return resolveSynthesizer(conflicts, synthesize);
+}
+
+function resolveLastWriteWins(
+  conflicts: ReadonlyArray<FileConflict>,
+  runStatuses: ReadonlyArray<{
+    runId: ProviderRunId;
+    completedAt: IsoDateTime;
+    status: PhaseRunStatus;
+  }>,
+): ReadonlyArray<ResolvedConflict> {
+  const statusMap = new Map(runStatuses.map((r) => [r.runId, r]));
+
+  return conflicts.map((conflict) => {
+    const candidates = conflict.runIds
+      .map((runId) => statusMap.get(runId))
+      .filter(
+        (r): r is { runId: ProviderRunId; completedAt: IsoDateTime; status: PhaseRunStatus } =>
+          r !== undefined && r.status === 'completed',
+      );
+
+    if (candidates.length === 0) {
+      // No completed run — fall back to deterministic sort on runId
+      const sorted = [...conflict.runIds].sort();
+      return { file: conflict.file, winnerRunId: sorted[0]!, reason: 'last_write_wins' };
+    }
+
+    // Sort descending by completedAt, tie-break ascending by runId (deterministic)
+    candidates.sort((a, b) => {
+      const timeDiff = b.completedAt.localeCompare(a.completedAt);
+      if (timeDiff !== 0) return timeDiff;
+      return a.runId.localeCompare(b.runId);
+    });
+
+    return { file: conflict.file, winnerRunId: candidates[0]!.runId, reason: 'last_write_wins' };
+  });
+}
+
+function resolveManual(
+  conflicts: ReadonlyArray<FileConflict>,
+  manualPicks: Record<string, ProviderRunId>,
+): ReadonlyArray<ResolvedConflict> {
+  const unresolved: string[] = [];
+  const resolved: ResolvedConflict[] = [];
+
+  for (const conflict of conflicts) {
+    const pick = manualPicks[conflict.file];
+    if (pick === undefined) {
+      unresolved.push(conflict.file);
+    } else {
+      resolved.push({ file: conflict.file, winnerRunId: pick, reason: 'manual_pick' });
+    }
+  }
+
+  if (unresolved.length > 0) {
+    throw new ManualResolutionRequiredError(unresolved);
+  }
+
+  return resolved;
+}
+
+async function resolveSynthesizer(
+  conflicts: ReadonlyArray<FileConflict>,
+  synthesize: ((conflict: FileConflict) => Promise<ProviderRunId>) | undefined,
+): Promise<ReadonlyArray<ResolvedConflict>> {
+  if (synthesize === undefined) {
+    throw new Error('synthesizer_driven strategy requires a synthesize callback');
+  }
+
+  return Promise.all(
+    conflicts.map(async (conflict) => {
+      const winnerRunId = await synthesize(conflict);
+      return { file: conflict.file, winnerRunId, reason: 'synthesizer' as const };
+    }),
+  );
+}

--- a/packages/core/src/scheduler/index.ts
+++ b/packages/core/src/scheduler/index.ts
@@ -8,6 +8,16 @@ import type {
   TurnEvent,
 } from '@kay-am/types';
 
+export {
+  detectConflicts,
+  resolveConflicts,
+  ManualResolutionRequiredError,
+  type RunFileTouches,
+  type FileConflict,
+  type ResolvedConflict,
+  type ConflictResolutionInput,
+} from './conflict';
+
 export type UnsubscribeFn = () => void;
 
 export interface SchedulerDeps {


### PR DESCRIPTION
## Summary

- Extracted `spawn_one` private helper from `turn_spawn` in `turn.rs` — single-run path unchanged, parallel correct by construction via shared fn
- Added `parallel_phase_run_spawn` command in `parallel_phases.rs`: accepts `ParallelSpawnArgs` (group_id + `Vec<ParallelRunSpec>`), spawns N children synchronously, each gets its own forwarding thread emitting `turn_event` tagged with its `run_id`; returns `Vec<RunId>` once all launched
- Registered command in `lib.rs` invoke_handler alongside existing group CRUD entries
- TS bridge `invokeParallelPhaseRunSpawn(args): Promise<ReadonlyArray<ProviderRunId>>` added to `apps/desktop/src/turn.ts`; existing `RawTurnEnvelope` listener already filters by `runId` — multiplexing works without frontend changes
- 4 Rust unit tests (struct deserialization + helper field access), 4 vitest smoke tests (args mapping, optional fields, empty runs, error propagation)

## Test plan

- [x] `cargo check` — clean (0 warnings after `#[allow(dead_code)]` on API-only fields)
- [x] `cargo test` — 4/4 pass
- [x] `pnpm --filter @kay-am/desktop typecheck` — clean
- [x] `pnpm --filter @kay-am/desktop test` — 27/27 pass

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)