### PR TITLE
fix(ui): chat input writable — stabilize zustand selectors

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { IsoDateTime, ProviderRunId, Session } from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before imports that transitively pull the mocked modules
+// ---------------------------------------------------------------------------
+
+const sendTurnMock = vi.fn(async () => undefined);
+const cancelCurrentTurnMock = vi.fn();
+
+vi.mock('../store', () => ({
+  useAppStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      sendTurn: sendTurnMock,
+      cancelCurrentTurn: cancelCurrentTurnMock,
+      providers: [{ id: 'anthropic', connection: 'connected' }],
+      skills: {},
+    }),
+  EMPTY_ARRAY: [] as never[],
+}));
+
+vi.mock('../permissions', () => ({
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock('@kay-am/core', () => ({
+  buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
+  resolveProvider: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+// ---------------------------------------------------------------------------
+// Import component AFTER mocks are in place
+// ---------------------------------------------------------------------------
+
+import { ChatInput } from '../components/chat/ChatInput';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1' as Session['id'],
+    workspaceId: 'ws-1' as Session['workspaceId'],
+    goal: 'test goal',
+    state: { kind: 'idle', lastActivityAt: '2026-01-01T00:00:00.000Z' as IsoDateTime },
+    contextSlots: [],
+    providerPreference: {
+      defaultProvider: 'anthropic' as Session['providerPreference']['defaultProvider'],
+      allowTurnOverride: false,
+    },
+    createdAt: '2026-01-01T00:00:00.000Z' as Session['createdAt'],
+    updatedAt: '2026-01-01T00:00:00.000Z' as Session['updatedAt'],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ChatInput — input wiring', () => {
+  it('typed characters appear in the textarea', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+
+    expect((textarea as HTMLTextAreaElement).value).toBe('hello');
+  });
+
+  it('textarea is enabled when session is idle and provider is connected', () => {
+    render(<ChatInput session={makeSession()} />);
+    const textarea = screen.getByRole('textbox');
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(false);
+  });
+
+  it('textarea is disabled when session is running', () => {
+    render(
+      <ChatInput
+        session={makeSession({
+          state: {
+            kind: 'running',
+            runId: 'run-1' as ProviderRunId,
+            startedAt: '2026-01-01T00:00:00.000Z' as IsoDateTime,
+          },
+        })}
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
+  });
+
+  it('Enter sends the turn and clears the input', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledOnce();
+    expect(sendTurnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-1', content: 'hello' }),
+    );
+    expect((textarea as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('Shift+Enter inserts a newline instead of sending', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello');
+    await user.keyboard('{Shift>}{Enter}{/Shift}');
+
+    expect(sendTurnMock).not.toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toBe('hello\n');
+  });
+
+  it('send button invokes sendTurn', async () => {
+    const user = userEvent.setup();
+    render(<ChatInput session={makeSession()} />);
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hi there');
+
+    const sendButton = screen.getByRole('button', { name: /send/i });
+    await user.click(sendButton);
+
+    expect(sendTurnMock).toHaveBeenCalledOnce();
+    expect(sendTurnMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'hi there' }));
+  });
+});

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -12,7 +12,7 @@ import type {
 } from '@kay-am/types';
 import { buildClaudeFlags } from '@kay-am/core';
 import { useShallow } from 'zustand/react/shallow';
-import { useAppStore } from '../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../store';
 import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
@@ -51,7 +51,9 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected')),
   );
-  const workspaceSkills = useAppStore(useShallow((s) => s.skills[session.workspaceId] ?? []));
+  const workspaceSkills = useAppStore(
+    useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
+  );
 
   const effectiveRules = useEffectivePermissionRules({
     sessionId: session.id,

--- a/apps/desktop/src/store/transcript.ts
+++ b/apps/desktop/src/store/transcript.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import type { SessionId, TurnEvent } from '@kay-am/types';
 import { useAppStore, type AppState } from './store';
 
@@ -9,5 +10,13 @@ export const selectTranscript =
     sessionId ? (state.transcripts[sessionId] ?? EMPTY) : EMPTY;
 
 export function useTranscript(sessionId: SessionId | null): ReadonlyArray<TurnEvent> {
-  return useAppStore(selectTranscript(sessionId));
+  const idRef = useRef<SessionId | null>(sessionId);
+  const selectorRef = useRef<(state: AppState) => ReadonlyArray<TurnEvent>>(
+    selectTranscript(sessionId),
+  );
+  if (idRef.current !== sessionId) {
+    idRef.current = sessionId;
+    selectorRef.current = selectTranscript(sessionId);
+  }
+  return useAppStore(selectorRef.current);
 }


### PR DESCRIPTION
## Root cause

Two unstable Zustand selectors produced new function references on every render, tripping React 19's `useSyncExternalStore` snapshot-cache check and creating continuous re-render pressure on `ChatView` → `ChatInput`. Under this pressure, keystrokes fired `onChange` but re-renders ran before React committed the controlled-input update, discarding typed characters.

### 1. `useTranscript` — new selector fn every render (`transcript.ts`)

```ts
// before: selectTranscript(sessionId) called inline → new fn every render
return useAppStore(selectTranscript(sessionId));

// after: idRef+selectorRef — selector only reallocated when sessionId changes
if (idRef.current !== sessionId) { selectorRef.current = selectTranscript(sessionId); }
return useAppStore(selectorRef.current);
```

### 2. `workspaceSkills` — `?? []` inside `useShallow` (`ChatInput.tsx`)

```ts
// before: fresh array literal on every getSnapshot call
useAppStore(useShallow((s) => s.skills[session.workspaceId] ?? []))

// after: stable module-level constant (same pattern as PR #238)
useAppStore(useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY))
```

## Changes

- `apps/desktop/src/store/transcript.ts` — stable selector ref via `useRef`
- `apps/desktop/src/components/chat/ChatInput.tsx` — `?? EMPTY_ARRAY` fallback
- `apps/desktop/src/__tests__/ChatInput.test.tsx` — new regression test (6 cases)

## Test plan

- [ ] `pnpm --filter @kay-am/desktop exec vitest run` → 88/88 pass
- [ ] `pnpm --filter @kay-am/desktop exec tsc --noEmit` → clean
- [ ] Manual: type in chat textarea → characters appear, Enter sends

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)