### PR TITLE
feat(desktop): add-workspace dialog — settings-style sidebar + previews

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -537,7 +537,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
   >
     <div
-      class="flex min-h-0 flex-col max-h-[85vh] w-[32rem]"
+      class="flex min-h-0 flex-col max-h-[85vh] w-[44rem]"
     >
       <header
         class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
@@ -555,7 +555,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             class="text-xs leading-relaxed text-muted-foreground"
             id="_r_0_-desc"
           >
-            point at a git repository on disk. each session creates its own worktree.
+            point at a git repository on disk. each task creates its own worktree.
           </p>
         </div>
         <button
@@ -575,34 +575,76 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
         class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
       >
         <div
-          class="flex flex-col gap-1.5"
+          class="flex h-full min-h-0 gap-0"
         >
-          <span
-            class="text-xs font-semibold text-foreground"
+          <nav
+            class="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2"
           >
-            repository path
-          </span>
-          <div
-            class="flex gap-2"
-          >
-            <input
-              class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 flex-1"
-              placeholder="/path/to/repo"
-              type="text"
-              value=""
-            />
             <button
-              class="inline-flex items-center justify-center gap-1.5 rounded-md border font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-muted text-foreground hover:bg-muted/70 border-border h-8 px-3 text-sm"
+              class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground"
               type="button"
             >
-              browse
+              <span
+                class="flex-1"
+              >
+                repository
+              </span>
             </button>
-          </div>
-          <p
-            class="text-xs leading-relaxed text-muted-foreground"
+            <button
+              class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <span
+                class="flex-1"
+              >
+                skills
+              </span>
+            </button>
+            <button
+              class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <span
+                class="flex-1"
+              >
+                workflows
+              </span>
+            </button>
+          </nav>
+          <div
+            class="min-w-0 flex-1 overflow-y-auto pl-4"
           >
