### PR TITLE
refactor(desktop): seed first workflow agent only (#424)

### DIFF
--- a/apps/desktop/src/components/WorkflowNextStepCta.test.ts
+++ b/apps/desktop/src/components/WorkflowNextStepCta.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  TaskId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@kay-am/types';
+import { pickNextWorkflowStep } from './WorkflowNextStepCta';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const TASK_ID = 't-1' as TaskId;
+const WF_ID = 'wf' as WorkflowId;
+const NOW = '2026-05-10T00:00:00.000Z' as IsoDateTime;
+
+function wf(): Workflow {
+  return {
+    id: WF_ID,
+    workspaceId: WS_ID,
+    name: 'Refactor',
+    description: '',
+    steps: [
+      { id: 's1' as StepId, workflowId: WF_ID, ordinal: 0, name: 'Scout', promptPrefix: '' },
+      { id: 's2' as StepId, workflowId: WF_ID, ordinal: 1, name: 'Plan', promptPrefix: '' },
+      { id: 's3' as StepId, workflowId: WF_ID, ordinal: 2, name: 'Refactor', promptPrefix: '' },
+    ],
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function run(stepId: StepId, status: Session['status'], idx = 0): Session {
+  return {
+    id: `r-${idx}` as SessionId,
+    taskId: TASK_ID,
+    stepId,
+    ordinal: idx,
+    name: stepId,
+    status,
+  };
+}
+
+describe('pickNextWorkflowStep', () => {
+  it('returns null when current step is still pending/running', () => {
+    expect(pickNextWorkflowStep(wf(), [run('s1' as StepId, 'pending', 0)])).toBeNull();
+    expect(pickNextWorkflowStep(wf(), [run('s1' as StepId, 'running', 0)])).toBeNull();
+  });
+
+  it('returns the next un-spawned step once the previous one is completed', () => {
+    const next = pickNextWorkflowStep(wf(), [run('s1' as StepId, 'completed', 0)]);
+    expect(next?.id).toBe('s2');
+  });
+
+  it('returns null when all steps are already spawned', () => {
+    const runs = [
+      run('s1' as StepId, 'completed', 0),
+      run('s2' as StepId, 'completed', 1),
+      run('s3' as StepId, 'pending', 2),
+    ];
+    expect(pickNextWorkflowStep(wf(), runs)).toBeNull();
+  });
+
+  it('skips ahead past completed steps to the next un-spawned one', () => {
+    const runs = [run('s1' as StepId, 'completed', 0), run('s2' as StepId, 'completed', 1)];
+    expect(pickNextWorkflowStep(wf(), runs)?.id).toBe('s3');
+  });
+
+  it('returns first step when no runs exist yet', () => {
+    expect(pickNextWorkflowStep(wf(), [])?.id).toBe('s1');
+  });
+});

--- a/apps/desktop/src/components/WorkflowNextStepCta.tsx
+++ b/apps/desktop/src/components/WorkflowNextStepCta.tsx
@@ -1,0 +1,79 @@
+import { useMemo, useState } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import type { Session, Step, Workflow } from '@kay-am/types';
+
+export interface WorkflowNextStepCtaProps {
+  readonly workflow: Workflow;
+  readonly runs: ReadonlyArray<Session>;
+  readonly onAdvance: (step: Step) => void | Promise<void>;
+  readonly className?: string;
+}
+
+/**
+ * Reusable lit CTA that surfaces the next un-spawned workflow step once the
+ * current step's agent has completed. Hidden when the next step is already
+ * spawned (the user can still iterate inside that agent) or when no step
+ * remains. Issue #424 wires this into the agents bar; future issues
+ * (#425/#426/#428) reuse the same hook point for additional surfaces.
+ */
+export function pickNextWorkflowStep(
+  workflow: Workflow,
+  runs: ReadonlyArray<Session>,
+): Step | null {
+  const sorted = [...workflow.steps].sort((a, b) => a.ordinal - b.ordinal);
+  const spawnedIds = new Set(
+    runs.map((r) => r.stepId).filter((id): id is Step['id'] => id !== undefined),
+  );
+  const next = sorted.find((s) => !spawnedIds.has(s.id));
+  if (!next) return null;
+  const prevSpawned = sorted.filter((s) => s.ordinal < next.ordinal);
+  if (prevSpawned.length === 0) return next;
+  const prevAllCompleted = prevSpawned.every((s) =>
+    runs.some((r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped')),
+  );
+  return prevAllCompleted ? next : null;
+}
+
+export function WorkflowNextStepCta({
+  workflow,
+  runs,
+  onAdvance,
+  className,
+}: WorkflowNextStepCtaProps) {
+  const [busy, setBusy] = useState(false);
+  const next = useMemo(() => pickNextWorkflowStep(workflow, runs), [workflow, runs]);
+  if (!next) return null;
+  const onClick = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onAdvance(next);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={() => void onClick()}
+      disabled={busy}
+      data-testid="workflow-next-step-cta"
+      className={cn(
+        'group flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
+        className,
+      )}
+      aria-label={`Start ${next.name}`}
+    >
+      <span className="flex items-center gap-1.5">
+        <span className="text-2xs uppercase tracking-wide opacity-70">start</span>
+        <span className="font-semibold">{next.name}</span>
+      </span>
+      <ArrowRight
+        size={13}
+        aria-hidden
+        className="transition-transform group-hover:translate-x-0.5"
+      />
+    </button>
+  );
+}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -48,6 +48,7 @@ import {
 } from '../store';
 import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
+import { WorkflowNextStepCta } from './WorkflowNextStepCta';
 import { formatCost, formatTokens, shortModel } from '../agentRowFormat';
 import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY } from '@kay-am/core';
 import { openUrl } from '../editor';
@@ -1293,6 +1294,15 @@ function AgentsSection({ task }: AgentsSectionProps) {
           ))}
         </ul>
       )}
