### PR TITLE
refactor(desktop): share lowercase provider label across callsites

### DIFF
--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -19,6 +19,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 import { shortModel } from '../agentRowFormat';
+import { PROVIDER_LABEL_LOWER } from '../providers';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../settings';
 import { EMPTY_ARRAY, useAppStore } from '../store';
 import { PlannerWidget } from './PlannerWidget';
@@ -46,12 +47,6 @@ function formatError(err: unknown): string {
 }
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
-
-const PROVIDER_LABEL: Record<ProviderId, string> = {
-  anthropic: 'claude',
-  cursor: 'cursor',
-  codex: 'codex',
-};
 
 function pickDefaultProvider(connectedIds: ReadonlySet<ProviderId>): ProviderId {
   for (const id of PROVIDER_ORDER) {
@@ -396,7 +391,7 @@ export function NewSessionDialog({
                           disabled ? 'cursor-not-allowed' : 'cursor-pointer',
                         )}
                       >
-                        <span className="font-medium">{PROVIDER_LABEL[id]}</span>
+                        <span className="font-medium">{PROVIDER_LABEL_LOWER[id]}</span>
                         {!connected && (
                           <button
                             type="button"

--- a/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
+++ b/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
@@ -1,12 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { Button } from '@kay-am/ui';
 import type { ProviderId } from '@kay-am/types';
-
-const PROVIDER_LABEL: Record<ProviderId, string> = {
-  anthropic: 'claude',
-  cursor: 'cursor',
-  codex: 'codex',
-};
+import { PROVIDER_LABEL_LOWER } from '../../providers';
 
 async function providerAction(id: ProviderId, action: 'login' | 'logout'): Promise<void> {
   return invoke('provider_action', { id, action });
@@ -19,7 +14,7 @@ interface AuthRequiredCalloutProps {
 }
 
 export function AuthRequiredCallout({ providerId, identity, onRefresh }: AuthRequiredCalloutProps) {
-  const label = PROVIDER_LABEL[providerId];
+  const label = PROVIDER_LABEL_LOWER[providerId];
 
   const onConnect = () => {
     void providerAction(providerId, 'login');

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -28,7 +28,7 @@ export interface ProviderInfo extends ProviderInfoBase {
   readonly docsUrl: string;
 }
 
-const PROVIDER_LABEL: Record<ProviderId, string> = {
+export const PROVIDER_LABEL_LOWER: Record<ProviderId, string> = {
   anthropic: 'claude',
   cursor: 'cursor',
   codex: 'codex',
@@ -114,7 +114,7 @@ function providerInfoFromStatus(
 ): ProviderInfo {
   const base = {
     id,
-    label: PROVIDER_LABEL[id],
+    label: PROVIDER_LABEL_LOWER[id],
     binary: status?.binary ?? PROVIDER_DEFAULT_BINARY[id],
     capabilities: EMPTY_CAPABILITIES,
     identity: auth?.identity ?? null,


### PR DESCRIPTION
Three files defined an identical lowercase `PROVIDER_LABEL` for in-sentence/phrase rendering (`providers.ts`, `AuthRequiredCallout.tsx`, `NewSessionDialog.tsx`). Export it once from `providers.ts` as `PROVIDER_LABEL_LOWER` and import in the two consumers. The capitalized variant in `chat-constants.ts` (used by `ModelPicker` chip labels) stays intentionally separate.

Closes #410