### PR TITLE
fix(core): structured unknown_payload turn event across adapters

### DIFF
--- a/apps/desktop/src/__tests__/store/unknown-payload.test.ts
+++ b/apps/desktop/src/__tests__/store/unknown-payload.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, ProviderRunId, SessionId } from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before store import
+// ---------------------------------------------------------------------------
+
+vi.mock('../../turn', () => ({
+  runTurn: vi.fn(),
+  cancelTurn: vi.fn(),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../../permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(async () => undefined),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+vi.mock('../../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: vi.fn(),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../../routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-opus-4-7',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../../repo', () => ({ validateGitRepo: vi.fn() }));
+
+vi.mock('../../providerPricing', () => ({
+  parseProviderPricingConfig: vi.fn(() => null),
+  getCodexPriceOverride: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'sess-1' as SessionId;
+const RUN_ID = 'run-1' as ProviderRunId;
+const AT: IsoDateTime = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+
+describe('store unknownPayloadCounts', () => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  let useAppStore: (typeof import('../../store/store'))['useAppStore'];
+
+  beforeEach(async () => {
+    vi.resetModules();
+    ({ useAppStore } = await import('../../store/store'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts at empty object', () => {
+    const counts = useAppStore.getState().unknownPayloadCounts;
+    expect(counts).toEqual({});
+  });
+
+  it('increments counter keyed by adapter:payloadType on first unknown_payload', () => {
+    const { appendTurnEvent } = useAppStore.getState();
+    appendTurnEvent(SESSION_ID, {
+      kind: 'unknown_payload',
+      runId: RUN_ID,
+      adapter: 'anthropic',
+      payloadType: 'ping',
+      raw: { type: 'ping' },
+      at: AT,
+    });
+    expect(useAppStore.getState().unknownPayloadCounts['anthropic:ping']).toBe(1);
+  });
+
+  it('accumulates multiple events of the same key', () => {
+    const { appendTurnEvent } = useAppStore.getState();
+    for (let i = 0; i < 3; i++) {
+      appendTurnEvent(SESSION_ID, {
+        kind: 'unknown_payload',
+        runId: RUN_ID,
+        adapter: 'cursor',
+        payloadType: 'debug_trace',
+        raw: {},
+        at: AT,
+      });
+    }
+    expect(useAppStore.getState().unknownPayloadCounts['cursor:debug_trace']).toBe(3);
+  });
+
+  it('tracks different adapter/payloadType keys independently', () => {
+    const { appendTurnEvent } = useAppStore.getState();
+    appendTurnEvent(SESSION_ID, {
+      kind: 'unknown_payload',
+      runId: RUN_ID,
+      adapter: 'anthropic',
+      payloadType: 'ping',
+      raw: {},
+      at: AT,
+    });
+    appendTurnEvent(SESSION_ID, {
+      kind: 'unknown_payload',
+      runId: RUN_ID,
+      adapter: 'codex',
+      payloadType: 'ping',
+      raw: {},
+      at: AT,
+    });
+    const counts = useAppStore.getState().unknownPayloadCounts;
+    expect(counts['anthropic:ping']).toBe(1);
+    expect(counts['codex:ping']).toBe(1);
+  });
+
+  it('does not increment counter for non-unknown_payload events', () => {
+    const { appendTurnEvent } = useAppStore.getState();
+    appendTurnEvent(SESSION_ID, {
+      kind: 'assistant_text',
+      runId: RUN_ID,
+      delta: 'hello',
+      at: AT,
+    });
+    expect(useAppStore.getState().unknownPayloadCounts).toEqual({});
+  });
+});

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -179,6 +179,7 @@ export interface AppState {
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<PhaseTemplate>>>;
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<PhaseRun>>>;
+  readonly unknownPayloadCounts: Readonly<Record<string, number>>;
 }
 
 export interface SummarizerSessionStatus {
@@ -277,6 +278,7 @@ const initialState: AppState = {
   skills: {},
   phaseTemplates: {},
   sessionPhaseRuns: {},
+  unknownPayloadCounts: {},
 };
 
 function buildProviderSpendBreakdown(
@@ -574,6 +576,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionBudgets: {},
       summarizerStatus: {},
       budgetAlerts: [],
+      unknownPayloadCounts: {},
     });
     if (id) {
       const [sessions, workspaceSummary, providerSummaries, budgetRules, skills, phaseTemplates] =
@@ -774,9 +777,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
   appendTurnEvent: (sessionId, event) => {
     set((state) => {
       const existing = state.transcripts[sessionId] ?? [];
-      return {
+      const next: Partial<AppStore> = {
         transcripts: { ...state.transcripts, [sessionId]: [...existing, event] },
       };
+      if (event.kind === 'unknown_payload') {
+        const key = `${event.adapter}:${event.payloadType}`;
+        next.unknownPayloadCounts = {
+          ...state.unknownPayloadCounts,
+          [key]: (state.unknownPayloadCounts[key] ?? 0) + 1,
+        };
+      }
+      return next;
     });
   },
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -777,17 +777,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
   appendTurnEvent: (sessionId, event) => {
     set((state) => {
       const existing = state.transcripts[sessionId] ?? [];
-      const next: Partial<AppStore> = {
-        transcripts: { ...state.transcripts, [sessionId]: [...existing, event] },
-      };
+      const updatedTranscripts = { ...state.transcripts, [sessionId]: [...existing, event] };
       if (event.kind === 'unknown_payload') {
         const key = `${event.adapter}:${event.payloadType}`;
-        next.unknownPayloadCounts = {
-          ...state.unknownPayloadCounts,
-          [key]: (state.unknownPayloadCounts[key] ?? 0) + 1,
+        return {
+          transcripts: updatedTranscripts,
+          unknownPayloadCounts: {
+            ...state.unknownPayloadCounts,
+            [key]: (state.unknownPayloadCounts[key] ?? 0) + 1,
+          },
         };
       }
-      return next;
+      return { transcripts: updatedTranscripts };
     });
   },
 

--- a/packages/core/src/providers/claude/adapter.contract.test.ts
+++ b/packages/core/src/providers/claude/adapter.contract.test.ts
@@ -168,7 +168,7 @@ describe('ClaudeAdapter — stream-json contract', () => {
     expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
   });
 
-  it('invokes onUnknown for unrecognized payload types and skips them', async () => {
+  it('emits unknown_payload event and invokes onUnknown for unrecognized payload types', async () => {
     const onUnknown = vi.fn();
     const lines = [
       FIXTURES.assistantText,
@@ -182,7 +182,17 @@ describe('ClaudeAdapter — stream-json contract', () => {
       onUnknown,
     });
     const events = await collect(adapter);
-    expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+    expect(events.map((e) => e.kind)).toEqual([
+      'assistant_text',
+      'unknown_payload',
+      'usage',
+      'done',
+    ]);
+    expect(events[1]).toMatchObject({
+      kind: 'unknown_payload',
+      adapter: 'anthropic',
+      payloadType: 'mystery_event',
+    });
     expect(onUnknown).toHaveBeenCalledWith(
       'mystery_event',
       expect.objectContaining({ type: 'mystery_event' }),

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -41,11 +41,7 @@ export class ClaudeAdapter implements ProviderAdapter {
     this.binary = deps.binary ?? 'claude';
     this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
     this.spawnFn = deps.spawnFn ?? spawn;
-    this.onUnknown =
-      deps.onUnknown ??
-      ((type) => {
-        console.warn(`[claude-adapter] unknown stream-json payload type: ${type}`);
-      });
+    this.onUnknown = deps.onUnknown ?? (() => undefined);
   }
 
   async detect(): Promise<DetectResult> {

--- a/packages/core/src/providers/claude/parser.test.ts
+++ b/packages/core/src/providers/claude/parser.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
 import { parseStreamJsonLine, type ParseContext } from './parser';
 
@@ -151,5 +151,26 @@ describe('parseStreamJsonLine', () => {
     const events = parse(JSON.stringify({ type: 'result', subtype: 'error', error: 'rate limit' }));
     const error = events.find((e) => e.kind === 'error');
     expect(error).toMatchObject({ kind: 'error', message: 'rate limit' });
+  });
+
+  it('emits unknown_payload for unrecognised payload types', () => {
+    const raw = { type: 'ping', extra: 42 };
+    const events = parse(JSON.stringify(raw));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'unknown_payload',
+      runId: ctx.runId,
+      adapter: 'anthropic',
+      payloadType: 'ping',
+      raw,
+      at,
+    });
+  });
+
+  it('calls onUnknown hook for unrecognised payload types', () => {
+    const onUnknown = vi.fn();
+    const raw = { type: 'debug_trace', data: 'x' };
+    parseStreamJsonLine(JSON.stringify(raw), { ...ctx, onUnknown });
+    expect(onUnknown).toHaveBeenCalledWith('debug_trace', raw);
   });
 });

--- a/packages/core/src/providers/claude/parser.ts
+++ b/packages/core/src/providers/claude/parser.ts
@@ -121,7 +121,20 @@ export function parseStreamJsonLine(line: string, ctx: ParseContext): ReadonlyAr
 
     default:
       if (typeof payload.type === 'string' && !KNOWN_PAYLOAD_TYPES.has(payload.type)) {
+        if (process.env['NODE_ENV'] !== 'production') {
+          console.warn(`[claude-adapter] unknown stream-json payload type: ${payload.type}`);
+        }
         ctx.onUnknown?.(payload.type, payload);
+        return [
+          {
+            kind: 'unknown_payload',
+            runId: ctx.runId,
+            adapter: 'anthropic',
+            payloadType: payload.type,
+            raw: payload,
+            at,
+          },
+        ];
       }
       return [];
   }

--- a/packages/core/src/providers/codex/adapter.ts
+++ b/packages/core/src/providers/codex/adapter.ts
@@ -43,11 +43,7 @@ export class CodexAdapter implements ProviderAdapter {
     this.binary = deps.binary ?? 'codex';
     this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
     this.spawnFn = deps.spawnFn ?? spawn;
-    this.onUnknown =
-      deps.onUnknown ??
-      ((type) => {
-        console.warn(`[codex-adapter] unknown json payload type: ${type}`);
-      });
+    this.onUnknown = deps.onUnknown ?? (() => undefined);
   }
 
   async detect(): Promise<DetectResult> {

--- a/packages/core/src/providers/codex/parser.test.ts
+++ b/packages/core/src/providers/codex/parser.test.ts
@@ -168,12 +168,19 @@ describe('parseJsonLine', () => {
     expect(events[0]).toMatchObject({ kind: 'error', message: 'rate limit exceeded' });
   });
 
-  it('calls onUnknown for unrecognized types and skips them', () => {
+  it('emits unknown_payload event and calls onUnknown for unrecognized types', () => {
     const onUnknown = vi.fn();
-    const events = parse(JSON.stringify({ type: 'mystery_event', payload: { x: 1 } }), {
-      onUnknown,
+    const raw = { type: 'mystery_event', payload: { x: 1 } };
+    const events = parse(JSON.stringify(raw), { onUnknown });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'unknown_payload',
+      runId: ctx.runId,
+      adapter: 'codex',
+      payloadType: 'mystery_event',
+      raw,
+      at,
     });
-    expect(events).toEqual([]);
     expect(onUnknown).toHaveBeenCalledWith(
       'mystery_event',
       expect.objectContaining({ type: 'mystery_event' }),

--- a/packages/core/src/providers/codex/parser.ts
+++ b/packages/core/src/providers/codex/parser.ts
@@ -167,7 +167,20 @@ export function parseJsonLine(line: string, ctx: ParseContext): ReadonlyArray<Tu
 
     default:
       if (typeof type === 'string' && !KNOWN_TYPES.has(type)) {
+        if (process.env['NODE_ENV'] !== 'production') {
+          console.warn(`[codex-adapter] unknown json payload type: ${type}`);
+        }
         ctx.onUnknown?.(type, payload);
+        return [
+          {
+            kind: 'unknown_payload',
+            runId: ctx.runId,
+            adapter: 'codex',
+            payloadType: type,
+            raw: payload,
+            at,
+          },
+        ];
       }
       return [];
   }

--- a/packages/core/src/providers/cursor/adapter.test.ts
+++ b/packages/core/src/providers/cursor/adapter.test.ts
@@ -187,7 +187,7 @@ describe('CursorAdapter — malformed JSON', () => {
     expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
   });
 
-  it('invokes onUnknown for unrecognised payload types and skips them', async () => {
+  it('emits unknown_payload event and invokes onUnknown for unrecognised payload types', async () => {
     const onUnknown = vi.fn();
     const lines = [
       FIXTURES.assistantText,
@@ -201,7 +201,17 @@ describe('CursorAdapter — malformed JSON', () => {
       onUnknown,
     });
     const events = await collect(adapter);
-    expect(events.map((e) => e.kind)).toEqual(['assistant_text', 'usage', 'done']);
+    expect(events.map((e) => e.kind)).toEqual([
+      'assistant_text',
+      'unknown_payload',
+      'usage',
+      'done',
+    ]);
+    expect(events[1]).toMatchObject({
+      kind: 'unknown_payload',
+      adapter: 'cursor',
+      payloadType: 'mystery_event',
+    });
     expect(onUnknown).toHaveBeenCalledWith(
       'mystery_event',
       expect.objectContaining({ type: 'mystery_event' }),

--- a/packages/core/src/providers/cursor/adapter.ts
+++ b/packages/core/src/providers/cursor/adapter.ts
@@ -43,11 +43,7 @@ export class CursorAdapter implements ProviderAdapter {
     this.binary = deps.binary ?? 'cursor-agent';
     this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
     this.spawnFn = deps.spawnFn ?? spawn;
-    this.onUnknown =
-      deps.onUnknown ??
-      ((type) => {
-        console.warn(`[cursor-adapter] unknown stream-json payload type: ${type}`);
-      });
+    this.onUnknown = deps.onUnknown ?? (() => undefined);
   }
 
   async detect(): Promise<DetectResult> {

--- a/packages/core/src/providers/cursor/parser.test.ts
+++ b/packages/core/src/providers/cursor/parser.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, ProviderRunId } from '@kay-am/types';
+import { parseCursorStreamLine, type ParseContext } from './parser';
+
+const at = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const ctx: ParseContext = {
+  runId: 'run_1' as ProviderRunId,
+  now: () => at,
+};
+
+function parse(line: string, overrides?: Partial<ParseContext>) {
+  return parseCursorStreamLine(line, { ...ctx, ...overrides });
+}
+
+describe('parseCursorStreamLine', () => {
+  it('returns [] for empty / blank lines', () => {
+    expect(parse('')).toEqual([]);
+    expect(parse('   ')).toEqual([]);
+  });
+
+  it('returns [] for malformed json', () => {
+    expect(parse('{not json')).toEqual([]);
+  });
+
+  it('ignores system events', () => {
+    expect(parse(JSON.stringify({ type: 'system', subtype: 'init' }))).toEqual([]);
+  });
+
+  it('emits assistant_text for text content blocks', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello' }] },
+      }),
+    );
+    expect(events).toEqual([{ kind: 'assistant_text', runId: ctx.runId, delta: 'hello', at }]);
+  });
+
+  it('emits usage + done for result success', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ kind: 'usage', usage: { inputTokens: 10, outputTokens: 5 } });
+    expect(events[1]).toMatchObject({ kind: 'done' });
+  });
+
+  it('emits unknown_payload for unrecognised payload types', () => {
+    const raw = { type: 'cursor_internal', seq: 7 };
+    const events = parse(JSON.stringify(raw));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'unknown_payload',
+      runId: ctx.runId,
+      adapter: 'cursor',
+      payloadType: 'cursor_internal',
+      raw,
+      at,
+    });
+  });
+
+  it('calls onUnknown hook for unrecognised payload types', () => {
+    const onUnknown = vi.fn();
+    const raw = { type: 'unknown_event', x: 1 };
+    parse(JSON.stringify(raw), { onUnknown });
+    expect(onUnknown).toHaveBeenCalledWith('unknown_event', raw);
+  });
+
+  it('does not call onUnknown for known types', () => {
+    const onUnknown = vi.fn();
+    parse(JSON.stringify({ type: 'system', subtype: 'init' }), { onUnknown });
+    parse(JSON.stringify({ type: 'assistant', message: { content: [] } }), { onUnknown });
+    expect(onUnknown).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/providers/cursor/parser.ts
+++ b/packages/core/src/providers/cursor/parser.ts
@@ -121,7 +121,20 @@ export function parseCursorStreamLine(line: string, ctx: ParseContext): Readonly
 
     default:
       if (typeof payload.type === 'string' && !KNOWN_PAYLOAD_TYPES.has(payload.type)) {
+        if (process.env['NODE_ENV'] !== 'production') {
+          console.warn(`[cursor-adapter] unknown stream-json payload type: ${payload.type}`);
+        }
         ctx.onUnknown?.(payload.type, payload);
+        return [
+          {
+            kind: 'unknown_payload',
+            runId: ctx.runId,
+            adapter: 'cursor',
+            payloadType: payload.type,
+            raw: payload,
+            at,
+          },
+        ];
       }
       return [];
   }

--- a/packages/core/src/session/reducer.ts
+++ b/packages/core/src/session/reducer.ts
@@ -79,6 +79,7 @@ function applyTurnEvent(state: SessionState, turn: TurnEvent): SessionState {
     case 'phase_transition':
     case 'permission_request':
     case 'permission_decision':
+    case 'unknown_payload':
       return state;
     default: {
       const _exhaustive: never = turn;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -98,6 +98,14 @@ export type TurnEvent =
       ruleId: PermissionRuleId | null;
       decidedBy: 'engine' | 'user' | 'default';
       at: IsoDateTime;
+    }
+  | {
+      kind: 'unknown_payload';
+      runId: ProviderRunId;
+      adapter: string;
+      payloadType: string;
+      raw: unknown;
+      at: IsoDateTime;
     };
 
 export interface ProviderAdapter {


### PR DESCRIPTION
## Summary

- Adds `unknown_payload` variant to `TurnEvent` discriminated union in `@kay-am/types`
- All three parsers (claude, cursor, codex) now emit `{ kind: 'unknown_payload', adapter, payloadType, raw }` instead of silently dropping unknown payload types
- `console.warn` preserved in non-production envs via `process.env.NODE_ENV !== 'production'` guard
- `onUnknown` hook retained as side-channel for adapters that need custom handling
- Store (`useAppStore`) accumulates `unknownPayloadCounts` keyed by `adapter:payloadType` for telemetry/debug
- `sessionReducer` handles `unknown_payload` as a no-op state transition

## Test plan

- [x] `packages/core/src/providers/claude/parser.test.ts` — new tests: emits `unknown_payload`, calls `onUnknown`
- [x] `packages/core/src/providers/cursor/parser.test.ts` — new file, full coverage including `unknown_payload`
- [x] `packages/core/src/providers/codex/parser.test.ts` — updated: asserts structured event returned (not `[]`)
- [x] `packages/core/src/providers/claude/adapter.contract.test.ts` — updated for new event sequence
- [x] `packages/core/src/providers/cursor/adapter.test.ts` — updated for new event sequence
- [x] `apps/desktop/src/__tests__/store/unknown-payload.test.ts` — new: counter increments, multi-key, non-payload events ignored
- [x] `pnpm --filter @kay-am/types typecheck` clean
- [x] `pnpm --filter @kay-am/core typecheck` clean
- [x] `pnpm --filter @kay-am/core test` — 370 passed
- [x] `pnpm --filter @kay-am/desktop test` (unknown-payload suite) — 5 passed

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)