### PR TITLE
feat(desktop): new-session dialog — settings-style sidebar layout

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
   open=""
 >
   <div
-    class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
+    class="flex min-h-0 flex-col max-h-[85vh] w-[44rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -86,91 +86,89 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
       class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
     >
       <div
-        class="flex flex-col gap-1.5"
+        class="flex h-full min-h-0 gap-0"
       >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          goal
-        </span>
-        <textarea
-          class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
-          placeholder="refactor auth domain"
-          style="height: 0px; overflow-y: hidden;"
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          what the session should accomplish.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          branch prefix
-        </span>
-        <input
-          class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-          placeholder="kay"
-          type="text"
-          value="kay"
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          branch name will be \`&lt;prefix&gt;/&lt;slug&gt;\`.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          soft cap (usd)
-        </span>
-        <input
-          class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-          min="0"
-          placeholder="e.g. 5.00"
-          step="0.01"
-          type="number"
-          value=""
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          optional spend limit. session is flagged when exceeded.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          workflow (optional)
-        </span>
-        <div
-          class="flex flex-wrap gap-1.5"
+        <nav
+          class="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2"
         >
           <button
-            class="rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-foreground text-background"
-            type="button"
-          >
-            single chat
-          </button>
-          <button
-            class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground"
-            title="design a custom workflow with the planner agent"
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-sparkles"
+              class="lucide lucide-target"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+              />
+              <circle
+                cx="12"
+                cy="12"
+                r="6"
+              />
+              <circle
+                cx="12"
+                cy="12"
+                r="2"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              goal
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-git-branch"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M15 6a9 9 0 0 0-9 9V3"
+              />
+              <circle
+                cx="18"
+                cy="6"
+                r="3"
+              />
+              <circle
+                cx="6"
+                cy="18"
+                r="3"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              branch
+            </span>
+            <svg
+              aria-label="filled"
+              class="lucide lucide-check text-success"
               fill="none"
               height="11"
               stroke="currentColor"
@@ -182,125 +180,127 @@ exports[`snapshot — empty states > NewSessionDialog: no phase templates 1`] = 
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-              />
-              <path
-                d="M20 2v4"
-              />
-              <path
-                d="M22 4h-4"
-              />
-              <circle
-                cx="4"
-                cy="20"
-                r="2"
+                d="M20 6 9 17l-5-5"
               />
             </svg>
-             design custom
           </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-dollar-sign"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <line
+                x1="12"
+                x2="12"
+                y1="2"
+                y2="22"
+              />
+              <path
+                d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              budget
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-layers"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+              />
+              <path
+                d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+              />
+              <path
+                d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              workflow
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-zap"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              provider
+            </span>
+          </button>
+        </nav>
+        <div
+          class="min-w-0 flex-1 overflow-y-auto pl-4"
+        >
+          <div
+            class="flex flex-col gap-1.5"
+          >
+            <span
+              class="text-xs font-semibold text-foreground"
+            >
+              goal
+            </span>
+            <textarea
+              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
+              placeholder="refactor auth domain"
+              style="height: 0px; overflow-y: hidden;"
+            />
+            <p
+              class="text-xs leading-relaxed text-muted-foreground"
+            >
+              what the session should accomplish.
+            </p>
+          </div>
         </div>
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          no workflows yet — design one with the planner below.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          provider
-        </span>
-        <ul
-          class="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border"
-        >
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-anthropic"
-              name="provider"
-              type="radio"
-              value="anthropic"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-anthropic"
-            >
-              <span
-                class="font-medium"
-              >
-                claude
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-cursor"
-              name="provider"
-              type="radio"
-              value="cursor"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-cursor"
-            >
-              <span
-                class="font-medium"
-              >
-                cursor
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-codex"
-              name="provider"
-              type="radio"
-              value="codex"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-codex"
-            >
-              <span
-                class="font-medium"
-              >
-                codex
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-        </ul>
       </div>
     </div>
     <footer
@@ -867,7 +867,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
   open=""
 >
   <div
-    class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
+    class="flex min-h-0 flex-col max-h-[85vh] w-[44rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -905,91 +905,89 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
     >
       <div
-        class="flex flex-col gap-1.5"
+        class="flex h-full min-h-0 gap-0"
       >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          goal
-        </span>
-        <textarea
-          class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
-          placeholder="refactor auth domain"
-          style="height: 0px; overflow-y: hidden;"
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          what the session should accomplish.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          branch prefix
-        </span>
-        <input
-          class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-          placeholder="kay"
-          type="text"
-          value="kay"
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          branch name will be \`&lt;prefix&gt;/&lt;slug&gt;\`.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          soft cap (usd)
-        </span>
-        <input
-          class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-          min="0"
-          placeholder="e.g. 5.00"
-          step="0.01"
-          type="number"
-          value=""
-        />
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          optional spend limit. session is flagged when exceeded.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          workflow (optional)
-        </span>
-        <div
-          class="flex flex-wrap gap-1.5"
+        <nav
+          class="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2"
         >
           <button
-            class="rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-foreground text-background"
-            type="button"
-          >
-            single chat
-          </button>
-          <button
-            class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground"
-            title="design a custom workflow with the planner agent"
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground"
             type="button"
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-sparkles"
+              class="lucide lucide-target"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+              />
+              <circle
+                cx="12"
+                cy="12"
+                r="6"
+              />
+              <circle
+                cx="12"
+                cy="12"
+                r="2"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              goal
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-git-branch"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M15 6a9 9 0 0 0-9 9V3"
+              />
+              <circle
+                cx="18"
+                cy="6"
+                r="3"
+              />
+              <circle
+                cx="6"
+                cy="18"
+                r="3"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              branch
+            </span>
+            <svg
+              aria-label="filled"
+              class="lucide lucide-check text-success"
               fill="none"
               height="11"
               stroke="currentColor"
@@ -1001,125 +999,127 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               xmlns="http://www.w3.org/2000/svg"
             >
               <path
-                d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-              />
-              <path
-                d="M20 2v4"
-              />
-              <path
-                d="M22 4h-4"
-              />
-              <circle
-                cx="4"
-                cy="20"
-                r="2"
+                d="M20 6 9 17l-5-5"
               />
             </svg>
-             design custom
           </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-dollar-sign"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <line
+                x1="12"
+                x2="12"
+                y1="2"
+                y2="22"
+              />
+              <path
+                d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              budget
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-layers"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+              />
+              <path
+                d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+              />
+              <path
+                d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              workflow
+            </span>
+          </button>
+          <button
+            class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-zap"
+              fill="none"
+              height="13"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="13"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
+              />
+            </svg>
+            <span
+              class="flex-1"
+            >
+              provider
+            </span>
+          </button>
+        </nav>
+        <div
+          class="min-w-0 flex-1 overflow-y-auto pl-4"
+        >
+          <div
+            class="flex flex-col gap-1.5"
+          >
+            <span
+              class="text-xs font-semibold text-foreground"
+            >
+              goal
+            </span>
+            <textarea
+              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
+              placeholder="refactor auth domain"
+              style="height: 0px; overflow-y: hidden;"
+            />
+            <p
+              class="text-xs leading-relaxed text-muted-foreground"
+            >
+              what the session should accomplish.
+            </p>
+          </div>
         </div>
-        <p
-          class="text-xs leading-relaxed text-muted-foreground"
-        >
-          no workflows yet — design one with the planner below.
-        </p>
-      </div>
-      <div
-        class="flex flex-col gap-1.5"
-      >
-        <span
-          class="text-xs font-semibold text-foreground"
-        >
-          provider
-        </span>
-        <ul
-          class="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border"
-        >
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-anthropic"
-              name="provider"
-              type="radio"
-              value="anthropic"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-anthropic"
-            >
-              <span
-                class="font-medium"
-              >
-                claude
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-cursor"
-              name="provider"
-              type="radio"
-              value="cursor"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-cursor"
-            >
-              <span
-                class="font-medium"
-              >
-                cursor
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-          <li
-            class="flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors opacity-50"
-          >
-            <input
-              class="accent-primary"
-              disabled=""
-              id="provider-codex"
-              name="provider"
-              type="radio"
-              value="codex"
-            />
-            <label
-              class="flex flex-1 items-center justify-between cursor-not-allowed"
-              for="provider-codex"
-            >
-              <span
-                class="font-medium"
-              >
-                codex
-              </span>
-              <button
-                class="text-xs text-primary underline hover:opacity-80"
-                type="button"
-              >
-                connect in settings
-              </button>
-            </label>
-          </li>
-        </ul>
       </div>
     </div>
     <footer

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
-import { Sparkles } from 'lucide-react';
+import { Check, DollarSign, GitBranch, Layers, Sparkles, Target, Zap } from 'lucide-react';
 import type {
   Workflow,
   WorkflowId,
@@ -120,156 +120,234 @@ export function NewSessionDialog({
     providers.filter((p) => p.connection === 'connected').map((p) => p.id),
   );
 
+  type SectionId = 'goal' | 'branch' | 'budget' | 'workflow' | 'provider';
+  const [activeSection, setActiveSection] = useState<SectionId>('goal');
+
+  const goalReady = goal.trim().length > 0;
+  const budgetReady = softCapRaw.trim().length > 0;
+  const workflowReady = selectedPhaseTemplateId !== '';
+  const providerReady = connectedProviderIds.has(selectedProvider);
+
+  const sections: ReadonlyArray<{
+    id: SectionId;
+    label: string;
+    icon: ReactNode;
+    ready: boolean;
+  }> = [
+    { id: 'goal', label: 'goal', icon: <Target size={13} aria-hidden />, ready: goalReady },
+    {
+      id: 'branch',
+      label: 'branch',
+      icon: <GitBranch size={13} aria-hidden />,
+      ready: prefix.trim().length > 0,
+    },
+    {
+      id: 'budget',
+      label: 'budget',
+      icon: <DollarSign size={13} aria-hidden />,
+      ready: budgetReady,
+    },
+    {
+      id: 'workflow',
+      label: 'workflow',
+      icon: <Layers size={13} aria-hidden />,
+      ready: workflowReady,
+    },
+    {
+      id: 'provider',
+      label: 'provider',
+      icon: <Zap size={13} aria-hidden />,
+      ready: providerReady,
+    },
+  ];
+
   return (
     <Dialog
       open={open}
       onClose={onClose}
       title="new session"
       description="creates a worktree on a fresh branch from the workspace root."
-      size="md"
+      size="lg"
       footer={
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={onClose}>
             cancel
           </Button>
-          <Button onClick={onCreate} disabled={goal.trim().length === 0 || busy}>
+          <Button onClick={onCreate} disabled={!goalReady || busy}>
             {busy ? 'creating…' : 'create session'}
           </Button>
         </>
       }
     >
-      <Field label="goal" hint="what the session should accomplish.">
-        <Textarea
-          value={goal}
-          placeholder="refactor auth domain"
-          onChange={(e) => setGoal(e.target.value)}
-          autoGrow
-          maxRows={12}
-        />
-      </Field>
-
-      <Field label="branch prefix" hint="branch name will be `<prefix>/<slug>`.">
-        <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} placeholder="kay" />
-      </Field>
-
-      <Field label="soft cap (usd)" hint="optional spend limit. session is flagged when exceeded.">
-        <Input
-          value={softCapRaw}
-          onChange={(e) => setSoftCapRaw(e.target.value)}
-          placeholder="e.g. 5.00"
-          type="number"
-          min="0"
-          step="0.01"
-        />
-      </Field>
-
-      <Field
-        label="workflow (optional)"
-        hint={
-          phaseTemplates.length === 0
-            ? 'no workflows yet — design one with the planner below.'
-            : 'pick a workflow blueprint. each step spawns its own agent with its own context.'
-        }
-      >
-        <div className="flex flex-wrap gap-1.5">
-          <WorkflowChip
-            label="single chat"
-            active={selectedPhaseTemplateId === ''}
-            onClick={() => setSelectedPhaseTemplateId('')}
-          />
-          {phaseTemplates.map((t) => (
-            <WorkflowChip
-              key={t.id}
-              label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
-              active={selectedPhaseTemplateId === t.id}
-              onClick={() => setSelectedPhaseTemplateId(t.id)}
-              title={t.description || undefined}
-            />
+      <div className="flex h-full min-h-0 gap-0">
+        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2">
+          {sections.map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => setActiveSection(s.id)}
+              className={cn(
+                'flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors',
+                activeSection === s.id
+                  ? 'bg-muted font-medium text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+              )}
+            >
+              {s.icon}
+              <span className="flex-1">{s.label}</span>
+              {s.ready ? <Check size={11} className="text-success" aria-label="filled" /> : null}
+            </button>
           ))}
-          <button
-            type="button"
-            onClick={() => setPlannerOpen((v) => !v)}
-            className={cn(
-              'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors',
-              plannerOpen
-                ? 'bg-foreground text-background'
-                : 'bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
-            )}
-            title="design a custom workflow with the planner agent"
-          >
-            <Sparkles size={11} aria-hidden /> design custom
-          </button>
-        </div>
-        {selectedPhaseTemplateId !== '' ? (
-          <WorkflowPreview
-            template={phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null}
-          />
-        ) : null}
-        {plannerOpen ? (
-          <PlannerWidget
-            workspaceId={workspaceId}
-            providerId={selectedProvider}
-            initialTheme={goal}
-            onWorkflowReady={(workflowId) => {
-              setSelectedPhaseTemplateId(workflowId);
-              setPlannerOpen(false);
-            }}
-          />
-        ) : null}
-      </Field>
+        </nav>
 
-      <Field label="provider">
-        <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border">
-          {PROVIDER_ORDER.map((id) => {
-            const connected = connectedProviderIds.has(id);
-            const disabled = !connected;
-            const selected = selectedProvider === id;
-            return (
-              <li
-                key={id}
-                className={cn(
-                  'flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors',
-                  disabled ? 'opacity-50' : 'hover:bg-muted/40',
-                  selected && !disabled ? 'bg-muted/60' : '',
-                )}
-              >
-                <input
-                  type="radio"
-                  name="provider"
-                  id={`provider-${id}`}
-                  value={id}
-                  checked={selected}
-                  disabled={disabled}
-                  onChange={() => setSelectedProvider(id)}
-                  className="accent-primary"
+        <div className="min-w-0 flex-1 overflow-y-auto pl-4">
+          {activeSection === 'goal' ? (
+            <Field label="goal" hint="what the session should accomplish.">
+              <Textarea
+                value={goal}
+                placeholder="refactor auth domain"
+                onChange={(e) => setGoal(e.target.value)}
+                autoGrow
+                maxRows={16}
+              />
+            </Field>
+          ) : null}
+
+          {activeSection === 'branch' ? (
+            <Field label="branch prefix" hint="branch name will be `<prefix>/<slug>`.">
+              <Input value={prefix} onChange={(e) => setPrefix(e.target.value)} placeholder="kay" />
+            </Field>
+          ) : null}
+
+          {activeSection === 'budget' ? (
+            <Field
+              label="soft cap (usd)"
+              hint="optional spend limit. session is flagged when exceeded."
+            >
+              <Input
+                value={softCapRaw}
+                onChange={(e) => setSoftCapRaw(e.target.value)}
+                placeholder="e.g. 5.00"
+                type="number"
+                min="0"
+                step="0.01"
+              />
+            </Field>
+          ) : null}
+
+          {activeSection === 'workflow' ? (
+            <Field
+              label="workflow (optional)"
+              hint={
+                phaseTemplates.length === 0
+                  ? 'no workflows yet — design one with the planner below.'
+                  : 'pick a workflow blueprint. each step pre-spawns its own agent.'
+              }
+            >
+              <div className="flex flex-wrap gap-1.5">
+                <WorkflowChip
+                  label="single chat"
+                  active={selectedPhaseTemplateId === ''}
+                  onClick={() => setSelectedPhaseTemplateId('')}
                 />
-                <label
-                  htmlFor={`provider-${id}`}
+                {phaseTemplates.map((t) => (
+                  <WorkflowChip
+                    key={t.id}
+                    label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
+                    active={selectedPhaseTemplateId === t.id}
+                    onClick={() => setSelectedPhaseTemplateId(t.id)}
+                    title={t.description || undefined}
+                  />
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setPlannerOpen((v) => !v)}
                   className={cn(
-                    'flex flex-1 items-center justify-between',
-                    disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                    'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors',
+                    plannerOpen
+                      ? 'bg-foreground text-background'
+                      : 'bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
                   )}
+                  title="design a custom workflow with the planner agent"
                 >
-                  <span className="font-medium">{PROVIDER_LABEL[id]}</span>
-                  {!connected && (
-                    <button
-                      type="button"
-                      className="text-xs text-primary underline hover:opacity-80"
-                      onClick={() => {
-                        onClose();
-                        onOpenSettings();
-                      }}
+                  <Sparkles size={11} aria-hidden /> design custom
+                </button>
+              </div>
+              {selectedPhaseTemplateId !== '' ? (
+                <WorkflowPreview
+                  template={phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null}
+                />
+              ) : null}
+              {plannerOpen ? (
+                <PlannerWidget
+                  workspaceId={workspaceId}
+                  providerId={selectedProvider}
+                  initialTheme={goal}
+                  onWorkflowReady={(workflowId) => {
+                    setSelectedPhaseTemplateId(workflowId);
+                    setPlannerOpen(false);
+                  }}
+                />
+              ) : null}
+            </Field>
+          ) : null}
+
+          {activeSection === 'provider' ? (
+            <Field label="provider">
+              <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border">
+                {PROVIDER_ORDER.map((id) => {
+                  const connected = connectedProviderIds.has(id);
+                  const disabled = !connected;
+                  const selected = selectedProvider === id;
+                  return (
+                    <li
+                      key={id}
+                      className={cn(
+                        'flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors',
+                        disabled ? 'opacity-50' : 'hover:bg-muted/40',
+                        selected && !disabled ? 'bg-muted/60' : '',
+                      )}
                     >
-                      connect in settings
-                    </button>
-                  )}
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-      </Field>
+                      <input
+                        type="radio"
+                        name="provider"
+                        id={`provider-${id}`}
+                        value={id}
+                        checked={selected}
+                        disabled={disabled}
+                        onChange={() => setSelectedProvider(id)}
+                        className="accent-primary"
+                      />
+                      <label
+                        htmlFor={`provider-${id}`}
+                        className={cn(
+                          'flex flex-1 items-center justify-between',
+                          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                        )}
+                      >
+                        <span className="font-medium">{PROVIDER_LABEL[id]}</span>
+                        {!connected && (
+                          <button
+                            type="button"
+                            className="text-xs text-primary underline hover:opacity-80"
+                            onClick={() => {
+                              onClose();
+                              onOpenSettings();
+                            }}
+                          >
+                            connect in settings
+                          </button>
+                        )}
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            </Field>
+          ) : null}
+        </div>
+      </div>
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary

PR7 of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). NewSessionDialog now matches the SettingsDialog pattern: a 40-wide left nav with one section per form area (goal / branch / budget / workflow / provider) and the content panel on the right. Was: vertical stack of 5 stacked Field blocks.

Each nav button shows a ✓ when its section is filled, so the user can see at a glance which sections still need attention.

## Test plan

- [x] pnpm typecheck + full vitest green
- [x] snapshot tests refreshed for empty / error states
- [ ] manual: open new-task → click each nav item, verify sections render

🤖 Generated with [Claude Code](https://claude.com/claude-code)