### PR TITLE
feat(desktop): chat UI refactor — picker, density, scope defaults

### DIFF
--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -59,55 +59,57 @@ export function ChatHeader({
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-[1200px] items-center gap-3 px-8 py-2.5">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
-          {isParallel && onSelectRun ? (
-            <ParallelProgressPill
-              parallelRunIds={parallelRunIds!}
-              runStatuses={runStatuses}
-              onSelectRun={onSelectRun}
-            />
-          ) : null}
-        </div>
-        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
-          <button
-            type="button"
-            onClick={() => void onCopyWorktree()}
-            className="inline-flex items-center gap-1 rounded-sm px-1 -mx-1 hover:bg-muted hover:text-foreground"
-            aria-label={`worktree — branch: ${branch}`}
-            title={`worktree — branch: ${branch}`}
-          >
-            <GitBranch size={12} aria-hidden />
-            <span className="font-mono">{branch}</span>
-            {copied ? <span className="text-success">copied</span> : null}
-          </button>
-          <span
-            className="inline-flex items-center gap-1"
-            title={`${userTurns} message${userTurns === 1 ? '' : 's'} sent · ${assistantReplies} reply${assistantReplies === 1 ? '' : 'ies'}`}
-          >
-            <MessagesSquare size={12} aria-hidden />
-            <span className="font-mono text-foreground/85">{userTurns}</span>
-            <span>turn{userTurns === 1 ? '' : 's'}</span>
-            {assistantReplies > 0 ? (
-              <span className="text-muted-foreground/60">· {assistantReplies} replies</span>
+    <div className="px-10 py-2.5">
+      <div className="mx-auto flex w-full max-w-[880px] items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="truncate text-sm font-semibold tracking-tight">{session.goal}</h1>
+            {isParallel && onSelectRun ? (
+              <ParallelProgressPill
+                parallelRunIds={parallelRunIds!}
+                runStatuses={runStatuses}
+                onSelectRun={onSelectRun}
+              />
             ) : null}
-          </span>
-          <span
-            className="inline-flex items-center gap-1 text-2xs text-muted-foreground"
-            title={mode.description}
-            aria-label={`permission mode: ${mode.label}`}
-          >
-            <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', mode.dot)} />
-            <span>{mode.label}</span>
-          </span>
-          {session.workflowId ? <PhaseProgressPill taskId={session.id} /> : null}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <button
+              type="button"
+              onClick={() => void onCopyWorktree()}
+              className="inline-flex items-center gap-1 rounded-sm px-1 -mx-1 hover:bg-muted hover:text-foreground"
+              aria-label={`worktree — branch: ${branch}`}
+              title={`worktree — branch: ${branch}`}
+            >
+              <GitBranch size={12} aria-hidden />
+              <span className="font-mono">{branch}</span>
+              {copied ? <span className="text-success">copied</span> : null}
+            </button>
+            <span
+              className="inline-flex items-center gap-1"
+              title={`${userTurns} message${userTurns === 1 ? '' : 's'} sent · ${assistantReplies} reply${assistantReplies === 1 ? '' : 'ies'}`}
+            >
+              <MessagesSquare size={12} aria-hidden />
+              <span className="font-mono text-foreground/85">{userTurns}</span>
+              <span>turn{userTurns === 1 ? '' : 's'}</span>
+              {assistantReplies > 0 ? (
+                <span className="text-muted-foreground/60">· {assistantReplies} replies</span>
+              ) : null}
+            </span>
+            <span
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground"
+              title={mode.description}
+              aria-label={`permission mode: ${mode.label}`}
+            >
+              <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', mode.dot)} />
+              <span>{mode.label}</span>
+            </span>
+            {session.workflowId ? <PhaseProgressPill taskId={session.id} /> : null}
+          </div>
         </div>
-      </div>
 
-      <div className="flex shrink-0 items-center gap-1">
-        <OpenInEditorButton worktreePath={worktreePath} />
+        <div className="flex shrink-0 items-center gap-1">
+          <OpenInEditorButton worktreePath={worktreePath} />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { GitBranch, MessagesSquare, ShieldCheck } from 'lucide-react';
-import { Button, Tooltip, cn } from '@kay-am/ui';
-import type { ClaudePermissionMode, Session, SessionStatus, ProviderRunId, Task, TaskId } from '@kay-am/types';
+import { GitBranch, MessagesSquare } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import type { Session, SessionStatus, ProviderRunId, Task, TaskId } from '@kay-am/types';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
 import { OpenInEditorButton } from '../OpenInEditorButton';
-import { SessionPermissionsPanel } from './SessionPermissionsPanel';
 import { ParallelProgressPill } from './ParallelProgressPill';
+import { permissionModeMeta } from './PermissionModePicker';
 
 interface ChatHeaderProps {
   session: Task;
@@ -20,27 +20,6 @@ function inferBranch(worktreePath: string | null, taskId: string): string {
   return tail ?? taskId.slice(0, 8);
 }
 
-const CYCLE_MODES: ReadonlyArray<ClaudePermissionMode> = ['bypassPermissions', 'acceptEdits', 'default', 'plan'];
-
-function nextPermissionMode(current: ClaudePermissionMode): ClaudePermissionMode {
-  const idx = CYCLE_MODES.indexOf(current);
-  return CYCLE_MODES[(idx + 1) % CYCLE_MODES.length] ?? 'bypassPermissions';
-}
-
-const MODE_LABELS: Partial<Record<ClaudePermissionMode, string>> = {
-  bypassPermissions: 'bypass',
-  acceptEdits: 'edits',
-  default: 'default',
-  plan: 'plan',
-};
-
-const MODE_DESCRIPTIONS: Partial<Record<ClaudePermissionMode, string>> = {
-  bypassPermissions: 'bypass — agent uses all tools freely',
-  acceptEdits: 'accept edits — asks before bash',
-  default: 'default — asks before writes/runs',
-  plan: 'plan — no tool calls executed',
-};
-
 export function ChatHeader({
   session,
   worktreePath,
@@ -48,11 +27,9 @@ export function ChatHeader({
   onSelectRun,
 }: ChatHeaderProps) {
   const [copied, setCopied] = useState(false);
-  const [permOpen, setPermOpen] = useState(false);
 
-  const setSessionPermissionMode = useAppStore((s) => s.setSessionPermissionMode);
-  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
   const branch = inferBranch(worktreePath, session.id);
+  const mode = permissionModeMeta(session.permissionMode);
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
   const events = useAppStore((s) => {
@@ -117,47 +94,21 @@ export function ChatHeader({
               <span className="text-muted-foreground/60">· {assistantReplies} replies</span>
             ) : null}
           </span>
+          <span
+            className="inline-flex items-center gap-1 text-2xs text-muted-foreground"
+            title={mode.description}
+            aria-label={`permission mode: ${mode.label}`}
+          >
+            <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', mode.dot)} />
+            <span>{mode.label}</span>
+          </span>
           {session.workflowId ? <PhaseProgressPill taskId={session.id} /> : null}
         </div>
       </div>
 
       <div className="flex shrink-0 items-center gap-1">
         <OpenInEditorButton worktreePath={worktreePath} />
-        <Tooltip
-          content={MODE_DESCRIPTIONS[session.permissionMode] ?? session.permissionMode}
-          side="bottom"
-        >
-          <button
-            type="button"
-            onClick={() => void setSessionPermissionMode(
-              session.id,
-              nextPermissionMode(session.permissionMode),
-            )}
-            className="rounded border border-border-soft px-1.5 py-0.5 font-mono text-2xs text-muted-foreground hover:border-border hover:text-foreground"
-            aria-label={`permission mode: ${session.permissionMode}`}
-          >
-            {MODE_LABELS[session.permissionMode] ?? session.permissionMode}
-          </button>
-        </Tooltip>
-        <Tooltip content="permissions" side="bottom">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setPermOpen((v) => !v)}
-            aria-label="permissions"
-          >
-            <ShieldCheck size={14} aria-hidden />
-          </Button>
-        </Tooltip>
       </div>
-
-      <SessionPermissionsPanel
-        taskId={session.id}
-        agentId={selectedAgentId}
-        workspaceId={session.workspaceId}
-        open={permOpen}
-        onClose={() => setPermOpen(false)}
-      />
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -393,13 +393,15 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           </p>
         ) : null}
       </div>
-      <SessionPermissionsPanel
-        taskId={session.id}
-        agentId={selectedAgentId}
-        workspaceId={session.workspaceId}
-        open={permOpen}
-        onClose={() => setPermOpen(false)}
-      />
+      {permOpen ? (
+        <SessionPermissionsPanel
+          taskId={session.id}
+          agentId={selectedAgentId}
+          workspaceId={session.workspaceId}
+          open={permOpen}
+          onClose={() => setPermOpen(false)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -108,7 +108,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
   const isSlashMode = slashQuery !== null;
 
-  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
   const selectedAgentState = useAppStore((s) =>
     selectedAgentId ? (s.agentTurnState[selectedAgentId] ?? null) : null,
   );
@@ -272,8 +271,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   }, [providerModels, effectiveModel]);
 
   return (
-    <div className="px-8 py-3">
-      <div className="mx-auto flex w-full max-w-[1200px] flex-col gap-2">
+    <div className="px-10 py-3">
+      <div className="mx-auto flex w-full max-w-[880px] flex-col gap-2">
         {!isRunning && !providerDisconnected ? (
           <RoutingIndicator
             sessionPreference={session.providerPreference}

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -6,8 +6,8 @@ import {
   useMemo,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
-import { Send, Square, X } from 'lucide-react';
-import { Textarea } from '@kay-am/ui';
+import { Send, ShieldCheck, Square, X } from 'lucide-react';
+import { Textarea, Tooltip } from '@kay-am/ui';
 import type {
   BudgetAlert,
   BudgetAlertKind,
@@ -28,6 +28,8 @@ import { EFFORT_LEVELS, type EffortLevel } from './chat-constants';
 import { ProviderUsagePill } from './ProviderUsagePill';
 import { PreflightPill } from './PreflightPill';
 import { ModelPicker } from './ModelPicker';
+import { PermissionModePicker } from './PermissionModePicker';
+import { SessionPermissionsPanel } from './SessionPermissionsPanel';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -98,7 +100,10 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
+  const [permOpen, setPermOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
 
   const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
   const isSlashMode = slashQuery !== null;
@@ -304,21 +309,34 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             ) : null}
           </div>
           <ProviderUsagePill provider={effectiveProvider} />
-          <ModelPicker
-            providers={providerCandidates}
-            models={modelCandidates}
-            provider={effectiveProvider}
-            model={effectiveModel}
-            effort={effort}
-            verbosity={verbosity}
-            connectedProviders={connectedProviderIds}
-            disabled={!allowOverride || isRunning}
-            disabledTitle={overrideDisabledTitle}
-            onSelectProvider={onSelectProvider}
-            onSelectModel={onSelectModel}
-            onSelectEffort={setEffort}
-            onSelectVerbosity={setVerbosity}
-          />
+          <div className="flex items-center gap-2">
+            <PermissionModePicker session={session} />
+            <ModelPicker
+              providers={providerCandidates}
+              models={modelCandidates}
+              provider={effectiveProvider}
+              model={effectiveModel}
+              effort={effort}
+              verbosity={verbosity}
+              connectedProviders={connectedProviderIds}
+              disabled={!allowOverride || isRunning}
+              disabledTitle={overrideDisabledTitle}
+              onSelectProvider={onSelectProvider}
+              onSelectModel={onSelectModel}
+              onSelectEffort={setEffort}
+              onSelectVerbosity={setVerbosity}
+            />
+            <Tooltip content="permissions" side="top">
+              <button
+                type="button"
+                onClick={() => setPermOpen((v) => !v)}
+                aria-label="permissions"
+                className="inline-flex items-center justify-center rounded-full bg-subtle px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ShieldCheck size={13} aria-hidden />
+              </button>
+            </Tooltip>
+          </div>
         </div>
         <div className="relative" ref={wrapperRef}>
           {showPopover && isSlashMode ? (
@@ -376,6 +394,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           </p>
         ) : null}
       </div>
+      <SessionPermissionsPanel
+        taskId={session.id}
+        agentId={selectedAgentId}
+        workspaceId={session.workspaceId}
+        open={permOpen}
+        onClose={() => setPermOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderRunId, SessionId, Task } from '@kay-am/types';
+import { cn } from '@kay-am/ui';
 import { EMPTY_ARRAY, useAppStore, useTranscript } from '../../store';
 import { detectParallelRunIds, filterEventsByRunId, reduceTranscript } from './transcript-items';
 import { TranscriptCard } from './TranscriptCards';
@@ -276,12 +277,12 @@ export function ChatView({ session }: ChatViewProps) {
         <div
           ref={scrollerRef}
           onScroll={onScroll}
-          className="flex-1 overflow-y-auto px-8 py-4"
+          className="flex-1 overflow-y-auto px-10 py-6"
           style={{ scrollbarGutter: 'stable' }}
         >
           {items.length === 0 ? (
             isProviderDisconnected ? (
-              <div className="mx-auto w-full max-w-[1200px]">
+              <div className="mx-auto w-full max-w-[880px]">
                 <AuthRequiredCallout
                   providerId={provider}
                   identity={providerIdentity}
@@ -289,13 +290,13 @@ export function ChatView({ session }: ChatViewProps) {
                 />
               </div>
             ) : (
-              <p className="mx-auto w-full max-w-[1200px] text-sm text-muted-foreground">
+              <p className="mx-auto w-full max-w-[880px] text-sm text-muted-foreground">
                 no turns yet — send a message.
               </p>
             )
           ) : (
             <ul
-              className="mx-auto flex w-full max-w-[1200px] flex-col"
+              className="mx-auto flex w-full max-w-[880px] flex-col"
               aria-live="polite"
               aria-relevant="additions"
             >
@@ -329,8 +330,17 @@ export function ChatView({ session }: ChatViewProps) {
                       lastDay = day;
                     }
                   }
+                  const isAssistantTurn = item.kind === 'assistant_text';
+                  const prevIsAssistant = prev?.kind === 'assistant_text';
+                  const showDivider = isAssistantTurn && prevIsAssistant;
                   node.push(
-                    <li key={item.key} className={tightToTool ? 'mt-0.5' : idx === 0 ? '' : 'mt-6'}>
+                    <li
+                      key={item.key}
+                      className={cn(
+                        tightToTool ? 'mt-0.5' : idx === 0 ? '' : 'mt-8',
+                        showDivider && 'border-t border-border/40 pt-8',
+                      )}
+                    >
                       <TranscriptCard
                         item={item}
                         taskId={session.id}
@@ -343,7 +353,7 @@ export function ChatView({ session }: ChatViewProps) {
                 });
               })()}
               {isThinking ? (
-                <li className="mt-6">
+                <li className="mt-8">
                   <ThinkingIndicator />
                 </li>
               ) : null}

--- a/apps/desktop/src/components/chat/PermissionModePicker.tsx
+++ b/apps/desktop/src/components/chat/PermissionModePicker.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import type { ClaudePermissionMode, Task } from '@kay-am/types';
+import { useAppStore } from '../../store';
+
+interface ModeMeta {
+  readonly value: ClaudePermissionMode;
+  readonly label: string;
+  readonly description: string;
+  readonly dot: string;
+  readonly text: string;
+}
+
+export const PERMISSION_MODES: ReadonlyArray<ModeMeta> = [
+  {
+    value: 'bypassPermissions',
+    label: 'bypass',
+    description: 'bypass — agent uses all tools freely',
+    dot: 'bg-red-500',
+    text: 'text-red-500',
+  },
+  {
+    value: 'acceptEdits',
+    label: 'edits',
+    description: 'accept edits — asks before bash',
+    dot: 'bg-amber-500',
+    text: 'text-amber-500',
+  },
+  {
+    value: 'default',
+    label: 'default',
+    description: 'default — asks before writes/runs',
+    dot: 'bg-blue-500',
+    text: 'text-blue-500',
+  },
+  {
+    value: 'plan',
+    label: 'plan',
+    description: 'plan — no tool calls executed',
+    dot: 'bg-slate-400',
+    text: 'text-slate-400',
+  },
+];
+
+export function permissionModeMeta(mode: ClaudePermissionMode): ModeMeta {
+  return PERMISSION_MODES.find((m) => m.value === mode) ?? PERMISSION_MODES[0]!;
+}
+
+interface PermissionModePickerProps {
+  readonly session: Task;
+}
+
+export function PermissionModePicker({ session }: PermissionModePickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const setSessionPermissionMode = useAppStore((s) => s.setSessionPermissionMode);
+  const current = permissionModeMeta(session.permissionMode);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('mousedown', onClick);
+    window.addEventListener('keydown', onEsc);
+    return () => {
+      window.removeEventListener('mousedown', onClick);
+      window.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const onPick = (mode: ClaudePermissionMode) => {
+    void setSessionPermissionMode(session.id, mode);
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={current.description}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-full bg-subtle px-2.5 py-0.5 text-xs transition-colors hover:bg-muted"
+      >
+        <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', current.dot)} />
+        <span className={cn('font-medium', current.text)}>{current.label}</span>
+        <ChevronDown size={11} aria-hidden className="text-muted-foreground/70" />
+      </button>
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="permission mode"
+          className="absolute bottom-full left-0 z-30 mb-1.5 w-64 overflow-hidden rounded-lg bg-background py-1.5 text-xs shadow-lg ring-1 ring-border-soft"
+        >
+          <div className="px-2.5 pb-0.5 pt-1 text-2xs uppercase tracking-wide text-muted-foreground/70">
+            permission mode
+          </div>
+          {PERMISSION_MODES.map((m) => {
+            const active = session.permissionMode === m.value;
+            return (
+              <button
+                key={m.value}
+                type="button"
+                onClick={() => onPick(m.value)}
+                className={cn(
+                  'flex w-full items-start gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted',
+                  active ? '' : 'opacity-80',
+                )}
+              >
+                <span
+                  aria-hidden
+                  className={cn('mt-1 inline-block h-1.5 w-1.5 shrink-0 rounded-full', m.dot)}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className={cn('block font-medium', m.text)}>{m.label}</span>
+                  <span className="block text-2xs text-muted-foreground">{m.description}</span>
+                </span>
+                {active ? (
+                  <span aria-hidden className="mt-0.5 text-2xs text-primary">
+                    ✓
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/chat/PermissionScopePicker.tsx
+++ b/apps/desktop/src/components/chat/PermissionScopePicker.tsx
@@ -59,6 +59,14 @@ export function PermissionScopePicker({
 
   const scopes: PermissionScope[] = ['global', 'workspace', 'task', 'once', 'deny'];
 
+  const SCOPE_TITLES: Record<PermissionScope, string> = {
+    global: 'allow for all sessions',
+    workspace: 'allow for this workspace',
+    task: 'allow for this task (recommended)',
+    once: 'allow this time only (not saved)',
+    deny: 'deny this request',
+  };
+
   return (
     <div className="mt-1.5 flex flex-wrap gap-1">
       {scopes.map((scope) => (
@@ -67,11 +75,14 @@ export function PermissionScopePicker({
           type="button"
           disabled={busy}
           onClick={() => void handle(scope)}
+          title={SCOPE_TITLES[scope]}
           className={cn(
             'rounded border px-2 py-0.5 text-2xs font-medium transition-colors',
-            scope === 'deny'
-              ? 'border-danger/40 text-danger hover:bg-danger/10'
-              : 'border-success/40 text-success hover:bg-success/10',
+            scope === 'task'
+              ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
+              : scope === 'deny'
+                ? 'border-danger/40 text-danger hover:bg-danger/10'
+                : 'border-success/40 text-success hover:bg-success/10',
             busy && 'cursor-not-allowed opacity-50',
           )}
         >

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -22,7 +22,12 @@ interface TranscriptCardProps {
   readonly onRefreshAuth?: () => void;
 }
 
-export function TranscriptCard({ item, taskId = null, agentId = null, onRefreshAuth }: TranscriptCardProps) {
+export function TranscriptCard({
+  item,
+  taskId = null,
+  agentId = null,
+  onRefreshAuth,
+}: TranscriptCardProps) {
   switch (item.kind) {
     case 'user_text':
       return <UserText text={item.text} at={item.at} />;
@@ -95,7 +100,7 @@ function formatCostUsd(cost: number): string {
 
 function AssistantText({ text }: { text: string }) {
   return (
-    <div className="group relative">
+    <div className="group relative text-[13px]">
       <div className="absolute -right-1 -top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
         <CopyButton value={text} label="message" />
       </div>
@@ -199,7 +204,7 @@ function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' 
       </button>
       {open ? (
         <div className="ml-[1.125rem] mt-0.5 flex min-w-0 flex-col gap-1">
-          <pre className="min-w-0 whitespace-pre-wrap break-words rounded bg-subtle p-2 text-2xs text-muted-foreground">
+          <pre className="min-w-0 whitespace-pre-wrap break-words rounded bg-subtle p-2 text-xs text-muted-foreground">
             input: {JSON.stringify(item.input, null, 2)}
           </pre>
           {item.ended ? (


### PR DESCRIPTION
## summary

3 commits, 3 concerns, disjoint files. Reviewable per commit.

### 1. `permission-mode dropdown picker + footer relocation`
- new `PermissionModePicker.tsx` mirrors `ModelPicker` (dropdown, not cycling button).
- header loses the cycling `[bypass]` pill + shield button → keeps a readonly colored-dot badge as status indicator.
- picker + shield button move down to the controls row near `ModelPicker` (semantically a sibling of model/effort/verbosity).

### 2. `chat transcript density + readable spacing`
- container `px-8 py-4` → `px-10 py-6`, max-width `1200px` → `880px` (reading width).
- assistant body `text-xs` → `text-[13px]`, expanded tool-call output `text-2xs` → `text-xs`.
- subtle `border-t border-border/40` divider between consecutive assistant turns.

### 3. `emphasize "task" as default permission scope`
- in `PermissionScopePicker`, `task` becomes the visual primary (solid bg); `once / workspace / global` stay muted; `deny` unchanged.
- added `title=` attrs on all 5 buttons.
- guides users toward session-persisted approvals instead of re-approving the same tool every turn.

## test plan
- [ ] header: no more cycling pill — only readonly mode badge next to turns count.
- [ ] footer controls row: `PermissionModePicker` · `ModelPicker` · shield → opens `SessionPermissionsPanel`.
- [ ] picker dropdown: 4 modes with colored dots + descriptions, click sets mode, persists across reload.
- [ ] transcript: noticeably more breathable, dividers between assistant turns, no layout regressions on long sessions.
- [ ] permission request card: `task` button visibly primary, other scopes muted, tooltips on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)