### PR TITLE
feat(desktop): chat ui overhaul — picker, queue, danger zones, guide

### DIFF
--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -68,7 +68,32 @@ impl serde::Serialize for EditorError {
 pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), EditorError> {
     let binary = editor.unwrap_or_else(|| DEFAULT_EDITOR.to_string());
 
-    match Command::new(&binary).arg(&path).spawn() {
+    // On macOS, cursor's CLI shim opens paths inside the current window which can
+    // resolve to a single file rather than the workspace folder. Use `open -a Cursor`
+    // when targeting a directory so the folder loads as a workspace.
+    #[cfg(target_os = "macos")]
+    {
+        if binary == "cursor" && std::path::Path::new(&path).is_dir() {
+            return match Command::new("open")
+                .args(["-a", "Cursor", "-n", &path])
+                .spawn()
+            {
+                Ok(_) => Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    Err(EditorError::NotFound(binary))
+                }
+                Err(source) => Err(EditorError::Spawn { binary, source }),
+            };
+        }
+    }
+
+    let mut cmd = Command::new(&binary);
+    if binary == "cursor" || binary == "code" {
+        cmd.arg("--new-window");
+    }
+    cmd.arg(&path);
+
+    match cmd.spawn() {
         Ok(_) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
             Err(EditorError::NotFound(binary))

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -261,27 +261,65 @@ fn check_cursor_auth() -> AuthState {
 }
 
 fn check_codex_auth() -> AuthState {
-    match run_auth_command(&["codex", "auth", "status"]) {
-        Ok(output) => {
-            let lower = output.to_lowercase();
-            if lower.contains("not logged") || lower.contains("unauthenticated") {
-                return AuthState {
-                    state: AuthStateKind::Disconnected,
-                    identity: None,
-                };
+    // codex CLI subcommand layout has shifted across versions; try the variants
+    // we've seen in the wild before giving up. order matters: most recent first.
+    let candidates: &[&[&str]] = &[
+        // codex CLI ≥ 0.13 (current). subcommand: `codex login status` →
+        // stdout "Logged in using ChatGPT" or "Not logged in".
+        &["codex", "login", "status"],
+        // legacy / fallback shapes from older versions, kept in case the user
+        // still has an older binary on PATH.
+        &["codex", "auth", "status"],
+        &["codex", "auth", "whoami"],
+        &["codex", "whoami"],
+        &["codex", "status"],
+    ];
+    let mut last_output: Option<String> = None;
+    for cmd in candidates {
+        match run_auth_command(cmd) {
+            Ok(output) => {
+                last_output = Some(output);
+                break;
             }
-            let identity = extract_email(&output)
-                .or_else(|| extract_json_string(&output, "email"))
-                .or_else(|| extract_json_string(&output, "username"));
-            AuthState {
-                state: AuthStateKind::Connected,
-                identity,
+            Err(err) => {
+                last_output = Some(err);
+                continue;
             }
         }
-        Err(_) => AuthState {
+    }
+    let Some(output) = last_output else {
+        return AuthState {
             state: AuthStateKind::Unknown,
             identity: None,
-        },
+        };
+    };
+    let lower = output.to_lowercase();
+    if lower.contains("not logged")
+        || lower.contains("unauthenticated")
+        || lower.contains("not signed in")
+        || lower.contains("no credentials")
+    {
+        return AuthState {
+            state: AuthStateKind::Disconnected,
+            identity: None,
+        };
+    }
+    if lower.contains("logged in")
+        || lower.contains("signed in")
+        || lower.contains("authenticated")
+        || extract_email(&output).is_some()
+    {
+        let identity = extract_email(&output)
+            .or_else(|| extract_json_string(&output, "email"))
+            .or_else(|| extract_json_string(&output, "username"));
+        return AuthState {
+            state: AuthStateKind::Connected,
+            identity,
+        };
+    }
+    AuthState {
+        state: AuthStateKind::Unknown,
+        identity: None,
     }
 }
 

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -100,7 +100,7 @@ describe('ChatInput — input wiring', () => {
     expect((textarea as HTMLTextAreaElement).disabled).toBe(false);
   });
 
-  it('textarea is disabled when session is running', () => {
+  it('textarea stays enabled when session is running so user can queue next message', () => {
     render(
       <ChatInput
         session={makeSession({
@@ -113,7 +113,7 @@ describe('ChatInput — input wiring', () => {
       />,
     );
     const textarea = screen.getByRole('textbox');
-    expect((textarea as HTMLTextAreaElement).disabled).toBe(true);
+    expect((textarea as HTMLTextAreaElement).disabled).toBe(false);
   });
 
   it('Enter sends the turn and clears the input', async () => {

--- a/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
+++ b/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
@@ -56,12 +56,6 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <div
         class="flex items-center gap-1"
       >
-        <span
-          class="rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide bg-muted text-muted-foreground"
-          title="no summarizer run yet — runs after each turn when an api key is set"
-        >
-          idle
-        </span>
         <button
           aria-label="hide context panel"
           class="rounded-sm p-0.5 hover:bg-muted text-muted-foreground hover:text-foreground"

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -41,8 +41,8 @@ exports[`snapshot — empty states > AlertCenter: no alerts 1`] = `
 
 exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
 <dialog
-  aria-describedby="_r_2_-desc"
-  aria-labelledby="_r_2_-title"
+  aria-describedby="_r_3_-desc"
+  aria-labelledby="_r_3_-title"
   class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
   open=""
 >
@@ -57,13 +57,13 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
       >
         <h2
           class="text-sm font-semibold tracking-tight text-foreground"
-          id="_r_2_-title"
+          id="_r_3_-title"
         >
           New session
         </h2>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
-          id="_r_2_-desc"
+          id="_r_3_-desc"
         >
           Creates a worktree on a fresh branch from the workspace root.
         </p>
@@ -92,6 +92,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
         >
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+            title="goal is required"
             type="button"
           >
             <svg
@@ -127,7 +128,36 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               class="flex-1"
             >
               Goal
+              <span
+                aria-hidden="true"
+                class="ml-0.5 text-warning"
+              >
+                *
+              </span>
             </span>
+            <svg
+              aria-label="goal required"
+              class="lucide lucide-triangle-alert text-warning"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
           </button>
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
@@ -251,6 +281,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           </button>
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            title="provider is required"
             type="button"
           >
             <svg
@@ -274,7 +305,36 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               class="flex-1"
             >
               Provider
+              <span
+                aria-hidden="true"
+                class="ml-0.5 text-warning"
+              >
+                *
+              </span>
             </span>
+            <svg
+              aria-label="provider required"
+              class="lucide lucide-triangle-alert text-warning"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
           </button>
         </nav>
         <div
@@ -289,9 +349,9 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               goal
             </span>
             <textarea
-              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
+              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
               placeholder="refactor auth domain"
-              style="height: 0px; overflow-y: hidden;"
+              style="height: 96px; overflow-y: hidden;"
             />
             <p
               class="text-xs leading-relaxed text-muted-foreground"
@@ -305,6 +365,34 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
+      <span
+        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-triangle-alert"
+          fill="none"
+          height="12"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+          />
+          <path
+            d="M12 9v4"
+          />
+          <path
+            d="M12 17h.01"
+          />
+        </svg>
+        complete: goal, provider
+      </span>
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
         type="button"
@@ -314,6 +402,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
         disabled=""
+        title="complete: goal, provider"
         type="button"
       >
         create session
@@ -464,6 +553,38 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
         </span>
       </div>
       <button
+        aria-label="open getting started guide"
+        class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title="getting started — guide"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-question-mark"
+          fill="none"
+          height="13"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="13"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <path
+            d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"
+          />
+          <path
+            d="M12 17h.01"
+          />
+        </svg>
+      </button>
+      <button
         aria-label="open settings"
         class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         title="settings (⌘,)"
@@ -498,10 +619,10 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] max-h-[40%] shrink-0"
   >
     <section
-      class="flex flex-col px-2 pb-2 pt-1"
+      class="flex flex-col px-2"
     >
       <header
-        class="flex items-baseline justify-between gap-2 px-2 pb-1.5"
+        class="flex items-baseline justify-between gap-2 pb-1.5"
       >
         <span
           class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
@@ -552,17 +673,13 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     </section>
   </div>
   <div
-    aria-hidden="true"
-    class="mx-3 my-5 h-px bg-border-soft"
-  />
-  <div
-    class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] flex-1"
+    class="overflow-auto [scrollbar-color:var(--color-border)_transparent] [scrollbar-width:thin] mt-8 flex-1"
   >
     <section
-      class="flex flex-col px-2 pt-2"
+      class="flex flex-col px-2"
     >
       <header
-        class="flex items-center justify-between gap-2 px-2 pb-1.5"
+        class="flex items-center justify-between gap-2 pb-1.5"
       >
         <span
           class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
@@ -641,14 +758,15 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     </button>
     <button
       aria-label="open pricing breakdown"
-      class="inline-flex items-center gap-2 rounded-full bg-muted px-2.5 py-0.5 text-xs hover:bg-muted/70"
-      title="open pricing breakdown"
+      class="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-xs hover:bg-muted/70"
+      title="session: $0
+workspace: $0"
       type="button"
     >
       <span
         class="font-medium"
       >
-        $0.0000
+        $0
       </span>
       <span
         class="text-muted-foreground"
@@ -664,12 +782,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
       <span
         class="font-medium"
       >
-        $0.0000
-      </span>
-      <span
-        class="text-muted-foreground"
-      >
-        total
+        $0
       </span>
     </button>
     <dialog
@@ -919,34 +1032,517 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
       </footer>
     </div>
   </dialog>
+  <dialog
+    aria-describedby="_r_2_-desc"
+    aria-labelledby="_r_2_-title"
+    class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl max-md:m-0 max-md:h-screen max-md:max-h-none max-md:w-screen max-md:max-w-none max-md:rounded-none max-md:border-0 max-md:shadow-none"
+  >
+    <div
+      class="flex min-h-0 flex-col h-[640px] w-[56rem] max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none"
+    >
+      <header
+        class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+      >
+        <div
+          class="flex min-w-0 flex-col gap-1"
+        >
+          <h2
+            class="text-sm font-semibold tracking-tight text-foreground"
+            id="_r_2_-title"
+          >
+            Getting started
+          </h2>
+          <p
+            class="text-xs leading-relaxed text-muted-foreground"
+            id="_r_2_-desc"
+          >
+            how kAY.am, sessions, agents, and CLI providers fit together.
+          </p>
+        </div>
+        <button
+          aria-label="close"
+          class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            class="text-base leading-none"
+          >
+            ×
+          </span>
+        </button>
+      </header>
+      <div
+        class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+      >
+        <div
+          class="flex h-full min-h-0 gap-0"
+        >
+          <nav
+            class="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2"
+          >
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-book-open"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 7v14"
+                />
+                <path
+                  d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                />
+              </svg>
+              <span>
+                Overview
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-git-branch"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 6a9 9 0 0 0-9 9V3"
+                />
+                <circle
+                  cx="18"
+                  cy="6"
+                  r="3"
+                />
+                <circle
+                  cx="6"
+                  cy="18"
+                  r="3"
+                />
+              </svg>
+              <span>
+                Sessions
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-messages-square"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"
+                />
+                <path
+                  d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1"
+                />
+              </svg>
+              <span>
+                Turns
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-wrench"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"
+                />
+              </svg>
+              <span>
+                Tools
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-coins"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13.744 17.736a6 6 0 1 1-7.48-7.48"
+                />
+                <path
+                  d="M15 6h1v4"
+                />
+                <path
+                  d="m6.134 14.768.866-.5 2 3.464"
+                />
+                <circle
+                  cx="16"
+                  cy="8"
+                  r="6"
+                />
+              </svg>
+              <span>
+                Tokens & cost
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-bot"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 8V4H8"
+                />
+                <rect
+                  height="12"
+                  rx="2"
+                  width="16"
+                  x="4"
+                  y="8"
+                />
+                <path
+                  d="M2 14h2"
+                />
+                <path
+                  d="M20 14h2"
+                />
+                <path
+                  d="M15 13v2"
+                />
+                <path
+                  d="M9 13v2"
+                />
+              </svg>
+              <span>
+                Agents
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-lightbulb"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"
+                />
+                <path
+                  d="M9 18h6"
+                />
+                <path
+                  d="M10 22h4"
+                />
+              </svg>
+              <span>
+                Tips
+              </span>
+            </button>
+          </nav>
+          <div
+            class="min-w-0 flex-1 overflow-y-auto pl-4 pr-1"
+          >
+            <article
+              class="flex flex-col gap-3 pb-6 text-sm leading-relaxed"
+            >
+              <h2
+                class="text-base font-semibold tracking-tight text-foreground"
+              >
+                What is kAY.am?
+              </h2>
+              <p
+                class="text-muted-foreground"
+              >
+                kAY.am orchestrates AI coding CLIs (claude, cursor-agent, codex) so you can run multiple agents in parallel against your repo, with budget caps, audit logs, and structured workflows.
+              </p>
+              <p
+                class="text-sm leading-relaxed text-muted-foreground"
+              >
+                kAY.am does 
+                <strong
+                  class="font-semibold text-foreground"
+                >
+                  not
+                </strong>
+                 talk to AI providers directly. It spawns the provider's CLI as a subprocess and streams events. That means: your usage, login, and quotas live in the CLI itself; kAY.am just adds the workspace layer on top.
+              </p>
+              <h3
+                class="mt-2 text-xs font-semibold uppercase tracking-wide text-foreground/85"
+              >
+                Mental model
+              </h3>
+              <ul
+                class="flex flex-col gap-1.5"
+              >
+                <li
+                  class="flex flex-col gap-0.5"
+                >
+                  <span
+                    class="text-sm font-semibold text-foreground"
+                  >
+                    Workspace
+                  </span>
+                  <span
+                    class="text-sm leading-relaxed text-muted-foreground"
+                  >
+                    a git repo on disk. you can connect many.
+                  </span>
+                </li>
+                <li
+                  class="flex flex-col gap-0.5"
+                >
+                  <span
+                    class="text-sm font-semibold text-foreground"
+                  >
+                    Session
+                  </span>
+                  <span
+                    class="text-sm leading-relaxed text-muted-foreground"
+                  >
+                    a chat with one goal, on its own git worktree + branch. like a feature branch with built-in chat.
+                  </span>
+                </li>
+                <li
+                  class="flex flex-col gap-0.5"
+                >
+                  <span
+                    class="text-sm font-semibold text-foreground"
+                  >
+                    Agent
+                  </span>
+                  <span
+                    class="text-sm leading-relaxed text-muted-foreground"
+                  >
+                    one provider/CLI invocation inside a session. a session may have several agents (e.g. one for planning, one for coding).
+                  </span>
+                </li>
+                <li
+                  class="flex flex-col gap-0.5"
+                >
+                  <span
+                    class="text-sm font-semibold text-foreground"
+                  >
+                    Turn
+                  </span>
+                  <span
+                    class="text-sm leading-relaxed text-muted-foreground"
+                  >
+                    a single user → assistant exchange inside an agent. tools called inside count as the same turn.
+                  </span>
+                </li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </div>
+      <footer
+        class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
+      >
+        <button
+          class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
+          type="button"
+        >
+          close
+        </button>
+      </footer>
+    </div>
+  </dialog>
 </div>
 `;
 
 exports[`snapshot — error states > App init error — BootSplash with error message 1`] = `
 <div
-  class="flex h-screen flex-col items-center justify-center gap-3 bg-background text-foreground"
+  class="relative flex h-screen flex-col items-center justify-center gap-6 overflow-hidden bg-background text-foreground"
 >
   <div
-    class="text-sm font-semibold tracking-tight"
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-0 -z-10"
+  />
+  <div
+    class="flex flex-col items-center gap-3"
   >
-    kAY.am
+    <div
+      aria-hidden="true"
+      class="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-subtle ring-1 ring-border-soft"
+    >
+      <span
+        class="absolute inset-0 rounded-2xl motion-safe:animate-ping"
+      />
+      <span
+        class="relative font-semibold tracking-tight text-foreground"
+      >
+        k
+      </span>
+    </div>
+    <div
+      class="text-base font-semibold tracking-tight"
+    >
+      kAY.am
+    </div>
   </div>
   <div
-    class="flex w-72 flex-col gap-2"
+    class="flex w-80 flex-col gap-2"
   >
-    <p
-      class="text-xs text-muted-foreground"
-    >
-      boot error
-    </p>
     <div
-      class="h-1 w-full overflow-hidden rounded-full bg-muted"
+      class="flex items-center justify-between text-2xs uppercase tracking-[0.08em] text-muted-foreground"
+    >
+      <span>
+        boot error
+      </span>
+      <span
+        class="font-mono text-muted-foreground/70"
+      >
+        0
+        %
+      </span>
+    </div>
+    <div
+      class="h-0.5 w-full overflow-hidden rounded-full bg-muted/60"
     >
       <div
-        class="h-full bg-primary motion-safe:transition-all"
+        class="h-full rounded-full bg-primary motion-safe:transition-all motion-safe:duration-500"
         style="width: 0%;"
       />
     </div>
+    <ul
+      class="mt-2 flex flex-col gap-0.5"
+    >
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          running database migrations…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          loading settings…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          detecting claude cli…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          loading workspaces…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          restoring last session…
+        </span>
+      </li>
+    </ul>
   </div>
   <div
     class="flex w-72 flex-col gap-3 rounded-lg border border-danger/30 bg-danger/5 p-4"
@@ -989,29 +1585,127 @@ exports[`snapshot — error states > App init error — BootSplash with error me
 
 exports[`snapshot — error states > BootSplash: boot-error phase 1`] = `
 <div
-  class="flex h-screen flex-col items-center justify-center gap-3 bg-background text-foreground"
+  class="relative flex h-screen flex-col items-center justify-center gap-6 overflow-hidden bg-background text-foreground"
 >
   <div
-    class="text-sm font-semibold tracking-tight"
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-0 -z-10"
+  />
+  <div
+    class="flex flex-col items-center gap-3"
   >
-    kAY.am
+    <div
+      aria-hidden="true"
+      class="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-subtle ring-1 ring-border-soft"
+    >
+      <span
+        class="absolute inset-0 rounded-2xl motion-safe:animate-ping"
+      />
+      <span
+        class="relative font-semibold tracking-tight text-foreground"
+      >
+        k
+      </span>
+    </div>
+    <div
+      class="text-base font-semibold tracking-tight"
+    >
+      kAY.am
+    </div>
   </div>
   <div
-    class="flex w-72 flex-col gap-2"
+    class="flex w-80 flex-col gap-2"
   >
-    <p
-      class="text-xs text-muted-foreground"
-    >
-      boot error
-    </p>
     <div
-      class="h-1 w-full overflow-hidden rounded-full bg-muted"
+      class="flex items-center justify-between text-2xs uppercase tracking-[0.08em] text-muted-foreground"
+    >
+      <span>
+        boot error
+      </span>
+      <span
+        class="font-mono text-muted-foreground/70"
+      >
+        0
+        %
+      </span>
+    </div>
+    <div
+      class="h-0.5 w-full overflow-hidden rounded-full bg-muted/60"
     >
       <div
-        class="h-full bg-primary motion-safe:transition-all"
+        class="h-full rounded-full bg-primary motion-safe:transition-all motion-safe:duration-500"
         style="width: 0%;"
       />
     </div>
+    <ul
+      class="mt-2 flex flex-col gap-0.5"
+    >
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          running database migrations…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          loading settings…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          detecting claude cli…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          loading workspaces…
+        </span>
+      </li>
+      <li
+        class="flex items-center gap-2 text-2xs text-muted-foreground/40"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block h-1.5 w-1.5 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="truncate"
+        >
+          restoring last session…
+        </span>
+      </li>
+    </ul>
   </div>
   <div
     class="flex w-72 flex-col gap-3 rounded-lg border border-danger/30 bg-danger/5 p-4"
@@ -1081,8 +1775,8 @@ exports[`snapshot — error states > BudgetRulesPanel: form error 1`] = `
 
 exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
 <dialog
-  aria-describedby="_r_4_-desc"
-  aria-labelledby="_r_4_-title"
+  aria-describedby="_r_5_-desc"
+  aria-labelledby="_r_5_-title"
   class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
   open=""
 >
@@ -1097,13 +1791,13 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
       >
         <h2
           class="text-sm font-semibold tracking-tight text-foreground"
-          id="_r_4_-title"
+          id="_r_5_-title"
         >
           End session?
         </h2>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
-          id="_r_4_-desc"
+          id="_r_5_-desc"
         >
           The worktree directory will be removed. The branch is preserved for manual merge.
         </p>
@@ -1156,8 +1850,8 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
 
 exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
 <dialog
-  aria-describedby="_r_3_-desc"
-  aria-labelledby="_r_3_-title"
+  aria-describedby="_r_4_-desc"
+  aria-labelledby="_r_4_-title"
   class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
   open=""
 >
@@ -1172,13 +1866,13 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       >
         <h2
           class="text-sm font-semibold tracking-tight text-foreground"
-          id="_r_3_-title"
+          id="_r_4_-title"
         >
           New session
         </h2>
         <p
           class="text-xs leading-relaxed text-muted-foreground"
-          id="_r_3_-desc"
+          id="_r_4_-desc"
         >
           Creates a worktree on a fresh branch from the workspace root.
         </p>
@@ -1207,6 +1901,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
         >
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+            title="goal is required"
             type="button"
           >
             <svg
@@ -1242,7 +1937,36 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               class="flex-1"
             >
               Goal
+              <span
+                aria-hidden="true"
+                class="ml-0.5 text-warning"
+              >
+                *
+              </span>
             </span>
+            <svg
+              aria-label="goal required"
+              class="lucide lucide-triangle-alert text-warning"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
           </button>
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
@@ -1366,6 +2090,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           </button>
           <button
             class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            title="provider is required"
             type="button"
           >
             <svg
@@ -1389,7 +2114,36 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               class="flex-1"
             >
               Provider
+              <span
+                aria-hidden="true"
+                class="ml-0.5 text-warning"
+              >
+                *
+              </span>
             </span>
+            <svg
+              aria-label="provider required"
+              class="lucide lucide-triangle-alert text-warning"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
           </button>
         </nav>
         <div
@@ -1404,9 +2158,9 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               goal
             </span>
             <textarea
-              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
+              class="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none"
               placeholder="refactor auth domain"
-              style="height: 0px; overflow-y: hidden;"
+              style="height: 96px; overflow-y: hidden;"
             />
             <p
               class="text-xs leading-relaxed text-muted-foreground"
@@ -1420,6 +2174,34 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
+      <span
+        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-triangle-alert"
+          fill="none"
+          height="12"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="12"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+          />
+          <path
+            d="M12 9v4"
+          />
+          <path
+            d="M12 17h.01"
+          />
+        </svg>
+        complete: goal, provider
+      </span>
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
         type="button"
@@ -1429,6 +2211,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
         disabled=""
+        title="complete: goal, provider"
         type="button"
       >
         create session

--- a/apps/desktop/src/components/BootSplash.tsx
+++ b/apps/desktop/src/components/BootSplash.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import type { BootPhase } from '../store';
 import { openUrl } from '../editor';
+import { cn as uiCn } from '@kay-am/ui';
 
 const PHASE_LABEL: Record<BootPhase, string> = {
   pending: 'starting…',
@@ -124,21 +125,78 @@ function BootErrorRecovery({
 export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: BootSplashProps) {
   const idx = PHASE_ORDER.indexOf(phase);
   const total = PHASE_ORDER.length;
+  const progressPct = phase === 'ready' ? 100 : Math.max(0, (idx / total) * 100);
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center gap-3 bg-background text-foreground">
-      <div className="text-sm font-semibold tracking-tight">kAY.am</div>
-      <div className="flex w-72 flex-col gap-2">
-        <p className="text-xs text-muted-foreground">{PHASE_LABEL[phase]}</p>
-        <div className="h-1 w-full overflow-hidden rounded-full bg-muted">
+    <div className="relative flex h-screen flex-col items-center justify-center gap-6 overflow-hidden bg-background text-foreground">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+        style={{
+          background:
+            'radial-gradient(ellipse at 50% 35%, oklch(from var(--color-primary) l c h / 0.10) 0%, transparent 55%)',
+        }}
+      />
+
+      <div className="flex flex-col items-center gap-3">
+        <div
+          aria-hidden
+          className="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-subtle ring-1 ring-border-soft"
+        >
+          <span
+            className="absolute inset-0 rounded-2xl motion-safe:animate-ping"
+            style={{ background: 'oklch(from var(--color-primary) l c h / 0.15)' }}
+          />
+          <span className="relative font-semibold tracking-tight text-foreground">k</span>
+        </div>
+        <div className="text-base font-semibold tracking-tight">kAY.am</div>
+      </div>
+
+      <div className="flex w-80 flex-col gap-2">
+        <div className="flex items-center justify-between text-2xs uppercase tracking-[0.08em] text-muted-foreground">
+          <span>{PHASE_LABEL[phase]}</span>
+          <span className="font-mono text-muted-foreground/70">{Math.round(progressPct)}%</span>
+        </div>
+        <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted/60">
           <div
-            className="h-full bg-primary motion-safe:transition-all"
-            style={{
-              width: phase === 'ready' ? '100%' : `${Math.max(0, (idx / total) * 100)}%`,
-            }}
+            className="h-full rounded-full bg-primary motion-safe:transition-all motion-safe:duration-500"
+            style={{ width: `${progressPct}%` }}
           />
         </div>
+        <ul className="mt-2 flex flex-col gap-0.5">
+          {PHASE_ORDER.map((p, i) => {
+            const done = i < idx || phase === 'ready';
+            const active = i === idx && phase !== 'ready';
+            return (
+              <li
+                key={p}
+                className={uiCn(
+                  'flex items-center gap-2 text-2xs',
+                  done
+                    ? 'text-success/80'
+                    : active
+                      ? 'text-foreground'
+                      : 'text-muted-foreground/40',
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={uiCn(
+                    'inline-block h-1.5 w-1.5 rounded-full',
+                    done
+                      ? 'bg-success'
+                      : active
+                        ? 'bg-primary motion-safe:animate-pulse'
+                        : 'bg-muted-foreground/30',
+                  )}
+                />
+                <span className="truncate">{PHASE_LABEL[p]}</span>
+              </li>
+            );
+          })}
+        </ul>
       </div>
+
       {error ? (
         <BootErrorRecovery
           error={error}

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -170,13 +170,13 @@ function SummarizerBadge({
   lastUpdate: string | null;
   error: string | null;
 }) {
-  const styles: Record<SummarizerStatusKind, string> = {
-    idle: 'bg-muted text-muted-foreground',
+  // hide when idle — no useful info, just visual noise.
+  if (status === 'idle') return null;
+  const styles: Record<Exclude<SummarizerStatusKind, 'idle'>, string> = {
     running: 'bg-info/10 text-info',
     error: 'bg-danger/10 text-danger',
   };
-  const labels: Record<SummarizerStatusKind, string> = {
-    idle: 'idle',
+  const labels: Record<Exclude<SummarizerStatusKind, 'idle'>, string> = {
     running: 'summarizing…',
     error: 'error',
   };
@@ -185,7 +185,7 @@ function SummarizerBadge({
       ? `last error: ${error}`
       : lastUpdate
         ? `last update: ${lastUpdate}`
-        : 'no summarizer run yet — runs after each turn when an api key is set';
+        : 'summarizer running';
   return (
     <span
       title={tooltip}

--- a/apps/desktop/src/components/GuideDialog.tsx
+++ b/apps/desktop/src/components/GuideDialog.tsx
@@ -1,0 +1,382 @@
+import { useState } from 'react';
+import { Button, Dialog, cn } from '@kay-am/ui';
+import { BookOpen, Bot, Coins, GitBranch, Lightbulb, MessagesSquare, Wrench } from 'lucide-react';
+
+interface GuideDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+type Section = 'overview' | 'session' | 'turn' | 'tools' | 'tokens' | 'agents' | 'tips';
+
+interface NavItem {
+  id: Section;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const NAV_ITEMS: ReadonlyArray<NavItem> = [
+  { id: 'overview', label: 'Overview', icon: <BookOpen size={14} aria-hidden /> },
+  { id: 'session', label: 'Sessions', icon: <GitBranch size={14} aria-hidden /> },
+  { id: 'turn', label: 'Turns', icon: <MessagesSquare size={14} aria-hidden /> },
+  { id: 'tools', label: 'Tools', icon: <Wrench size={14} aria-hidden /> },
+  { id: 'tokens', label: 'Tokens & cost', icon: <Coins size={14} aria-hidden /> },
+  { id: 'agents', label: 'Agents', icon: <Bot size={14} aria-hidden /> },
+  { id: 'tips', label: 'Tips', icon: <Lightbulb size={14} aria-hidden /> },
+];
+
+export function GuideDialog({ open, onClose }: GuideDialogProps) {
+  const [active, setActive] = useState<Section>('overview');
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Getting started"
+      description="how kAY.am, sessions, agents, and CLI providers fit together."
+      size="xl"
+      fixedHeightClass="h-[640px]"
+      fullScreenOnSmall
+      footer={
+        <Button variant="ghost" onClick={onClose}>
+          close
+        </Button>
+      }
+    >
+      <div className="flex h-full min-h-0 gap-0">
+        <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setActive(item.id)}
+              className={cn(
+                'relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+                active === item.id
+                  ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+              )}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </nav>
+        <div className="min-w-0 flex-1 overflow-y-auto pl-4 pr-1">
+          <Content section={active} />
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function Content({ section }: { section: Section }) {
+  switch (section) {
+    case 'overview':
+      return (
+        <Article
+          heading="What is kAY.am?"
+          intro="kAY.am orchestrates AI coding CLIs (claude, cursor-agent, codex) so you can run multiple agents in parallel against your repo, with budget caps, audit logs, and structured workflows."
+        >
+          <P>
+            kAY.am does <Strong>not</Strong> talk to AI providers directly. It spawns the provider's
+            CLI as a subprocess and streams events. That means: your usage, login, and quotas live
+            in the CLI itself; kAY.am just adds the workspace layer on top.
+          </P>
+          <H3>Mental model</H3>
+          <List
+            items={[
+              ['Workspace', 'a git repo on disk. you can connect many.'],
+              [
+                'Session',
+                'a chat with one goal, on its own git worktree + branch. like a feature branch with built-in chat.',
+              ],
+              [
+                'Agent',
+                'one provider/CLI invocation inside a session. a session may have several agents (e.g. one for planning, one for coding).',
+              ],
+              [
+                'Turn',
+                'a single user → assistant exchange inside an agent. tools called inside count as the same turn.',
+              ],
+            ]}
+          />
+        </Article>
+      );
+
+    case 'session':
+      return (
+        <Article
+          heading="Sessions"
+          intro="a session is one focused unit of work. it owns a git worktree, a branch, transcripts, and a goal."
+        >
+          <H3>What gets created</H3>
+          <List
+            items={[
+              ['worktree', 'a separate working directory cut from your repo root.'],
+              ['branch', '<prefix>/<slug> derived from the goal. configurable per workspace.'],
+              ['transcript', 'every user message, assistant reply, tool call, and edit is stored.'],
+              [
+                'budget (optional)',
+                'soft cap in usd. warning at 80%, error at 100%. session keeps running.',
+              ],
+            ]}
+          />
+          <H3>When to start a new session</H3>
+          <List
+            items={[
+              [
+                'goal shifts',
+                'if the task changes meaningfully, a new session is cheaper than steering an old one off-track.',
+              ],
+              [
+                'context bloat',
+                'context window getting close to full → start fresh. transferring the relevant decisions takes seconds, fighting a saturated agent costs more.',
+              ],
+              [
+                'parallel exploration',
+                'two ways to solve the same problem? spin two sessions, compare.',
+              ],
+            ]}
+          />
+          <H3>Archive vs delete</H3>
+          <P>
+            <Strong>archive</Strong> hides from the active list, keeps the worktree, transcripts,
+            and audit. <Strong>delete</Strong> removes everything irreversibly. when in doubt,
+            archive.
+          </P>
+        </Article>
+      );
+
+    case 'turn':
+      return (
+        <Article
+          heading="Turns"
+          intro="a turn is one user message + the assistant's full response (which may include many tool calls and edits)."
+        >
+          <H3>How turns are counted</H3>
+          <List
+            items={[
+              [
+                'user → assistant',
+                'each user message you send is one turn. the count in the chat header reflects that.',
+              ],
+              [
+                'tools inside a turn',
+                'when the agent calls grep, edit, run, etc., those are part of the same turn — not separate ones.',
+              ],
+              [
+                'queueing',
+                'while a turn is running you can still type. clicking send queues the message and fires automatically when the current turn ends.',
+              ],
+            ]}
+          />
+          <H3>Why this matters</H3>
+          <P>
+            providers bill per token across all messages in the conversation, not per turn. but from
+            a UX perspective, "i've sent 14 turns and we still don't have a working build" is a
+            useful signal that the session is drifting.
+          </P>
+        </Article>
+      );
+
+    case 'tools':
+      return (
+        <Article
+          heading="Tools"
+          intro="tools are actions the agent takes outside of just talking — reading files, running shell commands, editing code, fetching docs."
+        >
+          <H3>How they show up</H3>
+          <P>
+            in the transcript, a tool invocation collapses to a single row (e.g. <Code>Bash</Code>,{' '}
+            <Code>Read</Code>, <Code>Edit</Code>). click it to expand input/output. consecutive tool
+            rows are visually grouped to keep the chat readable.
+          </P>
+          <H3>Permissions</H3>
+          <P>
+            kAY.am proxies the CLI's permission system. above the input you see{' '}
+            <Code>permissions: X allow / Y deny</Code> — that's the rule set the next turn will run
+            under. click it to manage rules in settings.
+          </P>
+          <H3>Skills</H3>
+          <P>
+            type <Code>/</Code> in the input to invoke a workspace skill (a pre-defined prompt
+            template stored in <Code>.kay/skills/</Code> or <Code>.claude/skills/</Code>). useful
+            for repeatable flows — release notes, security review, migration plan.
+          </P>
+        </Article>
+      );
+
+    case 'tokens':
+      return (
+        <Article
+          heading="Tokens & cost"
+          intro="every message — yours and the assistant's — is converted into tokens before billing. roughly 1 token ≈ ¾ of an English word."
+        >
+          <H3>Input vs output</H3>
+          <List
+            items={[
+              [
+                'input tokens',
+                'everything sent into the model: system prompt, conversation history, tool results, your latest message. grows every turn — that is why later turns cost more even if your message is short.',
+              ],
+              [
+                'cached input tokens',
+                'portions of the prompt the provider can re-use from a recent call (Anthropic prompt cache). billed at ~10% of input rate. green numbers in pricing dialog.',
+              ],
+              [
+                'output tokens',
+                'what the model writes back: text + tool calls. the most expensive token category (5–15× input rate).',
+              ],
+            ]}
+          />
+          <H3>Context window</H3>
+          <P>
+            each model has a hard ceiling on how many tokens fit in one call (Opus 4.7 1M, Sonnet
+            4.6 / Haiku 4.5 200k, gpt-4o 128k). the bar under each agent shows how full the current
+            context is. above 75% → the agent starts forgetting; consider summarising or starting a
+            new session.
+          </P>
+          <H3>Cost colors</H3>
+          <List
+            items={[
+              [
+                'green models',
+                'cheap (haiku, cursor-small). good for grep-heavy / planning steps.',
+              ],
+              ['amber models', 'mid (sonnet, gpt-4o). default for most coding work.'],
+              [
+                'red models',
+                'expensive (opus). reserve for hard reasoning, refactors, last-resort fixes.',
+              ],
+            ]}
+          />
+          <P>
+            the picker sorts <Strong>cheapest first</Strong> on purpose — switching down a tier
+            often costs nothing in quality on routine tasks.
+          </P>
+        </Article>
+      );
+
+    case 'agents':
+      return (
+        <Article
+          heading="Agents"
+          intro="an agent is one provider invocation inside a session. a session can host multiple agents — same provider or different ones."
+        >
+          <H3>Why multiple agents per session</H3>
+          <List
+            items={[
+              [
+                'role separation',
+                'spawn a planning agent on Opus, then a coding agent on Sonnet. each keeps its own transcript.',
+              ],
+              [
+                'workflow steps',
+                'a workflow defines ordered steps (e.g. plan → implement → done). each step spawns an agent with its own model + system prompt.',
+              ],
+              [
+                'parallel exploration',
+                'two agents on the same goal, diff their results, pick the better diff at merge time.',
+              ],
+            ]}
+          />
+          <H3>Reading the agent row</H3>
+          <P>
+            the second line on each agent shows:{' '}
+            <Code>model · ↓ input · ↑ output · cost · ⏱ age</Code>. below it, a thin bar = context
+            window utilisation. tooltip on the bar gives exact numbers.
+          </P>
+        </Article>
+      );
+
+    case 'tips':
+      return (
+        <Article heading="Tips" intro="patterns that compound across sessions.">
+          <List
+            items={[
+              [
+                'pin one short goal per session',
+                'long open-ended sessions drift. when you notice scope creeping, spin a new one and link via context.',
+              ],
+              [
+                'set a soft cap',
+                'even a generous one. it forces a pause before a runaway agent burns $20 on a bad assumption.',
+              ],
+              [
+                'use cheap models for navigation',
+                'haiku / cursor-small can grep, list, summarise in seconds at 1/15th the price. swap up only when reasoning gets hard.',
+              ],
+              [
+                "queue, don't cancel",
+                "if the agent is mid-tool and you have a follow-up, type it — it'll queue. cancelling mid-turn loses the partial work.",
+              ],
+              [
+                'archive freely',
+                'archive is reversible. the only irreversible move is delete, and you have to confirm twice.',
+              ],
+              [
+                'restart on cli upgrades',
+                'when you update the underlying CLI (claude / cursor-agent / codex), restart kAY.am so it re-detects versions and auth.',
+              ],
+            ]}
+          />
+        </Article>
+      );
+  }
+}
+
+function Article({
+  heading,
+  intro,
+  children,
+}: {
+  heading: string;
+  intro: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <article className="flex flex-col gap-3 pb-6 text-sm leading-relaxed">
+      <h2 className="text-base font-semibold tracking-tight text-foreground">{heading}</h2>
+      <p className="text-muted-foreground">{intro}</p>
+      {children}
+    </article>
+  );
+}
+
+function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="mt-2 text-xs font-semibold uppercase tracking-wide text-foreground/85">
+      {children}
+    </h3>
+  );
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return <p className="text-sm leading-relaxed text-muted-foreground">{children}</p>;
+}
+
+function Strong({ children }: { children: React.ReactNode }) {
+  return <strong className="font-semibold text-foreground">{children}</strong>;
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em] text-foreground">
+      {children}
+    </code>
+  );
+}
+
+function List({ items }: { items: ReadonlyArray<readonly [string, string]> }) {
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {items.map(([term, desc]) => (
+        <li key={term} className="flex flex-col gap-0.5">
+          <span className="text-sm font-semibold text-foreground">{term}</span>
+          <span className="text-sm leading-relaxed text-muted-foreground">{desc}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
-import { Check, DollarSign, GitBranch, Layers, Sparkles, Target, Zap } from 'lucide-react';
+import {
+  AlertTriangle,
+  Check,
+  DollarSign,
+  GitBranch,
+  Layers,
+  Sparkles,
+  Target,
+  Zap,
+} from 'lucide-react';
 import type {
   Workflow,
   WorkflowId,
@@ -19,6 +28,21 @@ interface NewSessionDialogProps {
   onClose: () => void;
   workspaceId: WorkspaceId;
   onOpenSettings: () => void;
+}
+
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (err && typeof err === 'object') {
+    const maybe = err as { message?: unknown };
+    if (typeof maybe.message === 'string') return maybe.message;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return 'unknown error';
+    }
+  }
+  return String(err);
 }
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
@@ -110,7 +134,7 @@ export function NewSessionDialog({
       reset();
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(formatError(err));
     } finally {
       setBusy(false);
     }
@@ -133,33 +157,50 @@ export function NewSessionDialog({
     label: string;
     icon: ReactNode;
     ready: boolean;
+    required: boolean;
   }> = [
-    { id: 'goal', label: 'Goal', icon: <Target size={13} aria-hidden />, ready: goalReady },
+    {
+      id: 'goal',
+      label: 'Goal',
+      icon: <Target size={13} aria-hidden />,
+      ready: goalReady,
+      required: true,
+    },
     {
       id: 'branch',
       label: 'Branch',
       icon: <GitBranch size={13} aria-hidden />,
       ready: prefix.trim().length > 0,
+      required: false,
     },
     {
       id: 'budget',
       label: 'Budget',
       icon: <DollarSign size={13} aria-hidden />,
       ready: budgetReady,
+      required: false,
     },
     {
       id: 'workflow',
       label: 'Workflow',
       icon: <Layers size={13} aria-hidden />,
       ready: workflowReady,
+      required: false,
     },
     {
       id: 'provider',
       label: 'Provider',
       icon: <Zap size={13} aria-hidden />,
       ready: providerReady,
+      required: true,
     },
   ];
+
+  const missingRequired = sections.filter((s) => s.required && !s.ready);
+  const disabledReason =
+    missingRequired.length > 0
+      ? `complete: ${missingRequired.map((s) => s.label.toLowerCase()).join(', ')}`
+      : undefined;
 
   return (
     <Dialog
@@ -170,11 +211,22 @@ export function NewSessionDialog({
       size="lg"
       footer={
         <>
-          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
+          {error ? (
+            <span className="mr-auto text-xs text-danger">{error}</span>
+          ) : disabledReason ? (
+            <span className="mr-auto inline-flex items-center gap-1 text-xs text-warning">
+              <AlertTriangle size={12} aria-hidden />
+              {disabledReason}
+            </span>
+          ) : null}
           <Button variant="ghost" onClick={onClose}>
             cancel
           </Button>
-          <Button onClick={onCreate} disabled={!goalReady || busy}>
+          <Button
+            onClick={onCreate}
+            disabled={!goalReady || !providerReady || busy}
+            title={disabledReason}
+          >
             {busy ? 'creating…' : 'create session'}
           </Button>
         </>
@@ -187,6 +239,7 @@ export function NewSessionDialog({
               key={s.id}
               type="button"
               onClick={() => setActiveSection(s.id)}
+              title={s.required && !s.ready ? `${s.label.toLowerCase()} is required` : undefined}
               className={cn(
                 'relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
                 activeSection === s.id
@@ -195,8 +248,23 @@ export function NewSessionDialog({
               )}
             >
               {s.icon}
-              <span className="flex-1">{s.label}</span>
-              {s.ready ? <Check size={11} className="text-success" aria-label="filled" /> : null}
+              <span className="flex-1">
+                {s.label}
+                {s.required ? (
+                  <span aria-hidden className="ml-0.5 text-warning">
+                    *
+                  </span>
+                ) : null}
+              </span>
+              {s.ready ? (
+                <Check size={11} className="text-success" aria-label="filled" />
+              ) : s.required ? (
+                <AlertTriangle
+                  size={11}
+                  className="text-warning"
+                  aria-label={`${s.label.toLowerCase()} required`}
+                />
+              ) : null}
             </button>
           ))}
         </nav>
@@ -209,7 +277,9 @@ export function NewSessionDialog({
                 placeholder="refactor auth domain"
                 onChange={(e) => setGoal(e.target.value)}
                 autoGrow
+                minRows={4}
                 maxRows={16}
+                autoFocus
               />
             </Field>
           ) : null}
@@ -333,7 +403,11 @@ export function NewSessionDialog({
                             className="text-xs text-primary underline hover:opacity-80"
                             onClick={() => {
                               onClose();
-                              onOpenSettings();
+                              window.dispatchEvent(
+                                new CustomEvent('kayam:open-settings', {
+                                  detail: { section: 'providers' },
+                                }),
+                              );
                             }}
                           >
                             connect in settings

--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -2,7 +2,7 @@ import { cn } from '@kay-am/ui';
 import { useAppStore } from '../store';
 
 interface ProvidersChipProps {
-  onOpenSettings: () => void;
+  onOpenSettings?: () => void;
 }
 
 const PROVIDER_DOT: Record<string, string> = {
@@ -11,17 +11,23 @@ const PROVIDER_DOT: Record<string, string> = {
   codex: 'bg-[var(--color-provider-codex)]',
 };
 
-export function ProvidersChip({ onOpenSettings }: ProvidersChipProps) {
+export function ProvidersChip(_: ProvidersChipProps = {}) {
   const providers = useAppStore((s) => s.providers);
   const active = providers.filter((p) => p.connection !== 'coming-soon');
   const connected = active.filter((p) => p.connection === 'connected');
   const total = active.length;
   const allOk = total > 0 && connected.length === total;
 
+  const onClick = () => {
+    window.dispatchEvent(
+      new CustomEvent('kayam:open-settings', { detail: { section: 'providers' } }),
+    );
+  };
+
   return (
     <button
       type="button"
-      onClick={onOpenSettings}
+      onClick={onClick}
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs hover:bg-muted',
         allOk ? 'text-muted-foreground' : 'text-danger',

--- a/apps/desktop/src/components/SessionSettingsDialog.tsx
+++ b/apps/desktop/src/components/SessionSettingsDialog.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from 'react';
+import { Button, Dialog, Input, cn } from '@kay-am/ui';
+import { Archive, ArchiveRestore, Bot, DollarSign, GitBranch, Trash2 } from 'lucide-react';
+import type { TaskId } from '@kay-am/types';
+import { useAppStore } from '../store';
+
+interface SessionSettingsDialogProps {
+  taskId: TaskId;
+  open: boolean;
+  onClose: () => void;
+  archived: boolean;
+  onArchive: () => void;
+  onUnarchive: () => void;
+}
+
+type Section = 'general' | 'budget' | 'danger';
+
+interface NavItem {
+  id: Section;
+  label: string;
+  icon: React.ReactNode;
+}
+
+const NAV_ITEMS: ReadonlyArray<NavItem> = [
+  { id: 'general', label: 'General', icon: <Bot size={14} aria-hidden /> },
+  { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden /> },
+];
+
+const DANGER_NAV: NavItem = {
+  id: 'danger',
+  label: 'Delete',
+  icon: <Trash2 size={14} aria-hidden />,
+};
+
+export function SessionSettingsDialog({
+  taskId,
+  open,
+  onClose,
+  archived,
+  onArchive,
+  onUnarchive,
+}: SessionSettingsDialogProps) {
+  const session = useAppStore((s) => s.sessions.find((x) => x.id === taskId) ?? null);
+  const branch = useAppStore((s) => s.sessionBranches[taskId] ?? null);
+  const budget = useAppStore((s) => s.sessionBudgets[taskId] ?? null);
+  const sessionSummary = useAppStore((s) => s.sessionSummary);
+  const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
+  const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const renameTask = useAppStore((s) => s.renameTask);
+  const deleteTask = useAppStore((s) => s.deleteTask);
+
+  const [active, setActive] = useState<Section>('general');
+  const [goalDraft, setGoalDraft] = useState('');
+  const [capDraft, setCapDraft] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setActive('general');
+    setError(null);
+    setBusy(false);
+    setConfirmDelete(false);
+    void loadSessionBudget(taskId);
+  }, [open, taskId, loadSessionBudget]);
+
+  useEffect(() => {
+    setGoalDraft(session?.goal ?? '');
+  }, [session?.goal]);
+
+  useEffect(() => {
+    setCapDraft(budget?.softCapUsd != null ? String(budget.softCapUsd) : '');
+  }, [budget?.softCapUsd]);
+
+  if (!session) return null;
+
+  const isActiveSession = sessionSummary !== null;
+  const spent = isActiveSession ? (sessionSummary?.estimatedCostUsd ?? 0) : 0;
+
+  const onSaveGoal = async () => {
+    const trimmed = goalDraft.trim();
+    if (!trimmed) {
+      setError('goal cannot be empty');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await renameTask(taskId, trimmed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onSaveCap = async () => {
+    const parsed = parseFloat(capDraft);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      setError('cap must be a positive number');
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await setSessionBudget(taskId, parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDelete = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await deleteTask(taskId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setBusy(false);
+    }
+  };
+
+  const renderContent = () => {
+    switch (active) {
+      case 'general':
+        return (
+          <div className="flex flex-col gap-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              session
+            </div>
+            <Field
+              label="name"
+              hint="display name for the session in the sidebar. to update the actual goal text the agent reads, use the context panel on the right."
+            >
+              <div className="flex gap-2">
+                <Input
+                  value={goalDraft}
+                  onChange={(e) => setGoalDraft(e.target.value)}
+                  placeholder="refactor auth domain"
+                  className="flex-1"
+                />
+                <Button
+                  variant="secondary"
+                  onClick={() => void onSaveGoal()}
+                  disabled={busy || goalDraft.trim() === session.goal.trim()}
+                >
+                  save
+                </Button>
+              </div>
+            </Field>
+            <Field
+              label="branch"
+              hint="branch is created when the session spawns and cannot be renamed."
+            >
+              <div className="inline-flex items-center gap-2 rounded-md bg-subtle px-2.5 py-2 text-xs text-muted-foreground ring-1 ring-border-soft">
+                <GitBranch size={12} aria-hidden />
+                <code className="font-mono text-foreground">{branch ?? 'unknown'}</code>
+              </div>
+            </Field>
+            <Field label="provider" hint="set at creation time.">
+              <span className="inline-flex w-fit items-center gap-2 rounded-md bg-subtle px-2.5 py-1.5 text-xs text-muted-foreground ring-1 ring-border-soft">
+                {session.providerPreference.defaultProvider}
+              </span>
+            </Field>
+          </div>
+        );
+
+      case 'budget':
+        return (
+          <div className="flex flex-col gap-4">
+            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              soft cap
+            </div>
+            <Field
+              label="cap (usd)"
+              hint="warning fires at 80%, error at 100%. session keeps running unless you stop it."
+            >
+              <div className="flex gap-2">
+                <Input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={capDraft}
+                  onChange={(e) => setCapDraft(e.target.value)}
+                  placeholder="2.50"
+                  className="flex-1"
+                />
+                <Button variant="secondary" onClick={() => void onSaveCap()} disabled={busy}>
+                  save
+                </Button>
+              </div>
+            </Field>
+            {budget?.softCapUsd != null ? (
+              <div className="rounded-md bg-subtle p-3 text-xs text-muted-foreground ring-1 ring-border-soft">
+                <div className="flex items-center justify-between">
+                  <span>spent this session</span>
+                  <span className="font-mono text-foreground">
+                    ${spent.toFixed(2)} / ${budget.softCapUsd.toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        );
+
+      case 'danger':
+        return (
+          <div className="flex flex-col gap-5">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
+                danger zone
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                permanent actions on this session.
+              </p>
+            </div>
+
+            {/* Archive row */}
+            <div className="flex items-start justify-between gap-4 rounded-md border border-border-soft p-3">
+              <div className="flex-1">
+                <div className="text-xs font-semibold text-foreground">
+                  {archived ? 'unarchive' : 'archive'}
+                </div>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                  {archived
+                    ? 'restore this session to the active list.'
+                    : 'hide from the active list, keep history. reversible.'}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  archived ? onUnarchive() : onArchive();
+                  onClose();
+                }}
+                disabled={busy}
+              >
+                {archived ? (
+                  <>
+                    <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
+                    unarchive
+                  </>
+                ) : (
+                  <>
+                    <Archive size={13} aria-hidden className="mr-1.5" />
+                    archive
+                  </>
+                )}
+              </Button>
+            </div>
+
+            {/* Delete row */}
+            <div
+              className={cn(
+                'flex flex-col gap-3 rounded-md border p-3 transition-colors',
+                confirmDelete ? 'border-danger/40 bg-danger/5' : 'border-border-soft',
+              )}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-xs font-semibold text-foreground">delete session</div>
+                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    removes worktree, transcripts, audit logs, and the branch. cannot be undone.
+                  </p>
+                </div>
+                {!confirmDelete ? (
+                  <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
+                    <Trash2 size={13} aria-hidden className="mr-1.5" />
+                    delete
+                  </Button>
+                ) : null}
+              </div>
+
+              {confirmDelete ? (
+                <>
+                  <div className="flex items-center gap-2 text-xs text-warning">
+                    <Archive size={13} aria-hidden />
+                    <span>consider archiving instead — keeps history and is reversible.</span>
+                  </div>
+                  <div className="flex items-center justify-end gap-2">
+                    <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
+                      cancel
+                    </Button>
+                    {!archived ? (
+                      <Button
+                        variant="warning"
+                        onClick={() => {
+                          onArchive();
+                          setConfirmDelete(false);
+                          onClose();
+                        }}
+                        disabled={busy}
+                      >
+                        <Archive size={13} aria-hidden className="mr-1.5" />
+                        archive instead
+                      </Button>
+                    ) : null}
+                    <Button variant="danger" onClick={() => void onDelete()} disabled={busy}>
+                      {busy ? 'deleting…' : 'confirm delete'}
+                    </Button>
+                  </div>
+                </>
+              ) : null}
+            </div>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={session.goal}
+      description="rename, edit budget, or delete this session."
+      size="xl"
+      fixedHeightClass="h-[520px]"
+      fullScreenOnSmall
+      footer={
+        <>
+          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
+          <Button variant="ghost" onClick={onClose}>
+            close
+          </Button>
+        </>
+      }
+    >
+      <div className="flex h-full min-h-0 gap-0">
+        <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => setActive(item.id)}
+              className={`relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
+                active === item.id
+                  ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
+              }`}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </button>
+          ))}
+          <div className="mt-auto pt-3">
+            <button
+              type="button"
+              onClick={() => setActive('danger')}
+              className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
+                active === 'danger'
+                  ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
+                  : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
+              }`}
+            >
+              {DANGER_NAV.icon}
+              <span>{DANGER_NAV.label}</span>
+            </button>
+          </div>
+        </nav>
+        <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
+      </div>
+    </Dialog>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-xs font-semibold text-foreground">{label}</span>
+      {children}
+      {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -346,7 +346,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
     >
       <div className="flex h-full min-h-0 gap-0">
         <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
-          {NAV_ITEMS.map((item) => (
+          {NAV_ITEMS.filter((item) => item.id !== 'initialization').map((item) => (
             <button
               key={item.id}
               type="button"
@@ -362,6 +362,23 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
               {item.beta ? <BetaChip /> : null}
             </button>
           ))}
+          <div className="mt-auto pt-3">
+            {NAV_ITEMS.filter((item) => item.id === 'initialization').map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                onClick={() => setActiveSection(item.id)}
+                className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
+                  activeSection === item.id
+                    ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
+                    : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
+                }`}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </button>
+            ))}
+          </div>
         </nav>
         <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
       </div>

--- a/apps/desktop/src/components/TelemetryPill.tsx
+++ b/apps/desktop/src/components/TelemetryPill.tsx
@@ -2,24 +2,48 @@ import { useState } from 'react';
 import { useAppStore } from '../store';
 import { PricingDialog } from './PricingDialog';
 
-const formatCost = (usd: number): string => `$${usd.toFixed(4)}`;
+const EMPTY_SPEND: ReadonlyArray<never> = [];
+
+const formatCost = (usd: number): string => (usd === 0 ? '$0' : `$${usd.toFixed(2)}`);
+
+const PROVIDER_DOT: Record<string, string> = {
+  anthropic: 'bg-[var(--color-provider-anthropic)]',
+  cursor: 'bg-[var(--color-provider-cursor)]',
+  codex: 'bg-[var(--color-provider-codex)]',
+};
 
 export function TelemetryPill() {
   const sessionSummary = useAppStore((s) => s.sessionSummary);
   const workspaceSummary = useAppStore((s) => s.workspaceSummary);
+  const providerSpend = useAppStore((s) => s.providerSpendBreakdown ?? EMPTY_SPEND);
   const [open, setOpen] = useState(false);
 
   const sessionCost = sessionSummary?.estimatedCostUsd ?? 0;
   const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
+
+  const tooltipLines = [
+    `session: ${formatCost(sessionCost)}`,
+    `workspace: ${formatCost(workspaceCost)}`,
+    ...(providerSpend.length > 0
+      ? [
+          '',
+          'per provider:',
+          ...providerSpend.map(
+            (p) =>
+              `· ${p.provider}: ${formatCost(p.spentUsd)}${p.capUsd !== null ? ` / ${formatCost(p.capUsd)}` : ''}`,
+          ),
+        ]
+      : []),
+  ].join('\n');
 
   return (
     <>
       <button
         type="button"
         onClick={() => setOpen(true)}
-        title="open pricing breakdown"
+        title={tooltipLines}
         aria-label="open pricing breakdown"
-        className="inline-flex items-center gap-2 rounded-full bg-muted px-2.5 py-0.5 text-xs hover:bg-muted/70"
+        className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-xs hover:bg-muted/70"
       >
         <span className="font-medium">{formatCost(sessionCost)}</span>
         <span className="text-muted-foreground">session</span>
@@ -27,7 +51,19 @@ export function TelemetryPill() {
           ·
         </span>
         <span className="font-medium">{formatCost(workspaceCost)}</span>
-        <span className="text-muted-foreground">total</span>
+        {providerSpend.length > 0 ? (
+          <span aria-hidden className="ml-1 flex items-center -space-x-0.5">
+            {providerSpend
+              .filter((p) => p.spentUsd > 0)
+              .slice(0, 3)
+              .map((p) => (
+                <span
+                  key={p.provider}
+                  className={`inline-block h-2 w-2 rounded-full ring-1 ring-muted ${PROVIDER_DOT[p.provider] ?? 'bg-muted-foreground/40'}`}
+                />
+              ))}
+          </span>
+        ) : null}
       </button>
       <PricingDialog open={open} onClose={() => setOpen(false)} />
     </>

--- a/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
+++ b/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { WorkspaceId } from '@kay-am/types';
-import { Button, Dialog, Input } from '@kay-am/ui';
-import { FolderCode, GitBranch, Zap } from 'lucide-react';
+import { Button, Dialog, Input, cn } from '@kay-am/ui';
+import { FolderCode, GitBranch, Unplug, Zap } from 'lucide-react';
 import { SkillsPanel } from './SkillsPanel';
 import { PhasesPanel } from './PhasesPanel';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
@@ -14,7 +14,7 @@ interface WorkspaceSettingsDialogProps {
   onClose: () => void;
 }
 
-type Section = 'general' | 'skills' | 'phases';
+type Section = 'general' | 'skills' | 'phases' | 'danger';
 
 interface NavItem {
   id: Section;
@@ -28,6 +28,12 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'skills', label: 'Skills', icon: <Zap size={14} aria-hidden /> },
   { id: 'phases', label: 'Workflows', icon: <GitBranch size={14} aria-hidden />, beta: true },
 ];
+
+const DANGER_NAV: NavItem = {
+  id: 'danger',
+  label: 'Disconnect',
+  icon: <Unplug size={14} aria-hidden />,
+};
 
 function BetaChip() {
   return (
@@ -46,10 +52,32 @@ export function WorkspaceSettingsDialog({
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
 
+  const deleteWorkspace = useAppStore((s) => s.deleteWorkspace);
+
   const [active, setActive] = useState<Section>('general');
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setConfirmDisconnect(false);
+    setDisconnecting(false);
+  }, [open]);
+
+  const onDisconnect = async () => {
+    setDisconnecting(true);
+    setError(null);
+    try {
+      await deleteWorkspace(workspaceId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setDisconnecting(false);
+    }
+  };
 
   useEffect(() => {
     if (!open) return;
@@ -102,6 +130,65 @@ export function WorkspaceSettingsDialog({
         return <SkillsPanel workspaceId={workspaceId} />;
       case 'phases':
         return <PhasesPanel workspaceId={workspaceId} />;
+      case 'danger':
+        return (
+          <div className="flex flex-col gap-5">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
+                danger zone
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                irreversible workspace actions.
+              </p>
+            </div>
+
+            <div
+              className={cn(
+                'flex flex-col gap-3 rounded-md border p-3 transition-colors',
+                confirmDisconnect ? 'border-danger/40 bg-danger/5' : 'border-border-soft',
+              )}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  <div className="text-xs font-semibold text-foreground">disconnect workspace</div>
+                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                    removes kAY.am state (sessions, transcripts, worktrees, audit). the repository
+                    on disk is left untouched — you can re-add it later.
+                  </p>
+                </div>
+                {!confirmDisconnect ? (
+                  <Button
+                    variant="danger"
+                    onClick={() => setConfirmDisconnect(true)}
+                    disabled={disconnecting}
+                  >
+                    <Unplug size={13} aria-hidden className="mr-1.5" />
+                    disconnect
+                  </Button>
+                ) : null}
+              </div>
+
+              {confirmDisconnect ? (
+                <div className="flex items-center justify-end gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={() => setConfirmDisconnect(false)}
+                    disabled={disconnecting}
+                  >
+                    cancel
+                  </Button>
+                  <Button
+                    variant="danger"
+                    onClick={() => void onDisconnect()}
+                    disabled={disconnecting}
+                  >
+                    {disconnecting ? 'disconnecting…' : 'confirm disconnect'}
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        );
     }
   };
 
@@ -109,7 +196,7 @@ export function WorkspaceSettingsDialog({
     <Dialog
       open={open}
       onClose={onClose}
-      title={`${workspaceName} — settings`}
+      title={workspaceName}
       description="Per-workspace defaults, skills, and workflow templates."
       size="xl"
       fixedHeightClass="h-[640px]"
@@ -149,6 +236,20 @@ export function WorkspaceSettingsDialog({
               {item.beta ? <BetaChip /> : null}
             </button>
           ))}
+          <div className="mt-auto pt-3">
+            <button
+              type="button"
+              onClick={() => setActive('danger')}
+              className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
+                active === 'danger'
+                  ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
+                  : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
+              }`}
+            >
+              {DANGER_NAV.icon}
+              <span>{DANGER_NAV.label}</span>
+            </button>
+          </div>
         </nav>
         <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
       </div>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -2,15 +2,12 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
-  Archive,
-  ArchiveRestore,
   ArrowUpDown,
   ChevronDown,
   ChevronRight,
   FolderOpen,
   FolderPlus,
-  MoreHorizontal,
-  Pencil,
+  HelpCircle,
   Plus,
   Settings,
   Settings2,
@@ -18,6 +15,8 @@ import {
   X,
 } from 'lucide-react';
 import { WorkspaceSettingsDialog } from './WorkspaceSettingsDialog';
+import { SessionSettingsDialog } from './SessionSettingsDialog';
+import { GuideDialog } from './GuideDialog';
 import { ProvidersChip } from './ProvidersChip';
 import { AlertCenter } from './AlertCenter';
 import { TelemetryPill } from './TelemetryPill';
@@ -42,21 +41,14 @@ import {
   useSessions,
   useWorkspaces,
 } from '../store';
-import { DeleteWorkspaceDialog } from './DeleteWorkspaceDialog';
 import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
 import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
-import { WORKFLOW_LIBRARY } from '@kay-am/core';
+import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY } from '@kay-am/core';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
 }
-
-const PROVIDER_CHIP_COLOR: Record<ProviderId, string> = {
-  anthropic: 'bg-muted text-foreground',
-  cursor: 'bg-muted text-foreground',
-  codex: 'bg-muted text-foreground',
-};
 
 const PROVIDER_SHORT: Record<ProviderId, string> = {
   anthropic: 'cl',
@@ -91,7 +83,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const [sessionSort, setSessionSort] = useState<SessionSort>('updated');
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
-  const [workspaceToDelete, setWorkspaceToDelete] = useState<Workspace | null>(null);
+  const [guideOpen, setGuideOpen] = useState(false);
 
   const filteredWorkspaces = useMemo(
     () => [...workspaces].sort((a, b) => a.name.localeCompare(b.name)),
@@ -133,6 +125,15 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           <AlertCenter />
           <button
             type="button"
+            onClick={() => setGuideOpen(true)}
+            title="getting started — guide"
+            aria-label="open getting started guide"
+            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <HelpCircle size={13} aria-hidden />
+          </button>
+          <button
+            type="button"
             onClick={onOpenSettings}
             title="settings (⌘,)"
             aria-label="open settings"
@@ -144,8 +145,8 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       </div>
 
       <ScrollArea className="max-h-[40%] shrink-0">
-        <section className="flex flex-col px-2 pb-2 pt-1">
-          <header className="flex items-baseline justify-between gap-2 px-2 pb-1.5">
+        <section className="flex flex-col px-2">
+          <header className="flex items-baseline justify-between gap-2 pb-1.5">
             <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               Workspaces
             </span>
@@ -157,7 +158,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                 workspace={ws}
                 isActive={ws.id === currentWorkspace?.id}
                 onClick={() => void setCurrentWorkspace(ws.id)}
-                onDelete={() => setWorkspaceToDelete(ws)}
               />
             ))}
             <li>
@@ -171,11 +171,9 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
         </section>
       </ScrollArea>
 
-      <SectionDivider />
-
-      <ScrollArea className="flex-1">
-        <section className="flex flex-col px-2 pt-2">
-          <header className="flex items-center justify-between gap-2 px-2 pb-1.5">
+      <ScrollArea className="mt-8 flex-1">
+        <section className="flex flex-col px-2">
+          <header className="flex items-center justify-between gap-2 pb-1.5">
             <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
               Sessions
             </span>
@@ -214,12 +212,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           )}
         </section>
 
-        {currentSession ? (
-          <>
-            <SectionDivider />
-            <AgentsSection task={currentSession} />
-          </>
-        ) : null}
+        {currentSession ? <AgentsSection task={currentSession} /> : null}
       </ScrollArea>
 
       <div className="flex shrink-0 flex-col items-center gap-1.5 px-2 pb-2 pt-1.5">
@@ -228,6 +221,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       </div>
 
       <AddWorkspaceDialog open={addWorkspaceOpen} onClose={() => setAddWorkspaceOpen(false)} />
+      <GuideDialog open={guideOpen} onClose={() => setGuideOpen(false)} />
       {currentWorkspace ? (
         <NewSessionDialog
           open={newSessionOpen}
@@ -236,29 +230,17 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           onOpenSettings={onOpenSettings}
         />
       ) : null}
-      {workspaceToDelete ? (
-        <DeleteWorkspaceDialog
-          workspace={workspaceToDelete}
-          open={workspaceToDelete !== null}
-          onClose={() => setWorkspaceToDelete(null)}
-        />
-      ) : null}
     </div>
   );
-}
-
-function SectionDivider() {
-  return <div className="mx-3 my-5 h-px bg-border-soft" aria-hidden />;
 }
 
 interface WorkspaceRowProps {
   workspace: Workspace;
   isActive: boolean;
   onClick: () => void;
-  onDelete: () => void;
 }
 
-function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowProps) {
+function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
   const [wsSettingsOpen, setWsSettingsOpen] = useState(false);
 
   return (
@@ -294,23 +276,11 @@ function WorkspaceRow({ workspace, isActive, onClick, onDelete }: WorkspaceRowPr
             e.stopPropagation();
             setWsSettingsOpen(true);
           }}
-          className="mr-0.5 shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-muted hover:text-foreground group-hover:text-muted-foreground"
-          title="Workspace settings"
+          className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-muted hover:text-foreground group-hover:text-muted-foreground"
+          title="Workspace settings (incl. disconnect)"
           aria-label={`Settings for workspace ${workspace.name}`}
         >
           <Settings2 size={12} aria-hidden />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDelete();
-          }}
-          className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-muted hover:text-danger group-hover:text-muted-foreground"
-          title="Delete workspace"
-          aria-label={`Delete workspace ${workspace.name}`}
-        >
-          <Trash2 size={12} aria-hidden />
         </button>
       </div>
       <WorkspaceSettingsDialog
@@ -635,7 +605,6 @@ function SessionRow({
   onArchive,
   onUnarchive,
 }: SessionRowProps) {
-  const providerId = session.providerPreference.defaultProvider;
   const budget = useAppStore((s) => s.sessionBudgets[session.id as TaskId] ?? null);
   const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
   const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
@@ -650,6 +619,7 @@ function SessionRow({
   const [renameDraft, setRenameDraft] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
     if (!budgetLoaded.current) {
@@ -758,27 +728,16 @@ function SessionRow({
             <span className="line-clamp-1 flex-1">{session.goal}</span>
           )}
           <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
-            <span
-              className={cn(
-                'inline-flex items-center rounded-sm px-1 py-0.5 text-2xs font-medium leading-none',
-                PROVIDER_CHIP_COLOR[providerId],
-              )}
-              title={providerId}
-            >
-              {PROVIDER_SHORT[providerId]}
-            </span>
             <StatusBadge state={session.state} />
-            <SessionRowMenu
-              archived={archived}
-              onArchive={onArchive}
-              onUnarchive={onUnarchive}
-              onDelete={() => setConfirmDelete(true)}
-              onRename={() => {
-                setRenameDraft(session.goal);
-                setRenameError(null);
-                setRenaming(true);
-              }}
-            />
+            <button
+              type="button"
+              onClick={() => setSettingsOpen(true)}
+              className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+              title="session settings (rename · budget · archive · delete)"
+              aria-label="session settings"
+            >
+              <Settings2 size={12} aria-hidden />
+            </button>
           </div>
         </div>
 
@@ -830,6 +789,14 @@ function SessionRow({
           onCancel={() => setConfirmDelete(false)}
         />
       )}
+      <SessionSettingsDialog
+        taskId={session.id as TaskId}
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        archived={archived}
+        onArchive={onArchive}
+        onUnarchive={onUnarchive}
+      />
     </li>
   );
 }
@@ -838,110 +805,6 @@ interface DeleteConfirmDialogProps {
   sessionGoal: string;
   onConfirm: (e: React.MouseEvent) => void;
   onCancel: () => void;
-}
-
-interface SessionRowMenuProps {
-  archived: boolean;
-  onArchive: () => void;
-  onUnarchive: () => void;
-  onDelete: () => void;
-  onRename: () => void;
-}
-
-function SessionRowMenu({
-  archived,
-  onArchive,
-  onUnarchive,
-  onDelete,
-  onRename,
-}: SessionRowMenuProps) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onClick = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) setOpen(false);
-    };
-    window.addEventListener('mousedown', onClick);
-    return () => window.removeEventListener('mousedown', onClick);
-  }, [open]);
-
-  const choose = (fn: () => void) => () => {
-    setOpen(false);
-    fn();
-  };
-
-  return (
-    <div className="relative" ref={ref}>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((v) => !v);
-        }}
-        className="rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
-        title="session menu"
-        aria-label="session menu"
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        <MoreHorizontal size={12} aria-hidden />
-      </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-5 z-20 min-w-[8.5rem] overflow-hidden rounded-md bg-background py-1 text-xs shadow-lg ring-1 ring-border-soft"
-        >
-          <MenuItem onClick={choose(onRename)}>
-            <span className="flex items-center gap-2">rename</span>
-          </MenuItem>
-          {archived ? (
-            <MenuItem onClick={choose(onUnarchive)}>
-              <span className="flex items-center gap-2">
-                <ArchiveRestore size={11} aria-hidden /> unarchive
-              </span>
-            </MenuItem>
-          ) : (
-            <MenuItem onClick={choose(onArchive)}>
-              <span className="flex items-center gap-2">
-                <Archive size={11} aria-hidden /> archive
-              </span>
-            </MenuItem>
-          )}
-          <MenuItem onClick={choose(onDelete)} danger>
-            <span className="flex items-center gap-2">
-              <Trash2 size={11} aria-hidden /> delete
-            </span>
-          </MenuItem>
-        </div>
-      )}
-    </div>
-  );
-}
-
-function MenuItem({
-  children,
-  onClick,
-  danger,
-}: {
-  children: React.ReactNode;
-  onClick: () => void;
-  danger?: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      role="menuitem"
-      onClick={onClick}
-      className={cn(
-        'flex w-full items-center px-2.5 py-1.5 text-left transition-colors hover:bg-muted',
-        danger ? 'text-danger' : 'text-foreground',
-      )}
-    >
-      {children}
-    </button>
-  );
 }
 
 function DeleteConfirmDialog({ sessionGoal, onConfirm, onCancel }: DeleteConfirmDialogProps) {
@@ -1212,6 +1075,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const selectAgent = useAppStore((s) => s.selectAgent);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const renameAgent = useAppStore((s) => s.renameAgent);
+  const deleteAgent = useAppStore((s) => s.deleteAgent);
   const phaseTemplates = useAppStore(
     (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
   );
@@ -1257,9 +1121,17 @@ function AgentsSection({ task }: AgentsSectionProps) {
     }
   };
 
+  const onDeleteAgent = async (id: SessionId) => {
+    try {
+      await deleteAgent(task.id, id);
+    } catch (err) {
+      setSpawnError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
   return (
-    <section className="flex flex-col px-2 pb-3 pt-2">
-      <header className="flex items-center justify-between gap-2 px-2 pb-1.5">
+    <section className="mt-8 flex flex-col px-2 pb-3">
+      <header className="flex items-center justify-between gap-2 pb-1.5">
         <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
           Agents
         </span>
@@ -1286,6 +1158,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
               onRenameStart={() => setEditingId(run.id)}
               onRenameCommit={(name) => void onRenameCommit(run.id, name)}
               onRenameCancel={() => setEditingId(null)}
+              onDelete={() => void onDeleteAgent(run.id)}
             />
           ))}
         </ul>
@@ -1400,6 +1273,7 @@ interface AgentRowProps {
   readonly onRenameStart: () => void;
   readonly onRenameCommit: (name: string) => void;
   readonly onRenameCancel: () => void;
+  readonly onDelete: () => void;
 }
 
 function AgentRow({
@@ -1411,6 +1285,7 @@ function AgentRow({
   onRenameStart,
   onRenameCommit,
   onRenameCancel,
+  onDelete,
 }: AgentRowProps) {
   const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
   const titleParts = [
@@ -1425,14 +1300,31 @@ function AgentRow({
   ].filter((p): p is string => p !== null);
 
   const [draft, setDraft] = useState(run.name);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   useEffect(() => {
     if (isEditing) setDraft(run.name);
   }, [isEditing, run.name]);
+  useEffect(() => {
+    if (isEditing) setConfirmingDelete(false);
+  }, [isEditing]);
 
   return (
     <li
+      role={isEditing ? undefined : 'button'}
+      tabIndex={isEditing ? -1 : 0}
+      aria-pressed={isEditing ? undefined : isSelected}
+      onClick={isEditing ? undefined : onClick}
+      onDoubleClick={isEditing ? undefined : onRenameStart}
+      onKeyDown={(e) => {
+        if (isEditing) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onClick();
+        }
+      }}
       className={cn(
         'group rounded-md transition-colors',
+        isEditing ? '' : 'cursor-pointer',
         isSelected ? 'bg-muted' : 'hover:bg-muted/60',
       )}
     >
@@ -1449,7 +1341,10 @@ function AgentRow({
             autoFocus
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onDoubleClick={(e) => e.stopPropagation()}
             onKeyDown={(e) => {
+              e.stopPropagation();
               if (e.key === 'Enter') {
                 e.preventDefault();
                 onRenameCommit(draft);
@@ -1463,52 +1358,179 @@ function AgentRow({
             aria-label="rename agent"
           />
         ) : (
-          <button
-            type="button"
-            onClick={onClick}
+          <span
             className={cn(
-              'line-clamp-1 flex-1 rounded-full px-1.5 py-0.5 text-left text-2xs font-medium',
-              isSelected ? 'bg-primary text-primary-foreground' : 'bg-subtle text-foreground',
+              'line-clamp-1 flex-1 text-left text-2xs font-medium',
+              isSelected ? 'text-foreground' : 'text-muted-foreground',
             )}
-            aria-label={`role chip: ${run.name}`}
-            aria-pressed={isSelected}
           >
             {run.name}
-          </button>
+          </span>
         )}
         {!isEditing ? (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onRenameStart();
-            }}
-            className="invisible shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors group-hover:visible hover:text-foreground"
-            title="rename agent"
-            aria-label="rename agent"
-          >
-            <Pencil size={11} aria-hidden />
-          </button>
+          confirmingDelete ? (
+            <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                onClick={() => setConfirmingDelete(false)}
+                className="rounded px-1 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                title="cancel"
+              >
+                cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirmingDelete(false);
+                  onDelete();
+                }}
+                className="rounded px-1 py-0.5 text-2xs font-medium text-danger transition-colors hover:bg-danger/10"
+                title="confirm delete"
+              >
+                delete
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setConfirmingDelete(true);
+              }}
+              className="invisible shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors group-hover:visible hover:text-danger"
+              title="delete agent (double-click row to rename)"
+              aria-label="delete agent"
+            >
+              <Trash2 size={11} aria-hidden />
+            </button>
+          )
         ) : null}
         <span className="shrink-0 font-mono text-2xs text-muted-foreground">{run.ordinal + 1}</span>
       </div>
-      {telemetry ? (
-        <div className="flex items-center gap-1.5 px-2 pb-1.5 pl-[1.875rem] text-2xs text-muted-foreground/80">
-          <span>{shortModel(telemetry.model)}</span>
-          {total !== null ? (
+      <div className="flex flex-col gap-0.5 px-2 pb-1.5 pl-[1.875rem]">
+        <div className="flex items-center gap-1.5 text-2xs text-muted-foreground/80">
+          {telemetry ? (
             <>
+              <span>{shortModel(telemetry.model)}</span>
               <span aria-hidden>·</span>
-              <span title={`${total.toLocaleString()} tokens (last turn)`}>
-                {formatTokens(total)} tok
-              </span>
             </>
           ) : null}
-          <span aria-hidden>·</span>
-          <span title={`$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)`}>
-            {formatCost(telemetry.estimatedCostUsd)}
+          <span
+            title={
+              telemetry
+                ? `in: ${telemetry.inputTokens.toLocaleString()} tokens (last turn)`
+                : 'no input tokens yet'
+            }
+          >
+            ↓ {telemetry ? formatTokens(telemetry.inputTokens) : '0'}
           </span>
+          <span aria-hidden>·</span>
+          <span
+            title={
+              telemetry
+                ? `out: ${telemetry.outputTokens.toLocaleString()} tokens (last turn)`
+                : 'no output tokens yet'
+            }
+          >
+            ↑ {telemetry ? formatTokens(telemetry.outputTokens) : '0'}
+          </span>
+          <span aria-hidden>·</span>
+          <span
+            title={
+              telemetry ? `$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)` : 'no cost yet'
+            }
+          >
+            {telemetry ? formatCost(telemetry.estimatedCostUsd) : '$0'}
+          </span>
+          <span aria-hidden>·</span>
+          <AgentLifetime run={run} />
         </div>
-      ) : null}
+        <ContextWindowBar telemetry={telemetry} />
+      </div>
     </li>
+  );
+}
+
+function findContextWindow(model: string): number | null {
+  for (const cap of Object.values(PROVIDER_CAPABILITIES)) {
+    const m = cap.models.find((mm) => mm.id === model);
+    if (m) return m.contextWindow;
+  }
+  return null;
+}
+
+function formatRelativeDuration(fromIso: string, toIso?: string): string {
+  const fromMs = Date.parse(fromIso);
+  if (Number.isNaN(fromMs)) return '';
+  const toMs = toIso ? Date.parse(toIso) : Date.now();
+  if (Number.isNaN(toMs)) return '';
+  const diff = Math.max(0, Math.floor((toMs - fromMs) / 1000));
+  if (diff < 60) return `${diff}s`;
+  const m = Math.floor(diff / 60);
+  if (m < 60) return `${m}m ${diff % 60}s`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ${m % 60}m`;
+  const d = Math.floor(h / 24);
+  return `${d}d ${h % 24}h`;
+}
+
+function AgentLifetime({ run }: { run: Session }) {
+  const [now, setNow] = useState(() => Date.now());
+  const isLive = !!run.startedAt && !run.completedAt;
+  useEffect(() => {
+    if (!isLive) return;
+    const id = window.setInterval(() => setNow(Date.now()), 5000);
+    return () => window.clearInterval(id);
+  }, [isLive]);
+
+  if (!run.startedAt) {
+    return (
+      <span className="text-muted-foreground/60" title="agent spawned but has not run yet">
+        not started
+      </span>
+    );
+  }
+
+  const ageStr = formatRelativeDuration(run.startedAt, run.completedAt);
+  const dotNow = now;
+  void dotNow; // recalculation trigger
+  const tooltip = run.completedAt
+    ? `started ${run.startedAt}\ncompleted ${run.completedAt}\nworked ${ageStr}`
+    : `started ${run.startedAt}\nworking for ${ageStr}`;
+
+  return (
+    <span className="font-mono text-muted-foreground/80" title={tooltip}>
+      {run.completedAt ? `⏱ ${ageStr}` : `⏱ ${ageStr} (live)`}
+    </span>
+  );
+}
+
+function ContextWindowBar({ telemetry }: { telemetry: TelemetryRecord | null }) {
+  if (!telemetry) return null;
+  const window = findContextWindow(telemetry.model);
+  if (!window) return null;
+  const used = telemetry.inputTokens;
+  const pct = Math.min(1, used / window);
+  const tone =
+    pct >= 0.9 ? 'bg-danger' : pct >= 0.75 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
+  const windowLabel = window >= 1_000_000 ? `${window / 1_000_000}M` : `${window / 1_000}k`;
+  return (
+    <div
+      className="flex flex-col gap-0.5"
+      title={`context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)`}
+    >
+      <div className="flex items-center justify-between text-[9px] uppercase tracking-wide text-muted-foreground/60">
+        <span>ctx</span>
+        <span className="font-mono">
+          {formatTokens(used)} / {windowLabel} · {Math.round(pct * 100)}%
+        </span>
+      </div>
+      <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted/60">
+        <div
+          className={cn('h-full rounded-full transition-all', tone)}
+          style={{ width: `${pct * 100}%` }}
+        />
+      </div>
+    </div>
   );
 }

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { GitBranch, ShieldCheck } from 'lucide-react';
+import { GitBranch, MessagesSquare, ShieldCheck } from 'lucide-react';
 import { Button, Tooltip, cn } from '@kay-am/ui';
 import type { Session, SessionStatus, ProviderRunId, Task, TaskId } from '@kay-am/types';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
@@ -32,6 +32,9 @@ export function ChatHeader({
   const branch = inferBranch(worktreePath, session.id);
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
+  const events = useAppStore((s) => s.transcripts[session.id] ?? EMPTY_ARRAY);
+  const userTurns = events.filter((e) => e.kind === 'user_text').length;
+  const assistantReplies = events.filter((e) => e.kind === 'done').length;
 
   const runStatuses = Object.fromEntries(
     (parallelRunIds ?? []).map((rid) => {
@@ -53,7 +56,7 @@ export function ChatHeader({
   };
 
   return (
-    <div className="flex w-full items-center gap-3 px-4 py-2.5">
+    <div className="mx-auto flex w-full max-w-[1200px] items-center gap-3 px-8 py-2.5">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
@@ -77,6 +80,17 @@ export function ChatHeader({
             <span className="font-mono">{branch}</span>
             {copied ? <span className="text-success">copied</span> : null}
           </button>
+          <span
+            className="inline-flex items-center gap-1"
+            title={`${userTurns} message${userTurns === 1 ? '' : 's'} sent · ${assistantReplies} reply${assistantReplies === 1 ? '' : 'ies'}`}
+          >
+            <MessagesSquare size={12} aria-hidden />
+            <span className="font-mono text-foreground/85">{userTurns}</span>
+            <span>turn{userTurns === 1 ? '' : 's'}</span>
+            {assistantReplies > 0 ? (
+              <span className="text-muted-foreground/60">· {assistantReplies} replies</span>
+            ) : null}
+          </span>
           {session.workflowId ? <PhaseProgressPill taskId={session.id} /> : null}
         </div>
       </div>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -1,5 +1,12 @@
-import { useState, useRef, useCallback, useMemo, type KeyboardEvent } from 'react';
-import { Send, Square } from 'lucide-react';
+import {
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+  useEffect,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { Send, Square, X } from 'lucide-react';
 import { Textarea, cn } from '@kay-am/ui';
 import type {
   BudgetAlert,
@@ -122,7 +129,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const isSlashMode = slashQuery !== null;
 
   const isRunning = RUNNING_KINDS.has(session.state.kind);
-  const canSend = !isRunning && !providerDisconnected && value.trim().length > 0;
+  const wasRunning = useRef(isRunning);
+  interface QueuedTurn {
+    readonly content: string;
+    readonly override: TurnProviderOverride | undefined;
+  }
+  const [queued, setQueued] = useState<QueuedTurn | null>(null);
+  const canSend = !providerDisconnected && value.trim().length > 0;
   const allowOverride = session.providerPreference.allowTurnOverride;
   const defaultProvider = session.providerPreference.defaultProvider;
 
@@ -162,6 +175,12 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   };
 
   const onSelectProvider = (id: ProviderId) => {
+    if (!connectedProviderIds.includes(id)) {
+      window.dispatchEvent(
+        new CustomEvent('kayam:open-settings', { detail: { section: 'providers' } }),
+      );
+      return;
+    }
     if (!allowOverride || isRunning) return;
     setSelectedProvider(id);
     setSelectedModel(null);
@@ -172,9 +191,29 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setSelectedModel(id);
   };
 
+  const dispatchTurn = useCallback(
+    async (content: string, override: TurnProviderOverride | undefined) => {
+      try {
+        await sendTurn({
+          taskId: session.id,
+          content,
+          override,
+          onNewAlerts: (alerts) => {
+            for (const alert of alerts) {
+              showToast(toastKindForAlert(alert.kind), toastMessageForAlert(alert));
+            }
+          },
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    },
+    [sendTurn, session.id, showToast],
+  );
+
   const onSend = async () => {
     const content = value.trim();
-    if (!content || isRunning || providerDisconnected) return;
+    if (!content || providerDisconnected) return;
     setError(null);
     setValue('');
 
@@ -188,23 +227,26 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
     setSelectedProvider(null);
     setSelectedModel(null);
-    try {
-      await sendTurn({
-        taskId: session.id,
-        content,
-        override,
-        onNewAlerts: (alerts) => {
-          for (const alert of alerts) {
-            showToast(toastKindForAlert(alert.kind), toastMessageForAlert(alert));
-          }
-        },
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+
+    if (isRunning) {
+      setQueued({ content, override });
+      return;
     }
+
+    await dispatchTurn(content, override);
   };
 
-  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+  useEffect(() => {
+    const wasRun = wasRunning.current;
+    wasRunning.current = isRunning;
+    if (wasRun && !isRunning && queued) {
+      const { content, override } = queued;
+      setQueued(null);
+      void dispatchTurn(content, override);
+    }
+  }, [isRunning, queued, dispatchTurn]);
+
+  const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (
       showPopover &&
       (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'Tab')
@@ -223,11 +265,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     ? 'override disabled in session settings'
     : undefined;
 
-  const providerCandidates = useMemo<ReadonlyArray<ProviderId>>(() => {
-    const ids = new Set<ProviderId>(connectedProviderIds);
-    ids.add(defaultProvider);
-    return Array.from(ids);
-  }, [connectedProviderIds, defaultProvider]);
+  const providerCandidates: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
   const modelCandidates = useMemo<ReadonlyArray<string>>(() => {
     const ids = new Set(providerModels.map((m) => m.id));
@@ -236,8 +274,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   }, [providerModels, effectiveModel]);
 
   return (
-    <div className="px-4 py-3">
-      <div className="mx-auto flex max-w-3xl flex-col gap-2">
+    <div className="px-8 py-3">
+      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-2">
         {!isRunning && !providerDisconnected ? (
           <RoutingIndicator
             sessionPreference={session.providerPreference}
@@ -246,6 +284,46 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             onSendAnyway={value.trim().length > 0 ? () => void onSend() : undefined}
           />
         ) : null}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <PreflightPill
+              provider={effectiveProvider}
+              rules={effectiveRules}
+              taskId={session.id}
+              workspaceId={session.workspaceId}
+            />
+            {queued ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-2xs text-primary">
+                queued
+                <button
+                  type="button"
+                  onClick={() => {
+                    setQueued(null);
+                    setValue(queued.content);
+                  }}
+                  title="cancel queued message (returns to input)"
+                  aria-label="cancel queued message"
+                  className="rounded-full p-0.5 hover:bg-primary/20"
+                >
+                  <X size={10} aria-hidden />
+                </button>
+              </span>
+            ) : null}
+          </div>
+          <ModelPicker
+            providers={providerCandidates}
+            models={modelCandidates}
+            provider={effectiveProvider}
+            model={effectiveModel}
+            effort={effort}
+            connectedProviders={connectedProviderIds}
+            disabled={!allowOverride || isRunning}
+            disabledTitle={overrideDisabledTitle}
+            onSelectProvider={onSelectProvider}
+            onSelectModel={onSelectModel}
+            onSelectEffort={setEffort}
+          />
+        </div>
         <div className="relative" ref={wrapperRef}>
           {showPopover && isSlashMode ? (
             <SlashCommandPopover
@@ -260,37 +338,39 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             onChange={(e) => onValueChange(e.target.value)}
             onKeyDown={onKeyDown}
             placeholder={
-              isRunning
-                ? 'Turn running… cancel to send another'
-                : providerDisconnected
-                  ? 'Sign in to send a message.'
+              providerDisconnected
+                ? 'Sign in to send a message.'
+                : isRunning
+                  ? queued
+                    ? 'Message queued — type to replace.'
+                    : 'Turn running — type to queue next message.'
                   : 'Message Claude. Shift+enter for newline.'
             }
-            disabled={isRunning || providerDisconnected}
+            disabled={providerDisconnected}
             autoGrow
             maxRows={12}
             className="min-h-20 pr-12"
           />
-          {isRunning ? (
+          {isRunning && value.trim().length === 0 ? (
             <button
               type="button"
               onClick={() => void cancelCurrentTurn(session.id)}
               title="Cancel turn"
               aria-label="Cancel turn"
-              className="absolute bottom-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-md bg-danger text-danger-foreground transition-opacity hover:opacity-90"
+              className="absolute bottom-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-danger transition-colors hover:bg-danger/10"
             >
-              <Square size={13} aria-hidden fill="currentColor" />
+              <Square size={16} aria-hidden fill="currentColor" />
             </button>
           ) : (
             <button
               type="button"
               onClick={() => void onSend()}
               disabled={!canSend}
-              title={sendDisabledTitle ?? 'Send (enter)'}
-              aria-label="Send message"
-              className="absolute bottom-2 right-2 inline-flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-30"
+              title={sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')}
+              aria-label={isRunning ? 'Queue message' : 'Send message'}
+              className="absolute bottom-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-info transition-colors hover:bg-info/10 disabled:cursor-not-allowed disabled:text-muted-foreground/40 disabled:hover:bg-transparent"
             >
-              <Send size={13} aria-hidden className="-translate-x-px" />
+              <Send size={16} aria-hidden className="-translate-x-px" />
             </button>
           )}
         </div>
@@ -299,102 +379,268 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             {error}
           </p>
         ) : null}
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
-          <ChipRow disabledTitle={overrideDisabledTitle} disabled={!allowOverride || isRunning}>
-            {providerCandidates.map((id) => (
-              <Chip
-                key={id}
-                label={PROVIDER_LABEL[id]}
-                active={effectiveProvider === id}
-                onClick={() => onSelectProvider(id)}
-                disabled={!allowOverride || isRunning}
-              />
-            ))}
-          </ChipRow>
-          <ChipRow disabledTitle={overrideDisabledTitle} disabled={!allowOverride || isRunning}>
-            {modelCandidates.map((id) => (
-              <Chip
-                key={id}
-                label={modelLabel(id)}
-                active={effectiveModel === id}
-                onClick={() => onSelectModel(id)}
-                disabled={!allowOverride || isRunning}
-              />
-            ))}
-          </ChipRow>
-          {effectiveProvider === 'anthropic' ? (
-            <ChipRow>
-              {EFFORT_LEVELS.map((level) => (
-                <Chip
-                  key={level}
-                  label={EFFORT_LABEL[level]}
-                  active={effort === level}
-                  onClick={() => setEffort(level)}
-                />
-              ))}
-            </ChipRow>
-          ) : null}
-          <div className="ml-auto">
-            <PreflightPill
-              provider={effectiveProvider}
-              rules={effectiveRules}
-              taskId={session.id}
-              workspaceId={session.workspaceId}
-            />
-          </div>
-        </div>
       </div>
     </div>
   );
 }
 
-function ChipRow({
+const EFFORT_DOT: Record<EffortLevel, string> = {
+  low: 'bg-success',
+  medium: 'bg-info',
+  high: 'bg-warning',
+  'extra-high': 'bg-danger/80',
+  max: 'bg-danger',
+};
+
+const EFFORT_TEXT: Record<EffortLevel, string> = {
+  low: 'text-success',
+  medium: 'text-info',
+  high: 'text-warning',
+  'extra-high': 'text-danger/85',
+  max: 'text-danger',
+};
+
+type CostTier = 'cheap' | 'mid' | 'expensive';
+
+// Indicative cost weight per model (relative output-token price).
+// Sort ascending → cheapest first; tier drives chip color in the picker.
+const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
+  'claude-haiku-4-5': { weight: 5, tier: 'cheap' },
+  'cursor-small': { weight: 4, tier: 'cheap' },
+  'claude-sonnet-4-5': { weight: 15, tier: 'mid' },
+  'claude-sonnet-4-6': { weight: 15, tier: 'mid' },
+  'gpt-4o': { weight: 15, tier: 'mid' },
+  'claude-opus-4-7': { weight: 75, tier: 'expensive' },
+};
+
+function modelTier(model: string): CostTier {
+  const known = MODEL_COST[model];
+  if (known) return known.tier;
+  if (/haiku|small|mini|flash|nano/i.test(model)) return 'cheap';
+  if (/opus|max/i.test(model)) return 'expensive';
+  return 'mid';
+}
+
+function modelWeight(model: string): number {
+  return MODEL_COST[model]?.weight ?? 10;
+}
+
+const TIER_TEXT: Record<CostTier, string> = {
+  cheap: 'text-success',
+  mid: 'text-warning',
+  expensive: 'text-danger',
+};
+
+const TIER_DOT: Record<CostTier, string> = {
+  cheap: 'bg-success',
+  mid: 'bg-warning',
+  expensive: 'bg-danger',
+};
+
+const PROVIDER_TEXT: Record<ProviderId, string> = {
+  anthropic: 'text-[var(--color-provider-anthropic)]',
+  cursor: 'text-[var(--color-provider-cursor)]',
+  codex: 'text-[var(--color-provider-codex)]',
+};
+
+interface ModelPickerProps {
+  providers: ReadonlyArray<ProviderId>;
+  models: ReadonlyArray<string>;
+  provider: ProviderId;
+  model: string;
+  effort: EffortLevel;
+  connectedProviders: ReadonlyArray<ProviderId>;
+  disabled: boolean;
+  disabledTitle?: string;
+  onSelectProvider: (id: ProviderId) => void;
+  onSelectModel: (id: string) => void;
+  onSelectEffort: (level: EffortLevel) => void;
+}
+
+function ModelPicker({
+  providers,
+  models,
+  provider,
+  model,
+  effort,
+  connectedProviders,
   disabled,
   disabledTitle,
-  children,
-}: {
-  disabled?: boolean;
-  disabledTitle?: string;
-  children: React.ReactNode;
-}) {
+  onSelectProvider,
+  onSelectModel,
+  onSelectEffort,
+}: ModelPickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('mousedown', onClick);
+    window.addEventListener('keydown', onEsc);
+    return () => {
+      window.removeEventListener('mousedown', onClick);
+      window.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const showEffort = provider === 'anthropic';
+  const tier = modelTier(model);
+  const sortedModels = useMemo(
+    () => [...models].sort((a, b) => modelWeight(a) - modelWeight(b)),
+    [models],
+  );
+
   return (
-    <div
-      className={cn('flex flex-wrap items-center gap-1', disabled && 'opacity-60')}
-      title={disabled ? disabledTitle : undefined}
-    >
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => !disabled && setOpen((v) => !v)}
+        disabled={disabled}
+        title={disabled ? disabledTitle : 'choose provider · model · effort'}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-full bg-subtle px-2.5 py-0.5 text-xs transition-colors hover:bg-muted',
+          disabled && 'cursor-not-allowed opacity-60',
+        )}
+      >
+        <span className={cn('font-medium', PROVIDER_TEXT[provider])}>
+          {PROVIDER_LABEL[provider]}
+        </span>
+        <span aria-hidden className="text-muted-foreground/70">
+          ·
+        </span>
+        <span className={cn('font-medium', TIER_TEXT[tier])}>{modelLabel(model)}</span>
+        {showEffort ? (
+          <>
+            <span aria-hidden className="text-muted-foreground/70">
+              ·
+            </span>
+            <span className={EFFORT_TEXT[effort]}>{EFFORT_LABEL[effort].toLowerCase()}</span>
+          </>
+        ) : null}
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="model & effort"
+          className="absolute bottom-full right-0 z-30 mb-1.5 w-64 overflow-hidden rounded-lg bg-background py-1.5 text-xs shadow-lg ring-1 ring-border-soft"
+        >
+          <PickerSection label="provider">
+            {providers.map((id) => {
+              const isConnected = connectedProviders.includes(id);
+              return (
+                <PickerRow
+                  key={id}
+                  label={PROVIDER_LABEL[id]}
+                  active={provider === id}
+                  onClick={() => onSelectProvider(id)}
+                  labelClassName={isConnected ? PROVIDER_TEXT[id] : 'text-muted-foreground/60'}
+                  trailing={
+                    !isConnected ? (
+                      <span className="text-2xs text-warning">connect ↗</span>
+                    ) : undefined
+                  }
+                />
+              );
+            })}
+          </PickerSection>
+          <PickerDivider />
+          <PickerSection label="model · cheapest first">
+            {sortedModels.map((id) => {
+              const t = modelTier(id);
+              return (
+                <PickerRow
+                  key={id}
+                  label={modelLabel(id)}
+                  active={model === id}
+                  onClick={() => onSelectModel(id)}
+                  leadingDot={TIER_DOT[t]}
+                  labelClassName={TIER_TEXT[t]}
+                />
+              );
+            })}
+          </PickerSection>
+          {showEffort ? (
+            <>
+              <PickerDivider />
+              <PickerSection label="effort">
+                {EFFORT_LEVELS.map((level) => (
+                  <PickerRow
+                    key={level}
+                    label={EFFORT_LABEL[level]}
+                    leadingDot={EFFORT_DOT[level]}
+                    active={effort === level}
+                    onClick={() => onSelectEffort(level)}
+                    labelClassName={EFFORT_TEXT[level]}
+                  />
+                ))}
+              </PickerSection>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PickerSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <div className="px-2.5 pb-0.5 pt-1 text-2xs uppercase tracking-wide text-muted-foreground/70">
+        {label}
+      </div>
       {children}
     </div>
   );
 }
 
-function Chip({
+function PickerDivider() {
+  return <div className="my-1 h-px bg-border-soft" aria-hidden />;
+}
+
+function PickerRow({
   label,
   active,
   onClick,
-  disabled,
-  mono,
+  leadingDot,
+  labelClassName,
+  trailing,
 }: {
   label: string;
   active: boolean;
   onClick: () => void;
-  disabled?: boolean;
-  mono?: boolean;
+  leadingDot?: string;
+  labelClassName?: string;
+  trailing?: React.ReactNode;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      disabled={disabled}
       className={cn(
-        'rounded-full px-2.5 py-0.5 text-xs normal-case motion-safe:transition-colors',
-        mono && 'font-mono',
-        active
-          ? 'bg-primary text-primary-foreground'
-          : 'bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
-        disabled && 'cursor-not-allowed opacity-60',
+        'flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted',
+        active ? '' : 'opacity-80',
       )}
     >
-      {label}
+      {leadingDot ? (
+        <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', leadingDot)} />
+      ) : null}
+      <span className={cn('flex-1 truncate', labelClassName ?? 'text-muted-foreground')}>
+        {label}
+      </span>
+      {trailing}
+      {active ? (
+        <span aria-hidden className="text-2xs text-primary">
+          ✓
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -88,19 +88,41 @@ function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
   );
 }
 
+function dayKey(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return 'unknown';
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function formatDayLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const now = new Date();
+  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const diffDays = Math.round((startOf(now) - startOf(d)) / 86_400_000);
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays > 0 && diffDays < 7) {
+    return d.toLocaleDateString(undefined, { weekday: 'long' }).toLowerCase();
+  }
+  return d
+    .toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+    .toLowerCase();
+}
+
 function ThinkingIndicator() {
   return (
     <div
       role="status"
       aria-label="claude is thinking"
-      className="flex w-fit items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs text-muted-foreground"
+      className="flex w-fit items-center gap-1.5 px-1 py-0.5 text-2xs italic text-muted-foreground/80"
     >
-      <span className="flex gap-1">
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:0ms]" />
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:150ms]" />
-        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:300ms]" />
+      <span className="flex gap-0.5">
+        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:0ms]" />
+        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:150ms]" />
+        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:300ms]" />
       </span>
-      thinking…
+      thinking
     </div>
   );
 }
@@ -244,30 +266,70 @@ export function ChatView({ session }: ChatViewProps) {
     <div className="flex h-full flex-col">
       <ChatHeader session={session} worktreePath={worktreePath} />
       <div className="relative flex min-h-0 flex-1 flex-col">
-        <div ref={scrollerRef} onScroll={onScroll} className="flex-1 overflow-y-auto px-6 py-4">
+        <div
+          ref={scrollerRef}
+          onScroll={onScroll}
+          className="flex-1 overflow-y-auto px-8 py-4"
+          style={{ scrollbarGutter: 'stable' }}
+        >
           {items.length === 0 ? (
             isProviderDisconnected ? (
-              <AuthRequiredCallout
-                providerId={provider}
-                identity={providerIdentity}
-                onRefresh={() => void refreshProviders()}
-              />
+              <div className="mx-auto w-full max-w-[1200px]">
+                <AuthRequiredCallout
+                  providerId={provider}
+                  identity={providerIdentity}
+                  onRefresh={() => void refreshProviders()}
+                />
+              </div>
             ) : (
-              <p className="text-sm text-muted-foreground">no turns yet — send a message.</p>
+              <p className="mx-auto w-full max-w-[1200px] text-sm text-muted-foreground">
+                no turns yet — send a message.
+              </p>
             )
           ) : (
             <ul
-              className="mx-auto flex max-w-3xl flex-col gap-6"
+              className="mx-auto flex w-full max-w-[1200px] flex-col"
               aria-live="polite"
               aria-relevant="additions"
             >
-              {items.map((item) => (
-                <li key={item.key}>
-                  <TranscriptCard item={item} onRefreshAuth={() => void refreshProviders()} />
-                </li>
-              ))}
+              {(() => {
+                const tightKinds = new Set([
+                  'tool_call',
+                  'file_edit',
+                  'skill_invocation',
+                  'permission_request',
+                  'permission_decision',
+                  'usage',
+                ]);
+                let lastDay: string | null = null;
+                return items.map((item, idx) => {
+                  const prev = idx > 0 ? (items[idx - 1] ?? null) : null;
+                  const isTight =
+                    prev !== null && tightKinds.has(item.kind) && tightKinds.has(prev.kind);
+                  const node: React.ReactNode[] = [];
+                  if (item.kind === 'user_text') {
+                    const day = dayKey(item.at);
+                    if (day !== lastDay) {
+                      node.push(
+                        <li key={`day-${day}-${idx}`} className="my-4 flex justify-center">
+                          <span className="rounded-full bg-muted/60 px-2.5 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
+                            {formatDayLabel(item.at)}
+                          </span>
+                        </li>,
+                      );
+                      lastDay = day;
+                    }
+                  }
+                  node.push(
+                    <li key={item.key} className={isTight ? 'mt-1' : idx === 0 ? '' : 'mt-6'}>
+                      <TranscriptCard item={item} onRefreshAuth={() => void refreshProviders()} />
+                    </li>,
+                  );
+                  return node;
+                });
+              })()}
               {isThinking ? (
-                <li>
+                <li className="mt-6">
                   <ThinkingIndicator />
                 </li>
               ) : null}

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Collapsible, CopyButton, Markdown, cn } from '@kay-am/ui';
+import { Check, ChevronRight, Copy, Wrench } from 'lucide-react';
+import { CopyButton, Markdown, cn } from '@kay-am/ui';
 import type { TranscriptItem } from './transcript-items';
 import { AuthRequiredCallout } from './AuthRequiredCallout';
 import { SkillInvocationCard } from './SkillInvocationCard';
@@ -21,7 +22,7 @@ interface TranscriptCardProps {
 export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
   switch (item.kind) {
     case 'user_text':
-      return <UserText text={item.text} />;
+      return <UserText text={item.text} at={item.at} />;
     case 'assistant_text':
       return <AssistantText text={item.text} />;
     case 'tool_call':
@@ -83,48 +84,111 @@ function AssistantText({ text }: { text: string }) {
   );
 }
 
-function UserText({ text }: { text: string }) {
+function formatHHMM(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function InlineCopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(value);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = value;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.focus();
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  };
   return (
-    <div className="group relative ml-auto w-fit max-w-[85%] rounded-2xl bg-muted px-4 py-2.5">
-      <div className="absolute right-1 top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
-        <CopyButton value={text} label="message" />
-      </div>
+    <button
+      type="button"
+      onClick={(e) => void onCopy(e)}
+      title={copied ? 'copied' : 'copy message'}
+      aria-label="copy message"
+      className="rounded p-0.5 text-foreground/60 transition-colors hover:bg-primary/20 hover:text-foreground"
+    >
+      {copied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
+    </button>
+  );
+}
+
+function UserText({ text, at }: { text: string; at: string }) {
+  return (
+    <div className="ml-auto flex w-fit max-w-[85%] flex-col gap-1 rounded-2xl bg-primary/15 px-4 pb-1.5 pt-2.5 ring-1 ring-primary/20">
       <p className="whitespace-pre-wrap text-sm text-foreground">{text}</p>
+      <div className="flex items-center justify-end gap-1.5 text-2xs text-foreground/55">
+        <span className="font-mono">{formatHHMM(at)}</span>
+        <InlineCopyButton value={text} />
+      </div>
     </div>
   );
 }
 
 function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' }> }) {
   const [open, setOpen] = useState(false);
-  const tone = item.isError ? 'border-danger/40 bg-danger/5' : 'border-border bg-muted';
+  const running = !item.ended;
+  const accent = item.isError
+    ? 'text-danger'
+    : running
+      ? 'text-muted-foreground/70'
+      : 'text-muted-foreground';
+
   return (
-    <div className={cn('rounded-md border px-2 py-1.5', tone)}>
-      <Collapsible
-        open={open}
-        onOpenChange={setOpen}
-        trigger={
-          <span className="flex items-center gap-2 text-xs font-medium">
-            <span className="rounded bg-background px-1.5 py-0.5 font-mono text-2xs uppercase">
-              tool
-            </span>
-            {item.toolName}
-            {!item.ended ? (
-              <span className="text-muted-foreground">…</span>
-            ) : item.isError ? (
-              <span className="text-danger">error</span>
-            ) : null}
-          </span>
-        }
+    <div className="group">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60',
+          item.isError && 'text-danger',
+        )}
       >
-        <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-muted-foreground">
-          input: {JSON.stringify(item.input, null, 2)}
-        </pre>
-        {item.ended ? (
-          <pre className="mt-1 overflow-x-auto rounded bg-background p-2 text-xs text-muted-foreground">
-            output: {JSON.stringify(item.output, null, 2)}
-          </pre>
+        <ChevronRight
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-muted-foreground/60 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <Wrench size={11} aria-hidden className={cn('shrink-0', accent)} />
+        <span className="font-mono text-foreground/85">{item.toolName}</span>
+        {running ? (
+          <span className="flex shrink-0 gap-0.5">
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
+          </span>
+        ) : item.isError ? (
+          <span className="text-2xs uppercase tracking-wide text-danger">error</span>
         ) : null}
-      </Collapsible>
+      </button>
+      {open ? (
+        <div className="ml-[1.125rem] mt-1 flex flex-col gap-1">
+          <pre className="overflow-x-auto rounded bg-subtle p-2 text-2xs text-muted-foreground">
+            input: {JSON.stringify(item.input, null, 2)}
+          </pre>
+          {item.ended ? (
+            <pre className="overflow-x-auto rounded bg-subtle p-2 text-2xs text-muted-foreground">
+              output: {JSON.stringify(item.output, null, 2)}
+            </pre>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/transcript-items.ts
+++ b/apps/desktop/src/components/chat/transcript-items.ts
@@ -9,7 +9,7 @@ import type {
 import { decodeAuthRequiredMessage } from '../../turn';
 
 export type TranscriptItem =
-  | { kind: 'user_text'; key: string; text: string }
+  | { kind: 'user_text'; key: string; text: string; at: IsoDateTime }
   | { kind: 'assistant_text'; key: string; text: string }
   | {
       kind: 'tool_call';
@@ -102,7 +102,7 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
 
     switch (event.kind) {
       case 'user_text':
-        items.push({ kind: 'user_text', key: `user-${i}`, text: event.text });
+        items.push({ kind: 'user_text', key: `user-${i}`, text: event.text, at: event.at });
         break;
       case 'tool_call_start': {
         const key = `tool-${event.toolUseId}`;

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -37,8 +37,9 @@ const PROVIDER_LABEL: Record<ProviderId, string> = {
 
 const PROVIDER_DOCS: Record<ProviderId, string> = {
   anthropic: 'https://docs.claude.com/en/docs/claude-code/overview',
-  cursor: 'https://docs.cursor.com/cli',
-  codex: 'https://github.com/openai/codex',
+  // cursor-agent (CLI), NOT cursor IDE — point at the agent CLI install docs.
+  cursor: 'https://docs.cursor.com/en/cli/installation',
+  codex: 'https://github.com/openai/codex#installation',
 };
 
 const TRACKING_ISSUES: Partial<Record<ProviderId, string>> = {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -306,6 +306,7 @@ export interface AppActions {
   selectAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
   spawnAgent(taskId: TaskId, args: { stepId?: StepId; name?: string }): Promise<SessionId>;
   renameAgent(taskId: TaskId, agentId: SessionId, name: string): Promise<void>;
+  deleteAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
   wipeLocalDatabase(): Promise<void>;
   dismissSystemAlert(id: string): void;
   setSessionMergeConflicts(taskId: TaskId, conflicts: ReadonlyArray<FileConflict>): void;
@@ -1329,6 +1330,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
       if (nextState.kind === 'draft') {
         nextState = turnReducer(nextState, { kind: 'start', at: now() });
       }
+      if (nextState.kind === 'error') {
+        nextState = turnReducer(nextState, { kind: 'retry', at: now() });
+      }
       nextState = turnReducer(nextState, { kind: 'send', runId, at: now() });
       await updateTaskState(tauriDatabase, taskId, nextState, now());
       applySessionUpdate(set, taskId, nextState);
@@ -1447,6 +1451,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
       let nextStateP: TurnState = session.state;
       if (nextStateP.kind === 'draft') {
         nextStateP = turnReducer(nextStateP, { kind: 'start', at: now() });
+      }
+      if (nextStateP.kind === 'error') {
+        nextStateP = turnReducer(nextStateP, { kind: 'retry', at: now() });
       }
       nextStateP = turnReducer(nextStateP, {
         kind: 'send',
@@ -2191,6 +2198,24 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set((s) => ({
       sessionPhaseRuns: { ...s.sessionPhaseRuns, [taskId]: refreshed },
     }));
+  },
+
+  deleteAgent: async (taskId, agentId) => {
+    await tauriDatabase.execute('DELETE FROM sessions WHERE id = ?', [agentId]);
+    const refreshed = await invokePhaseRunList(taskId);
+    set((s) => {
+      const wasSelected = s.selectedAgentId[taskId] === agentId;
+      const nextSelected = { ...s.selectedAgentId };
+      if (wasSelected) {
+        const fallback = refreshed[0]?.id ?? null;
+        if (fallback) nextSelected[taskId] = fallback;
+        else delete nextSelected[taskId];
+      }
+      return {
+        sessionPhaseRuns: { ...s.sessionPhaseRuns, [taskId]: refreshed },
+        selectedAgentId: nextSelected,
+      };
+    });
   },
 
   wipeLocalDatabase: async () => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -103,3 +103,42 @@ dialog::backdrop {
     scroll-behavior: auto !important;
   }
 }
+
+/* Thin, non-intrusive scrollbars across the whole app. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+*::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+  background: transparent;
+}
+
+*::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 999px;
+  transition: background-color var(--motion-normal) var(--ease-default);
+}
+
+*:hover::-webkit-scrollbar-thumb,
+*:focus-within::-webkit-scrollbar-thumb {
+  background: oklch(from var(--color-border) l c h / 0.5);
+}
+
+*::-webkit-scrollbar-thumb:hover {
+  background: oklch(from var(--color-border) l c h / 0.85);
+}
+
+*::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+*:hover {
+  scrollbar-color: oklch(from var(--color-border) l c h / 0.5) transparent;
+}

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactNode } from 'react';
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
 import { cn } from '../cn';
 
 export interface AppShellProps {
@@ -9,21 +9,53 @@ export interface AppShellProps {
   className?: string;
 }
 
-const LEFT_SIDEBAR_WIDTH = '280px';
-const RIGHT_SIDEBAR_WIDTH = '340px';
-const RIGHT_RAIL_WIDTH = '40px';
+const LEFT_SIDEBAR_MIN = 220;
+const LEFT_SIDEBAR_MAX = 480;
+const LEFT_SIDEBAR_DEFAULT = 280;
+const LEFT_SIDEBAR_STORAGE_KEY = 'kayam:left-sidebar-width';
 
-function buildLayout(opts: { collapsed: boolean; hasRightSidebar: boolean }): {
+const RIGHT_SIDEBAR_MIN = 260;
+const RIGHT_SIDEBAR_MAX = 560;
+const RIGHT_SIDEBAR_DEFAULT = 340;
+const RIGHT_SIDEBAR_STORAGE_KEY = 'kayam:right-sidebar-width';
+const RIGHT_RAIL_WIDTH = 40;
+
+function readPersistedWidth(key: string, def: number, min: number, max: number): number {
+  if (typeof localStorage === 'undefined') return def;
+  const raw = localStorage.getItem(key);
+  if (!raw) return def;
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return def;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function buildLayout(opts: {
+  collapsed: boolean;
+  hasRightSidebar: boolean;
+  leftWidthPx: number;
+  rightWidthPx: number;
+}): {
   templateAreas: string;
   templateColumns: string;
 } {
-  const { collapsed, hasRightSidebar } = opts;
-  const rightColWidth = collapsed ? RIGHT_RAIL_WIDTH : RIGHT_SIDEBAR_WIDTH;
-  const templateColumns = hasRightSidebar
-    ? `${LEFT_SIDEBAR_WIDTH} minmax(0,1fr) ${rightColWidth}`
-    : `${LEFT_SIDEBAR_WIDTH} minmax(0,1fr)`;
-  const templateAreas = hasRightSidebar ? `"left main right"` : `"left main"`;
-  return { templateAreas, templateColumns };
+  const { collapsed, hasRightSidebar, leftWidthPx, rightWidthPx } = opts;
+  const leftCol = `${leftWidthPx}px`;
+  if (!hasRightSidebar) {
+    return {
+      templateAreas: `"left lhandle main"`,
+      templateColumns: `${leftCol} 6px minmax(0,1fr)`,
+    };
+  }
+  if (collapsed) {
+    return {
+      templateAreas: `"left lhandle main right"`,
+      templateColumns: `${leftCol} 6px minmax(0,1fr) ${RIGHT_RAIL_WIDTH}px`,
+    };
+  }
+  return {
+    templateAreas: `"left lhandle main rhandle right"`,
+    templateColumns: `${leftCol} 6px minmax(0,1fr) 6px ${rightWidthPx}px`,
+  };
 }
 
 export function AppShell({
@@ -34,7 +66,103 @@ export function AppShell({
   className,
 }: AppShellProps) {
   const hasRightSidebar = rightSidebar !== null && rightSidebar !== undefined;
-  const layout = buildLayout({ collapsed: rightSidebarCollapsed, hasRightSidebar });
+  const [leftWidth, setLeftWidth] = useState<number>(() =>
+    readPersistedWidth(
+      LEFT_SIDEBAR_STORAGE_KEY,
+      LEFT_SIDEBAR_DEFAULT,
+      LEFT_SIDEBAR_MIN,
+      LEFT_SIDEBAR_MAX,
+    ),
+  );
+  const [rightWidth, setRightWidth] = useState<number>(() =>
+    readPersistedWidth(
+      RIGHT_SIDEBAR_STORAGE_KEY,
+      RIGHT_SIDEBAR_DEFAULT,
+      RIGHT_SIDEBAR_MIN,
+      RIGHT_SIDEBAR_MAX,
+    ),
+  );
+  const draggingRef = useRef<'left' | 'right' | null>(null);
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(LEFT_SIDEBAR_STORAGE_KEY, String(leftWidth));
+  }, [leftWidth]);
+
+  useEffect(() => {
+    if (typeof localStorage === 'undefined') return;
+    localStorage.setItem(RIGHT_SIDEBAR_STORAGE_KEY, String(rightWidth));
+  }, [rightWidth]);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      const which = draggingRef.current;
+      if (!which) return;
+      e.preventDefault();
+      if (which === 'left') {
+        const next = Math.max(LEFT_SIDEBAR_MIN, Math.min(LEFT_SIDEBAR_MAX, e.clientX));
+        setLeftWidth(next);
+      } else {
+        // right handle: width grows as cursor moves toward the left edge
+        const next = Math.max(
+          RIGHT_SIDEBAR_MIN,
+          Math.min(RIGHT_SIDEBAR_MAX, window.innerWidth - e.clientX),
+        );
+        setRightWidth(next);
+      }
+    };
+    const onUp = () => {
+      if (!draggingRef.current) return;
+      draggingRef.current = null;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, []);
+
+  const startDrag = (which: 'left' | 'right') => (e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = which;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  };
+
+  const onLeftKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const step = e.shiftKey ? 32 : 8;
+    setLeftWidth((w) =>
+      Math.max(
+        LEFT_SIDEBAR_MIN,
+        Math.min(LEFT_SIDEBAR_MAX, w + (e.key === 'ArrowLeft' ? -step : step)),
+      ),
+    );
+  };
+
+  const onRightKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const step = e.shiftKey ? 32 : 8;
+    // ArrowLeft → grow right sidebar; ArrowRight → shrink it
+    setRightWidth((w) =>
+      Math.max(
+        RIGHT_SIDEBAR_MIN,
+        Math.min(RIGHT_SIDEBAR_MAX, w + (e.key === 'ArrowLeft' ? step : -step)),
+      ),
+    );
+  };
+
+  const layout = buildLayout({
+    collapsed: rightSidebarCollapsed,
+    hasRightSidebar,
+    leftWidthPx: leftWidth,
+    rightWidthPx: rightWidth,
+  });
   const gridStyle: CSSProperties = {
     gridTemplateAreas: layout.templateAreas,
     gridTemplateColumns: layout.templateColumns,
@@ -44,11 +172,7 @@ export function AppShell({
   return (
     <div className="h-screen w-screen bg-background">
       <div
-        className={cn(
-          'grid h-full w-full overflow-hidden text-foreground',
-          'motion-safe:[transition:grid-template-columns_var(--motion-normal,200ms)_var(--ease-emphasized,cubic-bezier(0.2,0,0,1))]',
-          className,
-        )}
+        className={cn('grid h-full w-full overflow-hidden text-foreground', className)}
         style={gridStyle}
       >
         <aside
@@ -57,15 +181,44 @@ export function AppShell({
         >
           {leftSidebar}
         </aside>
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="resize left sidebar"
+          tabIndex={0}
+          onMouseDown={startDrag('left')}
+          onKeyDown={onLeftKeyDown}
+          className="group relative cursor-col-resize select-none"
+          style={{ gridArea: 'lhandle' }}
+        >
+          <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border group-focus-visible:bg-primary" />
+        </div>
         <main
           className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background"
           style={{ gridArea: 'main' }}
         >
           {main}
         </main>
+        {hasRightSidebar && !rightSidebarCollapsed ? (
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="resize right sidebar"
+            tabIndex={0}
+            onMouseDown={startDrag('right')}
+            onKeyDown={onRightKeyDown}
+            className="group relative cursor-col-resize select-none"
+            style={{ gridArea: 'rhandle' }}
+          >
+            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border group-focus-visible:bg-primary" />
+          </div>
+        ) : null}
         {hasRightSidebar ? (
           <aside
-            className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background"
+            className={cn(
+              'flex min-h-0 min-w-0 flex-col overflow-hidden',
+              rightSidebarCollapsed ? 'bg-background' : 'm-3 rounded-xl bg-subtle shadow-sm',
+            )}
             style={{ gridArea: 'right' }}
           >
             {rightSidebar}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from 'react';
 import { cn } from '../cn';
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger';
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'warning';
 export type ButtonSize = 'sm' | 'md';
 
 export interface ButtonProps extends Omit<ComponentProps<'button'>, 'type'> {
@@ -15,6 +15,7 @@ const variantClasses: Record<ButtonVariant, string> = {
   secondary: 'bg-muted text-foreground hover:bg-muted/70 border-border',
   ghost: 'text-foreground hover:bg-muted',
   danger: 'bg-danger text-danger-foreground hover:bg-danger/90',
+  warning: 'bg-warning text-warning-foreground hover:bg-warning/90',
 };
 
 const sizeClasses: Record<ButtonSize, string> = {

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -252,14 +252,53 @@ function renderInline(input: string, keyPrefix: string): ReactNode {
   while (i < input.length) {
     const ch = input[i];
 
-    // Inline code: `...`
+    // Inline ctx marker: <<tag>> (standalone, no body — full callouts handled at block level).
+    if (ch === '<' && input[i + 1] === '<') {
+      const close = input.indexOf('>>', i + 2);
+      if (close > i) {
+        const inner = input.slice(i + 2, close);
+        if (/^[a-zA-Z][a-zA-Z0-9_-]*$/.test(inner)) {
+          flush();
+          const label = inner.replace(/^ctx-?/i, '') || inner;
+          out.push(
+            <span
+              key={nextKey()}
+              className="mx-0.5 inline-flex items-center rounded bg-primary/10 px-1.5 py-0.5 align-baseline text-[0.7em] font-semibold uppercase tracking-wide text-primary"
+            >
+              {label}
+            </span>,
+          );
+          i = close + 2;
+          continue;
+        }
+      }
+    }
+
+    // Inline code: `...` (skip if it just wraps a <<tag>> marker — render as chip instead).
     if (ch === '`') {
       const end = input.indexOf('`', i + 1);
       if (end > i) {
+        const inner = input.slice(i + 1, end);
+        const ctxMatch = inner.match(/^<<([a-zA-Z][a-zA-Z0-9_-]*)>>$/);
+        if (ctxMatch) {
+          flush();
+          const tag = ctxMatch[1]!;
+          const label = tag.replace(/^ctx-?/i, '') || tag;
+          out.push(
+            <span
+              key={nextKey()}
+              className="mx-0.5 inline-flex items-center rounded bg-primary/10 px-1.5 py-0.5 align-baseline text-[0.7em] font-semibold uppercase tracking-wide text-primary"
+            >
+              {label}
+            </span>,
+          );
+          i = end + 1;
+          continue;
+        }
         flush();
         out.push(
           <code key={nextKey()} className="rounded bg-muted px-1 py-0.5 font-mono text-[0.875em]">
-            {input.slice(i + 1, end)}
+            {inner}
           </code>,
         );
         i = end + 1;

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -4,6 +4,7 @@ import { cn } from '../cn';
 export type TextareaProps = ComponentProps<'textarea'> & {
   autoGrow?: boolean;
   maxRows?: number;
+  minRows?: number;
 };
 
 const LINE_HEIGHT_PX = 20;
@@ -13,39 +14,39 @@ export function Textarea({
   className,
   autoGrow = false,
   maxRows = 12,
+  minRows = 1,
   style,
   onChange,
+  value,
   ...rest
 }: TextareaProps) {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const minPx = minRows * LINE_HEIGHT_PX + PADDING_PX;
+  const maxPx = maxRows * LINE_HEIGHT_PX + PADDING_PX;
 
   const resize = useCallback(() => {
     const el = ref.current;
     if (!el || !autoGrow) return;
     el.style.height = 'auto';
-    const maxPx = maxRows * LINE_HEIGHT_PX + PADDING_PX;
-    const next = Math.min(el.scrollHeight, maxPx);
+    const next = Math.max(minPx, Math.min(el.scrollHeight, maxPx));
     el.style.height = `${next}px`;
     el.style.overflowY = el.scrollHeight > maxPx ? 'auto' : 'hidden';
-  }, [autoGrow, maxRows]);
+  }, [autoGrow, maxPx, minPx]);
 
   useEffect(() => {
     resize();
-  });
+  }, [resize, value]);
 
   return (
     <textarea
       ref={ref}
+      value={value}
       className={cn(
-        'w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none',
+        'w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 resize-none',
         !autoGrow && 'min-h-16',
         className,
       )}
-      style={
-        autoGrow
-          ? { ...style, height: `${LINE_HEIGHT_PX + PADDING_PX}px`, overflowY: 'hidden' }
-          : style
-      }
+      style={autoGrow ? { ...style, height: `${minPx}px`, overflowY: 'hidden' } : style}
       onChange={(e) => {
         onChange?.(e);
         resize();


### PR DESCRIPTION
## Summary
- comprehensive chat ui pass: queue messages while running, icon-only send/stop, model picker (provider · model · effort) sorted by cost with color tiers
- session/workspace settings reworked with inline danger zones (no modal-over-modal)
- whatsapp-style user bubbles with timestamp, day clusters, copy icon
- new GuideDialog + agent age + context-window bar + resizable right sidebar
- bug fixes: codex auth detection, cursor-open-folder on macOS, retry-on-error before send

## Test plan
- [ ] open the app, verify boot splash animates with phase checklist
- [ ] start a new session — required-field warnings show on Goal/Provider
- [ ] send messages, verify timestamp + copy icon in user bubble; day cluster divider when crossing midnight
- [ ] while a turn runs, type and click send → message queued (chip), fires after turn ends
- [ ] click ModelPicker, verify provider/model/effort sections; click disconnected codex → opens settings
- [ ] open session settings via gear: rename, branch read-only, provider read-only, budget editable
- [ ] danger zone: delete shows inline confirm with archive-instead suggestion
- [ ] open workspace settings → Disconnect: inline confirm, no nested modal
- [ ] resize left + right sidebars (drag handles, persisted), keyboard ←→ with focus
- [ ] click `?` icon → GuideDialog with all 7 sections renders
- [ ] header turn count updates live as messages send
- [ ] codex CLI: install + login → providers panel shows Connected (after app restart)
- [ ] open in cursor on macOS opens the workspace folder, not a single file

🤖 Generated with [Claude Code](https://claude.com/claude-code)