### PR TITLE
feat(desktop): agent row telemetry — chip + model + tokens + cost

### DIFF
--- a/apps/desktop/src/__tests__/agent-row-format.test.ts
+++ b/apps/desktop/src/__tests__/agent-row-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
+
+describe('formatTokens', () => {
+  it('renders raw count under 1k', () => {
+    expect(formatTokens(0)).toBe('0');
+    expect(formatTokens(42)).toBe('42');
+    expect(formatTokens(999)).toBe('999');
+  });
+
+  it('renders 1-decimal k under 100k', () => {
+    expect(formatTokens(1_000)).toBe('1.0k');
+    expect(formatTokens(12_345)).toBe('12.3k');
+    expect(formatTokens(99_999)).toBe('100.0k');
+  });
+
+  it('renders integer k at or above 100k', () => {
+    expect(formatTokens(100_000)).toBe('100k');
+    expect(formatTokens(1_234_567)).toBe('1235k');
+  });
+});
+
+describe('formatCost', () => {
+  it('shows $0 for zero', () => {
+    expect(formatCost(0)).toBe('$0');
+  });
+
+  it('shows <$0.01 below the cent', () => {
+    expect(formatCost(0.0001)).toBe('<$0.01');
+    expect(formatCost(0.0099)).toBe('<$0.01');
+  });
+
+  it('shows 3 decimals between 1 cent and 1 dollar', () => {
+    expect(formatCost(0.012)).toBe('$0.012');
+    expect(formatCost(0.999)).toBe('$0.999');
+  });
+
+  it('shows 2 decimals at or above 1 dollar', () => {
+    expect(formatCost(1)).toBe('$1.00');
+    expect(formatCost(12.345)).toBe('$12.35');
+  });
+});
+
+describe('shortModel', () => {
+  it('extracts the family from a versioned claude model', () => {
+    expect(shortModel('claude-haiku-4-5')).toBe('haiku');
+    expect(shortModel('claude-sonnet-4-6')).toBe('sonnet');
+    expect(shortModel('claude-opus-4-7')).toBe('opus');
+  });
+
+  it('passes non-claude models through', () => {
+    expect(shortModel('gpt-5.1')).toBe('gpt-5.1');
+    expect(shortModel('cursor-fast')).toBe('cursor-fast');
+  });
+
+  it('handles uppercase family in claude id', () => {
+    expect(shortModel('CLAUDE-HAIKU-4-5')).toBe('haiku');
+  });
+});

