### PR TITLE
chore(repo): drop dead 'coming-soon' provider state + trackingIssueUrl

### DIFF
--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -13,9 +13,8 @@ const PROVIDER_DOT: Record<string, string> = {
 
 export function ProvidersChip(_: ProvidersChipProps = {}) {
   const providers = useAppStore((s) => s.providers);
-  const active = providers.filter((p) => p.connection !== 'coming-soon');
-  const connected = active.filter((p) => p.connection === 'connected');
-  const total = active.length;
+  const connected = providers.filter((p) => p.connection === 'connected');
+  const total = providers.length;
   const allOk = total > 0 && connected.length === total;
 
   const onClick = () => {

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -11,7 +11,6 @@ const STATE_LABEL: Record<ProviderConnectionState, string> = {
   installed_disconnected: 'installed, not logged in',
   missing: 'not installed',
   error: 'error',
-  'coming-soon': 'integration in v0.2',
 };
 
 const STATE_DOT: Record<ProviderConnectionState, string> = {
@@ -19,7 +18,6 @@ const STATE_DOT: Record<ProviderConnectionState, string> = {
   installed_disconnected: 'bg-warning',
   missing: 'bg-muted-foreground/40',
   error: 'bg-danger',
-  'coming-soon': 'bg-muted-foreground/40',
 };
 
 export function ProvidersPanel() {
@@ -68,11 +66,8 @@ export function ProvidersPanel() {
 }
 
 function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
-  const placeholder = info.connection === 'coming-soon';
   return (
-    <li
-      className={cn('flex items-center gap-3 px-3 py-2.5 text-xs', placeholder ? 'opacity-60' : '')}
-    >
+    <li className="flex items-center gap-3 px-3 py-2.5 text-xs">
       <span
         aria-hidden
         className={cn('inline-block h-2 w-2 shrink-0 rounded-full', STATE_DOT[info.connection])}
@@ -129,18 +124,6 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
       // terminal launch failed — fall through to show note anyway
     }
   };
-
-  if (info.connection === 'coming-soon') {
-    return info.trackingIssueUrl ? (
-      <button
-        type="button"
-        className="shrink-0 text-xs text-muted-foreground underline hover:text-foreground"
-        onClick={() => void openUrl(info.trackingIssueUrl!)}
-      >
-        track ↗
-      </button>
-    ) : null;
-  }
 
   if (info.connection === 'missing') {
     return (

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -26,7 +26,6 @@ export interface ProviderInfo extends ProviderInfoBase {
   readonly label: string;
   readonly error: string | null;
   readonly docsUrl: string;
-  readonly trackingIssueUrl?: string;
 }
 
 const PROVIDER_LABEL: Record<ProviderId, string> = {
@@ -40,11 +39,6 @@ const PROVIDER_DOCS: Record<ProviderId, string> = {
   // cursor-agent (CLI), NOT cursor IDE — point at the agent CLI install docs.
   cursor: 'https://docs.cursor.com/en/cli/installation',
   codex: 'https://github.com/openai/codex#installation',
-};
-
-const TRACKING_ISSUES: Partial<Record<ProviderId, string>> = {
-  cursor: 'https://github.com/akhayam99/kay-am/issues/68',
-  codex: 'https://github.com/akhayam99/kay-am/issues/69',
 };
 
 const PROVIDER_DEFAULT_BINARY: Record<ProviderId, string> = {
@@ -125,7 +119,6 @@ function providerInfoFromStatus(
     capabilities: EMPTY_CAPABILITIES,
     identity: auth?.identity ?? null,
     docsUrl: PROVIDER_DOCS[id],
-    ...(TRACKING_ISSUES[id] !== undefined ? { trackingIssueUrl: TRACKING_ISSUES[id] } : {}),
   };
   if (id === 'anthropic') {
     if (!status) {

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -1,11 +1,6 @@
 export type ProviderId = 'anthropic' | 'cursor' | 'codex';
 
-export type ProviderConnectionState =
-  | 'connected'
-  | 'installed_disconnected'
-  | 'missing'
-  | 'error'
-  | 'coming-soon';
+export type ProviderConnectionState = 'connected' | 'installed_disconnected' | 'missing' | 'error';
 
 export interface ModelTier {
   readonly id: string;


### PR DESCRIPTION
`'coming-soon'` was a pre-v0.2 placeholder for Cursor/Codex rows. Both adapters now produce real connection states; `providers.ts` (the sole producer) never emits this variant. Remove every dead branch and the unused `trackingIssueUrl` field that piggybacked on it.

Closes #405