### PR TITLE
fix(desktop): align rust workflow commands with renamed schema

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"7e97a8c5-4922-4104-8c1f-076dae472642","pid":12355,"procStart":"Sat May  9 10:07:23 2026","acquiredAt":1778324794327}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"7e97a8c5-4922-4104-8c1f-076dae472642","pid":12355,"procStart":"Sat May  9 10:07:23 2026","acquiredAt":1778324794327}

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ coverage/
 # misc
 *.tsbuildinfo
 .claude/launch.json
+.claude/scheduled_tasks.lock

--- a/apps/desktop/src-tauri/src/config_export.rs
+++ b/apps/desktop/src-tauri/src/config_export.rs
@@ -60,7 +60,7 @@ pub struct SkillBundle {
 pub struct PhaseDefinitionBundle {
     pub id: String,
     #[serde(rename = "workflowId")]
-    pub template_id: String,
+    pub workflow_id: String,
     pub ordinal: i64,
     pub name: String,
     #[serde(rename = "promptPrefix")]
@@ -78,7 +78,7 @@ pub struct PhaseTemplateBundle {
     pub workspace_id: String,
     pub name: String,
     pub description: String,
-    pub definitions: Vec<PhaseDefinitionBundle>,
+    pub steps: Vec<PhaseDefinitionBundle>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
     #[serde(rename = "updatedAt")]
@@ -261,7 +261,7 @@ pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportE
         rows.collect::<Result<Vec<_>, _>>()?
     };
 
-    // phase templates + definitions
+    // workflows + steps
     let phase_templates = {
         let mut stmt = conn.prepare(
             "SELECT id, workspace_id, name, description, created_at, updated_at
@@ -282,16 +282,16 @@ pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportE
         for row in template_rows {
             let (id, workspace_id, name, description, created_at, updated_at) = row?;
             let mut def_stmt = conn.prepare(
-                "SELECT id, template_id, ordinal, name, prompt_prefix, provider_override, model_override
+                "SELECT id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override
                  FROM steps
-                 WHERE template_id = ?1
+                 WHERE workflow_id = ?1
                  ORDER BY ordinal ASC",
             )?;
             let defs = def_stmt
                 .query_map(rusqlite::params![id], |r| {
                     Ok(PhaseDefinitionBundle {
                         id: r.get(0)?,
-                        template_id: r.get(1)?,
+                        workflow_id: r.get(1)?,
                         ordinal: r.get(2)?,
                         name: r.get(3)?,
                         prompt_prefix: r.get(4)?,
@@ -305,7 +305,7 @@ pub fn export_config(state: State<'_, Db>) -> Result<ConfigBundle, ConfigExportE
                 workspace_id,
                 name,
                 description,
-                definitions: defs,
+                steps: defs,
                 created_at,
                 updated_at,
             });
@@ -562,10 +562,10 @@ pub fn import_config(
                     t.created_at, t.updated_at,
                 ],
             )?;
-            for d in &t.definitions {
+            for d in &t.steps {
                 conn.execute(
                     "INSERT INTO steps
-                       (id, template_id, ordinal, name, prompt_prefix, provider_override, model_override)
+                       (id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override)
                      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
                      ON CONFLICT(id) DO UPDATE SET
                        ordinal          = excluded.ordinal,
@@ -574,7 +574,7 @@ pub fn import_config(
                        provider_override = excluded.provider_override,
                        model_override   = excluded.model_override",
                     rusqlite::params![
-                        d.id, d.template_id, d.ordinal, d.name,
+                        d.id, d.workflow_id, d.ordinal, d.name,
                         d.prompt_prefix, d.provider_override, d.model_override,
                     ],
                 )?;

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -11,7 +11,7 @@ use crate::db::{Db, DbError};
 pub struct StepRow {
     pub id: String,
     #[serde(rename = "workflowId")]
-    pub template_id: String,
+    pub workflow_id: String,
     pub ordinal: i64,
     pub name: String,
     #[serde(rename = "promptPrefix")]
@@ -29,7 +29,7 @@ pub struct WorkflowRow {
     pub workspace_id: String,
     pub name: String,
     pub description: String,
-    pub definitions: Vec<StepRow>,
+    pub steps: Vec<StepRow>,
     #[serde(rename = "createdAt")]
     pub created_at: String,
     #[serde(rename = "updatedAt")]
@@ -56,7 +56,7 @@ pub struct PhaseTemplateUpsertInput {
     pub workspace_id: String,
     pub name: String,
     pub description: String,
-    pub definitions: Vec<StepInput>,
+    pub steps: Vec<StepInput>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -169,20 +169,20 @@ impl From<DbError> for PhaseError {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn load_definitions(
+fn load_steps(
     conn: &rusqlite::Connection,
-    template_id: &str,
+    workflow_id: &str,
 ) -> Result<Vec<StepRow>, rusqlite::Error> {
     let mut stmt = conn.prepare(
-        "SELECT id, template_id, ordinal, name, prompt_prefix, provider_override, model_override
+        "SELECT id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override
          FROM steps
-         WHERE template_id = ?1
+         WHERE workflow_id = ?1
          ORDER BY ordinal ASC",
     )?;
-    let rows = stmt.query_map(rusqlite::params![template_id], |row| {
+    let rows = stmt.query_map(rusqlite::params![workflow_id], |row| {
         Ok(StepRow {
             id: row.get(0)?,
-            template_id: row.get(1)?,
+            workflow_id: row.get(1)?,
             ordinal: row.get(2)?,
             name: row.get(3)?,
             prompt_prefix: row.get(4)?,
@@ -202,13 +202,13 @@ fn row_to_template(
     created_at: String,
     updated_at: String,
 ) -> Result<WorkflowRow, rusqlite::Error> {
-    let definitions = load_definitions(conn, &id)?;
+    let steps = load_steps(conn, &id)?;
     Ok(WorkflowRow {
         id,
         workspace_id,
         name,
         description,
-        definitions,
+        steps,
         created_at,
         updated_at,
     })
@@ -341,18 +341,18 @@ pub fn workflow_upsert(
         ],
     )?;
 
-    // Replace definitions atomically.
+    // Replace steps atomically.
     conn.execute(
-        "DELETE FROM steps WHERE template_id = ?1",
+        "DELETE FROM steps WHERE workflow_id = ?1",
         rusqlite::params![id],
     )?;
 
-    let mut definitions = Vec::with_capacity(input.definitions.len());
-    for def in &input.definitions {
+    let mut steps = Vec::with_capacity(input.steps.len());
+    for def in &input.steps {
         let def_id = def.id.clone().unwrap_or_else(uuid_v4);
         conn.execute(
             "INSERT INTO steps
-               (id, template_id, ordinal, name, prompt_prefix, provider_override, model_override)
+               (id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
             rusqlite::params![
                 def_id,
@@ -364,9 +364,9 @@ pub fn workflow_upsert(
                 def.model_override,
             ],
         )?;
-        definitions.push(StepRow {
+        steps.push(StepRow {
             id: def_id,
-            template_id: id.clone(),
+            workflow_id: id.clone(),
             ordinal: def.ordinal,
             name: def.name.clone(),
             prompt_prefix: def.prompt_prefix.clone(),
@@ -380,7 +380,7 @@ pub fn workflow_upsert(
         workspace_id: input.workspace_id,
         name: input.name,
         description: input.description,
-        definitions,
+        steps,
         created_at,
         updated_at: now,
     })
@@ -404,7 +404,7 @@ pub fn workflow_delete(
         return Err(PhaseError::TemplateNotFound(id));
     }
 
-    // Cascade delete handled by FK ON DELETE CASCADE on phase_definitions.
+    // Cascade delete handled by FK ON DELETE CASCADE on steps.
     conn.execute(
         "DELETE FROM workflows WHERE id = ?1",
         rusqlite::params![id],

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -62,12 +62,20 @@ export function NewSessionDialog({
 
   useEffect(() => {
     if (!open) return;
+    // Open should always present a virgin form: reset every field, not just
+    // prefix/provider. Otherwise stale goal/template/budget/planner state from
+    // a previous (cancelled) attempt — or from a previous workspace — leaks in.
+    setGoal('');
+    setSoftCapRaw('');
+    setSelectedPhaseTemplateId('');
+    setPlannerOpen(false);
+    setError(null);
     void loadSetting(settingKey).then((value) => {
       setPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
     const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
     setSelectedProvider(pickDefaultProvider(ids));
-  }, [open, settingKey, loadSetting, providers]);
+  }, [open, settingKey, loadSetting, providers, workspaceId]);
 
   const reset = () => {
     setGoal('');

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1776,6 +1776,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
       throw new Error(check.error ?? 'not a git repository');
     }
     const resolvedRoot = check.rootPath;
+
+    // Surface a friendly error if the repo is already registered, instead of leaking
+    // SQLite's UNIQUE constraint violation as `[object Object]` to the dialog.
+    const existing = get().workspaces.find((w) => w.rootPath === resolvedRoot);
+    if (existing) {
+      throw new Error(`workspace already exists: ${existing.name}`);
+    }
+
     const inferredName =
       name?.trim() || resolvedRoot.split('/').filter(Boolean).at(-1) || 'workspace';
     const now = new Date().toISOString() as IsoDateTime;
@@ -1786,7 +1794,22 @@ export const useAppStore = create<AppStore>((set, get) => ({
       createdAt: now,
       updatedAt: now,
     };
-    await insertWorkspace(tauriDatabase, workspace);
+    try {
+      await insertWorkspace(tauriDatabase, workspace);
+    } catch (err) {
+      // Tauri serializes Rust errors as `{kind, message}`. Without normalization the dialog
+      // surfaces "[object Object]" because plain objects stringify to that.
+      const msg =
+        err instanceof Error
+          ? err.message
+          : typeof err === 'object' && err !== null && 'message' in err
+            ? String((err as { message: unknown }).message)
+            : String(err);
+      if (msg.toLowerCase().includes('unique')) {
+        throw new Error(`workspace already exists at ${resolvedRoot}`);
+      }
+      throw new Error(`failed to register workspace: ${msg}`);
+    }
     set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
 
     // Seed default workflow library so the new-task wizard always has presets.


### PR DESCRIPTION
## Summary

Three bugs left over from the phase→workflow domain rename surfaced while testing the planner-driven custom workflow flow:

- **workflows.rs / config_export.rs** still queried the old \`template_id\` column on \`steps\` and serialized the workflow's children as \`definitions\`. The schema migration renamed those to \`workflow_id\` and \`steps\` (TS contract), so every CRUD path was broken:
  - \`workflow_list\` / \`workflow_get\` died with \"no such column: template_id\"
  - \`workflow_upsert\` rejected the TS payload with \"missing field \`definitions\`\"
  - cascade-delete comment + config-bundle export/import all on the same wrong column
- **addWorkspace** leaked Rust DbError objects to the dialog (\"[object Object]\") on duplicate root_path. Now short-circuits and returns a friendly message.

## Test plan

- [x] cargo check
- [x] cargo test (9 passed)
- [x] pnpm typecheck
- [x] pnpm test (386 + 172 passed)
- [ ] manual: add workspace → create task → planner → \"use this workflow\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)