### PR TITLE
fix(core): support .claude/skills/ convention for skill discovery

### DIFF
--- a/packages/core/src/skills/registry.test.ts
+++ b/packages/core/src/skills/registry.test.ts
@@ -13,6 +13,7 @@ import { SkillRegistry, SkillRegistryError } from './registry';
 const WORKSPACE_ID = 'ws_test' as WorkspaceId;
 const ROOT = '/fake/root';
 const SKILLS_DIR = `${ROOT}/.kay/skills`;
+const CLAUDE_SKILLS_DIR = `${ROOT}/.claude/skills`;
 
 const FIXED_NOW = '2024-01-01T00:00:00.000Z' as IsoDateTime;
 
@@ -55,10 +56,24 @@ async function makeSeededDb(): Promise<DbInterface> {
 function makeFs(files: Record<string, string>): SkillFs {
   return {
     async readDir(path: string): Promise<string[]> {
-      if (path !== SKILLS_DIR) return [];
-      return Object.keys(files)
-        .filter((f) => f.startsWith(`${SKILLS_DIR}/`))
-        .map((f) => f.slice(`${SKILLS_DIR}/`.length));
+      if (path === SKILLS_DIR) {
+        return Object.keys(files)
+          .filter((f) => f.startsWith(`${SKILLS_DIR}/`))
+          .map((f) => f.slice(`${SKILLS_DIR}/`.length));
+      }
+      if (path === CLAUDE_SKILLS_DIR) {
+        // Return the immediate subdirectory names under .claude/skills/
+        const subdirs = new Set<string>();
+        for (const f of Object.keys(files)) {
+          if (f.startsWith(`${CLAUDE_SKILLS_DIR}/`)) {
+            const rel = f.slice(`${CLAUDE_SKILLS_DIR}/`.length);
+            const firstSegment = rel.split('/')[0];
+            if (firstSegment !== undefined) subdirs.add(firstSegment);
+          }
+        }
+        return [...subdirs];
+      }
+      return [];
     },
     async readFile(path: string): Promise<string> {
       const content = files[path];
@@ -66,6 +81,9 @@ function makeFs(files: Record<string, string>): SkillFs {
       return content;
     },
     async stat(path: string): Promise<{ exists: boolean }> {
+      // Exact file match
+      if (files[path] !== undefined) return { exists: true };
+      // Directory / prefix match
       const hasFiles = Object.keys(files).some((f) => f.startsWith(`${path}/`));
       return { exists: hasFiles };
     },
@@ -202,5 +220,67 @@ describe('SkillRegistry.getSkillByName', () => {
 
     const skill = await registry.getSkillByName(WORKSPACE_ID, 'nonexistent', db);
     expect(skill).toBeNull();
+  });
+});
+
+describe('SkillRegistry.scanWorkspace – Claude Code convention (.claude/skills)', () => {
+  const CLAUDE_SKILL_BAR = `---
+name: bar
+description: Claude Code skill bar
+---
+
+Body of bar.
+`;
+
+  it('discovers skill from .claude/skills/<name>/SKILL.md', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${CLAUDE_SKILLS_DIR}/bar/SKILL.md`]: CLAUDE_SKILL_BAR,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('bar');
+    expect(result[0]?.filePath).toBe(`${CLAUDE_SKILLS_DIR}/bar/SKILL.md`);
+  });
+
+  it('discovers skills from BOTH .kay/skills and .claude/skills simultaneously', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${SKILLS_DIR}/skill-a.md`]: SKILL_A,
+      [`${CLAUDE_SKILLS_DIR}/bar/SKILL.md`]: CLAUDE_SKILL_BAR,
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(2);
+    const names = result.map((s) => s.name).sort();
+    expect(names).toEqual(['bar', 'skill-a']);
+  });
+
+  it('ignores .claude/skills subdirs with no SKILL.md', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({
+      [`${CLAUDE_SKILLS_DIR}/bar/SKILL.md`]: CLAUDE_SKILL_BAR,
+      [`${CLAUDE_SKILLS_DIR}/empty-dir/other.md`]: '# not a skill',
+    });
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.name).toBe('bar');
+  });
+
+  it('missing .claude/skills dir → returns empty (no throw)', async () => {
+    const db = await makeSeededDb();
+    const fs = makeFs({});
+    const registry = new SkillRegistry({ fs, now: makeNow() });
+
+    const result = await registry.scanWorkspace(WORKSPACE_ID, ROOT, db);
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -24,6 +24,14 @@ export class SkillRegistryError extends Error {
   }
 }
 
+/**
+ * Represents a single skill file path to scan: the resolved path and its
+ * canonical file path used as a stable DB key.
+ */
+interface SkillCandidate {
+  filePath: string;
+}
+
 export class SkillRegistry {
   private readonly fs: SkillFs;
   private readonly now: () => IsoDateTime;
@@ -33,26 +41,63 @@ export class SkillRegistry {
     this.now = deps.now;
   }
 
-  async scanWorkspace(
-    workspaceId: WorkspaceId,
-    rootPath: string,
-    db: SqlDatabase,
-  ): Promise<ReadonlyArray<Skill>> {
+  /**
+   * Collects skill file paths from a flat `.kay/skills/*.md` directory.
+   * Returns an empty array when the directory is absent.
+   */
+  private async collectKaySkills(rootPath: string): Promise<SkillCandidate[]> {
     const skillsDir = `${rootPath}/.kay/skills`;
-
     let filenames: string[];
     try {
       filenames = await this.fs.readDir(skillsDir);
     } catch (err) {
       const { exists } = await this.fs.stat(skillsDir).catch(() => ({ exists: false }));
-      if (!exists) {
-        filenames = [];
-      } else {
-        throw new SkillRegistryError(`failed to read skills directory: ${skillsDir}`, err);
-      }
+      if (!exists) return [];
+      throw new SkillRegistryError(`failed to read skills directory: ${skillsDir}`, err);
+    }
+    return filenames
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => ({ filePath: `${skillsDir}/${f}` }));
+  }
+
+  /**
+   * Collects skill file paths from the Claude Code convention:
+   * `.claude/skills/<skill-name>/SKILL.md` (one subdirectory per skill).
+   * Returns an empty array when the directory is absent.
+   */
+  private async collectClaudeSkills(rootPath: string): Promise<SkillCandidate[]> {
+    const skillsDir = `${rootPath}/.claude/skills`;
+    let entries: string[];
+    try {
+      entries = await this.fs.readDir(skillsDir);
+    } catch (err) {
+      const { exists } = await this.fs.stat(skillsDir).catch(() => ({ exists: false }));
+      if (!exists) return [];
+      throw new SkillRegistryError(`failed to read skills directory: ${skillsDir}`, err);
     }
 
-    const mdFiles = filenames.filter((f) => f.endsWith('.md'));
+    const candidates: SkillCandidate[] = [];
+    for (const entry of entries) {
+      const skillFilePath = `${skillsDir}/${entry}/SKILL.md`;
+      const { exists } = await this.fs.stat(skillFilePath).catch(() => ({ exists: false }));
+      if (exists) {
+        candidates.push({ filePath: skillFilePath });
+      }
+    }
+    return candidates;
+  }
+
+  async scanWorkspace(
+    workspaceId: WorkspaceId,
+    rootPath: string,
+    db: SqlDatabase,
+  ): Promise<ReadonlyArray<Skill>> {
+    const [kaySkills, claudeSkills] = await Promise.all([
+      this.collectKaySkills(rootPath),
+      this.collectClaudeSkills(rootPath),
+    ]);
+
+    const candidates = [...kaySkills, ...claudeSkills];
 
     const existing = await listSkillsForWorkspace(db, workspaceId);
     const existingByPath = new Map<string, Skill>(existing.map((s) => [s.filePath, s]));
@@ -60,8 +105,7 @@ export class SkillRegistry {
     const scannedPaths = new Set<string>();
     const result: Skill[] = [];
 
-    for (const filename of mdFiles) {
-      const filePath = `${skillsDir}/${filename}`;
+    for (const { filePath } of candidates) {
       scannedPaths.add(filePath);
 
       let raw: string;


### PR DESCRIPTION
## Summary

- Root cause: `SkillRegistry.scanWorkspace` only probed `${rootPath}/.kay/skills/*.md` (flat files). Claude Code projects (e.g. `app-web`) store skills under `.claude/skills/<name>/SKILL.md` (one subdirectory per skill).
- Fix: extracted `collectKaySkills` (existing convention) and `collectClaudeSkills` (Claude Code convention); `scanWorkspace` now runs both in parallel and merges results.
- Both conventions can coexist in the same workspace.

## Test plan

- [x] `SkillRegistry.scanWorkspace – Claude Code convention` (4 new tests): single `.claude/skills` skill, dual-convention workspace, subdirs without `SKILL.md` ignored, missing dir → no throw
- [x] All pre-existing registry tests still pass (regression)
- [x] `pnpm --filter @kay-am/core typecheck` clean
- [x] `pnpm --filter @kay-am/core test` — 364 passed, 0 failures

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)