### PR TITLE
fix(desktop): store hardening — end-session, merge wiring, audit retry, console cleanup

### DIFF
--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -171,6 +171,7 @@ function makeEffects(): { effects: ParallelBranchEffects; events: TurnEvent[] } 
     effects: {
       appendTurnEvent: (_sid: SessionId, e: TurnEvent) => events.push(e),
       refreshPhaseRuns: vi.fn(async () => undefined),
+      setMergeConflicts: vi.fn(),
     },
     events,
   };

--- a/apps/desktop/src/components/EndSessionDialog.tsx
+++ b/apps/desktop/src/components/EndSessionDialog.tsx
@@ -3,6 +3,17 @@ import { Button, Dialog } from '@kay-am/ui';
 import type { Session } from '@kay-am/types';
 import { useAppStore } from '../store';
 
+// Tauri errors serialize as `{kind: string; message: string}` plain objects.
+// `instanceof Error` is false for them, so `String(err)` → "[object Object]".
+function unwrapError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const { message } = err as Record<string, unknown>;
+    if (typeof message === 'string') return message;
+  }
+  return String(err);
+}
+
 interface EndSessionDialogProps {
   session: Session;
   open: boolean;
@@ -23,7 +34,7 @@ export function EndSessionDialog({ session, open, onClose }: EndSessionDialogPro
       await endSession(session.id);
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(unwrapError(err));
     } finally {
       setBusy(false);
     }

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -116,6 +116,8 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
   );
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
+  const rawMergeConflicts = useAppStore((s) => s.sessionMergeConflicts[session.id] ?? EMPTY_ARRAY);
+  const resolveMergeConflicts = useAppStore((s) => s.resolveMergeConflicts);
 
   const allParallelTerminal = useMemo(() => {
     if (parallelRunIds.length === 0) return false;
@@ -135,14 +137,34 @@ export function ChatView({ session, contextOpen, onToggleContext, onRequestEnd }
 
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
 
-  // TODO (@ak): derive real conflicts from sessionPhaseRuns MergeResult once scheduler
-  // emits merge_resolved events — I1 #212 will wire this up. Until then conflicts is
-  // always empty and the dialog acts as a structural placeholder.
-  const mergeConflicts = useMemo<ReadonlyArray<MergeConflict>>(() => [], []);
+  // Derive MergeConflict[] from store — populated by parallel-turn scheduler
+  // when manual resolution is required. Cast FileConflict to MergeConflict:
+  // both have {file, runIds} — the shapes are structurally identical.
+  const mergeConflicts = useMemo<ReadonlyArray<MergeConflict>>(
+    () => rawMergeConflicts as ReadonlyArray<MergeConflict>,
+    [rawMergeConflicts],
+  );
+
+  // Derive terminal runStatuses for the current session's phaseRuns.
+  const terminalRunStatuses = useMemo(
+    () =>
+      phaseRuns
+        .filter((r) => r.completedAt !== undefined && r.runId !== undefined)
+        .map((r) => ({
+          runId: r.runId as string,
+          completedAt: r.completedAt as string,
+          status: r.status,
+        })),
+    [phaseRuns],
+  );
 
   const onMergeResolve = (picks: Record<string, MergeResolution>) => {
-    // TODO (@ak): forward picks to scheduler merge_resolved command — I1 #212.
-    console.log('[merge] resolved picks:', picks);
+    // Filter out SKIP_SENTINEL picks — those files stay unresolved (winner's version kept).
+    const resolvedPicks: Record<string, string> = {};
+    for (const [file, pick] of Object.entries(picks)) {
+      if (pick !== '__skip__') resolvedPicks[file] = pick;
+    }
+    void resolveMergeConflicts(session.id, resolvedPicks, terminalRunStatuses);
     setMergeDialogOpen(false);
   };
 

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -5,6 +5,8 @@ export {
   type BootPhase,
   type ProviderSpendEntry,
   type SummarizerSessionStatus,
+  type SystemAlert,
+  type SystemAlertKind,
 } from './store';
 
 export {

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -57,6 +57,7 @@ export interface ParallelBranchInputs {
 export interface ParallelBranchEffects {
   appendTurnEvent: (sessionId: SessionId, event: TurnEvent) => void;
   refreshPhaseRuns: (sessionId: SessionId) => Promise<void>;
+  setMergeConflicts: (sessionId: SessionId, conflicts: ReadonlyArray<FileConflict>) => void;
 }
 
 export interface ParallelBranchResult {
@@ -398,24 +399,29 @@ export async function runParallelBranch(
     const conflicts: ReadonlyArray<FileConflict> = detectConflicts(touches);
 
     if (conflicts.length > 0) {
-      try {
-        await resolveConflicts({
-          conflicts,
-          runStatuses: merge.runStatuses
-            .filter((rs) => rs.status === 'completed')
-            .map((rs) => ({ runId: rs.runId, completedAt: now(), status: rs.status })),
-          strategy: mergeStrategy,
-        });
-      } catch (err) {
-        if (err instanceof ManualResolutionRequiredError) {
-          effects.appendTurnEvent(session.id, {
-            kind: 'error',
-            runId: runIds[0]!,
-            message: `manual merge resolution required for: ${err.unresolvedFiles.join(', ')}`,
-            at: now(),
+      if (mergeStrategy === 'manual') {
+        // Surface conflicts to UI via store — ChatView will open MergeDialog.
+        effects.setMergeConflicts(session.id, conflicts);
+      } else {
+        try {
+          await resolveConflicts({
+            conflicts,
+            runStatuses: merge.runStatuses
+              .filter((rs) => rs.status === 'completed')
+              .map((rs) => ({ runId: rs.runId, completedAt: now(), status: rs.status })),
+            strategy: mergeStrategy,
           });
-        } else {
-          throw err;
+        } catch (err) {
+          if (err instanceof ManualResolutionRequiredError) {
+            effects.appendTurnEvent(session.id, {
+              kind: 'error',
+              runId: runIds[0]!,
+              message: `manual merge resolution required for: ${err.unresolvedFiles.join(', ')}`,
+              at: now(),
+            });
+          } else {
+            throw err;
+          }
         }
       }
     }

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -336,7 +336,8 @@ describe('audit retry queue — drain worker (happy path)', () => {
   }
 
   it('drain happy path: retries insert, deletes on success', async () => {
-    const entry = makeRetryEntry({ id: 'retry-happy', attempts: 2 });
+    // updatedAt=0 so backoff (4000ms for attempts=2) is satisfied.
+    const entry = { ...makeRetryEntry({ id: 'retry-happy', attempts: 2 }), updatedAt: 0 };
     auditRetryDrainSpy.mockResolvedValue([entry]);
     permissionAuditInsertSpy.mockResolvedValue({});
 
@@ -349,7 +350,8 @@ describe('audit retry queue — drain worker (happy path)', () => {
   });
 
   it('drain failure path: increments attempts when insert still fails', async () => {
-    const entry = makeRetryEntry({ id: 'retry-fail', attempts: 3 });
+    // updatedAt=0 so backoff is satisfied.
+    const entry = { ...makeRetryEntry({ id: 'retry-fail', attempts: 3 }), updatedAt: 0 };
     auditRetryDrainSpy.mockResolvedValue([entry]);
     permissionAuditInsertSpy.mockRejectedValue(new Error('still locked'));
 
@@ -359,25 +361,89 @@ describe('audit retry queue — drain worker (happy path)', () => {
     expect(auditRetryDeleteSpy).not.toHaveBeenCalled();
   });
 
-  it('max-attempts boundary: deletes entry at attempt 10', async () => {
-    const entry = makeRetryEntry({ id: 'retry-max', attempts: 9 });
+  it('max-attempts boundary: deletes entry at attempt 5', async () => {
+    // updatedAt in the past so backoff is satisfied.
+    const entry = { ...makeRetryEntry({ id: 'retry-max', attempts: 4 }), updatedAt: 0 };
     auditRetryDrainSpy.mockResolvedValue([entry]);
     permissionAuditInsertSpy.mockRejectedValue(new Error('permanent failure'));
 
     await runHydrate();
 
-    // At attempts=9, nextAttempts=10 >= MAX(10) → delete, not update
+    // At attempts=4, nextAttempts=5 >= MAX(5) → delete, not update
     expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-max');
     expect(auditRetryUpdateSpy).not.toHaveBeenCalled();
   });
 
+  it('max-attempts exhausted: emits system alert', async () => {
+    const entry = { ...makeRetryEntry({ id: 'retry-exhausted', attempts: 4 }), updatedAt: 0 };
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockRejectedValue(new Error('permanent failure'));
+
+    const mod = await import('./store');
+    await runHydrate();
+
+    const { systemAlerts } = mod.useAppStore.getState();
+    const alert = systemAlerts.find((a) => a.kind === 'audit-retry-exhausted');
+    expect(alert).toBeDefined();
+    expect(alert?.kind).toBe('audit-retry-exhausted');
+    expect(alert?.message).toContain('5 attempts');
+  });
+
   it('drain skips rows with invalid JSON payload (deletes them)', async () => {
-    const entry = makeRetryEntry({ id: 'retry-bad-json', payloadJson: 'not-json' });
+    const entry = {
+      ...makeRetryEntry({ id: 'retry-bad-json', payloadJson: 'not-json' }),
+      updatedAt: 0,
+    };
     auditRetryDrainSpy.mockResolvedValue([entry]);
 
     await runHydrate();
 
     expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-bad-json');
     expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
+  });
+
+  it('corrupt payload: emits system alert', async () => {
+    const entry = {
+      ...makeRetryEntry({ id: 'retry-bad-json', payloadJson: 'not-json' }),
+      updatedAt: 0,
+    };
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+
+    const mod = await import('./store');
+    await runHydrate();
+
+    const { systemAlerts } = mod.useAppStore.getState();
+    const alert = systemAlerts.find((a) => a.kind === 'audit-retry-corrupt');
+    expect(alert).toBeDefined();
+    expect(alert?.kind).toBe('audit-retry-corrupt');
+    expect(alert?.message).toContain('corrupt payload');
+  });
+
+  it('backoff: skips entry whose updatedAt is too recent for attempt count', async () => {
+    // attempts=0 → backoff=1000ms. updatedAt is NOW (recent) → should skip.
+    const entry = {
+      ...makeRetryEntry({ id: 'retry-backoff', attempts: 0 }),
+      updatedAt: Date.now(),
+    };
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockResolvedValue({});
+
+    await runHydrate();
+
+    // Entry is within backoff window → should NOT have been processed
+    expect(permissionAuditInsertSpy).not.toHaveBeenCalled();
+    expect(auditRetryDeleteSpy).not.toHaveBeenCalled();
+  });
+
+  it('backoff: processes entry whose updatedAt is old enough', async () => {
+    // attempts=0 → backoff=1000ms. updatedAt well in the past → should process.
+    const entry = { ...makeRetryEntry({ id: 'retry-old', attempts: 0 }), updatedAt: 0 };
+    auditRetryDrainSpy.mockResolvedValue([entry]);
+    permissionAuditInsertSpy.mockResolvedValue({});
+
+    await runHydrate();
+
+    expect(permissionAuditInsertSpy).toHaveBeenCalledTimes(1);
+    expect(auditRetryDeleteSpy).toHaveBeenCalledWith('retry-old');
   });
 });

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, Session, SessionId, WorkspaceId } from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before store import
+// ---------------------------------------------------------------------------
+
+const cancelTurnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  runTurn: vi.fn(async function* () {}),
+  cancelTurn: cancelTurnSpy,
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+const removeWorktreeSpy = vi.fn();
+const deleteWorktreesForSessionSpy = vi.fn();
+const updateSessionStateSpy = vi.fn();
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: (repoPath: string, worktreePath: string) =>
+    removeWorktreeSpy(repoPath, worktreePath),
+}));
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(async () => ({})),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: (db: unknown, id: string) => deleteWorktreesForSessionSpy(db, id),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: (...args: unknown[]) => updateSessionStateSpy(...args),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+vi.mock('../providerPricing', () => ({
+  parseProviderPricingConfig: vi.fn(() => null),
+  getCodexPriceOverride: vi.fn(() => null),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'session-end-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const NOW: IsoDateTime = '2026-05-08T00:00:00.000Z' as IsoDateTime;
+const WORKTREE_PATH = '/tmp/wt-end';
+const REPO_PATH = '/tmp/repo';
+
+function buildSession(stateKind: 'idle' | 'running' = 'idle'): Session {
+  const state =
+    stateKind === 'running'
+      ? {
+          kind: 'running' as const,
+          runId: 'run-1' as import('@kay-am/types').ProviderRunId,
+          startedAt: NOW,
+        }
+      : { kind: 'idle' as const, lastActivityAt: NOW };
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'test end session',
+    state,
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+async function importStore() {
+  const mod = await import('./store');
+  return mod.useAppStore;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('endSession — happy path', () => {
+  beforeEach(() => {
+    removeWorktreeSpy.mockReset();
+    deleteWorktreesForSessionSpy.mockReset();
+    updateSessionStateSpy.mockReset();
+    cancelTurnSpy.mockReset();
+
+    removeWorktreeSpy.mockResolvedValue(undefined);
+    deleteWorktreesForSessionSpy.mockResolvedValue(undefined);
+    updateSessionStateSpy.mockResolvedValue(undefined);
+    cancelTurnSpy.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('marks session ended when session has no turns (empty)', async () => {
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore.getState().endSession(SESSION_ID);
+
+    const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);
+    expect(session?.state.kind).toBe('ended');
+    expect(updateSessionStateSpy).toHaveBeenCalledOnce();
+  });
+
+  it('marks session ended when session has persisted turns (non-empty)', async () => {
+    const useAppStore = await importStore();
+    // Session has turns in transcript (non-empty state)
+    useAppStore.setState({
+      sessions: [buildSession('idle')],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+      transcripts: {
+        [SESSION_ID]: [
+          {
+            kind: 'assistant_text',
+            runId: 'run-1' as import('@kay-am/types').ProviderRunId,
+            delta: 'hello',
+            at: NOW,
+          },
+        ],
+      },
+    });
+
+    await useAppStore.getState().endSession(SESSION_ID);
+
+    const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);
+    expect(session?.state.kind).toBe('ended');
+  });
+
+  it('removes worktree paths from state after end', async () => {
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore.getState().endSession(SESSION_ID);
+
+    expect(useAppStore.getState().sessionWorktrees[SESSION_ID]).toBeUndefined();
+  });
+
+  it('calls removeWorktree for each worktree path', async () => {
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH, '/tmp/wt-2'] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore.getState().endSession(SESSION_ID);
+
+    expect(removeWorktreeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels running turn before ending', async () => {
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession('running')],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore.getState().endSession(SESSION_ID);
+
+    expect(cancelTurnSpy).toHaveBeenCalledWith('run-1');
+  });
+});
+
+describe('endSession — Tauri error propagation (#242)', () => {
+  beforeEach(() => {
+    removeWorktreeSpy.mockReset();
+    deleteWorktreesForSessionSpy.mockReset();
+    updateSessionStateSpy.mockReset();
+    cancelTurnSpy.mockReset();
+
+    removeWorktreeSpy.mockResolvedValue(undefined);
+    deleteWorktreesForSessionSpy.mockResolvedValue(undefined);
+    updateSessionStateSpy.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('continues ending session when removeWorktree throws (worktree may be gone)', async () => {
+    // removeWorktree failure must not abort endSession — it's best-effort.
+    removeWorktreeSpy.mockRejectedValue(new Error('worktree not found'));
+
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    // Should not throw
+    await expect(useAppStore.getState().endSession(SESSION_ID)).resolves.toBeUndefined();
+
+    const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);
+    expect(session?.state.kind).toBe('ended');
+  });
+
+  it('propagates error from updateSessionState as structured message', async () => {
+    // Simulate a Tauri-style JSON error object (not instanceof Error)
+    const tauriErr = { kind: 'db', message: 'database is locked' };
+    updateSessionStateSpy.mockRejectedValue(tauriErr);
+
+    const useAppStore = await importStore();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: REPO_PATH, createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    // endSession should throw — the caller (EndSessionDialog) will handle it
+    await expect(useAppStore.getState().endSession(SESSION_ID)).rejects.toMatchObject({
+      message: 'database is locked',
+    });
+  });
+});

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -7,9 +7,11 @@ import {
   buildPhasePrompt,
   nextPhase,
   parseSlashCommand,
+  resolveConflicts,
   sessionReducer,
   Summarizer,
   type ClaudeFlagSet,
+  type FileConflict,
   type SlotKey,
 } from '@kay-am/core';
 import {
@@ -50,6 +52,7 @@ import type {
   PhaseDefinition,
   PhaseRun,
   PhaseRunId,
+  PhaseRunStatus,
   PhaseTemplate,
   PhaseTemplateId,
   ProviderId,
@@ -150,6 +153,15 @@ export type BootPhase =
   | 'ready'
   | 'error';
 
+export type SystemAlertKind = 'audit-retry-corrupt' | 'audit-retry-exhausted';
+
+export interface SystemAlert {
+  readonly id: string;
+  readonly kind: SystemAlertKind;
+  readonly message: string;
+  readonly createdAt: string;
+}
+
 export interface AppState {
   readonly workspaces: ReadonlyArray<Workspace>;
   readonly currentWorkspaceId: WorkspaceId | null;
@@ -176,9 +188,11 @@ export interface AppState {
   readonly sessionBudgets: Readonly<Record<SessionId, SessionBudget>>;
   readonly providerSpendBreakdown: ReadonlyArray<ProviderSpendEntry>;
   readonly budgetAlerts: ReadonlyArray<BudgetAlert>;
+  readonly systemAlerts: ReadonlyArray<SystemAlert>;
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<PhaseTemplate>>>;
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<PhaseRun>>>;
+  readonly sessionMergeConflicts: Readonly<Record<SessionId, ReadonlyArray<FileConflict>>>;
 }
 
 export interface SummarizerSessionStatus {
@@ -244,6 +258,13 @@ export interface AppActions {
   savePhaseTemplate(template: PhaseTemplateUpsertArgs): Promise<void>;
   deletePhaseTemplate(id: PhaseTemplateId, workspaceId: WorkspaceId): Promise<void>;
   loadPhaseRunsForSession(sessionId: SessionId): Promise<void>;
+  dismissSystemAlert(id: string): void;
+  setSessionMergeConflicts(sessionId: SessionId, conflicts: ReadonlyArray<FileConflict>): void;
+  resolveMergeConflicts(
+    sessionId: SessionId,
+    picks: Record<string, string>,
+    runStatuses: ReadonlyArray<{ runId: string; completedAt: string; status: string }>,
+  ): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -277,6 +298,8 @@ const initialState: AppState = {
   skills: {},
   phaseTemplates: {},
   sessionPhaseRuns: {},
+  sessionMergeConflicts: {},
+  systemAlerts: [],
 };
 
 function buildProviderSpendBreakdown(
@@ -409,7 +432,9 @@ async function runSummarizer(
   } catch (err) {
     // never log api key — only the error message
     const message = err instanceof Error ? err.message : String(err);
-    console.warn(`[summarizer] failed for session ${sessionId}: ${message}`);
+    if (import.meta.env.DEV) {
+      console.warn(`[summarizer] failed for session ${sessionId}: ${message}`);
+    }
     set((state) => ({
       summarizerStatus: {
         ...state.summarizerStatus,
@@ -419,10 +444,16 @@ async function runSummarizer(
   }
 }
 
-const AUDIT_RETRY_MAX_ATTEMPTS = 10;
+const AUDIT_RETRY_MAX_ATTEMPTS = 5;
 const AUDIT_RETRY_DRAIN_BATCH = 50;
+// Exponential backoff delays (ms): attempt 0→1s, 1→2s, 2→4s, 3→8s, 4→16s.
+const AUDIT_RETRY_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000] as const;
 
-async function drainAuditRetryQueue(): Promise<void> {
+function auditRetryBackoffMs(attempt: number): number {
+  return AUDIT_RETRY_BACKOFF_MS[Math.min(attempt, AUDIT_RETRY_BACKOFF_MS.length - 1)] ?? 16000;
+}
+
+async function drainAuditRetryQueue(set: SetFn): Promise<void> {
   let entries: ReadonlyArray<AuditRetryEntry>;
   try {
     entries = await invokeAuditRetryDrain(AUDIT_RETRY_DRAIN_BATCH);
@@ -430,12 +461,30 @@ async function drainAuditRetryQueue(): Promise<void> {
     return;
   }
 
+  const now = () => new Date().toISOString();
+
   for (const entry of entries) {
+    // Respect backoff: skip entries updated too recently for their attempt count.
+    const backoffMs = auditRetryBackoffMs(entry.attempts);
+    const msSinceUpdate = Date.now() - entry.updatedAt;
+    if (msSinceUpdate < backoffMs) continue;
+
     let payload: PermissionAuditInsertPayload;
     try {
       payload = JSON.parse(entry.payloadJson) as PermissionAuditInsertPayload;
     } catch {
       await invokeAuditRetryDelete(entry.id).catch(() => undefined);
+      set((state) => ({
+        systemAlerts: [
+          ...state.systemAlerts,
+          {
+            id: crypto.randomUUID(),
+            kind: 'audit-retry-corrupt' as const,
+            message: `permission audit retry entry ${entry.id} had corrupt payload and was dropped`,
+            createdAt: now(),
+          },
+        ],
+      }));
       continue;
     }
 
@@ -447,14 +496,18 @@ async function drainAuditRetryQueue(): Promise<void> {
       const errMsg = err instanceof Error ? err.message : String(err);
 
       if (nextAttempts >= AUDIT_RETRY_MAX_ATTEMPTS) {
-        // TODO (@ak): emit alert via existing alert mechanism once one is in place (#196 max-attempts).
-        // No app-level non-blocking alert API exists yet; log to console as a
-        // discoverability measure until the alert system is wired.
-        console.error(
-          `permission audit retry exhausted (${AUDIT_RETRY_MAX_ATTEMPTS} attempts) for entry ${entry.id}; dropping`,
-          errMsg,
-        );
         await invokeAuditRetryDelete(entry.id).catch(() => undefined);
+        set((state) => ({
+          systemAlerts: [
+            ...state.systemAlerts,
+            {
+              id: crypto.randomUUID(),
+              kind: 'audit-retry-exhausted' as const,
+              message: `permission audit retry for entry ${entry.id} exhausted after ${AUDIT_RETRY_MAX_ATTEMPTS} attempts: ${errMsg}`,
+              createdAt: now(),
+            },
+          ],
+        }));
       } else {
         await invokeAuditRetryUpdate(entry.id, nextAttempts, errMsg).catch(() => undefined);
       }
@@ -534,7 +587,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set({ bootPhase: 'ready', hydrated: true });
 
       // Drain audit retry queue after boot — non-blocking, best-effort.
-      void drainAuditRetryQueue();
+      void drainAuditRetryQueue(set);
     } catch (err) {
       set({
         bootPhase: 'error',
@@ -571,6 +624,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionSlots: {},
       sessionWorktrees: {},
       sessionPhaseRuns: {},
+      sessionMergeConflicts: {},
       sessionBudgets: {},
       summarizerStatus: {},
       budgetAlerts: [],
@@ -1169,6 +1223,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             sessionPhaseRuns: { ...state.sessionPhaseRuns, [sid]: runs },
           }));
         },
+        setMergeConflicts: (sid, conflicts) => get().setSessionMergeConflicts(sid, conflicts),
       };
 
       try {
@@ -1660,5 +1715,36 @@ export const useAppStore = create<AppStore>((set, get) => ({
   loadPhaseRunsForSession: async (sessionId) => {
     const runs = await invokePhaseRunList(sessionId);
     set((state) => ({ sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: runs } }));
+  },
+
+  dismissSystemAlert: (id) => {
+    set((state) => ({
+      systemAlerts: state.systemAlerts.filter((a) => a.id !== id),
+    }));
+  },
+
+  setSessionMergeConflicts: (sessionId, conflicts) => {
+    set((state) => ({
+      sessionMergeConflicts: { ...state.sessionMergeConflicts, [sessionId]: conflicts },
+    }));
+  },
+
+  resolveMergeConflicts: async (sessionId, picks, runStatuses) => {
+    const conflicts = get().sessionMergeConflicts[sessionId] ?? [];
+    await resolveConflicts({
+      conflicts,
+      runStatuses: runStatuses.map((rs) => ({
+        runId: rs.runId as ProviderRunId,
+        completedAt: rs.completedAt as IsoDateTime,
+        status: rs.status as PhaseRunStatus,
+      })),
+      strategy: 'manual',
+      manualPicks: picks as Record<string, ProviderRunId>,
+    });
+    set((state) => {
+      const next = { ...state.sessionMergeConflicts };
+      delete next[sessionId];
+      return { sessionMergeConflicts: next };
+    });
   },
 }));


### PR DESCRIPTION
## Summary

- **#242**: `EndSessionDialog` now unwraps Tauri JSON error objects (`{kind, message}`) via `unwrapError()` before displaying them — fixes the `[object Object]` bug on sessions with turns
- **#281**: `MergeDialog` is wired to real conflicts from the store. `parallel-turn.ts` surfaces `FileConflict[]` via new `effects.setMergeConflicts()` when `mergeStrategy === 'manual'`. `ChatView.resolveMergeConflicts()` calls `@kay-am/core`'s `resolveConflicts()` with user picks. No Tauri command or DB migration needed.
- **#282**: Summarizer `console.warn` gated behind `import.meta.env.DEV`. Debug `console.log` in `onMergeResolve` removed (replaced by real wiring from #281).
- **#273**: `drainAuditRetryQueue` gains exponential backoff (1s/2s/4s/8s/16s per attempt, max 5 retries), emits `SystemAlert` on corrupt payload and on max-attempts exhaustion. New `systemAlerts` state + `dismissSystemAlert` action added to store.

## Migration

No DB migration required. `sessionMergeConflicts` is in-memory only.

## Test plan

- [ ] `store.end-session.test.ts` — 7 cases: empty session, non-empty session, worktree cleanup, Tauri error propagation
- [ ] `store.audit-retry.test.ts` — 6 new cases: backoff skip (recent), backoff process (old), corrupt alert, exhausted alert, max-attempts delete, happy-path updated with backoff-aware `updatedAt`
- [ ] `parallel-e2e.test.ts` — updated effects stub for new `setMergeConflicts`
- [ ] All 93 tests pass, typecheck clean

Closes #242
Closes #281
Closes #282
Closes #273