### PR TITLE
feat(types,core): permission_request + permission_decision turn events

### DIFF
--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, PermissionRuleId, ProviderRunId, TurnEvent } from '@kay-am/types';
+import { reduceTranscript } from '../components/chat/transcript-items';
+
+const RUN = 'run-1' as ProviderRunId;
+const AT = '2026-01-01T00:00:00.000Z' as IsoDateTime;
+const RULE_ID = 'rule-abc' as PermissionRuleId;
+
+function permReqEvent(toolUseId = 'tu-1'): TurnEvent {
+  return {
+    kind: 'permission_request',
+    runId: RUN,
+    toolUseId,
+    toolName: 'bash',
+    input: { cmd: 'ls' },
+    at: AT,
+  };
+}
+
+function permDecEvent(
+  toolUseId = 'tu-1',
+  decision: 'allow' | 'deny' = 'allow',
+  ruleId: PermissionRuleId | null = RULE_ID,
+  decidedBy: 'engine' | 'user' | 'default' = 'engine',
+): TurnEvent {
+  return {
+    kind: 'permission_decision',
+    runId: RUN,
+    toolUseId,
+    decision,
+    ruleId,
+    decidedBy,
+    at: AT,
+  };
+}
+
+describe('reduceTranscript — permission_request', () => {
+  it('produces a permission_request item', () => {
+    const items = reduceTranscript([permReqEvent()]);
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.kind).toBe('permission_request');
+    if (item.kind !== 'permission_request') return;
+    expect(item.toolName).toBe('bash');
+    expect(item.toolUseId).toBe('tu-1');
+    expect(item.input).toEqual({ cmd: 'ls' });
+    expect(item.at).toBe(AT);
+  });
+
+  it('key contains toolUseId', () => {
+    const items = reduceTranscript([permReqEvent('tu-xyz')]);
+    const item = items[0]!;
+    expect(item.key).toContain('tu-xyz');
+  });
+
+  it('multiple permission_request events produce separate items', () => {
+    const items = reduceTranscript([permReqEvent('tu-1'), permReqEvent('tu-2')]);
+    expect(items).toHaveLength(2);
+    expect(items[0]!.kind).toBe('permission_request');
+    expect(items[1]!.kind).toBe('permission_request');
+  });
+});
+
+describe('reduceTranscript — permission_decision', () => {
+  it('produces a permission_decision item with allow + ruleId', () => {
+    const items = reduceTranscript([permDecEvent('tu-1', 'allow', RULE_ID, 'engine')]);
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.kind).toBe('permission_decision');
+    if (item.kind !== 'permission_decision') return;
+    expect(item.decision).toBe('allow');
+    expect(item.ruleId).toBe(RULE_ID);
+    expect(item.decidedBy).toBe('engine');
+  });
+
+  it('produces a deny decision with null ruleId', () => {
+    const items = reduceTranscript([permDecEvent('tu-2', 'deny', null, 'default')]);
+    const item = items[0]!;
+    expect(item.kind).toBe('permission_decision');
+    if (item.kind !== 'permission_decision') return;
+    expect(item.decision).toBe('deny');
+    expect(item.ruleId).toBeNull();
+    expect(item.decidedBy).toBe('default');
+  });
+
+  it('key contains toolUseId', () => {
+    const items = reduceTranscript([permDecEvent('tu-abc')]);
+    const item = items[0]!;
+    expect(item.key).toContain('tu-abc');
+  });
+});
+
+describe('reduceTranscript — request + decision pair', () => {
+  it('produces two items for a request followed by a decision', () => {
+    const events: TurnEvent[] = [permReqEvent('tu-1'), permDecEvent('tu-1', 'deny', null, 'user')];
+    const items = reduceTranscript(events);
+    expect(items).toHaveLength(2);
+    expect(items[0]!.kind).toBe('permission_request');
+    expect(items[1]!.kind).toBe('permission_decision');
+  });
+});

