### PR TITLE
feat(core): workflow library seed with 4 default templates

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,9 +92,13 @@ export {
   nextStep,
   WorkflowPropagator,
   type WorkflowPropagatorDeps,
+  WORKFLOW_LIBRARY,
+  type WorkflowLibraryEntry,
+  type WorkflowLibraryStep,
 } from './workflows';
-// WorkflowRegistry (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
-// Import directly from packages/core/src/workflows/registry in Node/Tauri command contexts.
+// WorkflowRegistry + seeder (@kay-am/db → node) are intentionally excluded from this
+// browser-safe barrel. Import directly from packages/core/src/workflows/registry
+// or packages/core/src/workflows/seeder in Node/Tauri command contexts.
 
 export {
   PermissionEngine,

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,4 +1,7 @@
 export { buildStepPrompt, isWorkflowComplete, nextStep } from './sequencer';
 export { WorkflowPropagator, type WorkflowPropagatorDeps } from './propagator';
+export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';
+// seeder.ts (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/workflows/seeder in Node/Tauri command contexts.
 // registry.ts (@kay-am/db → node) is intentionally excluded from this browser-safe barrel.
-// Import directly from packages/core/src/phases/registry in Node/Tauri command contexts.
+// Import directly from packages/core/src/workflows/registry in Node/Tauri command contexts.

--- a/packages/core/src/workflows/library.ts
+++ b/packages/core/src/workflows/library.ts
@@ -1,0 +1,134 @@
+export interface WorkflowLibraryStep {
+  readonly name: string;
+  readonly role: string;
+  readonly promptPrefix: string;
+  readonly expectedOutput: string;
+}
+
+export interface WorkflowLibraryEntry {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly steps: ReadonlyArray<WorkflowLibraryStep>;
+}
+
+export const WORKFLOW_LIBRARY: ReadonlyArray<WorkflowLibraryEntry> = [
+  {
+    slug: 'refactor',
+    name: 'Refactor',
+    description: 'Scout the area, plan the change, refactor, then verify.',
+    steps: [
+      {
+        name: 'Scout',
+        role: 'scout',
+        promptPrefix:
+          'Survey the area of code in scope. List relevant files, key abstractions, callers, and any tests. Do not propose changes yet.',
+        expectedOutput: 'A short map of the area: files, abstractions, callers, tests.',
+      },
+      {
+        name: 'Plan',
+        role: 'planner',
+        promptPrefix:
+          'Propose a refactor plan. Order changes by risk. Identify what stays, what moves, and what gets deleted. Flag any tests that need updating.',
+        expectedOutput: 'An ordered plan with risk notes and impacted tests.',
+      },
+      {
+        name: 'Refactor',
+        role: 'implementer',
+        promptPrefix:
+          'Apply the refactor in small commits. Keep behavior unchanged unless the plan says otherwise. Update tests in lock-step.',
+        expectedOutput: 'Working tree with the refactor applied; tests still green.',
+      },
+      {
+        name: 'Verify',
+        role: 'reviewer',
+        promptPrefix:
+          'Run the test suite and review the diff against the plan. Note anything that drifted, anything skipped, and any new tech-debt introduced.',
+        expectedOutput: 'A pass/fail report with diff vs plan + open follow-ups.',
+      },
+    ],
+  },
+  {
+    slug: 'bug-fix',
+    name: 'Bug fix',
+    description: 'Reproduce, diagnose, fix, verify.',
+    steps: [
+      {
+        name: 'Reproduce',
+        role: 'investigator',
+        promptPrefix:
+          'Find a minimal reproduction. Capture the failing input, expected output, and actual output. Add a failing test if feasible.',
+        expectedOutput: 'A reliable repro + a failing test (or a precise unwritten test plan).',
+      },
+      {
+        name: 'Diagnose',
+        role: 'investigator',
+        promptPrefix:
+          'Trace the failure to its root cause. Identify the smallest set of files involved. Avoid speculation; back claims with code references.',
+        expectedOutput: 'A root-cause statement with file:line references.',
+      },
+      {
+        name: 'Fix',
+        role: 'implementer',
+        promptPrefix:
+          'Apply the smallest change that resolves the root cause. Do not bundle unrelated cleanup. Make the failing test pass.',
+        expectedOutput: 'A focused diff that turns the failing test green.',
+      },
+      {
+        name: 'Verify',
+        role: 'reviewer',
+        promptPrefix:
+          'Run the full test suite. Confirm no regressions. Re-read the diff to ensure scope did not creep.',
+        expectedOutput: 'All tests green + a one-paragraph summary of the fix.',
+      },
+    ],
+  },
+  {
+    slug: 'feature',
+    name: 'Feature',
+    description: 'Spec the change, design it, implement it, test it.',
+    steps: [
+      {
+        name: 'Spec',
+        role: 'product',
+        promptPrefix:
+          'Clarify the user-facing behavior in 5-10 bullets. List acceptance criteria. Flag open questions before any code is written.',
+        expectedOutput: 'A short spec with ACs and open questions.',
+      },
+      {
+        name: 'Design',
+        role: 'architect',
+        promptPrefix:
+          'Propose the technical approach. Identify the modules touched, new types, data flow, and any migrations. Keep alternatives short.',
+        expectedOutput: 'A design note with modules, types, data flow, and migration notes.',
+      },
+      {
+        name: 'Implement',
+        role: 'implementer',
+        promptPrefix:
+          'Build the feature against the design. Stop at the first acceptance criterion that needs clarification. Keep diffs reviewable.',
+        expectedOutput: 'Working code that satisfies the ACs from the spec.',
+      },
+      {
+        name: 'Test',
+        role: 'tester',
+        promptPrefix:
+          'Cover the happy path, edge cases, and at least one regression case for prior bugs in the area. Prefer integration tests where they pay back.',
+        expectedOutput: 'A test suite that exercises the spec and guards regressions.',
+      },
+    ],
+  },
+  {
+    slug: 'exploration',
+    name: 'Exploration',
+    description: 'Single open-ended chat with the active provider.',
+    steps: [
+      {
+        name: 'Explore',
+        role: 'explorer',
+        promptPrefix: '',
+        expectedOutput: '',
+      },
+    ],
+  },
+];

--- a/packages/core/src/workflows/seeder.test.ts
+++ b/packages/core/src/workflows/seeder.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import type { IsoDateTime, WorkspaceId } from '@kay-am/types';
+import { migrate, listWorkflows, insertWorkspace, type Database as DbInterface } from '@kay-am/db';
+import { WORKFLOW_LIBRARY } from './library';
+import { seedWorkflowLibrary } from './seeder';
+
+const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+function makeDb(): DbInterface {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  return {
+    async exec(sql) {
+      db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      const stmt = db.prepare(sql);
+      const result = stmt.run(...(params as ReadonlyArray<never>));
+      return { rowsAffected: result.changes };
+    },
+    async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+      const stmt = db.prepare(sql);
+      return stmt.all(...(params as ReadonlyArray<never>)) as unknown as ReadonlyArray<T>;
+    },
+  };
+}
+
+async function setup() {
+  const db = makeDb();
+  await migrate(db);
+  const workspaceId = 'ws_seed_test' as WorkspaceId;
+  await insertWorkspace(db, {
+    id: workspaceId,
+    name: 'seed-test',
+    rootPath: '/tmp/seed-test',
+    createdAt: now(),
+    updatedAt: now(),
+  });
+  return { db, workspaceId };
+}
+
+describe('seedWorkflowLibrary', () => {
+  it('seeds all library entries with deterministic ids', async () => {
+    const { db, workspaceId } = await setup();
+    const result = await seedWorkflowLibrary({ db }, workspaceId);
+
+    expect(result.seeded).toHaveLength(WORKFLOW_LIBRARY.length);
+    for (const entry of WORKFLOW_LIBRARY) {
+      const seeded = result.seeded.find((s) => s.slug === entry.slug);
+      expect(seeded).toBeDefined();
+      expect(seeded!.workflowId).toBe(`wf_seed_${entry.slug}_${workspaceId}`);
+    }
+  });
+
+  it('persists each entry with its steps in the right order', async () => {
+    const { db, workspaceId } = await setup();
+    await seedWorkflowLibrary({ db }, workspaceId);
+
+    const workflows = await listWorkflows(db, workspaceId);
+    expect(workflows).toHaveLength(WORKFLOW_LIBRARY.length);
+
+    for (const entry of WORKFLOW_LIBRARY) {
+      const wf = workflows.find((w) => w.name === entry.name);
+      expect(wf).toBeDefined();
+      expect(wf!.steps).toHaveLength(entry.steps.length);
+      entry.steps.forEach((s, i) => {
+        expect(wf!.steps[i]!.name).toBe(s.name);
+        expect(wf!.steps[i]!.ordinal).toBe(i);
+        expect(wf!.steps[i]!.promptPrefix).toBe(s.promptPrefix);
+      });
+    }
+  });
+
+  it('is idempotent: re-seeding does not duplicate', async () => {
+    const { db, workspaceId } = await setup();
+    await seedWorkflowLibrary({ db }, workspaceId);
+    await seedWorkflowLibrary({ db }, workspaceId);
+
+    const workflows = await listWorkflows(db, workspaceId);
+    expect(workflows).toHaveLength(WORKFLOW_LIBRARY.length);
+  });
+
+  it('uses the injected now() if provided', async () => {
+    const { db, workspaceId } = await setup();
+    const fixed = '2026-05-09T12:00:00.000Z' as IsoDateTime;
+    await seedWorkflowLibrary({ db, now: () => fixed }, workspaceId);
+
+    const workflows = await listWorkflows(db, workspaceId);
+    for (const wf of workflows) {
+      expect(wf.createdAt).toBe(fixed);
+      expect(wf.updatedAt).toBe(fixed);
+    }
+  });
+});

