### PR TITLE
feat(desktop): persist turn events for crash recovery

### DIFF
--- a/apps/desktop/src/__tests__/store/unknown-payload.test.ts
+++ b/apps/desktop/src/__tests__/store/unknown-payload.test.ts
@@ -52,6 +52,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../../providers', () => ({

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -76,6 +76,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -69,6 +69,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: (...args: unknown[]) => updateSessionStateSpy(...args),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -65,6 +65,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -81,6 +81,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -74,6 +74,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -26,11 +26,14 @@ import {
   insertTask,
   insertTaskWorktree,
   insertTelemetry,
+  insertTurnEvent,
   insertWorkspace,
   deleteWorkspace,
   listContextSlotsForTask,
   listMessagesForAgent,
   listMessagesForTask,
+  listTurnEventsForAgent,
+  listTurnEventsForTask,
   listTasksForWorkspace,
   listTelemetryForTask,
   listWorkspaces,
@@ -395,26 +398,6 @@ function mergeSlots(
   const copy = existing.slice();
   copy[idx] = next;
   return copy;
-}
-
-function messageToTurnEvent(message: Message): TurnEvent | null {
-  if (message.role === 'user') {
-    return {
-      kind: 'user_text',
-      runId: 'history' as ProviderRunId,
-      text: message.content,
-      at: message.createdAt,
-    };
-  }
-  if (message.role === 'assistant') {
-    return {
-      kind: 'assistant_text',
-      runId: 'history' as ProviderRunId,
-      delta: message.content,
-      at: message.createdAt,
-    };
-  }
-  return null;
 }
 
 type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
@@ -794,10 +777,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       const fallbackAgent = sortedAgents[0] ?? null;
       const selectedAgent =
         (previouslySelected && agents.find((a) => a.id === previouslySelected)) || fallbackAgent;
-      const messages = selectedAgent
-        ? await listMessagesForAgent(tauriDatabase, selectedAgent.id)
-        : [];
-      const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
+      const [messages, events] = selectedAgent
+        ? await Promise.all([
+            listMessagesForAgent(tauriDatabase, selectedAgent.id),
+            listTurnEventsForAgent(tauriDatabase, selectedAgent.id),
+          ])
+        : [[] as ReadonlyArray<Message>, [] as ReadonlyArray<TurnEvent>];
       set((state) => ({
         sessionSummary: summary,
         sessionPhaseRuns: { ...state.sessionPhaseRuns, [id]: agents },
@@ -990,8 +975,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   loadTranscript: async (taskId) => {
-    const messages = await listMessagesForTask(tauriDatabase, taskId);
-    const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
+    const [messages, events] = await Promise.all([
+      listMessagesForTask(tauriDatabase, taskId),
+      listTurnEventsForTask(tauriDatabase, taskId),
+    ]);
     set((state) => ({
       messages: { ...state.messages, [taskId]: messages },
       transcripts: { ...state.transcripts, [taskId]: events },
@@ -999,6 +986,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   appendTurnEvent: (taskId, event) => {
+    const agentId = get().selectedAgentId[taskId] ?? null;
     set((state) => {
       const existing = state.transcripts[taskId] ?? [];
       const updatedTranscripts = { ...state.transcripts, [taskId]: [...existing, event] };
@@ -1014,6 +1002,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
       return { transcripts: updatedTranscripts };
     });
+    if (agentId) {
+      void insertTurnEvent(tauriDatabase, {
+        id: crypto.randomUUID(),
+        taskId,
+        agentId,
+        event,
+      }).catch((err) => {
+        if (import.meta.env.DEV) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(`[turn-events] insert failed for task ${taskId}: ${message}`);
+        }
+      });
+    }
   },
 
   resetTranscript: (taskId) => {
@@ -2145,8 +2146,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   selectAgent: async (taskId, agentId) => {
-    const messages = await listMessagesForAgent(tauriDatabase, agentId);
-    const events = messages.map(messageToTurnEvent).filter((e): e is TurnEvent => e !== null);
+    const [messages, events] = await Promise.all([
+      listMessagesForAgent(tauriDatabase, agentId),
+      listTurnEventsForAgent(tauriDatabase, agentId),
+    ]);
     set((state) => ({
       selectedAgentId: { ...state.selectedAgentId, [taskId]: agentId },
       transcripts: { ...state.transcripts, [taskId]: events },

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -52,6 +52,10 @@ vi.mock('@kay-am/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateTaskState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
 }));
 
 vi.mock('../providers', () => ({

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -115,7 +115,7 @@ export class Summarizer {
   async summarize(input: SummarizeInput): Promise<SummarizerResult> {
     const userMessage = buildUserPrompt(input);
 
-    const result = await this.invokeFn<SummarizeCommandResult>('summarize_session', {
+    const result = await this.invokeFn<SummarizeCommandResult>('summarize_task', {
       args: {
         providerId: this.providerId,
         model: this.model,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -20,6 +20,11 @@ export {
   deleteTask,
 } from './queries/task';
 export { insertMessage, listMessagesForAgent, listMessagesForTask } from './queries/message';
+export {
+  insertTurnEvent,
+  listTurnEventsForAgent,
+  listTurnEventsForTask,
+} from './queries/turn-event';
 export { upsertContextSlot, listContextSlotsForTask } from './queries/context-slot';
 export {
   insertProviderRun,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -13,6 +13,7 @@ import { m012SettingsOverrides } from './m012-settings-overrides';
 import { m013BudgetExtraTokens } from './m013-budget-extra-tokens';
 import { m014RenameDomain } from './m014-rename-domain';
 import { m015AgentsPerChat } from './m015-agents-per-chat';
+import { m016TurnEvents } from './m016-turn-events';
 
 export interface Migration {
   readonly version: number;
@@ -35,4 +36,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 13, sql: m013BudgetExtraTokens },
   { version: 14, sql: m014RenameDomain },
   { version: 15, sql: m015AgentsPerChat },
+  { version: 16, sql: m016TurnEvents },
 ];

--- a/packages/db/src/migrations/m016-turn-events.ts
+++ b/packages/db/src/migrations/m016-turn-events.ts
@@ -1,0 +1,37 @@
+export const m016TurnEvents = /* sql */ `
+CREATE TABLE turn_events (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  payload TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_turn_events_agent_created ON turn_events(agent_id, created_at);
+CREATE INDEX idx_turn_events_task_created ON turn_events(task_id, created_at);
+
+INSERT INTO turn_events (id, task_id, agent_id, payload, created_at)
+SELECT
+  m.id,
+  m.task_id,
+  m.agent_id,
+  CASE m.role
+    WHEN 'user' THEN json_object(
+      'kind', 'user_text',
+      'runId', 'history',
+      'text', m.content,
+      'at', strftime('%Y-%m-%dT%H:%M:%fZ', m.created_at / 1000.0, 'unixepoch')
+    )
+    WHEN 'assistant' THEN json_object(
+      'kind', 'assistant_text',
+      'runId', 'history',
+      'delta', m.content,
+      'at', strftime('%Y-%m-%dT%H:%M:%fZ', m.created_at / 1000.0, 'unixepoch')
+    )
+  END,
+  m.created_at
+FROM messages m
+WHERE m.role IN ('user', 'assistant');
+`;

--- a/packages/db/src/queries/turn-event.ts
+++ b/packages/db/src/queries/turn-event.ts
@@ -1,0 +1,64 @@
+import type { SessionId, TaskId, TurnEvent } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface TurnEventRow {
+  id: string;
+  task_id: string;
+  agent_id: string;
+  payload: string;
+  created_at: number;
+}
+
+function rowToEvent(row: TurnEventRow): TurnEvent | null {
+  try {
+    return JSON.parse(row.payload) as TurnEvent;
+  } catch {
+    return null;
+  }
+}
+
+function eventTimestamp(event: TurnEvent): number {
+  if ('at' in event && typeof event.at === 'string') {
+    const parsed = Date.parse(event.at);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return Date.now();
+}
+
+export async function insertTurnEvent(
+  db: Database,
+  args: {
+    readonly id: string;
+    readonly taskId: TaskId;
+    readonly agentId: SessionId;
+    readonly event: TurnEvent;
+  },
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO turn_events (id, task_id, agent_id, payload, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [args.id, args.taskId, args.agentId, JSON.stringify(args.event), eventTimestamp(args.event)],
+  );
+}
+
+export async function listTurnEventsForAgent(
+  db: Database,
+  agentId: SessionId,
+): Promise<ReadonlyArray<TurnEvent>> {
+  const rows = await db.select<TurnEventRow>(
+    'SELECT * FROM turn_events WHERE agent_id = ? ORDER BY created_at ASC, rowid ASC',
+    [agentId],
+  );
+  return rows.map(rowToEvent).filter((e): e is TurnEvent => e !== null);
+}
+
+export async function listTurnEventsForTask(
+  db: Database,
+  taskId: TaskId,
+): Promise<ReadonlyArray<TurnEvent>> {
+  const rows = await db.select<TurnEventRow>(
+    'SELECT * FROM turn_events WHERE task_id = ? ORDER BY created_at ASC, rowid ASC',
+    [taskId],
+  );
+  return rows.map(rowToEvent).filter((e): e is TurnEvent => e !== null);
+}


### PR DESCRIPTION
## Summary

- **fix(core)**: summarizer was invoking the wrong Tauri command (`summarize_session`) after the cascade rename in 8520ea3. Every turn ended with the summarizer in `error` state — fixed to `summarize_task` to match the Rust handler.
- **feat(desktop)**: every `TurnEvent` (assistant text deltas, tool calls, file edits, skill invocations, permission events, …) is now persisted to a new `turn_events` table. On reload, the transcript is replayed from the event log instead of being reconstructed from `messages`, so tool history survives restarts and partial assistant output survives mid-stream crashes.

## Why

Reported symptom: "after the app crash on context update, all CLI output is lost; tool calls disappear too." Root causes:

1. `messages` table was the only persistence; it was written only at end-of-turn, so any crash mid-stream lost the in-flight text.
2. Tool/file/skill/permission events were never persisted at all — they lived in a Zustand `transcripts` map that died with the process.
3. `messageToTurnEvent` could only round-trip `user_text` and `assistant_text`, so even on graceful exit the tool history was gone after reload.

## Schema (m016)

```sql
CREATE TABLE turn_events (
  id TEXT PRIMARY KEY,
  task_id TEXT NOT NULL,
  agent_id TEXT NOT NULL,
  payload TEXT NOT NULL,        -- JSON.stringify(TurnEvent)
  created_at INTEGER NOT NULL,
  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
);
```

Backfill in the same migration copies prior `messages` rows in as `user_text` / `assistant_text` events so existing chat history stays visible after upgrade. Ordering uses `(created_at, rowid)` to break ms ties without an explicit seq column.

## Behavior changes

- `appendTurnEvent` does fire-and-forget `insertTurnEvent` after updating the in-memory transcript. Failures log in DEV and don't bubble.
- `setCurrentSession` / `selectAgent` / `loadTranscript` now read from `listTurnEventsFor*` instead of mapping over messages.
- `messages` table is still written at end-of-turn (kept as-is for forward compat / future prompt-context use); it's just no longer read for the UI transcript.
- Removed dead `messageToTurnEvent` helper.

## Caveats

- **Parallel mode attribution**: `appendTurnEvent` resolves `agent_id` from `selectedAgentId[taskId]`. Single-agent flows are correct; concurrent parallel runs may misattribute events to whichever agent is currently selected. Acceptable for v1 — can be refined later via a `runId → agentId` map maintained when each run starts.
- **Row volume**: ~1 row per `assistant_text` delta. Order of ~100 rows per typical 1k-token turn. The existing `reduceTranscript` reducer concatenates adjacent deltas on read, so this is transparent to the UI.

## Test plan

- [x] `pnpm turbo run typecheck` — 9/9 green
- [x] `pnpm turbo run test` — desktop 190/190, db 14/14 (migration runner exercises m016 on a fresh DB)
- [ ] Manual: send a turn that triggers tool calls → quit the app → reopen → verify the tool history is still there.
- [ ] Manual: send a turn → kill the process mid-stream → reopen → verify partial assistant output is recoverable.
- [ ] Manual: open an existing session created before this PR → verify backfill from `messages` reproduces the prior transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)