### PR TITLE
feat(core): planner agent (theme → custom workflow json)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -141,3 +141,15 @@ export {
 } from './worktree/parallel';
 
 export { resolveSettings, type ResolveSettingsInput } from './settings/resolver';
+
+export {
+  parsePlannerOutput,
+  PlannerParseError,
+  PLANNER_SYSTEM_PROMPT,
+  buildPlannerUserPrompt,
+  type PlannerInput,
+  type PlannerOutput,
+  type PlannerStep,
+} from './planner';
+// PlannerAgent (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/planner/cli in Node/Tauri command contexts.

--- a/packages/core/src/planner/cli.test.ts
+++ b/packages/core/src/planner/cli.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { PlannerAgent, PlannerSpawnError } from './cli';
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+}
+
+function makeFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
+const validPlannerJson = JSON.stringify({
+  workflowName: 'Cleanup',
+  reasoning: 'Two steps to scope and execute.',
+  steps: [
+    {
+      name: 'Scope',
+      role: 'planner',
+      promptPrefix: 'List the affected files.',
+      expectedOutput: 'A short file list.',
+    },
+    {
+      name: 'Cleanup',
+      role: 'implementer',
+      promptPrefix: 'Apply the cleanup.',
+      expectedOutput: 'A diff with the cleanup applied.',
+    },
+  ],
+});
+
+describe('PlannerAgent', () => {
+  it('spawns the cli, parses claude json envelope, and returns parsed output', async () => {
+    const claudeEnvelope = JSON.stringify({
+      result: validPlannerJson,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 10,
+      },
+    });
+
+    const child = makeFakeChild();
+    const spawnFn = vi.fn().mockReturnValue(child);
+
+    const agent = new PlannerAgent({
+      providerId: 'anthropic',
+      spawnFn: spawnFn as never,
+    });
+
+    const promise = agent.plan({ theme: 'Refactor auth module' });
+
+    setImmediate(() => {
+      child.stdout.emit('data', Buffer.from(claudeEnvelope, 'utf8'));
+      child.emit('close', 0);
+    });
+
+    const result = await promise;
+    expect(result.output.workflowName).toBe('Cleanup');
+    expect(result.output.steps).toHaveLength(2);
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.outputTokens).toBe(50);
+    expect(spawnFn).toHaveBeenCalledOnce();
+  });
+
+  it('throws PlannerSpawnError on non-zero exit', async () => {
+    const child = makeFakeChild();
+    const spawnFn = vi.fn().mockReturnValue(child);
+
+    const agent = new PlannerAgent({
+      providerId: 'anthropic',
+      spawnFn: spawnFn as never,
+    });
+
+    const promise = agent.plan({ theme: 'X' });
+
+    setImmediate(() => {
+      child.stderr.emit('data', Buffer.from('boom', 'utf8'));
+      child.emit('close', 1);
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(PlannerSpawnError);
+  });
+
+  it('passes theme + repoContext into user message', async () => {
+    const claudeEnvelope = JSON.stringify({ result: validPlannerJson });
+    const child = makeFakeChild();
+    let capturedArgs: string[] = [];
+    const spawnFn = vi.fn().mockImplementation((_bin: string, args: string[]) => {
+      capturedArgs = args;
+      return child;
+    });
+
+    const agent = new PlannerAgent({
+      providerId: 'anthropic',
+      spawnFn: spawnFn as never,
+    });
+
+    const promise = agent.plan({
+      theme: 'Migrate to Drizzle ORM',
+      repoContext: 'Workspace: kay-am — TypeScript monorepo',
+    });
+
+    setImmediate(() => {
+      child.stdout.emit('data', Buffer.from(claudeEnvelope, 'utf8'));
+      child.emit('close', 0);
+    });
+
+    await promise;
+    const userMsg = capturedArgs[1] ?? '';
+    expect(userMsg).toContain('Migrate to Drizzle ORM');
+    expect(userMsg).toContain('Workspace: kay-am');
+  });
+});

