### PR TITLE
fix(desktop): pre-1.0 cluster — chat, cli, ui, context

### DIFF
--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -127,12 +127,21 @@ pub(crate) fn spawn_one(
 
     let mut command = Command::new(args.binary);
     command
+        .current_dir(args.working_dir)
+        // Strip env vars that signal "running inside another Claude Code /
+        // Agent SDK session". When kay-am is launched from such a context the
+        // vars propagate to children; the claude CLI then either refuses with
+        // a nested-session error or falls through to broken auth (401). We
+        // want every spawn to behave as a fresh shell invocation that hits
+        // claude's own ~/.claude credentials.
+        .env_remove("CLAUDECODE")
+        .env_remove("CLAUDE_CODE_ENTRYPOINT")
+        .env_remove("CLAUDE_AGENT_SDK_VERSION")
         .arg("-p")
         .arg(args.prompt)
         .arg("--output-format")
         .arg("stream-json")
-        .arg("--working-dir")
-        .arg(args.working_dir)
+        .arg("--verbose")
         .arg("--model")
         .arg(args.model)
         .arg("--permission-mode")

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -47,6 +47,9 @@ export function App() {
   const currentSession = useCurrentSession();
   const slots = useSessionSlots(currentSession?.id ?? null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [settingsInitialSection, setSettingsInitialSection] = useState<string | undefined>(
+    undefined,
+  );
   const [endOpen, setEndOpen] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
@@ -59,7 +62,11 @@ export function App() {
   }, [hydrate]);
 
   useEffect(() => {
-    const handler = () => setSettingsOpen(true);
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ section?: string }>).detail;
+      setSettingsInitialSection(detail?.section);
+      setSettingsOpen(true);
+    };
     window.addEventListener('kayam:open-settings', handler);
     return () => window.removeEventListener('kayam:open-settings', handler);
   }, []);
