### PR TITLE
feat(desktop): workflow ux overhaul, autorun, sidebar polish

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -72,6 +72,7 @@ function makeSession(overrides: Partial<Task> = {}): Task {
       allowTurnOverride: false,
     },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: '2026-01-01T00:00:00.000Z' as Task['createdAt'],
     updatedAt: '2026-01-01T00:00:00.000Z' as Task['updatedAt'],
     ...overrides,

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -17,6 +17,8 @@ vi.mock('../store', () => ({
       toggleSessionSlot: vi.fn(),
       summarizerStatus: {},
       sessionTelemetry: {},
+      sessionWorktrees: {},
+      settings: {},
       githubStatus: null,
       sessionBranches: {},
       sessionGithub: {},
@@ -26,6 +28,7 @@ vi.mock('../store', () => ({
       createPrForSession: vi.fn(),
       spawnAgent: vi.fn(),
       clearSessionNextActions: vi.fn(),
+      loadDiffComments: vi.fn(),
     };
     return selector(state);
   }),
@@ -35,6 +38,7 @@ vi.mock('../store', () => ({
     .mockReturnValue({ status: 'idle', lastUpdate: null, error: null, lastUsage: null }),
   useSlotHistory: vi.fn().mockReturnValue([]),
   useSessionNextActions: vi.fn().mockReturnValue([]),
+  useDiffComments: vi.fn().mockReturnValue([]),
 }));
 
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -114,6 +114,7 @@ function makeSession() {
     providerPreference: { defaultProvider: 'anthropic' as ProviderId, allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
     workflowId: TEMPLATE_ID,
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/__tests__/sidebar.test.ts
+++ b/apps/desktop/src/__tests__/sidebar.test.ts
@@ -12,6 +12,7 @@ function makeSession(overrides: Partial<Task> = {}): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic' as ProviderId, allowTurnOverride: true },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: DT,
     updatedAt: DT,
     ...overrides,

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -47,10 +47,10 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
   open=""
 >
   <div
-    class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+    class="flex min-h-0 flex-col h-[640px] w-[56rem]"
   >
     <header
-      class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+      class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
     >
       <div
         class="flex min-w-0 flex-col gap-1"
@@ -82,7 +82,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
     >
       <div
         class="flex h-full min-h-0 gap-0"
@@ -793,7 +793,7 @@ workspace: $0"
         class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
       >
         <header
-          class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+          class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
         >
           <div
             class="flex min-w-0 flex-col gap-1"
@@ -819,7 +819,7 @@ workspace: $0"
           </button>
         </header>
         <div
-          class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+          class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
         >
           <div
             class="flex flex-col gap-4 text-sm"
@@ -906,7 +906,7 @@ workspace: $0"
       class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
     >
       <header
-        class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+        class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
       >
         <div
           class="flex min-w-0 flex-col gap-1"
@@ -938,7 +938,7 @@ workspace: $0"
         </button>
       </header>
       <div
-        class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+        class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
       >
         <div
           class="flex h-full min-h-0 gap-0"
@@ -1041,7 +1041,7 @@ workspace: $0"
       class="flex min-h-0 flex-col h-[640px] w-[56rem] max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none"
     >
       <header
-        class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+        class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
       >
         <div
           class="flex min-w-0 flex-col gap-1"
@@ -1073,7 +1073,7 @@ workspace: $0"
         </button>
       </header>
       <div
-        class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+        class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
       >
         <div
           class="flex h-full min-h-0 gap-0"
@@ -1784,7 +1784,7 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
     class="flex flex-col max-h-[85vh] min-h-[16rem] w-[24rem]"
   >
     <header
-      class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+      class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
     >
       <div
         class="flex min-w-0 flex-col gap-1"
@@ -1816,7 +1816,7 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
     >
       <div
         class="rounded-md border border-border-soft bg-subtle px-3 py-2 text-xs text-muted-foreground"
@@ -1856,10 +1856,10 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
   open=""
 >
   <div
-    class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
+    class="flex min-h-0 flex-col h-[640px] w-[56rem]"
   >
     <header
-      class="flex shrink-0 items-start justify-between gap-4 border-b border-border-soft px-6 py-4"
+      class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
     >
       <div
         class="flex min-w-0 flex-col gap-1"
@@ -1891,7 +1891,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-6 py-5 text-sm"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
     >
       <div
         class="flex h-full min-h-0 gap-0"

--- a/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
+++ b/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
@@ -139,6 +139,7 @@ function buildSession() {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic' as const, allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: AT,
     updatedAt: AT,
   };

--- a/apps/desktop/src/agentKind.ts
+++ b/apps/desktop/src/agentKind.ts
@@ -18,12 +18,12 @@ export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; lab
   planner: {
     bg: 'bg-violet-100',
     fg: 'text-violet-700',
-    label: 'planner',
+    label: 'plan',
   },
   implementer: {
     bg: 'bg-emerald-100',
     fg: 'text-emerald-700',
-    label: 'impl',
+    label: 'imple',
   },
   debugger: {
     bg: 'bg-orange-100',

--- a/apps/desktop/src/components/CostBadge.tsx
+++ b/apps/desktop/src/components/CostBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from '@kay-am/ui';
+import { formatCost } from '../agentRowFormat';
+
+export interface CostBadgeProps {
+  readonly value: number;
+  readonly className?: string;
+  readonly title?: string;
+}
+
+export function CostBadge({ value, className, title }: CostBadgeProps) {
+  const formatted = formatCost(value);
+  const split = splitDollarsCents(formatted);
+  return (
+    <span className={cn('inline-flex items-baseline tabular-nums', className)} title={title}>
+      {split ? (
+        <>
+          <span>{split.dollars}</span>
+          <span className="text-[0.78em] opacity-70">{split.cents}</span>
+        </>
+      ) : (
+        <span>{formatted}</span>
+      )}
+    </span>
+  );
+}
+
+function splitDollarsCents(formatted: string): { dollars: string; cents: string } | null {
+  const m = formatted.match(/^(\$\d+)(\.\d+)$/);
+  if (!m) return null;
+  return { dollars: m[1]!, cents: m[2]! };
+}

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -48,6 +48,30 @@ function formatError(err: unknown): string {
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
+type WorkflowMode = 'one-off' | 'preset' | 'custom';
+
+const WORKFLOW_MODES: ReadonlyArray<{
+  id: WorkflowMode;
+  label: string;
+  hint: string;
+}> = [
+  {
+    id: 'one-off',
+    label: 'one-off',
+    hint: 'single chat — spawn agents manually when you need them.',
+  },
+  {
+    id: 'preset',
+    label: 'preset',
+    hint: 'pick a saved workflow blueprint. each step pre-spawns its own agent.',
+  },
+  {
+    id: 'custom',
+    label: 'custom',
+    hint: 'design a fresh workflow with the planner agent, then run it.',
+  },
+];
+
 function pickDefaultProvider(connectedIds: ReadonlySet<ProviderId>): ProviderId {
   for (const id of PROVIDER_ORDER) {
     if (connectedIds.has(id)) return id;
@@ -72,7 +96,8 @@ export function NewSessionDialog({
   const [prefix, setPrefix] = useState(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
   const [softCapRaw, setSoftCapRaw] = useState('');
   const [selectedPhaseTemplateId, setSelectedPhaseTemplateId] = useState<WorkflowId | ''>('');
-  const [plannerOpen, setPlannerOpen] = useState(false);
+  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('one-off');
+  const [autoRun, setAutoRun] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -89,7 +114,8 @@ export function NewSessionDialog({
     setGoal('');
     setSoftCapRaw('');
     setSelectedPhaseTemplateId('');
-    setPlannerOpen(false);
+    setWorkflowMode('one-off');
+    setAutoRun(false);
     setError(null);
     void loadSetting(settingKey).then((value) => {
       setPrefix(value ?? DEFAULT_BRANCH_PREFIX);
@@ -103,7 +129,8 @@ export function NewSessionDialog({
     setPrefix(storedPrefix ?? DEFAULT_BRANCH_PREFIX);
     setSoftCapRaw('');
     setSelectedPhaseTemplateId('');
-    setPlannerOpen(false);
+    setWorkflowMode('one-off');
+    setAutoRun(false);
     setError(null);
   };
 
@@ -115,12 +142,14 @@ export function NewSessionDialog({
         defaultProvider: selectedProvider,
         allowTurnOverride: true,
       };
+      const hasWorkflow = selectedPhaseTemplateId !== '';
       const { session } = await createSession({
         workspaceId,
         goal,
         branchPrefix: prefix,
         providerPreference,
-        ...(selectedPhaseTemplateId ? { workflowId: selectedPhaseTemplateId as WorkflowId } : {}),
+        ...(hasWorkflow ? { workflowId: selectedPhaseTemplateId as WorkflowId } : {}),
+        ...(hasWorkflow && autoRun ? { autoRun: true } : {}),
       });
       const parsedCap = parseFloat(softCapRaw);
       if (softCapRaw.trim().length > 0 && !isNaN(parsedCap) && parsedCap > 0) {
@@ -191,6 +220,16 @@ export function NewSessionDialog({
     },
   ];
 
+  const onWorkflowModeChange = (next: WorkflowMode) => {
+    setWorkflowMode(next);
+    if (next === 'one-off') {
+      setSelectedPhaseTemplateId('');
+      setAutoRun(false);
+    } else if (next === 'preset' || next === 'custom') {
+      setSelectedPhaseTemplateId('');
+    }
+  };
+
   const missingRequired = sections.filter((s) => s.required && !s.ready);
   const disabledReason =
     missingRequired.length > 0
@@ -203,7 +242,8 @@ export function NewSessionDialog({
       onClose={onClose}
       title="New session"
       description="Creates a worktree on a fresh branch from the workspace root."
-      size="lg"
+      size="xl"
+      fixedHeightClass="h-[640px]"
       footer={
         <>
           {error ? (
@@ -302,58 +342,85 @@ export function NewSessionDialog({
           ) : null}
 
           {activeSection === 'workflow' ? (
-            <Field
-              label="workflow (optional)"
-              hint={
-                phaseTemplates.length === 0
-                  ? 'no workflows yet — design one with the planner below.'
-                  : 'pick a workflow blueprint. each step pre-spawns its own agent.'
-              }
-            >
-              <div className="flex flex-wrap gap-1.5">
-                <WorkflowChip
-                  label="single chat"
-                  active={selectedPhaseTemplateId === ''}
-                  onClick={() => setSelectedPhaseTemplateId('')}
-                />
-                {phaseTemplates.map((t) => (
-                  <WorkflowChip
-                    key={t.id}
-                    label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
-                    active={selectedPhaseTemplateId === t.id}
-                    onClick={() => setSelectedPhaseTemplateId(t.id)}
-                    title={t.description || undefined}
-                  />
-                ))}
-                <button
-                  type="button"
-                  onClick={() => setPlannerOpen((v) => !v)}
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs motion-safe:transition-colors',
-                    plannerOpen
-                      ? 'bg-foreground text-background'
-                      : 'bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
-                  )}
-                  title="design a custom workflow with the planner agent"
-                >
-                  <Sparkles size={11} aria-hidden /> design custom
-                </button>
-              </div>
-              {selectedPhaseTemplateId !== '' ? (
-                <WorkflowPreview
-                  template={phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null}
-                />
+            <Field label="workflow (optional)" hint={workflowModeHint(workflowMode)}>
+              <WorkflowModeSegmented mode={workflowMode} onChange={onWorkflowModeChange} />
+
+              {workflowMode === 'one-off' ? (
+                <div className="mt-3 rounded-md border border-dashed border-border-soft bg-subtle px-3 py-4 text-xs leading-relaxed text-muted-foreground">
+                  no workflow attached. you can spawn agents on demand from the chat sidebar.
+                </div>
               ) : null}
-              {plannerOpen ? (
-                <PlannerWidget
-                  workspaceId={workspaceId}
-                  providerId={selectedProvider}
-                  initialTheme={goal}
-                  onWorkflowReady={(workflowId) => {
-                    setSelectedPhaseTemplateId(workflowId);
-                    setPlannerOpen(false);
-                  }}
-                />
+
+              {workflowMode === 'preset' ? (
+                <div className="mt-3 flex flex-col gap-3">
+                  {phaseTemplates.length === 0 ? (
+                    <p className="rounded-md border border-dashed border-border-soft bg-subtle px-3 py-4 text-xs leading-relaxed text-muted-foreground">
+                      no presets yet — switch to <span className="font-medium">custom</span> and
+                      design one with the planner.
+                    </p>
+                  ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                      {phaseTemplates.map((t) => (
+                        <WorkflowChip
+                          key={t.id}
+                          label={`${t.name.toLowerCase()}${t.steps.length > 0 ? ` · ${t.steps.length}` : ''}`}
+                          active={selectedPhaseTemplateId === t.id}
+                          onClick={() => setSelectedPhaseTemplateId(t.id)}
+                          title={t.description || undefined}
+                        />
+                      ))}
+                    </div>
+                  )}
+                  {selectedPhaseTemplateId !== '' ? (
+                    <WorkflowPreview
+                      template={
+                        phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null
+                      }
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+
+              {workflowMode === 'custom' ? (
+                <div className="mt-3 flex flex-col gap-3">
+                  <div className="rounded-md border border-border-soft bg-subtle px-3 py-3">
+                    <div className="mb-1 flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                      <Sparkles size={12} aria-hidden /> design with planner
+                    </div>
+                    <PlannerWidget
+                      workspaceId={workspaceId}
+                      providerId={selectedProvider}
+                      initialTheme={goal}
+                      onWorkflowReady={(workflowId) => {
+                        setSelectedPhaseTemplateId(workflowId);
+                      }}
+                    />
+                  </div>
+                  {selectedPhaseTemplateId !== '' ? (
+                    <WorkflowPreview
+                      template={
+                        phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null
+                      }
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+
+              {workflowMode !== 'one-off' && selectedPhaseTemplateId !== '' ? (
+                <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={autoRun}
+                    onChange={(e) => setAutoRun(e.target.checked)}
+                    className="mt-0.5 accent-primary"
+                  />
+                  <span className="flex flex-col gap-0.5">
+                    <span className="font-medium text-foreground">run autonomously</span>
+                    <span className="text-muted-foreground">
+                      auto-spawn each step on completion. pauses on error or budget exceed.
+                    </span>
+                  </span>
+                </label>
               ) : null}
             </Field>
           ) : null}
@@ -512,4 +579,45 @@ function WorkflowChip({
       {label}
     </button>
   );
+}
+
+function WorkflowModeSegmented({
+  mode,
+  onChange,
+}: {
+  mode: WorkflowMode;
+  onChange: (next: WorkflowMode) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      aria-label="workflow mode"
+      className="inline-flex rounded-md border border-border bg-subtle p-0.5"
+    >
+      {WORKFLOW_MODES.map((m) => {
+        const active = mode === m.id;
+        return (
+          <button
+            key={m.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(m.id)}
+            className={cn(
+              'rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors',
+              active
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {m.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function workflowModeHint(mode: WorkflowMode): string {
+  return WORKFLOW_MODES.find((m) => m.id === mode)?.hint ?? '';
 }

--- a/apps/desktop/src/components/NextActionChips.tsx
+++ b/apps/desktop/src/components/NextActionChips.tsx
@@ -4,7 +4,8 @@ import { cn } from '@kay-am/ui';
 import type { NextAction } from '@kay-am/core';
 import type { TaskId } from '@kay-am/types';
 import { useAppStore, useSessionNextActions } from '../store';
-import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE, type AgentKind } from '../agentKind';
+import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE } from '../agentKind';
+import { spawnKindForAction } from '../spawnFromNextAction';
 
 export interface NextActionChipsProps {
   readonly taskId: TaskId;
@@ -95,7 +96,7 @@ function Chip({
   disabled: boolean;
   onClick: () => void;
 }) {
-  const kind = spawnKindFor(action);
+  const kind = spawnKindForAction(action);
   const palette = kind ? AGENT_KIND_PALETTE[kind] : null;
   const defaults = kind ? AGENT_KIND_DEFAULTS[kind] : null;
   const title = defaults ? `model: ${defaults.model} · effort: ${defaults.effort}` : action.label;
@@ -132,17 +133,4 @@ function Chip({
       />
     </button>
   );
-}
-
-function spawnKindFor(action: NextAction): AgentKind | null {
-  switch (action.id) {
-    case 'spawn_planner':
-      return 'planner';
-    case 'spawn_implementer':
-      return 'implementer';
-    case 'spawn_debugger':
-      return 'debugger';
-    default:
-      return null;
-  }
 }

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
+  ArrowRight,
   ArrowUpDown,
   ChevronDown,
   ChevronRight,
@@ -16,7 +17,11 @@ import {
   Settings,
   Settings2,
   Trash2,
+  Users,
+  Workflow as WorkflowIcon,
   X,
+  Zap,
+  ZapOff,
 } from 'lucide-react';
 import { WorkspaceSettingsDialog } from './WorkspaceSettingsDialog';
 import { SessionSettingsDialog } from './SessionSettingsDialog';
@@ -43,25 +48,29 @@ import {
   useAppStore,
   useCurrentSession,
   useCurrentWorkspace,
+  useSessionNextActions,
   useSessions,
   useWorkspaces,
 } from '../store';
 import { NewSessionDialog } from './NewSessionDialog';
 import { StatusBadge } from './StatusBadge';
 import { WorkflowNextStepCta } from './WorkflowNextStepCta';
+import { CostBadge } from './CostBadge';
 import {
   computeLatestTelemetryByAgentId,
   formatCost,
   formatTokens,
   shortModel,
 } from '../agentRowFormat';
-import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY } from '@kay-am/core';
+import { PROVIDER_CAPABILITIES, WORKFLOW_LIBRARY, type NextAction } from '@kay-am/core';
 import {
+  AGENT_KIND_DEFAULTS,
   AGENT_KIND_PALETTE,
   type AgentKind,
   inferAgentKindFromName,
   inferAgentKindFromStep,
 } from '../agentKind';
+import { spawnFromNextAction, spawnKindForAction } from '../spawnFromNextAction';
 import { openUrl } from '../editor';
 
 interface WorkspacesSidebarProps {
@@ -698,8 +707,15 @@ function SessionRow({
 }: SessionRowProps) {
   const budget = useAppStore((s) => s.sessionBudgets[session.id as TaskId] ?? null);
   const spentUsd = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
+  const agentCount = useAppStore((s) => s.sessionPhaseRuns[session.id as TaskId]?.length ?? 0);
+  const workflowName = useAppStore((s) => {
+    if (!session.workflowId) return null;
+    const templates = s.phaseTemplates[session.workspaceId] ?? [];
+    return templates.find((t) => t.id === session.workflowId)?.name ?? null;
+  });
   const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const setSessionAutoRun = useAppStore((s) => s.setSessionAutoRun);
   const renameTask = useAppStore((s) => s.renameTask);
   const deleteTask = useAppStore((s) => s.deleteTask);
   const budgetLoaded = useRef(false);
@@ -832,6 +848,52 @@ function SessionRow({
             </button>
           </div>
         </div>
+
+        {isActive && (
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 pl-3.5 text-2xs text-muted-foreground">
+            {workflowName ? (
+              <span className="inline-flex items-center gap-1" title="workflow">
+                <WorkflowIcon size={10} aria-hidden />
+                <span className="truncate">{workflowName.toLowerCase()}</span>
+              </span>
+            ) : null}
+            <span
+              className="inline-flex items-center gap-1"
+              title={`${agentCount} agent${agentCount === 1 ? '' : 's'}`}
+            >
+              <Users size={10} aria-hidden />
+              <span className="tabular-nums">{agentCount}</span>
+            </span>
+            {spentUsd !== null && spentUsd > 0 ? (
+              <CostBadge
+                value={spentUsd}
+                title={`$${spentUsd.toFixed(4)} total session cost`}
+                className="text-2xs"
+              />
+            ) : null}
+            {session.workflowId ? (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void setSessionAutoRun(session.id as TaskId, !session.autoRun);
+                }}
+                title={
+                  session.autoRun ? 'autorun on — click to pause' : 'autorun off — click to enable'
+                }
+                className={cn(
+                  'inline-flex items-center gap-1 rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide motion-safe:transition-colors',
+                  session.autoRun
+                    ? 'bg-primary/15 text-primary hover:bg-primary/25'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/70',
+                )}
+              >
+                {session.autoRun ? <Zap size={10} aria-hidden /> : <ZapOff size={10} aria-hidden />}
+                auto
+              </button>
+            ) : null}
+          </div>
+        )}
 
         {cap !== null && (
           <div className="flex flex-col gap-0.5 pl-3.5">
@@ -1332,7 +1394,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
         </div>
       ) : null}
       <div className="pl-2">
-        <SpawnAgentControl workflow={workflow} onSpawn={onSpawn} />
+        <SpawnAgentControl taskId={task.id} workflow={workflow} onSpawn={onSpawn} />
       </div>
       {spawnError ? <p className="mt-1 px-2 text-2xs text-danger">{spawnError}</p> : null}
     </section>
@@ -1340,13 +1402,17 @@ function AgentsSection({ task }: AgentsSectionProps) {
 }
 
 interface SpawnAgentControlProps {
+  taskId: TaskId;
   workflow: Workflow | null;
   onSpawn: (stepId: Step['id'] | null, model?: string) => void | Promise<void>;
 }
 
-function SpawnAgentControl({ workflow, onSpawn }: SpawnAgentControlProps) {
+function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const nextActions = useSessionNextActions(taskId);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const clearSessionNextActions = useAppStore((s) => s.clearSessionNextActions);
 
   useEffect(() => {
     if (!open) return;
@@ -1361,6 +1427,14 @@ function SpawnAgentControl({ workflow, onSpawn }: SpawnAgentControlProps) {
     () => (workflow ? [...workflow.steps].sort((a, b) => a.ordinal - b.ordinal) : []),
     [workflow],
   );
+
+  const suggestions = workflow ? [] : nextActions;
+
+  const onPickSuggestion = async (action: NextAction) => {
+    setOpen(false);
+    const did = await spawnFromNextAction(action, taskId, spawnAgent);
+    if (did) clearSessionNextActions(taskId);
+  };
 
   return (
     <div className="relative mt-1" ref={ref}>
@@ -1377,8 +1451,23 @@ function SpawnAgentControl({ workflow, onSpawn }: SpawnAgentControlProps) {
       {open ? (
         <div
           role="menu"
-          className="absolute bottom-full left-0 right-0 z-20 mb-1 max-h-60 overflow-y-auto rounded-md bg-background py-1 text-xs shadow-lg ring-1 ring-border-soft"
+          className="absolute bottom-full left-0 right-0 z-20 mb-1 max-h-72 overflow-y-auto rounded-md bg-background py-1 text-xs shadow-lg ring-1 ring-border-soft"
         >
+          {suggestions.length > 0 ? (
+            <>
+              <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">
+                suggested next
+              </div>
+              {suggestions.map((action) => (
+                <SuggestionMenuItem
+                  key={action.id}
+                  action={action}
+                  onSelect={() => void onPickSuggestion(action)}
+                />
+              ))}
+              <div className="mt-1 border-t border-border-soft" aria-hidden />
+            </>
+          ) : null}
           <button
             type="button"
             role="menuitem"
@@ -1421,6 +1510,30 @@ function SpawnAgentControl({ workflow, onSpawn }: SpawnAgentControlProps) {
         </div>
       ) : null}
     </div>
+  );
+}
+
+function SuggestionMenuItem({ action, onSelect }: { action: NextAction; onSelect: () => void }) {
+  const kind = spawnKindForAction(action);
+  const palette = kind ? AGENT_KIND_PALETTE[kind] : null;
+  const defaults = kind ? AGENT_KIND_DEFAULTS[kind] : null;
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      title={defaults ? `${defaults.model} · ${defaults.effort} effort` : action.label}
+      className={cn(
+        'flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors',
+        palette ? `${palette.bg} ${palette.fg} hover:opacity-90` : 'hover:bg-muted',
+      )}
+    >
+      <span className="flex items-center gap-1.5">
+        <ArrowRight size={11} aria-hidden />
+        <span className="font-medium">{action.label}</span>
+      </span>
+      {defaults ? <span className="text-2xs opacity-70">{shortModel(defaults.model)}</span> : null}
+    </button>
   );
 }
 
@@ -1517,6 +1630,18 @@ function AgentRow({
             AGENT_STATUS_TONE[run.status],
           )}
         />
+        <span
+          className={cn(
+            'shrink-0 rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide',
+            'w-[3.25rem]',
+            AGENT_KIND_PALETTE[kind].bg,
+            AGENT_KIND_PALETTE[kind].fg,
+          )}
+          aria-label={`agent kind: ${AGENT_KIND_PALETTE[kind].label}`}
+          title={`agent ${run.ordinal + 1} — ${AGENT_KIND_PALETTE[kind].label}`}
+        >
+          {AGENT_KIND_PALETTE[kind].label}
+        </span>
         {isEditing ? (
           <input
             autoFocus
@@ -1548,14 +1673,6 @@ function AgentRow({
             {run.name}
           </span>
         )}
-        {!isSelected && !isEditing && aggregate ? (
-          <span
-            className="shrink-0 tabular-nums text-2xs text-muted-foreground/70"
-            title={`$${aggregate.estimatedCostUsd.toFixed(4)} cumulative across providers`}
-          >
-            {formatCost(aggregate.estimatedCostUsd)}
-          </span>
-        ) : null}
         {!isEditing ? (
           confirmingDelete ? (
             <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
@@ -1594,18 +1711,6 @@ function AgentRow({
             </button>
           )
         ) : null}
-        <span
-          className={cn(
-            'shrink-0 rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide',
-            'w-[3.25rem]',
-            AGENT_KIND_PALETTE[kind].bg,
-            AGENT_KIND_PALETTE[kind].fg,
-          )}
-          aria-label={`agent kind: ${AGENT_KIND_PALETTE[kind].label}`}
-          title={`agent ${run.ordinal + 1} — ${AGENT_KIND_PALETTE[kind].label}`}
-        >
-          {AGENT_KIND_PALETTE[kind].label}
-        </span>
       </div>
       <div
         className={cn(
@@ -1645,16 +1750,14 @@ function AgentRow({
               <span aria-hidden className="text-muted-foreground/40">
                 ·
               </span>
-              <span
-                className="tabular-nums"
+              <CostBadge
+                value={aggregate?.estimatedCostUsd ?? 0}
                 title={
                   aggregate
                     ? `$${aggregate.estimatedCostUsd.toFixed(4)} cumulative across providers`
                     : 'no cost yet'
                 }
-              >
-                {aggregate ? formatCost(aggregate.estimatedCostUsd) : '$0'}
-              </span>
+              />
             </div>
             <div className="flex items-center gap-1.5 whitespace-nowrap text-2xs text-muted-foreground/70">
               {telemetry ? (

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -103,10 +103,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
   const isSlashMode = slashQuery !== null;
 
-  const selectedAgentState = useAppStore((s) => {
-    const agentId = s.selectedAgentId[session.id] ?? null;
-    return agentId ? (s.agentTurnState[agentId] ?? null) : null;
-  });
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
+  const selectedAgentState = useAppStore((s) =>
+    selectedAgentId ? (s.agentTurnState[selectedAgentId] ?? null) : null,
+  );
+  const agentModelOverride = useAppStore((s) =>
+    selectedAgentId ? (s.agentModelOverride[selectedAgentId] ?? null) : null,
+  );
   const isRunning = RUNNING_KINDS.has(selectedAgentState?.kind ?? session.state.kind);
   const wasRunning = useRef(isRunning);
   interface QueuedTurn {
@@ -120,7 +123,9 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const effectiveProvider: ProviderId = selectedProvider ?? defaultProvider;
   const defaultModel =
-    session.providerPreference.defaultModel ?? getDefaultTurnModel(defaultProvider);
+    agentModelOverride ??
+    session.providerPreference.defaultModel ??
+    getDefaultTurnModel(defaultProvider);
   const effectiveModel = selectedModel ?? defaultModel;
 
   const providerModels = PROVIDER_CAPABILITIES[effectiveProvider].models;
@@ -228,6 +233,11 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
       void dispatchTurn(content, override);
     }
   }, [isRunning, queued, dispatchTurn]);
+
+  useEffect(() => {
+    setSelectedProvider(null);
+    setSelectedModel(null);
+  }, [selectedAgentId]);
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (

--- a/apps/desktop/src/spawnFromNextAction.ts
+++ b/apps/desktop/src/spawnFromNextAction.ts
@@ -1,0 +1,37 @@
+import type { NextAction } from '@kay-am/core';
+import type { TaskId } from '@kay-am/types';
+import { AGENT_KIND_DEFAULTS, type AgentKind } from './agentKind';
+
+export type SpawnAgentFn = (
+  taskId: TaskId,
+  args: { name?: string; model?: string; effort?: 'low' | 'medium' | 'high' },
+) => Promise<unknown>;
+
+export function spawnKindForAction(action: NextAction): AgentKind | null {
+  switch (action.id) {
+    case 'spawn_planner':
+      return 'planner';
+    case 'spawn_implementer':
+      return 'implementer';
+    case 'spawn_debugger':
+      return 'debugger';
+    default:
+      return null;
+  }
+}
+
+export async function spawnFromNextAction(
+  action: NextAction,
+  taskId: TaskId,
+  spawnAgent: SpawnAgentFn,
+): Promise<boolean> {
+  const kind = spawnKindForAction(action);
+  if (!kind) return false;
+  const defaults = AGENT_KIND_DEFAULTS[kind];
+  await spawnAgent(taskId, {
+    name: action.label,
+    model: defaults.model,
+    effort: defaults.effort,
+  });
+  return true;
+}

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -158,6 +158,7 @@ function buildSession(): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -155,6 +155,7 @@ function buildSession(stateKind: 'idle' | 'running' = 'idle'): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -141,6 +141,7 @@ function buildSession(): Task {
       allowTurnOverride: false,
     },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -168,6 +168,7 @@ function buildSession(): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     workflowId: TEMPLATE_ID,
     createdAt: now,
     updatedAt: now,

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -156,6 +156,7 @@ function buildSession(): Task {
       allowTurnOverride: false,
     },
     permissionMode: 'bypassPermissions',
+    autoRun: false,
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -170,6 +170,7 @@ function buildTask(): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions' as const,
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -50,6 +50,7 @@ import {
   summarizeWorkspaceProviderTelemetry,
   updateProviderRunStatus,
   updateTaskPermissionMode,
+  updateTaskAutoRun,
   updateTaskState,
   upsertContextSlot,
   insertDiffComment,
@@ -344,7 +345,10 @@ export interface AppActions {
     branchPrefix?: string;
     providerPreference?: TaskProviderPreference;
     workflowId?: WorkflowId;
+    autoRun?: boolean;
   }): Promise<{ session: Task; worktree: CreatedWorktree }>;
+  setSessionAutoRun(taskId: TaskId, autoRun: boolean): Promise<void>;
+  maybeAutoAdvanceWorkflow(taskId: TaskId): Promise<void>;
   loadTranscript(agentId: SessionId, taskId: TaskId): Promise<void>;
   appendTurnEvent(agentId: SessionId, taskId: TaskId, event: TurnEvent): void;
   resetTranscript(agentId: SessionId): void;
@@ -1157,7 +1161,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     });
   },
 
-  createSession: async ({ workspaceId, goal, branchPrefix, providerPreference, workflowId }) => {
+  createSession: async ({
+    workspaceId,
+    goal,
+    branchPrefix,
+    providerPreference,
+    workflowId,
+    autoRun,
+  }) => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) throw new Error(`workspace not found: ${workspaceId}`);
 
@@ -1180,6 +1191,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       providerPreference: providerPreference ?? DEFAULT_TASK_PROVIDER_PREFERENCE,
       permissionMode: 'bypassPermissions',
       ...(workflowId !== undefined ? { workflowId } : {}),
+      autoRun: autoRun === true && workflowId !== undefined,
       createdAt: now,
       updatedAt: now,
     };
@@ -2043,6 +2055,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             ),
           }),
         }));
+        void get().maybeAutoAdvanceWorkflow(taskId);
       }
 
       // Auto-populate ContextPanel from this turn's output: file paths come
@@ -2943,6 +2956,54 @@ export const useAppStore = create<AppStore>((set, get) => ({
         s.id === taskId ? { ...s, permissionMode: mode, updatedAt: now } : s,
       ),
     }));
+  },
+
+  setSessionAutoRun: async (taskId, autoRun) => {
+    const now = new Date().toISOString() as IsoDateTime;
+    await updateTaskAutoRun(tauriDatabase, taskId, autoRun, now);
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === taskId ? { ...s, autoRun, updatedAt: now } : s,
+      ),
+    }));
+    if (autoRun) void get().maybeAutoAdvanceWorkflow(taskId);
+  },
+
+  maybeAutoAdvanceWorkflow: async (taskId) => {
+    const state = get();
+    const task = state.sessions.find((s) => s.id === taskId);
+    if (!task || !task.autoRun || !task.workflowId) return;
+    const template = (state.phaseTemplates[task.workspaceId] ?? []).find(
+      (t) => t.id === task.workflowId,
+    );
+    if (!template) return;
+    const runs = state.sessionPhaseRuns[taskId] ?? [];
+    if (runs.some((r) => r.status === 'failed')) return;
+    const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+    const spawnedStepIds = new Set(
+      runs.map((r) => r.stepId).filter((id): id is StepId => id !== undefined),
+    );
+    const next = sortedSteps.find((s) => !spawnedStepIds.has(s.id));
+    if (!next) return;
+    const prevSteps = sortedSteps.filter((s) => s.ordinal < next.ordinal);
+    const prevAllCompleted = prevSteps.every((s) =>
+      runs.some((r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped')),
+    );
+    if (!prevAllCompleted) return;
+    const exceeded = state.budgetAlerts.some(
+      (a) =>
+        a.dismissedAt === undefined &&
+        ((a.kind === 'task-exceeded' && a.taskId === taskId) || a.kind === 'provider-exceeded'),
+    );
+    if (exceeded) return;
+    const kind = inferAgentKindFromName(next.name);
+    const defaults = AGENT_KIND_DEFAULTS[kind];
+    await get().spawnAgent(taskId, {
+      name: next.name,
+      stepId: next.id,
+      model: defaults.model,
+      effort: defaults.effort,
+    });
   },
 
   createPrForSession: async (taskId) => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -37,6 +37,7 @@ import {
   listMessagesForTask,
   listTurnEventsForAgent,
   listTurnEventsForTask,
+  listAgentRunIdsForTask,
   listTasksForWorkspace,
   listTelemetryForTask,
   listWorkspaces,
@@ -1020,11 +1021,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setCurrentSession: async (id) => {
     set({ currentSessionId: id, sessionSummary: null });
     if (id) {
-      const [summary, telemetry, slots, agents] = await Promise.all([
+      const [summary, telemetry, slots, agents, agentRunIds] = await Promise.all([
         summarizeTaskTelemetry(tauriDatabase, id),
         listTelemetryForTask(tauriDatabase, id),
         listContextSlotsForTask(tauriDatabase, id),
         invokePhaseRunList(id),
+        listAgentRunIdsForTask(tauriDatabase, id),
       ]);
       // Pick the previously-selected agent if it still exists, else the
       // lowest-ordinal one (= default "agent 1" or first workflow step).
@@ -1039,20 +1041,21 @@ export const useAppStore = create<AppStore>((set, get) => ({
             listTurnEventsForAgent(tauriDatabase, selectedAgent.id),
           ])
         : [[] as ReadonlyArray<Message>, [] as ReadonlyArray<TurnEvent>];
-      // Seed agentRunHistory from each agent's current runId so previously-run
-      // agents at least have ONE entry to aggregate against. New runIds get
-      // appended on each turn going forward.
+      // Seed agentRunHistory with EVERY provider run an agent ever spawned, not
+      // just its latest. Recovered from turn_events (single source of truth post
+      // restart) so aggregate token/cost counters in the sidebar reflect the
+      // full agent lifetime — birth to death — instead of the last turn.
       const seededHistory: Record<string, ReadonlyArray<ProviderRunId>> = {};
       const seededTurnState: Record<string, TurnState> = {};
       const task = get().sessions.find((s) => s.id === id);
       const taskState =
         task?.state ?? ({ kind: 'idle', lastActivityAt: new Date().toISOString() } as TurnState);
       for (const agent of agents) {
-        if (agent.runId) {
-          const prev = get().agentRunHistory[agent.id] ?? [];
-          if (!prev.includes(agent.runId)) {
-            seededHistory[agent.id] = [...prev, agent.runId];
-          }
+        const historical = agentRunIds.get(agent.id) ?? [];
+        const merged: ProviderRunId[] = [...historical];
+        if (agent.runId && !merged.includes(agent.runId)) merged.push(agent.runId);
+        if (merged.length > 0) {
+          seededHistory[agent.id] = merged;
         }
         if (agent.status === 'running' && agent.runId) {
           seededTurnState[agent.id] = {

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -127,6 +127,7 @@ function buildIdleSession(id: TaskId, wsId: WorkspaceId): Task {
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions',
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };
@@ -141,6 +142,7 @@ function buildRunningSession(id: TaskId, wsId: WorkspaceId, runId: ProviderRunId
     contextSlots: [],
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
     permissionMode: 'bypassPermissions',
+    autoRun: false,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -26,6 +26,7 @@ export {
   insertTurnEvent,
   listTurnEventsForAgent,
   listTurnEventsForTask,
+  listAgentRunIdsForTask,
 } from './queries/turn-event';
 export {
   upsertContextSlot,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -15,6 +15,7 @@ export {
   insertTask,
   updateTaskState,
   updateTaskPermissionMode,
+  updateTaskAutoRun,
   getTaskById,
   listTasksForWorkspace,
   renameTask,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -19,6 +19,7 @@ import { m018GithubPrCache } from './m018-github-pr-cache';
 import { m019TaskPermissionMode } from './m019-task-permission-mode';
 import { m020DiffComments } from './m020-diff-comments';
 import { m021DiffCommentLine } from './m021-diff-comment-line';
+import { m022TaskAutorun } from './m022-task-autorun';
 
 export interface Migration {
   readonly version: number;
@@ -47,4 +48,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 19, sql: m019TaskPermissionMode },
   { version: 20, sql: m020DiffComments },
   { version: 21, sql: m021DiffCommentLine },
+  { version: 22, sql: m022TaskAutorun },
 ];

--- a/packages/db/src/migrations/m022-task-autorun.ts
+++ b/packages/db/src/migrations/m022-task-autorun.ts
@@ -1,0 +1,3 @@
+export const m022TaskAutorun = /* sql */ `
+ALTER TABLE tasks ADD COLUMN auto_run INTEGER NOT NULL DEFAULT 0;
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -94,6 +94,7 @@ describe('migrate', () => {
       contextSlots: [],
       providerPreference: DEFAULT_TASK_PROVIDER_PREFERENCE,
       permissionMode: 'bypassPermissions',
+      autoRun: false,
       createdAt: now(),
       updatedAt: now(),
     };
@@ -126,6 +127,7 @@ describe('migrate', () => {
       contextSlots: [],
       providerPreference: { defaultProvider: 'cursor', allowTurnOverride: false },
       permissionMode: 'bypassPermissions',
+      autoRun: false,
       createdAt: now(),
       updatedAt: now(),
     };
@@ -157,6 +159,7 @@ describe('migrate', () => {
       contextSlots: [],
       providerPreference: DEFAULT_TASK_PROVIDER_PREFERENCE,
       permissionMode: 'bypassPermissions',
+      autoRun: false,
       createdAt: now(),
       updatedAt: now(),
     };
@@ -255,6 +258,7 @@ describe('migrate', () => {
       contextSlots: [],
       providerPreference: DEFAULT_TASK_PROVIDER_PREFERENCE,
       permissionMode: 'bypassPermissions',
+      autoRun: false,
       createdAt: now(),
       updatedAt: now(),
     };
@@ -310,6 +314,7 @@ describe('migrate', () => {
       contextSlots: [],
       providerPreference: DEFAULT_TASK_PROVIDER_PREFERENCE,
       permissionMode: 'bypassPermissions',
+      autoRun: false,
       createdAt: now(),
       updatedAt: now(),
     };

--- a/packages/db/src/queries/task.ts
+++ b/packages/db/src/queries/task.ts
@@ -22,6 +22,7 @@ interface TaskRow {
   permission_mode: string | null;
   workflow_id: string | null;
   current_step_ordinal: number | null;
+  auto_run: number;
   created_at: number;
   updated_at: number;
 }
@@ -67,6 +68,7 @@ function toDomain(row: TaskRow, contextSlots: Task['contextSlots']): Task {
     permissionMode: toPermissionMode(row.permission_mode),
     ...(row.workflow_id && { workflowId: row.workflow_id as WorkflowId }),
     ...(row.current_step_ordinal !== null && { currentStepOrdinal: row.current_step_ordinal }),
+    autoRun: row.auto_run !== 0,
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
   };
@@ -81,8 +83,8 @@ export async function insertTask(db: Database, task: Task): Promise<void> {
   const { kind, payload } = splitState(task.state);
   await db.execute(
     `INSERT INTO tasks
-      (id, workspace_id, goal, state_kind, state_payload, provider_default, provider_allow_override, permission_mode, workflow_id, current_step_ordinal, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, workspace_id, goal, state_kind, state_payload, provider_default, provider_allow_override, permission_mode, workflow_id, current_step_ordinal, auto_run, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       task.id,
       task.workspaceId,
@@ -94,10 +96,24 @@ export async function insertTask(db: Database, task: Task): Promise<void> {
       task.permissionMode,
       task.workflowId ?? null,
       task.currentStepOrdinal ?? null,
+      task.autoRun ? 1 : 0,
       Date.parse(task.createdAt),
       Date.parse(task.updatedAt),
     ],
   );
+}
+
+export async function updateTaskAutoRun(
+  db: Database,
+  id: TaskId,
+  autoRun: boolean,
+  updatedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute('UPDATE tasks SET auto_run = ?, updated_at = ? WHERE id = ?', [
+    autoRun ? 1 : 0,
+    Date.parse(updatedAt),
+    id,
+  ]);
 }
 
 export async function updateTaskState(
@@ -119,10 +135,11 @@ export async function updateTaskPermissionMode(
   permissionMode: ClaudePermissionMode,
   updatedAt: IsoDateTime,
 ): Promise<void> {
-  await db.execute(
-    'UPDATE tasks SET permission_mode = ?, updated_at = ? WHERE id = ?',
-    [permissionMode, Date.parse(updatedAt), id],
-  );
+  await db.execute('UPDATE tasks SET permission_mode = ?, updated_at = ? WHERE id = ?', [
+    permissionMode,
+    Date.parse(updatedAt),
+    id,
+  ]);
 }
 
 export async function getTaskById(db: Database, id: TaskId): Promise<Task | null> {

--- a/packages/db/src/queries/turn-event.ts
+++ b/packages/db/src/queries/turn-event.ts
@@ -1,4 +1,4 @@
-import type { SessionId, TaskId, TurnEvent } from '@kay-am/types';
+import type { ProviderRunId, SessionId, TaskId, TurnEvent } from '@kay-am/types';
 import type { Database } from '../client';
 
 interface TurnEventRow {
@@ -61,4 +61,33 @@ export async function listTurnEventsForTask(
     [taskId],
   );
   return rows.map(rowToEvent).filter((e): e is TurnEvent => e !== null);
+}
+
+export async function listAgentRunIdsForTask(
+  db: Database,
+  taskId: TaskId,
+): Promise<Map<SessionId, ReadonlyArray<ProviderRunId>>> {
+  const rows = await db.select<TurnEventRow>(
+    'SELECT * FROM turn_events WHERE task_id = ? ORDER BY created_at ASC, rowid ASC',
+    [taskId],
+  );
+  const result = new Map<SessionId, ProviderRunId[]>();
+  const seen = new Map<SessionId, Set<string>>();
+  for (const row of rows) {
+    const event = rowToEvent(row);
+    if (!event) continue;
+    const runId = event.runId;
+    if (!runId || runId === ('history' as ProviderRunId)) continue;
+    const agentId = row.agent_id as SessionId;
+    let bucket = seen.get(agentId);
+    if (!bucket) {
+      bucket = new Set();
+      seen.set(agentId, bucket);
+      result.set(agentId, []);
+    }
+    if (bucket.has(runId)) continue;
+    bucket.add(runId);
+    result.get(agentId)!.push(runId);
+  }
+  return result;
 }

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -44,6 +44,7 @@ export type Task = Readonly<{
   permissionMode: ClaudePermissionMode;
   workflowId?: WorkflowId;
   currentStepOrdinal?: number;
+  autoRun: boolean;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }>;


### PR DESCRIPTION
## Summary

Single-PR resolution for 8 UX issues n-bro flagged on workflow modal, agent rows, session rows, and autorun.

### Fixes
- **Issue 1 — model display sync** ([ChatInput.tsx](apps/desktop/src/components/chat/ChatInput.tsx)): chip showed `opus` while workflow-spawned agent ran with `haiku`. Now reads `agentModelOverride[selectedAgentId]` first, session default second.
- **Issue 5 — kind labels** ([agentKind.ts](apps/desktop/src/agentKind.ts)): `planner` → `plan`, `impl` → `imple` for visual parity in the chip.

### New components / files
- [`CostBadge.tsx`](apps/desktop/src/components/CostBadge.tsx) — renders dollars normal, cents smaller (`0.78em / opacity-70`).
- [`spawnFromNextAction.ts`](apps/desktop/src/spawnFromNextAction.ts) — shared helper for spawning agents from `NextAction`. Used by `NextActionChips` and `SpawnAgentControl`.
- [`m022-task-autorun.ts`](packages/db/src/migrations/m022-task-autorun.ts) — adds `auto_run INTEGER NOT NULL DEFAULT 0` to `tasks`.

### Redesigned UI
- **NewSessionDialog**: bumped from `lg` → `xl` + `fixedHeightClass=h-[640px]`. Workflow section now uses a 3-tab segmented control (one-off / preset / custom). Custom mode embeds `PlannerWidget` in-section. Autorun checkbox appears when a workflow is selected.
- **AgentRow** (in WorkspacesSidebar): collapsed view drops cost; layout reorder = `[status dot] [kind chip] [name] [delete CTA]`, delete always rightmost. Expanded panel uses `<CostBadge>`.
- **SessionRow** (active only): new info row with workflow name, agent count, total cost (CostBadge), autorun toggle button (Zap/ZapOff).
- **SpawnAgentControl popover**: shows `suggested next` section (color-coded by agent kind) at the top when one-off session has pending `NextAction`s.

### Store / persistence
- `Task.autoRun: boolean` on type + DB.
- `createSession({ ..., autoRun })` accepts the flag (only honored if `workflowId` set).
- `setSessionAutoRun(taskId, value)` for runtime toggle.
- `maybeAutoAdvanceWorkflow(taskId)` triggers post-completion: finds next un-spawned step, checks prior steps all `completed`/`skipped`, no `failed`, no exceeded budget alerts → spawns next step with `AGENT_KIND_DEFAULTS`. Hooked from the `completed` status transition in `sendTurn`.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 261 desktop tests pass (incl. snapshot updates and updated mocks for the new `loadDiffComments`/`sessionWorktrees`/`settings` selectors in `context-panel-rail.test.tsx`)
- [ ] manual: create preset workflow, enable autorun → verify next step auto-spawns when previous completes
- [ ] manual: create workflow → spawn first step → verify chip shows correct model (haiku/sonnet not opus)
- [ ] manual: one-off session → trigger summarize → verify `suggested next` appears in spawn-agent popover
- [ ] manual: AgentRow collapsed/expanded states, delete CTA placement
- [ ] manual: SessionRow active expansion + autorun toggle

## Out of scope (explicit)
- effort/verbosity sync (Issue 1 follow-up)
- `merge_pr` action wiring (#425 follow-up)
- workflow step drag-reorder

🤖 Generated with [Claude Code](https://claude.com/claude-code)