### PR TITLE
refactor(desktop,db): sidebar mega — nesting, search/filter, status icons, rename, delete

### DIFF
--- a/apps/desktop/src/__tests__/sidebar.test.ts
+++ b/apps/desktop/src/__tests__/sidebar.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  ProviderId,
+  Session,
+  SessionId,
+  SessionState,
+  WorkspaceId,
+} from '@kay-am/types';
+
+const DT = '2024-01-01T00:00:00Z' as IsoDateTime;
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1' as SessionId,
+    workspaceId: 'ws-1' as WorkspaceId,
+    goal: 'test session',
+    state: { kind: 'idle', lastActivityAt: DT } as SessionState,
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic' as ProviderId, allowTurnOverride: true },
+    createdAt: DT,
+    updatedAt: DT,
+    ...overrides,
+  };
+}
+
+function filterSessions(
+  sessions: ReadonlyArray<Session>,
+  search: string,
+  stateFilter: ReadonlyArray<SessionState['kind']>,
+  providerFilter: ReadonlyArray<ProviderId>,
+): ReadonlyArray<Session> {
+  return sessions.filter((s) => {
+    const matchesSearch = s.goal.toLowerCase().includes(search.toLowerCase());
+    const matchesState = stateFilter.length === 0 || stateFilter.includes(s.state.kind);
+    const matchesProvider =
+      providerFilter.length === 0 || providerFilter.includes(s.providerPreference.defaultProvider);
+    return matchesSearch && matchesState && matchesProvider;
+  });
+}
+
+describe('sidebar session filtering', () => {
+  const sessions: ReadonlyArray<Session> = [
+    makeSession({ id: 's1' as SessionId, goal: 'refactor auth module' }),
+    makeSession({
+      id: 's2' as SessionId,
+      goal: 'add new feature',
+      state: { kind: 'running', runId: 'r1' as never, startedAt: DT },
+    }),
+    makeSession({
+      id: 's3' as SessionId,
+      goal: 'fix bug in payment',
+      state: { kind: 'ended', endedAt: DT },
+      providerPreference: { defaultProvider: 'cursor' as ProviderId, allowTurnOverride: false },
+    }),
+    makeSession({
+      id: 's4' as SessionId,
+      goal: 'deploy to prod',
+      state: { kind: 'error', message: 'oops', failedAt: DT },
+    }),
+  ];
+
+  it('no filters → all sessions returned', () => {
+    expect(filterSessions(sessions, '', [], [])).toHaveLength(4);
+  });
+
+  it('search filters by goal (case-insensitive)', () => {
+    const result = filterSessions(sessions, 'AUTH', [], []);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('s1');
+  });
+
+  it('state filter shows only matching states', () => {
+    const result = filterSessions(sessions, '', ['running', 'error'], []);
+    expect(result).toHaveLength(2);
+    expect(result.map((s) => s.id)).toEqual(['s2', 's4']);
+  });
+
+  it('provider filter shows only matching provider', () => {
+    const result = filterSessions(sessions, '', [], ['cursor']);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('s3');
+  });
+
+  it('combined search + state filter', () => {
+    const result = filterSessions(sessions, 'bug', ['ended'], []);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('s3');
+  });
+
+  it('combined search + state + provider filters with no match', () => {
+    const result = filterSessions(sessions, 'auth', ['running'], ['cursor']);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('rename validation', () => {
+  it('empty goal rejects', () => {
+    const validate = (goal: string) => {
+      if (!goal.trim()) throw new Error('session name cannot be empty');
+    };
+    expect(() => validate('')).toThrow('session name cannot be empty');
+    expect(() => validate('  ')).toThrow('session name cannot be empty');
+    expect(() => validate('valid name')).not.toThrow();
+  });
+});
+
+describe('status icon mapping', () => {
+  const EXPECTED_KINDS: ReadonlyArray<SessionState['kind']> = [
+    'draft',
+    'starting',
+    'idle',
+    'running',
+    'ended',
+    'error',
+  ];
+
+  it('all SessionState kinds have a defined icon mapping', () => {
+    const ICON_MAP: Readonly<Record<SessionState['kind'], string>> = {
+      draft: 'pencil',
+      starting: 'loader',
+      idle: 'circle',
+      running: 'pulse',
+      ended: 'check',
+      error: 'x',
+    };
+    EXPECTED_KINDS.forEach((kind) => {
+      expect(ICON_MAP[kind]).toBeDefined();
+    });
+  });
+});
+
+describe('delete session logic', () => {
+  it('deleteSession removes session from list', () => {
+    const sessions: ReadonlyArray<Session> = [
+      makeSession({ id: 's1' as SessionId }),
+      makeSession({ id: 's2' as SessionId }),
+    ];
+    const afterDelete = sessions.filter((s) => s.id !== ('s1' as SessionId));
+    expect(afterDelete).toHaveLength(1);
+    expect(afterDelete[0]?.id).toBe('s2');
+  });
+
+  it('currentSessionId cleared when deleting active session', () => {
+    const currentSessionId = 's1' as SessionId;
+    const deletedId = 's1' as SessionId;
+    const nextId = currentSessionId === deletedId ? null : currentSessionId;
+    expect(nextId).toBeNull();
+  });
+
+  it('currentSessionId preserved when deleting non-active session', () => {
+    const currentSessionId = 's2' as SessionId;
+    const deletedId = 's1' as SessionId;
+    const nextId = currentSessionId === deletedId ? null : currentSessionId;
+    expect(nextId).toBe('s2');
+  });
+});
+
+describe('sessionBranches', () => {
+  it('branch stored separately from worktree path', () => {
+    const sessionBranches: Record<string, string> = {
+      s1: 'kay/refactor-auth',
+    };
+    expect(sessionBranches['s1']).toBe('kay/refactor-auth');
+    expect(sessionBranches['s2']).toBeUndefined();
+  });
+
+  it('branch cleared on delete', () => {
+    const sessionBranches: Record<string, string> = {
+      s1: 'kay/refactor-auth',
+      s2: 'kay/fix-bug',
+    };
+    const after = { ...sessionBranches };
+    delete after['s1'];
+    expect(after['s1']).toBeUndefined();
+    expect(after['s2']).toBe('kay/fix-bug');
+  });
+});

--- a/apps/desktop/src/components/StatusBadge.tsx
+++ b/apps/desktop/src/components/StatusBadge.tsx
@@ -1,25 +1,54 @@
+import { Check, Circle, Loader, Pencil, X } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import type { SessionState } from '@kay-am/types';
 
+interface StatusIconProps {
+  kind: SessionState['kind'];
+  className?: string;
+}
+
+function StatusIcon({ kind, className }: StatusIconProps) {
+  switch (kind) {
+    case 'draft':
+      return <Pencil size={11} className={className} aria-hidden />;
+    case 'starting':
+      return <Loader size={11} className={cn('motion-safe:animate-spin', className)} aria-hidden />;
+    case 'running':
+      return (
+        <span
+          className={cn(
+            'inline-block h-2 w-2 rounded-full bg-current motion-safe:animate-pulse',
+            className,
+          )}
+          aria-hidden
+        />
+      );
+    case 'idle':
+      return <Circle size={11} fill="currentColor" className={className} aria-hidden />;
+    case 'ended':
+      return <Check size={11} className={className} aria-hidden />;
+    case 'error':
+      return <X size={11} className={className} aria-hidden />;
+  }
+}
+
 const TONE: Record<SessionState['kind'], string> = {
-  draft: 'bg-muted text-muted-foreground',
-  starting: 'bg-primary/10 text-primary',
-  idle: 'bg-muted text-foreground',
-  running: 'bg-primary/15 text-primary',
-  error: 'bg-danger/10 text-danger',
-  ended: 'bg-muted text-muted-foreground',
+  draft: 'text-muted-foreground',
+  starting: 'text-primary',
+  idle: 'text-foreground/60',
+  running: 'text-primary',
+  error: 'text-danger',
+  ended: 'text-success',
 };
 
 export function StatusBadge({ state, className }: { state: SessionState; className?: string }) {
   return (
     <span
-      className={cn(
-        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
-        TONE[state.kind],
-        className,
-      )}
+      className={cn('inline-flex items-center', TONE[state.kind], className)}
+      title={state.kind}
+      aria-label={state.kind}
     >
-      {state.kind}
+      <StatusIcon kind={state.kind} />
     </span>
   );
 }

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -10,12 +10,6 @@ interface StatusBarProps {
   onOpenTelemetry?: () => void;
 }
 
-function inferBranch(worktreePath: string | null, sessionId: string | null): string | null {
-  if (!worktreePath) return sessionId ? sessionId.slice(0, 8) : null;
-  const tail = worktreePath.split('/').filter(Boolean).at(-1);
-  return tail ?? null;
-}
-
 function shortenHome(path: string): string {
   const home = '/Users/';
   const idx = path.indexOf(home);
@@ -37,12 +31,11 @@ export function StatusBar({ onEndSession, onOpenTelemetry }: StatusBarProps) {
   const worktreePath = useAppStore((s) =>
     session ? ((s.sessionWorktrees[session.id] ?? [])[0] ?? null) : null,
   );
+  const branch = useAppStore((s) => (session ? (s.sessionBranches[session.id] ?? null) : null));
   const editorBinary = useAppStore(
     (s) => s.settings[SETTING_EDITOR_BINARY] ?? DEFAULT_EDITOR_BINARY,
   );
   const [copied, setCopied] = useState<string | null>(null);
-
-  const branch = session ? inferBranch(worktreePath, session.id) : null;
   const lastTurn = sessionTelemetry?.[sessionTelemetry.length - 1] ?? null;
   const sessionStateLabel = session?.state.kind ?? 'idle';
 

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,8 +1,17 @@
 import { useEffect, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
-import { FolderOpen, FolderPlus, Plus, Trash2 } from 'lucide-react';
-import type { ProviderId, Session, SessionId, Workspace } from '@kay-am/types';
+import {
+  ChevronDown,
+  ChevronRight,
+  FolderOpen,
+  FolderPlus,
+  Plus,
+  Search,
+  Trash2,
+  X,
+} from 'lucide-react';
+import type { ProviderId, Session, SessionId, SessionState, Workspace } from '@kay-am/types';
 import {
   useAppStore,
   useCurrentSession,
@@ -31,6 +40,13 @@ const PROVIDER_SHORT: Record<ProviderId, string> = {
   codex: 'cx',
 };
 
+const STATE_FILTER_OPTIONS: ReadonlyArray<SessionState['kind']> = [
+  'idle',
+  'running',
+  'ended',
+  'error',
+];
+
 export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
@@ -39,24 +55,126 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
 
+  const sidebarWorkspaceSearch = useAppStore((s) => s.sidebarWorkspaceSearch);
+  const sidebarSessionSearch = useAppStore((s) => s.sidebarSessionSearch);
+  const sidebarStateFilter = useAppStore((s) => s.sidebarStateFilter);
+  const sidebarProviderFilter = useAppStore((s) => s.sidebarProviderFilter);
+  const setSidebarWorkspaceSearch = useAppStore((s) => s.setSidebarWorkspaceSearch);
+  const setSidebarSessionSearch = useAppStore((s) => s.setSidebarSessionSearch);
+  const setSidebarStateFilter = useAppStore((s) => s.setSidebarStateFilter);
+  const setSidebarProviderFilter = useAppStore((s) => s.setSidebarProviderFilter);
+
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [workspaceToDelete, setWorkspaceToDelete] = useState<Workspace | null>(null);
+  const [expandedWorkspaces, setExpandedWorkspaces] = useState<ReadonlySet<string>>(new Set());
+
+  useEffect(() => {
+    if (currentWorkspace) {
+      setExpandedWorkspaces((prev) => new Set([...prev, currentWorkspace.id]));
+    }
+  }, [currentWorkspace]);
+
+  const filteredWorkspaces = workspaces.filter((ws) =>
+    ws.name.toLowerCase().includes(sidebarWorkspaceSearch.toLowerCase()),
+  );
+
+  const filteredSessions = sessions.filter((s) => {
+    const matchesSearch = s.goal.toLowerCase().includes(sidebarSessionSearch.toLowerCase());
+    const matchesState =
+      sidebarStateFilter.length === 0 || sidebarStateFilter.includes(s.state.kind);
+    const matchesProvider =
+      sidebarProviderFilter.length === 0 ||
+      sidebarProviderFilter.includes(s.providerPreference.defaultProvider);
+    return matchesSearch && matchesState && matchesProvider;
+  });
+
+  const toggleWorkspaceExpanded = (wsId: string) => {
+    setExpandedWorkspaces((prev) => {
+      const next = new Set(prev);
+      if (next.has(wsId)) {
+        next.delete(wsId);
+      } else {
+        next.add(wsId);
+      }
+      return next;
+    });
+  };
+
+  const providerFilterOptions: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+
+  const toggleStateFilter = (kind: SessionState['kind']) => {
+    const next = sidebarStateFilter.includes(kind)
+      ? sidebarStateFilter.filter((k) => k !== kind)
+      : [...sidebarStateFilter, kind];
+    setSidebarStateFilter(next);
+  };
+
+  const toggleProviderFilter = (provider: ProviderId) => {
+    const next = sidebarProviderFilter.includes(provider)
+      ? sidebarProviderFilter.filter((p) => p !== provider)
+      : [...sidebarProviderFilter, provider];
+    setSidebarProviderFilter(next);
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-col gap-1 px-2 pt-2">
+        <SearchInput
+          value={sidebarWorkspaceSearch}
+          onChange={setSidebarWorkspaceSearch}
+          placeholder="search workspaces…"
+        />
+      </div>
+
       <ScrollArea className="flex-1">
-        <Section title="workspaces">
+        <section className="flex flex-col px-2 pt-2">
+          <header className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              workspaces
+            </span>
+          </header>
           <ul className="flex flex-col gap-0.5">
-            {workspaces.map((ws) => (
-              <WorkspaceRow
-                key={ws.id}
-                workspace={ws}
-                isActive={ws.id === currentWorkspace?.id}
-                onClick={() => void setCurrentWorkspace(ws.id)}
-                onDelete={() => setWorkspaceToDelete(ws)}
-              />
-            ))}
+            {filteredWorkspaces.map((ws) => {
+              const isActive = ws.id === currentWorkspace?.id;
+              const isExpanded = expandedWorkspaces.has(ws.id);
+              const wsSessions = filteredSessions.filter((s) => s.workspaceId === ws.id);
+
+              return (
+                <WorkspaceRow
+                  key={ws.id}
+                  workspace={ws}
+                  isActive={isActive}
+                  isExpanded={isExpanded}
+                  onToggleExpand={() => toggleWorkspaceExpanded(ws.id)}
+                  onClick={() => void setCurrentWorkspace(ws.id)}
+                  onDelete={() => setWorkspaceToDelete(ws)}
+                  sessionList={
+                    isExpanded ? (
+                      <SessionList
+                        sessions={wsSessions}
+                        currentSessionId={currentSession?.id ?? null}
+                        workspaceId={ws.id}
+                        sidebarSessionSearch={
+                          ws.id === currentWorkspace?.id ? sidebarSessionSearch : ''
+                        }
+                        onSessionSearch={
+                          ws.id === currentWorkspace?.id ? setSidebarSessionSearch : () => undefined
+                        }
+                        stateFilter={sidebarStateFilter}
+                        providerFilter={sidebarProviderFilter}
+                        stateFilterOptions={STATE_FILTER_OPTIONS}
+                        providerFilterOptions={providerFilterOptions}
+                        onToggleState={toggleStateFilter}
+                        onToggleProvider={toggleProviderFilter}
+                        onSelectSession={(id) => void setCurrentSession(id)}
+                        onNewSession={() => setNewSessionOpen(true)}
+                      />
+                    ) : null
+                  }
+                />
+              );
+            })}
             <li>
               <AddRow
                 label="add workspace"
@@ -65,38 +183,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
               />
             </li>
           </ul>
-        </Section>
-
-        <div className="my-2 border-t border-border-soft" />
-
-        <Section
-          title="sessions"
-          subtitle={currentWorkspace ? currentWorkspace.name : 'select a workspace'}
-        >
-          {!currentWorkspace ? (
-            <p className="px-2 py-1 text-[11px] text-muted-foreground">
-              pick a workspace to see its sessions.
-            </p>
-          ) : (
-            <ul className="flex flex-col gap-0.5">
-              {sessions.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  isActive={session.id === currentSession?.id}
-                  onClick={() => void setCurrentSession(session.id)}
-                />
-              ))}
-              <li>
-                <AddRow
-                  label="add session"
-                  icon={<Plus size={13} aria-hidden />}
-                  onClick={() => setNewSessionOpen(true)}
-                />
-              </li>
-            </ul>
-          )}
-        </Section>
+        </section>
       </ScrollArea>
 
       <AddWorkspaceDialog open={addWorkspaceOpen} onClose={() => setAddWorkspaceOpen(false)} />
@@ -119,36 +206,60 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   );
 }
 
-interface SectionProps {
-  title: string;
-  subtitle?: string;
-  children: React.ReactNode;
+interface SearchInputProps {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
 }
 
-function Section({ title, subtitle, children }: SectionProps) {
+function SearchInput({ value, onChange, placeholder }: SearchInputProps) {
   return (
-    <section className="flex flex-col px-2 pt-3">
-      <header className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-          {title}
-        </span>
-        {subtitle ? (
-          <span className="line-clamp-1 text-[10px] text-muted-foreground/80">{subtitle}</span>
-        ) : null}
-      </header>
-      {children}
-    </section>
+    <div className="relative flex items-center">
+      <Search
+        size={11}
+        className="pointer-events-none absolute left-2 text-muted-foreground"
+        aria-hidden
+      />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-md border border-border-soft bg-muted/40 py-1 pl-6 pr-2 text-[11px] placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-primary"
+      />
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          className="absolute right-1.5 text-muted-foreground hover:text-foreground"
+          aria-label="clear search"
+        >
+          <X size={11} />
+        </button>
+      ) : null}
+    </div>
   );
 }
 
 interface WorkspaceRowProps {
   workspace: Workspace;
   isActive: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
   onClick: () => void;
   onDelete: () => void;
+  sessionList: React.ReactNode;
 }
 
-function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowProps) {
+function WorkspaceRow({
+  workspace,
+  isActive,
+  isExpanded,
+  onToggleExpand,
+  onClick,
+  onDelete,
+  sessionList,
+}: WorkspaceRowProps) {
   return (
     <li className="group">
       <div
@@ -159,7 +270,10 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
       >
         <button
           type="button"
-          onClick={onClick}
+          onClick={() => {
+            onClick();
+            onToggleExpand();
+          }}
           className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
         >
           <span
@@ -175,6 +289,11 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
             className={cn('shrink-0', isActive ? 'text-foreground' : 'text-muted-foreground')}
           />
           <span className="line-clamp-1 flex-1 font-medium">{workspace.name}</span>
+          {isExpanded ? (
+            <ChevronDown size={11} className="shrink-0 text-muted-foreground" aria-hidden />
+          ) : (
+            <ChevronRight size={11} className="shrink-0 text-muted-foreground" aria-hidden />
+          )}
         </button>
         <button
           type="button"
@@ -189,7 +308,136 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
           <Trash2 size={12} aria-hidden />
         </button>
       </div>
+      {sessionList}
     </li>
+  );
+}
+
+interface SessionListProps {
+  sessions: ReadonlyArray<Session>;
+  currentSessionId: SessionId | null;
+  workspaceId: string;
+  sidebarSessionSearch: string;
+  onSessionSearch: (v: string) => void;
+  stateFilter: ReadonlyArray<SessionState['kind']>;
+  providerFilter: ReadonlyArray<ProviderId>;
+  stateFilterOptions: ReadonlyArray<SessionState['kind']>;
+  providerFilterOptions: ReadonlyArray<ProviderId>;
+  onToggleState: (kind: SessionState['kind']) => void;
+  onToggleProvider: (provider: ProviderId) => void;
+  onSelectSession: (id: SessionId) => void;
+  onNewSession: () => void;
+}
+
+function SessionList({
+  sessions,
+  currentSessionId,
+  sidebarSessionSearch,
+  onSessionSearch,
+  stateFilter,
+  providerFilter,
+  stateFilterOptions,
+  providerFilterOptions,
+  onToggleState,
+  onToggleProvider,
+  onSelectSession,
+  onNewSession,
+}: SessionListProps) {
+  return (
+    <div className="ml-3 mt-0.5 flex flex-col gap-1 border-l border-border-soft pl-2">
+      <SearchInput
+        value={sidebarSessionSearch}
+        onChange={onSessionSearch}
+        placeholder="search sessions…"
+      />
+
+      {(stateFilter.length > 0 || providerFilter.length > 0) && (
+        <div className="flex flex-wrap gap-0.5">
+          {stateFilter.map((k) => (
+            <FilterChip key={k} label={k} onRemove={() => onToggleState(k)} />
+          ))}
+          {providerFilter.map((p) => (
+            <FilterChip
+              key={p}
+              label={PROVIDER_SHORT[p] ?? p}
+              onRemove={() => onToggleProvider(p)}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-0.5">
+        {stateFilterOptions.map((kind) => (
+          <button
+            key={kind}
+            type="button"
+            onClick={() => onToggleState(kind)}
+            className={cn(
+              'rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide transition-colors',
+              stateFilter.includes(kind)
+                ? 'bg-primary/15 text-primary'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+          >
+            {kind}
+          </button>
+        ))}
+        {providerFilterOptions.map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => onToggleProvider(p)}
+            className={cn(
+              'rounded px-1 py-0.5 text-[9px] font-medium uppercase tracking-wide transition-colors',
+              providerFilter.includes(p)
+                ? cn(PROVIDER_CHIP_COLOR[p])
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            )}
+          >
+            {PROVIDER_SHORT[p]}
+          </button>
+        ))}
+      </div>
+
+      <ul className="flex flex-col gap-0.5">
+        {sessions.map((session) => (
+          <SessionRow
+            key={session.id}
+            session={session}
+            isActive={session.id === currentSessionId}
+            onClick={() => onSelectSession(session.id)}
+          />
+        ))}
+        <li>
+          <AddRow
+            label="add session"
+            icon={<Plus size={13} aria-hidden />}
+            onClick={onNewSession}
+          />
+        </li>
+      </ul>
+    </div>
+  );
+}
+
+interface FilterChipProps {
+  label: string;
+  onRemove: () => void;
+}
+
+function FilterChip({ label, onRemove }: FilterChipProps) {
+  return (
+    <span className="inline-flex items-center gap-0.5 rounded bg-primary/10 px-1 py-0.5 text-[9px] text-primary">
+      {label}
+      <button
+        type="button"
+        onClick={onRemove}
+        className="hover:text-danger"
+        aria-label={`remove filter ${label}`}
+      >
+        <X size={9} />
+      </button>
+    </span>
   );
 }
 
@@ -206,10 +454,16 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
   const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
   const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const renameSession = useAppStore((s) => s.renameSession);
+  const deleteSession = useAppStore((s) => s.deleteSession);
   const budgetLoaded = useRef(false);
 
   const [editingCap, setEditingCap] = useState(false);
   const [capDraft, setCapDraft] = useState('');
+  const [renaming, setRenaming] = useState(false);
+  const [renameDraft, setRenameDraft] = useState('');
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   useEffect(() => {
     if (!budgetLoaded.current) {
@@ -244,19 +498,57 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
     if (e.key === 'Escape') setEditingCap(false);
   };
 
+  const startRename = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRenameDraft(session.goal);
+    setRenameError(null);
+    setRenaming(true);
+  };
+
+  const commitRename = async () => {
+    if (!renameDraft.trim()) {
+      setRenameError('name cannot be empty');
+      return;
+    }
+    try {
+      await renameSession(session.id as SessionId, renameDraft.trim());
+      setRenaming(false);
+      setRenameError(null);
+    } catch (err) {
+      setRenameError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') void commitRename();
+    if (e.key === 'Escape') {
+      setRenaming(false);
+      setRenameError(null);
+    }
+  };
+
+  const onDeleteConfirm = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    await deleteSession(session.id as SessionId);
+    setConfirmDelete(false);
+  };
+
   return (
-    <li className="group">
+    <li>
       <div
+        role="button"
+        tabIndex={0}
+        onClick={onClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onClick();
+        }}
+        onDoubleClick={startRename}
         className={cn(
-          'flex flex-col gap-1 rounded-md px-2 py-1.5 transition-colors',
+          'group flex cursor-pointer flex-col gap-1 rounded-md px-2 py-1.5 transition-colors',
           isActive ? 'bg-muted' : 'hover:bg-muted/60',
         )}
       >
-        <button
-          type="button"
-          onClick={onClick}
-          className="flex w-full items-center gap-2 text-left text-sm"
-        >
+        <div className="flex w-full items-center gap-2 text-sm">
           <span
             className={cn(
               'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
@@ -264,8 +556,22 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
             )}
             aria-hidden
           />
-          <span className="line-clamp-1 flex-1">{session.goal}</span>
-          <div className="flex shrink-0 items-center gap-1">
+          {renaming ? (
+            <div className="flex flex-1 flex-col gap-0.5" onClick={(e) => e.stopPropagation()}>
+              <input
+                autoFocus
+                value={renameDraft}
+                onChange={(e) => setRenameDraft(e.target.value)}
+                onBlur={() => void commitRename()}
+                onKeyDown={onRenameKeyDown}
+                className="flex-1 rounded border border-border bg-background px-1 py-0 text-xs outline-none focus:ring-1 focus:ring-primary"
+              />
+              {renameError ? <span className="text-[10px] text-danger">{renameError}</span> : null}
+            </div>
+          ) : (
+            <span className="line-clamp-1 flex-1">{session.goal}</span>
+          )}
+          <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
             <span
               className={cn(
                 'inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium leading-none',
@@ -276,8 +582,20 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
               {PROVIDER_SHORT[providerId]}
             </span>
             <StatusBadge state={session.state} />
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmDelete(true);
+              }}
+              className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-danger group-hover:opacity-100"
+              title="delete session"
+              aria-label="delete session"
+            >
+              <Trash2 size={11} />
+            </button>
           </div>
-        </button>
+        </div>
 
         {cap !== null && (
           <div className="flex flex-col gap-0.5 pl-3.5">
@@ -325,11 +643,50 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
             (isActive || worktreePath !== null) && 'group-hover:opacity-100',
             isActive && 'opacity-100',
           )}
+          onClick={(e) => e.stopPropagation()}
         >
           <OpenInEditorButton worktreePath={worktreePath} label="vscode" />
         </div>
       </div>
+
+      {confirmDelete && (
+        <DeleteConfirmDialog
+          sessionGoal={session.goal}
+          onConfirm={onDeleteConfirm}
+          onCancel={() => setConfirmDelete(false)}
+        />
+      )}
     </li>
+  );
+}
+
+interface DeleteConfirmDialogProps {
+  sessionGoal: string;
+  onConfirm: (e: React.MouseEvent) => void;
+  onCancel: () => void;
+}
+
+function DeleteConfirmDialog({ sessionGoal, onConfirm, onCancel }: DeleteConfirmDialogProps) {
+  return (
+    <Dialog
+      open
+      onClose={onCancel}
+      title="delete session?"
+      description={`"${sessionGoal}" will be permanently removed. worktree, transcripts, and audit logs will be deleted. this cannot be undone.`}
+      size="sm"
+      footer={
+        <>
+          <Button variant="ghost" onClick={onCancel}>
+            cancel
+          </Button>
+          <Button variant="danger" onClick={onConfirm}>
+            delete
+          </Button>
+        </>
+      }
+    >
+      <span />
+    </Dialog>
   );
 }
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -30,6 +30,8 @@ import {
   listWorkspaces,
   listWorktreesForSession,
   deleteWorktreesForSession,
+  renameSession as renameSessionInDb,
+  deleteSession as deleteSessionFromDb,
   setSetting as dbSetSetting,
   summarizeSessionTelemetry,
   summarizeWorkspaceTelemetry,
@@ -181,6 +183,7 @@ export interface AppState {
   readonly transcripts: Readonly<Record<string, ReadonlyArray<TurnEvent>>>;
   readonly messages: Readonly<Record<string, ReadonlyArray<Message>>>;
   readonly sessionWorktrees: Readonly<Record<string, ReadonlyArray<string>>>;
+  readonly sessionBranches: Readonly<Record<string, string>>;
   readonly sessionTelemetry: Readonly<Record<string, ReadonlyArray<TelemetryRecord>>>;
   readonly workspaceSummary: TelemetrySummary | null;
   readonly sessionSlots: Readonly<Record<string, ReadonlyArray<ContextSlot>>>;
@@ -195,6 +198,10 @@ export interface AppState {
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<PhaseRun>>>;
   readonly sessionMergeConflicts: Readonly<Record<SessionId, ReadonlyArray<FileConflict>>>;
   readonly unknownPayloadCounts: Readonly<Record<string, number>>;
+  readonly sidebarWorkspaceSearch: string;
+  readonly sidebarSessionSearch: string;
+  readonly sidebarStateFilter: ReadonlyArray<SessionState['kind']>;
+  readonly sidebarProviderFilter: ReadonlyArray<ProviderId>;
 }
 
 export interface SummarizerSessionStatus {
@@ -268,6 +275,12 @@ export interface AppActions {
     picks: Record<string, string>,
     runStatuses: ReadonlyArray<{ runId: string; completedAt: string; status: string }>,
   ): Promise<void>;
+  renameSession(sessionId: SessionId, goal: string): Promise<void>;
+  deleteSession(sessionId: SessionId): Promise<void>;
+  setSidebarWorkspaceSearch(query: string): void;
+  setSidebarSessionSearch(query: string): void;
+  setSidebarStateFilter(states: ReadonlyArray<SessionState['kind']>): void;
+  setSidebarProviderFilter(providers: ReadonlyArray<ProviderId>): void;
 }
 
 type AppStore = AppState & AppActions;
@@ -290,6 +303,7 @@ const initialState: AppState = {
   transcripts: {},
   messages: {},
   sessionWorktrees: {},
+  sessionBranches: {},
   sessionTelemetry: {},
   workspaceSummary: null,
   sessionSlots: {},
@@ -304,6 +318,10 @@ const initialState: AppState = {
   sessionMergeConflicts: {},
   unknownPayloadCounts: {},
   systemAlerts: [],
+  sidebarWorkspaceSearch: '',
+  sidebarSessionSearch: '',
+  sidebarStateFilter: [],
+  sidebarProviderFilter: [],
 };
 
 function buildProviderSpendBreakdown(
@@ -627,12 +645,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionTelemetry: {},
       sessionSlots: {},
       sessionWorktrees: {},
+      sessionBranches: {},
       sessionPhaseRuns: {},
       sessionMergeConflicts: {},
       sessionBudgets: {},
       summarizerStatus: {},
       budgetAlerts: [],
       unknownPayloadCounts: {},
+      sidebarSessionSearch: '',
+      sidebarStateFilter: [],
+      sidebarProviderFilter: [],
     });
     if (id) {
       const [sessions, workspaceSummary, providerSummaries, budgetRules, skills, phaseTemplates] =
@@ -648,16 +670,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
         sessions.map((s) => listWorktreesForSession(tauriDatabase, s.id)),
       );
       const sessionWorktrees: Record<string, ReadonlyArray<string>> = {};
+      const sessionBranches: Record<string, string> = {};
       for (let i = 0; i < sessions.length; i++) {
         const s = sessions[i]!;
         const rows = worktreeRows[i]!;
         if (rows.length > 0) {
           sessionWorktrees[s.id] = rows.map((r) => r.worktreePath);
+          const primaryRow = rows[0];
+          if (primaryRow) sessionBranches[s.id] = primaryRow.branch;
         }
       }
       set((state) => ({
         sessions,
         sessionWorktrees,
+        sessionBranches,
         workspaceSummary,
         providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
         skills: { ...state.skills, [id]: skills },
@@ -814,6 +840,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionWorktrees: {
         ...state.sessionWorktrees,
         [session.id]: [worktree.worktreePath],
+      },
+      sessionBranches: {
+        ...state.sessionBranches,
+        [session.id]: worktree.branchName,
       },
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
@@ -1597,7 +1627,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set((state) => {
       const nextWorktrees = { ...state.sessionWorktrees };
       delete nextWorktrees[sessionId];
-      return { sessionWorktrees: nextWorktrees };
+      const nextBranches = { ...state.sessionBranches };
+      delete nextBranches[sessionId];
+      return { sessionWorktrees: nextWorktrees, sessionBranches: nextBranches };
     });
   },
 
@@ -1826,4 +1858,63 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return { sessionMergeConflicts: next };
     });
   },
+
+  renameSession: async (sessionId, goal) => {
+    if (!goal.trim()) throw new Error('session name cannot be empty');
+    const now = new Date().toISOString() as IsoDateTime;
+    const prev = get().sessions.find((s) => s.id === sessionId);
+    if (!prev) throw new Error(`session not found: ${sessionId}`);
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === sessionId ? { ...s, goal: goal.trim(), updatedAt: now } : s,
+      ),
+    }));
+    try {
+      await renameSessionInDb(tauriDatabase, sessionId, goal.trim(), now);
+    } catch (err) {
+      set((state) => ({
+        sessions: state.sessions.map((s) => (s.id === sessionId ? prev : s)),
+      }));
+      throw err;
+    }
+  },
+
+  deleteSession: async (sessionId) => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) throw new Error(`session not found: ${sessionId}`);
+    if (session.state.kind === 'running') {
+      await cancelTurn((session.state as { kind: 'running'; runId: ProviderRunId }).runId).catch(
+        () => undefined,
+      );
+    }
+    const worktreePaths = get().sessionWorktrees[sessionId] ?? [];
+    const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    if (workspace) {
+      for (const worktreePath of worktreePaths) {
+        try {
+          await removeWorktree(workspace.rootPath, worktreePath);
+        } catch {
+          // worktree may already be gone
+        }
+      }
+    }
+    await deleteSessionFromDb(tauriDatabase, sessionId);
+    set((state) => {
+      const nextWorktrees = { ...state.sessionWorktrees };
+      delete nextWorktrees[sessionId];
+      const nextBranches = { ...state.sessionBranches };
+      delete nextBranches[sessionId];
+      return {
+        sessions: state.sessions.filter((s) => s.id !== sessionId),
+        currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
+        sessionWorktrees: nextWorktrees,
+        sessionBranches: nextBranches,
+      };
+    });
+  },
+
+  setSidebarWorkspaceSearch: (query) => set({ sidebarWorkspaceSearch: query }),
+  setSidebarSessionSearch: (query) => set({ sidebarSessionSearch: query }),
+  setSidebarStateFilter: (states) => set({ sidebarStateFilter: states }),
+  setSidebarProviderFilter: (providers) => set({ sidebarProviderFilter: providers }),
 }));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,8 @@ export {
   updateSessionState,
   getSessionById,
   listSessionsForWorkspace,
+  renameSession,
+  deleteSession,
 } from './queries/session';
 export { insertMessage, listMessagesForSession } from './queries/message';
 export { upsertContextSlot, listContextSlotsForSession } from './queries/context-slot';

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -113,3 +113,20 @@ export async function listSessionsForWorkspace(
   );
   return rows.map((row) => toDomain(row, []));
 }
