### PR TITLE
fix(desktop,ui): stabilize zustand selectors (#238)

### DIFF
--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -8,7 +8,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
-import { useAppStore } from '../store';
+import { EMPTY_ARRAY, useAppStore } from '../store';
 
 interface NewSessionDialogProps {
   open: boolean;
@@ -44,7 +44,7 @@ export function NewSessionDialog({
   const providers = useAppStore((s) => s.providers);
   const settingKey = settingBranchPrefix(workspaceId);
   const storedPrefix = useAppStore((s) => s.settings[settingKey]);
-  const phaseTemplates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? []);
+  const phaseTemplates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? EMPTY_ARRAY);
   const [goal, setGoal] = useState('');
   const [prefix, setPrefix] = useState(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
   const [softCapRaw, setSoftCapRaw] = useState('');

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -8,7 +8,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 import type { ProviderId } from '@kay-am/types';
-import { useAppStore } from '../store';
+import { EMPTY_ARRAY, useAppStore } from '../store';
 import type { PhaseTemplateUpsertArgs, PhaseDefinitionUpsertArgs } from '../phases';
 
 interface PhasesPanelProps {
@@ -62,7 +62,7 @@ function templateToForm(t: PhaseTemplate): TemplateForm {
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
 export function PhasesPanel({ workspaceId }: PhasesPanelProps) {
-  const templates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? []);
+  const templates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? EMPTY_ARRAY);
   const loadPhaseTemplates = useAppStore((s) => s.loadPhaseTemplates);
   const savePhaseTemplate = useAppStore((s) => s.savePhaseTemplate);
   const deletePhaseTemplate = useAppStore((s) => s.deletePhaseTemplate);

--- a/apps/desktop/src/components/SkillsPanel.tsx
+++ b/apps/desktop/src/components/SkillsPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Button, Input, Textarea } from '@kay-am/ui';
 import type { Skill, SkillFrontmatter, WorkspaceId } from '@kay-am/types';
-import { useAppStore } from '../store';
+import { EMPTY_ARRAY, useAppStore } from '../store';
 
 interface SkillsPanelProps {
   readonly workspaceId: WorkspaceId;
@@ -55,7 +55,7 @@ function parseChips(raw: string): ReadonlyArray<string> {
 }
 
 export function SkillsPanel({ workspaceId }: SkillsPanelProps) {
-  const skills = useAppStore((s) => s.skills[workspaceId] ?? []);
+  const skills = useAppStore((s) => s.skills[workspaceId] ?? EMPTY_ARRAY);
   const loadSkills = useAppStore((s) => s.loadSkills);
   const saveSkill = useAppStore((s) => s.saveSkill);
   const deleteSkill = useAppStore((s) => s.deleteSkill);

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -20,7 +20,7 @@ import type {
 import { getDefaultTurnModel } from '@kay-am/core';
 import { openInEditor } from '../../editor';
 import { DEFAULT_EDITOR_BINARY, SETTING_EDITOR_BINARY } from '../../settings';
-import { useAppStore } from '../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../store';
 import { PermissionAuditPanel } from './PermissionAuditPanel';
 import { ParallelProgressPill } from './ParallelProgressPill';
 
@@ -87,7 +87,7 @@ export function ChatHeader({
     }
   };
 
-  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? []);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
 
   const runStatuses = Object.fromEntries(
     (parallelRunIds ?? []).map((rid) => {
@@ -202,7 +202,7 @@ const STATUS_DOT: Record<PhaseRunStatus, string> = {
 };
 
 function PhaseProgressPill({ sessionId }: { sessionId: SessionId }) {
-  const runs = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? []);
+  const runs = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
 
   if (runs.length === 0) return null;
 

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderRunId, Session } from '@kay-am/types';
-import { useAppStore, useTranscript } from '../../store';
+import { EMPTY_ARRAY, useAppStore, useTranscript } from '../../store';
 import { detectParallelRunIds, filterEventsByRunId, reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
 import { AuthRequiredCallout } from './AuthRequiredCallout';
@@ -115,7 +115,7 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
     [events, flagOn],
   );
 
-  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? []);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
 
   const allParallelTerminal = useMemo(() => {
     if (parallelRunIds.length === 0) return false;

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -20,3 +20,5 @@ export {
   useWorkspaces,
 } from './selectors';
 export { selectTranscript, useTranscript } from './transcript';
+
+export const EMPTY_ARRAY: readonly never[] = [];


### PR DESCRIPTION
Closes #238

## Summary

- App andava in boot loop / crash su `ChatView` e cambio workspace/session
- Console: `getSnapshot should be cached to avoid an infinite loop` + `Maximum update depth exceeded` in `<ChatHeader>`
- Root cause: 6 selector zustand con fallback inline `?? []` allocavano un nuovo array literal a ogni `getSnapshot` → snapshot-cache mismatch → re-render infinito
- Pattern identico già correttamente usato in `store/transcript.ts` (costante module-level `EMPTY`)

## Fix

Esportato `EMPTY_ARRAY: readonly never[]` da `store/index.ts`. Sostituiti i fallback inline nei selector affetti con il riferimento condiviso.

Callsite corretti:
- [ChatView.tsx:118](apps/desktop/src/components/chat/ChatView.tsx#L118) — `sessionPhaseRuns`
- [ChatHeader.tsx:90](apps/desktop/src/components/chat/ChatHeader.tsx#L90) — `sessionPhaseRuns`
- [ChatHeader.tsx:205](apps/desktop/src/components/chat/ChatHeader.tsx#L205) — `sessionPhaseRuns`
- [NewSessionDialog.tsx:47](apps/desktop/src/components/NewSessionDialog.tsx#L47) — `phaseTemplates`
- [PhasesPanel.tsx:65](apps/desktop/src/components/PhasesPanel.tsx#L65) — `phaseTemplates`
- [SkillsPanel.tsx:58](apps/desktop/src/components/SkillsPanel.tsx#L58) — `skills`

NB: `ChatInput.tsx:54` già protetto da `useShallow`. `ChatView.tsx:98` e `WorkspacesSidebar.tsx:176` collassano a primitivo (`[0] ?? null`) → safe, lasciati invariati.

## Test plan

- [x] `pnpm --filter @kay-am/desktop typecheck` — clean
- [ ] Manuale: avvio app → boot completa senza crash
- [ ] Manuale: cambio workspace → no loop
- [ ] Manuale: cambio session → no loop
- [ ] Manuale: apertura `ChatView` con `experimental.enable_parallel_agents=true` → header rendera senza error boundary

## Out of scope

Slegato dalla milestone v0.7. Hotfix puro per restoring boot.