### PR TITLE
refactor(repo,desktop,ui): terminology audit + glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 kAY.am sits between you and your AI agents. It doesn't replace your editor or your terminal — it commands them.
 
-Manage macro sessions. Route work across providers (Anthropic, OpenAI, Cursor, ...) based on priority and budget. Get real-time visibility on tokens and cost. Automate the repeatable with skills.
+Manage sessions. Route work across providers (Anthropic, OpenAI, Cursor, ...) based on priority and budget. Get real-time visibility on tokens and cost. Automate the repeatable with skills.
 
 > **Status**: v0.7 complete. Experimental parallel multi-agent mode available (enable via `experimental.enable_parallel_agents` in settings). v1.0 next.
 

--- a/VISION.md
+++ b/VISION.md
@@ -14,11 +14,11 @@ kAY.am is a local-first AI workspace orchestrator that sits between you and your
 
 ## Core concepts
 
-### Macro sessions
+### Sessions
 
-A macro session is a container for a goal. Not a chat. Not a thread. A goal.
+A session is a container for a goal. Not a chat. Not a thread. A goal.
 
-"Refactor authentication domain" is a macro session. Inside it, you declare phases — setup, planning, implementation, review — and each phase spawns its own agent with only the context it needs. The macro session holds the big picture. The agents do the work.
+"Refactor authentication domain" is a session. Inside it, you declare phases — setup, planning, implementation, review — and each phase spawns its own agent with only the context it needs. The session holds the big picture. The agents do the work.
 
 ### Synthetic context
 
@@ -37,10 +37,10 @@ Register your AI providers (Anthropic, OpenAI, Cursor, etc.). Set priorities. Se
 Every interaction is metered. kAY.am gives you total visibility on what you're spending and where, in real time.
 
 - **Token usage**: input/output tokens per request, per session, per provider, per model.
-- **Estimated cost**: live cost estimate based on provider pricing, with running totals per session and per macro session.
+- **Estimated cost**: live cost estimate based on provider pricing, with running totals per session.
 - **Session lifecycle metrics**: when a session starts, when it resets, when it hits a threshold, when it switches provider, when it ends.
 - **Budgets**: per-provider monthly cap, per-session soft cap. Visual alerts before you hit limits.
-- **Historical view**: spend over time, broken down by provider, model, task type, macro session.
+- **Historical view**: spend over time, broken down by provider, model, task type, session.
 - **Provider efficiency**: compare cost-per-task across providers to inform routing rules.
 
 All metrics are computed and stored locally. Nothing transmitted.

--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -58,9 +58,9 @@ export function StatusBar({ onFocusWorkspaces }: StatusBarProps) {
         </button>
         {branch ? (
           <CopyItem
-            label={`branch:${branch}`}
+            label={`worktree:${branch}`}
             copyValue={branch}
-            copyLabel="branch"
+            copyLabel="worktree"
             onCopy={onCopy}
           />
         ) : null}

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -45,7 +45,7 @@ export function ChatHeader({
 
   const isParallel = (parallelRunIds?.length ?? 0) > 1;
 
-  const onCopyBranch = async () => {
+  const onCopyWorktree = async () => {
     try {
       await navigator.clipboard.writeText(branch);
       setCopied(true);
@@ -71,9 +71,10 @@ export function ChatHeader({
         <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
           <button
             type="button"
-            onClick={() => void onCopyBranch()}
+            onClick={() => void onCopyWorktree()}
             className="inline-flex items-center gap-1 rounded-sm px-1 -mx-1 hover:bg-muted hover:text-foreground"
-            title="copy branch name"
+            aria-label={`worktree — branch: ${branch}`}
+            title={`worktree — branch: ${branch}`}
           >
             <GitBranch size={12} aria-hidden />
             <span className="font-mono">{branch}</span>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,16 @@
+# Glossary
+
+Canonical term definitions for kAY.am. Use these in code, UI, docs, and issues.
+
+| Term                | Definition                                                                                                                                                |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **workspace**       | A registered repository directory. The root git repo kAY.am tracks and creates sessions inside.                                                           |
+| **session**         | A goal-oriented conversation inside a workspace, tracked from start to end. Each session gets its own worktree and branch.                                |
+| **phase**           | A named stage inside a session (e.g. planner, coder, reviewer). Phases are declared in a phase template and executed in order.                            |
+| **run**             | An execution instance of a phase. One phase can produce multiple runs (e.g. retries or parallel fan-out).                                                 |
+| **parallel group**  | Multiple phase runs executing in parallel on throwaway worktrees, merged back at completion.                                                              |
+| **worktree**        | The git worktree directory for a session — the path on disk where files live during that session. Removed when the session ends; the branch is preserved. |
+| **branch**          | The git branch the worktree checks out. Named `<prefix>/<slug>` by default. Preserved after session ends for manual review or merge.                      |
+| **skill**           | A markdown + scripts automation invocable from chat via `/skill-name`. Stored locally, provider-agnostic.                                                 |
+| **permission rule** | A matcher pattern for tool-call interception. Determines whether a tool invocation is allowed, denied, or requires confirmation.                          |
+| **turn**            | One user prompt → one assistant response, including all streaming events in between. The atomic unit of interaction within a session.                     |


### PR DESCRIPTION
## Summary

- **VISION.md**: drop `macro session` → `session` throughout (section header + 3 body occurrences)
- **README.md**: `Manage macro sessions` → `Manage sessions`
- **ChatHeader**: branch button `title`/`aria-label` → `worktree — branch: <name>` (label disambiguates worktree path from branch name)
- **StatusBar**: `CopyItem` label `branch:<name>` → `worktree:<name>`, `copyLabel` `branch` → `worktree`
- **docs/glossary.md** (new): canonical definitions for workspace, session, phase, run, parallel group, worktree, branch, skill, permission rule, turn

## Decisions

- `branch prefix` field in `NewSessionDialog` / `SettingsDialog` stays as "branch prefix" — it refers to the git branch naming config, not the worktree path concept.
- `branch preserved` text in `EndSessionDialog` / `ChatView` stays — factually correct, refers to git branch object.
- `inferBranch` internal fn name unchanged — internal impl detail, not UI-facing.

## Test plan

- [x] `pnpm --filter @kay-am/desktop typecheck` — clean
- [x] `pnpm --filter @kay-am/desktop test` — 139/139 pass (snapshots unaffected, no branch string in snapshot baseline)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)