--- a/packages/core/src/planner/cli.ts
+++ b/packages/core/src/planner/cli.ts
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process';
+import type { ProviderId } from '@kay-am/types';
+import { computeCostUsd } from '../providers/claude/cost';
+import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
+import { parsePlannerOutput } from './parser';
+import { PLANNER_SYSTEM_PROMPT, buildPlannerUserPrompt } from './prompt';
+import type { PlannerInput, PlannerOutput } from './types';
+
+export interface PlannerUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cachedInputTokens: number;
+  readonly estimatedCostUsd: number;
+}
+
+export interface PlannerResult {
+  readonly output: PlannerOutput;
+  readonly usage: PlannerUsage;
+  readonly model: string;
+}
+
+export interface PlannerAgentDeps {
+  readonly providerId: ProviderId;
+  readonly binary?: string;
+  readonly spawnFn?: typeof spawn;
+}
+
+export class PlannerSpawnError extends Error {
+  constructor(
+    public readonly exitCode: number | null,
+    public readonly stderr: string,
+  ) {
+    super(`planner cli exited with code ${exitCode ?? 'null'}`);
+    this.name = 'PlannerSpawnError';
+  }
+}
+
+interface ClaudeJsonResult {
+  readonly result?: string;
+  readonly usage?: {
+    readonly input_tokens?: number;
+    readonly output_tokens?: number;
+    readonly cache_read_input_tokens?: number;
+  };
+}
+
+export class PlannerAgent {
+  private readonly providerId: ProviderId;
+  private readonly binary: string;
+  private readonly model: string;
+  private readonly spawnFn: typeof spawn;
+
+  constructor(deps: PlannerAgentDeps) {
+    this.providerId = deps.providerId;
+    this.binary = deps.binary ?? defaultBinary(deps.providerId);
+    this.model = cheapModel(deps.providerId);
+    this.spawnFn = deps.spawnFn ?? spawn;
+  }
+
+  async plan(input: PlannerInput): Promise<PlannerResult> {
+    const userMessage = buildPlannerUserPrompt(input);
+    const { stdout, stderr, exitCode } = await this.spawnCli(userMessage);
+
+    if (exitCode !== 0) {
+      throw new PlannerSpawnError(exitCode, stderr);
+    }
+
+    const { text, usage } = this.extractTextAndUsage(stdout);
+    const output = parsePlannerOutput(text);
+    return { output, usage, model: this.model };
+  }
+
+  private spawnCli(
+    userMessage: string,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+    return new Promise((resolve, reject) => {
+      const args = buildCliArgs(this.providerId, this.model, PLANNER_SYSTEM_PROMPT, userMessage);
+      const child = this.spawnFn(this.binary, args, {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+      });
+      child.on('error', (err) => reject(err));
+      child.on('close', (code) => resolve({ stdout, stderr, exitCode: code }));
+    });
+  }
+
+  private extractTextAndUsage(stdout: string): { text: string; usage: PlannerUsage } {
+    if (this.providerId === 'anthropic') {
+      return extractClaudeJsonOutput(stdout, this.model);
+    }
+    return { text: stdout.trim(), usage: zeroUsage() };
+  }
+}
+
+function cheapModel(providerId: ProviderId): string {
+  const caps = PROVIDER_CAPABILITIES[providerId];
+  return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
+}
+
+function defaultBinary(providerId: ProviderId): string {
+  switch (providerId) {
+    case 'anthropic':
+      return 'claude';
+    case 'cursor':
+      return 'cursor-agent';
+    case 'codex':
+      return 'codex';
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
+    }
+  }
+}
+
+function buildCliArgs(
+  providerId: ProviderId,
+  model: string,
+  systemPrompt: string,
+  userMessage: string,
+): string[] {
+  switch (providerId) {
+    case 'anthropic':
+      return [
+        '-p',
+        userMessage,
+        '--model',
+        model,
+        '--system-prompt',
+        systemPrompt,
+        '--output-format',
+        'json',
+        '--no-session-persistence',
+      ];
+    case 'cursor':
+      return [
+        '-p',
+        `${systemPrompt}\n\n${userMessage}`,
+        '--model',
+        model,
+        '--output-format',
+        'stream-json',
+        '--force',
+      ];
+    case 'codex':
+      return ['exec', '--json', '--model', model, '--', `${systemPrompt}\n\n${userMessage}`];
+    default: {
+      const _exhaustive: never = providerId;
+      throw new Error(`unknown provider: ${_exhaustive}`);
+    }
+  }
+}
+
+function extractClaudeJsonOutput(
+  stdout: string,
+  model: string,
+): { text: string; usage: PlannerUsage } {
+  const trimmed = stdout.trim();
+  let parsed: ClaudeJsonResult;
+  try {
+    parsed = JSON.parse(trimmed) as ClaudeJsonResult;
+  } catch {
+    return { text: trimmed, usage: zeroUsage() };
+  }
+
+  const text = parsed.result ?? '';
+  const rawUsage = parsed.usage ?? {};
+  const inputTokens = rawUsage.input_tokens ?? 0;
+  const outputTokens = rawUsage.output_tokens ?? 0;
+  const cachedInputTokens = rawUsage.cache_read_input_tokens ?? 0;
+  const estimatedCostUsd = computeCostUsd(
+    { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd: 0 },
+    model,
+  );
+  return { text, usage: { inputTokens, outputTokens, cachedInputTokens, estimatedCostUsd } };
+}
+
+function zeroUsage(): PlannerUsage {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 };
+}

