### PR TITLE
feat(desktop): wire parallel scheduler into sendTurn (#212)

### DIFF
--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -1,0 +1,461 @@
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  buildPhasePrompt,
+  detectConflicts,
+  fanOut,
+  awaitMerge,
+  cancelGroup,
+  resolveConflicts,
+  ManualResolutionRequiredError,
+  type FileConflict,
+  type MergeResult,
+  type RunFileTouches,
+  type SchedulerDeps,
+  type SchedulerHandle,
+} from '@kay-am/core';
+import { parseStreamJsonLine } from '@kay-am/core';
+import type {
+  IsoDateTime,
+  ParallelMergeStrategy,
+  ParallelPhaseGroupId,
+  ParallelPhaseRun,
+  ParallelPhaseRunId,
+  PhaseDefinition,
+  PhaseRunStatus,
+  PhaseTemplate,
+  ProviderRunId,
+  Session,
+  SessionId,
+  TurnEvent,
+  Workspace,
+} from '@kay-am/types';
+import {
+  invokeParallelPhaseGroupCreate,
+  invokeParallelPhaseGroupUpdateCompletedAt,
+  invokePhaseRunInsert,
+  invokePhaseRunList,
+  invokePhaseRunUpdateStatus,
+} from '../phases';
+import { invokeParallelPhaseRunSpawn, cancelTurn } from '../turn';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ParallelBranchInputs {
+  readonly session: Session;
+  readonly workspace: Workspace;
+  readonly currentDef: PhaseDefinition;
+  readonly groupDefs: ReadonlyArray<PhaseDefinition>;
+  readonly workingDir: string;
+  readonly resolvedPromptBase: string;
+  readonly carryForwardContext: string;
+  readonly mergeStrategy: ParallelMergeStrategy;
+  readonly maxParallelism: number;
+}
+
+export interface ParallelBranchEffects {
+  appendTurnEvent: (sessionId: SessionId, event: TurnEvent) => void;
+  refreshPhaseRuns: (sessionId: SessionId) => Promise<void>;
+}
+
+export interface ParallelBranchResult {
+  readonly groupId: ParallelPhaseGroupId;
+  readonly merge: MergeResult;
+  readonly runIds: ReadonlyArray<ProviderRunId>;
+  readonly anyFailed: boolean;
+  readonly allFailed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+export interface ParallelDetection {
+  readonly currentDef: PhaseDefinition;
+  readonly groupDefs: ReadonlyArray<PhaseDefinition>;
+}
+
+/**
+ * Returns the sibling group iff:
+ *  - currentDef has parallelGroup set
+ *  - >= 2 sibling definitions share the same parallelGroup
+ *  - definitions are sorted by ordinal (deterministic spawn order)
+ */
+export function detectParallelGroup(
+  template: PhaseTemplate,
+  currentDef: PhaseDefinition,
+): ParallelDetection | null {
+  if (currentDef.parallelGroup === undefined) return null;
+  const siblings = template.definitions
+    .filter((d) => d.parallelGroup === currentDef.parallelGroup)
+    .slice()
+    .sort((a, b) => a.ordinal - b.ordinal);
+  if (siblings.length < 2) return null;
+  return { currentDef, groupDefs: siblings };
+}
+
+// ---------------------------------------------------------------------------
+// Listener — multiplexes turn_event envelopes to per-runId callbacks.
+// Single global listener, routed by runId — avoids N independent listeners
+// (each subscribing to the same Tauri channel) which would be wasteful.
+// ---------------------------------------------------------------------------
+
+interface RawTurnEnvelope {
+  readonly runId: string;
+  readonly type: 'line' | 'end' | 'error';
+  readonly line?: string;
+  readonly exit_code?: number | null;
+  readonly stderr?: string;
+  readonly message?: string;
+}
+
+interface RunListenerState {
+  readonly onEvent: (e: TurnEvent) => void;
+  readonly onSettle: (status: PhaseRunStatus, error?: string) => void;
+  collectedFiles: Set<string>;
+}
+
+export interface MultiplexedListener {
+  unlisten: () => Promise<void>;
+  registerRun: (runId: ProviderRunId, state: RunListenerState) => void;
+  filesTouchedByRun: (runId: ProviderRunId) => ReadonlyArray<string>;
+}
+
+export async function startMultiplexedTurnListener(
+  now: () => IsoDateTime,
+): Promise<MultiplexedListener> {
+  const states = new Map<string, RunListenerState>();
+
+  const unlistenFn: UnlistenFn = await listen<RawTurnEnvelope>('turn_event', (event) => {
+    const payload = event.payload;
+    const state = states.get(payload.runId);
+    if (!state) return;
+
+    if (payload.type === 'line' && typeof payload.line === 'string') {
+      const ctx = { runId: payload.runId as ProviderRunId, now };
+      for (const ev of parseStreamJsonLine(payload.line, ctx)) {
+        state.onEvent(ev);
+        if (ev.kind === 'file_edit') state.collectedFiles.add(ev.path);
+      }
+    } else if (payload.type === 'end') {
+      const exit = payload.exit_code ?? 0;
+      state.onSettle(exit === 0 ? 'completed' : 'failed', exit !== 0 ? payload.stderr : undefined);
+    } else if (payload.type === 'error') {
+      state.onSettle('failed', payload.message ?? 'unknown error');
+    }
+  });
+
+  return {
+    unlisten: async () => unlistenFn(),
+    registerRun: (runId, st) => {
+      states.set(runId, st);
+    },
+    filesTouchedByRun: (runId) => Array.from(states.get(runId)?.collectedFiles ?? []),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler deps factory — design (b): pre-batch via invokeParallelPhaseRunSpawn,
+// scheduler.spawnRun resolves on per-runId 'end' envelope. Aligns with T2 (#208)
+// batched spawn design and keeps the scheduler purely an await-only orchestrator.
+// ---------------------------------------------------------------------------
+
+export interface BuildSchedulerDepsArgs {
+  readonly listener: MultiplexedListener;
+  readonly settleHandlers: Map<
+    ProviderRunId,
+    {
+      promise: Promise<{ status: PhaseRunStatus; error?: string }>;
+      onEvent: (cb: (e: TurnEvent) => void) => void;
+    }
+  >;
+}
+
+export function buildSchedulerDeps(args: BuildSchedulerDepsArgs): SchedulerDeps {
+  const { settleHandlers } = args;
+
+  return {
+    spawnRun: async (run, onEvent) => {
+      const handler = settleHandlers.get(run.runId);
+      if (!handler) {
+        // Should be impossible — every run has a pre-registered handler.
+        return { status: 'failed', outputSummary: null, error: 'no settle handler registered' };
+      }
+      handler.onEvent(onEvent);
+      const result = await handler.promise;
+      return {
+        status: result.status,
+        outputSummary: null,
+        ...(result.error !== undefined && { error: result.error }),
+      };
+    },
+    cancelRun: async (runId) => {
+      await cancelTurn(runId).catch(() => undefined);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main entry — orchestrates the parallel branch end-to-end.
+// ---------------------------------------------------------------------------
+
+export interface RunParallelBranchDeps {
+  readonly now: () => IsoDateTime;
+  readonly providerBinary: string | undefined;
+  readonly model: string;
+  readonly permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
+  readonly allowedTools?: ReadonlyArray<string>;
+  readonly disallowedTools?: ReadonlyArray<string>;
+  readonly effects: ParallelBranchEffects;
+}
+
+export async function runParallelBranch(
+  inputs: ParallelBranchInputs,
+  deps: RunParallelBranchDeps,
+): Promise<ParallelBranchResult> {
+  const { session, currentDef, groupDefs, mergeStrategy, maxParallelism, workingDir } = inputs;
+  const { now, effects } = deps;
+
+  // Cap by maxParallelism — defensive guard; UI clamps but accept any spec list.
+  const cappedDefs = groupDefs.slice(0, Math.max(1, maxParallelism));
+
+  // Persist parallel group up front so the audit trail captures it even if spawn fails.
+  const groupRow = await invokeParallelPhaseGroupCreate({
+    sessionId: session.id,
+    ordinal: currentDef.ordinal,
+    mergeStrategy,
+    createdAt: now(),
+  });
+  const groupId = groupRow.id;
+
+  // Generate runIds + per-def prompts up front. Same ID flows through every layer.
+  const runIds: ProviderRunId[] = cappedDefs.map(() => crypto.randomUUID() as ProviderRunId);
+  const promptsByIndex: string[] = cappedDefs.map((def) =>
+    buildPhasePrompt({
+      definition: def,
+      carryForwardContext: inputs.carryForwardContext,
+      userMessage: inputs.resolvedPromptBase,
+    }),
+  );
+
+  // Boot listener BEFORE spawn — race-free: events arrive only after spawn.
+  const listener = await startMultiplexedTurnListener(now);
+
+  const settleResolvers = new Map<
+    ProviderRunId,
+    (v: { status: PhaseRunStatus; error?: string }) => void
+  >();
+
+  // Per-run scheduler progress callbacks — set by scheduler.spawnRun, invoked by
+  // listener. Listener registration must happen up front (before spawn) so no
+  // events leak before scheduler subscribes. Until spawnRun fires, scheduler
+  // progress callbacks are absent — benign because scheduler progress fan-out is
+  // best-effort UI plumbing; the canonical transcript stream still flows via
+  // appendTurnEvent below.
+  const progressCallbacks = new Map<ProviderRunId, ((e: TurnEvent) => void) | null>();
+
+  // Per-run settle handlers — promise resolves when listener observes 'end'/'error'
+  // for the matching runId. scheduler.spawnRun awaits the promise; onEvent stores
+  // the scheduler's progress callback for the listener to dispatch into.
+  const settleHandlers = new Map<
+    ProviderRunId,
+    {
+      promise: Promise<{ status: PhaseRunStatus; error?: string }>;
+      onEvent: (cb: (e: TurnEvent) => void) => void;
+    }
+  >();
+
+  for (const runId of runIds) {
+    progressCallbacks.set(runId, null);
+    const promise = new Promise<{ status: PhaseRunStatus; error?: string }>((resolve) => {
+      settleResolvers.set(runId, resolve);
+    });
+    settleHandlers.set(runId, {
+      promise,
+      onEvent: (cb) => {
+        progressCallbacks.set(runId, cb);
+      },
+    });
+    listener.registerRun(runId, {
+      onEvent: (e) => {
+        const cb = progressCallbacks.get(runId);
+        if (cb) cb(e);
+        effects.appendTurnEvent(session.id, e);
+      },
+      onSettle: (status, error) => {
+        const r = settleResolvers.get(runId);
+        if (r) r({ status, ...(error !== undefined && { error }) });
+      },
+      collectedFiles: new Set<string>(),
+    });
+  }
+
+  // Persist N phase_runs rows (status=running). Using the existing single-run
+  // invoker — group_id remains NULL for now (Rust insert doesn't accept it yet),
+  // but session_id+ordinal+phaseDefinitionId still uniquely identifies each run.
+  for (let i = 0; i < cappedDefs.length; i++) {
+    const def = cappedDefs[i]!;
+    const runId = runIds[i]!;
+    await invokePhaseRunInsert({
+      sessionId: session.id,
+      phaseDefinitionId: def.id,
+      ordinal: def.ordinal,
+      name: def.name,
+      status: 'running',
+      providerRunId: runId,
+      startedAt: now(),
+    });
+  }
+  await effects.refreshPhaseRuns(session.id);
+
+  // Build ParallelPhaseRun records the scheduler operates on. parallelIndex
+  // matches the spec's order. We DO NOT wire createParallelWorktrees here — the
+  // issue scope keeps worktree-per-run out of v1: every run executes in the
+  // session's primary worktree (existing single-run invariant). Workdir
+  // collisions are still surfaced by detectConflicts via emitted file_edit events.
+  // TODO (@ak, #212-followup): wire createParallelWorktrees + per-run workingDir
+  // once Rust phase_run_insert accepts (group_id, parallel_index).
+  const parallelRuns: ParallelPhaseRun[] = cappedDefs.map((def, i) => ({
+    id: crypto.randomUUID() as ParallelPhaseRunId,
+    groupId,
+    phaseDefinitionId: def.id,
+    parallelIndex: i,
+    runId: runIds[i]!,
+    status: 'running',
+    worktreePath: workingDir,
+    outputSummary: null,
+    startedAt: now(),
+    completedAt: null,
+  }));
+
+  // Pre-batch spawn — keeps registration atomic on the rust side. Per-run prompts
+  // differ, so we issue one invokeParallelPhaseRunSpawn PER definition with a single
+  // run each. (T2's batch invoker is designed for same-prompt fan-out; here each
+  // run has a distinct prompt because each is a different phase definition.)
+  const spawnPromises = cappedDefs.map(async (_def, i) => {
+    const runId = runIds[i]!;
+    return invokeParallelPhaseRunSpawn({
+      groupId,
+      runs: [{ runId, workingDir, parallelIndex: i }],
+      ...(deps.providerBinary !== undefined && { binary: deps.providerBinary }),
+      model: deps.model,
+      prompt: promptsByIndex[i]!,
+      ...(deps.permissionMode !== undefined && { permissionMode: deps.permissionMode }),
+      ...(deps.allowedTools !== undefined && { allowedTools: deps.allowedTools }),
+      ...(deps.disallowedTools !== undefined && { disallowedTools: deps.disallowedTools }),
+    });
+  });
+
+  let handle: SchedulerHandle | null = null;
+  try {
+    await Promise.all(spawnPromises);
+
+    const schedDeps = buildSchedulerDeps({ listener, settleHandlers });
+    handle = fanOut(
+      schedDeps,
+      {
+        id: groupId,
+        sessionId: session.id,
+        ordinal: currentDef.ordinal,
+        mergeStrategy,
+        createdAt: groupRow.createdAt,
+        completedAt: null,
+      },
+      parallelRuns,
+    );
+
+    const merge = await awaitMerge(handle);
+
+    // Update each phase_run row with terminal status.
+    for (let i = 0; i < cappedDefs.length; i++) {
+      const def = cappedDefs[i]!;
+      const runId = runIds[i]!;
+      const status = merge.runStatuses.find((rs) => rs.runId === runId);
+      const phaseRunsAfter = await invokePhaseRunList(session.id);
+      const row = phaseRunsAfter.find((r) => r.runId === runId && r.phaseDefinitionId === def.id);
+      if (row) {
+        await invokePhaseRunUpdateStatus(row.id, {
+          status: (status?.status ?? 'failed') as PhaseRunStatus,
+          completedAt: now(),
+        });
+      }
+    }
+    await effects.refreshPhaseRuns(session.id);
+
+    // Conflict detection + auto-resolve.
+    // Auto-resolution path only — manual MergeDialog wiring is deferred. Reason:
+    // surfacing conflicts to the user requires emitting MergeResult into ChatView
+    // state (currently a TODO placeholder in MergeDialog). Default to the group's
+    // mergeStrategy; if 'manual' and unresolved, swallow the rejection and emit
+    // a warning event so the parallel branch never blocks the turn pipeline.
+    // TODO (@ak, #212-followup): plumb MergeResult to ChatView and gate completion
+    // on user picks for mergeStrategy === 'manual'.
+    const touches: ReadonlyArray<RunFileTouches> = runIds.map((rid) => ({
+      runId: rid,
+      files: listener.filesTouchedByRun(rid),
+    }));
+    const conflicts: ReadonlyArray<FileConflict> = detectConflicts(touches);
+
+    if (conflicts.length > 0) {
+      try {
+        await resolveConflicts({
+          conflicts,
+          runStatuses: merge.runStatuses
+            .filter((rs) => rs.status === 'completed')
+            .map((rs) => ({ runId: rs.runId, completedAt: now(), status: rs.status })),
+          strategy: mergeStrategy,
+        });
+      } catch (err) {
+        if (err instanceof ManualResolutionRequiredError) {
+          effects.appendTurnEvent(session.id, {
+            kind: 'error',
+            runId: runIds[0]!,
+            message: `manual merge resolution required for: ${err.unresolvedFiles.join(', ')}`,
+            at: now(),
+          });
+        } else {
+          throw err;
+        }
+      }
+    }
+
+    const completedCount = merge.runStatuses.filter((rs) => rs.status === 'completed').length;
+    const allFailed = completedCount === 0 && merge.runStatuses.length > 0;
+    const anyFailed = merge.runStatuses.some((rs) => rs.status !== 'completed');
+
+    // Emit synthetic phase_transition marking sync-point completion.
+    // We use the first runId for routing; UI treats parallel groups as one phase boundary.
+    if (!allFailed) {
+      effects.appendTurnEvent(session.id, {
+        kind: 'phase_transition',
+        runId: runIds[0]!,
+        fromPhase: { ordinal: currentDef.ordinal, name: currentDef.name },
+        toPhase: { ordinal: currentDef.ordinal + 1, name: 'next' },
+        carryForwardContext: '',
+        at: now(),
+      });
+    }
+
+    // Mark group complete only when at least one run completed. allFailed runs
+    // leave completedAt NULL so the user can inspect/retry without rolling up.
+    if (!allFailed) {
+      await invokeParallelPhaseGroupUpdateCompletedAt(groupId, now());
+    }
+
+    return {
+      groupId,
+      merge,
+      runIds,
+      anyFailed,
+      allFailed,
+    };
+  } catch (err) {
+    if (handle) {
+      await cancelGroup(handle).catch(() => undefined);
+    }
+    throw err;
+  } finally {
+    await listener.unlisten();
+  }
+}

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -1,0 +1,408 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  ParallelMergeStrategy,
+  ParallelPhaseGroupId,
+  PhaseDefinition,
+  PhaseDefinitionId,
+  PhaseRun,
+  PhaseRunId,
+  PhaseTemplate,
+  PhaseTemplateId,
+  ProviderRunId,
+  Session,
+  SessionId,
+  WorkspaceId,
+} from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before importing the store.
+// ---------------------------------------------------------------------------
+
+const runTurnSpy = vi.fn();
+const cancelTurnSpy = vi.fn();
+const invokeParallelPhaseRunSpawnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  runTurn: (args: unknown) => runTurnSpy(args),
+  cancelTurn: cancelTurnSpy,
+  invokeParallelPhaseRunSpawn: (args: unknown) => invokeParallelPhaseRunSpawnSpy(args),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+// Listener mock — captures the registered handler so tests can drive 'end' events.
+const listenHandlers: Array<(payload: unknown) => void> = [];
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (_event: string, cb: (e: { payload: unknown }) => void) => {
+    listenHandlers.push((payload) => cb({ payload }));
+    return () => undefined; // unlisten
+  }),
+}));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: vi.fn(),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+const phaseRunInsertSpy = vi.fn();
+const phaseRunUpdateStatusSpy = vi.fn();
+const phaseRunListSpy = vi.fn<(sid: SessionId) => Promise<ReadonlyArray<PhaseRun>>>(async () => []);
+const parallelPhaseGroupCreateSpy = vi.fn();
+const parallelPhaseGroupUpdateCompletedAtSpy = vi.fn();
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: (sid: SessionId) => phaseRunListSpy(sid),
+  invokePhaseRunInsert: (args: unknown) => phaseRunInsertSpy(args),
+  invokePhaseRunUpdateStatus: (id: PhaseRunId, fields: unknown) =>
+    phaseRunUpdateStatusSpy(id, fields),
+  invokeParallelPhaseGroupCreate: (args: unknown) => parallelPhaseGroupCreateSpy(args),
+  invokeParallelPhaseGroupUpdateCompletedAt: (id: ParallelPhaseGroupId, at: IsoDateTime) =>
+    parallelPhaseGroupUpdateCompletedAtSpy(id, at),
+}));
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const TEMPLATE_ID = 'template-1' as PhaseTemplateId;
+
+function buildSession(): Session {
+  const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'test',
+    state: { kind: 'idle', lastActivityAt: now },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+    phaseTemplateId: TEMPLATE_ID,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function buildDef(args: {
+  id: string;
+  ordinal?: number;
+  name?: string;
+  promptPrefix?: string;
+  parallelGroup?: number;
+}): PhaseDefinition {
+  return {
+    id: args.id as PhaseDefinitionId,
+    templateId: TEMPLATE_ID,
+    ordinal: args.ordinal ?? 1,
+    name: args.name ?? args.id,
+    promptPrefix: args.promptPrefix ?? `[${args.id}]`,
+    ...(args.parallelGroup !== undefined && { parallelGroup: args.parallelGroup }),
+  };
+}
+
+function buildTemplate(definitions: ReadonlyArray<PhaseDefinition>): PhaseTemplate {
+  const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+  return {
+    id: TEMPLATE_ID,
+    workspaceId: WORKSPACE_ID,
+    name: 'parallel-template',
+    description: '',
+    definitions,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function emitEnd(runId: ProviderRunId, exitCode: number = 0): void {
+  for (const h of listenHandlers) {
+    h({ runId, type: 'end', exit_code: exitCode, stderr: exitCode === 0 ? '' : 'failed' });
+  }
+}
+
+async function importStore() {
+  const mod = await import('./store');
+  return mod.useAppStore;
+}
+
+function setupSession(
+  useAppStore: Awaited<ReturnType<typeof importStore>>,
+  definitions: ReadonlyArray<PhaseDefinition>,
+) {
+  useAppStore.setState({
+    sessions: [buildSession()],
+    sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+    settings: {
+      'experimental.enable_parallel_agents': 'true',
+      'experimental.max_parallelism': '4',
+    },
+    phaseTemplates: { [WORKSPACE_ID]: [buildTemplate(definitions)] },
+    providers: [
+      {
+        id: 'anthropic',
+        binary: 'claude',
+        connection: 'connected',
+        name: 'Claude',
+        installation: 'installed',
+      } as never,
+    ],
+    authResults: {
+      anthropic: { state: 'connected', identity: 'test' },
+      cursor: { state: 'connected', identity: 'test' },
+      codex: { state: 'connected', identity: 'test' },
+    } as never,
+    workspaces: [
+      {
+        id: WORKSPACE_ID,
+        name: 'ws',
+        rootPath: '/tmp',
+        createdAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+        updatedAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+      },
+    ],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendTurn — parallel agents branch', () => {
+  beforeEach(() => {
+    runTurnSpy.mockReset();
+    cancelTurnSpy.mockReset();
+    invokeParallelPhaseRunSpawnSpy.mockReset();
+    phaseRunInsertSpy.mockReset();
+    phaseRunUpdateStatusSpy.mockReset();
+    phaseRunListSpy.mockReset();
+    parallelPhaseGroupCreateSpy.mockReset();
+    parallelPhaseGroupUpdateCompletedAtSpy.mockReset();
+    listenHandlers.length = 0;
+
+    invokeParallelPhaseRunSpawnSpy.mockResolvedValue([]);
+    const insertedPhaseRuns: PhaseRun[] = [];
+    phaseRunInsertSpy.mockImplementation(
+      async (args: {
+        phaseDefinitionId: string;
+        providerRunId: string;
+        ordinal: number;
+        name: string;
+      }) => {
+        const row: PhaseRun = {
+          id: `phase-run-${args.phaseDefinitionId}` as PhaseRunId,
+          sessionId: SESSION_ID,
+          phaseDefinitionId: args.phaseDefinitionId as PhaseDefinitionId,
+          ordinal: args.ordinal,
+          name: args.name,
+          status: 'running',
+          runId: args.providerRunId as ProviderRunId,
+        };
+        insertedPhaseRuns.push(row);
+        return row;
+      },
+    );
+    phaseRunListSpy.mockImplementation(async () => insertedPhaseRuns.slice());
+    parallelPhaseGroupCreateSpy.mockImplementation(
+      async (args: {
+        sessionId: string;
+        ordinal: number;
+        mergeStrategy: ParallelMergeStrategy;
+      }) => ({
+        id: 'group-test' as ParallelPhaseGroupId,
+        sessionId: args.sessionId,
+        ordinal: args.ordinal,
+        mergeStrategy: args.mergeStrategy,
+        createdAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+        completedAt: null,
+      }),
+    );
+    parallelPhaseGroupUpdateCompletedAtSpy.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flag OFF → uses single-run path (no parallel spawn)', async () => {
+    async function* emptyStream() {}
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [
+      buildDef({ id: 'd-a', ordinal: 1, parallelGroup: 1 }),
+      buildDef({ id: 'd-b', ordinal: 2, parallelGroup: 1 }),
+    ]);
+    useAppStore.setState({
+      settings: { 'experimental.enable_parallel_agents': 'false' },
+    });
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    expect(invokeParallelPhaseRunSpawnSpy).not.toHaveBeenCalled();
+    expect(parallelPhaseGroupCreateSpy).not.toHaveBeenCalled();
+  });
+
+  it('flag ON + parallelGroup with 2 siblings → spawns N runs and awaits merge', async () => {
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => args.runs.map((r) => r.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [
+      buildDef({ id: 'd-a', ordinal: 1, parallelGroup: 7 }),
+      buildDef({ id: 'd-b', ordinal: 2, parallelGroup: 7 }),
+    ]);
+
+    const turnPromise = useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'plan' });
+
+    // Wait for spawn registration so listeners are wired before we emit 'end'.
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(2);
+    expect(parallelPhaseGroupCreateSpy).toHaveBeenCalledOnce();
+
+    // Pull runIds from the spawn calls and emit 'end' for each.
+    const allCalls = invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+      [{ runs: ReadonlyArray<{ runId: ProviderRunId }> }]
+    >;
+    for (const [args] of allCalls) {
+      const runId = args.runs[0]!.runId;
+      emitEnd(runId, 0);
+    }
+
+    await turnPromise;
+
+    // Merge completion was persisted.
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
+    // Both phase runs were inserted then updated.
+    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(2);
+    expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('flag ON but only 1 sibling → falls back to single-run path', async () => {
+    async function* emptyStream() {}
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [buildDef({ id: 'solo', ordinal: 1, parallelGroup: 99 })]);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'go' });
+
+    expect(invokeParallelPhaseRunSpawnSpy).not.toHaveBeenCalled();
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('one run fails (non-zero exit) → group still completes; group not marked as failed when at least one succeeds', async () => {
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => args.runs.map((r) => r.runId),
+    );
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore, [
+      buildDef({ id: 'd-a', ordinal: 1, parallelGroup: 3 }),
+      buildDef({ id: 'd-b', ordinal: 2, parallelGroup: 3 }),
+    ]);
+
+    const turnPromise = useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, content: 'mixed' });
+    await new Promise((r) => setTimeout(r, 5));
+
+    const calls = invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+      [{ runs: ReadonlyArray<{ runId: ProviderRunId }> }]
+    >;
+    emitEnd(calls[0]![0].runs[0]!.runId, 0);
+    emitEnd(calls[1]![0].runs[0]!.runId, 1);
+
+    await turnPromise;
+
+    // Mixed result: at least one completed → group completedAt is set.
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -91,6 +91,11 @@ import {
   SETTING_LAST_SESSION_ID,
   SETTING_LAST_WORKSPACE_ID,
   SETTING_PROVIDER_PRICING_CONFIG,
+  SETTING_ENABLE_PARALLEL_AGENTS,
+  SETTING_MAX_PARALLELISM,
+  DEFAULT_MAX_PARALLELISM,
+  MAX_PARALLELISM,
+  MIN_PARALLELISM,
 } from '../settings';
 import { parseProviderPricingConfig, getCodexPriceOverride } from '../providerPricing';
 import { runTurn, cancelTurn, encodeAuthRequiredMessage, isAuthErrorMessage } from '../turn';
@@ -129,6 +134,11 @@ import {
   invokePhaseRunUpdateStatus,
   type PhaseTemplateUpsertArgs,
 } from '../phases';
+import {
+  detectParallelGroup,
+  runParallelBranch,
+  type ParallelBranchEffects,
+} from './parallel-turn';
 
 export type BootPhase =
   | 'pending'
@@ -849,6 +859,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     let phaseDefinition: PhaseDefinition | null = null;
     let phasePromptCarryForward = '';
     let phaseTransitionEvent: Extract<TurnEvent, { kind: 'phase_transition' }> | null = null;
+    let parallelDispatch: {
+      template: PhaseTemplate;
+      currentDef: PhaseDefinition;
+      groupDefs: ReadonlyArray<PhaseDefinition>;
+    } | null = null;
+    // Capture user prompt PRE phase build — needed if parallel branch fires, so per-def
+    // prompts can be rebuilt inside runParallelBranch.
+    const userPromptForPhase = resolvedPrompt;
 
     if (session.phaseTemplateId) {
       const templates = get().phaseTemplates[session.workspaceId] ?? [];
@@ -895,11 +913,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
             };
           }
           phaseDefinition = nextDef;
-          resolvedPrompt = buildPhasePrompt({
-            definition: nextDef,
-            carryForwardContext: phasePromptCarryForward,
-            userMessage: resolvedPrompt,
-          });
+
+          // Detect parallel group — only when experimental flag is on AND nextDef
+          // belongs to a group with >= 2 siblings. Defer prompt rebuild for parallel
+          // path: per-def prompts are built inside runParallelBranch using
+          // userPromptForPhase + phasePromptCarryForward.
+          const enableParallelRaw = get().settings[SETTING_ENABLE_PARALLEL_AGENTS];
+          const enableParallel = enableParallelRaw === 'true';
+          if (enableParallel) {
+            const detection = detectParallelGroup(template, nextDef);
+            if (detection !== null) {
+              parallelDispatch = {
+                template,
+                currentDef: detection.currentDef,
+                groupDefs: detection.groupDefs,
+              };
+            }
+          }
+
+          if (parallelDispatch === null) {
+            resolvedPrompt = buildPhasePrompt({
+              definition: nextDef,
+              carryForwardContext: phasePromptCarryForward,
+              userMessage: resolvedPrompt,
+            });
+          }
         }
       }
     }
