### PR TITLE
feat(desktop,db): delete workspace with cascade + running-session refusal

### DIFF
--- a/apps/desktop/src/components/DeleteWorkspaceDialog.tsx
+++ b/apps/desktop/src/components/DeleteWorkspaceDialog.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { Button, Dialog } from '@kay-am/ui';
+import type { Workspace } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+interface DeleteWorkspaceDialogProps {
+  workspace: Workspace;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DeleteWorkspaceDialog({ workspace, open, onClose }: DeleteWorkspaceDialogProps) {
+  const deleteWorkspace = useAppStore((s) => s.deleteWorkspace);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteWorkspace(workspace.id);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (busy) return;
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title="delete workspace?"
+      description="all sessions in this workspace will also be removed. this cannot be undone."
+      size="sm"
+      footer={
+        <>
+          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
+          <Button variant="ghost" onClick={handleClose} disabled={busy}>
+            cancel
+          </Button>
+          <Button variant="danger" onClick={() => void onConfirm()} disabled={busy}>
+            {busy ? 'deleting…' : 'delete workspace'}
+          </Button>
+        </>
+      }
+    >
+      <div className="rounded-md border border-border-soft bg-subtle px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-mono text-foreground">{workspace.name}</span>
+        <span className="ml-2 text-muted-foreground/60">{workspace.rootPath}</span>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
-import { FolderOpen, FolderPlus, Plus } from 'lucide-react';
+import { FolderOpen, FolderPlus, Plus, Trash2 } from 'lucide-react';
 import type { ProviderId, Session, SessionId, Workspace } from '@kay-am/types';
 import {
   useAppStore,
@@ -10,6 +10,7 @@ import {
   useSessions,
   useWorkspaces,
 } from '../store';
+import { DeleteWorkspaceDialog } from './DeleteWorkspaceDialog';
 import { NewSessionDialog } from './NewSessionDialog';
 import { OpenInEditorButton } from './OpenInEditorButton';
 import { StatusBadge } from './StatusBadge';
@@ -40,6 +41,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
 
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
+  const [workspaceToDelete, setWorkspaceToDelete] = useState<Workspace | null>(null);
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -52,6 +54,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                 workspace={ws}
                 isActive={ws.id === currentWorkspace?.id}
                 onClick={() => void setCurrentWorkspace(ws.id)}
+                onDelete={() => setWorkspaceToDelete(ws)}
               />
             ))}
             <li>
@@ -105,6 +108,13 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           onOpenSettings={onOpenSettings}
         />
       ) : null}
+      {workspaceToDelete ? (
+        <DeleteWorkspaceDialog
+          workspace={workspaceToDelete}
+          open={workspaceToDelete !== null}
+          onClose={() => setWorkspaceToDelete(null)}
+        />
+      ) : null}
     </div>
   );
 }
@@ -135,33 +145,50 @@ interface WorkspaceRowProps {
   workspace: Workspace;
   isActive: boolean;
   onClick: () => void;
+  onDelete: () => void;
 }
 
