### PR TITLE
feat(ui): pre-1.0 visual foundation — typography + softer dividers

### DIFF
--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -7,11 +7,11 @@
 
   --color-background: oklch(0.16 0 0);
   --color-foreground: oklch(0.93 0 0);
-  --color-subtle: oklch(0.20 0 0);
-  --color-muted: oklch(0.26 0 0);
+  --color-subtle: oklch(0.19 0 0);
+  --color-muted: oklch(0.24 0 0);
   --color-muted-foreground: oklch(0.62 0 0);
-  --color-border: oklch(0.32 0 0);
-  --color-border-soft: oklch(0.24 0 0);
+  --color-border: oklch(0.26 0 0);
+  --color-border-soft: oklch(0.21 0 0);
   --color-primary: oklch(0.78 0 0);
   --color-primary-foreground: oklch(0.16 0 0);
   --color-danger: oklch(0.62 0.025 25);
@@ -23,15 +23,17 @@
   --color-info: oklch(0.66 0.02 240);
   --color-info-foreground: oklch(0.16 0 0);
 
-  --text-2xs: 10px;
-  --text-xs: 11px;
-  --text-sm: 13px;
-  --text-base: 14px;
-  --text-lg: 16px;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 20px;
 
   --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 8px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
 
   --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.35);
   --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.45);
@@ -51,8 +53,8 @@ html,
 body,
 #root {
   height: 100%;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 15px;
+  line-height: 1.55;
   background: var(--color-background);
   color: var(--color-foreground);
   color-scheme: dark;

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -11,9 +11,9 @@ export interface AppShellProps {
   className?: string;
 }
 
-const LEFT_SIDEBAR_WIDTH = '260px';
-const RIGHT_SIDEBAR_WIDTH = '320px';
-const RIGHT_RAIL_WIDTH = '36px';
+const LEFT_SIDEBAR_WIDTH = '280px';
+const RIGHT_SIDEBAR_WIDTH = '340px';
+const RIGHT_RAIL_WIDTH = '40px';
 
 function buildLayout(opts: { collapsed: boolean; hasRightSidebar: boolean; hasFooter: boolean }): {
   templateAreas: string;
@@ -70,13 +70,13 @@ export function AppShell({
         style={gridStyle}
       >
         <header
-          className="flex h-9 min-w-0 items-center border-b border-border bg-background px-3 text-sm"
+          className="flex h-11 min-w-0 items-center border-b border-border-soft bg-background px-4 text-sm"
           style={{ gridArea: 'header' }}
         >
           {header}
         </header>
         <aside
-          className="flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-border bg-subtle"
+          className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-subtle"
           style={{ gridArea: 'left' }}
         >
           {leftSidebar}
@@ -89,7 +89,7 @@ export function AppShell({
         </main>
         {hasRightSidebar ? (
           <aside
-            className="flex min-h-0 min-w-0 flex-col overflow-hidden border-l border-border bg-background"
+            className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background"
             style={{ gridArea: 'right' }}
           >
             {rightSidebar}
@@ -97,7 +97,7 @@ export function AppShell({
         ) : null}
         {footer ? (
           <footer
-            className="flex h-6 min-w-0 items-center border-t border-border bg-subtle px-3 font-mono text-xs text-muted-foreground"
+            className="flex h-7 min-w-0 items-center border-t border-border-soft bg-subtle px-4 font-mono text-xs text-muted-foreground"
             style={{ gridArea: 'footer' }}
           >
             {footer}


### PR DESCRIPTION
PR8 of pre-1.0 ux overhaul. First slice: typography + spacing + dividers softened (no hard section borders).

ui+desktop typecheck green. 172/172 desktop tests pass.

Followups:
- PR9: sidebar overlay + 3-block restructure
- PR10: chat — bubble only for user
- PR11: input area chips (provider/model/effort)
- PR12: pricing modal
- PR13: agent concept (scopes + sub-agents)
- PR14: new-task wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)