### PR TITLE
feat(types): rename phase/session domain to task/workflow/step

### DIFF
--- a/packages/types/CONVENTIONS.md
+++ b/packages/types/CONVENTIONS.md
@@ -15,9 +15,9 @@ Pure TypeScript types. **Zero runtime code.** This package exists only to be imp
 ```
 src/
 ├── index.ts          # public API (re-exports only)
-├── workspace.ts      # workspace, session, task types
+├── workspace.ts      # workspace, task, turn-state, context-slot
+├── workflow.ts       # workflow, step, session, parallel-group
 ├── provider.ts       # provider, adapter, balance types
-├── db.ts             # database row shapes
 └── ids.ts            # branded ID types
 ```
 

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
+import type { IsoDateTime, PermissionRuleId, ProviderRunId, TaskId } from './ids';
 import type { ProviderName } from './provider';
 
 export interface ProviderCapabilities {
@@ -31,7 +31,7 @@ export interface TurnPermissionFlags {
 
 export interface TurnRequest {
   readonly runId: ProviderRunId;
-  readonly sessionId: SessionId;
+  readonly taskId: TaskId;
   readonly model: string;
   readonly workingDir: string;
   readonly systemPrompt: string;
@@ -76,10 +76,10 @@ export type TurnEvent =
       at: IsoDateTime;
     }
   | {
-      kind: 'phase_transition';
+      kind: 'step_transition';
       runId: ProviderRunId;
-      fromPhase: { ordinal: number; name: string };
-      toPhase: { ordinal: number; name: string };
+      fromStep: { ordinal: number; name: string };
+      toStep: { ordinal: number; name: string };
       carryForwardContext: string;
       at: IsoDateTime;
     }

--- a/packages/types/src/budget.ts
+++ b/packages/types/src/budget.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, SessionId } from './ids';
+import type { IsoDateTime, TaskId } from './ids';
 import type { ProviderName } from './provider';
 import type { ProviderId } from './provider-registry';
 
@@ -14,8 +14,8 @@ export type BudgetRule = Readonly<{
   createdAt: IsoDateTime;
 }>;
 
-export type SessionBudget = Readonly<{
-  sessionId: SessionId;
+export type TaskBudget = Readonly<{
+  taskId: TaskId;
   softCapUsd: number;
 }>;
 
@@ -38,14 +38,14 @@ export type RoutingDecision = Readonly<{
 export type BudgetAlertKind =
   | 'provider-threshold'
   | 'provider-exceeded'
-  | 'session-threshold'
-  | 'session-exceeded';
+  | 'task-threshold'
+  | 'task-exceeded';
 
 export type BudgetAlert = Readonly<{
   id: string;
   kind: BudgetAlertKind;
   provider?: ProviderName;
-  sessionId?: SessionId;
+  taskId?: TaskId;
   currentUsd: number;
   capUsd: number;
   createdAt: IsoDateTime;

--- a/packages/types/src/config-bundle.ts
+++ b/packages/types/src/config-bundle.ts
@@ -10,7 +10,7 @@ export type ConfigBundleWorkspace = Readonly<{
   updatedAt: string;
   overrides: {
     defaultProviderId: string | null;
-    defaultPhaseTemplateId: string | null;
+    defaultWorkflowId: string | null;
     defaultBranchPrefix: string | null;
     parallelEnabled: boolean | null;
   };
@@ -28,9 +28,9 @@ export type ConfigBundleSkill = Readonly<{
   updatedAt: string;
 }>;
 
-export type ConfigBundlePhaseDefinition = Readonly<{
+export type ConfigBundleStep = Readonly<{
   id: string;
-  templateId: string;
+  workflowId: string;
   ordinal: number;
   name: string;
   promptPrefix: string;
@@ -38,12 +38,12 @@ export type ConfigBundlePhaseDefinition = Readonly<{
   modelOverride: string | null;
 }>;
 
-export type ConfigBundlePhaseTemplate = Readonly<{
+export type ConfigBundleWorkflow = Readonly<{
   id: string;
   workspaceId: string;
   name: string;
   description: string;
-  definitions: ReadonlyArray<ConfigBundlePhaseDefinition>;
+  steps: ReadonlyArray<ConfigBundleStep>;
   createdAt: string;
   updatedAt: string;
 }>;
@@ -52,7 +52,7 @@ export type ConfigBundlePermissionRule = Readonly<{
   id: string;
   scope: string;
   workspaceId: string | null;
-  sessionId: string | null;
+  taskId: string | null;
   patternTool: string;
   patternArgsMatcher: string | null;
   decision: string;
@@ -82,7 +82,7 @@ export type ConfigBundle = Readonly<{
   exportedAt: string;
   workspaces: ReadonlyArray<ConfigBundleWorkspace>;
   skills: ReadonlyArray<ConfigBundleSkill>;
-  phaseTemplates: ReadonlyArray<ConfigBundlePhaseTemplate>;
+  workflows: ReadonlyArray<ConfigBundleWorkflow>;
   permissionRules: ReadonlyArray<ConfigBundlePermissionRule>;
   budgetRules: ReadonlyArray<ConfigBundleBudgetRule>;
   settings: ConfigBundleSettings;
@@ -99,7 +99,7 @@ export type ConfigBundleImportResult = Readonly<{
   stats: Readonly<{
     workspaces: number;
     skills: number;
-    phaseTemplates: number;
+    workflows: number;
     permissionRules: number;
     budgetRules: number;
   }>;

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -1,14 +1,14 @@
 export type WorkspaceId = string & { readonly __brand: 'WorkspaceId' };
-export type SessionId = string & { readonly __brand: 'SessionId' };
+export type TaskId = string & { readonly __brand: 'TaskId' };
 export type MessageId = string & { readonly __brand: 'MessageId' };
 export type ProviderRunId = string & { readonly __brand: 'ProviderRunId' };
 export type TelemetryRecordId = string & { readonly __brand: 'TelemetryRecordId' };
 export type SkillId = string & { readonly __brand: 'SkillId' };
-export type PhaseTemplateId = string & { readonly __brand: 'PhaseTemplateId' };
-export type PhaseDefinitionId = string & { readonly __brand: 'PhaseDefinitionId' };
-export type PhaseRunId = string & { readonly __brand: 'PhaseRunId' };
-export type ParallelPhaseGroupId = string & { readonly __brand: 'ParallelPhaseGroupId' };
-export type ParallelPhaseRunId = string & { readonly __brand: 'ParallelPhaseRunId' };
+export type WorkflowId = string & { readonly __brand: 'WorkflowId' };
+export type StepId = string & { readonly __brand: 'StepId' };
+export type SessionId = string & { readonly __brand: 'SessionId' };
+export type ParallelGroupId = string & { readonly __brand: 'ParallelGroupId' };
+export type ParallelSessionId = string & { readonly __brand: 'ParallelSessionId' };
 
 export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,18 +3,18 @@ export type {
   MessageId,
   PermissionRequestId,
   PermissionRuleId,
-  ParallelPhaseGroupId,
-  ParallelPhaseRunId,
-  PhaseDefinitionId,
-  PhaseRunId,
-  PhaseTemplateId,
+  ParallelGroupId,
+  ParallelSessionId,
   ProviderRunId,
   SessionId,
   SkillId,
+  StepId,
+  TaskId,
   TelemetryRecordId,
+  WorkflowId,
   WorkspaceId,
 } from './ids';
-export type { ContextSlot, Session, SessionState, Workspace } from './workspace';
+export type { ContextSlot, Task, TurnState, Workspace } from './workspace';
 export type { Message, MessageRole } from './message';
 export type { ProviderName, ProviderRun, ProviderRunStatus } from './provider';
 export type {
@@ -35,14 +35,14 @@ export type {
   ProviderId,
   ProviderRegistryCapabilities,
 } from './provider-registry';
-export type { SessionProviderPreference, TurnProviderOverride } from './provider-preference';
-export { DEFAULT_SESSION_PROVIDER_PREFERENCE } from './provider-preference';
+export type { TaskProviderPreference, TurnProviderOverride } from './provider-preference';
+export { DEFAULT_TASK_PROVIDER_PREFERENCE } from './provider-preference';
 export type { Skill, SkillFrontmatter, SkillInvocation, SlashCommand } from './skill';
 export type {
   BudgetRule,
   BudgetPeriod,
   BudgetCheckResult,
-  SessionBudget,
+  TaskBudget,
   RoutingReason,
   RoutingDecision,
   BudgetAlertKind,
@@ -51,25 +51,25 @@ export type {
 export type { TelemetrySummary, TelemetryPeriodSummary } from './telemetry-period';
 export type {
   ParallelMergeStrategy,
-  ParallelPhaseGroup,
-  ParallelPhaseRun,
-  PhaseDefinition,
-  PhaseRun,
-  PhaseRunStatus,
-  PhaseTemplate,
-  PhaseTransition,
-} from './phase';
+  ParallelGroup,
+  ParallelSession,
+  Session,
+  SessionStatus,
+  Step,
+  StepTransition,
+  Workflow,
+} from './workflow';
 export type { GlobalSettings, OverrideSettings, ResolvedSettings, SettingsScope } from './settings';
 export type {
   ConfigBundle,
   ConfigBundleBudgetRule,
   ConfigBundleImportResult,
   ConfigBundlePermissionRule,
-  ConfigBundlePhaseDefinition,
-  ConfigBundlePhaseTemplate,
   ConfigBundleSettings,
   ConfigBundleSkill,
+  ConfigBundleStep,
   ConfigBundleValidationError,
+  ConfigBundleWorkflow,
   ConfigBundleWorkspace,
 } from './config-bundle';
 export { CONFIG_BUNDLE_SCHEMA_VERSION } from './config-bundle';

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -1,11 +1,11 @@
-import type { IsoDateTime, MessageId, SessionId } from './ids';
+import type { IsoDateTime, MessageId, TaskId } from './ids';
 import type { TurnProviderOverride } from './provider-preference';
 
 export type MessageRole = 'user' | 'assistant' | 'system';
 
 export type Message = Readonly<{
   id: MessageId;
-  sessionId: SessionId;
+  taskId: TaskId;
   role: MessageRole;
   content: string;
   createdAt: IsoDateTime;

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -3,11 +3,11 @@ import type {
   PermissionRequestId,
   PermissionRuleId,
   ProviderRunId,
-  SessionId,
+  TaskId,
   WorkspaceId,
 } from './ids';
 
-export type PermissionRuleScope = 'workspace' | 'session' | 'global';
+export type PermissionRuleScope = 'workspace' | 'task' | 'global';
 
 export type PermissionDecisionKind = 'allow' | 'deny' | 'ask';
 
@@ -20,7 +20,7 @@ export interface PermissionRule {
   readonly id: PermissionRuleId;
   readonly scope: PermissionRuleScope;
   readonly workspaceId?: WorkspaceId;
-  readonly sessionId?: SessionId;
+  readonly taskId?: TaskId;
   readonly pattern: PermissionRulePattern;
   readonly decision: PermissionDecisionKind;
   readonly priority: number;

--- a/packages/types/src/provider-preference.ts
+++ b/packages/types/src/provider-preference.ts
@@ -1,6 +1,6 @@
 import type { ProviderId } from './provider-registry';
 
-export interface SessionProviderPreference {
+export interface TaskProviderPreference {
   readonly defaultProvider: ProviderId;
   readonly defaultModel?: string;
   readonly allowTurnOverride: boolean;
@@ -11,7 +11,7 @@ export interface TurnProviderOverride {
   readonly model?: string;
 }
 
-export const DEFAULT_SESSION_PROVIDER_PREFERENCE: SessionProviderPreference = {
+export const DEFAULT_TASK_PROVIDER_PREFERENCE: TaskProviderPreference = {
   defaultProvider: 'anthropic',
   allowTurnOverride: true,
 };

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
+import type { IsoDateTime, ProviderRunId, TaskId } from './ids';
 import type { RoutingDecision } from './budget';
 
 export type ProviderName = 'anthropic' | 'openai' | 'cursor' | 'codex';
@@ -12,7 +12,7 @@ export type ProviderRunStatus =
 
 export type ProviderRun = Readonly<{
   id: ProviderRunId;
-  sessionId: SessionId;
+  taskId: TaskId;
   provider: ProviderName;
   model: string;
   status: ProviderRunStatus;

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,18 +1,18 @@
-import type { PhaseTemplateId, SessionId, WorkspaceId } from './ids';
+import type { TaskId, WorkflowId, WorkspaceId } from './ids';
 import type { ProviderId } from './provider-registry';
 
-/** Fields that can be overridden at workspace or session scope. Null = inherit from parent. */
+/** Fields that can be overridden at workspace or task scope. Null = inherit from parent. */
 export type OverrideSettings = Readonly<{
   defaultProviderId: ProviderId | null;
-  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string | null;
   parallelEnabled: boolean | null;
 }>;
 
-/** Fully-resolved settings after applying global → workspace → session cascade. */
+/** Fully-resolved settings after applying global → workspace → task cascade. */
 export type ResolvedSettings = Readonly<{
   defaultProviderId: ProviderId;
-  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string;
   parallelEnabled: boolean;
 }>;
@@ -20,7 +20,7 @@ export type ResolvedSettings = Readonly<{
 /** Global settings (non-nullable — always has a value). */
 export type GlobalSettings = Readonly<{
   defaultProviderId: ProviderId;
-  defaultPhaseTemplateId: PhaseTemplateId | null;
+  defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string;
   parallelEnabled: boolean;
 }>;
@@ -28,4 +28,4 @@ export type GlobalSettings = Readonly<{
 export type SettingsScope =
   | { kind: 'global' }
   | { kind: 'workspace'; workspaceId: WorkspaceId }
-  | { kind: 'session'; sessionId: SessionId };
+  | { kind: 'task'; taskId: TaskId };

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, ProviderRunId, SessionId, TelemetryRecordId } from './ids';
+import type { IsoDateTime, ProviderRunId, TaskId, TelemetryRecordId } from './ids';
 import type { ProviderName } from './provider';
 
 export type TelemetryKind = 'turn' | 'summarizer';
@@ -6,7 +6,7 @@ export type TelemetryKind = 'turn' | 'summarizer';
 export type TelemetryRecord = Readonly<{
   id: TelemetryRecordId;
   runId: ProviderRunId;
-  sessionId: SessionId;
+  taskId: TaskId;
   kind: TelemetryKind;
   provider: ProviderName;
   model: string;

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -1,23 +1,23 @@
 import type {
   IsoDateTime,
-  ParallelPhaseGroupId,
-  ParallelPhaseRunId,
-  PhaseDefinitionId,
-  PhaseRunId,
-  PhaseTemplateId,
+  ParallelGroupId,
+  ParallelSessionId,
   ProviderRunId,
   SessionId,
+  StepId,
+  TaskId,
+  WorkflowId,
   WorkspaceId,
 } from './ids';
 import type { ProviderId } from './provider-registry';
 
-export type PhaseRunStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
+export type SessionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 
 export type ParallelMergeStrategy = 'last_write_wins' | 'manual' | 'synthesizer_driven';
 
-export type PhaseDefinition = Readonly<{
-  id: PhaseDefinitionId;
-  templateId: PhaseTemplateId;
+export type Step = Readonly<{
+  id: StepId;
+  workflowId: WorkflowId;
   ordinal: number;
   name: string;
   promptPrefix: string;
@@ -26,52 +26,52 @@ export type PhaseDefinition = Readonly<{
   parallelGroup?: number;
 }>;
 
-export type PhaseTemplate = Readonly<{
-  id: PhaseTemplateId;
+export type Workflow = Readonly<{
+  id: WorkflowId;
   workspaceId: WorkspaceId;
   name: string;
   description: string;
-  definitions: ReadonlyArray<PhaseDefinition>;
+  steps: ReadonlyArray<Step>;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }>;
 
-export type PhaseRun = Readonly<{
-  id: PhaseRunId;
-  sessionId: SessionId;
-  phaseDefinitionId: PhaseDefinitionId;
+export type Session = Readonly<{
+  id: SessionId;
+  taskId: TaskId;
+  stepId: StepId;
   ordinal: number;
   name: string;
-  status: PhaseRunStatus;
+  status: SessionStatus;
   runId?: ProviderRunId;
   outputSummary?: string;
   startedAt?: IsoDateTime;
   completedAt?: IsoDateTime;
 }>;
 
-export type PhaseTransition = Readonly<{
+export type StepTransition = Readonly<{
   fromOrdinal: number;
   toOrdinal: number;
   carryForwardContext: string;
   at: IsoDateTime;
 }>;
 
-export interface ParallelPhaseGroup {
-  readonly id: ParallelPhaseGroupId;
-  readonly sessionId: SessionId;
+export interface ParallelGroup {
+  readonly id: ParallelGroupId;
+  readonly taskId: TaskId;
   readonly ordinal: number;
   readonly mergeStrategy: ParallelMergeStrategy;
   readonly createdAt: IsoDateTime;
   readonly completedAt: IsoDateTime | null;
 }
 
-export interface ParallelPhaseRun {
-  readonly id: ParallelPhaseRunId;
-  readonly groupId: ParallelPhaseGroupId;
-  readonly phaseDefinitionId: PhaseDefinitionId;
+export interface ParallelSession {
+  readonly id: ParallelSessionId;
+  readonly groupId: ParallelGroupId;
+  readonly stepId: StepId;
   readonly parallelIndex: number;
   readonly runId: ProviderRunId;
-  readonly status: PhaseRunStatus;
+  readonly status: SessionStatus;
   readonly worktreePath: string;
   readonly outputSummary: string | null;
   readonly startedAt: IsoDateTime;

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -1,5 +1,5 @@
-import type { IsoDateTime, PhaseTemplateId, ProviderRunId, SessionId, WorkspaceId } from './ids';
-import type { SessionProviderPreference } from './provider-preference';
+import type { IsoDateTime, ProviderRunId, TaskId, WorkflowId, WorkspaceId } from './ids';
+import type { TaskProviderPreference } from './provider-preference';
 
 export type Workspace = Readonly<{
   id: WorkspaceId;
@@ -15,7 +15,7 @@ export type ContextSlot = Readonly<{
   enabled: boolean;
 }>;
 
-export type SessionState =
+export type TurnState =
   | { kind: 'draft' }
   | { kind: 'starting'; startedAt: IsoDateTime }
   | { kind: 'idle'; lastActivityAt: IsoDateTime }
@@ -23,15 +23,15 @@ export type SessionState =
   | { kind: 'error'; message: string; failedAt: IsoDateTime }
   | { kind: 'ended'; endedAt: IsoDateTime };
 
-export type Session = Readonly<{
-  id: SessionId;
+export type Task = Readonly<{
+  id: TaskId;
   workspaceId: WorkspaceId;
   goal: string;
-  state: SessionState;
+  state: TurnState;
   contextSlots: ReadonlyArray<ContextSlot>;
-  providerPreference: SessionProviderPreference;
-  phaseTemplateId?: PhaseTemplateId;
-  currentPhaseOrdinal?: number;
+  providerPreference: TaskProviderPreference;
+  workflowId?: WorkflowId;
+  currentStepOrdinal?: number;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }>;


### PR DESCRIPTION
## Summary

PR1 of pre-1.0 rename initiative. Resolves naming overload where "session" meant both *goal-container* and *atomic CLI run*.

New domain hierarchy:

```
Workspace → Task (was Session) → Session (was PhaseRun)
Workflow (was PhaseTemplate) = blueprint of Steps (was PhaseDefinition)
```

## Scope

`packages/types` only. PR2 (db) and PR3 (core, desktop) cascade the rename to consumers — typecheck on those packages will fail until merged in sequence.

## Naming map

**ids**
- `SessionId → TaskId`
- `PhaseTemplateId → WorkflowId`
- `PhaseDefinitionId → StepId`
- `PhaseRunId → SessionId`
- `ParallelPhaseGroupId → ParallelGroupId`
- `ParallelPhaseRunId → ParallelSessionId`

**domain**
- `Session → Task`, `SessionState → TurnState`
- `PhaseTemplate → Workflow`, `PhaseDefinition → Step`, `PhaseRun → Session`
- `PhaseTransition → StepTransition`
- `PhaseRunStatus → SessionStatus`
- `ParallelPhaseGroup → ParallelGroup`, `ParallelPhaseRun → ParallelSession`
- `SessionProviderPreference → TaskProviderPreference`
- `SessionBudget → TaskBudget`

**discriminators**
- `TurnEvent.kind: phase_transition → step_transition`
- `PermissionRule.scope: 'session' → 'task'`
- `BudgetAlertKind: session-* → task-*`
- `SettingsScope: { kind: 'session' } → { kind: 'task' }`

**fields**
- `Task.phaseTemplateId → workflowId`
- `Task.currentPhaseOrdinal → currentStepOrdinal`
- `Step.templateId → workflowId`
- `Workflow.definitions → steps`
- `Session.phaseDefinitionId → stepId`
- All `sessionId` fields referring to the old goal-session → `taskId`

**files**
- `packages/types/src/phase.ts → workflow.ts` (git mv preserves history)

## Decisions

Captured in conversation (anchored to VISION.md):

1. **Naming = Task** — boring + correct. Mission/Initiative/Goal rejected.
2. **Task lifecycle deferred** — only rename existing types; `draft → active → completed | archived` lands in a later PR.
3. **`SessionState → TurnState`** — the 6-value runtime state machine semantically describes a turn, not a goal lifecycle. Future Task lifecycle will be a separate type.
4. **No new fields, no new entities** — pure rename. Consumers untouched intentionally.

## Test plan

- [x] `pnpm typecheck` on `@kay-am/types` (passes — package has no internal consumers)
- [ ] PR2 (db) lands → typecheck reflects schema rename
- [ ] PR3 (core + desktop) lands → full repo typecheck green
- [ ] Manual smoke after PR3: open task, run step, verify chat transcript renders `step_transition` events

## Cascade impact (expected)

This PR alone breaks typecheck on `@kay-am/db`, `@kay-am/core`, `@kay-am/ui`, `apps/desktop`. By design — keeps PR review small and reversible. CI on this branch will be red until PR2 + PR3 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
