### PR TITLE
feat(desktop): spawn free agents — stepid optional in sidebar

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -65,7 +65,7 @@ pub struct SessionRow {
     #[serde(rename = "taskId")]
     pub task_id: String,
     #[serde(rename = "stepId")]
-    pub step_id: String,
+    pub step_id: Option<String>,
     pub ordinal: i64,
     pub name: String,
     pub status: String,
@@ -85,7 +85,7 @@ pub struct PhaseRunInsertInput {
     #[serde(rename = "taskId")]
     pub task_id: String,
     #[serde(rename = "stepId")]
-    pub step_id: String,
+    pub step_id: Option<String>,
     pub ordinal: i64,
     pub name: String,
     pub status: String,

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -19,11 +19,14 @@ import { WorkspaceSettingsDialog } from './WorkspaceSettingsDialog';
 import type {
   ProviderId,
   Session,
+  SessionId,
   SessionStatus,
+  Step,
   Task,
   TaskId,
   TelemetryRecord,
   TurnState,
+  Workflow,
   Workspace,
 } from '@kay-am/types';
 import {
@@ -1186,8 +1189,31 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const telemetry = useAppStore(
     (s) => s.sessionTelemetry[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
   );
+  const selectedAgentRunId = useAppStore((s) => s.selectedAgentRunId[task.id] ?? null);
+  const setSelectedAgent = useAppStore((s) => s.setSelectedAgent);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const phaseTemplates = useAppStore(
+    (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const workflow = task.workflowId
+    ? (phaseTemplates.find((t) => t.id === task.workflowId) ?? null)
+    : null;
+  const [spawnError, setSpawnError] = useState<string | null>(null);
 
   const sorted = useMemo(() => [...phaseRuns].sort((a, b) => a.ordinal - b.ordinal), [phaseRuns]);
+
+  const onSelectAgent = (sid: SessionId) => {
+    setSelectedAgent(task.id, selectedAgentRunId === sid ? null : sid);
+  };
+
+  const onSpawn = async (stepId: Step['id'] | null) => {
+    setSpawnError(null);
+    try {
+      await spawnAgent(task.id, stepId ? { stepId } : {});
+    } catch (err) {
+      setSpawnError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   // Most recent telemetry record per runId — the per-agent display reflects
   // its latest turn (full multi-turn aggregation needs a session_runs join
@@ -1215,7 +1241,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
       </header>
       {sorted.length === 0 ? (
         <p className="px-1 py-2 text-xs text-muted-foreground/70">
-          no agents yet — start a workflow to spawn the first one.
+          no agents yet — spawn one below.
         </p>
       ) : (
         <ul className="flex flex-col gap-0.5">
@@ -1224,11 +1250,100 @@ function AgentsSection({ task }: AgentsSectionProps) {
               key={run.id}
               run={run}
               telemetry={run.runId ? (telemetryByRunId.get(run.runId) ?? null) : null}
+              isSelected={run.id === selectedAgentRunId}
+              onClick={() => onSelectAgent(run.id)}
             />
           ))}
         </ul>
       )}
+      <SpawnAgentControl workflow={workflow} onSpawn={onSpawn} />
+      {spawnError ? <p className="mt-1 px-1 text-2xs text-danger">{spawnError}</p> : null}
     </section>
+  );
+}
+
+interface SpawnAgentControlProps {
+  workflow: Workflow | null;
+  onSpawn: (stepId: Step['id'] | null) => void | Promise<void>;
+}
+
+function SpawnAgentControl({ workflow, onSpawn }: SpawnAgentControlProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener('mousedown', onDocClick);
+    return () => window.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  const sortedSteps = useMemo(
+    () => (workflow ? [...workflow.steps].sort((a, b) => a.ordinal - b.ordinal) : []),
+    [workflow],
+  );
+
+  return (
+    <div className="relative mt-1" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 rounded-md border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <Plus size={13} aria-hidden />
+        spawn agent
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute bottom-full left-0 right-0 z-20 mb-1 max-h-60 overflow-y-auto rounded-md bg-background py-1 text-xs shadow-lg ring-1 ring-border-soft"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              void onSpawn(null);
+            }}
+            className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted"
+          >
+            <span className="font-medium text-foreground">+ free agent</span>
+            <span className="text-2xs text-muted-foreground">no role</span>
+          </button>
+          {sortedSteps.length > 0 ? (
+            <>
+              <div className="mt-1 border-t border-border-soft" aria-hidden />
+              <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">
+                from workflow
+              </div>
+              {sortedSteps.map((step) => (
+                <button
+                  key={step.id}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setOpen(false);
+                    void onSpawn(step.id);
+                  }}
+                  className="flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted"
+                >
+                  <span className="font-medium text-foreground">{step.name}</span>
+                  {step.modelOverride ? (
+                    <span className="text-2xs text-muted-foreground">
+                      {shortModel(step.modelOverride)}
+                    </span>
+                  ) : null}
+                </button>
+              ))}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -1243,13 +1358,16 @@ const AGENT_STATUS_TONE: Record<SessionStatus, string> = {
 interface AgentRowProps {
   readonly run: Session;
   readonly telemetry: TelemetryRecord | null;
+  readonly isSelected: boolean;
+  readonly onClick: () => void;
 }
 
-function AgentRow({ run, telemetry }: AgentRowProps) {
+function AgentRow({ run, telemetry, isSelected, onClick }: AgentRowProps) {
   const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
   const titleParts = [
     `step #${run.ordinal + 1}`,
     `status: ${run.status}`,
+    isSelected ? 'selected — next turn routes here' : 'click to route next turn here',
     telemetry ? `provider: ${telemetry.provider}` : null,
     telemetry ? `model: ${telemetry.model}` : null,
     total !== null
@@ -1258,43 +1376,56 @@ function AgentRow({ run, telemetry }: AgentRowProps) {
   ].filter((p): p is string => p !== null);
 
   return (
-    <li
-      className="group flex flex-col gap-0.5 rounded-md px-2 py-1 text-xs"
-      title={titleParts.join('\n')}
-    >
-      <div className="flex items-center gap-2">
-        <span
-          aria-hidden
-          className={cn(
-            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-            AGENT_STATUS_TONE[run.status],
-          )}
-        />
-        <span
-          className="line-clamp-1 flex-1 rounded-full bg-subtle px-1.5 py-px text-2xs font-medium text-foreground"
-          aria-label={`role chip: ${run.name}`}
-        >
-          {run.name}
-        </span>
-        <span className="shrink-0 font-mono text-2xs text-muted-foreground">{run.ordinal + 1}</span>
-      </div>
-      {telemetry ? (
-        <div className="flex items-center gap-1.5 pl-3.5 text-2xs text-muted-foreground/80">
-          <span>{shortModel(telemetry.model)}</span>
-          {total !== null ? (
-            <>
-              <span aria-hidden>·</span>
-              <span title={`${total.toLocaleString()} tokens (last turn)`}>
-                {formatTokens(total)} tok
-              </span>
-            </>
-          ) : null}
-          <span aria-hidden>·</span>
-          <span title={`$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)`}>
-            {formatCost(telemetry.estimatedCostUsd)}
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'group flex w-full flex-col gap-0.5 rounded-md px-2 py-1 text-left text-xs transition-colors',
+          isSelected ? 'bg-muted' : 'hover:bg-muted/60',
+        )}
+        title={titleParts.join('\n')}
+        aria-pressed={isSelected}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className={cn(
+              'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+              AGENT_STATUS_TONE[run.status],
+            )}
+          />
+          <span
+            className={cn(
+              'line-clamp-1 flex-1 rounded-full px-1.5 py-px text-2xs font-medium',
+              isSelected ? 'bg-foreground text-background' : 'bg-subtle text-foreground',
+            )}
+            aria-label={`role chip: ${run.name}`}
+          >
+            {run.name}
+          </span>
+          <span className="shrink-0 font-mono text-2xs text-muted-foreground">
+            {run.ordinal + 1}
           </span>
         </div>
-      ) : null}
+        {telemetry ? (
+          <div className="flex items-center gap-1.5 pl-3.5 text-2xs text-muted-foreground/80">
+            <span>{shortModel(telemetry.model)}</span>
+            {total !== null ? (
+              <>
+                <span aria-hidden>·</span>
+                <span title={`${total.toLocaleString()} tokens (last turn)`}>
+                  {formatTokens(total)} tok
+                </span>
+              </>
+            ) : null}
+            <span aria-hidden>·</span>
+            <span title={`$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)`}>
+              {formatCost(telemetry.estimatedCostUsd)}
+            </span>
+          </div>
+        ) : null}
+      </button>
     </li>
   );
 }

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -44,7 +44,7 @@ interface RawPhaseTemplateRow {
 interface RawPhaseRunRow {
   readonly id: string;
   readonly taskId: string;
-  readonly stepId: string;
+  readonly stepId: string | null;
   readonly ordinal: number;
   readonly name: string;
   readonly status: string;
@@ -86,7 +86,7 @@ function rowToPhaseRun(row: RawPhaseRunRow): Session {
   return {
     id: row.id as SessionId,
     taskId: row.taskId as TaskId,
-    stepId: row.stepId as StepId,
+    ...(row.stepId != null && { stepId: row.stepId as StepId }),
     ordinal: row.ordinal,
     name: row.name,
     status: row.status as SessionStatus,
@@ -164,7 +164,7 @@ export async function invokePhaseRunList(taskId: TaskId): Promise<Session[]> {
 export interface PhaseRunInsertArgs {
   readonly id?: SessionId;
   readonly taskId: TaskId;
-  readonly stepId: StepId;
+  readonly stepId?: StepId;
   readonly ordinal: number;
   readonly name: string;
   readonly status: SessionStatus;
@@ -179,7 +179,7 @@ export async function invokePhaseRunInsert(run: PhaseRunInsertArgs): Promise<Ses
     input: {
       id: run.id ?? null,
       taskId: run.taskId,
-      stepId: run.stepId,
+      stepId: run.stepId ?? null,
       ordinal: run.ordinal,
       name: run.name,
       status: run.status,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -60,6 +60,7 @@ import type {
   PermissionRequestId,
   PermissionRule,
   Step,
+  StepId,
   Session,
   SessionId,
   SessionStatus,
@@ -225,6 +226,7 @@ export interface AppState {
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly sessionPhaseRuns: Readonly<Record<TaskId, ReadonlyArray<Session>>>;
+  readonly selectedAgentRunId: Readonly<Record<TaskId, SessionId | null>>;
   readonly sessionMergeConflicts: Readonly<Record<TaskId, ReadonlyArray<FileConflict>>>;
   readonly unknownPayloadCounts: Readonly<Record<string, number>>;
   readonly detectedEditors: ReadonlyArray<DetectedEditor>;
@@ -300,6 +302,8 @@ export interface AppActions {
   savePhaseTemplate(template: PhaseTemplateUpsertArgs): Promise<void>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
   loadPhaseRunsForSession(taskId: TaskId): Promise<void>;
+  setSelectedAgent(taskId: TaskId, sessionId: SessionId | null): void;
+  spawnAgent(taskId: TaskId, args: { stepId?: StepId; name?: string }): Promise<SessionId>;
   dismissSystemAlert(id: string): void;
   setSessionMergeConflicts(taskId: TaskId, conflicts: ReadonlyArray<FileConflict>): void;
   resolveMergeConflicts(
@@ -353,6 +357,7 @@ const initialState: AppState = {
   skills: {},
   phaseTemplates: {},
   sessionPhaseRuns: {},
+  selectedAgentRunId: {},
   sessionMergeConflicts: {},
   unknownPayloadCounts: {},
   detectedEditors: [],
@@ -1089,10 +1094,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
           sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: freshRuns },
         }));
         // Resolve the step the next turn should land on. Auto-advance is gone:
-        // currentStep keeps the agent on its current role until the user
-        // explicitly spawns a new agent (future PR). Multiple turns now stack
-        // on the same Session row instead of inserting a fresh row per message.
-        const nextDef = currentStep(template, freshRuns);
+        // if the user picked an agent in the sidebar, route to *that* Session
+        // row's step. Otherwise currentStep keeps the agent on its current role
+        // until the user explicitly switches/spawns a new agent. Multiple turns
+        // stack on the same Session row instead of inserting a fresh row per
+        // user message.
+        const selectedRunId = get().selectedAgentRunId[taskId] ?? null;
+        const selectedRun = selectedRunId
+          ? (freshRuns.find((r) => r.id === selectedRunId) ?? null)
+          : null;
+        const nextDef = selectedRun
+          ? (template.steps.find((s) => s.id === selectedRun.stepId) ?? null)
+          : currentStep(template, freshRuns);
         if (nextDef) {
           const sortedDefs = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
           const prevDef =
@@ -1260,7 +1273,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // it at the new providerRunId, instead of inserting a fresh row per
       // user message. New rows only appear when the user spawns a new agent.
       const runsForTask = get().sessionPhaseRuns[taskId] ?? [];
-      const reusable = findReusableSession(runsForTask, phaseDefinition.id);
+      const explicitRunId = get().selectedAgentRunId[taskId] ?? null;
+      const explicit = explicitRunId
+        ? (runsForTask.find((r) => r.id === explicitRunId && r.stepId === phaseDefinition.id) ??
+          null)
+        : null;
+      const reusable = explicit ?? findReusableSession(runsForTask, phaseDefinition.id);
       let resolved: Session;
       if (reusable) {
         resolved = await invokePhaseRunUpdateStatus(reusable.id, {
@@ -2080,6 +2098,49 @@ export const useAppStore = create<AppStore>((set, get) => ({
   loadPhaseRunsForSession: async (taskId) => {
     const runs = await invokePhaseRunList(taskId);
     set((state) => ({ sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: runs } }));
+  },
+
+  setSelectedAgent: (taskId, sessionId) => {
+    set((state) => ({
+      selectedAgentRunId: { ...state.selectedAgentRunId, [taskId]: sessionId },
+    }));
+  },
+
+  spawnAgent: async (taskId, args) => {
+    const state = get();
+    const task = state.sessions.find((s) => s.id === taskId);
+    if (!task) throw new Error(`task not found: ${taskId}`);
+    let resolvedName = args.name;
+    let resolvedStepId: StepId | undefined;
+    if (args.stepId) {
+      const templates = state.phaseTemplates[task.workspaceId] ?? [];
+      const template = task.workflowId
+        ? (templates.find((t) => t.id === task.workflowId) ?? null)
+        : null;
+      const step = template?.steps.find((s) => s.id === args.stepId) ?? null;
+      if (!step) throw new Error(`step not found in workflow: ${args.stepId}`);
+      resolvedStepId = args.stepId;
+      resolvedName = resolvedName ?? step.name;
+    }
+    if (!resolvedName) {
+      const free = (state.sessionPhaseRuns[taskId] ?? []).filter((r) => r.stepId === undefined);
+      resolvedName = `agent ${free.length + 1}`;
+    }
+    const currentRuns = state.sessionPhaseRuns[taskId] ?? [];
+    const nextOrdinal = currentRuns.reduce((max, r) => Math.max(max, r.ordinal), -1) + 1;
+    const inserted = await invokePhaseRunInsert({
+      taskId,
+      ...(resolvedStepId !== undefined && { stepId: resolvedStepId }),
+      ordinal: nextOrdinal,
+      name: resolvedName,
+      status: 'pending',
+    });
+    const refreshed = await invokePhaseRunList(taskId);
+    set((s) => ({
+      sessionPhaseRuns: { ...s.sessionPhaseRuns, [taskId]: refreshed },
+      selectedAgentRunId: { ...s.selectedAgentRunId, [taskId]: inserted.id },
+    }));
+    return inserted.id;
   },
 
   dismissSystemAlert: (id) => {

--- a/packages/core/src/workflows/sequencer.ts
+++ b/packages/core/src/workflows/sequencer.ts
@@ -2,7 +2,10 @@ import type { Step, Session, Workflow } from '@kay-am/types';
 
 export function nextStep(template: Workflow, runs: ReadonlyArray<Session>): Step | null {
   const doneIds = new Set(
-    runs.filter((r) => r.status === 'completed' || r.status === 'skipped').map((r) => r.stepId),
+    runs
+      .filter((r) => r.status === 'completed' || r.status === 'skipped')
+      .map((r) => r.stepId)
+      .filter((id): id is Step['id'] => id !== undefined),
   );
 
   const sorted = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
@@ -38,11 +41,15 @@ export function currentStep(template: Workflow, runs: ReadonlyArray<Session>): S
   const live = runs
     .filter((r) => r.status === 'running' || r.status === 'failed' || r.status === 'pending')
     .sort((a, b) => isStartedAt(b).localeCompare(isStartedAt(a)));
-  const liveStep = live.map((r) => stepById.get(r.stepId)).find((s): s is Step => !!s);
+  const liveStep = live
+    .map((r) => (r.stepId !== undefined ? stepById.get(r.stepId) : undefined))
+    .find((s): s is Step => !!s);
   if (liveStep) return liveStep;
 
   const recent = [...runs].sort((a, b) => isStartedAt(b).localeCompare(isStartedAt(a)));
-  const recentStep = recent.map((r) => stepById.get(r.stepId)).find((s): s is Step => !!s);
+  const recentStep = recent
+    .map((r) => (r.stepId !== undefined ? stepById.get(r.stepId) : undefined))
+    .find((s): s is Step => !!s);
   if (recentStep) return recentStep;
 
   return sorted[0] ?? null;
@@ -79,7 +86,10 @@ export function buildStepPrompt(input: {
 
 export function isWorkflowComplete(template: Workflow, runs: ReadonlyArray<Session>): boolean {
   const doneIds = new Set(
-    runs.filter((r) => r.status === 'completed' || r.status === 'skipped').map((r) => r.stepId),
+    runs
+      .filter((r) => r.status === 'completed' || r.status === 'skipped')
+      .map((r) => r.stepId)
+      .filter((id): id is Step['id'] => id !== undefined),
   );
   return template.steps.every((d) => doneIds.has(d.id));
 }

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -12,6 +12,7 @@ import { m011ParallelPhases } from './m011-parallel-phases';
 import { m012SettingsOverrides } from './m012-settings-overrides';
 import { m013BudgetExtraTokens } from './m013-budget-extra-tokens';
 import { m014RenameDomain } from './m014-rename-domain';
+import { m015AgentsNullableStep } from './m015-agents-nullable-step';
 
 export interface Migration {
   readonly version: number;
@@ -33,4 +34,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 12, sql: m012SettingsOverrides },
   { version: 13, sql: m013BudgetExtraTokens },
   { version: 14, sql: m014RenameDomain },
+  { version: 15, sql: m015AgentsNullableStep },
 ];

--- a/packages/db/src/migrations/m015-agents-nullable-step.ts
+++ b/packages/db/src/migrations/m015-agents-nullable-step.ts
@@ -1,0 +1,35 @@
+export const m015AgentsNullableStep = /* sql */ `
+CREATE TABLE sessions_new (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  step_id TEXT,
+  ordinal INTEGER NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  provider_run_id TEXT,
+  output_summary TEXT,
+  group_id TEXT,
+  parallel_index INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT,
+  completed_at TEXT,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (step_id) REFERENCES steps(id) ON DELETE SET NULL
+);
+
+INSERT INTO sessions_new (
+  id, task_id, step_id, ordinal, name, status,
+  provider_run_id, output_summary, group_id, parallel_index,
+  started_at, completed_at
+)
+SELECT
+  id, task_id, step_id, ordinal, name, status,
+  provider_run_id, output_summary, group_id, parallel_index,
+  started_at, completed_at
+FROM sessions;
+
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;
+
+CREATE INDEX idx_sessions_task_id ON sessions(task_id);
+CREATE INDEX idx_sessions_group ON sessions(group_id);
+`;

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -12,7 +12,7 @@ import type { Database } from '../client';
 interface SessionRow {
   id: string;
   task_id: string;
-  step_id: string;
+  step_id: string | null;
   ordinal: number;
   name: string;
   status: string;
@@ -26,7 +26,7 @@ function toSession(row: SessionRow): Session {
   return {
     id: row.id as SessionId,
     taskId: row.task_id as TaskId,
-    stepId: row.step_id as StepId,
+    ...(row.step_id != null && { stepId: row.step_id as StepId }),
     ordinal: row.ordinal,
     name: row.name,
     status: row.status as SessionStatus,
@@ -56,7 +56,7 @@ export async function insertSession(db: Database, session: Session): Promise<voi
     [
       session.id,
       session.taskId,
-      session.stepId,
+      session.stepId ?? null,
       session.ordinal,
       session.name,
       session.status,

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -39,7 +39,7 @@ export type Workflow = Readonly<{
 export type Session = Readonly<{
   id: SessionId;
   taskId: TaskId;
-  stepId: StepId;
+  stepId?: StepId;
   ordinal: number;
   name: string;
   status: SessionStatus;


### PR DESCRIPTION
## Summary

**Step 1 of model B.** Decouples agents from workflow steps. User can now spawn a "free agent" inside any session — with or without an active workflow — and select which agent the next turn routes to.

### Type / DB / Rust

- `Session.stepId` is now optional (`packages/types/src/workflow.ts`). `ParallelSession` keeps it required (parallel fan-out remains workflow-driven for now; folded into batchId in PR-2c).
- `m015-agents-nullable-step` rebuilds the `sessions` table with `step_id TEXT NULL` and relaxes the FK to `ON DELETE SET NULL`. Standard SQLite alter-column recipe (create new, copy, drop, rename, recreate indexes).
- `packages/db/src/queries/session.ts` reads/writes nullable `step_id`.
- `apps/desktop/src/phases.ts` `RawPhaseRunRow.stepId` and `PhaseRunInsertArgs.stepId` become nullable/optional.
- `apps/desktop/src-tauri/src/workflows.rs` `SessionRow.step_id` and `PhaseRunInsertInput.step_id` become `Option<String>`. rusqlite binds `Option` to NULL transparently — no SQL or query-param changes.

### Core

- `sequencer.nextStep` / `currentStep` / `isWorkflowComplete` filter out null `stepId`s before joining against template steps so free agents don't poison workflow progress.

### Store

- New state: `selectedAgentRunId: Record<TaskId, SessionId | null>` (which agent the next turn goes to).
- New actions:
  - `setSelectedAgent(taskId, sessionId | null)` — toggle which agent in the sidebar is the routing target.
  - `spawnAgent(taskId, { stepId?, name? }) → SessionId` — insert a fresh `Session` row. Without `stepId`, name defaults to `"agent N"` where N counts existing free agents.
- Send-turn flow already honors `selectedAgentRunId` (carry-forward step + reuse routing). For a selected free agent, `template.steps.find(s => s.id === undefined)` returns nothing, so `nextDef` is null and the flow falls through to the existing bare-turn path.

### UI

- `AgentsSection` always renders `SpawnAgentControl` (previously gated by `task.workflowId`).
- Dropdown:
  - `+ free agent` entry first (always present).
  - Divider.
  - `from workflow` heading + step entries when a workflow is active.
- `AgentRow` is now clickable and marks the selected agent (visual swap + aria-pressed).

### Known limitation

Free agents currently share the session's bare-turn flow. Picking a free agent + sending a message advances the session as if nothing was selected, and the spawned agent row stays in `'pending'`. Per-agent transcript + status flips land in **PR-2b** (rename + per-agent chat view).

## Test plan

- [x] `pnpm typecheck` — clean across all 5 packages
- [x] `pnpm test` — 444 core + 190 desktop + others, all green
- [ ] manual: open desktop app on a fresh DB → sessions sidebar shows "spawn agent" button always; dropdown has "+ free agent"; clicking it adds a row named "agent 1"; clicking the row highlights it as selected
- [ ] manual: with a workflow active, dropdown still shows the workflow's steps under "from workflow" heading
- [ ] manual: confirm m015 runs cleanly on the wiped DB at `~/.kay-am/data.db`