--- a/packages/core/src/workflows/seeder.ts
+++ b/packages/core/src/workflows/seeder.ts
@@ -1,0 +1,57 @@
+import type { IsoDateTime, Step, StepId, Workflow, WorkflowId, WorkspaceId } from '@kay-am/types';
+import { upsertWorkflow, type Database } from '@kay-am/db';
+import { WORKFLOW_LIBRARY } from './library';
+
+export interface SeedWorkflowLibraryDeps {
+  readonly db: Database;
+  readonly now?: () => IsoDateTime;
+}
+
+export interface SeedResult {
+  readonly seeded: ReadonlyArray<{ slug: string; workflowId: WorkflowId }>;
+}
+
+const isoNow = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+function makeWorkflowId(slug: string, workspaceId: WorkspaceId): WorkflowId {
+  return `wf_seed_${slug}_${workspaceId}` as WorkflowId;
+}
+
+function makeStepId(slug: string, stepName: string, workspaceId: WorkspaceId): StepId {
+  const stepSlug = stepName.toLowerCase().replace(/\s+/g, '_');
+  return `step_seed_${slug}_${stepSlug}_${workspaceId}` as StepId;
+}
+
+export async function seedWorkflowLibrary(
+  deps: SeedWorkflowLibraryDeps,
+  workspaceId: WorkspaceId,
+): Promise<SeedResult> {
+  const now = (deps.now ?? isoNow)();
+  const seeded: Array<{ slug: string; workflowId: WorkflowId }> = [];
+
+  for (const entry of WORKFLOW_LIBRARY) {
+    const workflowId = makeWorkflowId(entry.slug, workspaceId);
+    const steps: ReadonlyArray<Step> = entry.steps.map((s, ordinal) => ({
+      id: makeStepId(entry.slug, s.name, workspaceId),
+      workflowId,
+      ordinal,
+      name: s.name,
+      promptPrefix: s.promptPrefix,
+    }));
+
+    const workflow: Workflow = {
+      id: workflowId,
+      workspaceId,
+      name: entry.name,
+      description: entry.description,
+      steps,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await upsertWorkflow(deps.db, workflow);
+    seeded.push({ slug: entry.slug, workflowId });
+  }
+
+  return { seeded };
+}


### PR DESCRIPTION
## Summary

PR5 — workflow library seed. Adds the 4 default templates and an idempotent seeder per the planner-flow design.

## What's added

`packages/core/src/workflows/library.ts` — static `WORKFLOW_LIBRARY`:

| slug | name | steps |
|---|---|---|
| `refactor` | Refactor | scout → plan → refactor → verify |
| `bug-fix` | Bug fix | reproduce → diagnose → fix → verify |
| `feature` | Feature | spec → design → implement → test |
| `exploration` | Exploration | single open chat |

Each step declares `{ name, role, promptPrefix, expectedOutput }` aligned to the planner output schema.

`packages/core/src/workflows/seeder.ts` — `seedWorkflowLibrary(deps, workspaceId)`:

- Deterministic IDs: `wf_seed_<slug>_<workspaceId>`, `step_seed_<slug>_<step>_<workspaceId>`
- Idempotent: re-seeding overwrites the same row, never duplicates
- Injectable `now()` for deterministic tests

## Tests

`packages/core/src/workflows/seeder.test.ts` — 4 new tests:
- determinism of seeded IDs
- persistence with steps in correct order
- idempotency (re-seed → still N entries)
- injected `now()` propagates to `createdAt`/`updatedAt`

## Verification

- ✅ core typecheck green
- ✅ 386/386 tests pass (+4 new)

## Followups

- PR6 — Planner agent (theme → custom Workflow JSON)
- PR7 — Wire seeder into Tauri command + boot for workspace create
- PR8 — New-task wizard exposing both library + planner

## Branch

Based on `ak/pr4-desktop-cascade`. After full rename chain merges, this rebases to main cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
