### PR TITLE
feat(desktop): chat header + status bar — drop redundancy

### DIFF
--- a/apps/desktop/src/components/StatusBar.tsx
+++ b/apps/desktop/src/components/StatusBar.tsx
@@ -1,40 +1,15 @@
 import { CircleHelp } from 'lucide-react';
-import { useAppStore, useCurrentSession, useCurrentWorkspace } from '../store';
-import { useToast } from './Toast';
+import { useCurrentSession, useCurrentWorkspace } from '../store';
 import { TelemetryPill } from './TelemetryPill';
 
 interface StatusBarProps {
   onFocusWorkspaces?: () => void;
 }
 
-function shortenHome(path: string): string {
-  const home = '/Users/';
-  const idx = path.indexOf(home);
-  if (idx !== 0) return path;
-  const rest = path.slice(home.length);
-  const slash = rest.indexOf('/');
-  if (slash === -1) return path;
-  return `~${rest.slice(slash)}`;
-}
-
 export function StatusBar({ onFocusWorkspaces }: StatusBarProps) {
   const workspace = useCurrentWorkspace();
   const session = useCurrentSession();
-  const worktreePath = useAppStore((s) =>
-    session ? ((s.sessionWorktrees[session.id] ?? [])[0] ?? null) : null,
-  );
-  const branch = useAppStore((s) => (session ? (s.sessionBranches[session.id] ?? null) : null));
-  const { showToast } = useToast();
   const sessionStateLabel = session?.state.kind ?? 'idle';
-
-  const onCopy = async (text: string, label: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      showToast('success', `copied ${label}`);
-    } catch {
-      // clipboard denied — silent
-    }
-  };
 
   return (
     <div className="flex w-full items-center gap-3">
@@ -49,22 +24,6 @@ export function StatusBar({ onFocusWorkspaces }: StatusBarProps) {
         >
           {workspace?.name ?? 'no workspace'}
         </button>
-        {branch ? (
-          <CopyItem
-            label={`worktree:${branch}`}
-            copyValue={branch}
-            copyLabel="worktree"
-            onCopy={onCopy}
-          />
-        ) : null}
-        {worktreePath ? (
-          <CopyItem
-            label={`worktree:${shortenHome(worktreePath)}`}
-            copyValue={worktreePath}
-            copyLabel="worktree path"
-            onCopy={onCopy}
-          />
-        ) : null}
         <span className="text-muted-foreground">{sessionStateLabel}</span>
       </div>
       <div className="flex shrink-0 items-center gap-3">
@@ -72,32 +31,8 @@ export function StatusBar({ onFocusWorkspaces }: StatusBarProps) {
         <span className="inline-flex items-center gap-1" title="open settings">
           <CircleHelp size={11} aria-hidden />
           <kbd className="font-mono">⌘,</kbd>
-          {/* TODO (@ak): cmd+K palette not shipped yet */}
         </span>
       </div>
     </div>
-  );
-}
-
-function CopyItem({
-  label,
-  copyValue,
-  copyLabel,
-  onCopy,
-}: {
-  label: string;
-  copyValue: string;
-  copyLabel: string;
-  onCopy: (text: string, label: string) => Promise<void>;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => void onCopy(copyValue, copyLabel)}
-      title={`copy ${copyLabel}`}
-      className="truncate rounded-sm px-1 hover:bg-muted hover:text-foreground"
-    >
-      {label}
-    </button>
   );
 }

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { GitBranch, Square, ShieldCheck } from 'lucide-react';
+import { GitBranch, ShieldCheck } from 'lucide-react';
 import { Button, Tooltip, cn } from '@kay-am/ui';
 import type { Session, SessionStatus, ProviderRunId, Task, TaskId } from '@kay-am/types';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
@@ -10,7 +10,6 @@ import { ParallelProgressPill } from './ParallelProgressPill';
 interface ChatHeaderProps {
   session: Task;
   worktreePath: string | null;
-  onEndSession: () => void;
   parallelRunIds?: ReadonlyArray<ProviderRunId>;
   onSelectRun?: (runId: ProviderRunId) => void;
 }
@@ -24,7 +23,6 @@ function inferBranch(worktreePath: string | null, taskId: string): string {
 export function ChatHeader({
   session,
   worktreePath,
-  onEndSession,
   parallelRunIds,
   onSelectRun,
 }: ChatHeaderProps) {
@@ -32,7 +30,6 @@ export function ChatHeader({
   const [auditOpen, setAuditOpen] = useState(false);
 
   const branch = inferBranch(worktreePath, session.id);
-  const isEnded = session.state.kind === 'ended';
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
 
@@ -56,7 +53,7 @@ export function ChatHeader({
   };
 
   return (
-    <div className="flex w-full items-center gap-3 border-b border-border px-4 py-2.5">
+    <div className="flex w-full items-center gap-3 px-4 py-2.5">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
@@ -86,16 +83,6 @@ export function ChatHeader({
 
       <div className="flex shrink-0 items-center gap-1">
         <OpenInEditorButton worktreePath={worktreePath} />
-        {!isEnded ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={onEndSession}
-            title="end session — removes worktree, preserves branch"
-          >
-            <Square size={12} aria-hidden /> end session
-          </Button>
-        ) : null}
         <Tooltip content="permission audit log" side="bottom">
           <Button
             variant="ghost"

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -10,7 +10,7 @@ import { MergeDialog, type MergeConflict, type MergeResolution } from './MergeDi
 
 interface ChatViewProps {
   session: Task;
-  onRequestEnd: () => void;
+  onRequestEnd?: () => void;
 }
 
 const PIN_TOLERANCE_PX = 32;
@@ -107,7 +107,7 @@ function ThinkingIndicator() {
   );
 }
 
-export function ChatView({ session, onRequestEnd }: ChatViewProps) {
+export function ChatView({ session }: ChatViewProps) {
   const events = useTranscript(session.id);
   const items = useMemo(() => reduceTranscript(events), [events]);
   const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
@@ -192,7 +192,6 @@ export function ChatView({ session, onRequestEnd }: ChatViewProps) {
         <ChatHeader
           session={session}
           worktreePath={worktreePath}
-          onEndSession={onRequestEnd}
           parallelRunIds={parallelRunIds}
           onSelectRun={onSelectRun}
         />
@@ -245,7 +244,7 @@ export function ChatView({ session, onRequestEnd }: ChatViewProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <ChatHeader session={session} worktreePath={worktreePath} onEndSession={onRequestEnd} />
+      <ChatHeader session={session} worktreePath={worktreePath} />
       <div
         ref={scrollerRef}
         onScroll={onScroll}


### PR DESCRIPTION
PR13 of pre-1.0 ux overhaul. Removes the redundant End session CTA and the duplicate worktree refs from the footer.

172/172 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)