### PR TITLE
feat(desktop): preset = pre-spawn agents at task creation

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -911,6 +911,33 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     }
 
+    // Pre-spawn one Session row per Step in the chosen workflow so the
+    // sidebar's "agents" block is populated immediately — the user sees the
+    // full preset (e.g. scout / planner / implementer / reviewer) the moment
+    // a Task is created, instead of agents appearing one-by-one as the user
+    // types. Each row starts in `pending` and flips to `running` on its
+    // first turn (sendTurn handles the reuse).
+    let prespawnedRuns: ReadonlyArray<Session> = [];
+    if (workflowId) {
+      const templates = get().phaseTemplates[workspaceId] ?? [];
+      const template = templates.find((t) => t.id === workflowId);
+      if (template) {
+        const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+        const inserts = await Promise.all(
+          sortedSteps.map((step) =>
+            invokePhaseRunInsert({
+              taskId: session.id,
+              stepId: step.id,
+              ordinal: step.ordinal,
+              name: step.name,
+              status: 'pending',
+            }),
+          ),
+        );
+        prespawnedRuns = inserts;
+      }
+    }
+
     set((state) => ({
       sessions:
         state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
@@ -928,6 +955,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         ...state.sessionSlots,
         [session.id]: goalText.length > 0 ? [{ key: 'goal', value: goalText, enabled: true }] : [],
       },
+      sessionPhaseRuns:
+        prespawnedRuns.length > 0
+          ? { ...state.sessionPhaseRuns, [session.id]: prespawnedRuns }
+          : state.sessionPhaseRuns,
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
 


### PR DESCRIPTION
## Summary

PR5 of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). Selecting a workflow preset when creating a Task now pre-spawns one Session row per Step in \`pending\` status, so the sidebar's agents block paints the full preset immediately (scout / planner / implementer / reviewer) instead of materializing agents one at a time.

Each pending Session flips to running on its first turn — sendTurn's existing reuse path (PR1) handles the transition. Auto-chain stays dead.

## Test plan

- [x] pnpm typecheck, full vitest green
- [ ] manual: creating a Task with the \"refactor\" workflow shows 4 pending agent rows in the sidebar before any message is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)