--- a/apps/desktop/src/components/chat/PermissionDecisionCard.tsx
+++ b/apps/desktop/src/components/chat/PermissionDecisionCard.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@kay-am/ui';
+import type { TranscriptItem } from './transcript-items';
+
+interface PermissionDecisionCardProps {
+  readonly item: Extract<TranscriptItem, { kind: 'permission_decision' }>;
+}
+
+const DECISION_TONE: Record<'allow' | 'deny', string> = {
+  allow: 'text-success',
+  deny: 'text-danger',
+};
+
+export function PermissionDecisionCard({ item }: PermissionDecisionCardProps) {
+  const timestamp = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(item.at));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted px-2 py-1.5 text-xs">
+      <span className="rounded bg-background px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        perm decision
+      </span>
+      <code className="font-mono text-foreground">{item.toolUseId}</code>
+      <span className={cn('font-semibold', DECISION_TONE[item.decision])}>{item.decision}</span>
+      {item.ruleId !== null ? (
+        <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-secondary-foreground">
+          {item.ruleId}
+        </span>
+      ) : null}
+      <span className="ml-auto text-[10px] text-muted-foreground">{timestamp}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/desktop/src/components/chat/PermissionRequestCard.tsx
@@ -1,0 +1,23 @@
+import type { TranscriptItem } from './transcript-items';
+
+interface PermissionRequestCardProps {
+  readonly item: Extract<TranscriptItem, { kind: 'permission_request' }>;
+}
+
+export function PermissionRequestCard({ item }: PermissionRequestCardProps) {
+  const timestamp = new Intl.DateTimeFormat(undefined, {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).format(new Date(item.at));
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted px-2 py-1.5 text-xs">
+      <span className="rounded bg-background px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        perm request
+      </span>
+      <code className="font-mono text-foreground">{item.toolName}</code>
+      <span className="ml-auto text-[10px] text-muted-foreground">{timestamp}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -5,6 +5,8 @@ import type { TranscriptItem } from './transcript-items';
 import { AuthRequiredCallout } from './AuthRequiredCallout';
 import { SkillInvocationCard } from './SkillInvocationCard';
 import { PhaseTransitionCard } from './PhaseTransitionCard';
+import { PermissionRequestCard } from './PermissionRequestCard';
+import { PermissionDecisionCard } from './PermissionDecisionCard';
 
 const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
   create: 'bg-primary/10 text-primary',
@@ -62,6 +64,10 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
       return <PhaseTransitionCard item={item} />;
     case 'done':
       return <hr className="border-border" />;
+    case 'permission_request':
+      return <PermissionRequestCard item={item} />;
+    case 'permission_decision':
+      return <PermissionDecisionCard item={item} />;
   }
 }
 

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -1,4 +1,11 @@
-import type { ProviderId, ProviderRunId, ProviderUsage, TurnEvent } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  PermissionRuleId,
+  ProviderId,
+  ProviderRunId,
+  ProviderUsage,
+  TurnEvent,
+} from '@kay-am/types';
 import { decodeAuthRequiredMessage } from '../../turn';
 
 export type TranscriptItem =
@@ -26,7 +33,24 @@ export type TranscriptItem =
       carryForwardContext: string;
       at: string;
     }
