### PR TITLE
chore(desktop): drop unused providers-chip onOpenSettings prop

### DIFF
--- a/apps/desktop/src/components/ProvidersChip.tsx
+++ b/apps/desktop/src/components/ProvidersChip.tsx
@@ -1,17 +1,13 @@
 import { cn } from '@kay-am/ui';
 import { useAppStore } from '../store';
 
-interface ProvidersChipProps {
-  onOpenSettings?: () => void;
-}
-
 const PROVIDER_DOT: Record<string, string> = {
   anthropic: 'bg-[var(--color-provider-anthropic)]',
   cursor: 'bg-[var(--color-provider-cursor)]',
   codex: 'bg-[var(--color-provider-codex)]',
 };
 
-export function ProvidersChip(_: ProvidersChipProps = {}) {
+export function ProvidersChip() {
   const providers = useAppStore((s) => s.providers);
   const connected = providers.filter((p) => p.connection === 'connected');
   const total = providers.length;

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -235,7 +235,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       </ScrollArea>
 
       <div className="flex shrink-0 flex-col items-center gap-1.5 px-2 pb-2 pt-1.5">
-        <ProvidersChip onOpenSettings={onOpenSettings} />
+        <ProvidersChip />
         <TelemetryPill />
       </div>
 


### PR DESCRIPTION
`ProvidersChip` declared an `onOpenSettings` prop but ignored it (param was `_`); click handler dispatched `kayam:open-settings` instead — the correct pattern for the chip (shared with `PreflightPill`, `ChatInput`, `NewSessionDialog`). Drop the dead prop + interface and the fake-passing in `WorkspacesSidebar`.

Closes #412