-function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
+function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowProps) {
   return (
-    <li>
-      <button
-        type="button"
-        onClick={onClick}
+    <li className="group">
+      <div
         className={cn(
-          'group flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors',
+          'flex items-center gap-1 rounded-md transition-colors',
           isActive ? 'bg-muted text-foreground' : 'hover:bg-muted/60',
         )}
       >
-        <span
-          className={cn(
-            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-            isActive ? 'bg-primary' : 'bg-muted-foreground/30',
-          )}
-          aria-hidden
-        />
-        <FolderOpen
-          size={13}
-          aria-hidden
-          className={cn('shrink-0', isActive ? 'text-foreground' : 'text-muted-foreground')}
-        />
-        <span className="line-clamp-1 flex-1 font-medium">{workspace.name}</span>
-      </button>
+        <button
+          type="button"
+          onClick={onClick}
+          className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
+        >
+          <span
+            className={cn(
+              'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+              isActive ? 'bg-primary' : 'bg-muted-foreground/30',
+            )}
+            aria-hidden
+          />
+          <FolderOpen
+            size={13}
+            aria-hidden
+            className={cn('shrink-0', isActive ? 'text-foreground' : 'text-muted-foreground')}
+          />
+          <span className="line-clamp-1 flex-1 font-medium">{workspace.name}</span>
+        </button>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground/50 hover:!text-danger"
+          title="delete workspace"
+          aria-label={`delete workspace ${workspace.name}`}
+        >
+          <Trash2 size={12} aria-hidden />
+        </button>
+      </div>
     </li>
   );
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -20,6 +20,7 @@ import {
   insertSessionWorktree,
   insertTelemetry,
   insertWorkspace,
+  deleteWorkspace,
   listContextSlotsForSession,
   listMessagesForSession,
   listSessionsForWorkspace,
@@ -206,6 +207,7 @@ export interface AppActions {
   refreshProviderStatus(status: ProviderStatus): void;
   refreshProviders(): Promise<void>;
   addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
+  deleteWorkspace(id: WorkspaceId): Promise<void>;
   createSession(input: {
     workspaceId: WorkspaceId;
     goal: string;
@@ -1602,6 +1604,71 @@ export const useAppStore = create<AppStore>((set, get) => ({
     await insertWorkspace(tauriDatabase, workspace);
     set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
     return workspace;
+  },
+
+  deleteWorkspace: async (id) => {
+    const state = get();
+    const workspace = state.workspaces.find((w) => w.id === id);
+    if (!workspace) throw new Error(`workspace not found: ${id}`);
+
+    const sessions = await listSessionsForWorkspace(tauriDatabase, id);
+    const aliveSessions = sessions.filter(
+      (s) => s.state.kind === 'running' || s.state.kind === 'idle',
+    );
+    if (aliveSessions.length > 0) {
+      throw new Error(
+        `${aliveSessions.length} session${aliveSessions.length > 1 ? 's are' : ' is'} still running or idle. end them before deleting this workspace.`,
+      );
+    }
+
+    // Remove all worktrees from disk for sessions that have ended
+    for (const session of sessions) {
+      const worktreePaths = state.sessionWorktrees[session.id] ?? [];
+      for (const worktreePath of worktreePaths) {
+        try {
+          await removeWorktree(workspace.rootPath, worktreePath);
+        } catch {
+          // worktree may already be gone — best-effort cleanup
+        }
+      }
+    }
+
+    // Optimistic UI update
+    const prevWorkspaces = state.workspaces;
+    const wasCurrentWorkspace = state.currentWorkspaceId === id;
+    set((s) => ({
+      workspaces: s.workspaces.filter((w) => w.id !== id),
+      ...(wasCurrentWorkspace
+        ? {
+            currentWorkspaceId: null,
+            currentSessionId: null,
+            sessions: [],
+            sessionSummary: null,
+            workspaceSummary: null,
+            transcripts: {},
+            messages: {},
+            sessionTelemetry: {},
+            sessionSlots: {},
+            sessionWorktrees: {},
+            sessionPhaseRuns: {},
+            sessionBudgets: {},
+            summarizerStatus: {},
+            budgetAlerts: [],
+            unknownPayloadCounts: {},
+          }
+        : {}),
+    }));
+
+    try {
+      await deleteWorkspace(tauriDatabase, id);
+    } catch (err) {
+      // Rollback optimistic update
+      set((s) => ({
+        workspaces: prevWorkspaces,
+        ...(wasCurrentWorkspace ? { currentWorkspaceId: id } : {}),
+      }));
+      throw err;
+    }
   },
 
   refreshProviderSpendBreakdown: async (workspaceId) => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -5,7 +5,12 @@ export { migrations, type Migration } from './migrations';
 
 export { NotFoundError, UniqueViolationError } from './shared/errors';
 
-export { insertWorkspace, getWorkspaceById, listWorkspaces } from './queries/workspace';
+export {
+  insertWorkspace,
+  getWorkspaceById,
+  listWorkspaces,
+  deleteWorkspace,
+} from './queries/workspace';
 export {
   insertSession,
   updateSessionState,

--- a/packages/db/src/queries/workspace.ts
+++ b/packages/db/src/queries/workspace.ts
@@ -38,3 +38,7 @@ export async function listWorkspaces(db: Database): Promise<ReadonlyArray<Worksp
   const rows = await db.select<WorkspaceRow>('SELECT * FROM workspaces ORDER BY created_at DESC');
   return rows.map(toDomain);
 }
+
+export async function deleteWorkspace(db: Database, id: WorkspaceId): Promise<void> {
+  await db.execute('DELETE FROM workspaces WHERE id = ?', [id]);
+}


### PR DESCRIPTION
## Summary

- Trash icon on each workspace row (hidden until hover, red on hover) — click opens confirm dialog
- `DeleteWorkspaceDialog`: warns "all sessions will also be removed, cannot be undone"; refuses with specific message if any session is `running` or `idle`
- `deleteWorkspace` store action: queries sessions, rejects alive ones, removes worktrees from disk (best-effort), optimistic UI update with rollback on DB error
- `deleteWorkspace` DB query: `DELETE FROM workspaces WHERE id = ?` — cascade handles all child rows

## Cascade policy

No migration needed — `sessions.workspace_id` already has `ON DELETE CASCADE` since m001. Full cascade chain:

```
workspaces → sessions (CASCADE)
           → session_worktrees (CASCADE via sessions)
           → messages (CASCADE via sessions)
           → context_slots (CASCADE via sessions)
           → provider_runs (CASCADE via sessions)
           → telemetry_records (CASCADE via sessions)
           → skills / phase_templates (workspace-scoped, deleted via FK)
```

Running/idle sessions: **refused** — store checks `state.kind === 'running' | 'idle'` before DB delete. User sees message: "N session(s) still running or idle. end them before deleting this workspace."

## Test plan

- [ ] Add workspace → appears in sidebar
- [ ] Hover workspace row → trash icon appears
- [ ] Click trash → confirm dialog shows workspace name + root path
- [ ] Cancel → nothing changes
- [ ] Confirm on workspace with only ended sessions → workspace + all sessions removed, sidebar clears
- [ ] Confirm on workspace with running/idle session → error shown in dialog, workspace stays
- [ ] If deleted workspace was active → sidebar clears to no-workspace state

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)