### PR TITLE
test(desktop,repo): e2e parallel fan-out/fan-in + roadmap v0.7 (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ kAY.am sits between you and your AI agents. It doesn't replace your editor or yo
 
 Manage macro sessions. Route work across providers (Anthropic, OpenAI, Cursor, ...) based on priority and budget. Get real-time visibility on tokens and cost. Automate the repeatable with skills.
 
-> **Status**: v0.3 complete. Budget & routing active.
+> **Status**: v0.7 complete. Experimental parallel multi-agent mode available (enable via `experimental.enable_parallel_agents` in settings). v1.0 next.
 
 ## Why
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 Local-first AI workspace orchestrator. This roadmap tracks the path from bootstrap to v1.0. Each version is a GitHub milestone; issues are created only as they approach implementation.
 
-> **Status**: v0.6 complete. v0.7 next planned.
+> **Status**: v0.7 complete. v1.0 next.
 
 ## Architectural decisions (locked)
 
@@ -86,7 +86,7 @@ Intercept tool-call requests from the agent, surface them in the kAY.am UI for e
 
 [v0.6 milestone](https://github.com/akhayam99/kay-am/milestone/6)
 
-### v0.7 — Multi-agent parallel (experimental)
+### v0.7 — Multi-agent parallel (experimental) ✓
 
 Multiple agents inside a single session, each on its own worktree, coordinating via shared synthetic context.
 
@@ -397,6 +397,44 @@ Permission proxy: tool-call interception via static rules + audit, removing `--d
        #174 → #177 → #180
                   ↘ #184 → #188
        #186 + #187 → #188
+```
+
+---
+
+## v0.7 issue index
+
+Consolidation (parte A — hardening + carryover from v0.6):
+
+- [#194 — fix(desktop): cleanup session-scoped state on workspace switch](https://github.com/akhayam99/kay-am/issues/194)
+- [#195 — feat(db,core,desktop): persist session worktrees in m009 table](https://github.com/akhayam99/kay-am/issues/195)
+- [#196 — feat(db,core,desktop): permission audit retry queue (m010)](https://github.com/akhayam99/kay-am/issues/196)
+- [#197 — refactor(core): cost truth cursor + codex via stream usage + settings override](https://github.com/akhayam99/kay-am/issues/197)
+- [#198 — refactor(core): parametrize claude TS adapter permission flags](https://github.com/akhayam99/kay-am/issues/198) — closes #185 part 2
+- [#199 — test(core): phase sequencer edge cases](https://github.com/akhayam99/kay-am/issues/199)
+- [#200 — test(core): summarizer client gated integration test](https://github.com/akhayam99/kay-am/issues/200)
+
+Multi-agent parallel (parte B — experimental):
+
+- [#201 — feat(types): parallel phase domain types](https://github.com/akhayam99/kay-am/issues/201)
+- [#202 — feat(db): m011 parallel_phases migration](https://github.com/akhayam99/kay-am/issues/202)
+- [#203 — feat(core): parallel scheduler (fan-out/fan-in)](https://github.com/akhayam99/kay-am/issues/203)
+- [#204 — feat(core): parallel conflict detection + merge strategy](https://github.com/akhayam99/kay-am/issues/204)
+- [#205 — feat(core): throwaway worktree helper for parallel runs](https://github.com/akhayam99/kay-am/issues/205)
+- [#206 — test(core): parallel scheduler + conflict integration tests](https://github.com/akhayam99/kay-am/issues/206)
+- [#207 — feat(desktop): parallel phase group CRUD tauri commands](https://github.com/akhayam99/kay-am/issues/207)
+- [#208 — feat(desktop): parallel phase run spawn batch tauri command](https://github.com/akhayam99/kay-am/issues/208)
+- [#209 — feat(desktop,ui): split-view transcript + experimental flag toggle](https://github.com/akhayam99/kay-am/issues/209)
+- [#210 — feat(desktop): multi-progress indicator for parallel runs](https://github.com/akhayam99/kay-am/issues/210)
+- [#211 — feat(desktop,ui): merge dialog conflict resolution UI](https://github.com/akhayam99/kay-am/issues/211)
+- [#212 — feat(desktop): wire parallel scheduler into sendTurn](https://github.com/akhayam99/kay-am/issues/212)
+- [#213 — feat(types,core): permission_request + permission_decision TurnEvent](https://github.com/akhayam99/kay-am/issues/213) — closes #185 part 1
+- [#214 — test(desktop,repo): e2e parallel fan-out/fan-in + ROADMAP/README v0.7](https://github.com/akhayam99/kay-am/issues/214)
+
+### Critical path
+
+```
+H1.0 → H1.1 → F1+F2 → C1+C2+C3 → C4 → T1+T2 → U1+U2+U3 → I1 → I3
+H2.* parallelizable with H1+F (independent file scope).
 ```
 
 ---

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -1,0 +1,544 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  ParallelPhaseGroupId,
+  PhaseDefinitionId,
+  PhaseRunId,
+  PhaseRunStatus,
+  PhaseTemplateId,
+  ProviderId,
+  ProviderRunId,
+  SessionId,
+  TurnEvent,
+  WorkspaceId,
+} from '@kay-am/types';
+import type { MergeResult } from '@kay-am/core';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before subject imports.
+// ---------------------------------------------------------------------------
+
+// Tauri invoke — stubbed per-test.
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+// Tauri event — captures listener so tests can drive envelopes.
+type TurnEnvelope = {
+  runId: string;
+  type: 'line' | 'end' | 'error';
+  line?: string;
+  exit_code?: number | null;
+  stderr?: string;
+  message?: string;
+};
+
+const capturedListeners: Array<(payload: TurnEnvelope) => void> = [];
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async (_event: string, cb: (e: { payload: TurnEnvelope }) => void) => {
+    capturedListeners.push((payload) => cb({ payload }));
+    return () => undefined;
+  }),
+}));
+
+// Phase invocations.
+const parallelPhaseGroupCreateSpy = vi.fn();
+const parallelPhaseGroupUpdateCompletedAtSpy = vi.fn();
+const phaseRunInsertSpy = vi.fn();
+const phaseRunUpdateStatusSpy = vi.fn();
+const phaseRunListSpy = vi.fn();
+
+vi.mock('../phases', () => ({
+  invokeParallelPhaseGroupCreate: (args: unknown) => parallelPhaseGroupCreateSpy(args),
+  invokeParallelPhaseGroupUpdateCompletedAt: (id: string, at: string) =>
+    parallelPhaseGroupUpdateCompletedAtSpy(id, at),
+  invokePhaseRunInsert: (args: unknown) => phaseRunInsertSpy(args),
+  invokePhaseRunUpdateStatus: (id: string, fields: unknown) => phaseRunUpdateStatusSpy(id, fields),
+  invokePhaseRunList: (sid: string) => phaseRunListSpy(sid),
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunDelete: vi.fn(),
+}));
+
+// Turn invocations.
+const invokeParallelPhaseRunSpawnSpy = vi.fn();
+const cancelTurnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  invokeParallelPhaseRunSpawn: (args: unknown) => invokeParallelPhaseRunSpawnSpy(args),
+  cancelTurn: (runId: string) => cancelTurnSpy(runId),
+  runTurn: vi.fn(async function* () {}),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+// Core scheduler — we keep the REAL fanOut/awaitMerge/cancelGroup so the
+// orchestration logic is exercised end-to-end. Only the Tauri surface is mocked.
+// detectConflicts + resolveConflicts stay real too.
+
+// ---------------------------------------------------------------------------
+// Subject under test.
+// ---------------------------------------------------------------------------
+
+import { runParallelBranch } from '../store/parallel-turn';
+import type { ParallelBranchInputs, ParallelBranchEffects } from '../store/parallel-turn';
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+const NOW = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'ses-1' as SessionId;
+const WORKSPACE_ID = 'ws-1' as WorkspaceId;
+const TEMPLATE_ID = 'tpl-1' as PhaseTemplateId;
+const GROUP_ID = 'grp-1' as ParallelPhaseGroupId;
+
+function makeDef(id: string, ordinal: number, pg = 42) {
+  return {
+    id: id as PhaseDefinitionId,
+    templateId: TEMPLATE_ID,
+    ordinal,
+    name: id,
+    promptPrefix: `[${id}]`,
+    parallelGroup: pg,
+  };
+}
+
+function makeSession() {
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'e2e-test',
+    state: { kind: 'idle' as const, lastActivityAt: NOW },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic' as ProviderId, allowTurnOverride: false },
+    phaseTemplateId: TEMPLATE_ID,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function makeWorkspace() {
+  return {
+    id: WORKSPACE_ID,
+    name: 'ws',
+    rootPath: '/tmp',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+// Emit a turn_event envelope to all captured listeners.
+function emit(payload: TurnEnvelope): void {
+  for (const fn of capturedListeners) fn(payload);
+}
+
+// Emit 'end' for a runId with a given exit_code.
+function emitEnd(runId: string, exitCode = 0): void {
+  emit({ runId, type: 'end', exit_code: exitCode, stderr: exitCode !== 0 ? 'run failed' : '' });
+}
+
+// Emit a JSONL 'line' event for a runId (assistant_text).
+function emitLine(runId: string, text: string): void {
+  const line = JSON.stringify({
+    type: 'assistant',
+    message: { content: [{ type: 'text', text }] },
+  });
+  emit({ runId, type: 'line', line });
+}
+
+// Build standard inputs for a 3-parallel-def group.
+function makeInputs(
+  groupDefs = [makeDef('d-a', 1), makeDef('d-b', 2), makeDef('d-c', 3)],
+): ParallelBranchInputs {
+  return {
+    session: makeSession(),
+    workspace: makeWorkspace(),
+    currentDef: groupDefs[0]!,
+    groupDefs,
+    workingDir: '/tmp/wt',
+    resolvedPromptBase: 'implement X',
+    carryForwardContext: '',
+    mergeStrategy: 'last_write_wins',
+    maxParallelism: 4,
+  };
+}
+
+// Effects stub — captures appended events.
+function makeEffects(): { effects: ParallelBranchEffects; events: TurnEvent[] } {
+  const events: TurnEvent[] = [];
+  return {
+    effects: {
+      appendTurnEvent: (_sid: SessionId, e: TurnEvent) => events.push(e),
+      refreshPhaseRuns: vi.fn(async () => undefined),
+    },
+    events,
+  };
+}
+
+// Deps stub.
+function makeDeps(effects: ParallelBranchEffects) {
+  return {
+    now: () => NOW,
+    providerBinary: 'claude',
+    model: 'claude-sonnet-4-6',
+    effects,
+  };
+}
+
+// Stable insertedPhaseRuns list shared between phaseRunInsert + phaseRunList spies.
+function wirePhaseRunSpies(
+  insertedPhaseRuns: Array<{
+    id: PhaseRunId;
+    sessionId: SessionId;
+    phaseDefinitionId: PhaseDefinitionId;
+    ordinal: number;
+    name: string;
+    status: PhaseRunStatus;
+    runId: ProviderRunId;
+  }>,
+): void {
+  phaseRunInsertSpy.mockImplementation(
+    async (args: {
+      phaseDefinitionId: string;
+      ordinal: number;
+      name: string;
+      providerRunId: string;
+    }) => {
+      const row = {
+        id: `pr-${args.phaseDefinitionId}` as PhaseRunId,
+        sessionId: SESSION_ID,
+        phaseDefinitionId: args.phaseDefinitionId as PhaseDefinitionId,
+        ordinal: args.ordinal,
+        name: args.name,
+        status: 'running' as PhaseRunStatus,
+        runId: args.providerRunId as ProviderRunId,
+      };
+      insertedPhaseRuns.push(row);
+      return row;
+    },
+  );
+  phaseRunListSpy.mockImplementation(async () => insertedPhaseRuns.slice());
+}
+
+// ---------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------
+
+describe('parallel e2e — fan-out/fan-in', () => {
+  beforeEach(() => {
+    parallelPhaseGroupCreateSpy.mockReset();
+    parallelPhaseGroupUpdateCompletedAtSpy.mockReset();
+    phaseRunInsertSpy.mockReset();
+    phaseRunUpdateStatusSpy.mockReset();
+    phaseRunListSpy.mockReset();
+    invokeParallelPhaseRunSpawnSpy.mockReset();
+    cancelTurnSpy.mockReset();
+    capturedListeners.length = 0;
+
+    parallelPhaseGroupCreateSpy.mockResolvedValue({
+      id: GROUP_ID,
+      sessionId: SESSION_ID,
+      ordinal: 1,
+      mergeStrategy: 'last_write_wins',
+      createdAt: NOW,
+      completedAt: null,
+    });
+    parallelPhaseGroupUpdateCompletedAtSpy.mockResolvedValue(undefined);
+    phaseRunUpdateStatusSpy.mockResolvedValue(undefined);
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => args.runs.map((r) => r.runId),
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path: 3 parallel runs, all succeed.
+  // -------------------------------------------------------------------------
+
+  it('happy path: 3 runs complete → transcript has events from all runIds, group marked complete', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    const { effects, events } = makeEffects();
+    const inputs = makeInputs();
+    const deps = makeDeps(effects);
+
+    const branchPromise = runParallelBranch(inputs, deps);
+
+    // Settle race: give spawn & listener registration time to wire before emitting.
+    await new Promise((r) => setTimeout(r, 10));
+
+    // 3 spawns → 3 runIds.
+    expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(3);
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([a]) => a.runs[0]!.runId);
+
+    const [idA, idB, idC] = spawnedRunIds as [string, string, string];
+
+    // Emit some text events from each run — distinct deltas per lane.
+    emitLine(idA, 'run-a output');
+    emitLine(idB, 'run-b output');
+    emitLine(idC, 'run-c output');
+
+    // All complete successfully.
+    emitEnd(idA, 0);
+    emitEnd(idB, 0);
+    emitEnd(idC, 0);
+
+    const result = await branchPromise;
+
+    // runIds tagged in result.
+    expect(result.runIds).toHaveLength(3);
+    expect(result.runIds).toContain(idA as ProviderRunId);
+    expect(result.runIds).toContain(idB as ProviderRunId);
+    expect(result.runIds).toContain(idC as ProviderRunId);
+
+    // No failures.
+    expect(result.anyFailed).toBe(false);
+    expect(result.allFailed).toBe(false);
+
+    // MergeResult has 3 completed run statuses.
+    const merge: MergeResult = result.merge;
+    expect(merge.runStatuses).toHaveLength(3);
+    for (const rs of merge.runStatuses) {
+      expect(rs.status).toBe('completed');
+    }
+
+    // Transcript received events tagged with distinct runIds.
+    const textEvents = events.filter((e) => e.kind === 'assistant_text');
+    const seenRunIds = new Set(textEvents.map((e) => e.runId));
+    expect(seenRunIds.size).toBe(3);
+    expect(seenRunIds.has(idA as ProviderRunId)).toBe(true);
+    expect(seenRunIds.has(idB as ProviderRunId)).toBe(true);
+    expect(seenRunIds.has(idC as ProviderRunId)).toBe(true);
+
+    // Cleanup: group marked complete.
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledWith(GROUP_ID, NOW);
+
+    // Phase run DB rows created + status-updated for each run.
+    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(3);
+    expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(3);
+
+    // Synthetic phase_transition event emitted (fan-in sync-point).
+    const phaseTransitions = events.filter((e) => e.kind === 'phase_transition');
+    expect(phaseTransitions).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error path: 1 of 3 runs fails.
+  // -------------------------------------------------------------------------
+
+  it('error path: 1 of 3 runs fails → partial merge proceeds, anyFailed=true, group still completes', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    const { effects, events } = makeEffects();
+    const inputs = makeInputs();
+    const deps = makeDeps(effects);
+
+    const branchPromise = runParallelBranch(inputs, deps);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(3);
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([a]) => a.runs[0]!.runId) as [string, string, string];
+
+    const [idA, idB, idC] = spawnedRunIds;
+
+    emitLine(idA, 'partial-a');
+    emitLine(idB, 'partial-b');
+    // idC fails.
+    emitEnd(idA, 0);
+    emitEnd(idB, 0);
+    emitEnd(idC, 1);
+
+    const result = await branchPromise;
+
+    expect(result.anyFailed).toBe(true);
+    expect(result.allFailed).toBe(false);
+
+    // MergeResult has 3 run statuses: 2 completed + 1 failed.
+    const merge: MergeResult = result.merge;
+    expect(merge.runStatuses).toHaveLength(3);
+    const completed = merge.runStatuses.filter((rs) => rs.status === 'completed');
+    const failed = merge.runStatuses.filter((rs) => rs.status === 'failed');
+    expect(completed).toHaveLength(2);
+    expect(failed).toHaveLength(1);
+    expect(failed[0]!.runId).toBe(idC as ProviderRunId);
+
+    // group still marked complete (at least one succeeded).
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
+
+    // Transcript still contains events from the 2 successful runs.
+    const textEvents = events.filter((e) => e.kind === 'assistant_text');
+    const seenRunIds = new Set(textEvents.map((e) => e.runId));
+    expect(seenRunIds.has(idA as ProviderRunId)).toBe(true);
+    expect(seenRunIds.has(idB as ProviderRunId)).toBe(true);
+    // idC emitted no text before failing.
+    expect(seenRunIds.has(idC as ProviderRunId)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // All-fail path: no runs succeed → group NOT marked complete.
+  // -------------------------------------------------------------------------
+
+  it('all-fail path: all 3 runs fail → allFailed=true, group completedAt not set', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    const { effects } = makeEffects();
+    const inputs = makeInputs();
+    const deps = makeDeps(effects);
+
+    const branchPromise = runParallelBranch(inputs, deps);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([a]) => a.runs[0]!.runId);
+
+    for (const id of spawnedRunIds) emitEnd(id, 1);
+
+    const result = await branchPromise;
+
+    expect(result.allFailed).toBe(true);
+    expect(result.anyFailed).toBe(true);
+
+    // Group NOT marked complete when all fail.
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Transcript event ordering: events from each runId arrive interleaved
+  // but each lane sees only its own events when filtered.
+  // -------------------------------------------------------------------------
+
+  it('transcript multi-lane: interleaved events remain correctly tagged per runId', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    const { effects, events } = makeEffects();
+    const inputs = makeInputs();
+    const deps = makeDeps(effects);
+
+    const branchPromise = runParallelBranch(inputs, deps);
+    await new Promise((r) => setTimeout(r, 10));
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([a]) => a.runs[0]!.runId) as [string, string, string];
+
+    const [idA, idB, idC] = spawnedRunIds;
+
+    // Interleaved emission pattern.
+    emitLine(idA, 'a-1');
+    emitLine(idB, 'b-1');
+    emitLine(idC, 'c-1');
+    emitLine(idA, 'a-2');
+    emitLine(idC, 'c-2');
+    emitLine(idB, 'b-2');
+
+    emitEnd(idA, 0);
+    emitEnd(idB, 0);
+    emitEnd(idC, 0);
+
+    await branchPromise;
+
+    const textEvents = events.filter((e) => e.kind === 'assistant_text');
+
+    const laneA = textEvents.filter((e) => e.runId === (idA as ProviderRunId));
+    const laneB = textEvents.filter((e) => e.runId === (idB as ProviderRunId));
+    const laneC = textEvents.filter((e) => e.runId === (idC as ProviderRunId));
+
+    expect(laneA).toHaveLength(2);
+    expect(laneB).toHaveLength(2);
+    expect(laneC).toHaveLength(2);
+
+    // No cross-lane leakage: every event in a lane matches that lane's runId.
+    for (const e of laneA) expect(e.runId).toBe(idA as ProviderRunId);
+    for (const e of laneB) expect(e.runId).toBe(idB as ProviderRunId);
+    for (const e of laneC) expect(e.runId).toBe(idC as ProviderRunId);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cancel mid-flight: cancelGroup propagates to all N runIds.
+  // -------------------------------------------------------------------------
+
+  it('cancel mid-flight: spawn throws → cancelGroup teardown, listener unlistened', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    // Make the second spawn fail so the overall spawn Promise.all rejects.
+    let callCount = 0;
+    invokeParallelPhaseRunSpawnSpy.mockImplementation(
+      async (args: { runs: ReadonlyArray<{ runId: string }> }) => {
+        callCount++;
+        if (callCount === 2) throw new Error('spawn failed for run-b');
+        return args.runs.map((r) => r.runId);
+      },
+    );
+
+    const { effects } = makeEffects();
+    const inputs = makeInputs();
+    const deps = makeDeps(effects);
+
+    await expect(runParallelBranch(inputs, deps)).rejects.toThrow('spawn failed for run-b');
+
+    // Group was created (persisted before spawn attempt).
+    expect(parallelPhaseGroupCreateSpy).toHaveBeenCalledOnce();
+
+    // No completedAt set on failure path.
+    expect(parallelPhaseGroupUpdateCompletedAtSpy).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Parallelism cap: maxParallelism=2 with 3 defs → only 2 spawned.
+  // -------------------------------------------------------------------------
+
+  it('maxParallelism cap: only 2 runs spawned when maxParallelism=2', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+
+    const { effects } = makeEffects();
+    const inputs: ParallelBranchInputs = {
+      ...makeInputs(),
+      maxParallelism: 2,
+    };
+    const deps = makeDeps(effects);
+
+    const branchPromise = runParallelBranch(inputs, deps);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Only 2 spawns despite 3 groupDefs.
+    expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(2);
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([a]) => a.runs[0]!.runId);
+
+    for (const id of spawnedRunIds) emitEnd(id, 0);
+
+    const result = await branchPromise;
+    expect(result.runIds).toHaveLength(2);
+    expect(result.allFailed).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- **e2e test** (`apps/desktop/src/__tests__/parallel-e2e.test.ts`): exercises `runParallelBranch` end-to-end at the store level with real core scheduler (`fanOut`/`awaitMerge`) and mocked Tauri surface
  - happy path: 3 parallel runs, all succeed, transcript has multi-lane events tagged with distinct runIds, group `completedAt` set, phase_transition emitted
  - error path: 1 of 3 fails, partial merge proceeds with 2 completed, `anyFailed=true`, group still marked complete
  - all-fail path: `allFailed=true`, group `completedAt` NOT set
  - transcript lane isolation: interleaved events remain correctly tagged per runId, no cross-lane leakage
  - spawn cancel propagation: spawn throw → branch rejects, group not completed
  - maxParallelism cap: 2-cap with 3 defs → only 2 spawns
- **ROADMAP.md**: adds v0.7 issue index (#194–#214) with parte A (consolidation) + parte B (parallel experimental), critical path block, status header → "v0.7 complete. v1.0 next.", v0.7 milestone bullet marked ✓
- **README.md**: status badge updated to v0.7 with note on experimental parallel mode and settings flag

Closes #214
Closes #185