### PR TITLE
chore(desktop): remove stale 'v0.7 will...' permission-proxy promises

### DIFF
--- a/apps/desktop/src/components/PermissionsPanel.tsx
+++ b/apps/desktop/src/components/PermissionsPanel.tsx
@@ -207,8 +207,8 @@ export function PermissionsPanel() {
       {showNonClaudeBanner && (
         <div className="flex items-start justify-between gap-2 rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
           <span>
-            permission proxy is currently claude-only. rules saved here will not affect cursor/codex
-            turns until v0.7.
+            permission proxy is currently claude-only. rules saved here will not affect cursor or
+            codex turns until proxy support lands for those providers.
           </span>
           <button
             type="button"

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -84,7 +84,7 @@ function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =>
           {info.id !== 'anthropic' ? (
             <span
               className="rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground"
-              title="v0.7 will extend the permission proxy to cursor and codex. For now, these providers continue with their previous defaults."
+              title="permission proxy currently covers claude only. cursor and codex run with their CLI defaults; coverage is tracked for a future milestone."
             >
               permission proxy: not supported
             </span>

--- a/apps/desktop/src/components/chat/PreflightPill.tsx
+++ b/apps/desktop/src/components/chat/PreflightPill.tsx
@@ -27,7 +27,7 @@ export function PreflightPill({ provider, rules, taskId, workspaceId }: Prefligh
       <button
         type="button"
         onClick={openSettings}
-        title="v0.7 will extend permission coverage to this provider."
+        title="permission proxy currently covers claude only."
         className="self-start rounded-full bg-subtle px-2 py-0.5 text-2xs text-muted-foreground hover:bg-muted"
       >
         permission proxy: claude only


### PR DESCRIPTION
Three UI strings claim "v0.7 will extend permission proxy to cursor/codex." v0.7 was multi-agent parallel — proxy was never extended, and v0.8 (GitHub integration) just shipped. Replace each version-pinned promise with a milestone-agnostic statement of fact.

- `ProvidersPanel.tsx` — "permission proxy: not supported" pill tooltip
- `PermissionsPanel.tsx` — non-claude scope banner text
- `PreflightPill.tsx` — non-anthropic chip tooltip

Closes #408