### PR TITLE
feat(desktop,ui): typography scale + reduced-motion + empty states

### DIFF
--- a/apps/desktop/src/components/AlertCenter.tsx
+++ b/apps/desktop/src/components/AlertCenter.tsx
@@ -57,14 +57,14 @@ export function AlertCenter() {
           type="button"
           onClick={() => setOpen((v) => !v)}
           className={cn(
-            'relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors',
+            'relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs motion-safe:transition-colors',
             open ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/60',
           )}
           aria-label={`alert center${count > 0 ? `, ${count} undismissed` : ''}`}
         >
           <Bell size={13} aria-hidden />
           {count > 0 && (
-            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-warning text-[9px] font-bold leading-none text-warning-foreground">
+            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-warning text-2xs font-bold leading-none text-warning-foreground">
               {count > 9 ? '9+' : count}
             </span>
           )}
@@ -90,7 +90,7 @@ export function AlertCenter() {
             </div>
 
             {undismissed.length === 0 ? (
-              <p className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+              <p className="px-3 py-4 text-center text-xs text-muted-foreground">
                 no active alerts
               </p>
             ) : (
@@ -103,7 +103,7 @@ export function AlertCenter() {
                         <div className="flex flex-wrap items-center gap-1.5">
                           <span
                             className={cn(
-                              'rounded px-1 py-0.5 text-[10px] font-medium leading-none',
+                              'rounded px-1 py-0.5 text-2xs font-medium leading-none',
                               badge.className,
                             )}
                           >
@@ -113,7 +113,7 @@ export function AlertCenter() {
                             {alertLabel(alert)}
                           </span>
                         </div>
-                        <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
+                        <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                           <span>
                             ${alert.currentUsd.toFixed(2)} / ${alert.capUsd.toFixed(2)}
                           </span>
@@ -123,7 +123,7 @@ export function AlertCenter() {
                       </div>
                       <button
                         type="button"
-                        className="mt-0.5 shrink-0 text-[10px] text-muted-foreground underline-offset-2 hover:text-danger hover:underline"
+                        className="mt-0.5 shrink-0 text-2xs text-muted-foreground underline-offset-2 hover:text-danger hover:underline"
                         onClick={() => void dismissBudgetAlert(alert.id)}
                       >
                         dismiss

--- a/apps/desktop/src/components/BootSplash.tsx
+++ b/apps/desktop/src/components/BootSplash.tsx
@@ -85,7 +85,7 @@ function BootErrorRecovery({
           <button
             type="button"
             onClick={onRetry}
-            className="rounded-md border border-danger/30 bg-background px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/10"
+            className="rounded-md border border-danger/30 bg-background px-3 py-1.5 text-xs font-medium text-danger motion-safe:transition-colors hover:bg-danger/10"
           >
             retry
           </button>
@@ -95,7 +95,7 @@ function BootErrorRecovery({
           <button
             type="button"
             onClick={onSkipProviderDetection}
-            className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted"
+            className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted"
           >
             skip provider detection
           </button>
@@ -104,7 +104,7 @@ function BootErrorRecovery({
         <button
           type="button"
           onClick={openLogs}
-          className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-muted"
+          className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted"
         >
           open logs
         </button>
@@ -112,7 +112,7 @@ function BootErrorRecovery({
         <button
           type="button"
           onClick={openIssue}
-          className="text-left text-[11px] text-muted-foreground underline-offset-2 hover:underline"
+          className="text-left text-xs text-muted-foreground underline-offset-2 hover:underline"
         >
           report on github ↗
         </button>
@@ -132,7 +132,7 @@ export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: B
         <p className="text-xs text-muted-foreground">{PHASE_LABEL[phase]}</p>
         <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
           <div
-            className="h-full bg-primary transition-all"
+            className="h-full bg-primary motion-safe:transition-all"
             style={{
               width: phase === 'ready' ? '100%' : `${Math.max(0, (idx / total) * 100)}%`,
             }}

--- a/apps/desktop/src/components/BudgetRulesPanel.tsx
+++ b/apps/desktop/src/components/BudgetRulesPanel.tsx
@@ -90,7 +90,7 @@ export function BudgetRulesPanel() {
       </div>
 
       {budgetRules.length === 0 && !showForm && (
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           no rules defined. add one to cap monthly spend per provider.
         </p>
       )}
@@ -126,7 +126,7 @@ function BudgetRuleRow({ rule, onDelete }: { rule: BudgetRule; onDelete: () => v
     <li className="flex items-center gap-3 px-3 py-2.5 text-xs">
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="font-medium">{rule.provider}</span>
-        <span className="text-[11px] text-muted-foreground">
+        <span className="text-xs text-muted-foreground">
           ${rule.capUsd.toFixed(2)} / month · alert at {rule.alertThresholdPct}%
           {rule.extraTokensBudget != null
             ? ` · ${rule.extraTokensBudget.toLocaleString()} extra tokens`
@@ -135,7 +135,7 @@ function BudgetRuleRow({ rule, onDelete }: { rule: BudgetRule; onDelete: () => v
       </div>
       <button
         type="button"
-        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-danger"
+        className="shrink-0 text-xs text-muted-foreground underline hover:text-danger"
         onClick={onDelete}
       >
         delete
@@ -162,7 +162,7 @@ function AddRuleForm({
   return (
     <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
       <div className="flex flex-col gap-1.5">
-        <label className="text-[11px] font-semibold text-foreground">provider</label>
+        <label className="text-xs font-semibold text-foreground">provider</label>
         <select
           className="w-full rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
           value={form.provider}
@@ -178,7 +178,7 @@ function AddRuleForm({
 
       <div className="flex gap-2">
         <div className="flex flex-1 flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">monthly cap (USD)</label>
+          <label className="text-xs font-semibold text-foreground">monthly cap (USD)</label>
           <Input
             type="number"
             min="0.01"
@@ -189,7 +189,7 @@ function AddRuleForm({
           />
         </div>
         <div className="flex flex-1 flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">alert threshold (%)</label>
+          <label className="text-xs font-semibold text-foreground">alert threshold (%)</label>
           <Input
             type="number"
             min="1"
@@ -203,7 +203,7 @@ function AddRuleForm({
       </div>
 
       <div className="flex flex-1 flex-col gap-1.5">
-        <label className="text-[11px] font-semibold text-foreground">
+        <label className="text-xs font-semibold text-foreground">
           extra-token budget <span className="font-normal text-muted-foreground">(optional)</span>
         </label>
         <Input
@@ -214,12 +214,12 @@ function AddRuleForm({
           value={form.extraTokensBudget}
           onChange={(e) => onChange({ ...form, extraTokensBudget: e.target.value })}
         />
-        <p className="text-[10px] text-muted-foreground">
+        <p className="text-2xs text-muted-foreground">
           additional token allowance per period. empty = no extra-token budget.
         </p>
       </div>
 
-      {error && <p className="text-[11px] text-danger">{error}</p>}
+      {error && <p className="text-xs text-danger">{error}</p>}
 
       <div className="flex items-center justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -57,7 +57,7 @@ export function ContextPanel({
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-4 p-4">
         <header className="flex items-center justify-between">
-          <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             context
           </span>
           <div className="flex items-center gap-1">
@@ -124,14 +124,14 @@ function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
   return (
     <li className="flex flex-col gap-1.5">
       <div className="flex items-center justify-between gap-2">
-        <label className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+        <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
           {SLOT_LABELS[slotKey]}
         </label>
         <button
           type="button"
           onClick={() => onToggle(!enabled)}
           className={cn(
-            'rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+            'rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide',
             enabled
               ? 'border-primary/30 bg-primary/10 text-primary'
               : 'border-border bg-muted text-muted-foreground',
@@ -211,7 +211,7 @@ function SummarizerBadge({
   return (
     <span
       title={tooltip}
-      className={cn('rounded-full px-2 py-0.5 text-[10px] uppercase tracking-wide', styles[status])}
+      className={cn('rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide', styles[status])}
     >
       {labels[status]}
     </span>

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -185,7 +185,7 @@ export function NewSessionDialog({
               <li
                 key={id}
                 className={cn(
-                  'flex items-center gap-2 px-3 py-2 text-sm transition-colors',
+                  'flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors',
                   disabled ? 'opacity-50' : 'hover:bg-muted/40',
                   selected && !disabled ? 'bg-muted/60' : '',
                 )}
@@ -211,7 +211,7 @@ export function NewSessionDialog({
                   {!connected && (
                     <button
                       type="button"
-                      className="text-[11px] text-primary underline hover:opacity-80"
+                      className="text-xs text-primary underline hover:opacity-80"
                       onClick={() => {
                         onClose();
                         onOpenSettings();
@@ -243,7 +243,7 @@ function Field({
     <div className="flex flex-col gap-1.5">
       <span className="text-xs font-semibold text-foreground">{label}</span>
       {children}
-      {hint ? <p className="text-[11px] leading-relaxed text-muted-foreground">{hint}</p> : null}
+      {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/OpenInEditorButton.tsx
+++ b/apps/desktop/src/components/OpenInEditorButton.tsx
@@ -116,7 +116,7 @@ export function OpenInEditorButton({
             >
               {ed.label}
               {ed.binary === resolvedDefault ? (
-                <span className="ml-auto text-[10px] text-muted-foreground">default</span>
+                <span className="ml-auto text-2xs text-muted-foreground">default</span>
               ) : null}
             </button>
           ))}

--- a/apps/desktop/src/components/PermissionsPanel.tsx
+++ b/apps/desktop/src/components/PermissionsPanel.tsx
@@ -205,7 +205,7 @@ export function PermissionsPanel() {
       />
 
       {showNonClaudeBanner && (
-        <div className="flex items-start justify-between gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-[11px] text-warning">
+        <div className="flex items-start justify-between gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
           <span>
             permission proxy is currently claude-only. rules saved here will not affect cursor/codex
             turns until v0.7.
@@ -221,18 +221,16 @@ export function PermissionsPanel() {
       )}
 
       {scope === 'workspace' && !workspace && (
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           select a workspace to manage workspace rules.
         </p>
       )}
       {scope === 'session' && !session && (
-        <p className="text-[11px] text-muted-foreground">
-          select a session to manage session rules.
-        </p>
+        <p className="text-xs text-muted-foreground">select a session to manage session rules.</p>
       )}
 
       {canLoadScope && !loading && rules.length === 0 && (
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-xs text-muted-foreground">
           no rules for this scope. add one to control which tools claude can use.
         </p>
       )}
@@ -268,7 +266,7 @@ function ScopeTabs({ current, onChange }: { current: ScopeTab; onChange: (s: Sco
         <button
           key={tab}
           type="button"
-          className={`rounded px-2.5 py-1 text-[11px] font-medium transition-colors ${
+          className={`rounded px-2.5 py-1 text-xs font-medium motion-safe:transition-colors ${
             current === tab
               ? 'bg-foreground text-background'
               : 'text-muted-foreground hover:text-foreground'
@@ -296,23 +294,23 @@ function RuleRow({
     <li className="flex items-center gap-3 px-3 py-2.5 text-xs">
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="font-mono font-medium">{rendered}</span>
-        <span className="text-[10px] text-muted-foreground">priority {rule.priority}</span>
+        <span className="text-2xs text-muted-foreground">priority {rule.priority}</span>
       </div>
       <span
-        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold ${DECISION_BADGE[rule.decision]}`}
+        className={`shrink-0 rounded px-1.5 py-0.5 text-2xs font-semibold ${DECISION_BADGE[rule.decision]}`}
       >
         {rule.decision}
       </span>
       <button
         type="button"
-        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-foreground"
+        className="shrink-0 text-xs text-muted-foreground underline hover:text-foreground"
         onClick={onEdit}
       >
         edit
       </button>
       <button
         type="button"
-        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-danger"
+        className="shrink-0 text-xs text-muted-foreground underline hover:text-danger"
         onClick={onDelete}
       >
         delete
@@ -323,7 +321,7 @@ function RuleRow({
 
 function DeleteConfirm({ onConfirm, onCancel }: { onConfirm: () => void; onCancel: () => void }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-md border border-danger/30 bg-danger/5 px-3 py-2.5 text-[11px]">
+    <div className="flex items-center justify-between gap-3 rounded-md border border-danger/30 bg-danger/5 px-3 py-2.5 text-xs">
       <span className="text-foreground">delete this rule?</span>
       <div className="flex gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>
@@ -368,7 +366,7 @@ function RuleEditor({
 
       <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
         <div className="relative flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">tool pattern</label>
+          <label className="text-xs font-semibold text-foreground">tool pattern</label>
           <Input
             value={form.tool}
             onChange={(e) => {
@@ -400,7 +398,7 @@ function RuleEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">
+          <label className="text-xs font-semibold text-foreground">
             args matcher <span className="font-normal text-muted-foreground">(optional)</span>
           </label>
           <Input
@@ -412,7 +410,7 @@ function RuleEditor({
 
         <div className="flex gap-2">
           <div className="flex flex-1 flex-col gap-1.5">
-            <label className="text-[11px] font-semibold text-foreground">decision</label>
+            <label className="text-xs font-semibold text-foreground">decision</label>
             <select
               className="w-full rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
               value={form.decision}
@@ -428,7 +426,7 @@ function RuleEditor({
             </select>
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
-            <label className="text-[11px] font-semibold text-foreground">priority</label>
+            <label className="text-xs font-semibold text-foreground">priority</label>
             <Input
               type="number"
               step="1"
@@ -440,12 +438,12 @@ function RuleEditor({
         </div>
 
         {preview && (
-          <div className="rounded bg-muted px-2.5 py-2 font-mono text-[10px] text-muted-foreground">
+          <div className="rounded bg-muted px-2.5 py-2 font-mono text-2xs text-muted-foreground">
             renders as: <span className="text-foreground">{preview}</span>
           </div>
         )}
 
-        {error && <p className="text-[11px] text-danger">{error}</p>}
+        {error && <p className="text-xs text-danger">{error}</p>}
 
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -160,7 +160,7 @@ export function PhasesPanel({ workspaceId }: PhasesPanelProps) {
       </div>
 
       {templates.length === 0 ? (
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-2xs text-muted-foreground">
           no phase templates for this workspace. create one to run multi-phase sessions.
         </p>
       ) : (
@@ -193,23 +193,23 @@ function TemplateRow({
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="font-medium">{template.name}</span>
         {template.description ? (
-          <span className="text-[11px] text-muted-foreground">{template.description}</span>
+          <span className="text-xs text-muted-foreground">{template.description}</span>
         ) : null}
-        <span className="text-[10px] text-muted-foreground/60">
+        <span className="text-2xs text-muted-foreground/60">
           {template.definitions.length} phase{template.definitions.length !== 1 ? 's' : ''}
         </span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <button
           type="button"
-          className="text-[11px] text-muted-foreground underline hover:text-foreground"
+          className="text-xs text-muted-foreground underline hover:text-foreground"
           onClick={onEdit}
         >
           edit
         </button>
         <button
           type="button"
-          className="text-[11px] text-muted-foreground underline hover:text-danger"
+          className="text-xs text-muted-foreground underline hover:text-danger"
           onClick={onDelete}
         >
           delete
@@ -273,7 +273,7 @@ function PhaseEditor({
 
       <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">name</label>
+          <label className="text-xs font-semibold text-foreground">name</label>
           <Input
             value={form.name}
             onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -282,7 +282,7 @@ function PhaseEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">description</label>
+          <label className="text-xs font-semibold text-foreground">description</label>
           <Input
             value={form.description}
             onChange={(e) => onChange({ ...form, description: e.target.value })}
@@ -292,10 +292,10 @@ function PhaseEditor({
 
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between">
-            <span className="text-[11px] font-semibold text-foreground">phases</span>
+            <span className="text-xs font-semibold text-foreground">phases</span>
             <button
               type="button"
-              className="text-[11px] text-primary underline hover:opacity-80"
+              className="text-xs text-primary underline hover:opacity-80"
               onClick={addDefinition}
             >
               add phase
@@ -316,7 +316,7 @@ function PhaseEditor({
           ))}
         </div>
 
-        {error ? <p className="text-[11px] text-danger">{error}</p> : null}
+        {error ? <p className="text-xs text-danger">{error}</p> : null}
 
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
@@ -351,11 +351,11 @@ function DefinitionEditor({
   return (
     <div className="flex flex-col gap-2 rounded border border-border-soft bg-background p-2.5">
       <div className="flex items-center justify-between">
-        <span className="text-[10px] font-semibold text-muted-foreground">phase {ordinal + 1}</span>
+        <span className="text-2xs font-semibold text-muted-foreground">phase {ordinal + 1}</span>
         <div className="flex items-center gap-1">
           <button
             type="button"
-            className="text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-30"
+            className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-30"
             onClick={onMoveUp}
             disabled={ordinal === 0}
             title="move up"
@@ -364,7 +364,7 @@ function DefinitionEditor({
           </button>
           <button
             type="button"
-            className="text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-30"
+            className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-30"
             onClick={onMoveDown}
             disabled={ordinal === total - 1}
             title="move down"
@@ -373,7 +373,7 @@ function DefinitionEditor({
           </button>
           <button
             type="button"
-            className="text-[11px] text-muted-foreground hover:text-danger"
+            className="text-xs text-muted-foreground hover:text-danger"
             onClick={onRemove}
             title="remove phase"
           >
@@ -384,7 +384,7 @@ function DefinitionEditor({
 
       <div className="flex gap-2">
         <div className="flex flex-1 flex-col gap-1">
-          <label className="text-[10px] font-semibold text-foreground">name</label>
+          <label className="text-2xs font-semibold text-foreground">name</label>
           <Input
             value={def.name}
             onChange={(e) => onUpdate({ name: e.target.value })}
@@ -394,7 +394,7 @@ function DefinitionEditor({
       </div>
 
       <div className="flex flex-col gap-1">
-        <label className="text-[10px] font-semibold text-foreground">prompt prefix</label>
+        <label className="text-2xs font-semibold text-foreground">prompt prefix</label>
         <Textarea
           value={def.promptPrefix}
           onChange={(e) => onUpdate({ promptPrefix: e.target.value })}
@@ -406,7 +406,7 @@ function DefinitionEditor({
 
       <div className="flex gap-2">
         <div className="flex flex-1 flex-col gap-1">
-          <label className="text-[10px] font-semibold text-foreground">provider override</label>
+          <label className="text-2xs font-semibold text-foreground">provider override</label>
           <select
             value={def.providerOverride}
             onChange={(e) => onUpdate({ providerOverride: e.target.value })}
@@ -421,7 +421,7 @@ function DefinitionEditor({
           </select>
         </div>
         <div className="flex flex-1 flex-col gap-1">
-          <label className="text-[10px] font-semibold text-foreground">model override</label>
+          <label className="text-2xs font-semibold text-foreground">model override</label>
           <Input
             value={def.modelOverride}
             onChange={(e) => onUpdate({ modelOverride: e.target.value })}

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -50,12 +50,16 @@ export function ProvidersPanel() {
           {refreshing ? 'refreshing…' : 'refresh all'}
         </Button>
       </div>
-      <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
-        {providers.map((p) => (
-          <ProviderRow key={p.id} info={p} onRefresh={onRefresh} />
-        ))}
-      </ul>
-      <p className="text-[11px] text-muted-foreground">
+      {providers.length === 0 ? (
+        <p className="text-2xs text-muted-foreground">no providers configured</p>
+      ) : (
+        <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
+          {providers.map((p) => (
+            <ProviderRow key={p.id} info={p} onRefresh={onRefresh} />
+          ))}
+        </ul>
+      )}
+      <p className="text-xs text-muted-foreground">
         kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run{' '}
         <code className="rounded bg-muted px-1">claude</code> in a terminal once).
       </p>
@@ -76,15 +80,15 @@ function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-2">
           <span className="font-medium">{info.label}</span>
-          <code className="text-[10px] text-muted-foreground">{info.binary}</code>
+          <code className="text-2xs text-muted-foreground">{info.binary}</code>
           {info.version ? (
-            <span className="rounded bg-muted px-1 text-[10px] text-muted-foreground">
+            <span className="rounded bg-muted px-1 text-2xs text-muted-foreground">
               {info.version}
             </span>
           ) : null}
           {info.id !== 'anthropic' ? (
             <span
-              className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+              className="rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground"
               title="v0.7 will extend the permission proxy to cursor and codex. For now, these providers continue with their previous defaults."
             >
               permission proxy: not supported
@@ -101,19 +105,17 @@ function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =>
 function RowStatus({ info }: { info: ProviderInfo }) {
   if (info.connection === 'connected') {
     return (
-      <div className="text-[11px] text-muted-foreground">
-        {info.identity ?? 'no identity reported'}
-      </div>
+      <div className="text-xs text-muted-foreground">{info.identity ?? 'no identity reported'}</div>
     );
   }
   if (info.connection === 'error') {
     return (
-      <div className="text-[11px]">
+      <div className="text-xs">
         <span className="text-danger">{info.error ?? 'unknown error'}</span>
       </div>
     );
   }
-  return <div className="text-[11px] text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
+  return <div className="text-xs text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
 }
 
 function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
@@ -132,7 +134,7 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     return info.trackingIssueUrl ? (
       <button
         type="button"
-        className="shrink-0 text-[11px] text-muted-foreground underline hover:text-foreground"
+        className="shrink-0 text-xs text-muted-foreground underline hover:text-foreground"
         onClick={() => void openUrl(info.trackingIssueUrl!)}
       >
         track ↗
@@ -144,7 +146,7 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     return (
       <button
         type="button"
-        className="shrink-0 text-[11px] text-primary underline hover:opacity-80"
+        className="shrink-0 text-xs text-primary underline hover:opacity-80"
         onClick={() => void openUrl(info.docsUrl)}
       >
         install ↗
@@ -165,14 +167,14 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
       <div className="flex shrink-0 flex-col items-end gap-0.5">
         <button
           type="button"
-          className="text-[11px] text-primary underline hover:opacity-80 disabled:opacity-50"
+          className="text-xs text-primary underline hover:opacity-80 disabled:opacity-50"
           disabled={pending === 'login'}
           onClick={() => void onAction('login')}
         >
           connect ↗
         </button>
         {pending === 'login' ? (
-          <span className="text-[10px] text-muted-foreground">
+          <span className="text-2xs text-muted-foreground">
             complete in terminal, then{' '}
             <button
               type="button"
@@ -203,14 +205,14 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
         <div className="flex flex-col items-end gap-0.5">
           <button
             type="button"
-            className="text-[11px] text-muted-foreground underline hover:text-foreground disabled:opacity-50"
+            className="text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50"
             disabled={pending === 'logout'}
             onClick={() => void onAction('logout')}
           >
             disconnect ↗
           </button>
           {pending === 'logout' ? (
-            <span className="text-[10px] text-muted-foreground">
+            <span className="text-2xs text-muted-foreground">
               complete in terminal, then{' '}
               <button
                 type="button"

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -249,7 +249,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             import config
           </Button>
         </div>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
+        <p className="text-xs leading-relaxed text-muted-foreground">
           export saves workspaces, skills, phase templates, permission rules, budget rules, and
           settings to a json file. api keys are never included.
         </p>
@@ -278,7 +278,7 @@ function Section({
     <div className="flex flex-col gap-1.5">
       <div className="text-xs font-semibold text-foreground">{label}</div>
       {children}
-      {help ? <p className="text-[11px] leading-relaxed text-muted-foreground">{help}</p> : null}
+      {help ? <p className="text-xs leading-relaxed text-muted-foreground">{help}</p> : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/SkillsPanel.tsx
+++ b/apps/desktop/src/components/SkillsPanel.tsx
@@ -167,7 +167,7 @@ export function SkillsPanel({ workspaceId }: SkillsPanelProps) {
       </div>
 
       {skills.length === 0 ? (
-        <p className="text-[11px] text-muted-foreground">
+        <p className="text-2xs text-muted-foreground">
           no skills for this workspace. create one or rescan the workspace directory.
         </p>
       ) : (
@@ -200,21 +200,21 @@ function SkillRow({
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <span className="font-medium">/{skill.name}</span>
         {skill.description ? (
-          <span className="text-[11px] text-muted-foreground">{skill.description}</span>
+          <span className="text-xs text-muted-foreground">{skill.description}</span>
         ) : null}
-        <span className="truncate text-[10px] text-muted-foreground/60">{skill.filePath}</span>
+        <span className="truncate text-2xs text-muted-foreground/60">{skill.filePath}</span>
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <button
           type="button"
-          className="text-[11px] text-muted-foreground underline hover:text-foreground"
+          className="text-xs text-muted-foreground underline hover:text-foreground"
           onClick={onEdit}
         >
           edit
         </button>
         <button
           type="button"
-          className="text-[11px] text-muted-foreground underline hover:text-danger"
+          className="text-xs text-muted-foreground underline hover:text-danger"
           onClick={onDelete}
         >
           delete
@@ -249,7 +249,7 @@ function SkillEditor({
 
       <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">name</label>
+          <label className="text-xs font-semibold text-foreground">name</label>
           <Input
             value={form.name}
             onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -258,7 +258,7 @@ function SkillEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">description</label>
+          <label className="text-xs font-semibold text-foreground">description</label>
           <Input
             value={form.description}
             onChange={(e) => onChange({ ...form, description: e.target.value })}
@@ -268,9 +268,7 @@ function SkillEditor({
 
         <div className="flex gap-2">
           <div className="flex flex-1 flex-col gap-1.5">
-            <label className="text-[11px] font-semibold text-foreground">
-              args (comma-separated)
-            </label>
+            <label className="text-xs font-semibold text-foreground">args (comma-separated)</label>
             <Input
               value={form.args}
               onChange={(e) => onChange({ ...form, args: e.target.value })}
@@ -278,7 +276,7 @@ function SkillEditor({
             />
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
-            <label className="text-[11px] font-semibold text-foreground">
+            <label className="text-xs font-semibold text-foreground">
               scripts (comma-separated)
             </label>
             <Input
@@ -290,7 +288,7 @@ function SkillEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-[11px] font-semibold text-foreground">body</label>
+          <label className="text-xs font-semibold text-foreground">body</label>
           <Textarea
             value={form.body}
             onChange={(e) => onChange({ ...form, body: e.target.value })}
@@ -300,7 +298,7 @@ function SkillEditor({
           />
         </div>
 
-        {error ? <p className="text-[11px] text-danger">{error}</p> : null}
+        {error ? <p className="text-xs text-danger">{error}</p> : null}
 
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>

--- a/apps/desktop/src/components/StatusBadge.tsx
+++ b/apps/desktop/src/components/StatusBadge.tsx
@@ -14,7 +14,7 @@ export function StatusBadge({ state, className }: { state: SessionState; classNa
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide',
+        'inline-flex items-center rounded-full px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide',
         TONE[state.kind],
         className,
       )}

--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -48,7 +48,7 @@ function ProviderSpendRow({ entry }: { entry: ProviderSpendEntry }) {
       {hasCap ? (
         <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
           <div
-            className={cn('h-full rounded-full transition-all', spendColor(entry.pct))}
+            className={cn('h-full rounded-full motion-safe:transition-all', spendColor(entry.pct))}
             style={{ width: `${pctClamped * 100}%` }}
           />
         </div>
@@ -159,7 +159,7 @@ export function TelemetryPill() {
 
           {providerSpendBreakdown.length > 0 ? (
             <div className="mt-2 border-b border-border pb-2">
-              <p className="mb-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              <p className="mb-1 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
                 by provider
               </p>
               <ul className="flex flex-col divide-y divide-border">
@@ -180,7 +180,7 @@ export function TelemetryPill() {
                     <span className="flex items-center gap-1 text-muted-foreground">
                       <span
                         className={cn(
-                          'rounded px-1 text-[10px] uppercase',
+                          'rounded px-1 text-2xs uppercase',
                           record.kind === 'summarizer'
                             ? 'bg-muted text-muted-foreground'
                             : 'bg-primary/10 text-primary',
@@ -189,7 +189,7 @@ export function TelemetryPill() {
                         {record.kind}
                       </span>
                       {hasMultipleProviders ? (
-                        <span className="rounded bg-muted px-1 text-[10px] text-muted-foreground">
+                        <span className="rounded bg-muted px-1 text-2xs text-muted-foreground">
                           {record.provider === 'anthropic' ? 'claude' : record.provider}
                         </span>
                       ) : null}
@@ -223,7 +223,7 @@ function SortChip({
       type="button"
       onClick={onClick}
       className={cn(
-        'rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+        'rounded px-1.5 py-0.5 text-2xs uppercase tracking-wide',
         active ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
       )}
     >

--- a/apps/desktop/src/components/Toast.tsx
+++ b/apps/desktop/src/components/Toast.tsx
@@ -95,7 +95,7 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
   return (
     <div
       className={cn(
-        'pointer-events-auto flex max-w-xs items-start gap-2 rounded-lg border px-3 py-2.5 shadow-md transition-all duration-200',
+        'pointer-events-auto flex max-w-xs items-start gap-2 rounded-lg border px-3 py-2.5 shadow-md motion-safe:transition-all motion-safe:duration-200',
         visible ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0',
         toast.kind === 'error'
           ? 'border-danger/30 bg-background text-danger'

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -46,24 +46,38 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
     <div className="flex h-full min-h-0 flex-col">
       <ScrollArea className="flex-1">
         <Section title="workspaces">
-          <ul className="flex flex-col gap-0.5">
-            {workspaces.map((ws) => (
-              <WorkspaceRow
-                key={ws.id}
-                workspace={ws}
-                isActive={ws.id === currentWorkspace?.id}
-                onClick={() => void setCurrentWorkspace(ws.id)}
-                onDelete={() => setWorkspaceToDelete(ws)}
-              />
-            ))}
-            <li>
-              <AddRow
-                label="add workspace"
-                icon={<FolderPlus size={13} aria-hidden />}
+          {workspaces.length === 0 ? (
+            <div className="px-3 py-6 text-center text-2xs text-muted-foreground">
+              no workspaces yet
+              <br />
+              <button
+                type="button"
+                className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
                 onClick={() => setAddWorkspaceOpen(true)}
-              />
-            </li>
-          </ul>
+              >
+                create one
+              </button>
+            </div>
+          ) : (
+            <ul className="flex flex-col gap-0.5">
+              {workspaces.map((ws) => (
+                <WorkspaceRow
+                  key={ws.id}
+                  workspace={ws}
+                  isActive={ws.id === currentWorkspace?.id}
+                  onClick={() => void setCurrentWorkspace(ws.id)}
+                  onDelete={() => setWorkspaceToDelete(ws)}
+                />
+              ))}
+              <li>
+                <AddRow
+                  label="add workspace"
+                  icon={<FolderPlus size={13} aria-hidden />}
+                  onClick={() => setAddWorkspaceOpen(true)}
+                />
+              </li>
+            </ul>
+          )}
         </Section>
 
         <div className="my-2 border-t border-border-soft" />
@@ -73,7 +87,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           subtitle={currentWorkspace ? currentWorkspace.name : 'select a workspace'}
         >
           {!currentWorkspace ? (
-            <p className="px-2 py-1 text-[11px] text-muted-foreground">
+            <p className="px-2 py-1 text-xs text-muted-foreground">
               pick a workspace to see its sessions.
             </p>
           ) : (
@@ -128,11 +142,11 @@ function Section({ title, subtitle, children }: SectionProps) {
   return (
     <section className="flex flex-col px-2 pt-3">
       <header className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
-        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
           {title}
         </span>
         {subtitle ? (
-          <span className="line-clamp-1 text-[10px] text-muted-foreground/80">{subtitle}</span>
+          <span className="line-clamp-1 text-2xs text-muted-foreground/80">{subtitle}</span>
         ) : null}
       </header>
       {children}
@@ -152,7 +166,7 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
     <li className="group">
       <div
         className={cn(
-          'flex items-center gap-1 rounded-md transition-colors',
+          'flex items-center gap-1 rounded-md motion-safe:transition-colors',
           isActive ? 'bg-muted text-foreground' : 'hover:bg-muted/60',
         )}
       >
@@ -181,7 +195,7 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
             e.stopPropagation();
             onDelete();
           }}
-          className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground/50 hover:!text-danger"
+          className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/0 motion-safe:transition-colors group-hover:text-muted-foreground/50 hover:!text-danger"
           title="delete workspace"
           aria-label={`delete workspace ${workspace.name}`}
         >
@@ -247,7 +261,7 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
     <li className="group">
       <div
         className={cn(
-          'flex flex-col gap-1 rounded-md px-2 py-1.5 transition-colors',
+          'flex flex-col gap-1 rounded-md px-2 py-1.5 motion-safe:transition-colors',
           isActive ? 'bg-muted' : 'hover:bg-muted/60',
         )}
       >
@@ -267,7 +281,7 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
           <div className="flex shrink-0 items-center gap-1">
             <span
               className={cn(
-                'inline-flex items-center rounded-sm px-1 py-0.5 text-[10px] font-medium leading-none',
+                'inline-flex items-center rounded-sm px-1 py-0.5 text-2xs font-medium leading-none',
                 PROVIDER_CHIP_COLOR[providerId],
               )}
               title={providerId}
@@ -282,17 +296,17 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
           <div className="flex flex-col gap-0.5 pl-3.5">
             <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
               <div
-                className={cn('h-full rounded-full transition-all', barColor)}
+                className={cn('h-full rounded-full motion-safe:transition-all', barColor)}
                 style={{ width: `${Math.min((pct ?? 0) * 100, 100)}%` }}
               />
             </div>
             <div className="flex items-center justify-between">
-              <span className="text-[10px] text-muted-foreground">
+              <span className="text-2xs text-muted-foreground">
                 ${spent.toFixed(2)} /{' '}
                 {editingCap ? null : (
                   <button
                     type="button"
-                    className="text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+                    className="text-2xs text-muted-foreground underline-offset-2 hover:underline"
                     onClick={onCapClick}
                     title="click to edit cap"
                   >
@@ -311,7 +325,7 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
                   onBlur={() => void onCapSave()}
                   onKeyDown={onCapKeyDown}
                   onClick={(e) => e.stopPropagation()}
-                  className="ml-1 w-16 rounded border border-border bg-background px-1 py-0 text-[10px] outline-none focus:ring-1 focus:ring-primary"
+                  className="ml-1 w-16 rounded border border-border bg-background px-1 py-0 text-2xs outline-none focus:ring-1 focus:ring-primary"
                 />
               )}
             </div>
@@ -333,7 +347,7 @@ function AddRow({ label, icon, onClick }: AddRowProps) {
     <button
       type="button"
       onClick={onClick}
-      className="mt-0.5 flex w-full items-center gap-2 rounded-md border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+      className="mt-0.5 flex w-full items-center gap-2 rounded-md border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground motion-safe:transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
     >
       <span className="text-muted-foreground" aria-hidden>
         {icon}
@@ -417,7 +431,7 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
             browse
           </Button>
         </div>
-        <p className="text-[11px] leading-relaxed text-muted-foreground">
+        <p className="text-xs leading-relaxed text-muted-foreground">
           the directory must contain a `.git` folder.
         </p>
       </div>

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -68,7 +68,7 @@ export function ChatHeader({
             />
           ) : null}
         </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           <button
             type="button"
             onClick={() => void onCopyWorktree()}
@@ -142,7 +142,7 @@ function PhaseProgressPill({ sessionId }: { sessionId: SessionId }) {
   if (!current) return null;
 
   return (
-    <div className="inline-flex items-center gap-1.5 rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-[10px] text-muted-foreground">
+    <div className="inline-flex items-center gap-1.5 rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-2xs text-muted-foreground">
       <span className="font-mono">
         {displayIdx + 1}/{sorted.length} · {current.name}
       </span>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -268,7 +268,7 @@ function PreflightPill({
         type="button"
         onClick={openSettings}
         title="v0.7 will extend permission coverage to this provider."
-        className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted"
+        className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-2xs text-muted-foreground hover:bg-muted"
       >
         permission proxy: claude only
       </button>
@@ -290,7 +290,7 @@ function PreflightPill({
       type="button"
       onClick={openSettings}
       title={tooltipLines || 'no permission rules configured'}
-      className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted"
+      className="self-start rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-2xs text-muted-foreground hover:bg-muted"
     >
       permissions: {allowedTools.length} allow / {disallowedTools.length} deny
     </button>
@@ -299,7 +299,7 @@ function PreflightPill({
 
 function ModelChip({ provider, model }: { provider: ProviderId; model: string }) {
   return (
-    <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
+    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
       <Cpu size={11} aria-hidden />
       <span className="font-mono">
         {PROVIDER_LABEL[provider]} · {model}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -53,7 +53,7 @@ function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
       data-run-column={runId}
       className="flex min-w-0 flex-col border-r border-border last:border-r-0"
     >
-      <div className="border-b border-border px-3 py-1.5 text-[11px] font-medium text-muted-foreground">
+      <div className="border-b border-border px-3 py-1.5 text-xs font-medium text-muted-foreground">
         p{index + 1}
       </div>
       <div
@@ -199,7 +199,7 @@ export function ChatView({ session, onRequestEnd }: ChatViewProps) {
             <button
               type="button"
               data-testid="merge-dialog-trigger"
-              className="rounded border border-border bg-background px-3 py-1 text-xs transition-colors hover:bg-muted"
+              className="rounded border border-border bg-background px-3 py-1 text-xs motion-safe:transition-colors hover:bg-muted"
               onClick={() => setMergeDialogOpen(true)}
             >
               merge

--- a/apps/desktop/src/components/chat/MergeDialog.tsx
+++ b/apps/desktop/src/components/chat/MergeDialog.tsx
@@ -87,7 +87,7 @@ export function MergeDialog({ open, conflicts, onResolve, onCancel }: MergeDialo
           that wire-up lands in I1 #212. When available, replace this placeholder
           with a per-conflict <DiffPreview> component rendered below the radio list. */}
       {conflicts.length > 0 ? (
-        <p className="text-[11px] text-muted-foreground/60 italic">
+        <p className="text-xs text-muted-foreground/60 italic">
           diff preview: [follow-on issue, not blocking merge]
         </p>
       ) : null}

--- a/apps/desktop/src/components/chat/ParallelProgressPill.tsx
+++ b/apps/desktop/src/components/chat/ParallelProgressPill.tsx
@@ -8,7 +8,7 @@ interface ParallelProgressPillProps {
 }
 
 const BADGE_CLASSES: Record<PhaseRunStatus, string> = {
-  running: 'bg-blue-500 animate-pulse',
+  running: 'bg-blue-500 motion-safe:animate-pulse',
   completed: 'bg-green-500',
   failed: 'bg-red-500',
   skipped: 'bg-muted-foreground/40',
@@ -34,7 +34,7 @@ export function ParallelProgressPill({
             title={`run p${i + 1} — ${status}`}
             onClick={() => onSelectRun(runId)}
             className={cn(
-              'inline-block h-2 w-2 rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              'inline-block h-2 w-2 rounded-full motion-safe:transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
               BADGE_CLASSES[status],
             )}
           />

--- a/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
+++ b/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
@@ -204,14 +204,14 @@ export function PermissionAuditPanel({ sessionId, open, onClose }: Props) {
                 return (
                   <div key={runId} className="flex flex-col gap-1">
                     <div className="flex items-center gap-2">
-                      <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/60">
+                      <span className="text-2xs font-semibold uppercase tracking-wider text-muted-foreground/60">
                         run
                       </span>
-                      <span className="font-mono text-[10px] text-muted-foreground">
+                      <span className="font-mono text-2xs text-muted-foreground">
                         {String(runId).slice(0, 12)}…
                       </span>
                       {firstAt ? (
-                        <span className="text-[10px] text-muted-foreground/60">
+                        <span className="text-2xs text-muted-foreground/60">
                           {formatTime(firstAt)}
                         </span>
                       ) : null}
@@ -249,10 +249,10 @@ function AuditRow({ entry }: { entry: PermissionAuditEntry }) {
 
   return (
     <li className="flex items-start gap-3 px-3 py-2 text-xs">
-      <span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">
+      <span className="shrink-0 font-mono text-2xs text-muted-foreground/70">
         {formatTime(entry.request.at)}
       </span>
-      <span className="min-w-0 flex-1 font-mono text-[11px]">
+      <span className="min-w-0 flex-1 font-mono text-xs">
         <span className="font-semibold">{entry.request.toolName}</span>
         <span className="ml-1 text-muted-foreground">{inputPreview(entry.request.input)}</span>
       </span>
@@ -260,13 +260,13 @@ function AuditRow({ entry }: { entry: PermissionAuditEntry }) {
         <span
           className={
             isAllow
-              ? 'rounded-full bg-green-100 px-1.5 py-0.5 text-[10px] font-medium text-green-700'
-              : 'rounded-full bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700'
+              ? 'rounded-full bg-green-100 px-1.5 py-0.5 text-2xs font-medium text-green-700'
+              : 'rounded-full bg-red-100 px-1.5 py-0.5 text-2xs font-medium text-red-700'
           }
         >
           {isAllow ? 'allow' : 'deny'}
         </span>
-        <span className="text-[9px] text-muted-foreground/60">{ruleLabel}</span>
+        <span className="text-2xs text-muted-foreground/60">{ruleLabel}</span>
       </div>
     </li>
   );

--- a/apps/desktop/src/components/chat/PermissionDecisionCard.tsx
+++ b/apps/desktop/src/components/chat/PermissionDecisionCard.tsx
@@ -19,17 +19,17 @@ export function PermissionDecisionCard({ item }: PermissionDecisionCardProps) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted px-2 py-1.5 text-xs">
-      <span className="rounded bg-background px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <span className="rounded bg-background px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
         perm decision
       </span>
       <code className="font-mono text-foreground">{item.toolUseId}</code>
       <span className={cn('font-semibold', DECISION_TONE[item.decision])}>{item.decision}</span>
       {item.ruleId !== null ? (
-        <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-secondary-foreground">
+        <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-2xs text-secondary-foreground">
           {item.ruleId}
         </span>
       ) : null}
-      <span className="ml-auto text-[10px] text-muted-foreground">{timestamp}</span>
+      <span className="ml-auto text-2xs text-muted-foreground">{timestamp}</span>
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/PermissionRequestCard.tsx
+++ b/apps/desktop/src/components/chat/PermissionRequestCard.tsx
@@ -13,11 +13,11 @@ export function PermissionRequestCard({ item }: PermissionRequestCardProps) {
 
   return (
     <div className="flex flex-wrap items-center gap-2 rounded-md border border-border bg-muted px-2 py-1.5 text-xs">
-      <span className="rounded bg-background px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <span className="rounded bg-background px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
         perm request
       </span>
       <code className="font-mono text-foreground">{item.toolName}</code>
-      <span className="ml-auto text-[10px] text-muted-foreground">{timestamp}</span>
+      <span className="ml-auto text-2xs text-muted-foreground">{timestamp}</span>
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/PhaseTransitionCard.tsx
+++ b/apps/desktop/src/components/chat/PhaseTransitionCard.tsx
@@ -22,17 +22,17 @@ export function PhaseTransitionCard({ item }: PhaseTransitionCardProps) {
         onOpenChange={setOpen}
         trigger={
           <span className="flex items-center gap-2 text-xs font-medium">
-            <span className="rounded bg-background px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            <span className="rounded bg-background px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
               phase
             </span>
             {header}
           </span>
         }
       >
-        <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-background p-2 text-[11px] text-muted-foreground">
+        <pre className="mt-1 overflow-x-auto whitespace-pre-wrap rounded bg-background p-2 text-xs text-muted-foreground">
           {item.carryForwardContext}
         </pre>
-        <p className="mt-1 text-right text-[10px] text-muted-foreground">{timestamp}</p>
+        <p className="mt-1 text-right text-2xs text-muted-foreground">{timestamp}</p>
       </Collapsible>
     </div>
   );

--- a/apps/desktop/src/components/chat/RoutingIndicator.tsx
+++ b/apps/desktop/src/components/chat/RoutingIndicator.tsx
@@ -62,7 +62,7 @@ export function RoutingIndicator({
             {label} / {decision.selectedModel}
           </span>
           {decision.reason === 'override' ? (
-            <span className="rounded bg-accent px-1 py-0.5 text-[10px] font-medium text-accent-foreground">
+            <span className="rounded bg-accent px-1 py-0.5 text-2xs font-medium text-accent-foreground">
               override
             </span>
           ) : null}

--- a/apps/desktop/src/components/chat/SkillInvocationCard.tsx
+++ b/apps/desktop/src/components/chat/SkillInvocationCard.tsx
@@ -7,14 +7,14 @@ interface SkillInvocationCardProps {
 export function SkillInvocationCard({ item }: SkillInvocationCardProps) {
   return (
     <div className="flex flex-wrap items-center gap-2 border-l-2 border-primary/40 pl-3 py-1">
-      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
         skill
       </span>
       <span className="text-xs font-medium text-foreground">{item.skillName}</span>
       {item.args.map((arg, idx) => (
         <span
           key={idx}
-          className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-secondary-foreground"
+          className="rounded bg-secondary px-1.5 py-0.5 font-mono text-xs text-secondary-foreground"
         >
           {arg}
         </span>

--- a/apps/desktop/src/components/chat/SlashCommandPopover.tsx
+++ b/apps/desktop/src/components/chat/SlashCommandPopover.tsx
@@ -59,7 +59,7 @@ export function SlashCommandPopover({
   return (
     <div className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-background shadow-md">
       {filtered.length === 0 ? (
-        <p className="px-3 py-2 text-[11px] text-muted-foreground">
+        <p className="px-3 py-2 text-xs text-muted-foreground">
           no skills — create one in settings
         </p>
       ) : (
@@ -78,7 +78,7 @@ export function SlashCommandPopover({
             >
               <span className="text-xs font-medium text-foreground">/{item.name}</span>
               {item.description ? (
-                <span className="text-[11px] text-muted-foreground">{item.description}</span>
+                <span className="text-xs text-muted-foreground">{item.description}</span>
               ) : null}
             </li>
           ))}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -73,7 +73,7 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
 function AssistantText({ text }: { text: string }) {
   return (
     <div className="group relative rounded-lg border border-border bg-background px-3 py-2">
-      <div className="absolute right-1 top-1 opacity-0 transition-opacity group-hover:opacity-100">
+      <div className="absolute right-1 top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
         <CopyButton value={text} label="message" />
       </div>
       <p className="whitespace-pre-wrap text-sm text-foreground">{text}</p>
@@ -91,7 +91,7 @@ function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' 
         onOpenChange={setOpen}
         trigger={
           <span className="flex items-center gap-2 text-xs font-medium">
-            <span className="rounded bg-background px-1.5 py-0.5 font-mono text-[10px] uppercase">
+            <span className="rounded bg-background px-1.5 py-0.5 font-mono text-2xs uppercase">
               tool
             </span>
             {item.toolName}
@@ -103,11 +103,11 @@ function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' 
           </span>
         }
       >
-        <pre className="overflow-x-auto rounded bg-background p-2 text-[11px] text-muted-foreground">
+        <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-muted-foreground">
           input: {JSON.stringify(item.input, null, 2)}
         </pre>
         {item.ended ? (
-          <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-[11px] text-muted-foreground">
+          <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-xs text-muted-foreground">
             output: {JSON.stringify(item.output, null, 2)}
           </pre>
         ) : null}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -77,3 +77,12 @@ dialog::backdrop {
   background-color: oklch(0.18 0.01 270 / 0.45);
   backdrop-filter: blur(2px);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -97,7 +97,7 @@ export function AppShell({
         ) : null}
         {footer ? (
           <footer
-            className="flex h-6 min-w-0 items-center border-t border-border bg-subtle px-3 font-mono text-[11px] text-muted-foreground"
+            className="flex h-6 min-w-0 items-center border-t border-border bg-subtle px-3 font-mono text-xs text-muted-foreground"
             style={{ gridArea: 'footer' }}
           >
             {footer}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -33,7 +33,7 @@ export function Button({
     <button
       type={type}
       className={cn(
-        'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         variantClasses[variant],
         sizeClasses[size],
         className,

--- a/packages/ui/src/components/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible.tsx
@@ -27,7 +27,10 @@ export function Collapsible({
         <span className="flex-1 text-left">{trigger}</span>
         <span
           aria-hidden
-          className={cn('text-muted-foreground transition-transform', open && 'rotate-90')}
+          className={cn(
+            'text-muted-foreground motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
         >
           ›
         </span>

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -107,7 +107,7 @@ export function Dialog({
                 type="button"
                 onClick={onClose}
                 aria-label="close"
-                className="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                className="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
               >
                 <span aria-hidden className="text-base leading-none">
                   ×

--- a/packages/ui/src/components/KbdPill.tsx
+++ b/packages/ui/src/components/KbdPill.tsx
@@ -7,7 +7,7 @@ export function KbdPill({ className, ...rest }: KbdPillProps) {
   return (
     <kbd
       className={cn(
-        'inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-[11px] text-muted-foreground',
+        'inline-flex h-5 min-w-5 items-center justify-center rounded border border-border bg-muted px-1 font-mono text-xs text-muted-foreground',
         className,
       )}
       {...rest}

--- a/packages/ui/src/components/Skeleton.tsx
+++ b/packages/ui/src/components/Skeleton.tsx
@@ -1,0 +1,11 @@
+import { cn } from '../cn';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className }: SkeletonProps) {
+  return (
+    <div className={cn('motion-safe:animate-pulse rounded bg-muted', className)} aria-hidden />
+  );
+}

--- a/packages/ui/src/components/Tooltip.tsx
+++ b/packages/ui/src/components/Tooltip.tsx
@@ -62,7 +62,7 @@ export function Tooltip({ content, side = 'top', children }: TooltipProps) {
         <span
           role="tooltip"
           className={cn(
-            'pointer-events-none absolute z-50 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-[11px] font-medium text-background shadow-sm',
+            'pointer-events-none absolute z-50 whitespace-nowrap rounded bg-foreground px-1.5 py-0.5 text-xs font-medium text-background shadow-sm',
             SIDE_CLASSES[side],
           )}
         >

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,3 +19,4 @@ export { ScrollArea } from './components/ScrollArea';
 export type { ScrollAreaProps } from './components/ScrollArea';
 export { Textarea } from './components/Textarea';
 export type { TextareaProps } from './components/Textarea';
+export { Skeleton } from './components/Skeleton';


### PR DESCRIPTION
## Summary
- Replace inline `text-[10/11/9px]` with `text-2xs`/`text-xs` tokens across all tsx files in `apps/desktop/src` and `packages/ui/src`
- Add `prefers-reduced-motion` CSS gate in `styles.css` + `motion-safe:` prefix on all transition/animation Tailwind classes
- New `Skeleton` primitive exported from `@kay-am/ui` + empty state CTAs in WorkspacesSidebar, ProvidersPanel, SkillsPanel, PhasesPanel

## Test plan
- [ ] No remaining `text-[10px]`/`text-[11px]` inline sizes in tsx files
- [ ] `prefers-reduced-motion` media query present in `styles.css`
- [ ] `motion-safe:` prefix on all transition/animate classes
- [ ] `Skeleton` exported from `@kay-am/ui`
- [ ] WorkspacesSidebar shows "no workspaces yet" + "create one" CTA when empty
- [ ] ProvidersPanel shows "no providers configured" when empty
- [ ] SkillsPanel and PhasesPanel empty state text uses `text-2xs`

Closes #292
Closes #288
Closes #293