### PR TITLE
feat(v0.8): GitHub integration

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -1,0 +1,178 @@
+use std::process::{Command, Stdio};
+
+use serde::Serialize;
+use thiserror::Error;
+
+use crate::secrets;
+
+const TOKEN_KEY: &str = "github.pat";
+
+#[derive(Debug, Error)]
+pub enum GithubError {
+    #[error("gh binary not found in PATH")]
+    NotFound,
+    #[error("gh command failed: {0}")]
+    Spawn(#[from] std::io::Error),
+    #[error("secret store error: {0}")]
+    Secret(#[from] secrets::SecretError),
+    #[error("gh validation failed: {0}")]
+    Validation(String),
+}
+
+impl Serialize for GithubError {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhStatus {
+    pub available: bool,
+    pub mode: String,
+    pub version: Option<String>,
+    pub user: Option<String>,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhRunResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+}
+
+fn gh_available() -> bool {
+    Command::new("gh")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn run_gh(
+    args: &[&str],
+    cwd: Option<&str>,
+    token: Option<&str>,
+) -> Result<GhRunResult, GithubError> {
+    if !gh_available() {
+        return Err(GithubError::NotFound);
+    }
+    let mut cmd = Command::new("gh");
+    cmd.args(args);
+    if let Some(dir) = cwd {
+        if !dir.is_empty() {
+            cmd.current_dir(dir);
+        }
+    }
+    if let Some(t) = token {
+        if !t.is_empty() {
+            cmd.env("GH_TOKEN", t);
+            cmd.env("GITHUB_TOKEN", t);
+        }
+    }
+    let output = cmd.output()?;
+    Ok(GhRunResult {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        exit_code: output.status.code().unwrap_or(-1),
+    })
+}
+
+fn parse_version(stdout: &str) -> Option<String> {
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("gh version "))
+        .and_then(|rest| rest.split_whitespace().next().map(|s| s.to_string()))
+}
+
+fn read_token() -> Option<String> {
+    secrets::read(TOKEN_KEY).ok().flatten()
+}
+
+#[tauri::command]
+pub fn gh_status() -> GhStatus {
+    if !gh_available() {
+        return GhStatus {
+            available: false,
+            mode: "absent".to_string(),
+            version: None,
+            user: None,
+            scopes: Vec::new(),
+        };
+    }
+    let version = run_gh(&["--version"], None, None)
+        .ok()
+        .and_then(|r| parse_version(&r.stdout));
+
+    let pat = read_token();
+    let token_ref = pat.as_deref();
+
+    let user = run_gh(&["api", "user", "-q", ".login"], None, token_ref)
+        .ok()
+        .filter(|r| r.exit_code == 0)
+        .map(|r| r.stdout.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    let mode = match (&user, pat.is_some()) {
+        (Some(_), true) => "pat",
+        (Some(_), false) => "gh-cli",
+        _ => "absent",
+    };
+
+    GhStatus {
+        available: true,
+        mode: mode.to_string(),
+        version,
+        user,
+        scopes: Vec::new(),
+    }
+}
+
+#[tauri::command]
+pub fn gh_set_token(token: String) -> Result<GhStatus, GithubError> {
+    if token.trim().is_empty() {
+        return Err(GithubError::Validation("token is empty".to_string()));
+    }
+    let res = run_gh(&["api", "user", "-q", ".login"], None, Some(&token))?;
+    if res.exit_code != 0 {
+        return Err(GithubError::Validation(if res.stderr.is_empty() {
+            format!("gh exited with {}", res.exit_code)
+        } else {
+            res.stderr.trim().to_string()
+        }));
+    }
+    secrets::set(TOKEN_KEY, &token)?;
+    Ok(gh_status())
+}
+
+#[tauri::command]
+pub fn gh_clear_token() -> Result<(), GithubError> {
+    secrets::clear(TOKEN_KEY)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn gh_run(args: Vec<String>, cwd: Option<String>) -> Result<GhRunResult, GithubError> {
+    let token = read_token();
+    let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    run_gh(&arg_refs, cwd.as_deref(), token.as_deref())
+}
+
+#[tauri::command]
+pub fn gh_pr_diff(repo: String, pr: u32, cwd: Option<String>) -> Result<String, GithubError> {
+    let token = read_token();
+    let pr_str = pr.to_string();
+    let res = run_gh(
+        &["pr", "diff", &pr_str, "--repo", &repo],
+        cwd.as_deref(),
+        token.as_deref(),
+    )?;
+    if res.exit_code != 0 {
+        return Err(GithubError::Validation(res.stderr.trim().to_string()));
+    }
+    Ok(res.stdout)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod budget;
 mod config_export;
 mod db;
 mod editor;
+mod github;
 mod parallel_groups;
 mod permissions;
 mod planner;
@@ -121,6 +122,11 @@ pub fn run() {
       config_export::import_config,
       config_export::export_config_to_file,
       config_export::import_config_from_file,
+      github::gh_status,
+      github::gh_set_token,
+      github::gh_clear_token,
+      github::gh_run,
+      github::gh_pr_diff,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/secrets.rs
+++ b/apps/desktop/src-tauri/src/secrets.rs
@@ -27,19 +27,27 @@ pub fn read(key: &str) -> Result<Option<String>, SecretError> {
     }
 }
 
-#[tauri::command]
-pub fn secret_set(key: String, value: String) -> Result<(), SecretError> {
-    entry(&key)?.set_password(&value)?;
+pub fn set(key: &str, value: &str) -> Result<(), SecretError> {
+    entry(key)?.set_password(value)?;
     Ok(())
 }
 
-#[tauri::command]
-pub fn secret_delete(key: String) -> Result<(), SecretError> {
-    match entry(&key)?.delete_credential() {
+pub fn clear(key: &str) -> Result<(), SecretError> {
+    match entry(key)?.delete_credential() {
         Ok(()) => Ok(()),
         Err(keyring::Error::NoEntry) => Ok(()),
         Err(err) => Err(err.into()),
     }
+}
+
+#[tauri::command]
+pub fn secret_set(key: String, value: String) -> Result<(), SecretError> {
+    set(&key, &value)
+}
+
+#[tauri::command]
+pub fn secret_delete(key: String) -> Result<(), SecretError> {
+    clear(&key)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -17,6 +17,13 @@ vi.mock('../store', () => ({
       toggleSessionSlot: vi.fn(),
       summarizerStatus: {},
       sessionTelemetry: {},
+      githubStatus: null,
+      sessionBranches: {},
+      sessionGithub: {},
+      sessions: [],
+      workspaces: [],
+      refreshSessionPr: vi.fn(),
+      createPrForSession: vi.fn(),
     };
     return selector(state);
   }),

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -1,13 +1,28 @@
 import { useEffect, useState, useCallback, useMemo } from 'react';
-import { PanelRightClose, PanelRightOpen, History, RotateCcw } from 'lucide-react';
-import { ScrollArea, Textarea, Dialog, cn } from '@kay-am/ui';
-import { SLOT_KEYS, SLOT_LABELS, type SlotKey } from '@kay-am/core';
+import {
+  PanelRightClose,
+  PanelRightOpen,
+  History,
+  RotateCcw,
+  GitPullRequest,
+  GitPullRequestDraft,
+  GitMerge,
+  RefreshCw,
+  ExternalLink,
+  Plus,
+  Loader2,
+  Copy,
+  X,
+} from 'lucide-react';
+import { ScrollArea, Textarea, Dialog, Button, cn } from '@kay-am/ui';
+import { SLOT_KEYS, SLOT_LABELS, type SlotKey, detectRepoSlug } from '@kay-am/core';
 import type {
   ContextSlot,
   ContextSlotHistoryEntry,
   Task,
   TaskId,
   TelemetryRecord,
+  PullRequestStateKind,
 } from '@kay-am/types';
 import {
   EMPTY_ARRAY,
@@ -16,6 +31,9 @@ import {
   useSlotHistory,
   useSummarizerStatus,
 } from '../store';
+import { openUrl } from '../editor';
+import { tauriGhRunner } from '../github';
+import { DiffViewerDialog } from './DiffViewerDialog';
 
 interface ContextPanelProps {
   session: Task;
@@ -109,6 +127,8 @@ export function ContextPanel({
           </div>
         </header>
 
+        <GitHubSection session={session} />
+
         <ul className="flex flex-col gap-4">
           {SLOT_KEYS.map((key) => {
             const slot = slotsByKey.get(key);
@@ -125,6 +145,236 @@ export function ContextPanel({
         </ul>
       </div>
     </ScrollArea>
+  );
+}
+
+const PR_STATE_LABEL: Record<PullRequestStateKind, string> = {
+  draft: 'draft',
+  open: 'open',
+  approved: 'approved',
+  merged: 'merged',
+  closed: 'closed',
+};
+
+const PR_STATE_STYLE: Record<PullRequestStateKind, string> = {
+  draft: 'bg-muted text-muted-foreground',
+  open: 'bg-success/10 text-success',
+  approved: 'bg-success/20 text-success',
+  merged: 'bg-accent/10 text-accent',
+  closed: 'bg-danger/10 text-danger',
+};
+
+function PrStateIcon({ state }: { state: PullRequestStateKind }) {
+  if (state === 'draft') return <GitPullRequestDraft size={11} aria-hidden />;
+  if (state === 'merged') return <GitMerge size={11} aria-hidden />;
+  return <GitPullRequest size={11} aria-hidden />;
+}
+
+function openInBrowser(url: string) {
+  openUrl(url).catch(() => window.open(url, '_blank'));
+}
+
+function GitHubSection({ session }: { session: Task }) {
+  const githubStatus = useAppStore((s) => s.githubStatus);
+  const branch = useAppStore((s) => s.sessionBranches[session.id]);
+  const ghState = useAppStore((s) => s.sessionGithub[session.id]);
+  const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === session.workspaceId));
+  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
+  const createPrForSession = useAppStore((s) => s.createPrForSession);
+
+  const [repoSlug, setRepoSlug] = useState<string | null>(null);
+  const [diffOpen, setDiffOpen] = useState(false);
+  const [issuesExpanded, setIssuesExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!branch || !workspace?.rootPath) return;
+    detectRepoSlug(tauriGhRunner, workspace.rootPath)
+      .then(setRepoSlug)
+      .catch(() => setRepoSlug(null));
+  }, [branch, workspace?.rootPath]);
+
+  useEffect(() => {
+    if (!branch || githubStatus?.mode === 'absent') return;
+    void refreshSessionPr(session.id);
+  }, [branch, githubStatus?.mode, session.id, refreshSessionPr]);
+
+  if (!branch || githubStatus?.mode === 'absent') return null;
+
+  const pr = ghState?.pr ?? null;
+  const linkedIssues = ghState?.linkedIssues ?? [];
+  const loading = ghState?.loading ?? false;
+  const ISSUE_LIMIT = 3;
+  const visibleIssues = issuesExpanded ? linkedIssues : linkedIssues.slice(0, ISSUE_LIMIT);
+  const hiddenCount = linkedIssues.length - ISSUE_LIMIT;
+
+  const copyBranch = () => {
+    navigator.clipboard.writeText(branch).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  const handleCreatePr = async () => {
+    setCreateError(null);
+    try {
+      await createPrForSession(session.id);
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          github
+        </span>
+        <button
+          type="button"
+          onClick={() => void refreshSessionPr(session.id, { force: true })}
+          disabled={loading}
+          title="refresh pr status"
+          aria-label="refresh pr status"
+          className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-40"
+        >
+          <RefreshCw size={11} className={cn(loading && 'animate-spin')} aria-hidden />
+        </button>
+      </div>
+
+      <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
+        <div className="flex items-center justify-between gap-1.5">
+          <span className="truncate font-mono text-xs text-foreground" title={branch}>
+            {branch}
+          </span>
+          <button
+            type="button"
+            onClick={copyBranch}
+            title="copy branch name"
+            aria-label="copy branch name"
+            className="shrink-0 rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            {copied ? <X size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
+          </button>
+        </div>
+
+        {pr ? (
+          <div className="flex items-start gap-1.5">
+            <button
+              type="button"
+              onClick={() => openInBrowser(pr.url)}
+              className="flex min-w-0 flex-1 items-center gap-1 text-left text-xs text-foreground hover:underline"
+              title={pr.title}
+            >
+              <PrStateIcon state={pr.state} />
+              <span className="truncate">
+                #{pr.number} {pr.title}
+              </span>
+            </button>
+            <div className="flex shrink-0 items-center gap-1">
+              <span
+                className={cn(
+                  'rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+                  PR_STATE_STYLE[pr.state],
+                )}
+              >
+                {PR_STATE_LABEL[pr.state]}
+              </span>
+              {repoSlug ? (
+                <button
+                  type="button"
+                  onClick={() => setDiffOpen(true)}
+                  title="view diff"
+                  aria-label="view pr diff"
+                  className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <ExternalLink size={10} aria-hidden />
+                </button>
+              ) : null}
+            </div>
+          </div>
+        ) : loading ? (
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Loader2 size={10} className="animate-spin" aria-hidden />
+            checking…
+          </div>
+        ) : (
+          <div className="flex items-center justify-between gap-1.5">
+            <span className="text-xs italic text-muted-foreground">no pr yet</span>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => void handleCreatePr()}
+              disabled={loading}
+              className="h-5 gap-0.5 px-1.5 text-[10px]"
+            >
+              <Plus size={10} aria-hidden />
+              open pr
+            </Button>
+          </div>
+        )}
+
+        {linkedIssues.length > 0 ? (
+          <div className="flex flex-col gap-0.5 border-t border-border-soft pt-1.5">
+            {visibleIssues.map((issue) => (
+              <div key={issue.number} className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    'shrink-0 rounded-sm px-1 py-0.5 text-[9px] uppercase tracking-wide',
+                    issue.closes ? 'bg-success/10 text-success' : 'bg-muted text-muted-foreground',
+                  )}
+                >
+                  {issue.closes ? 'closes' : 'ref'}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => openInBrowser(issue.url)}
+                  className="min-w-0 flex-1 truncate text-left text-xs text-muted-foreground hover:text-foreground hover:underline"
+                  title={issue.title ?? `#${issue.number}`}
+                >
+                  #{issue.number}
+                  {issue.title ? ` ${issue.title}` : ''}
+                </button>
+              </div>
+            ))}
+            {!issuesExpanded && hiddenCount > 0 ? (
+              <button
+                type="button"
+                onClick={() => setIssuesExpanded(true)}
+                className="self-start text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                +{hiddenCount} more
+              </button>
+            ) : issuesExpanded && hiddenCount > 0 ? (
+              <button
+                type="button"
+                onClick={() => setIssuesExpanded(false)}
+                className="self-start text-[10px] text-muted-foreground hover:text-foreground"
+              >
+                show less
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {createError ? (
+          <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-[10px] text-danger">
+            {createError}
+          </p>
+        ) : null}
+      </div>
+
+      {repoSlug && pr ? (
+        <DiffViewerDialog
+          open={diffOpen}
+          onClose={() => setDiffOpen(false)}
+          repoSlug={repoSlug}
+          prNumber={pr.number}
+          cwd={workspace?.rootPath}
+        />
+      ) : null}
+    </section>
   );
 }
 

--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Dialog, ScrollArea, cn } from '@kay-am/ui';
+import { parseUnifiedDiff } from '@kay-am/core';
+import type { FileDiff, FileDiffStatus } from '@kay-am/types';
+import { ghPrDiff } from '../github';
+
+interface DiffViewerDialogProps {
+  open: boolean;
+  onClose: () => void;
+  repoSlug: string;
+  prNumber: number;
+  cwd?: string;
+}
+
+const STATUS_GLYPH: Record<FileDiffStatus, string> = {
+  added: 'A',
+  modified: 'M',
+  deleted: 'D',
+  renamed: 'R',
+};
+
+const STATUS_COLOR: Record<FileDiffStatus, string> = {
+  added: 'text-success',
+  modified: 'text-info',
+  deleted: 'text-danger',
+  renamed: 'text-warning',
+};
+
+function truncatePathLeft(path: string, maxLen = 40): string {
+  if (path.length <= maxLen) return path;
+  return `…${path.slice(path.length - maxLen + 1)}`;
+}
+
+export function DiffViewerDialog({
+  open,
+  onClose,
+  repoSlug,
+  prNumber,
+  cwd,
+}: DiffViewerDialogProps) {
+  const [files, setFiles] = useState<ReadonlyArray<FileDiff>>([]);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    setSelectedIdx(0);
+    ghPrDiff(repoSlug, prNumber, cwd)
+      .then((raw) => {
+        setFiles(parseUnifiedDiff(raw));
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      });
+  }, [open, repoSlug, prNumber, cwd]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const tag = (e.target as HTMLElement).tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (e.key === 'j') {
+        setSelectedIdx((i) => Math.min(i + 1, files.length - 1));
+      } else if (e.key === 'k') {
+        setSelectedIdx((i) => Math.max(i - 1, 0));
+      }
+    },
+    [files.length, onClose],
+  );
+
+  const selected = files[selectedIdx];
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={`pr #${prNumber} diff`}
+      size="xl"
+      fixedHeightClass="h-[80vh] max-w-6xl"
+      className="w-[80vw] max-w-6xl"
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- dialog handles keyboard nav */}
+      <div className="flex h-full min-h-0 flex-1 gap-0 overflow-hidden" onKeyDown={handleKeyDown}>
+        {loading ? (
+          <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
+            <Loader2 size={14} className="animate-spin" aria-hidden />
+            loading diff…
+          </div>
+        ) : error ? (
+          <div className="flex flex-1 items-center justify-center text-xs text-danger">{error}</div>
+        ) : files.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+            no diff available
+          </div>
+        ) : (
+          <>
+            <FileRail files={files} selectedIdx={selectedIdx} onSelect={setSelectedIdx} />
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden border-l border-border-soft">
+              {selected ? <FileDiffPane file={selected} /> : null}
+            </div>
+          </>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
+function FileRail({
+  files,
+  selectedIdx,
+  onSelect,
+}: {
+  files: ReadonlyArray<FileDiff>;
+  selectedIdx: number;
+  onSelect: (i: number) => void;
+}) {
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIdx]);
+
+  return (
+    <ScrollArea className="w-[30%] shrink-0 overflow-y-auto border-r border-border-soft">
+      <ul className="flex flex-col py-1">
+        {files.map((f, i) => (
+          <li key={f.path}>
+            <button
+              ref={i === selectedIdx ? selectedRef : null}
+              type="button"
+              onClick={() => onSelect(i)}
+              className={cn(
+                'flex w-full items-center gap-2 px-3 py-1.5 text-left font-mono text-xs transition-colors',
+                i === selectedIdx
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+              )}
+            >
+              <span className={cn('shrink-0 font-bold', STATUS_COLOR[f.status])}>
+                {STATUS_GLYPH[f.status]}
+              </span>
+              <span className="min-w-0 flex-1 truncate" title={f.path}>
+                {truncatePathLeft(f.path)}
+              </span>
+              <span className="shrink-0 text-[10px]">
+                {f.additions > 0 ? <span className="text-success">+{f.additions}</span> : null}
+                {f.additions > 0 && f.deletions > 0 ? (
+                  <span className="text-muted-foreground">/</span>
+                ) : null}
+                {f.deletions > 0 ? <span className="text-danger">-{f.deletions}</span> : null}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </ScrollArea>
+  );
+}
+
+function FileDiffPane({ file }: { file: FileDiff }) {
+  return (
+    <ScrollArea className="flex-1 overflow-auto">
+      <div className="p-3">
+        {file.binary ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">binary file, no diff</p>
+        ) : file.hunks.length === 0 ? (
+          <p className="py-4 text-center text-xs text-muted-foreground">no changes</p>
+        ) : (
+          <table className="w-full border-collapse font-mono text-xs leading-5">
+            <tbody>
+              {file.hunks.map((hunk, hi) => (
+                <>
+                  <tr key={`hunk-${hi}-header`}>
+                    <td
+                      colSpan={3}
+                      className="bg-muted/40 px-2 py-0.5 text-[10px] text-muted-foreground"
+                    >
+                      {hunk.header}
+                    </td>
+                  </tr>
+                  {hunk.lines.map((line, li) => (
+                    <tr
+                      key={`hunk-${hi}-line-${li}`}
+                      className={cn(
+                        line.kind === 'add' && 'bg-success/10',
+                        line.kind === 'del' && 'bg-danger/10',
+                      )}
+                    >
+                      <td className="w-8 select-none px-1.5 text-right text-[10px] text-muted-foreground/60">
+                        {line.oldLine ?? ''}
+                      </td>
+                      <td className="w-8 select-none px-1.5 text-right text-[10px] text-muted-foreground/60">
+                        {line.newLine ?? ''}
+                      </td>
+                      <td
+                        className={cn(
+                          'whitespace-pre px-2',
+                          line.kind === 'add' && 'text-success',
+                          line.kind === 'del' && 'text-danger',
+                        )}
+                      >
+                        {line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' '}
+                        {line.text}
+                      </td>
+                    </tr>
+                  ))}
+                </>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/desktop/src/components/GithubPanel.tsx
+++ b/apps/desktop/src/components/GithubPanel.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react';
+import { GitFork as GithubIcon, Check, AlertCircle, Loader2 } from 'lucide-react';
+import { Button, Input, cn } from '@kay-am/ui';
+import { useAppStore } from '../store';
+
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+export function GithubPanel() {
+  const status = useAppStore((s) => s.githubStatus);
+  const refreshStatus = useAppStore((s) => s.refreshGithubStatus);
+  const setPat = useAppStore((s) => s.setGithubPat);
+  const clearToken = useAppStore((s) => s.clearGithubToken);
+
+  const [token, setToken] = useState('');
+  const [save, setSave] = useState<SaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!status) void refreshStatus();
+  }, [status, refreshStatus]);
+
+  const onConnect = async () => {
+    if (!token.trim()) return;
+    setSave('saving');
+    setError(null);
+    try {
+      await setPat(token.trim());
+      setToken('');
+      setSave('saved');
+    } catch (err) {
+      setSave('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onDisconnect = async () => {
+    setSave('saving');
+    setError(null);
+    try {
+      await clearToken();
+      setSave('saved');
+    } catch (err) {
+      setSave('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center gap-2">
+        <GithubIcon size={16} aria-hidden className="text-muted-foreground" />
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-foreground">GitHub</h2>
+      </div>
+
+      {status === null ? (
+        <p className="text-xs text-muted-foreground">checking gh status…</p>
+      ) : !status.available ? (
+        <NotInstalled />
+      ) : status.mode === 'absent' ? (
+        <Absent token={token} setToken={setToken} onConnect={onConnect} save={save} error={error} />
+      ) : (
+        <Connected status={status} onDisconnect={onDisconnect} save={save} />
+      )}
+    </div>
+  );
+}
+
+function NotInstalled() {
+  return (
+    <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs text-warning">
+      <div className="flex items-start gap-2">
+        <AlertCircle size={14} aria-hidden className="mt-0.5" />
+        <div className="flex flex-col gap-1">
+          <span className="font-medium">gh CLI not detected</span>
+          <span className="text-warning/80">
+            install from{' '}
+            <a
+              href="https://cli.github.com/"
+              target="_blank"
+              rel="noreferrer"
+              className="underline"
+            >
+              cli.github.com
+            </a>{' '}
+            so kAY.am can resolve PR state.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Absent({
+  token,
+  setToken,
+  onConnect,
+  save,
+  error,
+}: {
+  token: string;
+  setToken: (v: string) => void;
+  onConnect: () => void;
+  save: SaveState;
+  error: string | null;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        connect with a personal access token (classic or fine-grained, scope:{' '}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">repo</code>) — or run{' '}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">gh auth login</code> in
+        a terminal and reload kAY.am.
+      </p>
+      <div className="flex items-center gap-2">
+        <Input
+          type="password"
+          placeholder="ghp_…"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          className="flex-1 font-mono text-xs"
+          aria-label="GitHub personal access token"
+        />
+        <Button
+          size="sm"
+          onClick={onConnect}
+          disabled={save === 'saving' || token.trim().length === 0}
+        >
+          {save === 'saving' ? (
+            <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
+          ) : null}
+          connect
+        </Button>
+      </div>
+      {error ? (
+        <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+          {error}
+        </p>
+      ) : null}
+      <p className="text-[10px] text-muted-foreground">
+        token is stored in your OS keychain via the system credential store. it never leaves your
+        machine.
+      </p>
+    </div>
+  );
+}
+
+function Connected({
+  status,
+  onDisconnect,
+  save,
+}: {
+  status: { user?: string; mode: string; version?: string; scopes?: ReadonlyArray<string> };
+  onDisconnect: () => void;
+  save: SaveState;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success">
+        <div className="flex items-start gap-2">
+          <Check size={14} aria-hidden className="mt-0.5" />
+          <div className="flex flex-col gap-0.5">
+            <span className="font-medium">connected as {status.user ?? '(unknown user)'}</span>
+            <span className="text-success/80">
+              mode: {status.mode}
+              {status.version ? ` · gh ${status.version}` : ''}
+            </span>
+            {status.scopes && status.scopes.length > 0 ? (
+              <span className="text-success/80">scopes: {status.scopes.join(', ')}</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center justify-end">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onDisconnect}
+          disabled={save === 'saving'}
+          className={cn(save === 'saving' && 'opacity-60')}
+        >
+          disconnect
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react';
-import { Bot, Cpu, DollarSign, FileDown, FolderCode, Lock, Trash2 } from 'lucide-react';
+import { Bot, Cpu, DollarSign, FileDown, FolderCode, GitFork, Lock, Trash2 } from 'lucide-react';
 import { Button, Dialog, Input } from '@kay-am/ui';
 import { ProvidersPanel } from './ProvidersPanel';
 import { BudgetRulesPanel } from './BudgetRulesPanel';
 import { PermissionsPanel } from './PermissionsPanel';
+import { GithubPanel } from './GithubPanel';
 import { ImportConfigDialog } from './ImportConfigDialog';
 import type { ConfigBundleImportResult } from '@kay-am/types';
 import {
@@ -32,6 +33,7 @@ type NavSection =
   | 'budget'
   | 'agent'
   | 'permissions'
+  | 'github'
   | 'initialization'
   | 'advanced';
 
@@ -50,6 +52,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden />, beta: true },
   { id: 'agent', label: 'Agent', icon: <Bot size={14} aria-hidden />, beta: true },
   { id: 'permissions', label: 'Permissions', icon: <Lock size={14} aria-hidden />, beta: true },
+  { id: 'github', label: 'GitHub', icon: <GitFork size={14} aria-hidden /> },
   { id: 'initialization', label: 'Initialization', icon: <Trash2 size={14} aria-hidden /> },
   { id: 'advanced', label: 'Advanced', icon: <FileDown size={14} aria-hidden /> },
 ];
@@ -61,6 +64,7 @@ function isNavSection(value: string | undefined): value is NavSection {
     value === 'budget' ||
     value === 'agent' ||
     value === 'permissions' ||
+    value === 'github' ||
     value === 'initialization' ||
     value === 'advanced'
   );
@@ -241,6 +245,8 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
         );
       case 'permissions':
         return <PermissionsPanel />;
+      case 'github':
+        return <GithubPanel />;
       case 'initialization':
         return (
           <div className="flex flex-col gap-4">

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -7,6 +7,10 @@ import {
   ChevronRight,
   FolderOpen,
   FolderPlus,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestArrow,
+  GitPullRequestDraft,
   HelpCircle,
   Plus,
   Settings,
@@ -22,6 +26,7 @@ import { AlertCenter } from './AlertCenter';
 import { TelemetryPill } from './TelemetryPill';
 import type {
   ProviderId,
+  PullRequestStateKind,
   Session,
   SessionId,
   SessionStatus,
@@ -45,6 +50,7 @@ import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
 import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
 import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY } from '@kay-am/core';
+import { openUrl } from '../editor';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
@@ -74,6 +80,8 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const currentSession = useCurrentSession();
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const sessionBranches = useAppStore((s) => s.sessionBranches);
+  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
 
   const sidebarStateFilter = useAppStore((s) => s.sidebarStateFilter);
   const sidebarProviderFilter = useAppStore((s) => s.sidebarProviderFilter);
@@ -81,6 +89,17 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const setSidebarProviderFilter = useAppStore((s) => s.setSidebarProviderFilter);
 
   const [sessionSort, setSessionSort] = useState<SessionSort>('updated');
+
+  const warmedRef = useRef(false);
+  useEffect(() => {
+    if (warmedRef.current || sessions.length === 0) return;
+    warmedRef.current = true;
+    for (const s of sessions) {
+      if (sessionBranches[s.id]) {
+        void refreshSessionPr(s.id as TaskId);
+      }
+    }
+  }, [sessions, sessionBranches, refreshSessionPr]);
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
@@ -588,6 +607,66 @@ function FilterChip({ label, onRemove }: FilterChipProps) {
   );
 }
 
+const PR_ICON_MAP: Record<
+  Exclude<PullRequestStateKind, 'closed'>,
+  { icon: React.ElementType; label: string; className: string }
+> = {
+  draft: {
+    icon: GitPullRequestDraft,
+    label: 'draft',
+    className: 'text-muted-foreground',
+  },
+  open: {
+    icon: GitPullRequest,
+    label: 'open',
+    className: 'text-muted-foreground',
+  },
+  approved: {
+    icon: GitPullRequestArrow,
+    label: 'approved',
+    className: 'text-success',
+  },
+  merged: {
+    icon: GitMerge,
+    label: 'merged',
+    className: 'text-muted-foreground',
+  },
+};
+
+interface PrStatusIconProps {
+  taskId: TaskId;
+}
+
+function PrStatusIcon({ taskId }: PrStatusIconProps) {
+  const github = useAppStore((s) => s.sessionGithub[taskId]);
+  const branch = useAppStore((s) => s.sessionBranches[taskId]);
+
+  if (!branch || !github?.pr || github.pr.state === 'closed') return null;
+
+  const { pr } = github;
+  const entry = PR_ICON_MAP[pr.state as Exclude<PullRequestStateKind, 'closed'>];
+  if (!entry) return null;
+
+  const Icon = entry.icon;
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    void openUrl(pr.url);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={`PR #${pr.number} — ${entry.label}`}
+      aria-label={`PR #${pr.number} — ${entry.label}`}
+      className={cn('shrink-0 rounded p-0.5 transition-colors hover:bg-muted', entry.className)}
+    >
+      <Icon size={12} aria-hidden />
+    </button>
+  );
+}
+
 interface SessionRowProps {
   session: Task;
   isActive: boolean;
@@ -728,6 +807,7 @@ function SessionRow({
             <span className="line-clamp-1 flex-1">{session.goal}</span>
           )}
           <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
+            <PrStatusIcon taskId={session.id as TaskId} />
             <StatusBadge state={session.state} />
             <button
               type="button"

--- a/apps/desktop/src/github.ts
+++ b/apps/desktop/src/github.ts
@@ -1,0 +1,82 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { GhRunner, GhResult, GhRunOptions, PrCacheStore } from '@kay-am/core';
+import type { GhTokenStatus, GithubPrCacheEntry } from '@kay-am/types';
+import {
+  getGithubPrCache,
+  upsertGithubPrCache,
+  deleteGithubPrCache,
+  type Database,
+} from '@kay-am/db';
+
+interface RawGhRunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+interface RawGhStatus {
+  available: boolean;
+  mode: 'absent' | 'gh-cli' | 'pat';
+  version: string | null;
+  user: string | null;
+  scopes: ReadonlyArray<string>;
+}
+
+export async function ghStatus(): Promise<GhTokenStatus> {
+  const raw = await invoke<RawGhStatus>('gh_status');
+  return {
+    available: raw.available,
+    mode: raw.mode,
+    version: raw.version ?? undefined,
+    user: raw.user ?? undefined,
+    scopes: raw.scopes,
+  };
+}
+
+export async function ghSetToken(token: string): Promise<GhTokenStatus> {
+  const raw = await invoke<RawGhStatus>('gh_set_token', { token });
+  return {
+    available: raw.available,
+    mode: raw.mode,
+    version: raw.version ?? undefined,
+    user: raw.user ?? undefined,
+    scopes: raw.scopes,
+  };
+}
+
+export async function ghClearToken(): Promise<void> {
+  await invoke('gh_clear_token');
+}
+
+export async function ghPrDiff(repo: string, pr: number, cwd?: string): Promise<string> {
+  return invoke<string>('gh_pr_diff', { repo, pr, cwd });
+}
+
+export const tauriGhRunner: GhRunner = {
+  async run(args: ReadonlyArray<string>, opts: GhRunOptions = {}): Promise<GhResult> {
+    const raw = await invoke<RawGhRunResult>('gh_run', {
+      args: [...args],
+      cwd: opts.cwd,
+    });
+    return {
+      stdout: raw.stdout,
+      stderr: raw.stderr,
+      exitCode: raw.exitCode,
+    };
+  },
+};
+
+export function createTauriPrCacheStore(db: Database): PrCacheStore {
+  return {
+    async get(repoSlug, branch) {
+      const entry = await getGithubPrCache(db, repoSlug, branch);
+      return entry as GithubPrCacheEntry | null;
+    },
+    async upsert(entry) {
+      await upsertGithubPrCache(db, entry);
+    },
+    async invalidate(repoSlug, branch) {
+      await deleteGithubPrCache(db, repoSlug, branch);
+    },
+  };
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -90,11 +90,28 @@ import type {
   TurnProviderOverride,
   Workspace,
   WorkspaceId,
+  GhTokenStatus,
+  PullRequestState,
+  LinkedIssue,
 } from '@kay-am/types';
 import { DEFAULT_TASK_PROVIDER_PREFERENCE } from '@kay-am/types';
-import { computeCostUsd, computeCodexCostUsd, computeCursorCostUsd } from '@kay-am/core';
+import {
+  computeCostUsd,
+  computeCodexCostUsd,
+  computeCursorCostUsd,
+  getPrForBranch,
+  fetchLinkedIssues,
+  detectRepoSlug,
+} from '@kay-am/core';
 import { invokeSessionBudgetGet, invokeSessionBudgetSet } from '../budget';
 import { runDbMigrations, tauriDatabase, wipeDb } from '../db';
+import {
+  ghStatus,
+  ghSetToken,
+  ghClearToken,
+  tauriGhRunner,
+  createTauriPrCacheStore,
+} from '../github';
 import {
   buildProviderList,
   checkProviderAuth,
@@ -257,6 +274,16 @@ export interface AppState {
   readonly sidebarSessionSearch: string;
   readonly sidebarStateFilter: ReadonlyArray<TurnState['kind']>;
   readonly sidebarProviderFilter: ReadonlyArray<ProviderId>;
+  readonly githubStatus: GhTokenStatus | null;
+  readonly sessionGithub: Readonly<Record<TaskId, SessionGithubState>>;
+}
+
+export interface SessionGithubState {
+  readonly pr: PullRequestState | null;
+  readonly linkedIssues: ReadonlyArray<LinkedIssue>;
+  readonly fetchedAt: IsoDateTime | null;
+  readonly loading: boolean;
+  readonly error: string | null;
 }
 
 export interface SummarizerSessionStatus {
@@ -353,6 +380,11 @@ export interface AppActions {
   setSidebarProviderFilter(providers: ReadonlyArray<ProviderId>): void;
   exportConfig(): Promise<string | null>;
   importConfig(): Promise<import('@kay-am/types').ConfigBundleImportResult | null>;
+  refreshGithubStatus(): Promise<void>;
+  setGithubPat(token: string): Promise<GhTokenStatus>;
+  clearGithubToken(): Promise<void>;
+  refreshSessionPr(taskId: TaskId, opts?: { force?: boolean }): Promise<void>;
+  createPrForSession(taskId: TaskId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -401,6 +433,8 @@ const initialState: AppState = {
   sidebarSessionSearch: '',
   sidebarStateFilter: [],
   sidebarProviderFilter: [],
+  githubStatus: null,
+  sessionGithub: {},
 };
 
 function buildProviderSpendBreakdown(
@@ -724,6 +758,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
       // Drain audit retry queue after boot — non-blocking, best-effort.
       void drainAuditRetryQueue(set);
+
+      void get().refreshGithubStatus();
     } catch (err) {
       set({
         bootPhase: 'error',
@@ -2525,6 +2561,122 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   importConfig: async () => {
     return importConfigFromFile();
+  },
+
+  refreshGithubStatus: async () => {
+    try {
+      const status = await ghStatus();
+      set({ githubStatus: status });
+    } catch (err) {
+      set({
+        githubStatus: {
+          available: false,
+          mode: 'absent',
+          version: undefined,
+          user: undefined,
+          scopes: [],
+        },
+      });
+      console.warn('gh_status failed', err);
+    }
+  },
+
+  setGithubPat: async (token) => {
+    const status = await ghSetToken(token);
+    set({ githubStatus: status });
+    return status;
+  },
+
+  clearGithubToken: async () => {
+    await ghClearToken();
+    await get().refreshGithubStatus();
+  },
+
+  refreshSessionPr: async (taskId, opts) => {
+    const branch = get().sessionBranches[taskId];
+    if (!branch) return;
+    const session = get().sessions.find((s) => s.id === taskId);
+    if (!session) return;
+    const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    if (!workspace) return;
+    set((state) => ({
+      sessionGithub: {
+        ...state.sessionGithub,
+        [taskId]: {
+          pr: state.sessionGithub[taskId]?.pr ?? null,
+          linkedIssues: state.sessionGithub[taskId]?.linkedIssues ?? [],
+          fetchedAt: state.sessionGithub[taskId]?.fetchedAt ?? null,
+          loading: true,
+          error: null,
+        },
+      },
+    }));
+    try {
+      const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath);
+      if (!slug) {
+        set((state) => ({
+          sessionGithub: {
+            ...state.sessionGithub,
+            [taskId]: {
+              pr: null,
+              linkedIssues: [],
+              fetchedAt: new Date().toISOString() as IsoDateTime,
+              loading: false,
+              error: null,
+            },
+          },
+        }));
+        return;
+      }
+      const store = createTauriPrCacheStore(tauriDatabase);
+      const pr = await getPrForBranch(
+        { runner: tauriGhRunner, store },
+        { repoSlug: slug, branch, cwd: workspace.rootPath, force: opts?.force === true },
+      );
+      const linked = pr
+        ? await fetchLinkedIssues(tauriGhRunner, slug, pr, { cwd: workspace.rootPath })
+        : [];
+      set((state) => ({
+        sessionGithub: {
+          ...state.sessionGithub,
+          [taskId]: {
+            pr,
+            linkedIssues: linked,
+            fetchedAt: new Date().toISOString() as IsoDateTime,
+            loading: false,
+            error: null,
+          },
+        },
+      }));
+    } catch (err) {
+      set((state) => ({
+        sessionGithub: {
+          ...state.sessionGithub,
+          [taskId]: {
+            pr: state.sessionGithub[taskId]?.pr ?? null,
+            linkedIssues: state.sessionGithub[taskId]?.linkedIssues ?? [],
+            fetchedAt: state.sessionGithub[taskId]?.fetchedAt ?? null,
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          },
+        },
+      }));
+    }
+  },
+
+  createPrForSession: async (taskId) => {
+    const branch = get().sessionBranches[taskId];
+    const session = get().sessions.find((s) => s.id === taskId);
+    if (!branch || !session) return;
+    const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    if (!workspace) return;
+    const res = await tauriGhRunner.run(['pr', 'create', '--fill', '--draft'], {
+      cwd: workspace.rootPath,
+    });
+    if (res.exitCode !== 0) {
+      throw new Error(res.stderr.trim() || `gh pr create exited with ${res.exitCode}`);
+    }
+    await get().refreshSessionPr(taskId, { force: true });
   },
 }));
 

--- a/packages/core/src/github/__tests__/cache.test.ts
+++ b/packages/core/src/github/__tests__/cache.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GithubPrCacheEntry, PullRequestState } from '@kay-am/types';
+import type { GhRunner } from '../gh';
+import {
+  DEFAULT_PR_CACHE_TTL_MS,
+  type GetPrInput,
+  type PrCacheDeps,
+  type PrCacheStore,
+  getPrForBranch,
+  invalidatePrCache,
+} from '../cache';
+
+const SAMPLE_PR: PullRequestState = {
+  number: 1,
+  title: 'Test PR',
+  url: 'https://github.com/org/repo/pull/1',
+  state: 'open',
+  mergeable: true,
+  checks: null,
+  baseBranch: 'main',
+  headBranch: 'feature',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+function makeStore(initial: GithubPrCacheEntry | null = null): PrCacheStore & {
+  rows: Map<string, GithubPrCacheEntry>;
+} {
+  const rows = new Map<string, GithubPrCacheEntry>();
+  if (initial) rows.set(`${initial.repoSlug}/${initial.branch}`, initial);
+
+  return {
+    rows,
+    get: vi.fn(async (repoSlug: string, branch: string) => {
+      return rows.get(`${repoSlug}/${branch}`) ?? null;
+    }),
+    upsert: vi.fn(async (entry: GithubPrCacheEntry) => {
+      rows.set(`${entry.repoSlug}/${entry.branch}`, entry);
+    }),
+    invalidate: vi.fn(async (repoSlug: string, branch: string) => {
+      rows.delete(`${repoSlug}/${branch}`);
+    }),
+  };
+}
+
+function makeRunner(pr: PullRequestState | null): GhRunner {
+  const payload = pr
+    ? [
+        {
+          number: pr.number,
+          title: pr.title,
+          url: pr.url,
+          state: 'OPEN',
+          isDraft: pr.isDraft,
+          mergeable: 'MERGEABLE',
+          baseRefName: pr.baseBranch,
+          headRefName: pr.headBranch,
+          reviewDecision: null,
+          statusCheckRollup: null,
+          updatedAt: pr.updatedAt,
+          body: pr.body,
+        },
+      ]
+    : [];
+  return {
+    run: vi.fn().mockResolvedValue({
+      stdout: JSON.stringify(payload),
+      stderr: '',
+      exitCode: 0,
+    }),
+  };
+}
+
+const BASE_INPUT: GetPrInput = {
+  repoSlug: 'org/repo',
+  branch: 'feature',
+};
+
+const NOW = new Date('2024-06-01T12:00:00Z');
+
+describe('getPrForBranch', () => {
+  it('returns cached PR without calling runner when cache is fresh', async () => {
+    const freshAt = new Date(NOW.getTime() - 1000).toISOString();
+    const store = makeStore({
+      repoSlug: 'org/repo',
+      branch: 'feature',
+      pr: SAMPLE_PR,
+      fetchedAt: freshAt,
+    });
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    const result = await getPrForBranch(deps, BASE_INPUT);
+    expect(result).toEqual(SAMPLE_PR);
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+
+  it('calls runner and upserts when cache is stale', async () => {
+    const staleAt = new Date(NOW.getTime() - DEFAULT_PR_CACHE_TTL_MS - 1).toISOString();
+    const store = makeStore({
+      repoSlug: 'org/repo',
+      branch: 'feature',
+      pr: SAMPLE_PR,
+      fetchedAt: staleAt,
+    });
+    const freshPr = { ...SAMPLE_PR, title: 'Updated PR' };
+    const runner = makeRunner(freshPr);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    const result = await getPrForBranch(deps, BASE_INPUT);
+    expect(runner.run).toHaveBeenCalledOnce();
+    expect(store.upsert).toHaveBeenCalledOnce();
+    expect(result?.title).toBe('Updated PR');
+  });
+
+  it('calls runner when no cache entry exists', async () => {
+    const store = makeStore(null);
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    const result = await getPrForBranch(deps, BASE_INPUT);
+    expect(runner.run).toHaveBeenCalledOnce();
+    expect(result).not.toBeNull();
+  });
+
+  it('calls runner when force:true even if cache is fresh', async () => {
+    const freshAt = new Date(NOW.getTime() - 100).toISOString();
+    const store = makeStore({
+      repoSlug: 'org/repo',
+      branch: 'feature',
+      pr: SAMPLE_PR,
+      fetchedAt: freshAt,
+    });
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    await getPrForBranch(deps, { ...BASE_INPUT, force: true });
+    expect(runner.run).toHaveBeenCalledOnce();
+  });
+
+  it('upserts null and returns null when runner returns no PR', async () => {
+    const store = makeStore(null);
+    const runner = makeRunner(null);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    const result = await getPrForBranch(deps, BASE_INPUT);
+    expect(result).toBeNull();
+    expect(store.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({ pr: null, repoSlug: 'org/repo', branch: 'feature' }),
+    );
+  });
+
+  it('cached null is returned without runner call when fresh', async () => {
+    const freshAt = new Date(NOW.getTime() - 500).toISOString();
+    const store = makeStore({
+      repoSlug: 'org/repo',
+      branch: 'feature',
+      pr: null,
+      fetchedAt: freshAt,
+    });
+    const runner = makeRunner(SAMPLE_PR);
+    const deps: PrCacheDeps = { runner, store, now: () => NOW };
+
+    const result = await getPrForBranch(deps, BASE_INPUT);
+    expect(result).toBeNull();
+    expect(runner.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('invalidatePrCache', () => {
+  it('clears the cached row', async () => {
+    const store = makeStore({
+      repoSlug: 'org/repo',
+      branch: 'feature',
+      pr: SAMPLE_PR,
+      fetchedAt: NOW.toISOString(),
+    });
+
+    await invalidatePrCache({ store }, 'org/repo', 'feature');
+    expect(store.invalidate).toHaveBeenCalledWith('org/repo', 'feature');
+    expect(store.rows.get('org/repo/feature')).toBeUndefined();
+  });
+});
+
+describe('DEFAULT_PR_CACHE_TTL_MS', () => {
+  it('is 60 seconds', () => {
+    expect(DEFAULT_PR_CACHE_TTL_MS).toBe(60_000);
+  });
+});

--- a/packages/core/src/github/__tests__/diff.test.ts
+++ b/packages/core/src/github/__tests__/diff.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { parseUnifiedDiff } from '../diff';
+
+describe('parseUnifiedDiff', () => {
+  it('returns empty array for empty input', () => {
+    expect(parseUnifiedDiff('')).toEqual([]);
+  });
+
+  it('parses a simple modified file with one hunk', () => {
+    const diff = [
+      'diff --git a/src/foo.ts b/src/foo.ts',
+      'index abc..def 100644',
+      '--- a/src/foo.ts',
+      '+++ b/src/foo.ts',
+      '@@ -1,3 +1,4 @@',
+      ' const x = 1;',
+      '-const y = 2;',
+      '+const y = 3;',
+      '+const z = 4;',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files).toHaveLength(1);
+    const file = files[0];
+    expect(file?.path).toBe('src/foo.ts');
+    expect(file?.status).toBe('modified');
+    expect(file?.additions).toBe(2);
+    expect(file?.deletions).toBe(1);
+    expect(file?.binary).toBe(false);
+
+    const hunk = file?.hunks[0];
+    expect(hunk?.header).toBe('@@ -1,3 +1,4 @@');
+    expect(hunk?.oldStart).toBe(1);
+    expect(hunk?.oldLines).toBe(3);
+    expect(hunk?.newStart).toBe(1);
+    expect(hunk?.newLines).toBe(4);
+
+    const lines = hunk?.lines;
+    expect(lines).toHaveLength(4);
+    expect(lines?.[0]).toMatchObject({
+      kind: 'context',
+      oldLine: 1,
+      newLine: 1,
+      text: 'const x = 1;',
+    });
+    expect(lines?.[1]).toMatchObject({
+      kind: 'del',
+      oldLine: 2,
+      newLine: null,
+      text: 'const y = 2;',
+    });
+    expect(lines?.[2]).toMatchObject({
+      kind: 'add',
+      oldLine: null,
+      newLine: 2,
+      text: 'const y = 3;',
+    });
+    expect(lines?.[3]).toMatchObject({
+      kind: 'add',
+      oldLine: null,
+      newLine: 3,
+      text: 'const z = 4;',
+    });
+  });
+
+  it('recognises new file mode → status added', () => {
+    const diff = [
+      'diff --git a/new.ts b/new.ts',
+      'new file mode 100644',
+      'index 0000000..abc1234',
+      '--- /dev/null',
+      '+++ b/new.ts',
+      '@@ -0,0 +1 @@',
+      '+export const x = 1;',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.status).toBe('added');
+  });
+
+  it('recognises deleted file mode → status deleted', () => {
+    const diff = [
+      'diff --git a/old.ts b/old.ts',
+      'deleted file mode 100644',
+      'index abc1234..0000000',
+      '--- a/old.ts',
+      '+++ /dev/null',
+      '@@ -1 +0,0 @@',
+      '-export const x = 1;',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.status).toBe('deleted');
+  });
+
+  it('recognises rename → status renamed with oldPath', () => {
+    const diff = [
+      'diff --git a/old-name.ts b/new-name.ts',
+      'similarity index 95%',
+      'rename from old-name.ts',
+      'rename to new-name.ts',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.status).toBe('renamed');
+    expect(files[0]?.oldPath).toBe('old-name.ts');
+    expect(files[0]?.path).toBe('new-name.ts');
+  });
+
+  it('sets binary:true for binary files', () => {
+    const diff = [
+      'diff --git a/image.png b/image.png',
+      'index abc..def 100644',
+      'Binary files a/image.png and b/image.png differ',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.binary).toBe(true);
+  });
+
+  it('handles multiple files in one diff', () => {
+    const diff = [
+      'diff --git a/a.ts b/a.ts',
+      '--- a/a.ts',
+      '+++ b/a.ts',
+      '@@ -1 +1 @@',
+      '-old a',
+      '+new a',
+      'diff --git a/b.ts b/b.ts',
+      '--- a/b.ts',
+      '+++ b/b.ts',
+      '@@ -1 +1 @@',
+      '-old b',
+      '+new b',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files).toHaveLength(2);
+    expect(files[0]?.path).toBe('a.ts');
+    expect(files[1]?.path).toBe('b.ts');
+  });
+
+  it('tracks oldLine and newLine cursors through context/add/del lines', () => {
+    const diff = [
+      'diff --git a/x.ts b/x.ts',
+      '--- a/x.ts',
+      '+++ b/x.ts',
+      '@@ -5,4 +5,4 @@',
+      ' line5',
+      '-line6',
+      '+line6-new',
+      ' line7',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    const lines = files[0]?.hunks[0]?.lines;
+    expect(lines?.[0]).toMatchObject({ kind: 'context', oldLine: 5, newLine: 5 });
+    expect(lines?.[1]).toMatchObject({ kind: 'del', oldLine: 6, newLine: null });
+    expect(lines?.[2]).toMatchObject({ kind: 'add', oldLine: null, newLine: 6 });
+    expect(lines?.[3]).toMatchObject({ kind: 'context', oldLine: 7, newLine: 7 });
+  });
+
+  it('path without oldPath when old and new paths match (modified)', () => {
+    const diff = [
+      'diff --git a/same.ts b/same.ts',
+      '--- a/same.ts',
+      '+++ b/same.ts',
+      '@@ -1 +1 @@',
+      '-old',
+      '+new',
+    ].join('\n');
+
+    const files = parseUnifiedDiff(diff);
+    expect(files[0]?.path).toBe('same.ts');
+    expect(files[0]?.oldPath).toBeUndefined();
+  });
+});

--- a/packages/core/src/github/__tests__/gh.test.ts
+++ b/packages/core/src/github/__tests__/gh.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GhCliError, GhJsonParseError, type GhRunner, detect, runJson } from '../gh';
+
+function makeRunner(result: { stdout: string; stderr: string; exitCode: number }): GhRunner {
+  return { run: vi.fn().mockResolvedValue(result) };
+}
+
+describe('detect', () => {
+  it('returns available:false when runner throws', async () => {
+    const runner: GhRunner = { run: vi.fn().mockRejectedValue(new Error('spawn failed')) };
+    const result = await detect(runner);
+    expect(result).toEqual({ available: false });
+  });
+
+  it('returns available:false when exitCode is non-zero', async () => {
+    const runner = makeRunner({ stdout: '', stderr: 'not found', exitCode: 127 });
+    const result = await detect(runner);
+    expect(result).toEqual({ available: false });
+  });
+
+  it('parses version from gh version output', async () => {
+    const runner = makeRunner({
+      stdout: 'gh version 2.40.1 (2024-01-01)\nhttps://github.com/cli/cli/releases/tag/v2.40.1\n',
+      stderr: '',
+      exitCode: 0,
+    });
+    const result = await detect(runner);
+    expect(result).toEqual({ available: true, version: '2.40.1' });
+  });
+
+  it('returns available:true with no version when output is unexpected', async () => {
+    const runner = makeRunner({ stdout: 'something unexpected', stderr: '', exitCode: 0 });
+    const result = await detect(runner);
+    expect(result).toEqual({ available: true, version: undefined });
+  });
+});
+
+describe('runJson', () => {
+  it('throws GhCliError with preserved stderr and exitCode on non-zero exit', async () => {
+    const runner = makeRunner({ stdout: '', stderr: 'permission denied', exitCode: 1 });
+    await expect(runJson(runner, ['pr', 'list'])).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof GhCliError)) return false;
+      return err.exitCode === 1 && err.stderr === 'permission denied';
+    });
+  });
+
+  it('throws GhCliError (not GhJsonParseError) on non-zero exit even with json-like stdout', async () => {
+    const runner = makeRunner({ stdout: '{"foo":1}', stderr: 'err', exitCode: 2 });
+    await expect(runJson(runner, ['pr', 'list'])).rejects.toBeInstanceOf(GhCliError);
+  });
+
+  it('throws GhJsonParseError carrying raw stdout when output is invalid JSON', async () => {
+    const runner = makeRunner({ stdout: 'not-json', stderr: '', exitCode: 0 });
+    await expect(runJson(runner, ['pr', 'list'])).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof GhJsonParseError)) return false;
+      return err.raw === 'not-json';
+    });
+  });
+
+  it('returns parsed object on happy path', async () => {
+    const payload = [{ number: 42, title: 'My PR' }];
+    const runner = makeRunner({ stdout: JSON.stringify(payload), stderr: '', exitCode: 0 });
+    const result = await runJson<typeof payload>(runner, ['pr', 'list']);
+    expect(result).toEqual(payload);
+  });
+});

--- a/packages/core/src/github/__tests__/linked-issues.test.ts
+++ b/packages/core/src/github/__tests__/linked-issues.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { GhCliError } from '../gh';
+import { fetchLinkedIssues, parseLinkedIssuesFromBody } from '../resolver';
+import type { PullRequestState } from '@kay-am/types';
+
+const REPO_URL = 'https://github.com/org/repo/pull/42';
+const REPO_BASE = 'https://github.com/org/repo';
+
+const BASE_PR: PullRequestState = {
+  number: 42,
+  title: 'My PR',
+  url: REPO_URL,
+  state: 'open',
+  mergeable: true,
+  checks: null,
+  baseBranch: 'main',
+  headBranch: 'feature',
+  isDraft: false,
+  reviewDecision: null,
+  body: '',
+  updatedAt: '2024-01-01T00:00:00Z',
+};
+
+describe('parseLinkedIssuesFromBody', () => {
+  const closing = [
+    'close',
+    'closes',
+    'closed',
+    'fix',
+    'fixes',
+    'fixed',
+    'resolve',
+    'resolves',
+    'resolved',
+  ];
+  const referencing = ['ref', 'refs', 'reference', 'referenced'];
+
+  for (const keyword of closing) {
+    it(`recognises "${keyword}" as closes:true`, () => {
+      const result = parseLinkedIssuesFromBody(`${keyword} #123`, REPO_URL);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ number: 123, closes: true });
+    });
+  }
+
+  for (const keyword of referencing) {
+    it(`recognises "${keyword}" as closes:false`, () => {
+      const result = parseLinkedIssuesFromBody(`${keyword} #456`, REPO_URL);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ number: 456, closes: false });
+    });
+  }
+
+  it('is case-insensitive', () => {
+    const result = parseLinkedIssuesFromBody('CLOSES #10', REPO_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ number: 10, closes: true });
+  });
+
+  it('prefers closes:true when same issue referenced multiple times', () => {
+    const body = 'refs #99\ncloses #99';
+    const result = parseLinkedIssuesFromBody(body, REPO_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ number: 99, closes: true });
+  });
+
+  it('closes:false preserved when only referenced', () => {
+    const body = 'refs #99\nreference #99';
+    const result = parseLinkedIssuesFromBody(body, REPO_URL);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ number: 99, closes: false });
+  });
+
+  it('builds url from repo base stripping /pull/... from PR url', () => {
+    const result = parseLinkedIssuesFromBody('closes #7', REPO_URL);
+    expect(result[0]?.url).toBe(`${REPO_BASE}/issues/7`);
+  });
+
+  it('strips .git suffix from repo base', () => {
+    const result = parseLinkedIssuesFromBody('closes #7', `${REPO_BASE}.git/pull/1`);
+    expect(result[0]?.url).toBe(`${REPO_BASE}/issues/7`);
+  });
+
+  it('returns sorted by issue number', () => {
+    const body = 'closes #30\nfixes #10\nresolves #20';
+    const result = parseLinkedIssuesFromBody(body, REPO_URL);
+    expect(result.map((i) => i.number)).toEqual([10, 20, 30]);
+  });
+
+  it('returns empty array for body with no keywords', () => {
+    const result = parseLinkedIssuesFromBody('nothing to see here', REPO_URL);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('fetchLinkedIssues', () => {
+  it('falls back to body parse when GhCliError thrown', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockResolvedValue({ stdout: '', stderr: 'unauthorized', exitCode: 1 }),
+    };
+    const pr = { ...BASE_PR, body: 'closes #5' };
+    const result = await fetchLinkedIssues(runner, 'org/repo', pr);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ number: 5, closes: true });
+  });
+
+  it('re-throws non-GhCliError from runner', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockRejectedValue(new TypeError('connection reset')),
+    };
+    await expect(fetchLinkedIssues(runner, 'org/repo', BASE_PR)).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it('merges body issues and closingIssuesReferences', async () => {
+    const closingRefs = [{ number: 10, title: 'Bug in auth', url: `${REPO_BASE}/issues/10` }];
+    const runner: GhRunner = {
+      run: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ closingIssuesReferences: closingRefs }),
+        stderr: '',
+        exitCode: 0,
+      }),
+    };
+    const pr = { ...BASE_PR, body: 'closes #10\nrefs #20' };
+    const result = await fetchLinkedIssues(runner, 'org/repo', pr);
+    expect(result).toHaveLength(2);
+    const issue10 = result.find((i) => i.number === 10);
+    expect(issue10?.title).toBe('Bug in auth');
+    expect(issue10?.closes).toBe(true);
+    const issue20 = result.find((i) => i.number === 20);
+    expect(issue20?.closes).toBe(false);
+  });
+
+  it('closing ref title overrides body-parsed entry (no title)', async () => {
+    const closingRefs = [{ number: 3, title: 'Real title', url: `${REPO_BASE}/issues/3` }];
+    const runner: GhRunner = {
+      run: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ closingIssuesReferences: closingRefs }),
+        stderr: '',
+        exitCode: 0,
+      }),
+    };
+    const pr = { ...BASE_PR, body: 'closes #3' };
+    const result = await fetchLinkedIssues(runner, 'org/repo', pr);
+    const issue = result.find((i) => i.number === 3);
+    expect(issue?.title).toBe('Real title');
+  });
+
+  it('handles empty closingIssuesReferences', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockResolvedValue({
+        stdout: JSON.stringify({ closingIssuesReferences: [] }),
+        stderr: '',
+        exitCode: 0,
+      }),
+    };
+    const pr = { ...BASE_PR, body: 'closes #5' };
+    const result = await fetchLinkedIssues(runner, 'org/repo', pr);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.number).toBe(5);
+  });
+});

--- a/packages/core/src/github/__tests__/resolver.test.ts
+++ b/packages/core/src/github/__tests__/resolver.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { GhCliError } from '../gh';
+import { detectRepoSlug, resolvePrForBranch } from '../resolver';
+
+function makeRunner(result: { stdout: string; stderr: string; exitCode: number }): GhRunner {
+  return { run: vi.fn().mockResolvedValue(result) };
+}
+
+function makeJsonRunner(data: unknown): GhRunner {
+  return makeRunner({ stdout: JSON.stringify(data), stderr: '', exitCode: 0 });
+}
+
+const BASE_RAW = {
+  number: 1,
+  title: 'PR title',
+  url: 'https://github.com/org/repo/pull/1',
+  isDraft: false,
+  mergeable: 'MERGEABLE' as const,
+  baseRefName: 'main',
+  headRefName: 'feature',
+  reviewDecision: null as null,
+  statusCheckRollup: null as null,
+  updatedAt: '2024-01-01T00:00:00Z',
+  body: null as null,
+};
+
+describe('resolvePrForBranch', () => {
+  it('returns null when runner returns empty array', async () => {
+    const runner = makeJsonRunner([]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when GhCliError thrown', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockResolvedValue({ stdout: '', stderr: 'not found', exitCode: 1 }),
+    };
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result).toBeNull();
+  });
+
+  it('re-throws non-GhCliError errors', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockRejectedValue(new TypeError('network error')),
+    };
+    await expect(resolvePrForBranch(runner, 'org/repo', 'feature')).rejects.toBeInstanceOf(
+      TypeError,
+    );
+  });
+
+  it('returns most recent OPEN PR when multiple exist', async () => {
+    const prs = [
+      { ...BASE_RAW, number: 1, state: 'OPEN' as const, updatedAt: '2024-01-01T00:00:00Z' },
+      { ...BASE_RAW, number: 2, state: 'OPEN' as const, updatedAt: '2024-03-01T00:00:00Z' },
+      { ...BASE_RAW, number: 3, state: 'MERGED' as const, updatedAt: '2024-06-01T00:00:00Z' },
+    ];
+    const runner = makeJsonRunner(prs);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.number).toBe(2);
+  });
+
+  it('falls back to most recent overall when no OPEN PRs', async () => {
+    const prs = [
+      { ...BASE_RAW, number: 1, state: 'CLOSED' as const, updatedAt: '2024-01-01T00:00:00Z' },
+      { ...BASE_RAW, number: 2, state: 'MERGED' as const, updatedAt: '2024-06-01T00:00:00Z' },
+    ];
+    const runner = makeJsonRunner(prs);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.number).toBe(2);
+  });
+
+  it('maps MERGED state → merged', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'MERGED' as const };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('merged');
+  });
+
+  it('maps CLOSED state → closed', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'CLOSED' as const };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('closed');
+  });
+
+  it('maps isDraft:true on OPEN → draft', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const, isDraft: true };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('draft');
+  });
+
+  it('maps OPEN + reviewDecision APPROVED → approved (not draft)', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      isDraft: false,
+      reviewDecision: 'APPROVED' as const,
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('approved');
+  });
+
+  it('does not map APPROVED to approved when draft is true', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      isDraft: true,
+      reviewDecision: 'APPROVED' as const,
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('draft');
+  });
+
+  it('does not map APPROVED to approved when MERGED', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'MERGED' as const,
+      reviewDecision: 'APPROVED' as const,
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('merged');
+  });
+
+  it('CONFLICTING → mergeable: false', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      mergeable: 'CONFLICTING' as const,
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.mergeable).toBe(false);
+  });
+
+  it('MERGEABLE → mergeable: true', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const, mergeable: 'MERGEABLE' as const };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.mergeable).toBe(true);
+  });
+
+  it('UNKNOWN → mergeable: null', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const, mergeable: 'UNKNOWN' as const };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.mergeable).toBeNull();
+  });
+
+  it('checks: any FAILURE → failure', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [{ conclusion: 'SUCCESS' as const }, { conclusion: 'FAILURE' as const }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('failure');
+  });
+
+  it('checks: all SUCCESS → success', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [{ conclusion: 'SUCCESS' as const }, { conclusion: 'SUCCESS' as const }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('success');
+  });
+
+  it('checks: mixed SUCCESS + PENDING → pending', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      statusCheckRollup: [{ conclusion: 'SUCCESS' as const }, { state: 'PENDING' as const }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBe('pending');
+  });
+
+  it('checks: empty statusCheckRollup → null', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const, statusCheckRollup: [] };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBeNull();
+  });
+
+  it('checks: null statusCheckRollup → null', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const, statusCheckRollup: null };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.checks).toBeNull();
+  });
+});
+
+describe('detectRepoSlug', () => {
+  it('returns slug on success', async () => {
+    const runner = makeRunner({ stdout: 'org/repo\n', stderr: '', exitCode: 0 });
+    const result = await detectRepoSlug(runner, '/some/path');
+    expect(result).toBe('org/repo');
+  });
+
+  it('returns null on non-zero exit', async () => {
+    const runner = makeRunner({ stdout: '', stderr: 'not a repo', exitCode: 128 });
+    const result = await detectRepoSlug(runner, '/some/path');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when runner throws', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockRejectedValue(new Error('spawn failed')),
+    };
+    const result = await detectRepoSlug(runner, '/some/path');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when stdout is empty', async () => {
+    const runner = makeRunner({ stdout: '   ', stderr: '', exitCode: 0 });
+    const result = await detectRepoSlug(runner, '/some/path');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/core/src/github/cache.ts
+++ b/packages/core/src/github/cache.ts
@@ -1,0 +1,60 @@
+import type { GithubPrCacheEntry, PullRequestState } from '@kay-am/types';
+import type { GhRunner } from './gh';
+import { resolvePrForBranch } from './resolver';
+
+export interface PrCacheStore {
+  get(repoSlug: string, branch: string): Promise<GithubPrCacheEntry | null>;
+  upsert(entry: GithubPrCacheEntry): Promise<void>;
+  invalidate(repoSlug: string, branch: string): Promise<void>;
+}
+
+export interface PrCacheDeps {
+  runner: GhRunner;
+  store: PrCacheStore;
+  now?: () => Date;
+  ttlMs?: number;
+}
+
+export const DEFAULT_PR_CACHE_TTL_MS = 60_000;
+
+export interface GetPrInput {
+  repoSlug: string;
+  branch: string;
+  cwd?: string;
+  token?: string;
+  force?: boolean;
+}
+
+export async function getPrForBranch(
+  deps: PrCacheDeps,
+  input: GetPrInput,
+): Promise<PullRequestState | null> {
+  const ttl = deps.ttlMs ?? DEFAULT_PR_CACHE_TTL_MS;
+  const now = deps.now ? deps.now() : new Date();
+  const cached = await deps.store.get(input.repoSlug, input.branch);
+  if (!input.force && cached) {
+    const fetchedAt = new Date(cached.fetchedAt).getTime();
+    if (Number.isFinite(fetchedAt) && now.getTime() - fetchedAt < ttl) {
+      return cached.pr;
+    }
+  }
+  const fresh = await resolvePrForBranch(deps.runner, input.repoSlug, input.branch, {
+    cwd: input.cwd,
+    token: input.token,
+  });
+  await deps.store.upsert({
+    repoSlug: input.repoSlug,
+    branch: input.branch,
+    pr: fresh,
+    fetchedAt: now.toISOString(),
+  });
+  return fresh;
+}
+
+export async function invalidatePrCache(
+  deps: Pick<PrCacheDeps, 'store'>,
+  repoSlug: string,
+  branch: string,
+): Promise<void> {
+  await deps.store.invalidate(repoSlug, branch);
+}

--- a/packages/core/src/github/diff.ts
+++ b/packages/core/src/github/diff.ts
@@ -1,0 +1,148 @@
+import type {
+  DiffHunk,
+  DiffHunkLine,
+  FileDiff,
+  FileDiffStatus,
+  PullRequestDiff,
+} from '@kay-am/types';
+import type { GhRunner } from './gh';
+import { GhCliError } from './gh';
+
+interface MutableFile {
+  path: string;
+  oldPath?: string;
+  status: FileDiffStatus;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  hunks: DiffHunk[];
+}
+
+const FILE_HEADER = /^diff --git a\/(.+) b\/(.+)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+export function parseUnifiedDiff(diff: string): ReadonlyArray<FileDiff> {
+  const lines = diff.split('\n');
+  const files: MutableFile[] = [];
+  let current: MutableFile | null = null;
+  let hunk: {
+    header: string;
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    lines: DiffHunkLine[];
+  } | null = null;
+  let oldCursor = 0;
+  let newCursor = 0;
+
+  const flushHunk = () => {
+    if (current && hunk) {
+      current.hunks.push({
+        header: hunk.header,
+        oldStart: hunk.oldStart,
+        oldLines: hunk.oldLines,
+        newStart: hunk.newStart,
+        newLines: hunk.newLines,
+        lines: hunk.lines,
+      });
+    }
+    hunk = null;
+  };
+
+  for (const line of lines) {
+    const fileMatch = line.match(FILE_HEADER);
+    if (fileMatch) {
+      flushHunk();
+      if (current) files.push(current);
+      const oldPath = fileMatch[1];
+      const newPath = fileMatch[2];
+      if (!oldPath || !newPath) continue;
+      current = {
+        path: newPath,
+        oldPath: oldPath === newPath ? undefined : oldPath,
+        status: 'modified',
+        additions: 0,
+        deletions: 0,
+        binary: false,
+        hunks: [],
+      };
+      continue;
+    }
+    if (!current) continue;
+
+    if (line.startsWith('new file mode')) current.status = 'added';
+    else if (line.startsWith('deleted file mode')) current.status = 'deleted';
+    else if (line.startsWith('rename from')) {
+      current.status = 'renamed';
+      current.oldPath = line.slice('rename from '.length);
+    } else if (line.startsWith('rename to')) {
+      current.path = line.slice('rename to '.length);
+    } else if (line.startsWith('Binary files')) {
+      current.binary = true;
+    }
+
+    const hunkMatch = line.match(HUNK_HEADER);
+    if (hunkMatch && hunkMatch[1] && hunkMatch[3]) {
+      flushHunk();
+      const oldStart = Number.parseInt(hunkMatch[1], 10);
+      const oldLines = hunkMatch[2] ? Number.parseInt(hunkMatch[2], 10) : 1;
+      const newStart = Number.parseInt(hunkMatch[3], 10);
+      const newLines = hunkMatch[4] ? Number.parseInt(hunkMatch[4], 10) : 1;
+      hunk = {
+        header: line,
+        oldStart,
+        oldLines,
+        newStart,
+        newLines,
+        lines: [],
+      };
+      oldCursor = oldStart;
+      newCursor = newStart;
+      continue;
+    }
+
+    if (!hunk) continue;
+
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      hunk.lines.push({ kind: 'add', oldLine: null, newLine: newCursor, text: line.slice(1) });
+      current.additions += 1;
+      newCursor += 1;
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      hunk.lines.push({ kind: 'del', oldLine: oldCursor, newLine: null, text: line.slice(1) });
+      current.deletions += 1;
+      oldCursor += 1;
+    } else if (line.startsWith(' ')) {
+      hunk.lines.push({
+        kind: 'context',
+        oldLine: oldCursor,
+        newLine: newCursor,
+        text: line.slice(1),
+      });
+      oldCursor += 1;
+      newCursor += 1;
+    } else if (line.startsWith('\\ No newline')) {
+      // ignore marker
+    }
+  }
+
+  flushHunk();
+  if (current) files.push(current);
+  return files;
+}
+
+export async function fetchPrDiff(
+  runner: GhRunner,
+  repo: string,
+  prNumber: number,
+  opts: { cwd?: string; token?: string } = {},
+): Promise<PullRequestDiff> {
+  const res = await runner.run(['pr', 'diff', String(prNumber), '--repo', repo], opts);
+  if (res.exitCode !== 0) {
+    throw new GhCliError(`gh pr diff exited with ${res.exitCode}`, res.stderr, res.exitCode);
+  }
+  return {
+    prNumber,
+    files: parseUnifiedDiff(res.stdout),
+  };
+}

--- a/packages/core/src/github/gh.ts
+++ b/packages/core/src/github/gh.ts
@@ -1,0 +1,76 @@
+export interface GhResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface GhRunOptions {
+  cwd?: string;
+  token?: string;
+  timeoutMs?: number;
+}
+
+export interface GhRunner {
+  run(args: ReadonlyArray<string>, opts?: GhRunOptions): Promise<GhResult>;
+}
+
+export const DEFAULT_GH_TIMEOUT_MS = 8_000;
+
+export class GhCliError extends Error {
+  readonly stderr: string;
+  readonly exitCode: number;
+  constructor(message: string, stderr: string, exitCode: number) {
+    super(message);
+    this.name = 'GhCliError';
+    this.stderr = stderr;
+    this.exitCode = exitCode;
+  }
+}
+
+export class GhJsonParseError extends Error {
+  readonly raw: string;
+  constructor(message: string, raw: string) {
+    super(message);
+    this.name = 'GhJsonParseError';
+    this.raw = raw;
+  }
+}
+
+export interface GhDetectResult {
+  available: boolean;
+  version?: string;
+}
+
+export async function detect(runner: GhRunner): Promise<GhDetectResult> {
+  try {
+    const res = await runner.run(['--version']);
+    if (res.exitCode !== 0) return { available: false };
+    const match = res.stdout.match(/gh version (\S+)/);
+    return { available: true, version: match?.[1] };
+  } catch {
+    return { available: false };
+  }
+}
+
+export async function runJson<T>(
+  runner: GhRunner,
+  args: ReadonlyArray<string>,
+  opts?: GhRunOptions,
+): Promise<T> {
+  const res = await runner.run(args, opts);
+  if (res.exitCode !== 0) {
+    throw new GhCliError(
+      `gh ${args.join(' ')} exited with ${res.exitCode}`,
+      res.stderr,
+      res.exitCode,
+    );
+  }
+  try {
+    return JSON.parse(res.stdout) as T;
+  } catch (err) {
+    throw new GhJsonParseError(
+      `failed to parse JSON from gh: ${err instanceof Error ? err.message : String(err)}`,
+      res.stdout,
+    );
+  }
+}

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -1,0 +1,29 @@
+export {
+  DEFAULT_GH_TIMEOUT_MS,
+  GhCliError,
+  GhJsonParseError,
+  detect,
+  runJson,
+  type GhDetectResult,
+  type GhResult,
+  type GhRunOptions,
+  type GhRunner,
+} from './gh';
+
+export {
+  detectRepoSlug,
+  fetchLinkedIssues,
+  parseLinkedIssuesFromBody,
+  resolvePrForBranch,
+} from './resolver';
+
+export { fetchPrDiff, parseUnifiedDiff } from './diff';
+
+export {
+  DEFAULT_PR_CACHE_TTL_MS,
+  getPrForBranch,
+  invalidatePrCache,
+  type GetPrInput,
+  type PrCacheDeps,
+  type PrCacheStore,
+} from './cache';

--- a/packages/core/src/github/resolver.ts
+++ b/packages/core/src/github/resolver.ts
@@ -1,0 +1,215 @@
+import type { LinkedIssue, PullRequestState, PullRequestStateKind } from '@kay-am/types';
+import type { GhRunner } from './gh';
+import { GhCliError, runJson } from './gh';
+
+const PR_FIELDS = [
+  'number',
+  'title',
+  'url',
+  'state',
+  'isDraft',
+  'mergeable',
+  'baseRefName',
+  'headRefName',
+  'reviewDecision',
+  'statusCheckRollup',
+  'updatedAt',
+  'body',
+] as const;
+
+interface RawPullRequest {
+  number: number;
+  title: string;
+  url: string;
+  state: 'OPEN' | 'CLOSED' | 'MERGED';
+  isDraft: boolean;
+  mergeable: 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN' | null;
+  baseRefName: string;
+  headRefName: string;
+  reviewDecision: 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED' | null;
+  statusCheckRollup: ReadonlyArray<{
+    state?: 'SUCCESS' | 'FAILURE' | 'PENDING' | 'ERROR' | null;
+    conclusion?: 'SUCCESS' | 'FAILURE' | 'NEUTRAL' | 'CANCELLED' | 'TIMED_OUT' | null;
+  }> | null;
+  updatedAt: string;
+  body: string | null;
+}
+
+interface ClosingIssueRef {
+  number: number;
+  title?: string;
+  url: string;
+}
+
+function deriveStateKind(raw: RawPullRequest): PullRequestStateKind {
+  if (raw.state === 'MERGED') return 'merged';
+  if (raw.state === 'CLOSED') return 'closed';
+  if (raw.isDraft) return 'draft';
+  if (raw.reviewDecision === 'APPROVED') return 'approved';
+  return 'open';
+}
+
+function deriveChecks(raw: RawPullRequest): PullRequestState['checks'] {
+  const checks = raw.statusCheckRollup ?? [];
+  if (checks.length === 0) return null;
+  let pending = false;
+  for (const c of checks) {
+    const status = c.conclusion ?? c.state ?? null;
+    if (
+      status === 'FAILURE' ||
+      status === 'CANCELLED' ||
+      status === 'TIMED_OUT' ||
+      status === 'ERROR'
+    ) {
+      return 'failure';
+    }
+    if (status === 'PENDING' || status === null) pending = true;
+  }
+  return pending ? 'pending' : 'success';
+}
+
+function deriveMergeable(raw: RawPullRequest): boolean | null {
+  if (raw.mergeable === 'MERGEABLE') return true;
+  if (raw.mergeable === 'CONFLICTING') return false;
+  return null;
+}
+
+function toPullRequestState(raw: RawPullRequest): PullRequestState {
+  const reviewMap: Record<string, PullRequestState['reviewDecision']> = {
+    APPROVED: 'approved',
+    CHANGES_REQUESTED: 'changes_requested',
+    REVIEW_REQUIRED: 'review_required',
+  };
+  return {
+    number: raw.number,
+    title: raw.title,
+    url: raw.url,
+    state: deriveStateKind(raw),
+    mergeable: deriveMergeable(raw),
+    checks: deriveChecks(raw),
+    baseBranch: raw.baseRefName,
+    headBranch: raw.headRefName,
+    isDraft: raw.isDraft,
+    reviewDecision: raw.reviewDecision ? (reviewMap[raw.reviewDecision] ?? null) : null,
+    body: raw.body ?? '',
+    updatedAt: raw.updatedAt,
+  };
+}
+
+export async function resolvePrForBranch(
+  runner: GhRunner,
+  repo: string,
+  branch: string,
+  opts: { cwd?: string; token?: string } = {},
+): Promise<PullRequestState | null> {
+  const args = [
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--head',
+    branch,
+    '--state',
+    'all',
+    '--limit',
+    '5',
+    '--json',
+    PR_FIELDS.join(','),
+  ];
+  let raw: ReadonlyArray<RawPullRequest>;
+  try {
+    raw = await runJson<ReadonlyArray<RawPullRequest>>(runner, args, opts);
+  } catch (err) {
+    if (err instanceof GhCliError) return null;
+    throw err;
+  }
+  if (raw.length === 0) return null;
+  const open = raw.filter((p) => p.state === 'OPEN');
+  open.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  const head = open[0] ?? [...raw].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  return head ? toPullRequestState(head) : null;
+}
+
+const LINKED_KEYWORD_RE =
+  /\b(close[sd]?|fix(?:es|ed)?|resolve[sd]?|ref(?:s|erence[sd]?)?)\s+#(\d+)/gi;
+
+export function parseLinkedIssuesFromBody(
+  body: string,
+  repoUrl: string,
+): ReadonlyArray<LinkedIssue> {
+  const seen = new Map<number, LinkedIssue>();
+  const repoBase = repoUrl.replace(/\/pull\/\d+.*$/, '').replace(/\.git$/, '');
+  for (const match of body.matchAll(LINKED_KEYWORD_RE)) {
+    const keyword = match[1]?.toLowerCase();
+    const numberStr = match[2];
+    if (!keyword || !numberStr) continue;
+    const number = Number.parseInt(numberStr, 10);
+    if (!Number.isFinite(number)) continue;
+    const closes = !keyword.startsWith('ref');
+    const existing = seen.get(number);
+    if (!existing || (closes && !existing.closes)) {
+      seen.set(number, {
+        number,
+        url: `${repoBase}/issues/${number}`,
+        closes,
+      });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.number - b.number);
+}
+
+export async function fetchLinkedIssues(
+  runner: GhRunner,
+  repo: string,
+  pr: PullRequestState,
+  opts: { cwd?: string; token?: string } = {},
+): Promise<ReadonlyArray<LinkedIssue>> {
+  const fromBody = parseLinkedIssuesFromBody(pr.body, pr.url);
+  try {
+    const args = [
+      'pr',
+      'view',
+      String(pr.number),
+      '--repo',
+      repo,
+      '--json',
+      'closingIssuesReferences',
+    ];
+    const res = await runJson<{ closingIssuesReferences: ReadonlyArray<ClosingIssueRef> }>(
+      runner,
+      args,
+      opts,
+    );
+    const merged = new Map<number, LinkedIssue>();
+    for (const item of fromBody) merged.set(item.number, item);
+    for (const item of res.closingIssuesReferences ?? []) {
+      const existing = merged.get(item.number);
+      merged.set(item.number, {
+        number: item.number,
+        title: item.title,
+        url: item.url,
+        closes: existing?.closes ?? true,
+      });
+    }
+    return [...merged.values()].sort((a, b) => a.number - b.number);
+  } catch (err) {
+    if (err instanceof GhCliError) return fromBody;
+    throw err;
+  }
+}
+
+export async function detectRepoSlug(runner: GhRunner, cwd: string): Promise<string | null> {
+  try {
+    const res = await runner.run(
+      ['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'],
+      {
+        cwd,
+      },
+    );
+    if (res.exitCode !== 0) return null;
+    const slug = res.stdout.trim();
+    return slug.length > 0 ? slug : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,30 @@ export {
 export { resolveSettings, type ResolveSettingsInput } from './settings/resolver';
 
 export {
+  DEFAULT_GH_TIMEOUT_MS,
+  DEFAULT_PR_CACHE_TTL_MS,
+  GhCliError,
+  GhJsonParseError,
+  detect as detectGh,
+  detectRepoSlug,
+  fetchLinkedIssues,
+  fetchPrDiff,
+  getPrForBranch,
+  invalidatePrCache,
+  parseLinkedIssuesFromBody,
+  parseUnifiedDiff,
+  resolvePrForBranch,
+  runJson as ghRunJson,
+  type GetPrInput,
+  type GhDetectResult,
+  type GhResult,
+  type GhRunOptions,
+  type GhRunner,
+  type PrCacheDeps,
+  type PrCacheStore,
+} from './github';
+
+export {
   parsePlannerOutput,
   PlannerParseError,
   PLANNER_SYSTEM_PROMPT,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -93,3 +93,8 @@ export {
   getTaskOverrides,
   setTaskOverrides,
 } from './queries/settings-overrides';
+export {
+  getGithubPrCache,
+  upsertGithubPrCache,
+  deleteGithubPrCache,
+} from './queries/github-pr-cache';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -15,6 +15,7 @@ import { m014RenameDomain } from './m014-rename-domain';
 import { m015AgentsPerChat } from './m015-agents-per-chat';
 import { m016TurnEvents } from './m016-turn-events';
 import { m017ContextSlotHistory } from './m017-context-slot-history';
+import { m018GithubPrCache } from './m018-github-pr-cache';
 
 export interface Migration {
   readonly version: number;
@@ -39,4 +40,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 15, sql: m015AgentsPerChat },
   { version: 16, sql: m016TurnEvents },
   { version: 17, sql: m017ContextSlotHistory },
+  { version: 18, sql: m018GithubPrCache },
 ];

--- a/packages/db/src/migrations/m018-github-pr-cache.ts
+++ b/packages/db/src/migrations/m018-github-pr-cache.ts
@@ -1,0 +1,11 @@
+export const m018GithubPrCache = /* sql */ `
+CREATE TABLE github_pr_cache (
+  branch TEXT NOT NULL,
+  repo_slug TEXT NOT NULL,
+  pr_json TEXT,
+  fetched_at TEXT NOT NULL,
+  PRIMARY KEY (repo_slug, branch)
+);
+
+CREATE INDEX idx_github_pr_cache_branch ON github_pr_cache(branch);
+`;

--- a/packages/db/src/queries/github-pr-cache.ts
+++ b/packages/db/src/queries/github-pr-cache.ts
@@ -1,0 +1,53 @@
+import type { GithubPrCacheEntry, PullRequestState } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface Row {
+  branch: string;
+  repo_slug: string;
+  pr_json: string | null;
+  fetched_at: string;
+}
+
+function toDomain(row: Row): GithubPrCacheEntry {
+  return {
+    branch: row.branch,
+    repoSlug: row.repo_slug,
+    pr: row.pr_json ? (JSON.parse(row.pr_json) as PullRequestState) : null,
+    fetchedAt: row.fetched_at,
+  };
+}
+
+export async function getGithubPrCache(
+  db: Database,
+  repoSlug: string,
+  branch: string,
+): Promise<GithubPrCacheEntry | null> {
+  const rows = await db.select<Row>(
+    'SELECT branch, repo_slug, pr_json, fetched_at FROM github_pr_cache WHERE repo_slug = ? AND branch = ? LIMIT 1',
+    [repoSlug, branch],
+  );
+  const first = rows[0];
+  return first ? toDomain(first) : null;
+}
+
+export async function upsertGithubPrCache(db: Database, entry: GithubPrCacheEntry): Promise<void> {
+  await db.execute(
+    `INSERT INTO github_pr_cache (branch, repo_slug, pr_json, fetched_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(repo_slug, branch) DO UPDATE SET
+       pr_json = excluded.pr_json,
+       fetched_at = excluded.fetched_at`,
+    [entry.branch, entry.repoSlug, entry.pr ? JSON.stringify(entry.pr) : null, entry.fetchedAt],
+  );
+}
+
+export async function deleteGithubPrCache(
+  db: Database,
+  repoSlug: string,
+  branch: string,
+): Promise<void> {
+  await db.execute('DELETE FROM github_pr_cache WHERE repo_slug = ? AND branch = ?', [
+    repoSlug,
+    branch,
+  ]);
+}

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -1,0 +1,75 @@
+export type GhTokenMode = 'absent' | 'gh-cli' | 'pat';
+
+export interface GhTokenStatus {
+  mode: GhTokenMode;
+  available: boolean;
+  version?: string;
+  user?: string;
+  scopes?: ReadonlyArray<string>;
+}
+
+export type PullRequestStateKind = 'draft' | 'open' | 'approved' | 'merged' | 'closed';
+
+export type PullRequestChecks = 'pending' | 'success' | 'failure' | null;
+
+export interface PullRequestState {
+  number: number;
+  title: string;
+  url: string;
+  state: PullRequestStateKind;
+  mergeable: boolean | null;
+  checks: PullRequestChecks;
+  baseBranch: string;
+  headBranch: string;
+  isDraft: boolean;
+  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null;
+  body: string;
+  updatedAt: string;
+}
+
+export interface LinkedIssue {
+  number: number;
+  title?: string;
+  url: string;
+  closes: boolean;
+}
+
+export type FileDiffStatus = 'added' | 'modified' | 'deleted' | 'renamed';
+
+export interface DiffHunkLine {
+  kind: 'context' | 'add' | 'del';
+  oldLine: number | null;
+  newLine: number | null;
+  text: string;
+}
+
+export interface DiffHunk {
+  header: string;
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  lines: ReadonlyArray<DiffHunkLine>;
+}
+
+export interface FileDiff {
+  path: string;
+  oldPath?: string;
+  status: FileDiffStatus;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  hunks: ReadonlyArray<DiffHunk>;
+}
+
+export interface PullRequestDiff {
+  prNumber: number;
+  files: ReadonlyArray<FileDiff>;
+}
+
+export interface GithubPrCacheEntry {
+  branch: string;
+  repoSlug: string;
+  pr: PullRequestState | null;
+  fetchedAt: string;
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -91,3 +91,17 @@ export type {
   PermissionRulePattern,
   PermissionRuleScope,
 } from './permission';
+export type {
+  DiffHunk,
+  DiffHunkLine,
+  FileDiff,
+  FileDiffStatus,
+  GhTokenMode,
+  GhTokenStatus,
+  GithubPrCacheEntry,
+  LinkedIssue,
+  PullRequestChecks,
+  PullRequestDiff,
+  PullRequestState,
+  PullRequestStateKind,
+} from './github';


### PR DESCRIPTION
## Summary

Milestone [v0.8 — GitHub integration](https://github.com/akhayam99/kay-am/milestone/10).

Brings GitHub awareness into kAY.am via the local `gh` CLI: token storage, per-session PR resolution, linked issues, sidebar status icon, context-panel surface, and a smart diff viewer.

Closes #375 #376 #377 #378 #379 #380 #381 #382 #383 #384 #385 #386.

## Plan

Implementation orchestrated in waves with isolated worktrees per slice — see commits.

1. types + db migration (#375 #376)
2. core: gh adapter, resolver, cache, diff (#377 #378 #379)
3. tauri commands + secrets (#380)
4. settings panel (#381)
5. context panel section (#382)
6. sidebar icon (#383)
7. diff viewer (#384)
8. PR/refresh CTAs (#385)
9. tests (#386)

## Test plan

- [ ] `pnpm lint` clean
- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` green
- [ ] manual: connect via PAT, open repo, see PR badge in sidebar, context panel section, diff viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)