### PR TITLE
feat(desktop): agent kind taxonomy, chips and model defaults

### DIFF
--- a/apps/desktop/src/agentKind.test.ts
+++ b/apps/desktop/src/agentKind.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkflowLibraryStep } from '@kay-am/core';
+import {
+  AGENT_KIND_DEFAULTS,
+  AGENT_KIND_PALETTE,
+  type AgentKind,
+  inferAgentKindFromName,
+  inferAgentKindFromStep,
+} from './agentKind';
+
+const ALL_KINDS: ReadonlyArray<AgentKind> = [
+  'scout',
+  'planner',
+  'implementer',
+  'debugger',
+  'reviewer',
+  'docs',
+  'generic',
+];
+
+function makeStep(role: string, name = role): WorkflowLibraryStep {
+  return { name, role, promptPrefix: '', expectedOutput: '' };
+}
+
+describe('AGENT_KIND_PALETTE', () => {
+  it('has an entry for every AgentKind', () => {
+    for (const kind of ALL_KINDS) {
+      expect(AGENT_KIND_PALETTE[kind]).toBeDefined();
+    }
+  });
+
+  it('every entry has bg, fg, and label', () => {
+    for (const kind of ALL_KINDS) {
+      const entry = AGENT_KIND_PALETTE[kind];
+      expect(typeof entry.bg).toBe('string');
+      expect(entry.bg.length).toBeGreaterThan(0);
+      expect(typeof entry.fg).toBe('string');
+      expect(entry.fg.length).toBeGreaterThan(0);
+      expect(typeof entry.label).toBe('string');
+      expect(entry.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('AGENT_KIND_DEFAULTS', () => {
+  it('has an entry for every AgentKind', () => {
+    for (const kind of ALL_KINDS) {
+      expect(AGENT_KIND_DEFAULTS[kind]).toBeDefined();
+    }
+  });
+
+  it('scout / docs / generic → haiku, low effort', () => {
+    for (const kind of ['scout', 'docs', 'generic'] as AgentKind[]) {
+      expect(AGENT_KIND_DEFAULTS[kind].effort).toBe('low');
+      expect(AGENT_KIND_DEFAULTS[kind].model).toMatch(/haiku/i);
+    }
+  });
+
+  it('implementer / debugger / reviewer → sonnet, medium effort', () => {
+    for (const kind of ['implementer', 'debugger', 'reviewer'] as AgentKind[]) {
+      expect(AGENT_KIND_DEFAULTS[kind].effort).toBe('medium');
+      expect(AGENT_KIND_DEFAULTS[kind].model).toMatch(/sonnet/i);
+    }
+  });
+
+  it('planner → opus, high effort', () => {
+    expect(AGENT_KIND_DEFAULTS['planner'].effort).toBe('high');
+    expect(AGENT_KIND_DEFAULTS['planner'].model).toMatch(/opus/i);
+  });
+});
+
+describe('inferAgentKindFromStep', () => {
+  it.each([
+    ['scout', 'scout'],
+    ['explorer', 'scout'],
+    ['investigator', 'debugger'],
+    ['planner', 'planner'],
+    ['architect', 'planner'],
+    ['product', 'planner'],
+    ['implementer', 'implementer'],
+    ['tester', 'reviewer'],
+    ['reviewer', 'reviewer'],
+    ['docs', 'docs'],
+    ['writer', 'docs'],
+  ] as [string, AgentKind][])('role %s → %s', (role, expected) => {
+    expect(inferAgentKindFromStep(makeStep(role))).toBe(expected);
+  });
+
+  it('unknown role falls back to generic', () => {
+    expect(inferAgentKindFromStep(makeStep('oracle'))).toBe('generic');
+  });
+});
+
+describe('inferAgentKindFromName', () => {
+  it.each([
+    ['Scout', 'scout'],
+    ['Explore', 'scout'],
+    ['Plan the approach', 'planner'],
+    ['Spec', 'planner'],
+    ['Design', 'planner'],
+    ['Implement feature', 'implementer'],
+    ['Refactor', 'implementer'],
+    ['Debug crash', 'debugger'],
+    ['Diagnose', 'debugger'],
+    ['Fix', 'debugger'],
+    ['Reproduce', 'debugger'],
+    ['Review diff', 'reviewer'],
+    ['Verify', 'reviewer'],
+    ['Test', 'reviewer'],
+    ['Write docs', 'docs'],
+    ['agent 1', 'generic'],
+  ] as [string, AgentKind][])('name %s → %s', (name, expected) => {
+    expect(inferAgentKindFromName(name)).toBe(expected);
+  });
+});

--- a/apps/desktop/src/agentKind.ts
+++ b/apps/desktop/src/agentKind.ts
@@ -1,0 +1,91 @@
+import type { WorkflowLibraryStep } from '@kay-am/core';
+
+export type AgentKind =
+  | 'scout'
+  | 'planner'
+  | 'implementer'
+  | 'debugger'
+  | 'reviewer'
+  | 'docs'
+  | 'generic';
+
+export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; label: string }> = {
+  scout: {
+    bg: 'bg-sky-100',
+    fg: 'text-sky-700',
+    label: 'scout',
+  },
+  planner: {
+    bg: 'bg-violet-100',
+    fg: 'text-violet-700',
+    label: 'planner',
+  },
+  implementer: {
+    bg: 'bg-emerald-100',
+    fg: 'text-emerald-700',
+    label: 'impl',
+  },
+  debugger: {
+    bg: 'bg-orange-100',
+    fg: 'text-orange-700',
+    label: 'debug',
+  },
+  reviewer: {
+    bg: 'bg-blue-100',
+    fg: 'text-blue-700',
+    label: 'review',
+  },
+  docs: {
+    bg: 'bg-amber-100',
+    fg: 'text-amber-700',
+    label: 'docs',
+  },
+  generic: {
+    bg: 'bg-muted',
+    fg: 'text-muted-foreground',
+    label: 'agent',
+  },
+};
+
+export const AGENT_KIND_DEFAULTS: Record<
+  AgentKind,
+  { model: string; effort: 'low' | 'medium' | 'high'; verbosity?: 'low' | 'medium' | 'high' }
+> = {
+  scout: { model: 'claude-haiku-4-5', effort: 'low' },
+  docs: { model: 'claude-haiku-4-5', effort: 'low' },
+  generic: { model: 'claude-haiku-4-5', effort: 'low' },
+  implementer: { model: 'claude-sonnet-4-5', effort: 'medium' },
+  debugger: { model: 'claude-sonnet-4-5', effort: 'medium' },
+  reviewer: { model: 'claude-sonnet-4-5', effort: 'medium' },
+  planner: { model: 'claude-opus-4-5', effort: 'high' },
+};
+
+const ROLE_TO_KIND: Record<string, AgentKind> = {
+  scout: 'scout',
+  explorer: 'scout',
+  investigator: 'debugger',
+  planner: 'planner',
+  architect: 'planner',
+  product: 'planner',
+  implementer: 'implementer',
+  tester: 'reviewer',
+  reviewer: 'reviewer',
+  docs: 'docs',
+  writer: 'docs',
+};
+
+export function inferAgentKindFromStep(step: WorkflowLibraryStep): AgentKind {
+  const role = step.role.toLowerCase();
+  return ROLE_TO_KIND[role] ?? 'generic';
+}
+
+export function inferAgentKindFromName(name: string): AgentKind {
+  const lower = name.toLowerCase();
+  if (/scout|explor|survey|map/.test(lower)) return 'scout';
+  if (/plan|design|architect|spec|product/.test(lower)) return 'planner';
+  if (/impl|build|develop|code|feature|refactor/.test(lower)) return 'implementer';
+  if (/debug|diagno|fix|repro|investig/.test(lower)) return 'debugger';
+  if (/review|verify|test|check|qa/.test(lower)) return 'reviewer';
+  if (/doc|write|readme|changelog/.test(lower)) return 'docs';
+  return 'generic';
+}

--- a/apps/desktop/src/components/WorkflowNextStepCta.tsx
+++ b/apps/desktop/src/components/WorkflowNextStepCta.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import type { Session, Step, Workflow } from '@kay-am/types';
+import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE, inferAgentKindFromName } from '../agentKind';
 
 export interface WorkflowNextStepCtaProps {
   readonly workflow: Workflow;
@@ -43,6 +44,9 @@ export function WorkflowNextStepCta({
 }: WorkflowNextStepCtaProps) {
   const [busy, setBusy] = useState(false);
   const next = useMemo(() => pickNextWorkflowStep(workflow, runs), [workflow, runs]);
+  const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
+  const defaults = AGENT_KIND_DEFAULTS[kind];
+  const palette = AGENT_KIND_PALETTE[kind];
   if (!next) return null;
   const onClick = async () => {
     if (busy) return;
@@ -59,21 +63,37 @@ export function WorkflowNextStepCta({
       onClick={() => void onClick()}
       disabled={busy}
       data-testid="workflow-next-step-cta"
+      title={`model: ${defaults.model} · effort: ${defaults.effort}`}
       className={cn(
         'group flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
         className,
       )}
-      aria-label={`Start ${next.name}`}
+      aria-label={`Start ${next.name} (${defaults.model}, ${defaults.effort} effort)`}
     >
       <span className="flex items-center gap-1.5">
         <span className="text-2xs uppercase tracking-wide opacity-70">start</span>
         <span className="font-semibold">{next.name}</span>
+        <span
+          className={cn(
+            'rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
+            palette.bg,
+            palette.fg,
+          )}
+          aria-hidden
+        >
+          {palette.label}
+        </span>
       </span>
-      <ArrowRight
-        size={13}
-        aria-hidden
-        className="transition-transform group-hover:translate-x-0.5"
-      />
+      <span className="flex items-center gap-1.5">
+        <span className="text-[10px] font-normal opacity-60">
+          {defaults.model.split('-').slice(1, 3).join('-')}
+        </span>
+        <ArrowRight
+          size={13}
+          aria-hidden
+          className="transition-transform group-hover:translate-x-0.5"
+        />
+      </span>
     </button>
   );
 }

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -56,6 +56,12 @@ import {
   shortModel,
 } from '../agentRowFormat';
 import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY } from '@kay-am/core';
+import {
+  AGENT_KIND_PALETTE,
+  type AgentKind,
+  inferAgentKindFromName,
+  inferAgentKindFromStep,
+} from '../agentKind';
 import { openUrl } from '../editor';
 
 interface WorkspacesSidebarProps {
@@ -1291,22 +1297,29 @@ function AgentsSection({ task }: AgentsSectionProps) {
         </p>
       ) : (
         <ul className="flex flex-col gap-1 pl-2">
-          {sorted.map((run) => (
-            <AgentRow
-              key={run.id}
-              run={run}
-              telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
-              aggregate={aggregatesByAgentId.get(run.id) ?? null}
-              turns={turnsByAgentId.get(run.id) ?? 0}
-              isSelected={run.id === selectedAgentId}
-              isEditing={editingId === run.id}
-              onClick={() => onPickAgent(run.id)}
-              onRenameStart={() => setEditingId(run.id)}
-              onRenameCommit={(name) => void onRenameCommit(run.id, name)}
-              onRenameCancel={() => setEditingId(null)}
-              onDelete={() => void onDeleteAgent(run.id)}
-            />
-          ))}
+          {sorted.map((run) => {
+            const stepName = run.stepId
+              ? (workflow?.steps.find((s) => s.id === run.stepId)?.name ?? null)
+              : null;
+            const kind = inferAgentKindFromName(stepName ?? run.name);
+            return (
+              <AgentRow
+                key={run.id}
+                run={run}
+                kind={kind}
+                telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
+                aggregate={aggregatesByAgentId.get(run.id) ?? null}
+                turns={turnsByAgentId.get(run.id) ?? 0}
+                isSelected={run.id === selectedAgentId}
+                isEditing={editingId === run.id}
+                onClick={() => onPickAgent(run.id)}
+                onRenameStart={() => setEditingId(run.id)}
+                onRenameCommit={(name) => void onRenameCommit(run.id, name)}
+                onRenameCancel={() => setEditingId(null)}
+                onDelete={() => void onDeleteAgent(run.id)}
+              />
+            );
+          })}
         </ul>
       )}
       {workflow ? (
@@ -1428,6 +1441,7 @@ interface AgentAggregate {
 
 interface AgentRowProps {
   readonly run: Session;
+  readonly kind: AgentKind;
   readonly telemetry: TelemetryRecord | null;
   readonly aggregate: AgentAggregate | null;
   readonly turns: number;
@@ -1442,6 +1456,7 @@ interface AgentRowProps {
 
 function AgentRow({
   run,
+  kind,
   telemetry,
   aggregate,
   turns,
@@ -1502,6 +1517,16 @@ function AgentRow({
             AGENT_STATUS_TONE[run.status],
           )}
         />
+        <span
+          className={cn(
+            'shrink-0 rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
+            AGENT_KIND_PALETTE[kind].bg,
+            AGENT_KIND_PALETTE[kind].fg,
+          )}
+          aria-label={`agent kind: ${AGENT_KIND_PALETTE[kind].label}`}
+        >
+          {AGENT_KIND_PALETTE[kind].label}
+        </span>
         {isEditing ? (
           <input
             autoFocus


### PR DESCRIPTION
## Summary

- new `apps/desktop/src/agentKind.ts`: `AgentKind` union, `AGENT_KIND_PALETTE` (light-mode Tailwind), `AGENT_KIND_DEFAULTS` (model+effort per kind), `inferAgentKindFromStep`, `inferAgentKindFromName`
- colored kind chip rendered in `AgentRow` inside `WorkspacesSidebar` — derives kind from workflow step name or agent name heuristic; neutral chip for `generic`
- `WorkflowNextStepCta` reads `AGENT_KIND_DEFAULTS` for the upcoming step and displays the kind chip + model hint inline — user sees the prefill before clicking

## Kind → model mapping

| kind | model | effort |
|------|-------|--------|
| scout / docs / generic | haiku | low |
| implementer / debugger / reviewer | sonnet | medium |
| planner | opus | high |

## Tests

34 new unit tests: palette completeness, defaults coverage, `inferAgentKindFromStep` for all library roles, `inferAgentKindFromName` for all library step names.

Closes #426. Closes #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)