### PR TITLE
fix(ui): appshell fills viewport on ultrawide displays

### DIFF
--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -11,8 +11,6 @@ export interface AppShellProps {
   className?: string;
 }
 
-const SHELL_MAX_WIDTH = '1920px';
-const SHELL_MAX_HEIGHT = '1200px';
 const LEFT_SIDEBAR_WIDTH = '260px';
 const RIGHT_SIDEBAR_WIDTH = '320px';
 
@@ -48,15 +46,13 @@ export function AppShell({
 }: AppShellProps) {
   const layout = buildLayout({ collapsed: rightSidebarCollapsed, hasFooter: Boolean(footer) });
   const gridStyle: CSSProperties = {
-    maxWidth: SHELL_MAX_WIDTH,
-    maxHeight: SHELL_MAX_HEIGHT,
     gridTemplateAreas: layout.templateAreas,
     gridTemplateColumns: layout.templateColumns,
     gridTemplateRows: layout.templateRows,
   };
 
   return (
-    <div className="flex h-screen w-screen items-center justify-center bg-muted/40">
+    <div className="h-screen w-screen bg-muted/40">
       <div
         className={cn(
           'grid h-full w-full overflow-hidden border-border-soft bg-background text-foreground',


### PR DESCRIPTION
## summary
- remove `maxWidth: 1920px` / `maxHeight: 1200px` cap on `AppShell`
- remove outer `flex items-center justify-center` wrapper that letterboxed the grid

on 21:9 / 32" monitors (e.g. 3440×1440) the shell was centered with empty gutters around it. now header/footer/sidebars sit on the viewport edges and `main` fills the remaining space.

unrelated to any active milestone — pure layout fix.

## test plan
- [ ] open desktop app full-screen on ultrawide (21:9) display → no empty gutters
- [ ] standard 16:9 monitor → layout unchanged
- [ ] resize window → grid reflows correctly
- [ ] toggle right context panel → columns adjust without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)