### PR TITLE
docs: pre-1.0 walkthroughs, parallel agents, phase templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,44 @@ pnpm lint           # placeholder; lint runs in CI
 
 If the **claude cli missing** banner shows in the header, install the Claude CLI and reopen the app. If **api key missing** shows, click it to jump back into settings.
 
+## Getting started
+
+New to kAY.am? Follow these steps to spin up your first session.
+
+### 1. Boot splash → ready
+
+Launch `pnpm tauri:dev`. Wait for the splash screen to reach _ready_. See [docs/glossary.md](./docs/glossary.md#booting) for phase breakdown.
+
+### 2. Add your first workspace
+
+Top-right: **workspace dropdown** → **add workspace…** → pick a local git repo (existing or new, sandbox repos are fine). kAY.am runs all sessions inside isolated worktrees next to the repo.
+
+### 3. Connect a provider
+
+Top-right: **settings** → paste your **Anthropic API key**, set your **default editor** (e.g. `code`). See [Supported providers](#supported-providers) for install + login commands. kAY.am routes turns through your chosen provider's subscription cap — no separate API tokens needed.
+
+### 4. Create your first session
+
+Left sidebar: **+ new session** → give it a goal (e.g. "add dark mode toggle") → accept the branch prefix. kAY.am creates a fresh git worktree for this goal.
+
+### 5. First turn
+
+Type a message in the chat input → enter. You'll see:
+
+- streamed assistant text (real-time as tokens arrive)
+- cost meter ticking (provider + token cost)
+- worktree-{slug} directory created next to your repo root
+
+### 6. Monitor progress
+
+**Telemetry pill** (top-left): session elapsed time, token count, cost breakdown. **Status bar** (bottom): active worktree, branch info, provider. **Alerts**: watch for banners (missing API key, CLI not found, etc.).
+
+### 7. End session
+
+**End session** button → preserves the branch (no force-push, safe to merge manually later) → cleans up the worktree. Your code changes stay in git.
+
+**Optional: phase templates.** Structure multi-step goals with templates. See [docs/phase-templates.md](./docs/phase-templates.md) for how to author and apply. Experimental parallel agents also available — enable in **settings → Experimental** and see [docs/parallel-agents.md](./docs/parallel-agents.md).
+
 ## Roadmap & contributing
 
 - [ROADMAP.md](./ROADMAP.md) — milestones and the active issue list

--- a/docs/parallel-agents.md
+++ b/docs/parallel-agents.md
@@ -1,0 +1,73 @@
+# Parallel Agents (Experimental)
+
+Parallel agents let you fan out a goal across multiple independent agent threads, then merge results back into your main session. Experimental as of v0.7.
+
+## What it is
+
+**Fan-out/fan-in**: One goal → multiple agents work in parallel on throwaway worktrees → results converge.
+
+Example: Decompose a large refactor into 3 independent tasks (module A, B, C), run them in parallel, then merge conflicts in one place.
+
+Each parallel agent gets:
+
+- Its own isolated worktree (auto-cleaned on success or failure)
+- Copy of the parent context (goal + phase definitions)
+- Independent turn history (no bloat in main session)
+
+## Enable it
+
+**Settings → Experimental → toggle parallel agents** → set **max parallelism** slider (default 3, range 1–10).
+
+Restart the app for changes to take effect.
+
+## Create a parallel phase group
+
+In your phase template, add a phase group with **parallel mode enabled**:
+
+1. **PhasesPanel** (left sidebar) → **edit template** (pencil icon)
+2. **+ add phase group** → toggle **parallel execution**
+3. Add phase definitions (one per agent). Each phase gets its own agent instance.
+4. **Save template** → apply to your session
+
+Example:
+
+```
+parallelGroup:
+  enabled: true
+  maxConcurrency: 3
+  phases:
+    - name: refactor-module-a
+      prompt: Refactor auth module...
+    - name: refactor-module-b
+      prompt: Refactor state module...
+    - name: refactor-module-c
+      prompt: Refactor api module...
+```
+
+Each phase runs on a new worktree. On completion, kAY.am merges back into main branch (interactive merge conflict resolution if needed).
+
+## Known limitations
+
+- **Merge conflict resolution UI**: Wired post-#281. Use CLI `git merge` as fallback if conflicts arise.
+- **Turn history**: Each parallel agent has independent history; main session doesn't see sub-turn details.
+- **Context sharing**: Agents copy parent context once at launch. Real-time parent updates don't propagate to running agents.
+- **Provider quota**: Parallel agents count against your provider subscription cap. Running 3 agents uses 3x the quota.
+
+See [#214](https://github.com/serenis/kay-am/issues/214) for v0.7 integration tests (fan-out/fan-in verified).
+
+## Rollback
+
+If a parallel run fails:
+
+1. **Worktree auto-cleanup**: kAY.am deletes throwaway worktrees. No manual cleanup needed.
+2. **Main session unaffected**: Parent worktree + branch remain intact.
+3. **Git state**: Partial merges are rolled back. Re-run or abort safely.
+
+## Best practices
+
+- Keep parallel phases independent. Avoid cross-phase dependencies.
+- Narrow phase prompts (single responsibility per agent).
+- Test on a sandbox repo first.
+- Merge results manually if auto-merge feels risky — use `git merge` from CLI.
+
+See [docs/phase-templates.md](./phase-templates.md#example-decompose--fan-out-parallel--merge) for a full parallel example.

--- a/docs/phase-templates.md
+++ b/docs/phase-templates.md
@@ -1,0 +1,147 @@
+# Phase Templates
+
+Phase templates let you structure multi-step goals. Chain agents across phases, share context, and optionally run agents in parallel.
+
+## What's a phase template
+
+A sequence of **phase definitions**. Each phase is a discrete step with its own prompt and agent. Phases run sequentially (or in parallel groups). Output from phase N becomes context for phase N+1.
+
+Use templates to:
+
+- Avoid context bloat (split a large goal into focused phases)
+- Reuse patterns (planner → coder → reviewer workflows)
+- Run agents in parallel (experimental, see [docs/parallel-agents.md](./parallel-agents.md))
+
+## Structure
+
+A phase template is a YAML-like structure with:
+
+```
+name: template-name
+phases:
+  - name: phase-1
+    prompt: "Directive for agent 1"
+    transitions: [phase-2]
+  - name: phase-2
+    prompt: "Directive for agent 2"
+    transitions: []
+parallelGroups: []
+```
+
+**PhaseDefinition fields**:
+
+- **name**: unique phase identifier (alphanumeric + dash)
+- **prompt**: directive for the agent running this phase (can reference synthetic context from prior phases)
+- **transitions**: list of next phase names (empty = terminal phase)
+
+**Parallel groups** (optional):
+
+- **enabled**: run phases concurrently?
+- **maxConcurrency**: max agents running at once (default 3)
+- **phases**: list of PhaseDefinitions to run in parallel
+
+## Create via UI
+
+1. **Left sidebar → PhasesPanel**
+2. **+ new template** (or edit existing)
+3. **+ add phase** → fill name + prompt → set transitions
+4. **(optional) group into parallel execution** → toggle parallel mode, adjust concurrency
+5. **Save** → apply to current session or save as reusable template
+
+## Examples
+
+### Sequential: planner → coder → reviewer
+
+Three-phase pipeline. Planner breaks down the task → coder implements → reviewer checks quality.
+
+**Phase 1: Plan**
+
+- Name: `planner`
+- Prompt: "Break down the goal: {goal}. List deliverables, risks, and dependencies."
+- Transitions: `[coder]`
+
+**Phase 2: Code**
+
+- Name: `coder`
+- Prompt: "Given the plan from phase 1, implement the changes. Focus on {goal}."
+- Transitions: `[reviewer]`
+
+**Phase 3: Review**
+
+- Name: `reviewer`
+- Prompt: "Review the implementation. Check for: edge cases, tests, docs. Suggest fixes."
+- Transitions: `[]` (terminal)
+
+Flow: planner → coder → reviewer → done.
+
+### Parallel: decompose → fan-out → merge
+
+Large refactor split into 3 parallel agents.
+
+**Phase 0: Decompose**
+
+- Name: `decompose`
+- Prompt: "Plan a refactor of {goal}. Break into 3 independent modules. List each scope."
+- Transitions: `[parallel-group-1]`
+
+**Parallel group 1**:
+
+- enabled: true
+- maxConcurrency: 3
+- phases:
+  - `refactor-a`: "Refactor module A per decompose plan"
+  - `refactor-b`: "Refactor module B per decompose plan"
+  - `refactor-c`: "Refactor module C per decompose plan"
+- All 3 run concurrently on separate worktrees
+
+**Phase 1: Merge**
+
+- Name: `merge`
+- Prompt: "Integrate the 3 modules. Resolve any conflicts. Ensure tests pass."
+- Transitions: `[]`
+
+Flow: decompose → (a|b|c in parallel) → merge → done.
+
+## Prompt building
+
+Synthetic context flows from phase to phase. When phase 2 starts, kAY.am injects:
+
+```
+—— Context from prior phases ——
+Phase 1 (planner):
+{entire turn history and outputs from phase 1}
+
+Now execute phase 2:
+{your phase 2 prompt}
+```
+
+Write phase prompts assuming prior context is available. Use placeholders:
+
+- `{goal}`: the session goal
+- `{phase-N-output}`: explicit reference to a prior phase's output
+- `{workspace}`: repo path
+- `{worktree}`: current worktree path
+
+Example phase 2 prompt:
+
+```
+Build on the plan from phase-1. Focus on the deliverables:
+{phase-1-output}
+
+Now write the code.
+```
+
+## Best practices
+
+- **Narrow prompts**: Each phase should have one job. Avoid kitchen-sink prompts.
+- **Single responsibility**: Don't ask a phase to plan AND implement AND review. Split it.
+- **Test early**: Create a phase template on a sandbox repo. Verify flow before production use.
+- **Explicit context**: If phase 2 depends on phase 1 output, mention it in the prompt. Don't assume.
+- **Parallel limits**: Keep max parallelism ≤ 5 (provider quota + machine limits).
+- **Error recovery**: If a phase fails, kAY.am rolls back that phase's worktree. Re-run or abort.
+
+## Save and reuse
+
+Templates are stored locally (SQLite). After creating a template, **save as reusable** to apply it to future sessions without re-authoring.
+
+See [docs/parallel-agents.md](./parallel-agents.md) for experimental parallel mode caveats and enable/disable instructions.


### PR DESCRIPTION
## Summary

Bundle 3 docs issues for kAY.am pre-1.0:

- **README**: "Getting started" section (boot → workspace → provider → session → turn → monitoring → cleanup)
- **docs/parallel-agents.md** (new): Fan-out/fan-in workflow, enable toggle, parallel phase groups, known limitations, rollback safety
- **docs/phase-templates.md** (new): Phase template structure, UI creation, sequential & parallel examples, prompt context flow, best practices

Closes #302 Closes #303 Closes #304

## Test plan

- [ ] Links in README resolve correctly (glossary link deferred to parallel agent #TBD, phase-templates & parallel-agents links work)
- [ ] Markdown lint passes (checked via pre-commit)
- [ ] Content aligns with current v0.7 UI (experimental parallel flag, phase panel, etc.)