### PR TITLE
feat(desktop): batch ux + provider fixes

### DIFF
--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -93,6 +93,80 @@ pub struct TurnEventEnvelope {
 
 pub const EVENT_NAME: &str = "turn_event";
 
+/// Build per-binary CLI args. The Tauri side spawns the binary directly, so
+/// flag shapes have to match each CLI: claude code uses `-p / --output-format
+/// stream-json / --permission-mode / --allowedTools / --disallowedTools`,
+/// cursor-agent uses `-p / --output-format stream-json / --workspace /
+/// --model / --force`, and codex uses `exec --json --model --cwd -- prompt`.
+/// Falls back to claude flags for unknown binaries to preserve previous
+/// behaviour.
+fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String> {
+    let bin = std::path::Path::new(binary)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(binary);
+
+    match bin {
+        "cursor-agent" => {
+            let mut v = vec![
+                "-p".to_string(),
+                args.prompt.to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--workspace".to_string(),
+                args.working_dir.to_string(),
+                "--model".to_string(),
+                args.model.to_string(),
+                // matches the claude --dangerously-skip-permissions: cursor-agent
+                // runs tools without interactive confirmation.
+                "--force".to_string(),
+            ];
+            // permission rules + permission_mode aren't supported by cursor-agent
+            // today; intentionally dropped here to avoid unknown-flag errors.
+            let _ = (args.permission_mode, args.allowed_tools, args.disallowed_tools);
+            v.shrink_to_fit();
+            v
+        }
+        "codex" => {
+            // codex exec takes a single prompt argument after `--`. permission
+            // rules aren't supported by the codex CLI yet.
+            vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--model".to_string(),
+                args.model.to_string(),
+                "--cwd".to_string(),
+                args.working_dir.to_string(),
+                "--".to_string(),
+                args.prompt.to_string(),
+            ]
+        }
+        _ => {
+            // claude (default).
+            let mut v = vec![
+                "-p".to_string(),
+                args.prompt.to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--verbose".to_string(),
+                "--model".to_string(),
+                args.model.to_string(),
+                "--permission-mode".to_string(),
+                args.permission_mode.to_string(),
+            ];
+            if !args.allowed_tools.is_empty() {
+                v.push("--allowedTools".to_string());
+                v.push(args.allowed_tools.join(","));
+            }
+            if !args.disallowed_tools.is_empty() {
+                v.push("--disallowedTools".to_string());
+                v.push(args.disallowed_tools.join(","));
+            }
+            v
+        }
+    }
+}
+
 /// Per-run spawn parameters used by both `turn_spawn` and `parallel_session_spawn`.
 pub struct SpawnOneArgs<'a> {
     pub run_id: &'a str,