-            the directory must contain a \`.git\` folder.
-          </p>
+            <div
+              class="flex flex-col gap-1.5"
+            >
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                repository path
+              </span>
+              <div
+                class="flex gap-2"
+              >
+                <input
+                  class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 flex-1"
+                  placeholder="/path/to/repo"
+                  type="text"
+                  value=""
+                />
+                <button
+                  class="inline-flex items-center justify-center gap-1.5 rounded-md border font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-muted text-foreground hover:bg-muted/70 border-border h-8 px-3 text-sm"
+                  type="button"
+                >
+                  browse
+                </button>
+              </div>
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                the directory must contain a \`.git\` folder.
+              </p>
+            </div>
+          </div>
         </div>
       </div>
       <footer

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -38,6 +38,7 @@ import { DeleteWorkspaceDialog } from './DeleteWorkspaceDialog';
 import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
 import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
+import { WORKFLOW_LIBRARY } from '@kay-am/core';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
@@ -977,11 +978,13 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
   const [path, setPath] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
+  const [activeSection, setActiveSection] = useState<'repo' | 'skills' | 'workflows'>('repo');
 
   const reset = () => {
     setPath('');
     setError(null);
     setBusy(false);
+    setActiveSection('repo');
   };
 
   const onPick = async () => {
@@ -1012,8 +1015,8 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
       open={open}
       onClose={onClose}
       title="add workspace"
-      description="point at a git repository on disk. each session creates its own worktree."
-      size="md"
+      description="point at a git repository on disk. each task creates its own worktree."
+      size="lg"
       footer={
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
@@ -1026,25 +1029,149 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
         </>
       }
     >
-      <div className="flex flex-col gap-1.5">
-        <span className="text-xs font-semibold text-foreground">repository path</span>
-        <div className="flex gap-2">
-          <Input
-            autoFocus
-            value={path}
-            placeholder="/path/to/repo"
-            onChange={(e) => setPath(e.target.value)}
-            className="flex-1"
+      <div className="flex h-full min-h-0 gap-0">
+        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto border-r border-border-soft pr-2">
+          <AddWsNavItem
+            active={activeSection === 'repo'}
+            onClick={() => setActiveSection('repo')}
+            label="repository"
+            ready={path.length > 0}
           />
-          <Button variant="secondary" onClick={() => void onPick()} disabled={busy}>
-            browse
-          </Button>
+          <AddWsNavItem
+            active={activeSection === 'skills'}
+            onClick={() => setActiveSection('skills')}
+            label="skills"
+            ready={null}
+          />
+          <AddWsNavItem
+            active={activeSection === 'workflows'}
+            onClick={() => setActiveSection('workflows')}
+            label="workflows"
+            ready={null}
+          />
+        </nav>
+
+        <div className="min-w-0 flex-1 overflow-y-auto pl-4">
+          {activeSection === 'repo' ? (
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-semibold text-foreground">repository path</span>
+              <div className="flex gap-2">
+                <Input
+                  autoFocus
+                  value={path}
+                  placeholder="/path/to/repo"
+                  onChange={(e) => setPath(e.target.value)}
+                  className="flex-1"
+                />
+                <Button variant="secondary" onClick={() => void onPick()} disabled={busy}>
+                  browse
+                </Button>
+              </div>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                the directory must contain a `.git` folder.
+              </p>
+            </div>
+          ) : null}
+
+          {activeSection === 'skills' ? <AddWsSkillsPreview /> : null}
+
+          {activeSection === 'workflows' ? <AddWsWorkflowsPreview /> : null}
         </div>
-        <p className="text-xs leading-relaxed text-muted-foreground">
-          the directory must contain a `.git` folder.
-        </p>
       </div>
     </Dialog>
+  );
+}
+
+function AddWsNavItem({
+  active,
+  onClick,
+  label,
+  ready,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+  ready: boolean | null;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm motion-safe:transition-colors',
+        active
+          ? 'bg-muted font-medium text-foreground'
+          : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+      )}
+    >
+      <span className="flex-1">{label}</span>
+      {ready === true ? (
+        <span aria-label="filled" className="text-success text-2xs">
+          ✓
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+function AddWsSkillsPreview() {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <h3 className="text-xs font-semibold text-foreground">skills discovered on add</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          after the workspace is registered, kay.am scans these locations and surfaces every skill
+          it finds in chat as `/skill-name`. you don&rsquo;t need to author anything here — existing
+          files are picked up automatically.
+        </p>
+      </div>
+      <ul className="flex flex-col gap-1.5">
+        <li className="rounded-md bg-subtle px-3 py-2 text-xs">
+          <code className="font-mono text-foreground">&lt;root&gt;/.kay/skills/*.md</code>
+          <p className="mt-1 leading-relaxed text-muted-foreground">
+            flat directory of single-file skills (front-matter + body).
+          </p>
+        </li>
+        <li className="rounded-md bg-subtle px-3 py-2 text-xs">
+          <code className="font-mono text-foreground">
+            &lt;root&gt;/.claude/skills/&lt;name&gt;/SKILL.md
+          </code>
+          <p className="mt-1 leading-relaxed text-muted-foreground">
+            claude-cli-style skills (one folder per skill, optional sibling scripts).
+          </p>
+        </li>
+      </ul>
+      <p className="text-2xs text-muted-foreground/70">
+        re-scan anytime from settings &rarr; skills.
+      </p>
+    </div>
+  );
+}
+
+function AddWsWorkflowsPreview() {
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <h3 className="text-xs font-semibold text-foreground">workflow library auto-seeded</h3>
+        <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+          new workspaces get a small library of presets so the new-task dialog is never empty. you
+          can edit, delete, or design custom ones via the planner later.
+        </p>
+      </div>
+      <ul className="flex flex-col gap-1.5">
+        {WORKFLOW_LIBRARY.map((entry) => (
+          <li key={entry.slug} className="rounded-md bg-subtle px-3 py-2 text-xs">
+            <div className="flex items-baseline justify-between">
+              <span className="font-medium text-foreground">{entry.name.toLowerCase()}</span>
+              <span className="text-2xs text-muted-foreground">
+                {entry.steps.length} step{entry.steps.length === 1 ? '' : 's'}
+              </span>
+            </div>
+            <p className="mt-1 leading-relaxed text-muted-foreground">{entry.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

PR8 (final) of the [Task-as-shared-memory plan](https://github.com/akhayam99/kay-am/blob/main/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md). AddWorkspaceDialog mirrors the SettingsDialog pattern: 40-wide left nav with three sections (repository / skills / workflows) and a content panel on the right.

## New read-only previews

- **skills**: documents the two on-disk locations kay.am scans (\`<root>/.kay/skills/*.md\` and \`<root>/.claude/skills/<name>/SKILL.md\`)
- **workflows**: lists the WORKFLOW_LIBRARY entries that auto-seed (refactor / bug-fix / feature / exploration) with step counts + descriptions

## Test plan

- [x] pnpm typecheck + full vitest green
- [x] snapshot for \"no workspace selected\" empty state regenerated
- [ ] manual: open add-workspace, click skills + workflows tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)