### PR TITLE
feat(ui): consolidate design tokens (font scale, motion, focus ring)

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -19,6 +19,7 @@
   --color-info: oklch(0.62 0.13 230);
   --color-info-foreground: oklch(0.99 0 0);
 
+  --text-2xs: 10px;
   --text-xs: 11px;
   --text-sm: 13px;
   --text-base: 14px;
@@ -31,6 +32,15 @@
   --shadow-sm: 0 1px 2px 0 oklch(0.18 0.01 270 / 0.05);
   --shadow-md: 0 4px 12px -2px oklch(0.18 0.01 270 / 0.08);
   --shadow-lg: 0 12px 32px -8px oklch(0.18 0.01 270 / 0.12);
+
+  --motion-fast: 100ms;
+  --motion-normal: 200ms;
+  --motion-slow: 350ms;
+
+  --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+
+  --color-focus-ring: oklch(0.55 0.18 265 / 0.55);
 }
 
 html,
@@ -47,7 +57,7 @@ body {
 }
 
 :focus-visible {
-  outline: 2px solid color-mix(in oklch, var(--color-primary) 30%, transparent);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 1px;
   border-radius: var(--radius-sm);
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -104,3 +104,52 @@ import { cn } from '@kay-am/ui';
 
 <span className={cn('text-sm', isActive && 'font-medium')} />;
 ```
+
+## Design tokens
+
+All tokens live in `apps/desktop/src/styles.css` under `@theme`. Reference them via Tailwind utilities.
+
+### Font scale
+
+| Token         | Value | Utility     |
+| ------------- | ----- | ----------- |
+| `--text-2xs`  | 10px  | `text-2xs`  |
+| `--text-xs`   | 11px  | `text-xs`   |
+| `--text-sm`   | 13px  | `text-sm`   |
+| `--text-base` | 14px  | `text-base` |
+| `--text-lg`   | 16px  | `text-lg`   |
+
+`text-2xs` and `text-xs` replace ad-hoc `text-[10px]` / `text-[11px]` usage. `text-xs` was already 11px in this project (not Tailwind's default 13px) — no regression.
+
+### Motion durations
+
+| Token             | Value | Use                                             |
+| ----------------- | ----- | ----------------------------------------------- |
+| `--motion-fast`   | 100ms | micro-interactions (icon swap, badge)           |
+| `--motion-normal` | 200ms | standard transitions (hover, open)              |
+| `--motion-slow`   | 350ms | large surface transitions (panel slide, dialog) |
+
+Easings:
+
+| Token               | Value                          |
+| ------------------- | ------------------------------ |
+| `--ease-default`    | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `--ease-emphasized` | `cubic-bezier(0.2, 0, 0, 1)`   |
+
+### Motion policy
+
+All animation and transition classes **must** be gated with the `motion-safe:` Tailwind prefix. This respects `prefers-reduced-motion: reduce`.
+
+```tsx
+// correct
+<div className="motion-safe:transition-opacity motion-safe:duration-[--motion-normal]" />
+
+// wrong — plays regardless of OS accessibility setting
+<div className="transition-opacity duration-200" />
+```
+
+Rule: no bare `transition-*`, `animate-*`, or `duration-*` class without `motion-safe:` prefix. A lint rule will enforce this post-P2.
+
+### Focus ring
+
+`--color-focus-ring` is `oklch(0.55 0.18 265 / 0.55)` — primary hue at 55% opacity. Sufficient contrast on both white and muted backgrounds. Used automatically by the global `:focus-visible` rule.


### PR DESCRIPTION
## Summary

- Add `--text-2xs: 10px` to font scale alongside existing `--text-xs: 11px`
- Add motion duration tokens: `--motion-fast` (100ms), `--motion-normal` (200ms), `--motion-slow` (350ms)
- Add easing tokens: `--ease-default`, `--ease-emphasized`
- Bump focus ring to `--color-focus-ring: oklch(0.55 0.18 265 / 0.55)` (55% opacity, up from 30%) for contrast on muted backgrounds; update `:focus-visible` rule to consume it
- Document font scale, motion durations, easings, and `motion-safe:` policy in `packages/ui/README.md`

## Font scale option chosen

**Option B** (no rename). `text-xs` was already overridden to 11px in this project's `@theme` block — this is not the Tailwind default 13px. So the scale was: 11px (`text-xs`) / 13px (`text-sm`) / 14px (`text-base`) / 16px (`text-lg`). The only gap was 10px with no token. Adding `--text-2xs: 10px` fills the gap without touching any existing token → zero regression.

Option A (shifting `text-xs` → 11px, `text-xs` → new value) was moot because the project already had `text-xs = 11px`.

## Test plan

- [x] `pnpm --filter @kay-am/desktop typecheck` — passes
- [x] `pnpm --filter @kay-am/desktop build` — clean build, 0 errors
- [ ] Component propagation to replace `text-[10px]`/`text-[11px]` ad-hoc usage is P2 (#292)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)