+      {workflow ? (
+        <div className="mt-2 pl-2">
+          <WorkflowNextStepCta
+            workflow={workflow}
+            runs={sorted}
+            onAdvance={(step) => onSpawn(step.id)}
+          />
+        </div>
+      ) : null}
       <div className="pl-2">
         <SpawnAgentControl workflow={workflow} onSpawn={onSpawn} />
       </div>

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1161,38 +1161,44 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     }
 
-    // Every session spawns at least one agent — the default "agent 1" — so
-    // the chat view always has something to render and the user can fire off
-    // a turn without having to spawn manually first. When a workflow is
-    // attached we pre-spawn one row per Step on top of the default; the user
-    // can then pick which agent each turn routes to from the sidebar.
-    let prespawnedRuns: ReadonlyArray<Session> = [];
-    const defaultAgent = await invokePhaseRunInsert({
-      taskId: session.id,
-      ordinal: 0,
-      name: 'agent 1',
-      status: 'pending',
-    });
-    prespawnedRuns = [defaultAgent];
+    // Every session spawns exactly one agent up-front. Without a workflow
+    // attached this is a generic "agent 1" so the chat view has something to
+    // render. With a workflow attached this is the FIRST step's agent only —
+    // subsequent phases are user-driven via the lit "start <next>" CTA in the
+    // agents bar (issue #424). Spawning all phases up-front buried the
+    // current step in a list and removed any sense of progression.
+    let firstAgent: Session;
     if (workflowId) {
       const templates = get().phaseTemplates[workspaceId] ?? [];
-      const template = templates.find((t) => t.id === workflowId);
-      if (template) {
-        const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-        const inserts = await Promise.all(
-          sortedSteps.map((step, i) =>
-            invokePhaseRunInsert({
-              taskId: session.id,
-              stepId: step.id,
-              ordinal: i + 1,
-              name: step.name,
-              status: 'pending',
-            }),
-          ),
-        );
-        prespawnedRuns = [defaultAgent, ...inserts];
+      const template = templates.find((t) => t.id === workflowId) ?? null;
+      const firstStep = template
+        ? [...template.steps].sort((a, b) => a.ordinal - b.ordinal)[0]
+        : null;
+      if (template && firstStep) {
+        firstAgent = await invokePhaseRunInsert({
+          taskId: session.id,
+          stepId: firstStep.id,
+          ordinal: 0,
+          name: firstStep.name,
+          status: 'pending',
+        });
+      } else {
+        firstAgent = await invokePhaseRunInsert({
+          taskId: session.id,
+          ordinal: 0,
+          name: 'agent 1',
+          status: 'pending',
+        });
       }
+    } else {
+      firstAgent = await invokePhaseRunInsert({
+        taskId: session.id,
+        ordinal: 0,
+        name: 'agent 1',
+        status: 'pending',
+      });
     }
+    const prespawnedRuns: ReadonlyArray<Session> = [firstAgent];
 
     set((state) => ({
       sessions:
@@ -1212,10 +1218,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         [session.id]: goalText.length > 0 ? [{ key: 'goal', value: goalText, enabled: true }] : [],
       },
       sessionPhaseRuns: { ...state.sessionPhaseRuns, [session.id]: prespawnedRuns },
-      selectedAgentId: { ...state.selectedAgentId, [session.id]: defaultAgent.id },
-      transcripts: { ...state.transcripts, [defaultAgent.id]: [] },
+      selectedAgentId: { ...state.selectedAgentId, [session.id]: firstAgent.id },
+      transcripts: { ...state.transcripts, [firstAgent.id]: [] },
       messages: { ...state.messages, [session.id]: [] },
-      agentTurnState: { ...state.agentTurnState, [defaultAgent.id]: { kind: 'draft' } },
+      agentTurnState: { ...state.agentTurnState, [firstAgent.id]: { kind: 'draft' } },
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
 

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  TaskId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@kay-am/types';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted before subject import
+// ---------------------------------------------------------------------------
+
+vi.mock('../turn', () => ({
+  runTurn: vi.fn(),
+  cancelTurn: vi.fn(),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+vi.mock('../db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@kay-am/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertTask: vi.fn(),
+  insertTaskWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForTask: vi.fn(async () => []),
+  listMessagesForTask: vi.fn(async () => []),
+  listTasksForWorkspace: vi.fn(async () => []),
+  listTelemetryForTask: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => [
+    { id: 'ws-1', name: 'ws', rootPath: '/tmp', createdAt: '', updatedAt: '' },
+  ]),
+  setSetting: vi.fn(),
+  summarizeTaskTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateTaskState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
+}));
+
+vi.mock('../providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../routing', () => ({ resolveProviderForTurn: vi.fn() }));
+
+vi.mock('../budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+const phaseRunInsertSpy = vi.fn();
+const phaseRunListSpy = vi.fn();
+
+vi.mock('../phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: (sid: TaskId) => phaseRunListSpy(sid),
+  invokePhaseRunInsert: (args: unknown) => phaseRunInsertSpy(args),
+  invokePhaseRunUpdateStatus: vi.fn(),
+}));
+
+vi.mock('../worktree', () => ({
+  createWorktree: vi.fn(async () => ({
+    worktreePath: '/tmp/wt',
+    branchName: 'kay/test',
+    slug: 'test',
+  })),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../repo', () => ({ validateGitRepo: vi.fn() }));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const WORKFLOW_ID = 'wf-refactor' as WorkflowId;
+const NOW = '2026-05-10T00:00:00.000Z' as IsoDateTime;
+
+function makeRefactorWorkflow(): Workflow {
+  return {
+    id: WORKFLOW_ID,
+    workspaceId: WS_ID,
+    name: 'Refactor',
+    description: 'scout/plan/refactor/verify',
+    steps: [
+      {
+        id: 's-scout' as StepId,
+        workflowId: WORKFLOW_ID,
+        ordinal: 0,
+        name: 'Scout',
+        promptPrefix: '',
+      },
+      {
+        id: 's-plan' as StepId,
+        workflowId: WORKFLOW_ID,
+        ordinal: 1,
+        name: 'Plan',
+        promptPrefix: '',
+      },
+      {
+        id: 's-refactor' as StepId,
+        workflowId: WORKFLOW_ID,
+        ordinal: 2,
+        name: 'Refactor',
+        promptPrefix: '',
+      },
+      {
+        id: 's-verify' as StepId,
+        workflowId: WORKFLOW_ID,
+        ordinal: 3,
+        name: 'Verify',
+        promptPrefix: '',
+      },
+    ],
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+let inserted: Session[] = [];
+
+function wirePhaseSpies() {
+  inserted = [];
+  phaseRunInsertSpy.mockReset();
+  phaseRunInsertSpy.mockImplementation(async (args: Record<string, unknown>) => {
+    const row: Session = {
+      id: `ses-${inserted.length + 1}` as SessionId,
+      taskId: args['taskId'] as TaskId,
+      ordinal: args['ordinal'] as number,
+      name: args['name'] as string,
+      status: 'pending',
+      ...((args['stepId'] as StepId | undefined) !== undefined && {
+        stepId: args['stepId'] as StepId,
+      }),
+    };
+    inserted.push(row);
+    return row;
+  });
+  phaseRunListSpy.mockReset();
+  phaseRunListSpy.mockImplementation(async () => inserted);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createSession — workflow stepper seeding (#424)', () => {
+  beforeEach(() => {
+    wirePhaseSpies();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('seeds exactly one agent for the first workflow step (no redundant default agent)', async () => {
+    const { useAppStore } = await import('./store');
+    useAppStore.setState({
+      currentWorkspaceId: WS_ID,
+      phaseTemplates: { [WS_ID]: [makeRefactorWorkflow()] },
+    });
+
+    await useAppStore.getState().createSession({
+      workspaceId: WS_ID,
+      goal: 'extract helpers',
+      branchPrefix: 'kay',
+      workflowId: WORKFLOW_ID,
+    });
+
+    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(1);
+    const args = phaseRunInsertSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args['stepId']).toBe('s-scout');
+    expect(args['name']).toBe('Scout');
+    expect(args['ordinal']).toBe(0);
+
+    const state = useAppStore.getState();
+    const sid = state.currentSessionId as TaskId;
+    expect(state.sessionPhaseRuns[sid]?.length).toBe(1);
+  });
+
+  it('falls back to a single generic "agent 1" when no workflow is attached', async () => {
+    const { useAppStore } = await import('./store');
+    useAppStore.setState({ currentWorkspaceId: WS_ID, phaseTemplates: {} });
+
+    await useAppStore.getState().createSession({
+      workspaceId: WS_ID,
+      goal: 'free form',
+      branchPrefix: 'kay',
+    });
+
+    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(1);
+    const args = phaseRunInsertSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args['name']).toBe('agent 1');
+    expect(args['stepId']).toBeUndefined();
+  });
+
+  it('spawnAgent advances to the next workflow step after the first completes', async () => {
+    const { useAppStore } = await import('./store');
+    useAppStore.setState({
+      currentWorkspaceId: WS_ID,
+      phaseTemplates: { [WS_ID]: [makeRefactorWorkflow()] },
+    });
+
+    const { session } = await useAppStore.getState().createSession({
+      workspaceId: WS_ID,
+      goal: 'refactor X',
+      branchPrefix: 'kay',
+      workflowId: WORKFLOW_ID,
+    });
+
+    inserted = inserted.map((r) =>
+      r.stepId === ('s-scout' as StepId) ? { ...r, status: 'completed' as const } : r,
+    );
+
+    await useAppStore.getState().spawnAgent(session.id, { stepId: 's-plan' as StepId });
+
+    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(2);
+    const second = phaseRunInsertSpy.mock.calls[1]?.[0] as Record<string, unknown>;
+    expect(second['stepId']).toBe('s-plan');
+    expect(second['name']).toBe('Plan');
+
+    const state = useAppStore.getState();
+    expect(state.sessionPhaseRuns[session.id]?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- workflow sessions now seed only the first phase agent on createSession (no more 5-agent up-front spawn, no redundant "agent 1" default).
- agents bar surfaces a lit "start <next>" CTA once the current phase agent completes; clicking advances to the next phase with workflow preset config.
- new reusable `WorkflowNextStepCta` component + `pickNextWorkflowStep` helper, ready for #425/#426/#428 to hook into.

Closes #424.

## Test plan
- [x] `pnpm typecheck` passes (apps/desktop)
- [x] `pnpm test --run` passes (apps/desktop, packages/core)
- [x] new tests cover: refactor session has 1 agent right after creation; advancing to phase 2 spawns the second; non-workflow falls back to "agent 1"
- [ ] manual: spawn refactor workflow → see scout agent only → finish turn → CTA lights up → click → planner spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)