### PR TITLE
feat(core,db,desktop): settings inheritance foundation #248

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod phases;
 mod providers;
 mod repo;
 mod secrets;
+mod settings_overrides;
 mod skills;
 mod summarize;
 mod turn;
@@ -107,6 +108,10 @@ pub fn run() {
       permissions::permission_audit_retry_drain,
       permissions::permission_audit_retry_update,
       permissions::permission_audit_retry_delete,
+      settings_overrides::get_workspace_overrides,
+      settings_overrides::set_workspace_overrides,
+      settings_overrides::get_session_overrides,
+      settings_overrides::set_session_overrides,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::db::{Db, DbError};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SettingsOverrides {
+    #[serde(rename = "defaultProviderId")]
+    pub default_provider_id: Option<String>,
+    #[serde(rename = "defaultPhaseTemplateId")]
+    pub default_phase_template_id: Option<String>,
+    #[serde(rename = "defaultBranchPrefix")]
+    pub default_branch_prefix: Option<String>,
+    #[serde(rename = "parallelEnabled")]
+    pub parallel_enabled: Option<bool>,
+}
+
+#[tauri::command]
+pub fn get_workspace_overrides(
+    state: State<'_, Db>,
+    workspace_id: String,
+) -> Result<Option<SettingsOverrides>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT default_provider_id, default_phase_template_id, default_branch_prefix, parallel_enabled
+         FROM workspaces WHERE id = ?1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![workspace_id], |row| {
+        let parallel_raw: Option<i64> = row.get(3)?;
+        Ok(SettingsOverrides {
+            default_provider_id: row.get(0)?,
+            default_phase_template_id: row.get(1)?,
+            default_branch_prefix: row.get(2)?,
+            parallel_enabled: parallel_raw.map(|v| v != 0),
+        })
+    })?;
+    match rows.next() {
+        Some(row) => Ok(Some(row.map_err(DbError::Sqlite)?)),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub fn set_workspace_overrides(
+    state: State<'_, Db>,
+    workspace_id: String,
+    overrides: SettingsOverrides,
+) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let parallel_val: Option<i64> = overrides.parallel_enabled.map(|v| if v { 1 } else { 0 });
+    let now = now_ms();
+    conn.execute(
+        "UPDATE workspaces
+         SET default_provider_id = ?1,
+             default_phase_template_id = ?2,
+             default_branch_prefix = ?3,
+             parallel_enabled = ?4,
+             updated_at = ?5
+         WHERE id = ?6",
+        rusqlite::params![
+            overrides.default_provider_id,
+            overrides.default_phase_template_id,
+            overrides.default_branch_prefix,
+            parallel_val,
+            now,
+            workspace_id,
+        ],
+    )?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_session_overrides(
+    state: State<'_, Db>,
+    session_id: String,
+) -> Result<Option<SettingsOverrides>, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT default_provider_id, default_phase_template_id, default_branch_prefix, parallel_enabled
+         FROM sessions WHERE id = ?1",
+    )?;
+    let mut rows = stmt.query_map(rusqlite::params![session_id], |row| {
+        let parallel_raw: Option<i64> = row.get(3)?;
+        Ok(SettingsOverrides {
+            default_provider_id: row.get(0)?,
+            default_phase_template_id: row.get(1)?,
+            default_branch_prefix: row.get(2)?,
+            parallel_enabled: parallel_raw.map(|v| v != 0),
+        })
+    })?;
+    match rows.next() {
+        Some(row) => Ok(Some(row.map_err(DbError::Sqlite)?)),
+        None => Ok(None),
+    }
+}
+
+#[tauri::command]
+pub fn set_session_overrides(
+    state: State<'_, Db>,
+    session_id: String,
+    overrides: SettingsOverrides,
+) -> Result<(), DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let parallel_val: Option<i64> = overrides.parallel_enabled.map(|v| if v { 1 } else { 0 });
+    let now = now_ms();
+    conn.execute(
+        "UPDATE sessions
+         SET default_provider_id = ?1,
+             default_phase_template_id = ?2,
+             default_branch_prefix = ?3,
+             parallel_enabled = ?4,
+             updated_at = ?5
+         WHERE id = ?6",
+        rusqlite::params![
+            overrides.default_provider_id,
+            overrides.default_phase_template_id,
+            overrides.default_branch_prefix,
+            parallel_val,
+            now,
+            session_id,
+        ],
+    )?;
+    Ok(())
+}
+
+fn now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -8,6 +8,7 @@ import {
   nextPhase,
   parseSlashCommand,
   resolveConflicts,
+  resolveSettings,
   sessionReducer,
   Summarizer,
   type ClaudeFlagSet,
@@ -43,9 +44,11 @@ import type {
   BudgetAlert,
   BudgetRule,
   ContextSlot,
+  GlobalSettings,
   IsoDateTime,
   Message,
   MessageId,
+  OverrideSettings,
   PermissionRequest,
   PermissionRequestId,
   PermissionRule,
@@ -58,6 +61,7 @@ import type {
   ProviderId,
   ProviderRun,
   ProviderRunId,
+  ResolvedSettings,
   Session,
   SessionBudget,
   SessionId,
@@ -96,6 +100,8 @@ import {
   SETTING_PROVIDER_PRICING_CONFIG,
   SETTING_ENABLE_PARALLEL_AGENTS,
   SETTING_MAX_PARALLELISM,
+  DEFAULT_BRANCH_PREFIX,
+  DEFAULT_ENABLE_PARALLEL_AGENTS,
   DEFAULT_MAX_PARALLELISM,
   MAX_PARALLELISM,
   MIN_PARALLELISM,
@@ -194,6 +200,8 @@ export interface AppState {
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<PhaseRun>>>;
   readonly sessionMergeConflicts: Readonly<Record<SessionId, ReadonlyArray<FileConflict>>>;
   readonly unknownPayloadCounts: Readonly<Record<string, number>>;
+  readonly workspaceOverrides: Readonly<Record<WorkspaceId, OverrideSettings>>;
+  readonly sessionOverrides: Readonly<Record<SessionId, OverrideSettings>>;
 }
 
 export interface SummarizerSessionStatus {
@@ -266,6 +274,10 @@ export interface AppActions {
     picks: Record<string, string>,
     runStatuses: ReadonlyArray<{ runId: string; completedAt: string; status: string }>,
   ): Promise<void>;
+  loadWorkspaceOverrides(workspaceId: WorkspaceId): Promise<void>;
+  setWorkspaceOverrides(workspaceId: WorkspaceId, overrides: OverrideSettings): Promise<void>;
+  loadSessionOverrides(sessionId: SessionId): Promise<void>;
+  setSessionOverrides(sessionId: SessionId, overrides: OverrideSettings): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -302,6 +314,8 @@ const initialState: AppState = {
   sessionMergeConflicts: {},
   unknownPayloadCounts: {},
   systemAlerts: [],
+  workspaceOverrides: {},
+  sessionOverrides: {},
 };
 
 function buildProviderSpendBreakdown(
@@ -1759,4 +1773,58 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return { sessionMergeConflicts: next };
     });
   },
+
+  loadWorkspaceOverrides: async (workspaceId) => {
+    const overrides = await invoke<OverrideSettings | null>('get_workspace_overrides', {
+      workspaceId,
+    });
+    if (overrides) {
+      set((state) => ({
+        workspaceOverrides: { ...state.workspaceOverrides, [workspaceId]: overrides },
+      }));
+    }
+  },
+
+  setWorkspaceOverrides: async (workspaceId, overrides) => {
+    await invoke('set_workspace_overrides', { workspaceId, overrides });
+    set((state) => ({
+      workspaceOverrides: { ...state.workspaceOverrides, [workspaceId]: overrides },
+    }));
+  },
+
+  loadSessionOverrides: async (sessionId) => {
+    const overrides = await invoke<OverrideSettings | null>('get_session_overrides', { sessionId });
+    if (overrides) {
+      set((state) => ({
+        sessionOverrides: { ...state.sessionOverrides, [sessionId]: overrides },
+      }));
+    }
+  },
+
+  setSessionOverrides: async (sessionId, overrides) => {
+    await invoke('set_session_overrides', { sessionId, overrides });
+    set((state) => ({
+      sessionOverrides: { ...state.sessionOverrides, [sessionId]: overrides },
+    }));
+  },
 }));