@@ -958,30 +996,40 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     const resolvedOverride =
       session.providerPreference.allowTurnOverride && override != null ? override : undefined;
-    const userMessage: Message = {
-      id: crypto.randomUUID() as MessageId,
-      sessionId,
-      role: 'user',
-      content: userTurnText,
-      createdAt: now(),
-      ...(resolvedOverride !== undefined ? { providerOverride: resolvedOverride } : {}),
-    };
-    await insertMessage(tauriDatabase, userMessage);
 
+    // The single-run setup (user message persist, provider run row, phase run row,
+    // session.state=running) is gated when the parallel branch will fire below —
+    // the parallel branch inserts its own phase_run rows (one per sibling) and
+    // handles user-message + session-state itself. Without this gate we'd duplicate
+    // every row. The runId allocated here is still used as a placeholder for the
+    // gated paths so types stay consistent (it is unused if parallelDispatch fires).
     const runId = crypto.randomUUID() as ProviderRunId;
-    const run: ProviderRun = {
-      id: runId,
-      sessionId,
-      provider,
-      model,
-      status: { kind: 'streaming', startedAt: now() },
-      routingDecision,
-      createdAt: now(),
-    };
-    await insertProviderRun(tauriDatabase, run);
+
+    if (parallelDispatch === null) {
+      const userMessage: Message = {
+        id: crypto.randomUUID() as MessageId,
+        sessionId,
+        role: 'user',
+        content: userTurnText,
+        createdAt: now(),
+        ...(resolvedOverride !== undefined ? { providerOverride: resolvedOverride } : {}),
+      };
+      await insertMessage(tauriDatabase, userMessage);
+
+      const run: ProviderRun = {
+        id: runId,
+        sessionId,
+        provider,
+        model,
+        status: { kind: 'streaming', startedAt: now() },
+        routingDecision,
+        createdAt: now(),
+      };
+      await insertProviderRun(tauriDatabase, run);
+    }
 
     let phaseRunId: PhaseRunId | null = null;
