### PR TITLE
feat(core): agent multi-turn — kill workflow auto-advance

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -5,7 +5,8 @@ import {
   PermissionEngine,
   buildClaudeFlags,
   buildStepPrompt,
-  nextStep,
+  currentStep,
+  findReusableSession,
   parseSlashCommand,
   resolveConflicts,
   resolveSettings,
@@ -1036,7 +1037,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
         set((state) => ({
           sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: freshRuns },
         }));
-        const nextDef = nextStep(template, freshRuns);
+        // Resolve the step the next turn should land on. Auto-advance is gone:
+        // currentStep keeps the agent on its current role until the user
+        // explicitly spawns a new agent (future PR). Multiple turns now stack
+        // on the same Session row instead of inserting a fresh row per message.
+        const nextDef = currentStep(template, freshRuns);
         if (nextDef) {
           const sortedDefs = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
           const prevDef =
@@ -1048,7 +1053,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
           const prevRun = prevDef
             ? (freshRuns.find((r) => r.stepId === prevDef.id && r.status === 'completed') ?? null)
             : null;
-          if (prevDef && prevRun) {
+          // Carry-forward + transition event only fire on the *first* turn of a
+          // step. Subsequent iterations on the same step skip both, so the
+          // prompt isn't bloated by duplicating the previous step's summary on
+          // every message and the transcript doesn't show a phantom step
+          // transition mid-conversation.
+          const isFirstTurnOfStep = !freshRuns.some((r) => r.stepId === nextDef.id);
+          if (prevDef && prevRun && isFirstTurnOfStep) {
             const propagator = new WorkflowPropagator({
               summarizer: { summarizePhaseOutput: async (text) => text },
             });
@@ -1193,16 +1204,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     let sessionId: SessionId | null = null;
     if (phaseDefinition && parallelDispatch === null) {
-      const inserted = await invokePhaseRunInsert({
-        taskId,
-        stepId: phaseDefinition.id,
-        ordinal: phaseDefinition.ordinal,
-        name: phaseDefinition.name,
-        status: 'running',
-        providerRunId: runId,
-        startedAt: now(),
-      });
-      sessionId = inserted.id;
+      // Reuse the existing Session row for this step if one already exists.
+      // Agent-multi-turn: every turn flips the same row to running and points
+      // it at the new providerRunId, instead of inserting a fresh row per
+      // user message. New rows only appear when the user spawns a new agent.
+      const runsForTask = get().sessionPhaseRuns[taskId] ?? [];
+      const reusable = findReusableSession(runsForTask, phaseDefinition.id);
+      let resolved: Session;
+      if (reusable) {
+        resolved = await invokePhaseRunUpdateStatus(reusable.id, {
+          status: 'running',
+          providerRunId: runId,
+          startedAt: now(),
+        });
+      } else {
+        resolved = await invokePhaseRunInsert({
+          taskId,
+          stepId: phaseDefinition.id,
+          ordinal: phaseDefinition.ordinal,
+          name: phaseDefinition.name,
+          status: 'running',
+          providerRunId: runId,
+          startedAt: now(),
+        });
+      }
+      sessionId = resolved.id;
       const refreshedRuns = await invokePhaseRunList(taskId);
       set((state) => ({
         sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: refreshedRuns },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,8 @@ export {
 
 export {
   buildStepPrompt,
+  currentStep,
+  findReusableSession,
   isWorkflowComplete,
   nextStep,
   WorkflowPropagator,

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,4 +1,10 @@
-export { buildStepPrompt, isWorkflowComplete, nextStep } from './sequencer';
+export {
+  buildStepPrompt,
+  currentStep,
+  findReusableSession,
+  isWorkflowComplete,
+  nextStep,
+} from './sequencer';
 export { WorkflowPropagator, type WorkflowPropagatorDeps } from './propagator';
 export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';
 export { seedWorkflowLibrary, type SeedResult, type SeedWorkflowLibraryDeps } from './seeder';

--- a/packages/core/src/workflows/sequencer.test.ts
+++ b/packages/core/src/workflows/sequencer.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import type { Step, Session, Workflow } from '@kay-am/types';
-import { buildStepPrompt, isWorkflowComplete, nextStep } from './sequencer';
+import {
+  buildStepPrompt,
+  currentStep,
+  findReusableSession,
+  isWorkflowComplete,
+  nextStep,
+} from './sequencer';
 
 const D1: Step = {
   id: 'd1' as Step['id'],
@@ -36,14 +42,20 @@ const TEMPLATE: Workflow = {
   updatedAt: '2024-01-01T00:00:00.000Z' as Workflow['updatedAt'],
 };
 
-function makeRun(defId: string, status: Session['status'], ordinal: number): Session {
+function makeRun(
+  defId: string,
+  status: Session['status'],
+  ordinal: number,
+  startedAt?: string,
+): Session {
   return {
-    id: `run-${defId}` as Session['id'],
+    id: `run-${defId}-${startedAt ?? '0'}` as Session['id'],
     taskId: 's1' as Session['taskId'],
     stepId: defId as Session['stepId'],
     ordinal,
     name: `run for ${defId}`,
     status,
+    ...(startedAt && { startedAt: startedAt as Session['startedAt'] }),
   };
 }
 
@@ -155,6 +167,67 @@ describe('isWorkflowComplete', () => {
       makeRun('d3', 'pending', 3),
     ];
     expect(isWorkflowComplete(TEMPLATE, runs)).toBe(false);
+  });
+});
+
+describe('currentStep', () => {
+  it('returns first step on cold start (no runs)', () => {
+    expect(currentStep(TEMPLATE, [])).toBe(D1);
+  });
+
+  it('returns the step with a running run', () => {
+    const runs = [makeRun('d2', 'running', 2, '2026-01-02T00:00:00Z')];
+    expect(currentStep(TEMPLATE, runs)).toBe(D2);
+  });
+
+  it('stays on a completed step until user spawns a new agent', () => {
+    // The auto-advance behavior of nextStep would have skipped to D2 here.
+    // currentStep keeps the user on the most recent run regardless of status.
+    const runs = [makeRun('d1', 'completed', 1, '2026-01-01T00:00:00Z')];
+    expect(currentStep(TEMPLATE, runs)).toBe(D1);
+  });
+
+  it('prefers a non-terminal run over a more recent completed one', () => {
+    const runs = [
+      makeRun('d1', 'completed', 1, '2026-01-03T00:00:00Z'),
+      makeRun('d2', 'failed', 2, '2026-01-02T00:00:00Z'),
+    ];
+    expect(currentStep(TEMPLATE, runs)).toBe(D2);
+  });
+
+  it('picks the most recent run by startedAt when several are non-terminal', () => {
+    const runs = [
+      makeRun('d1', 'running', 1, '2026-01-01T00:00:00Z'),
+      makeRun('d2', 'running', 2, '2026-01-02T00:00:00Z'),
+    ];
+    expect(currentStep(TEMPLATE, runs)).toBe(D2);
+  });
+
+  it('falls back to first step when template empty', () => {
+    expect(currentStep({ ...TEMPLATE, steps: [] }, [])).toBeNull();
+  });
+});
+
+describe('findReusableSession', () => {
+  it('returns null when no run exists for the step', () => {
+    expect(findReusableSession([], 'd1' as Step['id'])).toBeNull();
+  });
+
+  it('returns the only matching run', () => {
+    const run = makeRun('d1', 'idle' as Session['status'], 1, '2026-01-01T00:00:00Z');
+    expect(findReusableSession([run], 'd1' as Step['id'])).toBe(run);
+  });
+
+  it('returns the most recently started run for the step', () => {
+    const older = makeRun('d1', 'completed', 1, '2026-01-01T00:00:00Z');
+    const newer = makeRun('d1', 'running', 1, '2026-01-02T00:00:00Z');
+    expect(findReusableSession([older, newer], 'd1' as Step['id'])).toBe(newer);
+  });
+
+  it('ignores runs for other steps', () => {
+    const a = makeRun('d1', 'completed', 1, '2026-01-02T00:00:00Z');
+    const b = makeRun('d2', 'running', 2, '2026-01-01T00:00:00Z');
+    expect(findReusableSession([a, b], 'd2' as Step['id'])).toBe(b);
   });
 });
 

--- a/packages/core/src/workflows/sequencer.ts
+++ b/packages/core/src/workflows/sequencer.ts
@@ -9,6 +9,63 @@ export function nextStep(template: Workflow, runs: ReadonlyArray<Session>): Step
   return sorted.find((d) => !doneIds.has(d.id)) ?? null;
 }
 
+/**
+ * Resolve the step that the next user message should be routed to.
+ *
+ * Replaces auto-advance: the orchestrator no longer skips to the next step
+ * the moment a previous one completes — it stays on whichever step has an
+ * existing in-flight or last-touched run. The user explicitly spawns a new
+ * agent (future PR) to move forward; until then, every message keeps
+ * iterating with the same role.
+ *
+ * Resolution order:
+ *  1. Most recent non-terminal run (running / failed / pending) → its step.
+ *  2. Most recent run regardless of status → its step (so completed steps
+ *     keep accepting follow-up turns until the user acts).
+ *  3. First step in the template (cold start, no runs yet).
+ */
+export function currentStep(template: Workflow, runs: ReadonlyArray<Session>): Step | null {
+  const sorted = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+  if (sorted.length === 0) return null;
+
+  if (runs.length === 0) {
+    return sorted[0] ?? null;
+  }
+
+  const stepById = new Map(sorted.map((s) => [s.id, s] as const));
+  const isStartedAt = (r: Session) => r.startedAt ?? '';
+
+  const live = runs
+    .filter((r) => r.status === 'running' || r.status === 'failed' || r.status === 'pending')
+    .sort((a, b) => isStartedAt(b).localeCompare(isStartedAt(a)));
+  const liveStep = live.map((r) => stepById.get(r.stepId)).find((s): s is Step => !!s);
+  if (liveStep) return liveStep;
+
+  const recent = [...runs].sort((a, b) => isStartedAt(b).localeCompare(isStartedAt(a)));
+  const recentStep = recent.map((r) => stepById.get(r.stepId)).find((s): s is Step => !!s);
+  if (recentStep) return recentStep;
+
+  return sorted[0] ?? null;
+}
+
+/**
+ * Find the existing Session row for a step that the next turn should reuse.
+ *
+ * A Session is now a long-lived agent: multiple ProviderRuns get attached to
+ * the same Session row instead of inserting a new row per user message.
+ * Returns the most recent run for the given step, or null if none exists yet
+ * (caller should insert a fresh Session row in that case).
+ */
+export function findReusableSession(
+  runs: ReadonlyArray<Session>,
+  stepId: Step['id'],
+): Session | null {
+  const matches = runs.filter((r) => r.stepId === stepId);
+  if (matches.length === 0) return null;
+  const sorted = [...matches].sort((a, b) => (b.startedAt ?? '').localeCompare(a.startedAt ?? ''));
+  return sorted[0] ?? null;
+}
+
 export function buildStepPrompt(input: {
   definition: Step;
   carryForwardContext: string;


### PR DESCRIPTION
## Summary

PR1 of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). Replaces \`nextStep\` auto-advance with \`currentStep\`: each Session row is a long-lived agent that accepts N turns until the user explicitly spawns a new one. Resolves the \"ogni input crea nuovo agent\" / \"step 4 chat fresca\" pain.

## Changes

- **core/sequencer**: new \`currentStep\` + \`findReusableSession\`, both pure
- **store/sendTurn**: swap \`nextStep\` → \`currentStep\`; on each turn, if a Session row exists for the resolved step, flip status to running and update providerRunId instead of inserting a fresh row
- **carry-forward** + step_transition event now fire only on the first turn of a step (no more prompt bloat)

## Test plan

- [x] new sequencer cases: cold-start, running, completed-stays, non-terminal preferred, most-recent tie-break, empty
- [x] findReusableSession: none / one / most-recent / other-step-isolation
- [x] cargo check, pnpm typecheck, pnpm test (386 + 180 + 14 green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)