### PR TITLE
feat(core): per-role defaults — scout=haiku, planner=opus, ...

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,15 @@ export {
   type SlotKey,
 } from './context';
 
+export {
+  ROLE_DEFAULTS,
+  defaultsForRole,
+  isAgentRole,
+  type AgentEffort,
+  type AgentRole,
+  type RoleDefaults,
+} from './roles';
+
 export { resolveProvider, type ResolveProviderInput } from './budget/router';
 
 export { computeCostUsd, priceFor } from './providers/claude/cost';

--- a/packages/core/src/roles.test.ts
+++ b/packages/core/src/roles.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { ROLE_DEFAULTS, defaultsForRole, isAgentRole } from './roles';
+
+describe('ROLE_DEFAULTS', () => {
+  it('covers every defined AgentRole', () => {
+    const expected = [
+      'scout',
+      'planner',
+      'implementer',
+      'reviewer',
+      'investigator',
+      'product',
+      'architect',
+      'tester',
+      'explorer',
+      'custom',
+    ];
+    for (const role of expected) {
+      expect(ROLE_DEFAULTS[role as keyof typeof ROLE_DEFAULTS]).toBeDefined();
+    }
+    expect(Object.keys(ROLE_DEFAULTS).sort()).toEqual([...expected].sort());
+  });
+
+  it('routes read-heavy roles to the cheap model', () => {
+    expect(ROLE_DEFAULTS.scout.model).toMatch(/haiku/);
+    expect(ROLE_DEFAULTS.investigator.model).toMatch(/haiku/);
+  });
+
+  it('routes design-heavy roles to the strong model', () => {
+    expect(ROLE_DEFAULTS.planner.model).toMatch(/opus/);
+    expect(ROLE_DEFAULTS.architect.model).toMatch(/opus/);
+  });
+
+  it('routes balanced roles to sonnet', () => {
+    expect(ROLE_DEFAULTS.implementer.model).toMatch(/sonnet/);
+    expect(ROLE_DEFAULTS.reviewer.model).toMatch(/sonnet/);
+  });
+
+  it('every default uses anthropic provider for now', () => {
+    for (const r of Object.values(ROLE_DEFAULTS)) {
+      expect(r.provider).toBe('anthropic');
+    }
+  });
+});
+
+describe('isAgentRole', () => {
+  it('returns true for known roles', () => {
+    expect(isAgentRole('scout')).toBe(true);
+    expect(isAgentRole('planner')).toBe(true);
+    expect(isAgentRole('custom')).toBe(true);
+  });
+
+  it('returns false for unknown roles', () => {
+    expect(isAgentRole('emperor')).toBe(false);
+    expect(isAgentRole('')).toBe(false);
+  });
+});
+
+describe('defaultsForRole', () => {
+  it('returns the registered defaults for a known role', () => {
+    expect(defaultsForRole('scout')).toBe(ROLE_DEFAULTS.scout);
+    expect(defaultsForRole('reviewer')).toBe(ROLE_DEFAULTS.reviewer);
+  });
+
+  it('falls back to custom for an unknown role (no throw)', () => {
+    expect(defaultsForRole('emperor')).toBe(ROLE_DEFAULTS.custom);
+  });
+});

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1,0 +1,115 @@
+import type { ProviderId } from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Per-role agent defaults.
+//
+// Each agent in a Task is assigned a "role" (the chip the user sees in the
+// sidebar). The role drives sensible default routing — the user shouldn't
+// have to pick a model for every spawn, but can override when needed. These
+// defaults are intentionally conservative: cheap models for read-heavy work,
+// stronger models for design-heavy work.
+//
+// Effort is included as a hint (used as a UI default in the spawn dialog and
+// passed to claude --effort when the provider supports it). Storing effort
+// on Step itself is deferred to a follow-up PR; for now the seeder only
+// applies provider + model.
+// ---------------------------------------------------------------------------
+
+export type AgentRole =
+  | 'scout'
+  | 'planner'
+  | 'implementer'
+  | 'reviewer'
+  | 'investigator'
+  | 'product'
+  | 'architect'
+  | 'tester'
+  | 'explorer'
+  | 'custom';
+
+export type AgentEffort = 'low' | 'medium' | 'high' | 'extra-high' | 'max';
+
+export interface RoleDefaults {
+  readonly provider: ProviderId;
+  readonly model: string;
+  readonly effort: AgentEffort;
+  readonly description: string;
+}
+
+export const ROLE_DEFAULTS: Readonly<Record<AgentRole, RoleDefaults>> = {
+  scout: {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    effort: 'low',
+    description: 'survey code, list relevant files, identify abstractions; no changes',
+  },
+  investigator: {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    effort: 'low',
+    description: 'reproduce, diagnose, root-cause; no fixes',
+  },
+  planner: {
+    provider: 'anthropic',
+    model: 'claude-opus-4-7',
+    effort: 'high',
+    description: 'design the change; produce an ordered plan',
+  },
+  architect: {
+    provider: 'anthropic',
+    model: 'claude-opus-4-7',
+    effort: 'high',
+    description: 'propose technical approach, modules, data flow, migrations',
+  },
+  product: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'clarify user-facing behavior + acceptance criteria',
+  },
+  implementer: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'apply the planned change in small commits',
+  },
+  reviewer: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'audit the diff, run tests, flag drift',
+  },
+  tester: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'write tests covering happy path + edge cases',
+  },
+  explorer: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'open-ended chat; no fixed structure',
+  },
+  custom: {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+    effort: 'medium',
+    description: 'user-defined role',
+  },
+};
+
+const KNOWN_ROLES = new Set<string>(Object.keys(ROLE_DEFAULTS));
+
+export function isAgentRole(role: string): role is AgentRole {
+  return KNOWN_ROLES.has(role);
+}
+
+/**
+ * Resolve a role string from the workflow library to its defaults. Unknown
+ * roles fall back to `custom` instead of throwing — library entries are
+ * data, not code, and a typo there should still produce a usable agent.
+ */
+export function defaultsForRole(role: string): RoleDefaults {
+  return isAgentRole(role) ? ROLE_DEFAULTS[role] : ROLE_DEFAULTS.custom;
+}