--- a/packages/core/src/planner/index.ts
+++ b/packages/core/src/planner/index.ts
@@ -1,0 +1,5 @@
+export { parsePlannerOutput, PlannerParseError } from './parser';
+export { PLANNER_SYSTEM_PROMPT, buildPlannerUserPrompt } from './prompt';
+export type { PlannerInput, PlannerOutput, PlannerStep } from './types';
+// PlannerAgent (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/planner/cli in Node/Tauri command contexts.

--- a/packages/core/src/planner/parser.test.ts
+++ b/packages/core/src/planner/parser.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { parsePlannerOutput, PlannerParseError } from './parser';
+
+const validJson = JSON.stringify({
+  workflowName: 'Auth Refactor',
+  reasoning: 'Two passes: scout the existing auth, then refactor in place.',
+  steps: [
+    {
+      name: 'Scout',
+      role: 'scout',
+      promptPrefix: 'Survey auth-related files.',
+      expectedOutput: 'A map of auth modules.',
+    },
+    {
+      name: 'Refactor',
+      role: 'implementer',
+      promptPrefix: 'Apply the refactor in small commits.',
+      expectedOutput: 'A diff with updated tests.',
+    },
+  ],
+});
+
+describe('parsePlannerOutput', () => {
+  it('parses a well-formed planner response', () => {
+    const out = parsePlannerOutput(validJson);
+    expect(out.workflowName).toBe('Auth Refactor');
+    expect(out.steps).toHaveLength(2);
+    expect(out.steps[0]!.name).toBe('Scout');
+    expect(out.steps[1]!.role).toBe('implementer');
+  });
+
+  it('strips json code fences', () => {
+    const fenced = '```json\n' + validJson + '\n```';
+    const out = parsePlannerOutput(fenced);
+    expect(out.workflowName).toBe('Auth Refactor');
+  });
+
+  it('strips bare code fences', () => {
+    const fenced = '```\n' + validJson + '\n```';
+    const out = parsePlannerOutput(fenced);
+    expect(out.steps).toHaveLength(2);
+  });
+
+  it('rejects invalid json', () => {
+    expect(() => parsePlannerOutput('{not json')).toThrow(PlannerParseError);
+  });
+
+  it('rejects missing workflowName', () => {
+    const bad = JSON.stringify({ reasoning: 'x', steps: [] });
+    expect(() => parsePlannerOutput(bad)).toThrow(/workflowName/);
+  });
+
+  it('rejects empty workflowName', () => {
+    const bad = JSON.stringify({ workflowName: '   ', reasoning: 'x', steps: [] });
+    expect(() => parsePlannerOutput(bad)).toThrow(/workflowName/);
+  });
+
+  it('rejects missing reasoning', () => {
+    const bad = JSON.stringify({ workflowName: 'X', steps: [] });
+    expect(() => parsePlannerOutput(bad)).toThrow(/reasoning/);
+  });
+
+  it('rejects non-array steps', () => {
+    const bad = JSON.stringify({ workflowName: 'X', reasoning: 'x', steps: 'nope' });
+    expect(() => parsePlannerOutput(bad)).toThrow(/steps/);
+  });
+
+  it('rejects empty steps', () => {
+    const bad = JSON.stringify({ workflowName: 'X', reasoning: 'x', steps: [] });
+    expect(() => parsePlannerOutput(bad)).toThrow(/at least one step/);
+  });
+
+  it('rejects step missing name', () => {
+    const bad = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ role: 'scout', promptPrefix: '', expectedOutput: '' }],
+    });
+    expect(() => parsePlannerOutput(bad)).toThrow(/name/);
+  });
+
+  it('rejects step missing role', () => {
+    const bad = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', promptPrefix: '', expectedOutput: '' }],
+    });
+    expect(() => parsePlannerOutput(bad)).toThrow(/role/);
+  });
+
+  it('rejects step missing promptPrefix', () => {
+    const bad = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'scout', expectedOutput: '' }],
+    });
+    expect(() => parsePlannerOutput(bad)).toThrow(/promptPrefix/);
+  });
+
+  it('rejects step missing expectedOutput', () => {
+    const bad = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'scout', promptPrefix: '' }],
+    });
+    expect(() => parsePlannerOutput(bad)).toThrow(/expectedOutput/);
+  });
+
+  it('exposes the raw input on error', () => {
+    try {
+      parsePlannerOutput('not json');
+    } catch (err) {
+      expect(err).toBeInstanceOf(PlannerParseError);
+      expect((err as PlannerParseError).raw).toBe('not json');
+    }
+  });
+
+  it('trims whitespace from workflowName', () => {
+    const padded = JSON.stringify({
+      workflowName: '  Auth  ',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'scout', promptPrefix: 'p', expectedOutput: 'o' }],
+    });
+    const out = parsePlannerOutput(padded);
+    expect(out.workflowName).toBe('Auth');
+  });
+});

