### PR TITLE
fix(desktop): restore providers chip dot list after rename

### DIFF
--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -34,7 +34,7 @@ export function ProvidersChip(_: ProvidersChipProps = {}) {
       title="open settings → providers"
     >
       <span aria-hidden className="flex items-center -space-x-0.5">
-        {active.map((p) => (
+        {providers.map((p) => (
           <span
             key={p.id}
             className={cn(


### PR DESCRIPTION
Hot-fix for main. PR #406 renamed the local `active` variable to `providers` but missed the `{active.map(...)}` site at the dot-list render in `ProvidersChip.tsx`. CI on main was red after #406 merged.

```
src/components/ProvidersChip.tsx(37,10): error TS2304: Cannot find name 'active'.
```

Refs #406