--- a/packages/core/src/workflows/seeder.ts
+++ b/packages/core/src/workflows/seeder.ts
@@ -1,6 +1,7 @@
 import type { IsoDateTime, Step, StepId, Workflow, WorkflowId, WorkspaceId } from '@kay-am/types';
 import { upsertWorkflow, type Database } from '@kay-am/db';
 import { WORKFLOW_LIBRARY } from './library';
+import { defaultsForRole } from '../roles';
 
 export interface SeedWorkflowLibraryDeps {
   readonly db: Database;
@@ -31,13 +32,21 @@ export async function seedWorkflowLibrary(
 
   for (const entry of WORKFLOW_LIBRARY) {
     const workflowId = makeWorkflowId(entry.slug, workspaceId);
-    const steps: ReadonlyArray<Step> = entry.steps.map((s, ordinal) => ({
-      id: makeStepId(entry.slug, s.name, workspaceId),
-      workflowId,
-      ordinal,
-      name: s.name,
-      promptPrefix: s.promptPrefix,
-    }));
+    const steps: ReadonlyArray<Step> = entry.steps.map((s, ordinal) => {
+      // Apply per-role defaults so the orchestrator routes each agent to a
+      // sensibly-priced model out of the box. The user can still override at
+      // the Step level later.
+      const roleDefaults = defaultsForRole(s.role);
+      return {
+        id: makeStepId(entry.slug, s.name, workspaceId),
+        workflowId,
+        ordinal,
+        name: s.name,
+        promptPrefix: s.promptPrefix,
+        providerOverride: roleDefaults.provider,
+        modelOverride: roleDefaults.model,
+      };
+    });
 
     const workflow: Workflow = {
       id: workflowId,


### PR DESCRIPTION
## Summary

PR4 of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). Each agent role ships with default routing so the orchestrator stops sending opus to a 1-line scout.

## Defaults

| role | model | effort |
|---|---|---|
| scout / investigator | haiku | low |
| planner / architect | opus | high |
| product / implementer / reviewer / tester / explorer / custom | sonnet | medium |

Seeded library workflows pre-fill \`providerOverride\` + \`modelOverride\` on each generated Step from these defaults. Effort hint is exposed via the \`AgentEffort\` type for the spawn dialog (PR5+).

## Test plan

- [x] 9 new role unit cases
- [x] existing seeder + propagator suites still green
- [x] cargo check, pnpm typecheck, full vitest green

🤖 Generated with [Claude Code](https://claude.com/claude-code)