-  | { kind: 'done'; key: string };
+  | { kind: 'done'; key: string }
+  | {
+      kind: 'permission_request';
+      key: string;
+      toolUseId: string;
+      toolName: string;
+      input: unknown;
+      at: IsoDateTime;
+    }
+  | {
+      kind: 'permission_decision';
+      key: string;
+      toolUseId: string;
+      decision: 'allow' | 'deny';
+      ruleId: PermissionRuleId | null;
+      decidedBy: 'engine' | 'user' | 'default';
+      at: IsoDateTime;
+    };
 
 /**
  * Returns distinct runIds from events, excluding the sentinel 'history' value
@@ -151,6 +175,27 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
         break;
       case 'done':
         items.push({ kind: 'done', key: `done-${i}` });
+        break;
+      case 'permission_request':
+        items.push({
+          kind: 'permission_request',
+          key: `perm-req-${event.toolUseId}-${i}`,
+          toolUseId: event.toolUseId,
+          toolName: event.toolName,
+          input: event.input,
+          at: event.at,
+        });
+        break;
+      case 'permission_decision':
+        items.push({
+          kind: 'permission_decision',
+          key: `perm-dec-${event.toolUseId}-${i}`,
+          toolUseId: event.toolUseId,
+          decision: event.decision,
+          ruleId: event.ruleId,
+          decidedBy: event.decidedBy,
+          at: event.at,
+        });
         break;
     }
   }

--- a/packages/core/src/permissions/events.test.ts
+++ b/packages/core/src/permissions/events.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, PermissionRuleId, ProviderRunId } from '@kay-am/types';
+import { createPermissionDecisionEvent, createPermissionRequestEvent } from './events';
+
+const RUN_ID = 'run-1' as ProviderRunId;
+const AT = '2026-01-01T00:00:00.000Z' as IsoDateTime;
+const RULE_ID = 'rule-abc' as PermissionRuleId;
+
+describe('createPermissionRequestEvent', () => {
+  it('produces a permission_request event with correct shape', () => {
+    const event = createPermissionRequestEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-1',
+      toolName: 'bash',
+      input: { cmd: 'ls' },
+      at: AT,
+    });
+    expect(event.kind).toBe('permission_request');
+    expect(event.runId).toBe(RUN_ID);
+    expect(event.toolUseId).toBe('tu-1');
+    expect(event.toolName).toBe('bash');
+    expect(event.input).toEqual({ cmd: 'ls' });
+    expect(event.at).toBe(AT);
+  });
+
+  it('accepts null/unknown input', () => {
+    const event = createPermissionRequestEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-2',
+      toolName: 'read_file',
+      input: null,
+      at: AT,
+    });
+    expect(event.input).toBeNull();
+  });
+});
+
+describe('createPermissionDecisionEvent', () => {
+  it('produces an allow decision with ruleId', () => {
+    const event = createPermissionDecisionEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-1',
+      decision: 'allow',
+      ruleId: RULE_ID,
+      decidedBy: 'engine',
+      at: AT,
+    });
+    expect(event.kind).toBe('permission_decision');
+    expect(event.decision).toBe('allow');
+    expect(event.ruleId).toBe(RULE_ID);
+    expect(event.decidedBy).toBe('engine');
+  });
+
+  it('produces a deny decision with null ruleId (default fallback)', () => {
+    const event = createPermissionDecisionEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-2',
+      decision: 'deny',
+      ruleId: null,
+      decidedBy: 'default',
+      at: AT,
+    });
+    expect(event.decision).toBe('deny');
+    expect(event.ruleId).toBeNull();
+    expect(event.decidedBy).toBe('default');
+  });
+
+  it('supports decidedBy user', () => {
+    const event = createPermissionDecisionEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-3',
+      decision: 'allow',
+      ruleId: null,
+      decidedBy: 'user',
+      at: AT,
+    });
+    expect(event.decidedBy).toBe('user');
+  });
+});

--- a/packages/core/src/permissions/events.ts
+++ b/packages/core/src/permissions/events.ts
@@ -1,0 +1,37 @@
+import type { IsoDateTime, PermissionRuleId, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+export function createPermissionRequestEvent(params: {
+  readonly runId: ProviderRunId;
+  readonly toolUseId: string;
+  readonly toolName: string;
+  readonly input: unknown;
+  readonly at: IsoDateTime;
+}): Extract<TurnEvent, { kind: 'permission_request' }> {
+  return {
+    kind: 'permission_request',
+    runId: params.runId,
+    toolUseId: params.toolUseId,
+    toolName: params.toolName,
+    input: params.input,
+    at: params.at,
+  };
+}
+
+export function createPermissionDecisionEvent(params: {
+  readonly runId: ProviderRunId;
+  readonly toolUseId: string;
+  readonly decision: 'allow' | 'deny';
+  readonly ruleId: PermissionRuleId | null;
+  readonly decidedBy: 'engine' | 'user' | 'default';
+  readonly at: IsoDateTime;
+}): Extract<TurnEvent, { kind: 'permission_decision' }> {
+  return {
+    kind: 'permission_decision',
+    runId: params.runId,
+    toolUseId: params.toolUseId,
+    decision: params.decision,
+    ruleId: params.ruleId,
+    decidedBy: params.decidedBy,
+    at: params.at,
+  };
+}

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -2,3 +2,4 @@ export { PermissionEngine, type PermissionEngineDeps } from './engine';
 export { formatToolPattern, parseArgsMatcher, parseToolPattern, type ToolMatcher } from './matcher';
 export { buildClaudeFlags, type ClaudeFlagSet } from './claude-flags';
 export { PermissionAuditRecorder, type AuditRecorderDeps, type AuditQuery } from './audit';
+export { createPermissionDecisionEvent, createPermissionRequestEvent } from './events';

--- a/packages/core/src/session/reducer.ts
+++ b/packages/core/src/session/reducer.ts
@@ -77,6 +77,8 @@ function applyTurnEvent(state: SessionState, turn: TurnEvent): SessionState {
     case 'usage':
     case 'skill_invocation':
     case 'phase_transition':
+    case 'permission_request':
+    case 'permission_decision':
       return state;
     default: {
       const _exhaustive: never = turn;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
+import type { IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
 import type { ProviderName } from './provider';
 
 export interface ProviderCapabilities {
@@ -80,6 +80,23 @@ export type TurnEvent =
       fromPhase: { ordinal: number; name: string };
       toPhase: { ordinal: number; name: string };
       carryForwardContext: string;
+      at: IsoDateTime;
+    }
+  | {
+      kind: 'permission_request';
+      runId: ProviderRunId;
+      toolUseId: string;
+      toolName: string;
+      input: unknown;
+      at: IsoDateTime;
+    }
+  | {
+      kind: 'permission_decision';
+      runId: ProviderRunId;
+      toolUseId: string;
+      decision: 'allow' | 'deny';
+      ruleId: PermissionRuleId | null;
+      decidedBy: 'engine' | 'user' | 'default';
       at: IsoDateTime;
     };
 


### PR DESCRIPTION
## Summary

- Extends `TurnEvent` union in `packages/types/src/adapter.ts` with `permission_request` and `permission_decision` variants
- Adds `createPermissionRequestEvent` / `createPermissionDecisionEvent` factory fns in `packages/core/src/permissions/events.ts`
- Updates exhaustive switch in `packages/core/src/session/reducer.ts` (both new kinds → `return state`)
- Extends `TranscriptItem` union + `reduceTranscript` switch in `apps/desktop/src/components/chat/transcript-items.ts`
- Adds `PermissionRequestCard` and `PermissionDecisionCard` compact info-only renderers; wires into `TranscriptCards.tsx`

## Exhaustive switch impact

Consumers with an exhaustive `switch (event.kind)` on `TurnEvent` without a `default` branch will fail to compile — by design, to force update. The only internal consumer (`session/reducer.ts`) has been updated in this PR. Consumers with a `default` fallthrough are unaffected at runtime.

## Test plan

- [x] `pnpm --filter @kay-am/types typecheck` — clean
- [x] `pnpm --filter @kay-am/core test` — 360 pass (5 new in `events.test.ts`)
- [x] `pnpm --filter @kay-am/desktop typecheck` — clean
- [x] `pnpm --filter @kay-am/desktop test` — 50 pass (7 new in `transcript-items.test.ts`)
- [x] `pnpm typecheck` — all 5 packages clean

Closes #213

Part 1 of #185 (deferred from v0.6). Part 2 was closed by #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)