### PR TITLE
feat(desktop,ui): split-view transcript + experimental flag toggle

### DIFF
--- a/apps/desktop/src/__tests__/chat-view-split.test.ts
+++ b/apps/desktop/src/__tests__/chat-view-split.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderRunId, TurnEvent, IsoDateTime } from '@kay-am/types';
+import { detectParallelRunIds, filterEventsByRunId } from '../components/chat/transcript-items';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AT = '2026-01-01T00:00:00.000Z' as IsoDateTime;
+
+function makeEvent(runId: string, delta = 'text'): TurnEvent {
+  return { kind: 'assistant_text', runId: runId as ProviderRunId, delta, at: AT };
+}
+
+// ---------------------------------------------------------------------------
+// detectParallelRunIds
+// ---------------------------------------------------------------------------
+
+describe('detectParallelRunIds', () => {
+  it('returns [] when events is empty', () => {
+    expect(detectParallelRunIds([])).toEqual([]);
+  });
+
+  it('returns [] when all events share one runId', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-a'), makeEvent('run-a')];
+    expect(detectParallelRunIds(events)).toEqual([]);
+  });
+
+  it('returns [] when only history events exist (loaded messages)', () => {
+    const events = [makeEvent('history'), makeEvent('history')];
+    expect(detectParallelRunIds(events)).toEqual([]);
+  });
+
+  it('returns [] when history + one real runId → single column', () => {
+    const events = [makeEvent('history'), makeEvent('run-a')];
+    expect(detectParallelRunIds(events)).toEqual([]);
+  });
+
+  it('returns 2 ids when two distinct runIds present → split view', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-b'), makeEvent('run-a')];
+    const ids = detectParallelRunIds(events);
+    expect(ids).toHaveLength(2);
+    expect(ids).toContain('run-a');
+    expect(ids).toContain('run-b');
+  });
+
+  it('returns 3 ids for a 3-run parallel group', () => {
+    const events = [
+      makeEvent('run-a'),
+      makeEvent('run-b'),
+      makeEvent('run-c'),
+      makeEvent('run-a'),
+      makeEvent('run-c'),
+    ];
+    const ids = detectParallelRunIds(events);
+    expect(ids).toHaveLength(3);
+  });
+
+  it('excludes history but includes real runIds when both present', () => {
+    const events = [makeEvent('history'), makeEvent('run-x'), makeEvent('run-y')];
+    const ids = detectParallelRunIds(events);
+    expect(ids).toHaveLength(2);
+    expect(ids).not.toContain('history');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterEventsByRunId
+// ---------------------------------------------------------------------------
+
+describe('filterEventsByRunId', () => {
+  it('returns only events matching the given runId', () => {
+    const events = [
+      makeEvent('run-a', 'hello'),
+      makeEvent('run-b', 'world'),
+      makeEvent('run-a', '!'),
+    ];
+    const filtered = filterEventsByRunId(events, 'run-a' as ProviderRunId);
+    expect(filtered).toHaveLength(2);
+    for (const e of filtered) {
+      expect(e.runId).toBe('run-a');
+    }
+  });
+
+  it('returns empty array when no events match', () => {
+    const events = [makeEvent('run-b')];
+    expect(filterEventsByRunId(events, 'run-a' as ProviderRunId)).toEqual([]);
+  });
+
+  it('returns all events when all share the same runId', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-a'), makeEvent('run-a')];
+    expect(filterEventsByRunId(events, 'run-a' as ProviderRunId)).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSplitView derivation (flag guard)
+// ---------------------------------------------------------------------------
+
+describe('isSplitView derivation', () => {
+  function isSplitView(flagOn: boolean, events: ReadonlyArray<TurnEvent>): boolean {
+    const ids = flagOn ? detectParallelRunIds(events) : [];
+    return ids.length > 1;
+  }
+
+  it('flag off → never split-view, even with parallel events', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-b'), makeEvent('run-c')];
+    expect(isSplitView(false, events)).toBe(false);
+  });
+
+  it('flag on, no parallel group → single column', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-a')];
+    expect(isSplitView(true, events)).toBe(false);
+  });
+
+  it('flag on, 2 parallel runIds → split view', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-b')];
+    expect(isSplitView(true, events)).toBe(true);
+  });
+
+  it('flag on, 3 parallel runIds → split view with 3 columns', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-b'), makeEvent('run-c')];
+    const ids = detectParallelRunIds(events);
+    expect(isSplitView(true, events)).toBe(true);
+    expect(ids).toHaveLength(3);
+  });
+
+  it('flag on, 4 parallel runIds → 4 columns', () => {
+    const events = [makeEvent('run-a'), makeEvent('run-b'), makeEvent('run-c'), makeEvent('run-d')];
+    const ids = detectParallelRunIds(events);
+    expect(ids).toHaveLength(4);
+    expect(isSplitView(true, events)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Column event filtering (correct per-column isolation)
+// ---------------------------------------------------------------------------
+
+describe('per-column event isolation', () => {
+  it('each column sees only its own events', () => {
+    const events = [
+      makeEvent('run-a', 'a1'),
+      makeEvent('run-b', 'b1'),
+      makeEvent('run-a', 'a2'),
+      makeEvent('run-b', 'b2'),
+      makeEvent('run-c', 'c1'),
+    ];
+    const ids = detectParallelRunIds(events);
+    expect(ids).toHaveLength(3);
+
+    for (const id of ids) {
+      const col = filterEventsByRunId(events, id);
+      for (const e of col) {
+        expect(e.runId).toBe(id);
+      }
+    }
+
+    const total = ids.reduce((sum, id) => sum + filterEventsByRunId(events, id).length, 0);
+    expect(total).toBe(events.length);
+  });
+});

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -9,7 +9,13 @@ import { PhasesPanel } from './PhasesPanel';
 import {
   DEFAULT_BRANCH_PREFIX,
   DEFAULT_EDITOR_BINARY,
+  DEFAULT_ENABLE_PARALLEL_AGENTS,
+  DEFAULT_MAX_PARALLELISM,
+  MAX_PARALLELISM,
+  MIN_PARALLELISM,
   SETTING_EDITOR_BINARY,
+  SETTING_ENABLE_PARALLEL_AGENTS,
+  SETTING_MAX_PARALLELISM,
   SETTING_PROVIDER_PRICING_CONFIG,
   settingBranchPrefix,
 } from '../settings';
@@ -31,6 +37,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   const [editorBinary, setEditorBinary] = useState(DEFAULT_EDITOR_BINARY);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [pricingConfig, setPricingConfig] = useState<ProviderPricingConfig>({});
+  const [enableParallelAgents, setEnableParallelAgents] = useState(DEFAULT_ENABLE_PARALLEL_AGENTS);
+  const [maxParallelism, setMaxParallelism] = useState(DEFAULT_MAX_PARALLELISM);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [error, setError] = useState<string | null>(null);
 
@@ -44,6 +52,17 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     void loadSetting(SETTING_PROVIDER_PRICING_CONFIG).then((v) =>
       setPricingConfig(parseProviderPricingConfig(v)),
     );
+    void loadSetting(SETTING_ENABLE_PARALLEL_AGENTS).then((v) =>
+      setEnableParallelAgents(v === 'true'),
+    );
+    void loadSetting(SETTING_MAX_PARALLELISM).then((v) => {
+      const parsed = v !== null ? parseInt(v, 10) : NaN;
+      setMaxParallelism(
+        !isNaN(parsed) && parsed >= MIN_PARALLELISM && parsed <= MAX_PARALLELISM
+          ? parsed
+          : DEFAULT_MAX_PARALLELISM,
+      );
+    });
     if (workspace) {
       void loadSetting(settingBranchPrefix(workspace.id)).then((v) =>
         setBranchPrefix(v ?? DEFAULT_BRANCH_PREFIX),
@@ -57,6 +76,12 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     try {
       await saveSetting(SETTING_EDITOR_BINARY, editorBinary.trim() || DEFAULT_EDITOR_BINARY);
       await saveSetting(SETTING_PROVIDER_PRICING_CONFIG, JSON.stringify(pricingConfig));
+      await saveSetting(SETTING_ENABLE_PARALLEL_AGENTS, enableParallelAgents ? 'true' : 'false');
+      const clampedParallelism = Math.max(
+        MIN_PARALLELISM,
+        Math.min(MAX_PARALLELISM, maxParallelism),
+      );
+      await saveSetting(SETTING_MAX_PARALLELISM, String(clampedParallelism));
       if (workspace) {
         await saveSetting(
           settingBranchPrefix(workspace.id),
@@ -116,6 +141,42 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
       <div className="border-t border-border-soft pt-4">
         <ProviderPricingPanel config={pricingConfig} onChange={setPricingConfig} />
+      </div>
+
+      <div className="flex flex-col gap-4 border-t border-border-soft pt-4">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          experimental — multi-agent parallel
+        </div>
+        <Section
+          label="enable parallel agents"
+          help="split-view transcript renders N columns when a parallel phase group is active."
+        >
+          <label className="flex cursor-pointer items-center gap-2">
+            <input
+              type="checkbox"
+              className="h-4 w-4 cursor-pointer rounded border border-border accent-primary"
+              checked={enableParallelAgents}
+              onChange={(e) => setEnableParallelAgents(e.target.checked)}
+            />
+            <span className="text-sm text-foreground">{enableParallelAgents ? 'on' : 'off'}</span>
+          </label>
+        </Section>
+        <Section
+          label="max parallelism"
+          help={`number of concurrent agent columns (${MIN_PARALLELISM}–${MAX_PARALLELISM}).`}
+        >
+          <Input
+            type="number"
+            value={maxParallelism}
+            min={MIN_PARALLELISM}
+            max={MAX_PARALLELISM}
+            onChange={(e) => {
+              const v = parseInt(e.target.value, 10);
+              if (!isNaN(v)) setMaxParallelism(v);
+            }}
+            disabled={!enableParallelAgents}
+          />
+        </Section>
       </div>
 
       <div className="flex flex-col gap-4 border-t border-border-soft pt-4">

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { Session } from '@kay-am/types';
+import type { ProviderRunId, Session } from '@kay-am/types';
 import { useAppStore, useTranscript } from '../../store';
-import { ChatHeader } from './ChatHeader';
-import { ChatInput } from './ChatInput';
-import { reduceTranscript } from './transcript-items';
+import { detectParallelRunIds, filterEventsByRunId, reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
 import { AuthRequiredCallout } from './AuthRequiredCallout';
+import { ChatHeader } from './ChatHeader';
+import { ChatInput } from './ChatInput';
 
 interface ChatViewProps {
   session: Session;
@@ -15,26 +15,17 @@ interface ChatViewProps {
 }
 
 const PIN_TOLERANCE_PX = 32;
+const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }: ChatViewProps) {
-  const events = useTranscript(session.id);
-  const items = useMemo(() => reduceTranscript(events), [events]);
-  const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
-  const authResults = useAppStore((s) => s.authResults);
-  const refreshProviders = useAppStore((s) => s.refreshProviders);
+function useScrollPin(deps: ReadonlyArray<unknown>) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState(true);
-
-  const provider = session.providerPreference.defaultProvider;
-  const providerAuthState = authResults?.[provider]?.state ?? null;
-  const providerIdentity = authResults?.[provider]?.identity ?? null;
-  const isProviderDisconnected = providerAuthState === 'disconnected';
 
   useEffect(() => {
     const el = scrollerRef.current;
     if (!el || !pinned) return;
     el.scrollTop = el.scrollHeight;
-  }, [items, pinned]);
+  }, [pinned, ...deps]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onScroll = () => {
     const el = scrollerRef.current;
@@ -43,7 +34,144 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
     setPinned(distance < PIN_TOLERANCE_PX);
   };
 
+  return { scrollerRef, pinned, setPinned, onScroll };
+}
+
+interface ColumnProps {
+  runId: ProviderRunId;
+  index: number;
+  events: ReturnType<typeof useTranscript>;
+  onRefreshAuth: () => void;
+}
+
+function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
+  const columnEvents = useMemo(() => filterEventsByRunId(events, runId), [events, runId]);
+  const items = useMemo(() => reduceTranscript(columnEvents), [columnEvents]);
+  const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
+
+  return (
+    <div className="flex min-w-0 flex-col border-r border-border last:border-r-0">
+      <div className="border-b border-border px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
+        p{index + 1}
+      </div>
+      <div
+        ref={scrollerRef}
+        onScroll={onScroll}
+        className="relative flex-1 overflow-y-auto px-3 py-3"
+      >
+        {items.length === 0 ? (
+          <p className="text-xs text-muted-foreground">no events yet for run p{index + 1}.</p>
+        ) : (
+          <ul className="flex flex-col gap-4">
+            {items.map((item) => (
+              <li key={item.key}>
+                <TranscriptCard item={item} onRefreshAuth={onRefreshAuth} />
+              </li>
+            ))}
+          </ul>
+        )}
+        {!pinned ? (
+          <button
+            type="button"
+            className="sticky bottom-2 left-1/2 -translate-x-1/2 rounded-full border border-border bg-background px-3 py-1 text-xs shadow-md"
+            onClick={() => {
+              setPinned(true);
+              const el = scrollerRef.current;
+              if (el) el.scrollTop = el.scrollHeight;
+            }}
+          >
+            jump to latest
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }: ChatViewProps) {
+  const events = useTranscript(session.id);
+  const items = useMemo(() => reduceTranscript(events), [events]);
+  const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
+  const authResults = useAppStore((s) => s.authResults);
+  const refreshProviders = useAppStore((s) => s.refreshProviders);
+  const settings = useAppStore((s) => s.settings);
+  const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
+
+  const provider = session.providerPreference.defaultProvider;
+  const providerAuthState = authResults?.[provider]?.state ?? null;
+  const providerIdentity = authResults?.[provider]?.identity ?? null;
+  const isProviderDisconnected = providerAuthState === 'disconnected';
+
   const isEnded = session.state.kind === 'ended';
+
+  const flagOn = settings['experimental.enable_parallel_agents'] === 'true';
+
+  const parallelRunIds = useMemo<ReadonlyArray<ProviderRunId>>(
+    () => (flagOn ? detectParallelRunIds(events) : []),
+    [events, flagOn],
+  );
+
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? []);
+
+  const allParallelTerminal = useMemo(() => {
+    if (parallelRunIds.length === 0) return false;
+    return parallelRunIds.every((rid) => {
+      const run = phaseRuns.find((r) => r.runId === rid);
+      return run ? TERMINAL_STATUSES.has(run.status) : false;
+    });
+  }, [parallelRunIds, phaseRuns]);
+
+  const isSplitView = flagOn && parallelRunIds.length > 1;
+
+  if (isSplitView) {
+    return (
+      <div className="flex h-full flex-col">
+        <ChatHeader
+          session={session}
+          worktreePath={worktreePath}
+          contextOpen={contextOpen}
+          onToggleContext={onToggleContext}
+          onEndSession={onRequestEnd}
+        />
+        <div
+          className="flex-1 overflow-hidden"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${parallelRunIds.length}, minmax(0, 1fr))`,
+          }}
+        >
+          {parallelRunIds.map((runId, i) => (
+            <ParallelColumn
+              key={runId}
+              runId={runId}
+              index={i}
+              events={events}
+              onRefreshAuth={() => void refreshProviders()}
+            />
+          ))}
+        </div>
+        {allParallelTerminal ? (
+          <div className="flex items-center justify-between border-t border-border bg-muted/40 px-4 py-2">
+            <span className="text-xs text-muted-foreground">merge pending — review conflicts</span>
+            <button
+              type="button"
+              className="rounded border border-border bg-background px-3 py-1 text-xs"
+              disabled
+            >
+              merge
+            </button>
+          </div>
+        ) : null}
+        {isEnded ? (
+          <div className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
+            session ended — no further turns. branch preserved.
+          </div>
+        ) : (
+          <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full flex-col">

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -1,4 +1,4 @@
-import type { ProviderId, ProviderUsage, TurnEvent } from '@kay-am/types';
+import type { ProviderId, ProviderRunId, ProviderUsage, TurnEvent } from '@kay-am/types';
 import { decodeAuthRequiredMessage } from '../../turn';
 
 export type TranscriptItem =
@@ -27,6 +27,30 @@ export type TranscriptItem =
       at: string;
     }
   | { kind: 'done'; key: string };
+
+/**
+ * Returns distinct runIds from events, excluding the sentinel 'history' value
+ * used for messages loaded from the DB. Two or more runIds indicates a parallel
+ * phase group is active — the caller decides whether to show split-view.
+ */
+export function detectParallelRunIds(
+  events: ReadonlyArray<TurnEvent>,
+): ReadonlyArray<ProviderRunId> {
+  const seen = new Set<ProviderRunId>();
+  for (const event of events) {
+    if (event.runId !== ('history' as ProviderRunId)) {
+      seen.add(event.runId);
+    }
+  }
+  return seen.size > 1 ? [...seen] : [];
+}
+
+export function filterEventsByRunId(
+  events: ReadonlyArray<TurnEvent>,
+  runId: ProviderRunId,
+): ReadonlyArray<TurnEvent> {
+  return events.filter((e) => e.runId === runId);
+}
 
 export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArray<TranscriptItem> {
   const items: TranscriptItem[] = [];

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -4,8 +4,14 @@ export const SETTING_EDITOR_BINARY = 'editor.binary';
 export const SETTING_LAST_WORKSPACE_ID = 'last.workspace_id';
 export const SETTING_LAST_SESSION_ID = 'last.session_id';
 export const SETTING_PROVIDER_PRICING_CONFIG = 'provider.pricing_config';
+export const SETTING_ENABLE_PARALLEL_AGENTS = 'experimental.enable_parallel_agents';
+export const SETTING_MAX_PARALLELISM = 'experimental.max_parallelism';
 export const DEFAULT_EDITOR_BINARY = 'code';
 export const DEFAULT_BRANCH_PREFIX = 'kay';
+export const DEFAULT_ENABLE_PARALLEL_AGENTS = false;
+export const DEFAULT_MAX_PARALLELISM = 4;
+export const MIN_PARALLELISM = 1;
+export const MAX_PARALLELISM = 8;
 
 export const settingBranchPrefix = (workspaceId: WorkspaceId): string =>
   `workspace.${workspaceId}.branch_prefix`;


### PR DESCRIPTION
## Summary

- Add `enableParallelAgents` (bool, default `false`) and `maxParallelism` (1–8, default `4`) settings keys to `settings.ts`
- Add "Experimental — multi-agent parallel" section in `SettingsDialog` with checkbox toggle + numeric input (disabled when flag off)
- `ChatView`: when flag on and transcript has N>1 distinct `runId`s → CSS-grid split-view (`repeat(N, minmax(0, 1fr))`), each column independently scrollable with events filtered by `runId`; sync-point divider with disabled "merge" button appears when all parallel runs reach terminal status
- Extract `detectParallelRunIds` and `filterEventsByRunId` into `transcript-items.ts` for pure-logic testability
- 16 Vitest unit tests covering: flag-off guard, no-parallel-group → single column, N=2/3/4 split view, per-column isolation, history sentinel exclusion

## Test plan

- [ ] typecheck: `pnpm --filter @kay-am/desktop typecheck` passes
- [ ] tests: `pnpm --filter @kay-am/desktop test` — 43 tests pass
- [ ] flag off: ChatView renders single-column (unchanged behaviour)
- [ ] flag on, normal session: still single-column (no parallel runIds detected)
- [ ] flag on, parallel spawn: N columns render, scroll independently, empty-state shown per column
- [ ] all runs terminal: sync-point divider appears at bottom

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)