### PR TITLE
feat(desktop): multi-progress indicator for parallel runs (#210)

### DIFF
--- a/apps/desktop/src/__tests__/ParallelProgressPill.test.tsx
+++ b/apps/desktop/src/__tests__/ParallelProgressPill.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { PhaseRunStatus, ProviderRunId } from '@kay-am/types';
+import { ParallelProgressPill } from '../components/chat/ParallelProgressPill';
+
+function rid(s: string): ProviderRunId {
+  return s as ProviderRunId;
+}
+
+const runIds: ReadonlyArray<ProviderRunId> = [rid('r1'), rid('r2'), rid('r3'), rid('r4')];
+
+const statusList: ReadonlyArray<PhaseRunStatus> = ['running', 'completed', 'failed', 'skipped'];
+
+const statuses = Object.fromEntries(runIds.map((r, i) => [r, statusList[i]])) as Readonly<
+  Record<ProviderRunId, PhaseRunStatus>
+>;
+
+afterEach(cleanup);
+
+describe('ParallelProgressPill', () => {
+  it('renders N badges for N runIds', () => {
+    const onSelectRun = vi.fn();
+    render(
+      <ParallelProgressPill
+        parallelRunIds={runIds}
+        runStatuses={statuses}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+  });
+
+  it('assigns correct aria-label per badge', () => {
+    const onSelectRun = vi.fn();
+    render(
+      <ParallelProgressPill
+        parallelRunIds={runIds}
+        runStatuses={statuses}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'run p1 — running' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'run p2 — completed' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'run p3 — failed' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'run p4 — skipped' })).toBeDefined();
+  });
+
+  it('click on badge calls onSelectRun with correct runId', () => {
+    const onSelectRun = vi.fn();
+    render(
+      <ParallelProgressPill
+        parallelRunIds={runIds}
+        runStatuses={statuses}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'run p2 — completed' }));
+    expect(onSelectRun).toHaveBeenCalledOnce();
+    expect(onSelectRun).toHaveBeenCalledWith(rid('r2'));
+  });
+
+  it('click on each badge calls onSelectRun with its specific runId', () => {
+    const onSelectRun = vi.fn();
+    render(
+      <ParallelProgressPill
+        parallelRunIds={runIds}
+        runStatuses={statuses}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    runIds.forEach((runId, i) => {
+      fireEvent.click(screen.getByRole('button', { name: `run p${i + 1} — ${statusList[i]}` }));
+      expect(onSelectRun).toHaveBeenNthCalledWith(i + 1, runId);
+    });
+    expect(onSelectRun).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns null when parallelRunIds is empty', () => {
+    const onSelectRun = vi.fn();
+    const { container } = render(
+      <ParallelProgressPill
+        parallelRunIds={[]}
+        runStatuses={{} as Readonly<Record<ProviderRunId, PhaseRunStatus>>}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('falls back to pending status when runId not in runStatuses', () => {
+    const onSelectRun = vi.fn();
+    render(
+      <ParallelProgressPill
+        parallelRunIds={[rid('unknown')]}
+        runStatuses={{} as Readonly<Record<ProviderRunId, PhaseRunStatus>>}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'run p1 — pending' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -9,12 +9,20 @@ import {
   ShieldCheck,
 } from 'lucide-react';
 import { Button, cn } from '@kay-am/ui';
-import type { PhaseRun, PhaseRunStatus, ProviderId, Session, SessionId } from '@kay-am/types';
+import type {
+  PhaseRun,
+  PhaseRunStatus,
+  ProviderId,
+  ProviderRunId,
+  Session,
+  SessionId,
+} from '@kay-am/types';
 import { getDefaultTurnModel } from '@kay-am/core';
 import { openInEditor } from '../../editor';
 import { DEFAULT_EDITOR_BINARY, SETTING_EDITOR_BINARY } from '../../settings';
 import { useAppStore } from '../../store';
 import { PermissionAuditPanel } from './PermissionAuditPanel';
+import { ParallelProgressPill } from './ParallelProgressPill';
 
 interface ChatHeaderProps {
   session: Session;
@@ -22,6 +30,8 @@ interface ChatHeaderProps {
   contextOpen: boolean;
   onToggleContext: () => void;
   onEndSession: () => void;
+  parallelRunIds?: ReadonlyArray<ProviderRunId>;
+  onSelectRun?: (runId: ProviderRunId) => void;
 }
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
@@ -42,6 +52,8 @@ export function ChatHeader({
   contextOpen,
   onToggleContext,
   onEndSession,
+  parallelRunIds,
+  onSelectRun,
 }: ChatHeaderProps) {
   const editorBinary = useAppStore(
     (s) => s.settings[SETTING_EDITOR_BINARY] ?? DEFAULT_EDITOR_BINARY,
@@ -75,10 +87,30 @@ export function ChatHeader({
     }
   };
 
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? []);
+
+  const runStatuses = Object.fromEntries(
+    (parallelRunIds ?? []).map((rid) => {
+      const run = phaseRuns.find((r) => r.runId === rid);
+      return [rid, run?.status ?? ('pending' as PhaseRunStatus)];
+    }),
+  ) as Readonly<Record<ProviderRunId, PhaseRunStatus>>;
+
+  const isParallel = (parallelRunIds?.length ?? 0) > 1;
+
   return (
     <div className="flex items-center gap-3 border-b border-border px-4 py-2.5">
       <div className="min-w-0 flex-1">
-        <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
+          {isParallel && onSelectRun ? (
+            <ParallelProgressPill
+              parallelRunIds={parallelRunIds!}
+              runStatuses={runStatuses}
+              onSelectRun={onSelectRun}
+            />
+          ) : null}
+        </div>
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
           <button
             type="button"

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -50,7 +50,10 @@ function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
 
   return (
-    <div className="flex min-w-0 flex-col border-r border-border last:border-r-0">
+    <div
+      data-run-column={runId}
+      className="flex min-w-0 flex-col border-r border-border last:border-r-0"
+    >
       <div className="border-b border-border px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
         p{index + 1}
       </div>
@@ -123,6 +126,12 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
 
   const isSplitView = flagOn && parallelRunIds.length > 1;
 
+  const onSelectRun = (runId: ProviderRunId) => {
+    document
+      .querySelector(`[data-run-column="${runId}"]`)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   if (isSplitView) {
     return (
       <div className="flex h-full flex-col">
@@ -132,6 +141,8 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
           contextOpen={contextOpen}
           onToggleContext={onToggleContext}
           onEndSession={onRequestEnd}
+          parallelRunIds={parallelRunIds}
+          onSelectRun={onSelectRun}
         />
         <div
           className="flex-1 overflow-hidden"

--- a/apps/desktop/src/components/chat/ParallelProgressPill.tsx
+++ b/apps/desktop/src/components/chat/ParallelProgressPill.tsx
@@ -1,0 +1,45 @@
+import { cn } from '@kay-am/ui';
+import type { PhaseRunStatus, ProviderRunId } from '@kay-am/types';
+
+interface ParallelProgressPillProps {
+  parallelRunIds: ReadonlyArray<ProviderRunId>;
+  runStatuses: Readonly<Record<ProviderRunId, PhaseRunStatus>>;
+  onSelectRun: (runId: ProviderRunId) => void;
+}
+
+const BADGE_CLASSES: Record<PhaseRunStatus, string> = {
+  running: 'bg-blue-500 animate-pulse',
+  completed: 'bg-green-500',
+  failed: 'bg-red-500',
+  skipped: 'bg-muted-foreground/40',
+  pending: 'bg-muted-foreground/25',
+};
+
+export function ParallelProgressPill({
+  parallelRunIds,
+  runStatuses,
+  onSelectRun,
+}: ParallelProgressPillProps) {
+  if (parallelRunIds.length === 0) return null;
+
+  return (
+    <div className="inline-flex items-center gap-1 rounded-full border border-border-soft bg-subtle px-2 py-0.5">
+      {parallelRunIds.map((runId, i) => {
+        const status: PhaseRunStatus = runStatuses[runId] ?? 'pending';
+        return (
+          <button
+            key={runId}
+            type="button"
+            aria-label={`run p${i + 1} — ${status}`}
+            title={`run p${i + 1} — ${status}`}
+            onClick={() => onSelectRun(runId)}
+            className={cn(
+              'inline-block h-2 w-2 rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              BADGE_CLASSES[status],
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'happy-dom',
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary

- New `ParallelProgressPill` component: N clickable badge buttons, one per `ProviderRunId`
- Color spec: `running` → blue + animate-pulse, `completed` → green, `failed` → red, `skipped` → gray, `pending` → muted
- Each badge has `aria-label="run p<i> — <status>"` for accessibility
- Click handler uses `data-run-column` attr for imperative DOM scroll (`scrollIntoView`) — avoids ref prop-drilling
- `ChatHeader` gets optional `parallelRunIds` + `onSelectRun` props; pill renders only when `isParallel`
- `ChatView` defines `onSelectRun`, stamps `data-run-column={runId}` on each `ParallelColumn`, passes both to `ChatHeader`
- `vitest.config.ts` added with `happy-dom` environment to enable React render tests

## Test plan

- [x] `pnpm --filter @kay-am/desktop typecheck` clean
- [x] `pnpm --filter @kay-am/desktop test` — 49 tests pass (6 new for `ParallelProgressPill`)
- [x] 6 unit tests: render count, aria-labels, click dispatch per-badge, all-badges isolation, empty→null, fallback to `pending`

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)