@@ -136,26 +210,11 @@ pub(crate) fn spawn_one(
         // claude's own ~/.claude credentials.
         .env_remove("CLAUDECODE")
         .env_remove("CLAUDE_CODE_ENTRYPOINT")
-        .env_remove("CLAUDE_AGENT_SDK_VERSION")
-        .arg("-p")
-        .arg(args.prompt)
-        .arg("--output-format")
-        .arg("stream-json")
-        .arg("--verbose")
-        .arg("--model")
-        .arg(args.model)
-        .arg("--permission-mode")
-        .arg(args.permission_mode);
+        .env_remove("CLAUDE_AGENT_SDK_VERSION");
 
-    if !args.allowed_tools.is_empty() {
-        command
-            .arg("--allowedTools")
-            .arg(args.allowed_tools.join(","));
-    }
-    if !args.disallowed_tools.is_empty() {
-        command
-            .arg("--disallowedTools")
-            .arg(args.disallowed_tools.join(","));
+    let cli_args = build_provider_cli_args(args.binary, &args);
+    for a in &cli_args {
+        command.arg(a);
     }
 
     let mut child = command

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -109,20 +109,17 @@ pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeErro
 
     let slug = sanitize_slug(&args.slug);
     let branch_name = format!("{}/{}", args.branch_prefix, slug);
-    let repo_name = repo_path
-        .file_name()
-        .map(|s| s.to_string_lossy().to_string())
-        .unwrap_or_else(|| "repo".to_string());
+    // Default location: <repo>/.kay-am/worktrees/<prefix>-<slug>. Keeps every
+    // session-scoped checkout inside the workspace folder so the user only has
+    // one project root to track. The .kay-am dir should be in the repo's
+    // .gitignore (we add it on first creation, see ensure_gitignore_entry).
     let parent = args
         .parent_dir
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            repo_path
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|| PathBuf::from("."))
-        });
-    let worktree_path = parent.join(format!("{repo_name}-{}-{slug}", args.branch_prefix));
+        .unwrap_or_else(|| repo_path.join(".kay-am").join("worktrees"));
+    let worktree_path = parent.join(format!("{}-{slug}", args.branch_prefix));
+
+    ensure_gitignore_entry(&repo_path, ".kay-am/")?;
 
     if let Some(existing) = find_existing(&repo_path, &worktree_path)? {
         return Ok(CreatedWorktree {
@@ -191,6 +188,32 @@ fn find_existing(
     Ok(entries
         .into_iter()
         .find(|w| Path::new(&w.path) == worktree_path))
+}
+
+/// Append a line to the repo's .gitignore if it isn't already present, so the
+/// worktree directory created by kay-am doesn't leak into git status. No-ops
+/// when the file is already gitignoring the entry, when no .gitignore exists
+/// and writing fails, or when the entry is already there.
+fn ensure_gitignore_entry(repo_path: &Path, entry: &str) -> Result<(), WorktreeError> {
+    let gitignore = repo_path.join(".gitignore");
+    let existing = std::fs::read_to_string(&gitignore).unwrap_or_default();
+    let has_entry = existing
+        .lines()
+        .any(|line| line.trim() == entry || line.trim() == entry.trim_end_matches('/'));
+    if has_entry {
+        return Ok(());
+    }
+    let needs_newline = !existing.is_empty() && !existing.ends_with('\n');
+    let mut next = existing;
+    if needs_newline {
+        next.push('\n');
+    }
+    next.push_str(entry);
+    next.push('\n');
+    // Best-effort: silently swallow write errors so a read-only repo doesn't
+    // block worktree creation.
+    let _ = std::fs::write(&gitignore, next);
+    Ok(())
 }
 
 fn ensure_clean(repo_path: &Path) -> Result<(), WorktreeError> {

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -18,6 +18,7 @@ vi.mock('../store', () => ({
       cancelCurrentTurn: cancelCurrentTurnMock,
       providers: [{ id: 'anthropic', connection: 'connected' }],
       skills: {},
+      providerSpendBreakdown: [],
     }),
   EMPTY_ARRAY: [] as never[],
 }));

--- a/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
+++ b/apps/desktop/src/__tests__/__snapshots__/context-panel-rail.test.tsx.snap
@@ -2,39 +2,42 @@
 
 exports[`snapshot — ContextPanel variants > collapsed: renders rail button, not slot content 1`] = `
 <div
-  aria-label="expand context panel"
-  class="flex h-full w-full cursor-pointer flex-col items-center justify-start pt-2 border-l border-border bg-background hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-  role="button"
-  tabindex="0"
-  title="expand context panel"
+  class="flex h-full w-full justify-end pr-4 pt-4"
 >
-  <svg
-    aria-hidden="true"
-    class="lucide lucide-panel-right-open text-muted-foreground"
-    fill="none"
-    height="13"
-    stroke="currentColor"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-    stroke-width="2"
-    viewBox="0 0 24 24"
-    width="13"
-    xmlns="http://www.w3.org/2000/svg"
+  <button
+    aria-label="expand context panel"
+    class="h-fit rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+    title="expand context panel"
+    type="button"
   >
-    <rect
-      height="18"
-      rx="2"
-      width="18"
-      x="3"
-      y="3"
-    />
-    <path
-      d="M15 3v18"
-    />
-    <path
-      d="m10 15-3-3 3-3"
-    />
-  </svg>
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-panel-right-open"
+      fill="none"
+      height="13"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="13"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        height="18"
+        rx="2"
+        width="18"
+        x="3"
+        y="3"
+      />
+      <path
+        d="M15 3v18"
+      />
+      <path
+        d="m10 15-3-3 3-3"
+      />
+    </svg>
+  </button>
 </div>
 `;
 
@@ -98,11 +101,45 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
       <li
         class="flex flex-col gap-1.5"
       >
-        <label
-          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="flex items-center justify-between"
         >
-          goal
-        </label>
+          <label
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            goal
+          </label>
+          <button
+            aria-label="view history for goal"
+            class="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="view history"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-history"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+              />
+              <path
+                d="M3 3v5h5"
+              />
+              <path
+                d="M12 7v5l4 2"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -113,15 +150,93 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
             empty — click to edit
           </span>
         </button>
+        <dialog
+          aria-labelledby="_r_0_-title"
+          class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+        >
+          <div
+            class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+          >
+            <header
+              class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+            >
+              <div
+                class="flex min-w-0 flex-col gap-1"
+              >
+                <h2
+                  class="text-sm font-semibold tracking-tight text-foreground"
+                  id="_r_0_-title"
+                >
+                  history — goal
+                </h2>
+              </div>
+              <button
+                aria-label="close"
+                class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="text-base leading-none"
+                >
+                  ×
+                </span>
+              </button>
+            </header>
+            <div
+              class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+            >
+              <p
+                class="text-xs text-muted-foreground italic"
+              >
+                no history yet
+              </p>
+            </div>
+          </div>
+        </dialog>
       </li>
       <li
         class="flex flex-col gap-1.5"
       >
-        <label
-          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="flex items-center justify-between"
         >
-          files touched
-        </label>
+          <label
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            files touched
+          </label>
+          <button
+            aria-label="view history for files touched"
+            class="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="view history"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-history"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+              />
+              <path
+                d="M3 3v5h5"
+              />
+              <path
+                d="M12 7v5l4 2"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -132,15 +247,93 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
             empty — click to edit
           </span>
         </button>
+        <dialog
+          aria-labelledby="_r_1_-title"
+          class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+        >
+          <div
+            class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+          >
+            <header
+              class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+            >
+              <div
+                class="flex min-w-0 flex-col gap-1"
+              >
+                <h2
+                  class="text-sm font-semibold tracking-tight text-foreground"
+                  id="_r_1_-title"
+                >
+                  history — files touched
+                </h2>
+              </div>
+              <button
+                aria-label="close"
+                class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="text-base leading-none"
+                >
+                  ×
+                </span>
+              </button>
+            </header>
+            <div
+              class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+            >
+              <p
+                class="text-xs text-muted-foreground italic"
+              >
+                no history yet
+              </p>
+            </div>
+          </div>
+        </dialog>
       </li>
       <li
         class="flex flex-col gap-1.5"
       >
-        <label
-          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="flex items-center justify-between"
         >
-          decisions
-        </label>
+          <label
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            decisions
+          </label>
+          <button
+            aria-label="view history for decisions"
+            class="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="view history"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-history"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+              />
+              <path
+                d="M3 3v5h5"
+              />
+              <path
+                d="M12 7v5l4 2"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -151,15 +344,93 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
             empty — click to edit
           </span>
         </button>
+        <dialog
+          aria-labelledby="_r_2_-title"
+          class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+        >
+          <div
+            class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+          >
+            <header
+              class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+            >
+              <div
+                class="flex min-w-0 flex-col gap-1"
+              >
+                <h2
+                  class="text-sm font-semibold tracking-tight text-foreground"
+                  id="_r_2_-title"
+                >
+                  history — decisions
+                </h2>
+              </div>
+              <button
+                aria-label="close"
+                class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="text-base leading-none"
+                >
+                  ×
+                </span>
+              </button>
+            </header>
+            <div
+              class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+            >
+              <p
+                class="text-xs text-muted-foreground italic"
+              >
+                no history yet
+              </p>
+            </div>
+          </div>
+        </dialog>
       </li>
       <li
         class="flex flex-col gap-1.5"
       >
-        <label
-          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="flex items-center justify-between"
         >
-          open questions
-        </label>
+          <label
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            open questions
+          </label>
+          <button
+            aria-label="view history for open questions"
+            class="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="view history"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-history"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+              />
+              <path
+                d="M3 3v5h5"
+              />
+              <path
+                d="M12 7v5l4 2"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -170,15 +441,93 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
             empty — click to edit
           </span>
         </button>
+        <dialog
+          aria-labelledby="_r_3_-title"
+          class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+        >
+          <div
+            class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+          >
+            <header
+              class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+            >
+              <div
+                class="flex min-w-0 flex-col gap-1"
+              >
+                <h2
+                  class="text-sm font-semibold tracking-tight text-foreground"
+                  id="_r_3_-title"
+                >
+                  history — open questions
+                </h2>
+              </div>
+              <button
+                aria-label="close"
+                class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="text-base leading-none"
+                >
+                  ×
+                </span>
+              </button>
+            </header>
+            <div
+              class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+            >
+              <p
+                class="text-xs text-muted-foreground italic"
+              >
+                no history yet
+              </p>
+            </div>
+          </div>
+        </dialog>
       </li>
       <li
         class="flex flex-col gap-1.5"
       >
-        <label
-          class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+        <div
+          class="flex items-center justify-between"
         >
-          last output summary
-        </label>
+          <label
+            class="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            last output summary
+          </label>
+          <button
+            aria-label="view history for last output summary"
+            class="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+            title="view history"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-history"
+              fill="none"
+              height="11"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="11"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+              />
+              <path
+                d="M3 3v5h5"
+              />
+              <path
+                d="M12 7v5l4 2"
+              />
+            </svg>
+          </button>
+        </div>
         <button
           class="whitespace-pre-wrap rounded-md border border-transparent bg-subtle px-2.5 py-2 text-left text-xs leading-relaxed hover:border-border-soft hover:bg-muted/40"
           type="button"
@@ -189,6 +538,50 @@ exports[`snapshot — ContextPanel variants > expanded: renders slot content, no
             empty — click to edit
           </span>
         </button>
+        <dialog
+          aria-labelledby="_r_4_-title"
+          class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl"
+        >
+          <div
+            class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+          >
+            <header
+              class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+            >
+              <div
+                class="flex min-w-0 flex-col gap-1"
+              >
+                <h2
+                  class="text-sm font-semibold tracking-tight text-foreground"
+                  id="_r_4_-title"
+                >
+                  history — last output summary
+                </h2>
+              </div>
+              <button
+                aria-label="close"
+                class="-mr-1 -mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted hover:text-foreground"
+                type="button"
+              >
+                <span
+                  aria-hidden="true"
+                  class="text-base leading-none"
+                >
+                  ×
+                </span>
+              </button>
+            </header>
+            <div
+              class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+            >
+              <p
+                class="text-xs text-muted-foreground italic"
+              >
+                no history yet
+              </p>
+            </div>
+          </div>
+        </dialog>
       </li>
     </ul>
   </div>

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -10,16 +10,21 @@ vi.mock('@tauri-apps/plugin-sql', () => ({
 }));
 
 vi.mock('../store', () => ({
+  EMPTY_ARRAY: [],
   useAppStore: vi.fn((selector: (s: unknown) => unknown) => {
     const state = {
       upsertSessionSlot: vi.fn(),
       toggleSessionSlot: vi.fn(),
       summarizerStatus: {},
+      sessionTelemetry: {},
     };
     return selector(state);
   }),
   useSessionSlots: vi.fn().mockReturnValue([]),
-  useSummarizerStatus: vi.fn().mockReturnValue({ status: 'idle', lastUpdate: null, error: null }),
+  useSummarizerStatus: vi
+    .fn()
+    .mockReturnValue({ status: 'idle', lastUpdate: null, error: null, lastUsage: null }),
+  useSlotHistory: vi.fn().mockReturnValue([]),
 }));
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -81,10 +86,11 @@ describe('ContextPanel rail — a11y attributes', () => {
     expect(rail.getAttribute('aria-label')).toBe('expand context panel');
   });
 
-  it('is focusable (tabIndex=0)', () => {
+  it('is focusable (native button)', () => {
     render(<ContextPanel session={makeSession()} collapsed={true} onExpand={vi.fn()} />);
     const rail = screen.getByRole('button', { name: /expand context panel/i });
-    expect(rail.getAttribute('tabindex')).toBe('0');
+    rail.focus();
+    expect(document.activeElement).toBe(rail);
   });
 });
 

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -1,9 +1,21 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useMemo } from 'react';
 import { PanelRightClose, PanelRightOpen, History, RotateCcw } from 'lucide-react';
 import { ScrollArea, Textarea, Dialog, cn } from '@kay-am/ui';
 import { SLOT_KEYS, SLOT_LABELS, type SlotKey } from '@kay-am/core';
-import type { ContextSlot, ContextSlotHistoryEntry, Task, TaskId } from '@kay-am/types';
-import { useAppStore, useSessionSlots, useSlotHistory, useSummarizerStatus } from '../store';
+import type {
+  ContextSlot,
+  ContextSlotHistoryEntry,
+  Task,
+  TaskId,
+  TelemetryRecord,
+} from '@kay-am/types';
+import {
+  EMPTY_ARRAY,
+  useAppStore,
+  useSessionSlots,
+  useSlotHistory,
+  useSummarizerStatus,
+} from '../store';
 
 interface ContextPanelProps {
   session: Task;
@@ -23,31 +35,48 @@ export function ContextPanel({
   const slots = useSessionSlots(session.id);
   const summarizer = useSummarizerStatus(session.id);
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
+  const sessionTelemetry = useAppStore(
+    (s) => s.sessionTelemetry[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
+  );
+
+  const summarizerTotals = useMemo(() => {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let estimatedCostUsd = 0;
+    let count = 0;
+    for (const rec of sessionTelemetry) {
+      if (rec.kind !== 'summarizer') continue;
+      inputTokens += rec.inputTokens;
+      outputTokens += rec.outputTokens;
+      estimatedCostUsd += rec.estimatedCostUsd;
+      count += 1;
+    }
+    return { inputTokens, outputTokens, estimatedCostUsd, count };
+  }, [sessionTelemetry]);
 
   const slotsByKey = new Map<string, ContextSlot>(slots.map((s) => [s.key, s]));
 
   if (collapsed) {
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        aria-label="expand context panel"
-        onClick={onExpand}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            onExpand?.();
-          }
-        }}
-        className={cn(
-          'flex h-full w-full cursor-pointer flex-col items-center justify-start pt-2',
-          'border-l border-border bg-background',
-          'hover:bg-muted/50',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-        )}
-        title="expand context panel"
-      >
-        <PanelRightOpen size={13} className="text-muted-foreground" aria-hidden />
+      <div className="flex h-full w-full justify-end pr-4 pt-4">
+        <button
+          type="button"
+          onClick={onExpand}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onExpand?.();
+            }
+          }}
+          title="expand context panel"
+          aria-label="expand context panel"
+          className={cn(
+            'h-fit rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+          )}
+        >
+          <PanelRightOpen size={13} aria-hidden />
+        </button>
       </div>
     );
   }
@@ -64,6 +93,7 @@ export function ContextPanel({
               status={summarizer.status}
               lastUpdate={summarizer.lastUpdate}
               error={summarizer.error}
+              totals={summarizerTotals}
             />
             {onCollapse ? (
               <button
@@ -209,7 +239,7 @@ interface SlotHistoryDialogProps {
 
 function SlotHistoryDialog({ label, open, entries, onRestore, onClose }: SlotHistoryDialogProps) {
   return (
-    <Dialog open={open} onClose={onClose} title={`history — ${label}`} size="sm">
+    <Dialog open={open} onClose={onClose} title={`history — ${label}`} size="lg">
       {entries.length === 0 ? (
         <p className="text-xs text-muted-foreground italic">no history yet</p>
       ) : (
@@ -267,12 +297,30 @@ function SummarizerBadge({
   status,
   lastUpdate,
   error,
+  totals,
 }: {
   status: SummarizerStatusKind;
   lastUpdate: string | null;
   error: string | null;
+  totals: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly estimatedCostUsd: number;
+    readonly count: number;
+  };
 }) {
-  if (status === 'idle') return null;
+  if (status === 'idle') {
+    if (totals.count === 0 || totals.estimatedCostUsd <= 0) return null;
+    const tooltip = `summary total · ${totals.count} run${totals.count === 1 ? '' : 's'} · ${totals.inputTokens} in / ${totals.outputTokens} out · $${totals.estimatedCostUsd.toFixed(4)}${lastUpdate ? ` · last ${lastUpdate}` : ''}`;
+    return (
+      <span
+        title={tooltip}
+        className="rounded-full bg-subtle px-2 py-0.5 text-2xs text-muted-foreground"
+      >
+        Σ ${totals.estimatedCostUsd.toFixed(4)}
+      </span>
+    );
+  }
   const styles: Record<Exclude<SummarizerStatusKind, 'idle'>, string> = {
     running: 'bg-info/10 text-info',
     error: 'bg-danger/10 text-danger',
@@ -286,12 +334,22 @@ function SummarizerBadge({
       ? `last error: ${error}`
       : lastUpdate
         ? `last update: ${lastUpdate}`
-        : 'summarizer running';
+        : 'summarizer running — keep typing, the app is not blocked';
   return (
     <span
       title={tooltip}
-      className={cn('rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide', styles[status])}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide',
+        styles[status],
+      )}
     >
+      {status === 'running' ? (
+        <span className="flex gap-0.5" aria-hidden>
+          <span className="h-1 w-1 animate-pulse rounded-full bg-info [animation-delay:0ms]" />
+          <span className="h-1 w-1 animate-pulse rounded-full bg-info [animation-delay:150ms]" />
+          <span className="h-1 w-1 animate-pulse rounded-full bg-info [animation-delay:300ms]" />
+        </span>
+      ) : null}
       {labels[status]}
     </span>
   );

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1071,6 +1071,8 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const telemetry = useAppStore(
     (s) => s.sessionTelemetry[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
   );
+  const messages = useAppStore((s) => s.messages[task.id] ?? EMPTY_ARRAY);
+  const agentRunHistory = useAppStore((s) => s.agentRunHistory);
   const selectedAgentId = useAppStore((s) => s.selectedAgentId[task.id] ?? null);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
@@ -1097,6 +1099,52 @@ function AgentsSection({ task }: AgentsSectionProps) {
     }
     return map;
   }, [telemetry]);
+
+  const turnsByAgentId = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const m of messages) {
+      if (m.role !== 'user') continue;
+      map.set(m.agentId, (map.get(m.agentId) ?? 0) + 1);
+    }
+    return map;
+  }, [messages]);
+
+  /**
+   * Cumulative telemetry per agent across every providerRun we recorded for
+   * that agent — needed so the cost/tokens row in the sidebar doesn't drop
+   * earlier providers' usage when the user swaps provider mid-session.
+   */
+  const aggregatesByAgentId = useMemo(() => {
+    const map = new Map<
+      string,
+      { inputTokens: number; outputTokens: number; estimatedCostUsd: number; turns: number }
+    >();
+    const telemetryByRun = new Map<string, TelemetryRecord>();
+    for (const rec of telemetry) {
+      if (rec.kind !== 'turn') continue;
+      const existing = telemetryByRun.get(rec.runId);
+      if (!existing || existing.recordedAt < rec.recordedAt) {
+        telemetryByRun.set(rec.runId, rec);
+      }
+    }
+    for (const run of phaseRuns) {
+      const runIds = agentRunHistory[run.id] ?? (run.runId ? [run.runId] : []);
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let estimatedCostUsd = 0;
+      let turns = 0;
+      for (const rid of runIds) {
+        const rec = telemetryByRun.get(rid);
+        if (!rec) continue;
+        inputTokens += rec.inputTokens;
+        outputTokens += rec.outputTokens;
+        estimatedCostUsd += rec.estimatedCostUsd;
+        turns += 1;
+      }
+      map.set(run.id, { inputTokens, outputTokens, estimatedCostUsd, turns });
+    }
+    return map;
+  }, [telemetry, phaseRuns, agentRunHistory]);
 
   const onPickAgent = (sid: SessionId) => {
     if (sid === selectedAgentId) return;
@@ -1152,6 +1200,8 @@ function AgentsSection({ task }: AgentsSectionProps) {
               key={run.id}
               run={run}
               telemetry={run.runId ? (telemetryByRunId.get(run.runId) ?? null) : null}
+              aggregate={aggregatesByAgentId.get(run.id) ?? null}
+              turns={turnsByAgentId.get(run.id) ?? 0}
               isSelected={run.id === selectedAgentId}
               isEditing={editingId === run.id}
               onClick={() => onPickAgent(run.id)}
@@ -1264,9 +1314,18 @@ const AGENT_STATUS_TONE: Record<SessionStatus, string> = {
   skipped: 'bg-muted-foreground/20',
 };
 
+interface AgentAggregate {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly estimatedCostUsd: number;
+  readonly turns: number;
+}
+
 interface AgentRowProps {
   readonly run: Session;
   readonly telemetry: TelemetryRecord | null;
+  readonly aggregate: AgentAggregate | null;
+  readonly turns: number;
   readonly isSelected: boolean;
   readonly isEditing: boolean;
   readonly onClick: () => void;
@@ -1279,6 +1338,8 @@ interface AgentRowProps {
 function AgentRow({
   run,
   telemetry,
+  aggregate,
+  turns,
   isSelected,
   isEditing,
   onClick,
@@ -1407,40 +1468,57 @@ function AgentRow({
         ) : null}
         <span className="shrink-0 font-mono text-2xs text-muted-foreground">{run.ordinal + 1}</span>
       </div>
-      <div className="flex flex-col gap-0.5 px-2 pb-1.5 pl-[1.875rem]">
-        <div className="flex items-center gap-1.5 text-2xs text-muted-foreground/80">
-          {telemetry ? (
-            <>
-              <span>{shortModel(telemetry.model)}</span>
-              <span aria-hidden>·</span>
-            </>
-          ) : null}
+      <div className="flex flex-col gap-1 px-2 pb-1.5 pl-[1.875rem]">
+        <div className="flex items-center gap-2 whitespace-nowrap text-2xs text-foreground/85">
           <span
+            className="inline-flex items-baseline gap-1 tabular-nums"
             title={
-              telemetry
-                ? `in: ${telemetry.inputTokens.toLocaleString()} tokens (last turn)`
+              aggregate
+                ? `in: ${aggregate.inputTokens.toLocaleString()} tokens (cumulative across providers)`
                 : 'no input tokens yet'
             }
           >
-            ↓ {telemetry ? formatTokens(telemetry.inputTokens) : '0'}
+            <span aria-hidden className="text-muted-foreground/60">
+              ↓
+            </span>
+            {aggregate ? formatTokens(aggregate.inputTokens) : '0'}
           </span>
-          <span aria-hidden>·</span>
           <span
+            className="inline-flex items-baseline gap-1 tabular-nums"
             title={
-              telemetry
-                ? `out: ${telemetry.outputTokens.toLocaleString()} tokens (last turn)`
+              aggregate
+                ? `out: ${aggregate.outputTokens.toLocaleString()} tokens (cumulative across providers)`
                 : 'no output tokens yet'
             }
           >
-            ↑ {telemetry ? formatTokens(telemetry.outputTokens) : '0'}
+            <span aria-hidden className="text-muted-foreground/60">
+              ↑
+            </span>
+            {aggregate ? formatTokens(aggregate.outputTokens) : '0'}
           </span>
-          <span aria-hidden>·</span>
+          <span aria-hidden className="text-muted-foreground/40">
+            ·
+          </span>
           <span
+            className="tabular-nums"
             title={
-              telemetry ? `$${telemetry.estimatedCostUsd.toFixed(4)} (last turn)` : 'no cost yet'
+              aggregate
+                ? `$${aggregate.estimatedCostUsd.toFixed(4)} cumulative across providers`
+                : 'no cost yet'
             }
           >
-            {telemetry ? formatCost(telemetry.estimatedCostUsd) : '$0'}
+            {aggregate ? formatCost(aggregate.estimatedCostUsd) : '$0'}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 whitespace-nowrap text-2xs text-muted-foreground/70">
+          {telemetry ? (
+            <>
+              <span className="truncate">{shortModel(telemetry.model)}</span>
+              <span aria-hidden>·</span>
+            </>
+          ) : null}
+          <span className="tabular-nums" title={`${turns} turn${turns === 1 ? '' : 's'}`}>
+            {turns}t
           </span>
           <span aria-hidden>·</span>
           <AgentLifetime run={run} />

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -6,7 +6,7 @@ import {
   useEffect,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-import { Send, Square, X } from 'lucide-react';
+import { Send, Square, X, Gauge } from 'lucide-react';
 import { Textarea, cn } from '@kay-am/ui';
 import type {
   BudgetAlert,
@@ -25,6 +25,13 @@ import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
 import { useEffectivePermissionRules } from '../../permissions';
+import {
+  VERBOSITY_LEVELS,
+  VERBOSITY_LABEL,
+  type VerbosityLevel,
+  readVerbosity,
+  writeVerbosity,
+} from '../../verbosity';
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
   anthropic: 'Claude',
@@ -122,6 +129,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
+  const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -172,6 +180,11 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const setEffort = (level: EffortLevel) => {
     setEffortState(level);
     writeEffort(session.id, level);
+  };
+
+  const setVerbosity = (level: VerbosityLevel) => {
+    setVerbosityState(level);
+    writeVerbosity(session.id, level);
   };
 
   const onSelectProvider = (id: ProviderId) => {
@@ -226,7 +239,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         : undefined;
 
     setSelectedProvider(null);
-    setSelectedModel(null);
 
     if (isRunning) {
       setQueued({ content, override });
@@ -310,18 +322,21 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
               </span>
             ) : null}
           </div>
+          <ProviderUsagePill provider={effectiveProvider} />
           <ModelPicker
             providers={providerCandidates}
             models={modelCandidates}
             provider={effectiveProvider}
             model={effectiveModel}
             effort={effort}
+            verbosity={verbosity}
             connectedProviders={connectedProviderIds}
             disabled={!allowOverride || isRunning}
             disabledTitle={overrideDisabledTitle}
             onSelectProvider={onSelectProvider}
             onSelectModel={onSelectModel}
             onSelectEffort={setEffort}
+            onSelectVerbosity={setVerbosity}
           />
         </div>
         <div className="relative" ref={wrapperRef}>
@@ -443,18 +458,65 @@ const PROVIDER_TEXT: Record<ProviderId, string> = {
   codex: 'text-[var(--color-provider-codex)]',
 };
 
+const VERBOSITY_DOT: Record<VerbosityLevel, string> = {
+  essential: 'bg-success',
+  minimal: 'bg-success/70',
+  normal: 'bg-info',
+  detailed: 'bg-warning',
+  verbose: 'bg-danger',
+};
+
+const VERBOSITY_TEXT: Record<VerbosityLevel, string> = {
+  essential: 'text-success',
+  minimal: 'text-success/85',
+  normal: 'text-info',
+  detailed: 'text-warning',
+  verbose: 'text-danger',
+};
+
+function nextMonthlyResetLabel(now = new Date()): string {
+  const next = new Date(now.getFullYear(), now.getMonth() + 1, 1);
+  return next.toLocaleDateString(undefined, { day: 'numeric', month: 'short' }).toLowerCase();
+}
+
+function ProviderUsagePill({ provider }: { provider: ProviderId }) {
+  const breakdown = useAppStore((s) => s.providerSpendBreakdown);
+  const entry = breakdown.find((e) => e.provider === provider);
+  if (!entry || entry.capUsd === null || entry.capUsd <= 0) return null;
+  const pctUsed = Math.max(0, Math.min(1, entry.pct));
+  const pctRemaining = Math.round((1 - pctUsed) * 100);
+  const tone =
+    pctRemaining > 50 ? 'text-success' : pctRemaining > 20 ? 'text-warning' : 'text-danger';
+  const reset = nextMonthlyResetLabel();
+  const tooltip = `${provider}: $${entry.spentUsd.toFixed(2)} / $${entry.capUsd.toFixed(2)} used (${Math.round(pctUsed * 100)}%) · resets ${reset}`;
+  return (
+    <span
+      title={tooltip}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full bg-subtle px-2 py-0.5 text-2xs',
+        tone,
+      )}
+    >
+      <Gauge size={10} aria-hidden />
+      {pctRemaining}% left · {reset}
+    </span>
+  );
+}
+
 interface ModelPickerProps {
   providers: ReadonlyArray<ProviderId>;
   models: ReadonlyArray<string>;
   provider: ProviderId;
   model: string;
   effort: EffortLevel;
+  verbosity: VerbosityLevel;
   connectedProviders: ReadonlyArray<ProviderId>;
   disabled: boolean;
   disabledTitle?: string;
   onSelectProvider: (id: ProviderId) => void;
   onSelectModel: (id: string) => void;
   onSelectEffort: (level: EffortLevel) => void;
+  onSelectVerbosity: (level: VerbosityLevel) => void;
 }
 
 function ModelPicker({
@@ -463,12 +525,14 @@ function ModelPicker({
   provider,
   model,
   effort,
+  verbosity,
   connectedProviders,
   disabled,
   disabledTitle,
   onSelectProvider,
   onSelectModel,
   onSelectEffort,
+  onSelectVerbosity,
 }: ModelPickerProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -525,6 +589,15 @@ function ModelPicker({
             <span className={EFFORT_TEXT[effort]}>{EFFORT_LABEL[effort].toLowerCase()}</span>
           </>
         ) : null}
+        <span aria-hidden className="text-muted-foreground/70">
+          ·
+        </span>
+        <span
+          className={VERBOSITY_TEXT[verbosity]}
+          title={`verbosity: ${VERBOSITY_LABEL[verbosity].toLowerCase()}`}
+        >
+          v:{VERBOSITY_LABEL[verbosity].toLowerCase()}
+        </span>
       </button>
       {open ? (
         <div
@@ -584,6 +657,19 @@ function ModelPicker({
               </PickerSection>
             </>
           ) : null}
+          <PickerDivider />
+          <PickerSection label="verbosity · cheaper first">
+            {VERBOSITY_LEVELS.map((level) => (
+              <PickerRow
+                key={level}
+                label={VERBOSITY_LABEL[level]}
+                leadingDot={VERBOSITY_DOT[level]}
+                active={verbosity === level}
+                onClick={() => onSelectVerbosity(level)}
+                labelClassName={VERBOSITY_TEXT[level]}
+              />
+            ))}
+          </PickerSection>
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -293,7 +293,7 @@ export function ChatView({ session }: ChatViewProps) {
               aria-relevant="additions"
             >
               {(() => {
-                const tightKinds = new Set([
+                const toolishKinds = new Set([
                   'tool_call',
                   'file_edit',
                   'skill_invocation',
@@ -304,8 +304,10 @@ export function ChatView({ session }: ChatViewProps) {
                 let lastDay: string | null = null;
                 return items.map((item, idx) => {
                   const prev = idx > 0 ? (items[idx - 1] ?? null) : null;
-                  const isTight =
-                    prev !== null && tightKinds.has(item.kind) && tightKinds.has(prev.kind);
+                  const tightToTool =
+                    prev !== null &&
+                    toolishKinds.has(item.kind) &&
+                    (toolishKinds.has(prev.kind) || prev.kind === 'assistant_text');
                   const node: React.ReactNode[] = [];
                   if (item.kind === 'user_text') {
                     const day = dayKey(item.at);
@@ -321,7 +323,7 @@ export function ChatView({ session }: ChatViewProps) {
                     }
                   }
                   node.push(
-                    <li key={item.key} className={isTight ? 'mt-1' : idx === 0 ? '' : 'mt-6'}>
+                    <li key={item.key} className={tightToTool ? 'mt-0.5' : idx === 0 ? '' : 'mt-6'}>
                       <TranscriptCard item={item} onRefreshAuth={() => void refreshProviders()} />
                     </li>,
                   );

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -42,8 +42,13 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
     case 'usage':
       return (
         <p className="text-xs text-muted-foreground">
-          {item.usage.inputTokens} in / {item.usage.outputTokens} out tokens
-          {item.usage.cachedInputTokens > 0 ? ` · ${item.usage.cachedInputTokens} cached` : ''}
+          {formatTokens(item.usage.inputTokens)} in / {formatTokens(item.usage.outputTokens)} out
+          {item.usage.cachedInputTokens > 0
+            ? ` · ${formatTokens(item.usage.cachedInputTokens)} cached`
+            : ''}
+          {item.usage.estimatedCostUsd > 0
+            ? ` · ~${formatCostUsd(item.usage.estimatedCostUsd)}`
+            : ''}
         </p>
       );
     case 'error':
@@ -71,6 +76,18 @@ export function TranscriptCard({ item, onRefreshAuth }: TranscriptCardProps) {
     case 'permission_decision':
       return <PermissionDecisionCard item={item} />;
   }
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 10_000) return `${(n / 1000).toFixed(1)}k`;
+  return `${Math.round(n / 1000)}k`;
+}
+
+function formatCostUsd(cost: number): string {
+  if (cost < 0.001) return `$${cost.toFixed(4)}`;
+  if (cost < 1) return `$${cost.toFixed(3)}`;
+  return `$${cost.toFixed(2)}`;
 }
 
 function AssistantText({ text }: { text: string }) {
@@ -178,12 +195,12 @@ function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' 
         ) : null}
       </button>
       {open ? (
-        <div className="ml-[1.125rem] mt-1 flex flex-col gap-1">
-          <pre className="overflow-x-auto rounded bg-subtle p-2 text-2xs text-muted-foreground">
+        <div className="ml-[1.125rem] mt-0.5 flex min-w-0 flex-col gap-1">
+          <pre className="min-w-0 whitespace-pre-wrap break-words rounded bg-subtle p-2 text-2xs text-muted-foreground">
             input: {JSON.stringify(item.input, null, 2)}
           </pre>
           {item.ended ? (
-            <pre className="overflow-x-auto rounded bg-subtle p-2 text-2xs text-muted-foreground">
+            <pre className="min-w-0 whitespace-pre-wrap break-words rounded bg-subtle p-2 text-2xs text-muted-foreground">
               output: {JSON.stringify(item.output, null, 2)}
             </pre>
           ) : null}

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -17,7 +17,12 @@ const EMPTY_SLOTS: ReadonlyArray<ContextSlot> = [];
 export const useSessionSlots = (taskId: TaskId | null): ReadonlyArray<ContextSlot> =>
   useAppStore((s) => (taskId ? (s.sessionSlots[taskId] ?? EMPTY_SLOTS) : EMPTY_SLOTS));
 
-const IDLE_STATUS: SummarizerSessionStatus = { status: 'idle', lastUpdate: null, error: null };
+const IDLE_STATUS: SummarizerSessionStatus = {
+  status: 'idle',
+  lastUpdate: null,
+  error: null,
+  lastUsage: null,
+};
 
 export const useSummarizerStatus = (taskId: TaskId | null): SummarizerSessionStatus =>
   useAppStore((s) => (taskId ? (s.summarizerStatus[taskId] ?? IDLE_STATUS) : IDLE_STATUS));

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -123,6 +123,7 @@ import {
 } from '../settings';
 import { getCodexPriceOverride, refreshPricingTable } from '../providerPricing';
 import { runTurn, cancelTurn, encodeAuthRequiredMessage, isAuthErrorMessage } from '../turn';
+import { readVerbosity, verbosityDirective } from '../verbosity';
 import { createWorktree, removeWorktree, type CreatedWorktree } from '../worktree';
 import {
   invokeBudgetRuleList,
@@ -188,6 +189,7 @@ const CONTEXT_MARKER_HINT =
   '## context handoff protocol\n' +
   'when you reach a durable design decision, wrap it as `<<ctx-decision>>your decision<</ctx-decision>>`.\n' +
   'when you have an open question that the user must answer before continuing, wrap it as `<<ctx-question>>your question<</ctx-question>>`.\n' +
+  'when an open question listed in the shared context above has just been answered (by the user, or because work has clarified it), wrap it as `<<ctx-resolved>>the original question text<</ctx-resolved>>` — the orchestrator removes matching lines from open_questions. emit one resolved marker per question; reuse the original phrasing closely so the substring match succeeds.\n' +
   "the orchestrator parses these markers and persists them to this task's shared context panel — every other agent in this task will see them automatically. don't repeat what's already in the shared context above.";
 
 function buildContextPreamble(sharedSlotsRendered: string): string {
@@ -237,6 +239,14 @@ export interface AppState {
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly sessionPhaseRuns: Readonly<Record<TaskId, ReadonlyArray<Session>>>;
   readonly selectedAgentId: Readonly<Record<TaskId, SessionId | null>>;
+  /**
+   * Runtime history of providerRunIds per agent (Session). Populated as turns
+   * fire so the sidebar can aggregate telemetry across provider switches —
+   * agents whose `runId` only points at the *latest* provider run would
+   * otherwise drop costs from previous providers when the user swaps mid-
+   * session. Lives in-memory only; rebuilt from current state on hydrate.
+   */
+  readonly agentRunHistory: Readonly<Record<SessionId, ReadonlyArray<ProviderRunId>>>;
   readonly sessionMergeConflicts: Readonly<Record<TaskId, ReadonlyArray<FileConflict>>>;
   readonly unknownPayloadCounts: Readonly<Record<string, number>>;
   readonly detectedEditors: ReadonlyArray<DetectedEditor>;
@@ -252,6 +262,11 @@ export interface SummarizerSessionStatus {
   readonly status: 'idle' | 'running' | 'error';
   readonly lastUpdate: IsoDateTime | null;
   readonly error: string | null;
+  readonly lastUsage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly estimatedCostUsd: number;
+  } | null;
 }
 
 export interface ProviderSpendEntry {
@@ -373,6 +388,7 @@ const initialState: AppState = {
   phaseTemplates: {},
   sessionPhaseRuns: {},
   selectedAgentId: {},
+  agentRunHistory: {},
   sessionMergeConflicts: {},
   unknownPayloadCounts: {},
   detectedEditors: [],
@@ -426,12 +442,20 @@ async function runSummarizer(
   turnOutput: string,
 ): Promise<void> {
   const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
-  set((state) => ({
-    summarizerStatus: {
-      ...state.summarizerStatus,
-      [taskId]: { status: 'running', lastUpdate: null, error: null },
-    },
-  }));
+  set((state) => {
+    const prev = state.summarizerStatus[taskId];
+    return {
+      summarizerStatus: {
+        ...state.summarizerStatus,
+        [taskId]: {
+          status: 'running',
+          lastUpdate: prev?.lastUpdate ?? null,
+          error: null,
+          lastUsage: prev?.lastUsage ?? null,
+        },
+      },
+    };
+  });
 
   try {
     const session = get().sessions.find((s) => s.id === taskId);
@@ -508,7 +532,16 @@ async function runSummarizer(
       sessionTelemetry: { ...state.sessionTelemetry, [taskId]: telemetry },
       summarizerStatus: {
         ...state.summarizerStatus,
-        [taskId]: { status: 'idle', lastUpdate: now(), error: null },
+        [taskId]: {
+          status: 'idle',
+          lastUpdate: now(),
+          error: null,
+          lastUsage: {
+            inputTokens: result.usage.inputTokens,
+            outputTokens: result.usage.outputTokens,
+            estimatedCostUsd: result.usage.estimatedCostUsd,
+          },
+        },
       },
       providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
     }));
@@ -518,12 +551,20 @@ async function runSummarizer(
     if (import.meta.env.DEV) {
       console.warn(`[summarizer] failed for session ${taskId}: ${message}`);
     }
-    set((state) => ({
-      summarizerStatus: {
-        ...state.summarizerStatus,
-        [taskId]: { status: 'error', lastUpdate: now(), error: message },
-      },
-    }));
+    set((state) => {
+      const prev = state.summarizerStatus[taskId];
+      return {
+        summarizerStatus: {
+          ...state.summarizerStatus,
+          [taskId]: {
+            status: 'error',
+            lastUpdate: now(),
+            error: message,
+            lastUsage: prev?.lastUsage ?? null,
+          },
+        },
+      };
+    });
   }
 }
 
@@ -712,6 +753,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionBranches: {},
       sessionPhaseRuns: {},
       selectedAgentId: {},
+      agentRunHistory: {},
       sessionMergeConflicts: {},
       sessionBudgets: {},
       summarizerStatus: {},
@@ -802,6 +844,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
             listTurnEventsForAgent(tauriDatabase, selectedAgent.id),
           ])
         : [[] as ReadonlyArray<Message>, [] as ReadonlyArray<TurnEvent>];
+      // Seed agentRunHistory from each agent's current runId so previously-run
+      // agents at least have ONE entry to aggregate against. New runIds get
+      // appended on each turn going forward.
+      const seededHistory: Record<string, ReadonlyArray<ProviderRunId>> = {};
+      for (const agent of agents) {
+        if (agent.runId) {
+          const prev = get().agentRunHistory[agent.id] ?? [];
+          if (!prev.includes(agent.runId)) {
+            seededHistory[agent.id] = [...prev, agent.runId];
+          }
+        }
+      }
       set((state) => ({
         sessionSummary: summary,
         sessionPhaseRuns: { ...state.sessionPhaseRuns, [id]: agents },
@@ -813,6 +867,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         transcripts: { ...state.transcripts, [id]: events },
         sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
         sessionSlots: { ...state.sessionSlots, [id]: slots },
+        agentRunHistory: { ...state.agentRunHistory, ...seededHistory },
       }));
     }
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, id ?? '');
@@ -1280,6 +1335,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
         });
         return;
       }
+      // Track this providerRunId against the agent so the sidebar can sum
+      // tokens/cost across provider switches within the same agent.
+      set((state) => {
+        const prev = state.agentRunHistory[activeAgentId] ?? [];
+        if (prev.includes(runId)) return state;
+        return {
+          agentRunHistory: { ...state.agentRunHistory, [activeAgentId]: [...prev, runId] },
+        };
+      });
       const userMessage: Message = {
         id: crypto.randomUUID() as MessageId,
         taskId,
@@ -1594,6 +1658,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (contextPreamble.length > 0) {
       resolvedPrompt = `${contextPreamble}\n\n${resolvedPrompt}`;
     }
+    const verbosityHint = verbosityDirective(readVerbosity(taskId));
+    resolvedPrompt = `${verbosityHint}\n\n${resolvedPrompt}`;
 
     let assistantText = '';
     let lastError: unknown = null;
@@ -2121,6 +2187,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             sessionWorktrees: {},
             sessionPhaseRuns: {},
             selectedAgentId: {},
+            agentRunHistory: {},
             sessionBudgets: {},
             summarizerStatus: {},
             budgetAlerts: [],

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -177,7 +177,9 @@ describe('setCurrentWorkspace — session-scoped state cleanup', () => {
       sessionWorktrees: { [SESSION_IDLE]: ['/tmp/wt'] },
       sessionPhaseRuns: { [SESSION_IDLE]: [] },
       sessionBudgets: { [SESSION_IDLE]: { softCapUsd: 10 } as never },
-      summarizerStatus: { [SESSION_IDLE]: { status: 'idle', lastUpdate: null, error: null } },
+      summarizerStatus: {
+        [SESSION_IDLE]: { status: 'idle', lastUpdate: null, error: null, lastUsage: null },
+      },
       budgetAlerts: [{ id: 'alert-1' } as never],
     });
 

--- a/apps/desktop/src/verbosity.ts
+++ b/apps/desktop/src/verbosity.ts
@@ -1,0 +1,52 @@
+import type { TaskId } from '@kay-am/types';
+
+export const VERBOSITY_LEVELS = ['essential', 'minimal', 'normal', 'detailed', 'verbose'] as const;
+export type VerbosityLevel = (typeof VERBOSITY_LEVELS)[number];
+
+export const VERBOSITY_LABEL: Record<VerbosityLevel, string> = {
+  essential: 'Essential',
+  minimal: 'Minimal',
+  normal: 'Normal',
+  detailed: 'Detailed',
+  verbose: 'Verbose',
+};
+
+const STORAGE_PREFIX = 'kayam:verbosity:';
+const DEFAULT_LEVEL: VerbosityLevel = 'essential';
+
+export function readVerbosity(taskId: TaskId): VerbosityLevel {
+  try {
+    const raw = localStorage.getItem(`${STORAGE_PREFIX}${taskId}`);
+    if (raw && (VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) {
+      return raw as VerbosityLevel;
+    }
+  } catch {
+    // ignore
+  }
+  return DEFAULT_LEVEL;
+}
+
+export function writeVerbosity(taskId: TaskId, level: VerbosityLevel): void {
+  try {
+    localStorage.setItem(`${STORAGE_PREFIX}${taskId}`, level);
+  } catch {
+    // ignore
+  }
+}
+
+const VERBOSITY_DIRECTIVE: Record<VerbosityLevel, string> = {
+  essential:
+    'Output verbosity: ESSENTIAL. Output only what is strictly required to answer or act. No preambles, no recaps, no explanations unless asked. Single short sentence per update; one-line end-of-turn.',
+  minimal:
+    'Output verbosity: MINIMAL. Brief but complete. Skip narration and pleasantries. Short paragraphs only when needed.',
+  normal:
+    'Output verbosity: NORMAL. Standard prose. Include rationale when non-obvious; avoid filler.',
+  detailed:
+    'Output verbosity: DETAILED. Provide additional context and rationale where it aids the reader. Still no filler or pleasantries.',
+  verbose:
+    'Output verbosity: VERBOSE. Include reasoning, alternatives considered, and trade-offs. Long-form is acceptable.',
+};
+
+export function verbosityDirective(level: VerbosityLevel): string {
+  return VERBOSITY_DIRECTIVE[level];
+}

--- a/packages/core/src/context/auto-populate.ts
+++ b/packages/core/src/context/auto-populate.ts
@@ -1,7 +1,7 @@
 import type { ContextSlot, TaskId } from '@kay-am/types';
 import type { Database } from '@kay-am/db';
 import { ContextEngine } from './engine';
-import { extractMarkers, mergeIntoSlot } from './extractors';
+import { extractMarkers, mergeIntoSlot, removeFromSlot } from './extractors';
 import type { SlotKey } from './slots';
 
 // ---------------------------------------------------------------------------
@@ -28,13 +28,22 @@ export async function autoPopulateContext(input: AutoPopulateInput): Promise<Aut
   const engine = new ContextEngine({ db: input.db });
   const slots = await engine.load(input.taskId);
 
-  const { decisions, questions } = extractMarkers(input.assistantText);
+  const { decisions, questions, resolved } = extractMarkers(input.assistantText);
 
   const updates: Array<{ key: SlotKey; value: string }> = [];
 
   pushUpdate(updates, slots, 'files_touched', input.filesEdited);
   pushUpdate(updates, slots, 'decisions', decisions);
-  pushUpdate(updates, slots, 'open_questions', questions);
+
+  // open_questions: add new ones, then remove resolved. Compose against the
+  // pending update if `pushUpdate` already staged one for this slot, so
+  // resolutions and additions in the same turn don't fight each other.
+  const existingQuestions = slots.find((s) => s.key === 'open_questions')?.value ?? '';
+  let nextQuestions = mergeIntoSlot(existingQuestions, questions);
+  nextQuestions = removeFromSlot(nextQuestions, resolved);
+  if (nextQuestions !== existingQuestions) {
+    updates.push({ key: 'open_questions', value: nextQuestions });
+  }
 
   for (const upd of updates) {
     await engine.upsert(input.taskId, upd.key, upd.value);

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -26,12 +26,17 @@ export function extractFilesTouched(events: ReadonlyArray<TurnEvent>): ReadonlyA
 
 const DECISION_RE = /<<ctx-decision>>([\s\S]*?)<<\/ctx-decision>>/g;
 const QUESTION_RE = /<<ctx-question>>([\s\S]*?)<<\/ctx-question>>/g;
+const RESOLVED_RE = /<<ctx-resolved>>([\s\S]*?)<<\/ctx-resolved>>/g;
 
 /**
  * Pull agent-emitted markers out of an assistant turn's full text. Agents
  * are instructed (via system prompt) to wrap durable observations like:
  *   <<ctx-decision>>switching auth to OAuth2 PKCE<</ctx-decision>>
  *   <<ctx-question>>do we need refresh tokens?<</ctx-question>>
+ *   <<ctx-resolved>>do we need refresh tokens?<</ctx-resolved>>
+ *
+ * `resolved` removes a previously open question once the user has answered it
+ * — same text as the original question (case-insensitive substring match).
  *
  * The marker form is intentionally verbose so the model rarely emits it by
  * accident in casual prose. Whitespace inside is trimmed.
@@ -39,10 +44,12 @@ const QUESTION_RE = /<<ctx-question>>([\s\S]*?)<<\/ctx-question>>/g;
 export function extractMarkers(assistantText: string): {
   readonly decisions: ReadonlyArray<string>;
   readonly questions: ReadonlyArray<string>;
+  readonly resolved: ReadonlyArray<string>;
 } {
   const decisions = extractAll(assistantText, DECISION_RE);
   const questions = extractAll(assistantText, QUESTION_RE);
-  return { decisions, questions };
+  const resolved = extractAll(assistantText, RESOLVED_RE);
+  return { decisions, questions, resolved };
 }
 
 function extractAll(text: string, re: RegExp): ReadonlyArray<string> {
@@ -79,4 +86,41 @@ export function mergeIntoSlot(existing: string, additions: ReadonlyArray<string>
     changed = true;
   }
   return changed ? lines.join('\n') : existing;
+}
+
+/**
+ * Remove lines from `existing` that match any string in `removals` — match is
+ * case-insensitive, ignores leading list markers (`-`, `*`, `1.`), and
+ * succeeds when one is a substring of the other. Used to clean up resolved
+ * open questions when the agent emits `<<ctx-resolved>>` markers.
+ *
+ * Returns the original string verbatim if nothing matched, so the caller can
+ * skip the upsert.
+ */
+export function removeFromSlot(existing: string, removals: ReadonlyArray<string>): string {
+  if (removals.length === 0 || existing.length === 0) return existing;
+  const norm = (s: string) =>
+    s
+      .replace(/^\s*(?:[-*]|\d+\.)\s+/, '')
+      .trim()
+      .toLowerCase();
+  const targets = removals.map(norm).filter((s) => s.length > 0);
+  if (targets.length === 0) return existing;
+  const lines = existing.split('\n');
+  const kept: string[] = [];
+  let changed = false;
+  for (const line of lines) {
+    const n = norm(line);
+    if (n.length === 0) {
+      kept.push(line);
+      continue;
+    }
+    const matches = targets.some((t) => n === t || n.includes(t) || t.includes(n));
+    if (matches) {
+      changed = true;
+      continue;
+    }
+    kept.push(line);
+  }
+  return changed ? kept.join('\n') : existing;
 }

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -8,7 +8,7 @@ export {
   SLOT_LABELS,
   type SlotKey,
 } from './slots';
-export { extractFilesTouched, extractMarkers, mergeIntoSlot } from './extractors';
+export { extractFilesTouched, extractMarkers, mergeIntoSlot, removeFromSlot } from './extractors';
 export {
   autoPopulateContext,
   type AutoPopulateInput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export {
   extractMarkers,
   isSlotKey,
   mergeIntoSlot,
+  removeFromSlot,
   serializeSlots,
   type AutoPopulateInput,
   type AutoPopulateResult,

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -84,13 +84,17 @@ interface SummarizeCommandResult {
   readonly exitCode: number | null;
 }
 
-const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session.
+const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session. The summary is the handoff payload — a fresh agent must be able to read these slots alone and continue the work without seeing any prior turns.
 
 There are exactly five slots, each with a stable key:
 ${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
 
 You will receive the previous slot values plus the most recent user turn and assistant turn.
-Decide which slots, if any, should change. Keep values terse: a sentence or short bullet list per slot.
+Decide which slots, if any, should change. Keep values terse: a sentence or short bullet list per slot. Prefer decisions, constraints, and unresolved items over verbose narration of what happened. Exclude raw tool output.
+
+Goal refinement: the "goal" slot is not write-once. As the conversation clarifies what the user actually wants, sharpen the goal — make it more specific, surface implicit constraints, drop vague phrasing. Update goal whenever the latest turn changed or clarified the target. Don't rewrite when nothing new emerged.
+
+Open questions: when the latest user turn answers a previously-listed open question, drop the resolved item from the open_questions slot value. Add new questions only when the assistant explicitly needs the user before continuing.
 
 You MUST respond with a single JSON object and nothing else. No prose, no markdown, no code fences.
 The schema is:

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -18,7 +18,7 @@ const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;
 const RIGHT_SIDEBAR_DEFAULT = 340;
 const RIGHT_SIDEBAR_STORAGE_KEY = 'kayam:right-sidebar-width';
-const RIGHT_RAIL_WIDTH = 40;
+const RIGHT_RAIL_WIDTH = 44;
 
 function readPersistedWidth(key: string, def: number, min: number, max: number): number {
   if (typeof localStorage === 'undefined') return def;
@@ -217,7 +217,9 @@ export function AppShell({
           <aside
             className={cn(
               'flex min-h-0 min-w-0 flex-col overflow-hidden',
-              rightSidebarCollapsed ? 'bg-background' : 'm-3 rounded-xl bg-subtle shadow-sm',
+              rightSidebarCollapsed
+                ? 'mr-3 mt-3 bg-background'
+                : 'm-3 rounded-xl bg-subtle shadow-sm',
             )}
             style={{ gridArea: 'right' }}
           >


### PR DESCRIPTION
## Summary

First batch of the UX/provider intervention plan. Closes ~17/24 items; the heavier feature work (suggested actions, right-panel split, markdown edit CTAs, phase CTAs, per-agent input/transcript isolation) is deferred to a follow-up agent — see the open plan in the conversation.

### UX
- Chat tool output wraps without double scroll, tighter spacing to its trigger text, per-message cost shown alongside tokens
- Context panel: collapsed rail icon aligned to expanded close icon (44px rail, mt-3 mr-3 + pr-4 pt-4); animated \"summarizing…\" badge with reassurance tooltip; cumulative summary spend (Σ \$) derived from telemetry; history modal upgraded to size=lg
- Summarizer prompt: explicit goal-refinement clause, handoff-ready guidance, instructions to drop resolved questions
- New \`<<ctx-resolved>>\` marker + \`removeFromSlot\` util to clean up answered \`open_questions\`

### Per-turn knobs
- Verbosity selector (essential → verbose, persisted per-task) injected as a directive on every prompt
- Provider usage pill near ModelPicker shows \`% left · resets <date>\` using existing \`providerSpendBreakdown\`

### Providers
- Rust \`turn.rs\` now branches CLI args by binary (cursor-agent uses \`-p / --workspace / --force\`, codex uses \`exec --json --cwd --\`, claude unchanged) — fixes Cursor/Codex turns that were silently being passed claude flags
- \`agentRunHistory\` tracks every providerRunId per agent so the sidebar sums tokens/cost across provider switches within the same agent
- Worktrees now default to \`<repo>/.kay-am/worktrees/<prefix>-<slug>\` and \`.kay-am/\` is appended to the repo's \`.gitignore\` on first creation

### Agent row
- 2-line layout, \`tabular-nums\`, \`whitespace-nowrap\`, turn count
- Token/cost values are cumulative across providers, not last-turn only

## Test plan
- [x] \`pnpm typecheck\` (monorepo)
- [x] \`pnpm test\` — 190/190
- [x] \`cargo check\` (Rust)
- [ ] Manual: send a turn with verbosity=Essential, confirm output is terse
- [ ] Manual: switch provider mid-agent, confirm sidebar tokens/cost keep accumulating
- [ ] Manual: collapse context panel, confirm icon stays at the same position
- [ ] Manual: cursor turn — should now spawn with cursor-agent flags (model name still needs cursor's catalog, see open issues)
- [ ] Manual: create new session, verify worktree lands in \`<repo>/.kay-am/worktrees/\` and \`.kay-am/\` is in \`.gitignore\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)