### PR TITLE
refactor(desktop): tighten database.select typing

### DIFF
--- a/apps/desktop/src/db.ts
+++ b/apps/desktop/src/db.ts
@@ -11,11 +11,11 @@ export const tauriDatabase: Database = {
       params: [...params],
     });
   },
-  async select(sql, params = []) {
-    return invoke<ReadonlyArray<Record<string, unknown>>>('db_select', {
+  async select<T>(sql: string, params: ReadonlyArray<unknown> = []) {
+    return invoke('db_select', {
       sql,
       params: [...params],
-    }) as unknown as Promise<ReadonlyArray<never>>;
+    }) as Promise<ReadonlyArray<T>>;
   },
 };
 


### PR DESCRIPTION
Drop the `as unknown as` double-cast in `apps/desktop/src/db.ts` in favor of a single boundary cast. The `select` wrapper now takes a proper generic.

Closes #392