--- a/packages/core/src/planner/parser.ts
+++ b/packages/core/src/planner/parser.ts
@@ -1,0 +1,83 @@
+import type { PlannerOutput, PlannerStep } from './types';
+
+export class PlannerParseError extends Error {
+  constructor(
+    message: string,
+    public readonly raw: string,
+  ) {
+    super(message);
+    this.name = 'PlannerParseError';
+  }
+}
+
+export function parsePlannerOutput(raw: string): PlannerOutput {
+  const stripped = stripCodeFences(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stripped);
+  } catch (err) {
+    throw new PlannerParseError(
+      `planner response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      raw,
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new PlannerParseError('planner response was not a JSON object', raw);
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  const workflowName = obj.workflowName;
+  if (typeof workflowName !== 'string' || workflowName.trim().length === 0) {
+    throw new PlannerParseError('planner response missing or empty "workflowName"', raw);
+  }
+
+  const reasoning = obj.reasoning;
+  if (typeof reasoning !== 'string') {
+    throw new PlannerParseError('planner response missing "reasoning" string', raw);
+  }
+
+  const stepsRaw = obj.steps;
+  if (!Array.isArray(stepsRaw)) {
+    throw new PlannerParseError('planner response "steps" was not an array', raw);
+  }
+  if (stepsRaw.length === 0) {
+    throw new PlannerParseError('planner response "steps" must contain at least one step', raw);
+  }
+
+  const steps: PlannerStep[] = [];
+  for (const [index, entry] of stepsRaw.entries()) {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new PlannerParseError(`planner step at index ${index} is not an object`, raw);
+    }
+    const e = entry as Record<string, unknown>;
+    const name = e.name;
+    const role = e.role;
+    const promptPrefix = e.promptPrefix;
+    const expectedOutput = e.expectedOutput;
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      throw new PlannerParseError(`planner step at index ${index} missing "name"`, raw);
+    }
+    if (typeof role !== 'string' || role.trim().length === 0) {
+      throw new PlannerParseError(`planner step at index ${index} missing "role"`, raw);
+    }
+    if (typeof promptPrefix !== 'string') {
+      throw new PlannerParseError(`planner step at index ${index} missing "promptPrefix"`, raw);
+    }
+    if (typeof expectedOutput !== 'string') {
+      throw new PlannerParseError(`planner step at index ${index} missing "expectedOutput"`, raw);
+    }
+    steps.push({ name, role, promptPrefix, expectedOutput });
+  }
+
+  return {
+    workflowName: workflowName.trim(),
+    reasoning,
+    steps,
+  };
+}
+
+function stripCodeFences(raw: string): string {
+  const fenced = /^```(?:json)?\s*([\s\S]*?)\s*```$/i.exec(raw.trim());
+  return (fenced?.[1] ?? raw).trim();
+}

--- a/packages/core/src/planner/prompt.ts
+++ b/packages/core/src/planner/prompt.ts
@@ -1,0 +1,44 @@
+import type { PlannerInput } from './types';
+
+export const PLANNER_SYSTEM_PROMPT = `You are a planning agent for an AI coding workspace.
+
+The user gives you a theme — a goal they want to accomplish on their codebase.
+Your job is to break that goal into a sequence of agent steps. Each step will be
+executed as its own LLM session. Steps run in order; the output of one step becomes
+context for the next.
+
+You MUST respond with a single JSON object and nothing else. No prose, no markdown,
+no code fences. The schema is:
+
+{
+  "workflowName": "<short title for the whole workflow>",
+  "reasoning": "<one paragraph explaining your decomposition>",
+  "steps": [
+    {
+      "name": "<short imperative title>",
+      "role": "<scout|planner|implementer|reviewer|tester|investigator|product|architect|explorer|other>",
+      "promptPrefix": "<system-style instructions for the step's agent>",
+      "expectedOutput": "<one sentence describing what the step should produce>"
+    },
+    ...
+  ]
+}
+
+Rules:
+- 1 to 6 steps. Smaller is better; only add a step if it carries its own load.
+- Steps are sequential by default. The user can reorder or mark some as parallel later.
+- A step's promptPrefix should make sense without seeing the user's original theme;
+  the theme will be appended automatically as the user message.
+- expectedOutput tells the post-step summarizer what to extract; be specific.
+- Pick roles from the canonical list above. Use "other" only if none fit.
+- Names should be short (1-3 words), in title case.
+- Do not include preamble, apologies, or explanations outside the JSON object.`;
+
+export function buildPlannerUserPrompt(input: PlannerInput): string {
+  const parts = ['Theme:', input.theme];
+  if (input.repoContext && input.repoContext.trim().length > 0) {
+    parts.push('', 'Repository context:', input.repoContext.trim());
+  }
+  parts.push('', 'Return the JSON object now.');
+  return parts.join('\n');
+}

--- a/packages/core/src/planner/types.ts
+++ b/packages/core/src/planner/types.ts
@@ -1,0 +1,17 @@
+export interface PlannerStep {
+  readonly name: string;
+  readonly role: string;
+  readonly promptPrefix: string;
+  readonly expectedOutput: string;
+}
+
+export interface PlannerOutput {
+  readonly workflowName: string;
+  readonly reasoning: string;
+  readonly steps: ReadonlyArray<PlannerStep>;
+}
+
+export interface PlannerInput {
+  readonly theme: string;
+  readonly repoContext?: string;
+}


### PR DESCRIPTION
## Summary

PR6 — planner agent. Turns a free-text theme into a structured `Workflow` proposal that the user reviews before any work runs.

## Design (per VISION decisions)

| Decision | Implementation |
|---|---|
| Cheap-tier active-provider CLI | Mirrors the summarizer pattern. No separate API key. |
| Strict JSON, fail loud | `parsePlannerOutput` throws `PlannerParseError` on any shape violation. |
| Planner doesn't write slots | Output is a Workflow proposal. User edits, then runs. One-writer rule. |
| Library-first, planner-second | `WORKFLOW_LIBRARY` (PR5) is the default; planner is opt-in. |

## Files

- `packages/core/src/planner/types.ts` — `PlannerInput`, `PlannerOutput`, `PlannerStep`
- `packages/core/src/planner/parser.ts` — strict JSON parser, fence stripping, full validation
- `packages/core/src/planner/prompt.ts` — `PLANNER_SYSTEM_PROMPT` + user prompt builder
- `packages/core/src/planner/cli.ts` — `PlannerAgent` (claude / cursor / codex CLI spawn)
- `packages/core/src/planner/index.ts` — barrel (CLI excluded from browser-safe export)
- 17 new tests (14 parser + 3 cli)

## Output schema

```json
{
  "workflowName": "<short title>",
  "reasoning": "<one paragraph>",
  "steps": [
    {
      "name": "<short imperative>",
      "role": "scout | planner | implementer | reviewer | tester | investigator | product | architect | explorer | other",
      "promptPrefix": "<system-style instructions>",
      "expectedOutput": "<one sentence>"
    }
  ]
}
```

Each step's `expectedOutput` becomes the post-step summarizer hint (slot signal-density).

## Verification

- ✅ core typecheck green
- ✅ 404/404 tests pass (+18)

## Followups

- PR7 — wire Tauri commands (`seedWorkflowLibrary`, `runPlanner`) + boot integration
- PR8 — new-task wizard (3-step: theme → planner suggest → user edits)
- PR9 — docs: VISION/ROADMAP/README/CLAUDE.md update + glossary

## Branch

Based on `ak/pr5-workflow-seed`. Final piece of core-side scaffolding for the planner-flow design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