--- a/apps/desktop/src/agentRowFormat.ts
+++ b/apps/desktop/src/agentRowFormat.ts
@@ -1,0 +1,23 @@
+// Display helpers for the sidebar agent row telemetry pill.
+// Extracted so they can be unit-tested without rendering React.
+
+export function formatTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 100_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${Math.round(n / 1000)}k`;
+}
+
+export function formatCost(usd: number): string {
+  if (usd === 0) return '$0';
+  if (usd < 0.01) return '<$0.01';
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+export function shortModel(model: string): string {
+  // claude-haiku-4-5 → haiku ; claude-opus-4-7 → opus ; claude-sonnet-4-6 → sonnet.
+  // Codex / cursor model strings pass through unchanged.
+  const m = model.match(/claude-(haiku|sonnet|opus)/i);
+  if (m && m[1]) return m[1].toLowerCase();
+  return model;
+}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -22,6 +22,7 @@ import type {
   SessionStatus,
   Task,
   TaskId,
+  TelemetryRecord,
   TurnState,
   Workspace,
 } from '@kay-am/types';
@@ -36,6 +37,7 @@ import {
 import { DeleteWorkspaceDialog } from './DeleteWorkspaceDialog';
 import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
+import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
@@ -1054,8 +1056,25 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const phaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
   );
+  const telemetry = useAppStore(
+    (s) => s.sessionTelemetry[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
+  );
 
   const sorted = useMemo(() => [...phaseRuns].sort((a, b) => a.ordinal - b.ordinal), [phaseRuns]);
+
+  // Most recent telemetry record per runId — the per-agent display reflects
+  // its latest turn (full multi-turn aggregation needs a session_runs join
+  // we don't have yet; deferred to a follow-up PR).
+  const telemetryByRunId = useMemo(() => {
+    const map = new Map<string, TelemetryRecord>();
+    for (const rec of telemetry) {
+      const existing = map.get(rec.runId);
+      if (!existing || existing.recordedAt < rec.recordedAt) {
+        map.set(rec.runId, rec);
+      }
+    }
+    return map;
+  }, [telemetry]);
 
   return (
     <section className="flex flex-col px-2 pb-3 pt-4">
@@ -1074,7 +1093,11 @@ function AgentsSection({ task }: AgentsSectionProps) {
       ) : (
         <ul className="flex flex-col gap-0.5">
           {sorted.map((run) => (
-            <AgentRow key={run.id} run={run} />
+            <AgentRow
+              key={run.id}
+              run={run}
+              telemetry={run.runId ? (telemetryByRunId.get(run.runId) ?? null) : null}
+            />
           ))}
         </ul>
       )}
@@ -1090,21 +1113,61 @@ const AGENT_STATUS_TONE: Record<SessionStatus, string> = {
   skipped: 'bg-muted-foreground/20',
 };
 
-function AgentRow({ run }: { run: Session }) {
+interface AgentRowProps {
+  readonly run: Session;
+  readonly telemetry: TelemetryRecord | null;
+}
+
+function AgentRow({ run, telemetry }: AgentRowProps) {
+  const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
+  const titleParts = [
+    `step #${run.ordinal + 1}`,
+    `status: ${run.status}`,
+    telemetry ? `provider: ${telemetry.provider}` : null,
+    telemetry ? `model: ${telemetry.model}` : null,
+    total !== null
+      ? `last turn: ${total} tokens · ${formatCost(telemetry!.estimatedCostUsd)}`
+      : null,
+  ].filter((p): p is string => p !== null);
+
   return (
     <li
-      className="group flex items-center gap-2 rounded-md px-2 py-1 text-xs"
-      title={`step #${run.ordinal + 1} · ${run.status}`}
+      className="group flex flex-col gap-0.5 rounded-md px-2 py-1 text-xs"
+      title={titleParts.join('\n')}
     >
-      <span
-        aria-hidden
-        className={cn(
-          'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-          AGENT_STATUS_TONE[run.status],
-        )}
-      />
-      <span className="line-clamp-1 flex-1 text-foreground">{run.name}</span>
-      <span className="shrink-0 font-mono text-2xs text-muted-foreground">{run.ordinal + 1}</span>
+      <div className="flex items-center gap-2">
+        <span
+          aria-hidden
+          className={cn(
+            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+            AGENT_STATUS_TONE[run.status],
+          )}
+        />
+        <span
+          className="line-clamp-1 flex-1 rounded-full bg-subtle px-1.5 py-px text-2xs font-medium text-foreground"
+          aria-label={`role chip: ${run.name}`}
+        >
+          {run.name}
+        </span>
+        <span className="shrink-0 font-mono text-2xs text-muted-foreground">{run.ordinal + 1}</span>
+      </div>
+      {telemetry ? (
+        <div className="flex items-center gap-1.5 pl-3.5 text-2xs text-muted-foreground/80">
+          <span>{shortModel(telemetry.model)}</span>
+          {total !== null ? (
+            <>
+              <span aria-hidden>·</span>
+              <span title={`${total.toLocaleString()} tokens (last turn)`}>
+                {formatTokens(total)} tok
+              </span>
+            </>
+          ) : null}
+          <span aria-hidden>·</span>
+          <span title={`$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)`}>
+            {formatCost(telemetry.estimatedCostUsd)}
+          </span>
+        </div>
+      ) : null}
     </li>
   );
 }


### PR DESCRIPTION
## Summary

PR3 of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). The sidebar's third block (one row per agent in the current Task) now shows model, token use, and cost. Was: name + ordinal + status only.

## Layout

\`\`\`
[●] [scout chip]                       (3)
     haiku · 12.4k tok · $0.024
\`\`\`

## Caveat

Telemetry is the agent's *last turn*, not lifetime aggregate — we'd need a session_runs join we don't have yet. Deferred to a follow-up. Hover title carries the full breakdown.

## Test plan

- [x] 10 vitest cases for the formatters (formatTokens / formatCost / shortModel) extracted to src/agentRowFormat.ts
- [x] cargo check, pnpm typecheck, full vitest green (190 desktop + 425 core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)