@@ -152,14 +159,27 @@ export function App() {
         rightSidebarCollapsed={rightSidebarCollapsed}
         footer={<StatusBar />}
       />
-      <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <SettingsDialog
+        open={settingsOpen}
+        onClose={() => {
+          setSettingsOpen(false);
+          setSettingsInitialSection(undefined);
+        }}
+        initialSection={settingsInitialSection}
+      />
       <ShortcutHelpDialog open={shortcutHelpOpen} onClose={() => setShortcutHelpOpen(false)} />
       {paletteOpen ? (
         <CommandPalette
           onClose={() => setPaletteOpen(false)}
-          onOpenSettings={() => { setSettingsOpen(true); setPaletteOpen(false); }}
+          onOpenSettings={() => {
+            setSettingsOpen(true);
+            setPaletteOpen(false);
+          }}
           onNewSession={() => setPaletteOpen(false)}
-          onOpenShortcutHelp={() => { setShortcutHelpOpen(true); setPaletteOpen(false); }}
+          onOpenShortcutHelp={() => {
+            setShortcutHelpOpen(true);
+            setPaletteOpen(false);
+          }}
         />
       ) : null}
       {currentSession ? (

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -33,6 +33,13 @@ vi.mock('../components/Toast', () => ({
 vi.mock('@kay-am/core', () => ({
   buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
   getDefaultTurnModel: () => 'claude-3-5-sonnet-latest',
+  PROVIDER_CAPABILITIES: {
+    anthropic: {
+      models: [{ id: 'claude-3-5-sonnet-latest', tier: 'turn', contextWindow: 200_000 }],
+    },
+    cursor: { models: [{ id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 }] },
+    codex: { models: [{ id: 'codex-latest', tier: 'turn', contextWindow: 128_000 }] },
+  },
   resolveProvider: vi.fn(async () => ({
     selectedProvider: 'anthropic',
     selectedModel: 'claude-3-5-sonnet-latest',

--- a/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
+++ b/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
@@ -104,22 +104,11 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <div
-          class="flex items-center justify-between gap-2"
+        <label
+          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >
-          <label
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            goal
-          </label>
-          <button
-            aria-pressed="true"
-            class="rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide border-primary/30 bg-primary/10 text-primary"
-            type="button"
-          >
-            on
-          </button>
-        </div>
+          goal
+        </label>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -134,22 +123,11 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <div
-          class="flex items-center justify-between gap-2"
+        <label
+          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >
-          <label
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            files touched
-          </label>
-          <button
-            aria-pressed="true"
-            class="rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide border-primary/30 bg-primary/10 text-primary"
-            type="button"
-          >
-            on
-          </button>
-        </div>
+          files touched
+        </label>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -164,22 +142,11 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <div
-          class="flex items-center justify-between gap-2"
+        <label
+          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >
-          <label
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            decisions
-          </label>
-          <button
-            aria-pressed="true"
-            class="rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide border-primary/30 bg-primary/10 text-primary"
-            type="button"
-          >
-            on
-          </button>
-        </div>
+          decisions
+        </label>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -194,22 +161,11 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <div
-          class="flex items-center justify-between gap-2"
+        <label
+          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >
-          <label
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            open questions
-          </label>
-          <button
-            aria-pressed="true"
-            class="rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide border-primary/30 bg-primary/10 text-primary"
-            type="button"
-          >
-            on
-          </button>
-        </div>
+          open questions
+        </label>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -224,22 +180,11 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <div
-          class="flex items-center justify-between gap-2"
+        <label
+          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
         >
-          <label
-            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-          >
-            last output summary
-          </label>
-          <button
-            aria-pressed="true"
-            class="rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide border-primary/30 bg-primary/10 text-primary"
-            type="button"
-          >
-            on
-          </button>
-        </div>
+          last output summary
+        </label>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
   open=""
 >
   <div
-    class="flex max-h-[85vh] min-h-0 flex-col w-[32rem]"
+    class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -154,13 +154,33 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
         >
           phase template (optional)
         </span>
-        bound HTMLSelectElement {
-          "0": <option
-            value=""
+        <span
+          class="relative items-center inline-flex"
+        >
+          bound HTMLSelectElement {
+            "0": <option
+              value=""
+            >
+              none
+            </option>,
+          }
+          <svg
+            aria-hidden="true"
+            class="pointer-events-none absolute text-muted-foreground right-1.5"
+            height="11"
+            viewBox="0 0 16 16"
+            width="11"
           >
-            none
-          </option>,
-        }
+            <path
+              d="M4 6l4 4 4-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </span>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
         >
@@ -380,45 +400,10 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
   class="flex h-full min-h-0 flex-col"
 >
   <div
-    class="flex flex-col gap-1 px-2 pt-2"
-  >
-    <div
-      class="relative flex items-center"
-    >
-      <svg
-        aria-hidden="true"
-        class="lucide lucide-search pointer-events-none absolute left-2 text-muted-foreground"
-        fill="none"
-        height="11"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        width="11"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m21 21-4.34-4.34"
-        />
-        <circle
-          cx="11"
-          cy="11"
-          r="8"
-        />
-      </svg>
-      <input
-        class="w-full rounded-md border border-border-soft bg-muted/40 py-1 pl-6 pr-2 text-xs placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-primary"
-        placeholder="search workspaces…"
-        type="text"
-      />
-    </div>
-  </div>
-  <div
-    class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] flex-1"
+    class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] max-h-[40%] shrink-0"
   >
     <section
-      class="flex flex-col px-2 pt-2"
+      class="flex flex-col px-2 pb-4 pt-3"
     >
       <header
         class="flex items-baseline justify-between gap-2 px-1 pb-1.5"
@@ -429,8 +414,39 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
           workspaces
         </span>
       </header>
+      <div
+        class="relative flex items-center"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-search pointer-events-none absolute left-2 text-muted-foreground"
+          fill="none"
+          height="11"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="11"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m21 21-4.34-4.34"
+          />
+          <circle
+            cx="11"
+            cy="11"
+            r="8"
+          />
+        </svg>
+        <input
+          class="w-full rounded-md border border-border-soft bg-muted/40 py-1 pl-6 pr-2 text-xs placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-primary"
+          placeholder="search workspaces…"
+          type="text"
+        />
+      </div>
       <ul
-        class="flex flex-col gap-0.5"
+        class="mt-1 flex flex-col gap-0.5"
       >
         <li>
           <button
@@ -471,13 +487,39 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
       </ul>
     </section>
   </div>
+  <div
+    aria-hidden="true"
+    class="my-1 border-t border-border"
+  />
+  <div
+    class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] flex-1"
+  >
+    <section
+      class="flex flex-col px-2 pt-4"
+    >
+      <header
+        class="flex items-baseline justify-between gap-2 px-1 pb-1.5"
+      >
+        <span
+          class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
+        >
+          sessions
+        </span>
+      </header>
+      <p
+        class="px-1 py-2 text-xs text-muted-foreground/70"
+      >
+        select a workspace to see its sessions.
+      </p>
+    </section>
+  </div>
   <dialog
     aria-describedby="_r_0_-desc"
     aria-labelledby="_r_0_-title"
     class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
   >
     <div
-      class="flex max-h-[85vh] min-h-0 flex-col w-[32rem]"
+      class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
     >
       <header
         class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -732,7 +774,7 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
   open=""
 >
   <div
-    class="flex max-h-[85vh] min-h-0 flex-col w-[24rem]"
+    class="flex min-h-0 flex-col max-h-[85vh] w-[24rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -807,7 +849,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
   open=""
 >
   <div
-    class="flex max-h-[85vh] min-h-0 flex-col w-[32rem]"
+    class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -913,13 +955,33 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
         >
           phase template (optional)
         </span>
-        bound HTMLSelectElement {
-          "0": <option
-            value=""
+        <span
+          class="relative items-center inline-flex"
+        >
+          bound HTMLSelectElement {
+            "0": <option
+              value=""
+            >
+              none
+            </option>,
+          }
+          <svg
+            aria-hidden="true"
+            class="pointer-events-none absolute text-muted-foreground right-1.5"
+            height="11"
+            viewBox="0 0 16 16"
+            width="11"
           >
-            none
-          </option>,
-        }
+            <path
+              d="M4 6l4 4 4-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+            />
+          </svg>
+        </span>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
         >

--- a/apps/desktop/src/components/BudgetRulesPanel.tsx
+++ b/apps/desktop/src/components/BudgetRulesPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Input } from '@kay-am/ui';
+import { Button, Input, Select } from '@kay-am/ui';
 import type { BudgetRule, ProviderName } from '@kay-am/types';
 import { useAppStore } from '../store';
 
@@ -163,8 +163,9 @@ function AddRuleForm({
     <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
       <div className="flex flex-col gap-1.5">
         <label className="text-xs font-semibold text-foreground">provider</label>
-        <select
-          className="w-full rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        <Select
+          size="sm"
+          block
           value={form.provider}
           onChange={(e) => onChange({ ...form, provider: e.target.value as ProviderName })}
         >
@@ -173,7 +174,7 @@ function AddRuleForm({
               {p}
             </option>
           ))}
-        </select>
+        </Select>
       </div>
 
       <div className="flex gap-2">

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -23,7 +23,6 @@ export function ContextPanel({
   const slots = useSessionSlots(session.id);
   const summarizer = useSummarizerStatus(session.id);
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
-  const toggleSessionSlot = useAppStore((s) => s.toggleSessionSlot);
 
   const slotsByKey = new Map<string, ContextSlot>(slots.map((s) => [s.key, s]));
 
@@ -89,7 +88,6 @@ export function ContextPanel({
                 slotKey={key}
                 slot={slot}
                 onCommit={(value) => void upsertSessionSlot(session.id, key, value)}
-                onToggle={(enabled) => void toggleSessionSlot(session.id, key, enabled)}
               />
             );
           })}
@@ -103,11 +101,9 @@ interface SlotRowProps {
   slotKey: SlotKey;
   slot: ContextSlot | undefined;
   onCommit: (value: string) => void;
-  onToggle: (enabled: boolean) => void;
 }
 
-function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
-  const enabled = slot?.enabled ?? true;
+function SlotRow({ slotKey, slot, onCommit }: SlotRowProps) {
   const value = slot?.value ?? '';
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -123,24 +119,9 @@ function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
 
   return (
     <li className="flex flex-col gap-1.5">
-      <div className="flex items-center justify-between gap-2">
-        <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          {SLOT_LABELS[slotKey]}
-        </label>
-        <button
-          type="button"
-          onClick={() => onToggle(!enabled)}
-          className={cn(
-            'rounded-full border px-1.5 py-0.5 text-2xs uppercase tracking-wide',
-            enabled
-              ? 'border-primary/30 bg-primary/10 text-primary'
-              : 'border-border bg-muted text-muted-foreground',
-          )}
-          aria-pressed={enabled}
-        >
-          {enabled ? 'on' : 'off'}
-        </button>
-      </div>
+      <label className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {SLOT_LABELS[slotKey]}
+      </label>
 
       {editing ? (
         <Textarea
@@ -167,10 +148,7 @@ function SlotRow({ slotKey, slot, onCommit, onToggle }: SlotRowProps) {
         <button
           type="button"
           onClick={() => setEditing(true)}
-          className={cn(
-            'whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40',
-            !enabled && 'opacity-60',
-          )}
+          className="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
         >
           {value.length > 0 ? (
             value

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
+import { Button, Dialog, Input, Select, Textarea, cn } from '@kay-am/ui';
 import type {
   PhaseTemplateId,
   ProviderId,
@@ -160,11 +160,11 @@ export function NewSessionDialog({
             : 'assign a multi-phase workflow to this session.'
         }
       >
-        <select
+        <Select
+          size="sm"
           value={selectedPhaseTemplateId}
           onChange={(e) => setSelectedPhaseTemplateId(e.target.value as PhaseTemplateId | '')}
           disabled={phaseTemplates.length === 0}
-          className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
         >
           <option value="">none</option>
           {phaseTemplates.map((t) => (
@@ -172,7 +172,7 @@ export function NewSessionDialog({
               {t.name}
             </option>
           ))}
-        </select>
+        </Select>
       </Field>
 
       <Field label="provider">

--- a/apps/desktop/src/components/PermissionsPanel.tsx
+++ b/apps/desktop/src/components/PermissionsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Input } from '@kay-am/ui';
+import { Button, Input, Select } from '@kay-am/ui';
 import type { PermissionDecisionKind, PermissionRule, PermissionRuleScope } from '@kay-am/types';
 import { formatToolPattern } from '@kay-am/core';
 import type { PermissionRuleId } from '@kay-am/types';
@@ -411,8 +411,9 @@ function RuleEditor({
         <div className="flex gap-2">
           <div className="flex flex-1 flex-col gap-1.5">
             <label className="text-xs font-semibold text-foreground">decision</label>
-            <select
-              className="w-full rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            <Select
+              size="sm"
+              block
               value={form.decision}
               onChange={(e) =>
                 onChange({ ...form, decision: e.target.value as PermissionDecisionKind })
@@ -423,7 +424,7 @@ function RuleEditor({
                   {d}
                 </option>
               ))}
-            </select>
+            </Select>
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
             <label className="text-xs font-semibold text-foreground">priority</label>

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Button, Input, Textarea } from '@kay-am/ui';
+import { Button, Input, Select, Textarea } from '@kay-am/ui';
 import type {
   PhaseDefinition,
   PhaseDefinitionId,
@@ -407,10 +407,11 @@ function DefinitionEditor({
       <div className="flex gap-2">
         <div className="flex flex-1 flex-col gap-1">
           <label className="text-2xs font-semibold text-foreground">provider override</label>
-          <select
+          <Select
+            size="sm"
+            block
             value={def.providerOverride}
             onChange={(e) => onUpdate({ providerOverride: e.target.value })}
-            className="rounded-md border border-border bg-background px-2 py-1.5 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
           >
             <option value="">default</option>
             {PROVIDER_IDS.map((id) => (
@@ -418,7 +419,7 @@ function DefinitionEditor({
                 {id}
               </option>
             ))}
-          </select>
+          </Select>
         </div>
         <div className="flex flex-1 flex-col gap-1">
           <label className="text-2xs font-semibold text-foreground">model override</label>

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -36,6 +36,7 @@ import { useAppStore, useCurrentWorkspace } from '../store';
 interface SettingsDialogProps {
   open: boolean;
   onClose: () => void;
+  initialSection?: string;
 }
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
@@ -67,7 +68,20 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'advanced', label: 'advanced', icon: <FileDown size={14} aria-hidden /> },
 ];
 
-export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
+function isNavSection(value: string | undefined): value is NavSection {
+  return (
+    value === 'app' ||
+    value === 'providers' ||
+    value === 'budget' ||
+    value === 'agent' ||
+    value === 'skills' ||
+    value === 'phases' ||
+    value === 'permissions' ||
+    value === 'advanced'
+  );
+}
+
+export function SettingsDialog({ open, onClose, initialSection }: SettingsDialogProps) {
   const workspace = useCurrentWorkspace();
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
@@ -95,6 +109,9 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    if (isNavSection(initialSection)) {
+      setActiveSection(initialSection);
+    }
     setSaveState('idle');
     setError(null);
     void loadSetting(SETTING_EDITOR_BINARY).then((v) =>
@@ -116,7 +133,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         setBranchPrefix(v ?? DEFAULT_BRANCH_PREFIX),
       );
     }
-  }, [open, workspace, loadSetting]);
+  }, [open, workspace, loadSetting, initialSection]);
 
   const onExport = async () => {
     setExportState('busy');
@@ -345,6 +362,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       title="settings"
       description="configure providers, editor, and workspace defaults."
       size="xl"
+      fixedHeightClass="h-[640px]"
+      fullScreenOnSmall
       footer={
         <>
           {saveState === 'saved' ? (
@@ -362,8 +381,8 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         </>
       }
     >
-      <div className="flex min-h-[480px] gap-0">
-        <nav className="flex w-40 shrink-0 flex-col gap-0.5 border-r border-border-soft pr-2">
+      <div className="flex h-full min-h-0 gap-0">
+        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2">
           {NAV_ITEMS.map((item) => (
             <button
               key={item.id}
@@ -380,7 +399,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
             </button>
           ))}
         </nav>
-        <div className="min-w-0 flex-1 pl-4">{renderContent()}</div>
+        <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
       </div>
 
       <ImportConfigDialog

--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -19,16 +19,16 @@ type SortKey = 'recent' | 'expensive';
 const SORT_KEY_STORAGE = 'telemetry-sort-key';
 
 function spendColor(pct: number): string {
-  if (pct >= 1) return 'bg-red-500';
-  if (pct >= 0.8) return 'bg-yellow-500';
-  return 'bg-green-500';
+  if (pct >= 1) return 'bg-danger';
+  if (pct >= 0.8) return 'bg-warning';
+  return 'bg-muted-foreground';
 }
 
 function spendTextColor(pct: number, hasCap: boolean): string {
   if (!hasCap) return 'text-foreground';
-  if (pct >= 1) return 'text-red-600';
-  if (pct >= 0.8) return 'text-yellow-600';
-  return 'text-green-700';
+  if (pct >= 1) return 'text-danger';
+  if (pct >= 0.8) return 'text-warning';
+  return 'text-foreground';
 }
 
 function ProviderSpendRow({ entry }: { entry: ProviderSpendEntry }) {
@@ -105,6 +105,28 @@ export function TelemetryPill() {
 
   const hasMultipleProviders = providerSpendBreakdown.length >= 2;
 
+  const modelBreakdown = useMemo(() => {
+    const map = new Map<
+      string,
+      { provider: string; model: string; tokensIn: number; tokensOut: number; spentUsd: number }
+    >();
+    for (const r of sessionTelemetry) {
+      const key = `${r.provider}//${r.model}`;
+      const prev = map.get(key) ?? {
+        provider: r.provider,
+        model: r.model,
+        tokensIn: 0,
+        tokensOut: 0,
+        spentUsd: 0,
+      };
+      prev.tokensIn += r.inputTokens;
+      prev.tokensOut += r.outputTokens;
+      prev.spentUsd += r.estimatedCostUsd;
+      map.set(key, prev);
+    }
+    return [...map.values()].sort((a, b) => b.spentUsd - a.spentUsd);
+  }, [sessionTelemetry]);
+
   const sessionCost = sessionSummary?.estimatedCostUsd ?? 0;
   const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
 
@@ -165,6 +187,35 @@ export function TelemetryPill() {
               <ul className="flex flex-col divide-y divide-border">
                 {providerSpendBreakdown.map((entry) => (
                   <ProviderSpendRow key={entry.provider} entry={entry} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          {modelBreakdown.length > 0 ? (
+            <div className="mt-2 border-b border-border pb-2">
+              <p className="mb-1 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+                by model
+              </p>
+              <ul className="flex flex-col divide-y divide-border">
+                {modelBreakdown.map((entry) => (
+                  <li
+                    key={`${entry.provider}//${entry.model}`}
+                    className="flex flex-col gap-0.5 py-1"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="flex min-w-0 items-center gap-1">
+                        <span className="rounded bg-muted px-1 text-2xs uppercase text-muted-foreground">
+                          {entry.provider === 'anthropic' ? 'cl' : entry.provider.slice(0, 2)}
+                        </span>
+                        <span className="truncate font-mono text-2xs">{entry.model}</span>
+                      </span>
+                      <span className="font-mono text-xs">{formatCost(entry.spentUsd)}</span>
+                    </div>
+                    <div className="text-2xs text-muted-foreground">
+                      {formatTokens(entry.tokensIn)}↓ / {formatTokens(entry.tokensOut)}↑
+                    </div>
+                  </li>
                 ))}
               </ul>
             </div>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,17 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
-import {
-  ChevronDown,
-  ChevronRight,
-  FolderOpen,
-  FolderPlus,
-  Plus,
-  Search,
-  Settings2,
-  Trash2,
-  X,
-} from 'lucide-react';
+import { FolderOpen, FolderPlus, Plus, Search, Settings2, Trash2, X } from 'lucide-react';
 import { WorkspaceSettingsDialog } from './WorkspaceSettingsDialog';
 import type { ProviderId, Session, SessionId, SessionState, Workspace } from '@kay-am/types';
 import {
@@ -30,9 +20,9 @@ interface WorkspacesSidebarProps {
 }
 
 const PROVIDER_CHIP_COLOR: Record<ProviderId, string> = {
-  anthropic: 'bg-orange-100 text-orange-700',
-  cursor: 'bg-blue-100 text-blue-700',
-  codex: 'bg-green-100 text-green-700',
+  anthropic: 'bg-muted text-foreground',
+  cursor: 'bg-muted text-foreground',
+  codex: 'bg-muted text-foreground',
 };
 
 const PROVIDER_SHORT: Record<ProviderId, string> = {
@@ -47,6 +37,8 @@ const STATE_FILTER_OPTIONS: ReadonlyArray<SessionState['kind']> = [
   'ended',
   'error',
 ];
+
+const PROVIDER_FILTER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
 export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const workspaces = useWorkspaces();
@@ -68,13 +60,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [workspaceToDelete, setWorkspaceToDelete] = useState<Workspace | null>(null);
-  const [expandedWorkspaces, setExpandedWorkspaces] = useState<ReadonlySet<string>>(new Set());
-
-  useEffect(() => {
-    if (currentWorkspace) {
-      setExpandedWorkspaces((prev) => new Set([...prev, currentWorkspace.id]));
-    }
-  }, [currentWorkspace]);
 
   const filteredWorkspaces = workspaces.filter((ws) =>
     ws.name.toLowerCase().includes(sidebarWorkspaceSearch.toLowerCase()),
@@ -89,20 +74,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       sidebarProviderFilter.includes(s.providerPreference.defaultProvider);
     return matchesSearch && matchesState && matchesProvider;
   });
-
-  const toggleWorkspaceExpanded = (wsId: string) => {
-    setExpandedWorkspaces((prev) => {
-      const next = new Set(prev);
-      if (next.has(wsId)) {
-        next.delete(wsId);
-      } else {
-        next.add(wsId);
-      }
-      return next;
-    });
-  };
-
-  const providerFilterOptions: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
   const toggleStateFilter = (kind: SessionState['kind']) => {
     const next = sidebarStateFilter.includes(kind)
@@ -120,62 +91,28 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex flex-col gap-1 px-2 pt-2">
-        <SearchInput
-          value={sidebarWorkspaceSearch}
-          onChange={setSidebarWorkspaceSearch}
-          placeholder="search workspaces…"
-        />
-      </div>
-
-      <ScrollArea className="flex-1">
-        <section className="flex flex-col px-2 pt-2">
+      <ScrollArea className="max-h-[40%] shrink-0">
+        <section className="flex flex-col px-2 pb-4 pt-3">
           <header className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
             <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               workspaces
             </span>
           </header>
-          <ul className="flex flex-col gap-0.5">
-            {filteredWorkspaces.map((ws) => {
-              const isActive = ws.id === currentWorkspace?.id;
-              const isExpanded = expandedWorkspaces.has(ws.id);
-              const wsSessions = filteredSessions.filter((s) => s.workspaceId === ws.id);
-
-              return (
-                <WorkspaceRow
-                  key={ws.id}
-                  workspace={ws}
-                  isActive={isActive}
-                  isExpanded={isExpanded}
-                  onToggleExpand={() => toggleWorkspaceExpanded(ws.id)}
-                  onClick={() => void setCurrentWorkspace(ws.id)}
-                  onDelete={() => setWorkspaceToDelete(ws)}
-                  sessionList={
-                    isExpanded ? (
-                      <SessionList
-                        sessions={wsSessions}
-                        currentSessionId={currentSession?.id ?? null}
-                        workspaceId={ws.id}
-                        sidebarSessionSearch={
-                          ws.id === currentWorkspace?.id ? sidebarSessionSearch : ''
-                        }
-                        onSessionSearch={
-                          ws.id === currentWorkspace?.id ? setSidebarSessionSearch : () => undefined
-                        }
-                        stateFilter={sidebarStateFilter}
-                        providerFilter={sidebarProviderFilter}
-                        stateFilterOptions={STATE_FILTER_OPTIONS}
-                        providerFilterOptions={providerFilterOptions}
-                        onToggleState={toggleStateFilter}
-                        onToggleProvider={toggleProviderFilter}
-                        onSelectSession={(id) => void setCurrentSession(id)}
-                        onNewSession={() => setNewSessionOpen(true)}
-                      />
-                    ) : null
-                  }
-                />
-              );
-            })}
+          <SearchInput
+            value={sidebarWorkspaceSearch}
+            onChange={setSidebarWorkspaceSearch}
+            placeholder="search workspaces…"
+          />
+          <ul className="mt-1 flex flex-col gap-0.5">
+            {filteredWorkspaces.map((ws) => (
+              <WorkspaceRow
+                key={ws.id}
+                workspace={ws}
+                isActive={ws.id === currentWorkspace?.id}
+                onClick={() => void setCurrentWorkspace(ws.id)}
+                onDelete={() => setWorkspaceToDelete(ws)}
+              />
+            ))}
             <li>
               <AddRow
                 label="add workspace"
@@ -184,6 +121,43 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
               />
             </li>
           </ul>
+        </section>
+      </ScrollArea>
+
+      <div className="my-1 border-t border-border" aria-hidden />
+
+      <ScrollArea className="flex-1">
+        <section className="flex flex-col px-2 pt-4">
+          <header className="flex items-baseline justify-between gap-2 px-1 pb-1.5">
+            <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              sessions
+            </span>
+            {currentWorkspace ? (
+              <span className="truncate text-2xs text-muted-foreground/70">
+                {currentWorkspace.name}
+              </span>
+            ) : null}
+          </header>
+          {currentWorkspace ? (
+            <SessionList
+              sessions={filteredSessions}
+              currentSessionId={currentSession?.id ?? null}
+              sessionSearch={sidebarSessionSearch}
+              onSessionSearch={setSidebarSessionSearch}
+              stateFilter={sidebarStateFilter}
+              providerFilter={sidebarProviderFilter}
+              stateFilterOptions={STATE_FILTER_OPTIONS}
+              providerFilterOptions={PROVIDER_FILTER_OPTIONS}
+              onToggleState={toggleStateFilter}
+              onToggleProvider={toggleProviderFilter}
+              onSelectSession={(id) => void setCurrentSession(id)}
+              onNewSession={() => setNewSessionOpen(true)}
+            />
+          ) : (
+            <p className="px-1 py-2 text-xs text-muted-foreground/70">
+              select a workspace to see its sessions.
+            </p>
+          )}
         </section>
       </ScrollArea>
 
@@ -245,22 +219,11 @@ function SearchInput({ value, onChange, placeholder }: SearchInputProps) {
 interface WorkspaceRowProps {
   workspace: Workspace;
   isActive: boolean;
-  isExpanded: boolean;
-  onToggleExpand: () => void;
   onClick: () => void;
   onDelete: () => void;
-  sessionList: React.ReactNode;
 }
 
-function WorkspaceRow({
-  workspace,
-  isActive,
-  isExpanded,
-  onToggleExpand,
-  onClick,
-  onDelete,
-  sessionList,
-}: WorkspaceRowProps) {
+function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowProps) {
   const [wsSettingsOpen, setWsSettingsOpen] = useState(false);
 
   return (
@@ -273,10 +236,7 @@ function WorkspaceRow({
       >
         <button
           type="button"
-          onClick={() => {
-            onClick();
-            onToggleExpand();
-          }}
+          onClick={onClick}
           className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
         >
           <span
@@ -292,11 +252,6 @@ function WorkspaceRow({
             className={cn('shrink-0', isActive ? 'text-foreground' : 'text-muted-foreground')}
           />
           <span className="line-clamp-1 flex-1 font-medium">{workspace.name}</span>
-          {isExpanded ? (
-            <ChevronDown size={11} className="shrink-0 text-muted-foreground" aria-hidden />
-          ) : (
-            <ChevronRight size={11} className="shrink-0 text-muted-foreground" aria-hidden />
-          )}
         </button>
         <button
           type="button"
@@ -323,7 +278,6 @@ function WorkspaceRow({
           <Trash2 size={12} aria-hidden />
         </button>
       </div>
-      {sessionList}
       <WorkspaceSettingsDialog
         workspaceId={workspace.id}
         workspaceName={workspace.name}
@@ -337,8 +291,7 @@ function WorkspaceRow({
 interface SessionListProps {
   sessions: ReadonlyArray<Session>;
   currentSessionId: SessionId | null;
-  workspaceId: string;
-  sidebarSessionSearch: string;
+  sessionSearch: string;
   onSessionSearch: (v: string) => void;
   stateFilter: ReadonlyArray<SessionState['kind']>;
   providerFilter: ReadonlyArray<ProviderId>;
@@ -353,7 +306,7 @@ interface SessionListProps {
 function SessionList({
   sessions,
   currentSessionId,
-  sidebarSessionSearch,
+  sessionSearch,
   onSessionSearch,
   stateFilter,
   providerFilter,
@@ -365,9 +318,9 @@ function SessionList({
   onNewSession,
 }: SessionListProps) {
   return (
-    <div className="ml-3 mt-0.5 flex flex-col gap-1 border-l border-border-soft pl-2">
+    <div className="flex flex-col gap-1">
       <SearchInput
-        value={sidebarSessionSearch}
+        value={sessionSearch}
         onChange={onSessionSearch}
         placeholder="search sessions…"
       />
@@ -396,7 +349,7 @@ function SessionList({
             className={cn(
               'rounded px-1 py-0.5 text-2xs font-medium uppercase tracking-wide transition-colors',
               stateFilter.includes(kind)
-                ? 'bg-primary/15 text-primary'
+                ? 'bg-foreground/15 text-foreground'
                 : 'bg-muted text-muted-foreground hover:bg-muted/80',
             )}
           >
@@ -411,7 +364,7 @@ function SessionList({
             className={cn(
               'rounded px-1 py-0.5 text-2xs font-medium uppercase tracking-wide transition-colors',
               providerFilter.includes(p)
-                ? cn(PROVIDER_CHIP_COLOR[p])
+                ? 'bg-foreground/15 text-foreground'
                 : 'bg-muted text-muted-foreground hover:bg-muted/80',
             )}
           >
@@ -448,7 +401,7 @@ interface FilterChipProps {
 
 function FilterChip({ label, onRemove }: FilterChipProps) {
   return (
-    <span className="inline-flex items-center gap-0.5 rounded bg-primary/10 px-1 py-0.5 text-2xs text-primary">
+    <span className="inline-flex items-center gap-0.5 rounded bg-foreground/10 px-1 py-0.5 text-2xs text-foreground">
       {label}
       <button
         type="button"
@@ -469,7 +422,6 @@ interface SessionRowProps {
 }
 
 function SessionRow({ session, isActive, onClick }: SessionRowProps) {
-  const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const providerId = session.providerPreference.defaultProvider;
   const budget = useAppStore((s) => s.sessionBudgets[session.id as SessionId] ?? null);
   const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
@@ -498,7 +450,7 @@ function SessionRow({ session, isActive, onClick }: SessionRowProps) {
   const pct = cap !== null && cap > 0 ? spent / cap : null;
 
   const barColor =
-    pct === null ? '' : pct >= 1 ? 'bg-red-500' : pct >= 0.8 ? 'bg-yellow-400' : 'bg-green-500';
+    pct === null ? '' : pct >= 1 ? 'bg-danger' : pct >= 0.8 ? 'bg-warning' : 'bg-muted-foreground';
 
   const onCapClick = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useMemo, type KeyboardEvent } from 'react';
 import { Cpu } from 'lucide-react';
-import { Button, Textarea } from '@kay-am/ui';
+import { Button, Select, Textarea } from '@kay-am/ui';
 import type {
   BudgetAlert,
   BudgetAlertKind,
@@ -11,7 +11,7 @@ import type {
   TurnProviderOverride,
   WorkspaceId,
 } from '@kay-am/types';
-import { buildClaudeFlags, getDefaultTurnModel } from '@kay-am/core';
+import { PROVIDER_CAPABILITIES, buildClaudeFlags, getDefaultTurnModel } from '@kay-am/core';
 import { useShallow } from 'zustand/react/shallow';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
 import { RoutingIndicator } from './RoutingIndicator';
@@ -70,6 +70,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [showPopover, setShowPopover] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -82,10 +83,20 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const defaultProvider = session.providerPreference.defaultProvider;
 
   const effectiveProvider: ProviderId = selectedProvider ?? defaultProvider;
+  const defaultModel =
+    session.providerPreference.defaultModel ?? getDefaultTurnModel(defaultProvider);
+  const effectiveModel = selectedModel ?? defaultModel;
 
+  const providerModels = PROVIDER_CAPABILITIES[effectiveProvider].models;
+
+  const providerChanged = selectedProvider !== null && selectedProvider !== defaultProvider;
+  const modelChanged = selectedModel !== null && selectedModel !== defaultModel;
   const routingOverride: TurnProviderOverride | undefined =
-    allowOverride && selectedProvider !== null && selectedProvider !== defaultProvider
-      ? { providerId: selectedProvider }
+    allowOverride && (providerChanged || modelChanged)
+      ? {
+          providerId: effectiveProvider,
+          ...(modelChanged ? { model: effectiveModel } : {}),
+        }
       : undefined;
 
   const connectedProviderIds = connectedProviders.map((p) => p.id);
@@ -108,11 +119,15 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setValue('');
 
     const override: TurnProviderOverride | undefined =
-      allowOverride && selectedProvider !== null && selectedProvider !== defaultProvider
-        ? { providerId: selectedProvider }
+      allowOverride && (providerChanged || modelChanged)
+        ? {
+            providerId: effectiveProvider,
+            ...(modelChanged ? { model: effectiveModel } : {}),
+          }
         : undefined;
 
     setSelectedProvider(null);
+    setSelectedModel(null);
     try {
       await sendTurn({
         sessionId: session.id,
@@ -209,14 +224,17 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             </Button>
           ) : (
             <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <span>via</span>
-                <select
+                <Select
+                  size="sm"
                   disabled={!allowOverride || isRunning}
                   title={overrideDisabledTitle}
                   value={effectiveProvider}
-                  onChange={(e) => setSelectedProvider(e.target.value as ProviderId)}
-                  className="rounded border border-border bg-background px-1 py-0.5 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                  onChange={(e) => {
+                    setSelectedProvider(e.target.value as ProviderId);
+                    setSelectedModel(null);
+                  }}
                 >
                   {connectedProviders.map((p) => (
                     <option key={p.id} value={p.id}>
@@ -226,7 +244,23 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
                   {connectedProviders.every((p) => p.id !== defaultProvider) ? (
                     <option value={defaultProvider}>{defaultProvider}</option>
                   ) : null}
-                </select>
+                </Select>
+                <Select
+                  size="sm"
+                  disabled={!allowOverride || isRunning}
+                  title={overrideDisabledTitle ?? 'model for this turn'}
+                  value={effectiveModel}
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                >
+                  {providerModels.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.id}
+                    </option>
+                  ))}
+                  {providerModels.every((m) => m.id !== effectiveModel) ? (
+                    <option value={effectiveModel}>{effectiveModel}</option>
+                  ) : null}
+                </Select>
               </div>
               <Button onClick={() => void onSend()} disabled={!canSend} title={sendDisabledTitle}>
                 send
@@ -259,7 +293,9 @@ function PreflightPill({
   );
 
   const openSettings = () => {
-    window.dispatchEvent(new CustomEvent('kayam:open-settings'));
+    window.dispatchEvent(
+      new CustomEvent('kayam:open-settings', { detail: { section: 'permissions' } }),
+    );
   };
 
   if (provider !== 'anthropic') {

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -90,6 +90,23 @@ function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
   );
 }
 
+function ThinkingIndicator() {
+  return (
+    <div
+      role="status"
+      aria-label="claude is thinking"
+      className="flex w-fit items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs text-muted-foreground"
+    >
+      <span className="flex gap-1">
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:0ms]" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:150ms]" />
+        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:300ms]" />
+      </span>
+      thinking…
+    </div>
+  );
+}
+
 export function ChatView({ session, onRequestEnd }: ChatViewProps) {
   const events = useTranscript(session.id);
   const items = useMemo(() => reduceTranscript(events), [events]);
@@ -105,6 +122,9 @@ export function ChatView({ session, onRequestEnd }: ChatViewProps) {
   const isProviderDisconnected = providerAuthState === 'disconnected';
 
   const isEnded = session.state.kind === 'ended';
+  const lastItem = items[items.length - 1];
+  const isThinking =
+    session.state.kind === 'running' && (lastItem?.kind ?? 'user_text') !== 'assistant_text';
 
   const flagOn = settings['experimental.enable_parallel_agents'] === 'true';
 
@@ -252,6 +272,11 @@ export function ChatView({ session, onRequestEnd }: ChatViewProps) {
                 <TranscriptCard item={item} onRefreshAuth={() => void refreshProviders()} />
               </li>
             ))}
+            {isThinking ? (
+              <li>
+                <ThinkingIndicator />
+              </li>
+            ) : null}
           </ul>
         )}
         {!pinned ? (

--- a/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
+++ b/apps/desktop/src/components/chat/PermissionAuditPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Button, Tooltip } from '@kay-am/ui';
+import { Button, Select, Tooltip } from '@kay-am/ui';
 import type { PermissionAuditEntry, ProviderRunId, SessionId } from '@kay-am/types';
 import { useAppStore } from '../../store';
 import { invokePermissionAuditList, invokePermissionAuditClear } from '../../permissions';
@@ -164,15 +164,15 @@ export function PermissionAuditPanel({ sessionId, open, onClose }: Props) {
             onChange={(e) => setFilterTool(e.target.value)}
             className="h-7 w-36 rounded border border-border bg-background px-2 text-xs text-foreground placeholder:text-muted-foreground"
           />
-          <select
+          <Select
+            size="sm"
             value={filterDecision}
             onChange={(e) => setFilterDecision(e.target.value as 'all' | 'allow' | 'deny')}
-            className="h-7 rounded border border-border bg-background px-1 text-xs text-foreground"
           >
             <option value="all">all decisions</option>
             <option value="allow">allow only</option>
             <option value="deny">deny only</option>
-          </select>
+          </Select>
           <input
             type="date"
             value={filterFrom}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -20,6 +20,8 @@ interface TranscriptCardProps {
 
 export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
   switch (item.kind) {
+    case 'user_text':
+      return <UserText text={item.text} />;
     case 'assistant_text':
       return <AssistantText text={item.text} />;
     case 'tool_call':
@@ -73,6 +75,17 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
 function AssistantText({ text }: { text: string }) {
   return (
     <div className="group relative rounded-lg border border-border bg-background px-3 py-2">
+      <div className="absolute right-1 top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
+        <CopyButton value={text} label="message" />
+      </div>
+      <p className="whitespace-pre-wrap text-sm text-foreground">{text}</p>
+    </div>
+  );
+}
+
+function UserText({ text }: { text: string }) {
+  return (
+    <div className="group relative ml-auto w-fit max-w-full rounded-lg bg-muted px-3 py-2">
       <div className="absolute right-1 top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
         <CopyButton value={text} label="message" />
       </div>

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -9,6 +9,7 @@ import type {
 import { decodeAuthRequiredMessage } from '../../turn';
 
 export type TranscriptItem =
+  | { kind: 'user_text'; key: string; text: string }
   | { kind: 'assistant_text'; key: string; text: string }
   | {
       kind: 'tool_call';
@@ -100,6 +101,9 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
     flushText();
 
     switch (event.kind) {
+      case 'user_text':
+        items.push({ kind: 'user_text', key: `user-${i}`, text: event.text });
+        break;
       case 'tool_call_start': {
         const key = `tool-${event.toolUseId}`;
         callIndex.set(event.toolUseId, items.length);

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  ProviderRunId,
+  Session,
+  SessionId,
+  TurnEvent,
+  WorkspaceId,
+} from '@kay-am/types';
+
+const runTurnSpy = vi.fn();
+const cancelTurnSpy = vi.fn();
+
+vi.mock('../turn', () => ({
+  runTurn: (args: unknown) => runTurnSpy(args),
+  cancelTurn: cancelTurnSpy,
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  deleteWorktreesForSession: vi.fn(),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+function buildSession(): Session {
+  const now = '2026-05-08T00:00:00.000Z' as IsoDateTime;
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'test',
+    state: { kind: 'idle', lastActivityAt: now },
+    contextSlots: [],
+    providerPreference: {
+      defaultProvider: 'anthropic',
+      allowTurnOverride: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function* emptyStream(): AsyncIterable<TurnEvent> {
+  // CLI exits without emitting any event — no `done`, no `error`, no
+  // `assistant_text`. Mirrors a provider that runs to completion but
+  // emits no parseable result line.
+}
+
+async function* doneOnlyStream(runId: ProviderRunId): AsyncIterable<TurnEvent> {
+  yield {
+    kind: 'done',
+    runId,
+    at: '2026-05-08T00:00:01.000Z' as IsoDateTime,
+  };
+}
+
+describe('sendTurn — terminal state guarantees', () => {
+  beforeEach(async () => {
+    runTurnSpy.mockReset();
+    cancelTurnSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+    const routingMod = await import('../routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-3-5-sonnet-latest',
+      reason: 'preference',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function importStore() {
+    const mod = await import('./store');
+    return mod.useAppStore;
+  }
+
+  function setupSession(useAppStore: Awaited<ReturnType<typeof importStore>>) {
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      transcripts: {},
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: {
+        anthropic: { state: 'connected', identity: 'test' },
+        cursor: { state: 'connected', identity: 'test' },
+        codex: { state: 'connected', identity: 'test' },
+      } as never,
+      workspaces: [
+        {
+          id: WORKSPACE_ID,
+          name: 'ws',
+          rootPath: '/tmp',
+          createdAt: '2026-05-08T00:00:00.000Z' as IsoDateTime,
+          updatedAt: '2026-05-08T00:00:00.000Z' as IsoDateTime,
+        },
+      ],
+    });
+  }
+
+  it('transitions session to idle after stream ends without a done event', async () => {
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hello' });
+
+    const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);
+    expect(session?.state.kind).toBe('idle');
+  });
+
+  it('appends an error event when the stream ends with no assistant text', async () => {
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hello' });
+
+    const transcript = useAppStore.getState().transcripts[SESSION_ID] ?? [];
+    const errorEvent = transcript.find((e) => e.kind === 'error');
+    expect(errorEvent).toBeDefined();
+    expect(errorEvent && 'message' in errorEvent ? errorEvent.message : '').toMatch(
+      /provider exited without a response/i,
+    );
+  });
+
+  it('appends user_text event so the user message is visible immediately', async () => {
+    runTurnSpy.mockImplementation(() => emptyStream());
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'ciao mondo' });
+
+    const transcript = useAppStore.getState().transcripts[SESSION_ID] ?? [];
+    const userEvent = transcript.find((e) => e.kind === 'user_text');
+    expect(userEvent).toBeDefined();
+    expect(userEvent && 'text' in userEvent ? userEvent.text : '').toBe('ciao mondo');
+  });
+
+  it('does not append a duplicate error event when the stream emits a done event', async () => {
+    runTurnSpy.mockImplementation((args: { runId: ProviderRunId }) => doneOnlyStream(args.runId));
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);
+    expect(session?.state.kind).toBe('idle');
+
+    const transcript = useAppStore.getState().transcripts[SESSION_ID] ?? [];
+    const errorEvents = transcript.filter((e) => e.kind === 'error');
+    expect(errorEvents).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -367,13 +367,23 @@ function mergeSlots(
 }
 
 function messageToTurnEvent(message: Message): TurnEvent | null {
-  if (message.role !== 'assistant') return null;
-  return {
-    kind: 'assistant_text',
-    runId: 'history' as ProviderRunId,
-    delta: message.content,
-    at: message.createdAt,
-  };
+  if (message.role === 'user') {
+    return {
+      kind: 'user_text',
+      runId: 'history' as ProviderRunId,
+      text: message.content,
+      at: message.createdAt,
+    };
+  }
+  if (message.role === 'assistant') {
+    return {
+      kind: 'assistant_text',
+      runId: 'history' as ProviderRunId,
+      delta: message.content,
+      at: message.createdAt,
+    };
+  }
+  return null;
 }
 
 type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
@@ -678,15 +688,36 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sidebarProviderFilter: [],
     });
     if (id) {
-      const [sessions, workspaceSummary, providerSummaries, budgetRules, skills, phaseTemplates] =
-        await Promise.all([
-          listSessionsForWorkspace(tauriDatabase, id),
-          summarizeWorkspaceTelemetry(tauriDatabase, id),
-          summarizeWorkspaceProviderTelemetry(tauriDatabase, id),
-          invokeBudgetRuleList(),
-          invokeSkillList(id),
-          invokePhaseTemplateList(id),
-        ]);
+      const [
+        loadedSessions,
+        workspaceSummary,
+        providerSummaries,
+        budgetRules,
+        skills,
+        phaseTemplates,
+      ] = await Promise.all([
+        listSessionsForWorkspace(tauriDatabase, id),
+        summarizeWorkspaceTelemetry(tauriDatabase, id),
+        summarizeWorkspaceProviderTelemetry(tauriDatabase, id),
+        invokeBudgetRuleList(),
+        invokeSkillList(id),
+        invokePhaseTemplateList(id),
+      ]);
+      // Boot-recovery: a session row in 'running' state is necessarily orphaned
+      // here — the Rust TurnRegistry is reset on every app start, so there is
+      // no live process to reattach to. Normalize to 'idle' so the UI re-enables
+      // the input. Persist the correction back to the DB.
+      const recoveryNow = new Date().toISOString() as IsoDateTime;
+      const sessions = await Promise.all(
+        loadedSessions.map(async (s) => {
+          if (s.state.kind !== 'running') return s;
+          const idleState: SessionState = { kind: 'idle', lastActivityAt: recoveryNow };
+          await updateSessionState(tauriDatabase, s.id, idleState, recoveryNow).catch(
+            () => undefined,
+          );
+          return { ...s, state: idleState, updatedAt: recoveryNow };
+        }),
+      );
       const worktreeRows = await Promise.all(
         sessions.map((s) => listWorktreesForSession(tauriDatabase, s.id)),
       );
@@ -853,6 +884,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
       createdAt: Date.now(),
     });
 
+    // Seed the goal context slot so the session prompt carries the user's
+    // stated goal from turn 1. Otherwise the goal lives only on the session
+    // row and never reaches the model unless the user retypes it in the
+    // context panel.
+    const goalText = session.goal.trim();
+    if (goalText.length > 0) {
+      await upsertContextSlot(tauriDatabase, session.id, {
+        key: 'goal',
+        value: goalText,
+        enabled: true,
+      });
+    }
+
     set((state) => ({
       sessions:
         state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
@@ -865,6 +909,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionBranches: {
         ...state.sessionBranches,
         [session.id]: worktree.branchName,
+      },
+      sessionSlots: {
+        ...state.sessionSlots,
+        [session.id]: goalText.length > 0 ? [{ key: 'goal', value: goalText, enabled: true }] : [],
       },
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
@@ -1134,6 +1182,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
         ...(resolvedOverride !== undefined ? { providerOverride: resolvedOverride } : {}),
       };
       await insertMessage(tauriDatabase, userMessage);
+      get().appendTurnEvent(sessionId, {
+        kind: 'user_text',
+        runId,
+        text: userTurnText,
+        at: userMessage.createdAt,
+      });
 
       const run: ProviderRun = {
         id: runId,
@@ -1268,6 +1322,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // for the legacy cancel path; for parallel groups, cancel routes through
       // cancelGroup via the scheduler handle inside runParallelBranch).
       const groupSessionRunId = crypto.randomUUID() as ProviderRunId;
+      get().appendTurnEvent(sessionId, {
+        kind: 'user_text',
+        runId: groupSessionRunId,
+        text: userTurnText,
+        at: userMessage.createdAt,
+      });
       let nextStateP: SessionState = session.state;
       if (nextStateP.kind === 'draft') {
         nextStateP = sessionReducer(nextStateP, { kind: 'start', at: now() });
@@ -1480,6 +1540,24 @@ export const useAppStore = create<AppStore>((set, get) => ({
           }
         }
       }
+      // Stream ended without a 'done'/'error' event — provider CLI exited
+      // cleanly but didn't emit a `result` line, so the reducer never left
+      // 'running'. Force-idle so input re-enables.
+      const afterStream = get().sessions.find((s) => s.id === sessionId);
+      if (afterStream?.state.kind === 'running') {
+        const idleState: SessionState = { kind: 'idle', lastActivityAt: now() };
+        await updateSessionState(tauriDatabase, sessionId, idleState, now());
+        applySessionUpdate(set, sessionId, idleState);
+        if (assistantText.length === 0) {
+          get().appendTurnEvent(sessionId, {
+            kind: 'error',
+            runId,
+            message:
+              'provider exited without a response. check that the CLI is configured correctly.',
+            at: now(),
+          });
+        }
+      }
       await updateProviderRunStatus(tauriDatabase, runId, {
         kind: 'succeeded',
         finishedAt: now(),
@@ -1560,7 +1638,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
   cancelCurrentTurn: async (sessionId) => {
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session || session.state.kind !== 'running') return;
-    await cancelTurn(session.state.runId);
+    // Best-effort: if the registry already evicted the run we still want to
+    // normalize session state locally so the UI re-enables the input.
+    await cancelTurn(session.state.runId).catch(() => undefined);
+    const now = new Date().toISOString() as IsoDateTime;
+    const idleState: SessionState = { kind: 'idle', lastActivityAt: now };
+    await updateSessionState(tauriDatabase, sessionId, idleState, now).catch(() => undefined);
+    applySessionUpdate(set, sessionId, idleState);
   },
 
   refreshWorkspaceSummary: async (workspaceId) => {
@@ -1620,7 +1704,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (!session) throw new Error(`session not found: ${sessionId}`);
     if (session.state.kind === 'ended') return;
     if (session.state.kind === 'running') {
-      await cancelTurn(session.state.runId);
+      // Best-effort cancel — Rust TurnRegistry may have already removed the
+      // run (process exited, app restarted, etc). A "turn not found" error
+      // here must not block end-session: the session row is the source of
+      // truth, not the in-memory registry.
+      await cancelTurn(session.state.runId).catch(() => undefined);
     }
 
     const worktreePaths = get().sessionWorktrees[sessionId] ?? [];

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1,26 +1,27 @@
 @import 'tailwindcss';
+@source '../../../packages/ui/src/**/*.{ts,tsx}';
 
 @theme {
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
 
-  --color-background: oklch(0.99 0 0);
-  --color-foreground: oklch(0.18 0.01 270);
-  --color-primary: oklch(0.55 0.18 265);
-  --color-primary-foreground: oklch(0.99 0 0);
-  --color-muted: oklch(0.96 0.005 270);
-  --color-muted-foreground: oklch(0.45 0.01 270);
-  --color-subtle: oklch(0.985 0.003 270);
-  --color-border: oklch(0.92 0.005 270);
-  --color-border-soft: oklch(0.95 0.004 270);
-  --color-danger: oklch(0.48 0.22 25);
-  --color-danger-foreground: oklch(0.99 0 0);
-  --color-warning: oklch(0.6 0.18 70);
-  --color-warning-foreground: oklch(0.15 0.02 70);
-  --color-success: oklch(0.62 0.15 150);
-  --color-success-foreground: oklch(0.99 0 0);
-  --color-info: oklch(0.62 0.13 230);
-  --color-info-foreground: oklch(0.99 0 0);
+  --color-background: oklch(0.16 0 0);
+  --color-foreground: oklch(0.93 0 0);
+  --color-subtle: oklch(0.20 0 0);
+  --color-muted: oklch(0.26 0 0);
+  --color-muted-foreground: oklch(0.62 0 0);
+  --color-border: oklch(0.32 0 0);
+  --color-border-soft: oklch(0.24 0 0);
+  --color-primary: oklch(0.78 0 0);
+  --color-primary-foreground: oklch(0.16 0 0);
+  --color-danger: oklch(0.62 0.025 25);
+  --color-danger-foreground: oklch(0.16 0 0);
+  --color-warning: oklch(0.72 0.025 85);
+  --color-warning-foreground: oklch(0.16 0 0);
+  --color-success: oklch(0.66 0.025 150);
+  --color-success-foreground: oklch(0.16 0 0);
+  --color-info: oklch(0.66 0.02 240);
+  --color-info-foreground: oklch(0.16 0 0);
 
   --text-2xs: 10px;
   --text-xs: 11px;
@@ -32,9 +33,9 @@
   --radius-md: 6px;
   --radius-lg: 8px;
 
-  --shadow-sm: 0 1px 2px 0 oklch(0.18 0.01 270 / 0.05);
-  --shadow-md: 0 4px 12px -2px oklch(0.18 0.01 270 / 0.08);
-  --shadow-lg: 0 12px 32px -8px oklch(0.18 0.01 270 / 0.12);
+  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.35);
+  --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.45);
+  --shadow-lg: 0 12px 32px -8px oklch(0 0 0 / 0.55);
 
   --motion-fast: 100ms;
   --motion-normal: 200ms;
@@ -43,7 +44,7 @@
   --ease-default: cubic-bezier(0.4, 0, 0.2, 1);
   --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
 
-  --color-focus-ring: oklch(0.55 0.18 265 / 0.55);
+  --color-focus-ring: oklch(0.78 0 0 / 0.5);
 }
 
 html,
@@ -52,6 +53,9 @@ body,
   height: 100%;
   font-size: 13px;
   line-height: 1.5;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  color-scheme: dark;
 }
 
 body {
@@ -65,16 +69,12 @@ body {
   border-radius: var(--radius-sm);
 }
 
-/*
- * Tailwind preflight zeros margins on every element; the UA `dialog`
- * selector relies on `margin: auto` for viewport centering. Restore it.
- */
 dialog {
   margin: auto;
 }
 
 dialog::backdrop {
-  background-color: oklch(0.18 0.01 270 / 0.45);
+  background-color: oklch(0 0 0 / 0.6);
   backdrop-filter: blur(2px);
 }
 

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -104,20 +104,35 @@ export async function* runTurn(
     }
   };
 
+  let receivedAnyLine = false;
+
   const unlisten: UnlistenFn = await listen<RawTurnEnvelope>(EVENT_NAME, (event) => {
     if (event.payload.runId !== args.runId) return;
 
     switch (event.payload.type) {
       case 'line':
+        receivedAnyLine = true;
         for (const ev of parseStreamJsonLine(event.payload.line, ctx)) {
           queue.push(ev);
         }
         flush();
         break;
-      case 'end':
+      case 'end': {
+        const exitCode = event.payload.exit_code;
+        const stderr = event.payload.stderr;
+        // Only surface exit-code as error when the stream emitted nothing —
+        // if any line came through, the parsed events (result/is_error,
+        // assistant_text) already convey the outcome and a duplicate
+        // "provider exited with code N" card would be noise.
+        if (!receivedAnyLine && exitCode !== null && exitCode !== 0) {
+          const tail = stderr.trim().split('\n').slice(-5).join('\n');
+          const detail = tail.length > 0 ? `: ${tail}` : '';
+          error = new Error(`provider exited with code ${exitCode}${detail}`);
+        }
         ended = true;
         flush();
         break;
+      }
       case 'error':
         error = new Error(event.payload.message);
         ended = true;

--- a/packages/core/src/context/engine.test.ts
+++ b/packages/core/src/context/engine.test.ts
@@ -64,10 +64,12 @@ describe('serializeSlots', () => {
     expect(a).toBe(b);
   });
 
-  it('skips disabled slots', () => {
-    const out = serializeSlots([{ key: 'goal', value: 'hidden', enabled: false }]);
-    expect(out).not.toContain('hidden');
-    expect(out).toMatch(/## goal\n—/);
+  it('serializes slots regardless of the legacy enabled flag', () => {
+    // The enabled flag is no longer respected at serialization time — slots
+    // with content always reach the model. The flag is kept on the type for
+    // schema compat but has no effect on output.
+    const out = serializeSlots([{ key: 'goal', value: 'visible-anyway', enabled: false }]);
+    expect(out).toContain('visible-anyway');
   });
 });
 
@@ -104,7 +106,7 @@ describe('ContextEngine', () => {
     expect(serialized).toContain('use claude only');
   });
 
-  it('toggles enabled', async () => {
+  it('keeps slot content visible even when enabled is toggled off (legacy flag is a no-op)', async () => {
     const db = makeDb();
     await migrate(db);
     await seedSession(db, 'sess_3' as SessionId);
@@ -114,6 +116,6 @@ describe('ContextEngine', () => {
     await engine.setEnabled('sess_3' as SessionId, 'goal', false);
 
     const out = await engine.serialize('sess_3' as SessionId);
-    expect(out).not.toContain('visible');
+    expect(out).toContain('visible');
   });
 });

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -40,7 +40,7 @@ export function assertSlotKey(key: string): asserts key is SlotKey {
 export function serializeSlots(slots: ReadonlyArray<ContextSlot>): string {
   const byKey = new Map<SlotKey, ContextSlot>();
   for (const slot of slots) {
-    if (isSlotKey(slot.key) && slot.enabled) {
+    if (isSlotKey(slot.key)) {
       byKey.set(slot.key, slot);
     }
   }

--- a/packages/core/src/session/reducer.ts
+++ b/packages/core/src/session/reducer.ts
@@ -70,6 +70,7 @@ function applyTurnEvent(state: SessionState, turn: TurnEvent): SessionState {
       return { kind: 'idle', lastActivityAt: turn.at };
     case 'error':
       return { kind: 'error', message: turn.message, failedAt: turn.at };
+    case 'user_text':
     case 'assistant_text':
     case 'tool_call_start':
     case 'tool_call_end':

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -40,6 +40,7 @@ export interface TurnRequest {
 }
 
 export type TurnEvent =
+  | { kind: 'user_text'; runId: ProviderRunId; text: string; at: IsoDateTime }
   | { kind: 'assistant_text'; runId: ProviderRunId; delta: string; at: IsoDateTime }
   | {
       kind: 'tool_call_start';

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -16,6 +16,18 @@ export interface DialogProps {
   closeOnBackdrop?: boolean;
   /** Override which element receives focus when the dialog opens. */
   initialFocusRef?: React.RefObject<HTMLElement | null>;
+  /**
+   * When true, the dialog collapses to fill the entire viewport on small
+   * screens (≤ 768px in either dimension), removing rounded corners and
+   * shadow so it reads as a full page rather than a floating modal.
+   */
+  fullScreenOnSmall?: boolean;
+  /**
+   * Lock the dialog body to a fixed height (e.g. `h-[640px]`). Without this,
+   * the dialog grows and shrinks with its content up to `max-h-[85vh]`.
+   * The fixed height yields when the viewport is too small to hold it.
+   */
+  fixedHeightClass?: string;
 }
 
 const SIZE: Record<DialogSize, string> = {
@@ -24,6 +36,8 @@ const SIZE: Record<DialogSize, string> = {
   lg: 'w-[44rem]',
   xl: 'w-[56rem]',
 };
+
+const SMALL_VIEWPORT = 'max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none';
 
 export function Dialog({
   open,
@@ -37,6 +51,8 @@ export function Dialog({
   showClose = true,
   closeOnBackdrop = true,
   initialFocusRef,
+  fullScreenOnSmall = false,
+  fixedHeightClass,
 }: DialogProps) {
   const ref = useRef<HTMLDialogElement>(null);
   const uid = useId();
@@ -86,9 +102,21 @@ export function Dialog({
       onClick={onBackdropClick}
       aria-labelledby={titleId}
       aria-describedby={descId}
-      className="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+      className={cn(
+        'overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl',
+        fullScreenOnSmall &&
+          'max-md:m-0 max-md:h-screen max-md:max-h-none max-md:w-screen max-md:max-w-none max-md:rounded-none max-md:border-0 max-md:shadow-none',
+      )}
     >
-      <div className={cn('flex max-h-[85vh] min-h-0 flex-col', SIZE[size], className)}>
+      <div
+        className={cn(
+          'flex min-h-0 flex-col',
+          fixedHeightClass ?? 'max-h-[85vh]',
+          SIZE[size],
+          fullScreenOnSmall && SMALL_VIEWPORT,
+          className,
+        )}
+      >
         {title || description || showClose ? (
           <header className="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4">
             <div className="flex min-w-0 flex-col gap-1">

--- a/packages/ui/src/components/Select.tsx
+++ b/packages/ui/src/components/Select.tsx
@@ -1,0 +1,57 @@
+import type { ComponentProps } from 'react';
+import { cn } from '../cn';
+
+export type SelectSize = 'sm' | 'md';
+
+export interface SelectProps extends Omit<ComponentProps<'select'>, 'size'> {
+  size?: SelectSize;
+  /** Stretch the wrapper to its container's width and make `<select>` w-full. */
+  block?: boolean;
+}
+
+const SIZE: Record<SelectSize, string> = {
+  sm: 'h-7 pl-2 pr-7 text-xs',
+  md: 'h-8 pl-2.5 pr-8 text-sm',
+};
+
+const CHEVRON_OFFSET: Record<SelectSize, string> = {
+  sm: 'right-1.5',
+  md: 'right-2',
+};
+
+export function Select({ className, size = 'md', block = false, children, ...rest }: SelectProps) {
+  return (
+    <span className={cn('relative items-center', block ? 'flex w-full' : 'inline-flex')}>
+      <select
+        className={cn(
+          'appearance-none rounded-md border border-border bg-background text-foreground',
+          'cursor-pointer transition-colors hover:border-foreground/30',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          SIZE[size],
+          block && 'w-full',
+          className,
+        )}
+        {...rest}
+      >
+        {children}
+      </select>
+      <svg
+        aria-hidden
+        viewBox="0 0 16 16"
+        width={size === 'sm' ? 11 : 13}
+        height={size === 'sm' ? 11 : 13}
+        className={cn('pointer-events-none absolute text-muted-foreground', CHEVRON_OFFSET[size])}
+      >
+        <path
+          d="M4 6l4 4 4-4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </span>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,8 @@ export { KbdPill } from './components/KbdPill';
 export type { KbdPillProps } from './components/KbdPill';
 export { ScrollArea } from './components/ScrollArea';
 export type { ScrollAreaProps } from './components/ScrollArea';
+export { Select } from './components/Select';
+export type { SelectProps, SelectSize } from './components/Select';
 export { Textarea } from './components/Textarea';
 export type { TextareaProps } from './components/Textarea';
 export { Skeleton } from './components/Skeleton';


### PR DESCRIPTION
## Summary

Four pre-1.0 fix clusters surfaced during a hands-on session of the desktop app, bundled here to keep the review surface coherent.

| Cluster | Issue | Highlights |
|---|---|---|
| chat session lifecycle | [#332](https://github.com/akhayam99/kay-am/issues/332) | user msg bubble visible immediately, force-idle on empty stream, thinking indicator, model picker, by-model cost breakdown, best-effort cancel/end, boot recovery for orphan running sessions |
| claude cli integration | [#333](https://github.com/akhayam99/kay-am/issues/333) | drop invalid \`--working-dir\`, use \`current_dir()\`, add \`--verbose\`, strip \`CLAUDECODE\` / \`CLAUDE_CODE_ENTRYPOINT\` / \`CLAUDE_AGENT_SDK_VERSION\` from spawned env, suppress duplicate exit-code error when stream emitted lines |
| ui polish | [#334](https://github.com/akhayam99/kay-am/issues/334) | dark grey-only theme, \`Dialog\` fixed-height + fullScreenOnSmall, sidebar reverted to two flat blocks with breathing room, new \`Select\` component (no lucide dep) replacing native selects across 6 panels |
| context + permissions | [#335](https://github.com/akhayam99/kay-am/issues/335) | seed \`goal\` slot at session creation, drop the per-slot on/off toggle (always-on), permissions pill opens settings on the permissions tab via \`detail.section\` |

Closes #332
Closes #333
Closes #334
Closes #335

## Test plan

- [x] \`pnpm -r typecheck\` clean across all 5 packages
- [x] \`pnpm -r test\` — 172/172 desktop, 380+/389 core (others unchanged)
- [x] new test \`store.idle-on-empty-stream.test.ts\` covers force-idle + error event + user_text bubble + done-event happy path (4 cases)
- [x] snapshot updates for Dialog class reorder, sidebar flatten, ContextPanel toggle removal
- [x] hands-on smoke: send → user bubble → thinking → assistant streams → idle; auth-error path renders cleanly without duplicate cards
- [x] cargo check + cargo test on \`src-tauri\` (9 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)