+
+export function useResolvedSettings(sessionId: SessionId | null): ResolvedSettings {
+  return useAppStore((state) => {
+    const session = sessionId ? (state.sessions.find((s) => s.id === sessionId) ?? null) : null;
+    const workspaceId = session?.workspaceId ?? null;
+
+    const globalSettings: GlobalSettings = {
+      defaultProviderId: DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider,
+      defaultPhaseTemplateId: null,
+      defaultBranchPrefix: DEFAULT_BRANCH_PREFIX,
+      parallelEnabled:
+        state.settings[SETTING_ENABLE_PARALLEL_AGENTS] === 'true' || DEFAULT_ENABLE_PARALLEL_AGENTS,
+    };
+
+    const workspaceOverride = workspaceId ? (state.workspaceOverrides[workspaceId] ?? null) : null;
+    const sessionOverride = sessionId ? (state.sessionOverrides[sessionId] ?? null) : null;
+
+    return resolveSettings({ global: globalSettings, workspaceOverride, sessionOverride });
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,3 +135,5 @@ export {
   type ParallelWorktreeDeps,
   type ParallelWorktreeResult,
 } from './worktree/parallel';
+
+export { resolveSettings, type ResolveSettingsInput } from './settings/resolver';

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSettings } from '../resolver';
+import type { GlobalSettings, OverrideSettings } from '@kay-am/types';
+import type { PhaseTemplateId } from '@kay-am/types';
+import type { ProviderId } from '@kay-am/types';
+
+const GLOBAL: GlobalSettings = {
+  defaultProviderId: 'anthropic' as ProviderId,
+  defaultPhaseTemplateId: null,
+  defaultBranchPrefix: 'kay',
+  parallelEnabled: false,
+};
+
+const NULL_OVERRIDE: OverrideSettings = {
+  defaultProviderId: null,
+  defaultPhaseTemplateId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+};
+
+describe('resolveSettings', () => {
+  it('null/null/null → global only', () => {
+    const result = resolveSettings({ global: GLOBAL });
+    expect(result.defaultProviderId).toBe('anthropic');
+    expect(result.defaultBranchPrefix).toBe('kay');
+    expect(result.parallelEnabled).toBe(false);
+    expect(result.defaultPhaseTemplateId).toBeNull();
+  });
+
+  it('null/value/null → workspace wins', () => {
+    const wsOverride: OverrideSettings = {
+      defaultProviderId: 'cursor' as ProviderId,
+      defaultPhaseTemplateId: 'tpl-1' as PhaseTemplateId,
+      defaultBranchPrefix: 'ws-prefix',
+      parallelEnabled: true,
+    };
+    const result = resolveSettings({ global: GLOBAL, workspaceOverride: wsOverride });
+    expect(result.defaultProviderId).toBe('cursor');
+    expect(result.defaultPhaseTemplateId).toBe('tpl-1');
+    expect(result.defaultBranchPrefix).toBe('ws-prefix');
+    expect(result.parallelEnabled).toBe(true);
+  });
+
+  it('null/null/value → session wins', () => {
+    const sessOverride: OverrideSettings = {
+      defaultProviderId: 'codex' as ProviderId,
+      defaultPhaseTemplateId: 'tpl-2' as PhaseTemplateId,
+      defaultBranchPrefix: 'sess-prefix',
+      parallelEnabled: true,
+    };
+    const result = resolveSettings({ global: GLOBAL, sessionOverride: sessOverride });
+    expect(result.defaultProviderId).toBe('codex');
+    expect(result.defaultPhaseTemplateId).toBe('tpl-2');
+    expect(result.defaultBranchPrefix).toBe('sess-prefix');
+    expect(result.parallelEnabled).toBe(true);
+  });
+
+  it('null/value/value → session wins over workspace', () => {
+    const wsOverride: OverrideSettings = {
+      defaultProviderId: 'cursor' as ProviderId,
+      defaultPhaseTemplateId: 'tpl-ws' as PhaseTemplateId,
+      defaultBranchPrefix: 'ws-prefix',
+      parallelEnabled: false,
+    };
+    const sessOverride: OverrideSettings = {
+      defaultProviderId: 'codex' as ProviderId,
+      defaultPhaseTemplateId: 'tpl-sess' as PhaseTemplateId,
+      defaultBranchPrefix: 'sess-prefix',
+      parallelEnabled: true,
+    };
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: wsOverride,
+      sessionOverride: sessOverride,
+    });
+    expect(result.defaultProviderId).toBe('codex');
+    expect(result.defaultPhaseTemplateId).toBe('tpl-sess');
+    expect(result.defaultBranchPrefix).toBe('sess-prefix');
+    expect(result.parallelEnabled).toBe(true);
+  });
+
+  it('null/value/null-fields → session null fields fall back to workspace', () => {
+    const wsOverride: OverrideSettings = {
+      defaultProviderId: 'cursor' as ProviderId,
+      defaultPhaseTemplateId: null,
+      defaultBranchPrefix: 'ws-prefix',
+      parallelEnabled: true,
+    };
+    const sessOverride: OverrideSettings = {
+      defaultProviderId: null,
+      defaultPhaseTemplateId: null,
+      defaultBranchPrefix: null,
+      parallelEnabled: null,
+    };
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: wsOverride,
+      sessionOverride: sessOverride,
+    });
+    expect(result.defaultProviderId).toBe('cursor');
+    expect(result.defaultBranchPrefix).toBe('ws-prefix');
+    expect(result.parallelEnabled).toBe(true);
+  });
+
+  it('all-null overrides → global used everywhere', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: NULL_OVERRIDE,
+      sessionOverride: NULL_OVERRIDE,
+    });
+    expect(result.defaultProviderId).toBe('anthropic');
+    expect(result.defaultBranchPrefix).toBe('kay');
+    expect(result.parallelEnabled).toBe(false);
+  });
+
+  it('undefined overrides treated same as null overrides', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: undefined,
+      sessionOverride: undefined,
+    });
+    expect(result.defaultProviderId).toBe('anthropic');
+    expect(result.defaultBranchPrefix).toBe('kay');
+  });
+
+  it('global with non-null phaseTemplateId is inherited when overrides are null', () => {
+    const globalWithTemplate: GlobalSettings = {
+      ...GLOBAL,
+      defaultPhaseTemplateId: 'global-tpl' as PhaseTemplateId,
+    };
+    const result = resolveSettings({ global: globalWithTemplate });
+    expect(result.defaultPhaseTemplateId).toBe('global-tpl');
+  });
+});