-    if (phaseDefinition) {
+    if (phaseDefinition && parallelDispatch === null) {
       const inserted = await invokePhaseRunInsert({
         sessionId,
         phaseDefinitionId: phaseDefinition.id,
@@ -1001,13 +1049,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
     }
 
-    let nextState: SessionState = session.state;
-    if (nextState.kind === 'draft') {
-      nextState = sessionReducer(nextState, { kind: 'start', at: now() });
+    if (parallelDispatch === null) {
+      let nextState: SessionState = session.state;
+      if (nextState.kind === 'draft') {
+        nextState = sessionReducer(nextState, { kind: 'start', at: now() });
+      }
+      nextState = sessionReducer(nextState, { kind: 'send', runId, at: now() });
+      await updateSessionState(tauriDatabase, sessionId, nextState, now());
+      applySessionUpdate(set, sessionId, nextState);
     }
-    nextState = sessionReducer(nextState, { kind: 'send', runId, at: now() });
-    await updateSessionState(tauriDatabase, sessionId, nextState, now());
-    applySessionUpdate(set, sessionId, nextState);
 
     const providerInfo = get().providers.find((p) => p.id === provider);
 
@@ -1035,6 +1085,164 @@ export const useAppStore = create<AppStore>((set, get) => ({
         claudeFlags = { allowedTools: [], disallowedTools: [], permissionMode: 'default' };
       }
     }
+
+    // ---- Parallel-agents branch -----------------------------------------
+    // Triggered iff: enableParallelAgents on + phaseTemplate active + current
+    // phase has parallelGroup with >= 2 siblings (already resolved above).
+    // Pre-flight: aggregate cost = single-run estimate × N. Existing single-run
+    // pre-flight is the routing decision itself (resolveProviderForTurn already
+    // selected the cheapest viable provider). For N runs we can only enforce a
+    // soft N-multiplier check against budget rules — implemented as a guard
+    // against runaway parallel spend if the user's session budget is set.
+    if (parallelDispatch !== null) {
+      const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
+      if (!workspace) {
+        get().appendTurnEvent(sessionId, {
+          kind: 'error',
+          runId: crypto.randomUUID() as ProviderRunId,
+          message: `workspace not found: ${session.workspaceId}`,
+          at: now(),
+        });
+        return;
+      }
+
+      const maxParallelismRaw = get().settings[SETTING_MAX_PARALLELISM];
+      const parsedMax = Number.parseInt(maxParallelismRaw ?? '', 10);
+      const maxParallelism = Number.isFinite(parsedMax)
+        ? Math.min(MAX_PARALLELISM, Math.max(MIN_PARALLELISM, parsedMax))
+        : DEFAULT_MAX_PARALLELISM;
+      const N = Math.min(parallelDispatch.groupDefs.length, maxParallelism);
+
+      // Aggregate budget pre-flight: if a session soft cap exists, ensure that
+      // running N parallel turns would not blow past it on this turn alone. We
+      // approximate per-turn cost from the most recent telemetry row for the
+      // session as a conservative ceiling. If no telemetry exists yet, we skip
+      // the check (no signal to compare against — first turn).
+      const sessBudget = get().sessionBudgets[sessionId];
+      if (sessBudget) {
+        const tele = get().sessionTelemetry[sessionId] ?? [];
+        const lastTurnCost = tele.length > 0 ? (tele[tele.length - 1]?.estimatedCostUsd ?? 0) : 0;
+        const projected = lastTurnCost * N;
+        const sessSpent = (get().sessionSummary?.estimatedCostUsd ?? 0) + projected;
+        if (lastTurnCost > 0 && sessSpent > sessBudget.softCapUsd) {
+          get().appendTurnEvent(sessionId, {
+            kind: 'error',
+            runId: crypto.randomUUID() as ProviderRunId,
+            message: `parallel turn aborted: projected spend (${sessSpent.toFixed(4)} USD) would exceed session soft cap (${sessBudget.softCapUsd.toFixed(4)} USD).`,
+            at: now(),
+          });
+          return;
+        }
+      }
+
+      // Persist user message once (mirrors single-run path).
+      const userMessage: Message = {
+        id: crypto.randomUUID() as MessageId,
+        sessionId,
+        role: 'user',
+        content: userTurnText,
+        createdAt: now(),
+      };
+      await insertMessage(tauriDatabase, userMessage);
+
+      // Mark session running with the FIRST runId (UI uses session.state.runId
+      // for the legacy cancel path; for parallel groups, cancel routes through
+      // cancelGroup via the scheduler handle inside runParallelBranch).
+      const groupSessionRunId = crypto.randomUUID() as ProviderRunId;
+      let nextStateP: SessionState = session.state;
+      if (nextStateP.kind === 'draft') {
+        nextStateP = sessionReducer(nextStateP, { kind: 'start', at: now() });
+      }
+      nextStateP = sessionReducer(nextStateP, {
+        kind: 'send',
+        runId: groupSessionRunId,
+        at: now(),
+      });
+      await updateSessionState(tauriDatabase, sessionId, nextStateP, now());
+      applySessionUpdate(set, sessionId, nextStateP);
+
+      const effects: ParallelBranchEffects = {
+        appendTurnEvent: (sid, ev) => get().appendTurnEvent(sid, ev),
+        refreshPhaseRuns: async (sid) => {
+          const runs = await invokePhaseRunList(sid);
+          set((state) => ({
+            sessionPhaseRuns: { ...state.sessionPhaseRuns, [sid]: runs },
+          }));
+        },
+      };
+
+      try {
+        const result = await runParallelBranch(
+          {
+            session,
+            workspace,
+            currentDef: parallelDispatch.currentDef,
+            groupDefs: parallelDispatch.groupDefs,
+            workingDir,
+            resolvedPromptBase: userPromptForPhase,
+            carryForwardContext: phasePromptCarryForward,
+            mergeStrategy: 'last_write_wins',
+            maxParallelism,
+          },
+          {
+            now,
+            providerBinary: providerInfo?.binary,
+            model,
+            ...(claudeFlags.permissionMode !== undefined && {
+              permissionMode: claudeFlags.permissionMode,
+            }),
+            ...(claudeFlags.allowedTools !== undefined && {
+              allowedTools: claudeFlags.allowedTools,
+            }),
+            ...(claudeFlags.disallowedTools !== undefined && {
+              disallowedTools: claudeFlags.disallowedTools,
+            }),
+            effects,
+          },
+        );
+
+        if (result.allFailed) {
+          // Don't auto-cleanup worktrees on full failure — user inspects per-run state.
+          // (Currently no per-run worktrees are created in v1; comment kept for the
+          // follow-on that wires createParallelWorktrees end-to-end.)
+          const errorState: SessionState = {
+            kind: 'error',
+            message: 'all parallel runs failed',
+            failedAt: now(),
+          };
+          await updateSessionState(tauriDatabase, sessionId, errorState, now());
+          applySessionUpdate(set, sessionId, errorState);
+        } else {
+          await updateSessionState(
+            tauriDatabase,
+            sessionId,
+            sessionReducer(get().sessions.find((s) => s.id === sessionId)?.state ?? nextStateP, {
+              kind: 'receive_event',
+              event: { kind: 'done', runId: result.runIds[0]!, at: now() },
+            }),
+            now(),
+          );
+        }
+      } catch (err) {
+        const rawMessage = err instanceof Error ? err.message : String(err);
+        get().appendTurnEvent(sessionId, {
+          kind: 'error',
+          runId: groupSessionRunId,
+          message: rawMessage,
+          at: now(),
+        });
+        const errorState: SessionState = {
+          kind: 'error',
+          message: rawMessage,
+          failedAt: now(),
+        };
+        await updateSessionState(tauriDatabase, sessionId, errorState, now());
+        applySessionUpdate(set, sessionId, errorState);
+        throw err;
+      }
+      return;
+    }
+    // ---- /Parallel-agents branch ----------------------------------------
 
     const pricingConfigRaw = await getSetting(tauriDatabase, SETTING_PROVIDER_PRICING_CONFIG);
     const pricingConfig = parseProviderPricingConfig(pricingConfigRaw);


### PR DESCRIPTION
## summary

- branches `sendTurn` into a parallel-agents path when `experimental.enable_parallel_agents` is on **and** the active phase template's next phase has a `parallelGroup` with ≥2 siblings
- fan-outs via `@kay-am/core` scheduler (#203), pre-batches via `parallel_phase_run_spawn` (#208), awaits merge, auto-resolves conflicts per group `mergeStrategy` (defaults to `last_write_wins`), emits synthetic `phase_transition` on sync-point completion
- aggregate budget pre-flight (last-turn cost × N) aborts before spawn when a session soft cap would be exceeded
- adds `apps/desktop/src/store/parallel-turn.ts` (orchestrator + multiplexed `turn_event` listener) and `store.parallel.test.ts` (4 cases)

## scheduler deps shape (decision: option b)

pre-batch via `invokeParallelPhaseRunSpawn`; scheduler `spawnRun` resolves on the per-runId `end` envelope. aligns with T2 (#208) batched-spawn design and keeps the scheduler purely an await-only orchestrator. a single multiplexed `turn_event` listener routes envelopes by `runId` to per-run progress + settle callbacks (avoids N redundant listeners on the same Tauri channel).

## conflict handling

auto-resolution via `resolveConflicts(group.mergeStrategy)`. MergeDialog wiring is **deferred** with a TODO referencing this PR — surfacing conflicts to the user requires plumbing `MergeResult` into ChatView state (currently a placeholder per #209). when `mergeStrategy === 'manual'` and picks are missing, the branch swallows `ManualResolutionRequiredError` and emits a warning event so the turn pipeline never blocks.

## scope notes

- per-run worktree creation (`createParallelWorktrees`) is **not** wired in v1: each run executes in the session's primary worktree. swapping to per-run worktrees requires Rust `phase_run_insert` to accept `(group_id, parallel_index)`. TODO (#212-followup) marked in source.
- when flag is off → no behavioural change to single-run path (verified by test).

## test plan

- [x] `pnpm --filter @kay-am/desktop typecheck`
- [x] `pnpm --filter @kay-am/desktop test` (76 passing — 4 new in `store.parallel.test.ts`)
- [x] `pnpm --filter @kay-am/core test` (360 passing)
- [x] `pnpm typecheck` (turbo, all packages green)
- [ ] manual smoke pending separate session: 3-run parallel turn, mixed pass/fail, single-run regression