+
+export async function renameSession(
+  db: Database,
+  id: SessionId,
+  goal: string,
+  updatedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute('UPDATE sessions SET goal = ?, updated_at = ? WHERE id = ?', [
+    goal,
+    Date.parse(updatedAt),
+    id,
+  ]);
+}
+
+export async function deleteSession(db: Database, id: SessionId): Promise<void> {
+  await db.execute('DELETE FROM sessions WHERE id = ?', [id]);
+}


### PR DESCRIPTION
## Summary

Pre-1.0 mega-refactor of WorkspacesSidebar, StatusBadge, store, and db layer.

- **#246** — workspace rows expand/collapse; session list nested inside each workspace; per-workspace "add session" CTA
- **#257** — full `div[role=button]` click target for session rows; inner action buttons (delete, cap edit, rename) call `stopPropagation`
- **#258** — `StatusBadge` replaces text labels with Lucide icons: `Pencil` (draft), spinning `Loader` (starting), pulsing dot (running), solid `Circle` (idle), `Check` (ended), `X` (error); tooltip on hover; animations gated `motion-safe`
- **#259** — inline rename via double-click on session row; empty name rejected with inline error; optimistic UI + rollback on DB error; `renameSession` added to `@kay-am/db`
- **#260** — trash icon on hover opens `DeleteConfirmDialog`; removes worktree + deletes session row (DB cascade covers transcripts, telemetry, worktrees); `deleteSession` added to `@kay-am/db`
- **#261** — added `sessionBranches: Record<string, string>` to store state; populated from `session_worktrees.branch` (not inferred from path); `StatusBar` now reads the real branch name — SHA-like string bug fixed at source
- **#262** — grepped entire codebase; no "ci" chip found; issue resolved with no-op
- **#284** — workspace search input at top of sidebar; session search input scoped inside each expanded workspace; state filter chips (idle/running/ended/error) and provider filter chips (cl/cu/cx); multi-select toggle; active filters shown as removable chips

**DB changes**: `renameSession` + `deleteSession` added to `packages/db/src/queries/session.ts` and exported from `packages/db/src/index.ts`. No migration needed — `goal` column already exists, `ON DELETE CASCADE` on `sessions` table covers full cascade delete.

**No Tauri commands added** — all DB operations go through the existing generic `db_execute`/`db_select` commands.

**Migration added**: no

**Components extracted**: `WorkspaceRow`, `SessionList`, `SessionRow`, `SearchInput`, `FilterChip`, `AddRow`, `DeleteConfirmDialog` (all named exports, co-located in `WorkspacesSidebar.tsx`)

## Coordination notes

- Does **not** touch "Open in IDE" button (parallel agent #252 handles removal)
- `WorkspaceRow` leaves layout room for a gear button slot (Settings agent #247)

## Test plan

- [ ] `pnpm --filter @kay-am/desktop typecheck` passes (clean)
- [ ] `vitest run` — 13 new tests in `sidebar.test.ts` all pass; 2 pre-existing happy-dom failures unchanged
- [ ] `cargo check` passes
- [ ] Manual: expand/collapse workspace rows, search workspaces + sessions, filter by state/provider, double-click rename, delete session with confirmation

Closes #246 #257 #258 #259 #260 #261 #262 #284