--- a/packages/core/src/settings/resolver.ts
+++ b/packages/core/src/settings/resolver.ts
@@ -1,0 +1,31 @@
+import type { GlobalSettings, OverrideSettings, ResolvedSettings } from '@kay-am/types';
+
+export type ResolveSettingsInput = {
+  readonly global: GlobalSettings;
+  readonly workspaceOverride?: OverrideSettings | null;
+  readonly sessionOverride?: OverrideSettings | null;
+};
+
+/**
+ * Pure fn — browser-safe, no I/O.
+ * Resolution order: session > workspace > global (null = inherit).
+ */
+export function resolveSettings(input: ResolveSettingsInput): ResolvedSettings {
+  const { global: g, workspaceOverride: ws, sessionOverride: sess } = input;
+
+  return {
+    defaultProviderId: sess?.defaultProviderId ?? ws?.defaultProviderId ?? g.defaultProviderId,
+
+    defaultPhaseTemplateId:
+      sess?.defaultPhaseTemplateId !== undefined
+        ? sess.defaultPhaseTemplateId
+        : ws?.defaultPhaseTemplateId !== undefined
+          ? ws.defaultPhaseTemplateId
+          : g.defaultPhaseTemplateId,
+
+    defaultBranchPrefix:
+      sess?.defaultBranchPrefix ?? ws?.defaultBranchPrefix ?? g.defaultBranchPrefix,
+
+    parallelEnabled: sess?.parallelEnabled ?? ws?.parallelEnabled ?? g.parallelEnabled,
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -79,3 +79,9 @@ export {
   deleteGroup,
   updateGroupCompletedAt,
 } from './queries/parallel-phases';
+export {
+  getWorkspaceOverrides,
+  setWorkspaceOverrides,
+  getSessionOverrides,
+  setSessionOverrides,
+} from './queries/settings-overrides';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -9,6 +9,7 @@ import { m008Permissions } from './m008-permissions';
 import { m009SessionWorktrees } from './m009-session-worktrees';
 import { m010PermissionAuditRetry } from './m010-permission-audit-retry';
 import { m011ParallelPhases } from './m011-parallel-phases';
+import { m012SettingsOverrides } from './m012-settings-overrides';
 
 export interface Migration {
   readonly version: number;
@@ -27,4 +28,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 9, sql: m009SessionWorktrees },
   { version: 10, sql: m010PermissionAuditRetry },
   { version: 11, sql: m011ParallelPhases },
+  { version: 12, sql: m012SettingsOverrides },
 ];

--- a/packages/db/src/migrations/m012-settings-overrides.ts
+++ b/packages/db/src/migrations/m012-settings-overrides.ts
@@ -1,0 +1,11 @@
+export const m012SettingsOverrides = /* sql */ `
+ALTER TABLE workspaces ADD COLUMN default_provider_id TEXT;
+ALTER TABLE workspaces ADD COLUMN default_phase_template_id TEXT;
+ALTER TABLE workspaces ADD COLUMN default_branch_prefix TEXT;
+ALTER TABLE workspaces ADD COLUMN parallel_enabled INTEGER CHECK (parallel_enabled IN (0, 1));
+
+ALTER TABLE sessions ADD COLUMN default_provider_id TEXT;
+ALTER TABLE sessions ADD COLUMN default_phase_template_id TEXT;
+ALTER TABLE sessions ADD COLUMN default_branch_prefix TEXT;
+ALTER TABLE sessions ADD COLUMN parallel_enabled INTEGER CHECK (parallel_enabled IN (0, 1));
+`;

--- a/packages/db/src/queries/settings-overrides.ts
+++ b/packages/db/src/queries/settings-overrides.ts
@@ -1,0 +1,100 @@
+import type { OverrideSettings, PhaseTemplateId, SessionId, WorkspaceId } from '@kay-am/types';
+import type { ProviderId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface WorkspaceOverrideRow {
+  default_provider_id: string | null;
+  default_phase_template_id: string | null;
+  default_branch_prefix: string | null;
+  parallel_enabled: number | null;
+}
+
+interface SessionOverrideRow {
+  default_provider_id: string | null;
+  default_phase_template_id: string | null;
+  default_branch_prefix: string | null;
+  parallel_enabled: number | null;
+}
+
+function rowToOverride(row: WorkspaceOverrideRow | SessionOverrideRow): OverrideSettings {
+  return {
+    defaultProviderId: row.default_provider_id as ProviderId | null,
+    defaultPhaseTemplateId: row.default_phase_template_id as PhaseTemplateId | null,
+    defaultBranchPrefix: row.default_branch_prefix,
+    parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
+  };
+}
+
+export async function getWorkspaceOverrides(
+  db: Database,
+  workspaceId: WorkspaceId,
+): Promise<OverrideSettings | null> {
+  const rows = await db.select<WorkspaceOverrideRow>(
+    `SELECT default_provider_id, default_phase_template_id, default_branch_prefix, parallel_enabled
+     FROM workspaces WHERE id = ?`,
+    [workspaceId],
+  );
+  const row = rows[0];
+  return row ? rowToOverride(row) : null;
+}
+
+export async function setWorkspaceOverrides(
+  db: Database,
+  workspaceId: WorkspaceId,
+  overrides: OverrideSettings,
+): Promise<void> {
+  await db.execute(
+    `UPDATE workspaces
+     SET default_provider_id = ?,
+         default_phase_template_id = ?,
+         default_branch_prefix = ?,
+         parallel_enabled = ?,
+         updated_at = ?
+     WHERE id = ?`,
+    [
+      overrides.defaultProviderId,
+      overrides.defaultPhaseTemplateId,
+      overrides.defaultBranchPrefix,
+      overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
+      Date.now(),
+      workspaceId,
+    ],
+  );
+}
+
+export async function getSessionOverrides(
+  db: Database,
+  sessionId: SessionId,
+): Promise<OverrideSettings | null> {
+  const rows = await db.select<SessionOverrideRow>(
+    `SELECT default_provider_id, default_phase_template_id, default_branch_prefix, parallel_enabled
+     FROM sessions WHERE id = ?`,
+    [sessionId],
+  );
+  const row = rows[0];
+  return row ? rowToOverride(row) : null;
+}
+
+export async function setSessionOverrides(
+  db: Database,
+  sessionId: SessionId,
+  overrides: OverrideSettings,
+): Promise<void> {
+  await db.execute(
+    `UPDATE sessions
+     SET default_provider_id = ?,
+         default_phase_template_id = ?,
+         default_branch_prefix = ?,
+         parallel_enabled = ?,
+         updated_at = ?
+     WHERE id = ?`,
+    [
+      overrides.defaultProviderId,
+      overrides.defaultPhaseTemplateId,
+      overrides.defaultBranchPrefix,
+      overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
+      Date.now(),
+      sessionId,
+    ],
+  );
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,6 +59,7 @@ export type {
   PhaseTemplate,
   PhaseTransition,
 } from './phase';
+export type { GlobalSettings, OverrideSettings, ResolvedSettings, SettingsScope } from './settings';
 export type {
   PermissionAuditEntry,
   PermissionDecision,

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,0 +1,31 @@
+import type { PhaseTemplateId, SessionId, WorkspaceId } from './ids';
+import type { ProviderId } from './provider-registry';
+
+/** Fields that can be overridden at workspace or session scope. Null = inherit from parent. */
+export type OverrideSettings = Readonly<{
+  defaultProviderId: ProviderId | null;
+  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultBranchPrefix: string | null;
+  parallelEnabled: boolean | null;
+}>;
+
+/** Fully-resolved settings after applying global → workspace → session cascade. */
+export type ResolvedSettings = Readonly<{
+  defaultProviderId: ProviderId;
+  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultBranchPrefix: string;
+  parallelEnabled: boolean;
+}>;
+
+/** Global settings (non-nullable — always has a value). */
+export type GlobalSettings = Readonly<{
+  defaultProviderId: ProviderId;
+  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultBranchPrefix: string;
+  parallelEnabled: boolean;
+}>;
+
+export type SettingsScope =
+  | { kind: 'global' }
+  | { kind: 'workspace'; workspaceId: WorkspaceId }
+  | { kind: 'session'; sessionId: SessionId };


### PR DESCRIPTION
## Summary

- **m012 migration**: nullable override columns (`default_provider_id`, `default_phase_template_id`, `default_branch_prefix`, `parallel_enabled`) on both `workspaces` and `sessions` tables
- **Types** (`@kay-am/types`): `OverrideSettings`, `ResolvedSettings`, `GlobalSettings`, `SettingsScope`
- **Resolver** (`@kay-am/core`): pure browser-safe `resolveSettings({ global, workspaceOverride, sessionOverride }) → ResolvedSettings` — null fields inherit from parent layer
- **DB queries** (`@kay-am/db`): `getWorkspaceOverrides`, `setWorkspaceOverrides`, `getSessionOverrides`, `setSessionOverrides`
- **Tauri commands**: `get_workspace_overrides`, `set_workspace_overrides`, `get_session_overrides`, `set_session_overrides`
- **Zustand store**: `workspaceOverrides` + `sessionOverrides` state maps, 4 load/set actions, `useResolvedSettings(sessionId)` selector
- **Tests**: 8 resolver unit tests covering all null/value combinations

UI (settings dialog, per-workspace gear, "inherited" indicator) deferred to follow-up PR.

Closes #248

## Test plan

- [ ] `pnpm --filter @kay-am/types typecheck` passes
- [ ] `pnpm --filter @kay-am/db typecheck` passes
- [ ] `pnpm --filter @kay-am/core typecheck && pnpm --filter @kay-am/core test` passes (8 new resolver tests)
- [ ] `pnpm --filter @kay-am/desktop typecheck` passes
- [ ] `cargo check` passes in `apps/desktop/src-tauri`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)