### PR TITLE
feat(desktop): planner wizard — design custom workflow from a theme

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -154,15 +154,55 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
         >
           workflow (optional)
         </span>
-        <p
-          class="text-xs text-muted-foreground/70"
+        <div
+          class="flex flex-wrap gap-1.5"
         >
-          none available
-        </p>
+          <button
+            class="rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-foreground text-background"
+            type="button"
+          >
+            single chat
+          </button>
+          <button
+            class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="design a custom workflow with the planner agent"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-sparkles"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+              />
+              <path
+                d="M20 2v4"
+              />
+              <path
+                d="M22 4h-4"
+              />
+              <circle
+                cx="4"
+                cy="20"
+                r="2"
+              />
+            </svg>
+             design custom
+          </button>
+        </div>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
         >
-          no workflows yet — create in Settings → Workflows.
+          no workflows yet — design one with the planner below.
         </p>
       </div>
       <div
@@ -933,15 +973,55 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
         >
           workflow (optional)
         </span>
-        <p
-          class="text-xs text-muted-foreground/70"
+        <div
+          class="flex flex-wrap gap-1.5"
         >
-          none available
-        </p>
+          <button
+            class="rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-foreground text-background"
+            type="button"
+          >
+            single chat
+          </button>
+          <button
+            class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="design a custom workflow with the planner agent"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-sparkles"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+              />
+              <path
+                d="M20 2v4"
+              />
+              <path
+                d="M22 4h-4"
+              />
+              <circle
+                cx="4"
+                cy="20"
+                r="2"
+              />
+            </svg>
+             design custom
+          </button>
+        </div>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
         >
-          no workflows yet — create in Settings → Workflows.
+          no workflows yet — design one with the planner below.
         </p>
       </div>
       <div

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
+import { Sparkles } from 'lucide-react';
 import type {
   WorkflowId,
   ProviderId,
@@ -9,6 +10,7 @@ import type {
 } from '@kay-am/types';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
 import { EMPTY_ARRAY, useAppStore } from '../store';
+import { PlannerWidget } from './PlannerWidget';
 
 interface NewSessionDialogProps {
   open: boolean;
@@ -49,6 +51,7 @@ export function NewSessionDialog({
   const [prefix, setPrefix] = useState(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
   const [softCapRaw, setSoftCapRaw] = useState('');
   const [selectedPhaseTemplateId, setSelectedPhaseTemplateId] = useState<WorkflowId | ''>('');
+  const [plannerOpen, setPlannerOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -71,6 +74,7 @@ export function NewSessionDialog({
     setPrefix(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
     setSoftCapRaw('');
     setSelectedPhaseTemplateId('');
+    setPlannerOpen(false);
     setError(null);
   };
 
@@ -154,30 +158,50 @@ export function NewSessionDialog({
         label="workflow (optional)"
         hint={
           phaseTemplates.length === 0
-            ? 'no workflows yet — create in Settings → Workflows.'
+            ? 'no workflows yet — design one with the planner below.'
             : 'pick a workflow blueprint. each step spawns its own agent with its own context.'
         }
       >
-        {phaseTemplates.length === 0 ? (
-          <p className="text-xs text-muted-foreground/70">none available</p>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1.5">
+          <WorkflowChip
+            label="single chat"
+            active={selectedPhaseTemplateId === ''}
+            onClick={() => setSelectedPhaseTemplateId('')}
+          />
+          {phaseTemplates.map((t) => (
             <WorkflowChip
-              label="single chat"
-              active={selectedPhaseTemplateId === ''}
-              onClick={() => setSelectedPhaseTemplateId('')}
+              key={t.id}
+              label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
+              active={selectedPhaseTemplateId === t.id}
+              onClick={() => setSelectedPhaseTemplateId(t.id)}
+              title={t.description || undefined}
             />
-            {phaseTemplates.map((t) => (
-              <WorkflowChip
-                key={t.id}
-                label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
-                active={selectedPhaseTemplateId === t.id}
-                onClick={() => setSelectedPhaseTemplateId(t.id)}
-                title={t.description || undefined}
-              />
-            ))}
-          </div>
-        )}
+          ))}
+          <button
+            type="button"
+            onClick={() => setPlannerOpen((v) => !v)}
+            className={cn(
+              'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors',
+              plannerOpen
+                ? 'bg-foreground text-background'
+                : 'bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
+            )}
+            title="design a custom workflow with the planner agent"
+          >
+            <Sparkles size={11} aria-hidden /> design custom
+          </button>
+        </div>
+        {plannerOpen ? (
+          <PlannerWidget
+            workspaceId={workspaceId}
+            providerId={selectedProvider}
+            initialTheme={goal}
+            onWorkflowReady={(workflowId) => {
+              setSelectedPhaseTemplateId(workflowId);
+              setPlannerOpen(false);
+            }}
+          />
+        ) : null}
       </Field>
 
       <Field label="provider">

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { Button, Textarea, cn } from '@kay-am/ui';
+import { PlannerClient, type PlannerOutput } from '@kay-am/core';
+import type { ProviderId, Step, StepId, Workflow, WorkflowId, WorkspaceId } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+interface PlannerWidgetProps {
+  workspaceId: WorkspaceId;
+  providerId: ProviderId;
+  initialTheme: string;
+  onWorkflowReady: (workflowId: WorkflowId) => void;
+}
+
+export function PlannerWidget({
+  workspaceId,
+  providerId,
+  initialTheme,
+  onWorkflowReady,
+}: PlannerWidgetProps) {
+  const savePhaseTemplate = useAppStore((s) => s.savePhaseTemplate);
+  const [theme, setTheme] = useState(initialTheme);
+  const [busy, setBusy] = useState(false);
+  const [plan, setPlan] = useState<PlannerOutput | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPlan = async () => {
+    if (theme.trim().length === 0) return;
+    setError(null);
+    setPlan(null);
+    setBusy(true);
+    try {
+      const client = new PlannerClient({ providerId, invokeFn: invoke });
+      const result = await client.plan({ theme: theme.trim() });
+      setPlan(result.output);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onSave = async () => {
+    if (!plan) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const now = new Date().toISOString() as Workflow['createdAt'];
+      const workflowId = `wf_planner_${crypto.randomUUID()}` as WorkflowId;
+      const steps: ReadonlyArray<Step> = plan.steps.map((s, ordinal) => ({
+        id: `step_planner_${crypto.randomUUID()}` as StepId,
+        workflowId,
+        ordinal,
+        name: s.name,
+        promptPrefix: s.promptPrefix,
+      }));
+      const workflow: Workflow = {
+        id: workflowId,
+        workspaceId,
+        name: plan.workflowName,
+        description: plan.reasoning,
+        steps,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await savePhaseTemplate(workflow);
+      onWorkflowReady(workflowId);
+      setPlan(null);
+      setTheme('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md bg-subtle p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold text-foreground">design with planner</span>
+        <span className="text-2xs text-muted-foreground">cheap-tier · {providerId}</span>
+      </div>
+      <Textarea
+        value={theme}
+        onChange={(e) => setTheme(e.target.value)}
+        placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
+        autoGrow
+        maxRows={5}
+      />
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-2xs text-muted-foreground">
+          planner returns a structured workflow you can review before saving.
+        </p>
+        <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
+          {busy && !plan ? 'planning…' : plan ? 're-plan' : 'generate plan'}
+        </Button>
+      </div>
+      {error ? (
+        <p role="alert" className="text-xs text-danger">
+          {error}
+        </p>
+      ) : null}
+      {plan ? (
+        <div className="flex flex-col gap-2 rounded-md bg-background p-3">
+          <div>
+            <div className="text-sm font-semibold">{plan.workflowName}</div>
+            {plan.reasoning ? (
+              <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                {plan.reasoning}
+              </p>
+            ) : null}
+          </div>
+          <ol className="flex flex-col gap-1.5">
+            {plan.steps.map((s, i) => (
+              <li key={`${i}-${s.name}`} className={cn('rounded-md bg-subtle px-2.5 py-1.5')}>
+                <div className="flex items-center justify-between gap-2 text-xs">
+                  <span className="font-medium">
+                    {i + 1}. {s.name}
+                  </span>
+                  <span className="rounded-full bg-muted px-1.5 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
+                    {s.role}
+                  </span>
+                </div>
+                <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+                  {s.expectedOutput}
+                </p>
+              </li>
+            ))}
+          </ol>
+          <Button size="sm" onClick={onSave} disabled={busy}>
+            {busy ? 'saving…' : 'use this workflow'}
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Wires PlannerClient into the new-session dialog. "Design custom" chip → theme input → cheap-tier planner run → preview → save & use. Closes the planner UI loop.

172/172 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)