### PR TITLE
feat(desktop): soften transcript contrast hierarchy

### DIFF
--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -44,7 +44,7 @@ export function TranscriptCard({ item, taskId = null, agentId = null, onRefreshA
       );
     case 'usage':
       return (
-        <p className="text-xs text-muted-foreground">
+        <p className="text-xs text-muted-foreground/70">
           {formatTokens(item.usage.inputTokens)} in / {formatTokens(item.usage.outputTokens)} out
           {item.usage.cachedInputTokens > 0
             ? ` · ${formatTokens(item.usage.cachedInputTokens)} cached`
@@ -186,7 +186,7 @@ function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' 
           )}
         />
         <Wrench size={11} aria-hidden className={cn('shrink-0', accent)} />
-        <span className="font-mono text-foreground/85">{item.toolName}</span>
+        <span className="font-mono text-muted-foreground">{item.toolName}</span>
         {running ? (
           <span className="flex shrink-0 gap-0.5">
             <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -297,7 +297,10 @@ function renderInline(input: string, keyPrefix: string): ReactNode {
         }
         flush();
         out.push(
-          <code key={nextKey()} className="rounded bg-muted px-1 py-0.5 font-mono text-[0.875em]">
+          <code
+            key={nextKey()}
+            className="rounded bg-muted px-1 py-0.5 font-mono text-[0.875em] text-foreground"
+          >
             {inner}
           </code>,
         );
@@ -400,12 +403,12 @@ function renderBlock(block: Block, idx: number): ReactNode {
       );
     case 'heading': {
       const sizes: Record<1 | 2 | 3 | 4 | 5 | 6, string> = {
-        1: 'text-lg font-semibold',
-        2: 'text-base font-semibold',
-        3: 'text-base font-semibold',
-        4: 'text-sm font-semibold',
-        5: 'text-sm font-semibold',
-        6: 'text-sm font-semibold',
+        1: 'text-lg font-semibold text-foreground',
+        2: 'text-base font-semibold text-foreground',
+        3: 'text-base font-medium text-foreground',
+        4: 'text-sm font-medium text-foreground',
+        5: 'text-sm font-medium text-foreground',
+        6: 'text-sm font-medium text-foreground',
       };
       const Tag = `h${block.level}` as 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
       return (
@@ -448,12 +451,12 @@ function renderBlock(block: Block, idx: number): ReactNode {
         <div key={key} className="overflow-x-auto">
           <table className="w-full border-collapse text-sm">
             <thead>
-              <tr className="border-b border-border-soft">
+              <tr className="border-b border-border-soft/60">
                 {block.headers.map((h, j) => (
                   <th
                     key={`${key}-h-${j}`}
                     className={cn(
-                      'px-3 py-1.5 font-semibold text-foreground',
+                      'px-3 py-1.5 font-medium text-foreground/75',
                       alignClass(block.align[j]),
                     )}
                   >
@@ -509,7 +512,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
 export function Markdown({ text, className }: MarkdownProps) {
   const blocks = parseBlocks(text);
   return (
-    <div className={cn('flex flex-col gap-2 text-base text-foreground', className)}>
+    <div className={cn('flex flex-col gap-2 text-base text-foreground/85', className)}>
       {blocks.map(renderBlock)}
     </div>
   );


### PR DESCRIPTION
## summary

Flat visual hierarchy in chat transcript made everything feel equally important. User feedback: *"é come se tutto avesse la stessa importanza, e mi da la sensazione di dover leggere tutto"*.

**Principle**: no new colors. Soften the body so natural accents (headings, **bold**, \`inline code\`, table headers) emerge by contrast against the body, not against the background.

## changes (2 files)

### \`packages/ui/src/components/Markdown.tsx\`
- body wrapper: \`text-foreground\` → \`text-foreground/85\`
- headings h1–h6: explicit \`text-foreground\` full strength (don't inherit /85); h3–h6 weight \`font-semibold\` → \`font-medium\` so the weight ramps with size
- inline \`<code>\`: explicit \`text-foreground\` so it breaks through soft body
- tables: header border opacity \`/60\`, \`<th>\` \`font-semibold text-foreground\` → \`font-medium text-foreground/75\` (was too heavy on dark theme)

### \`apps/desktop/src/components/chat/TranscriptCards.tsx\`
- tool-call name (collapsed): \`text-foreground/85\` → \`text-muted-foreground\` — passive tool entries feel shy until interacted with
- per-turn usage footer (\`N in / Y out · Z cached\`): \`text-muted-foreground\` → \`/70\` — invisible until you look for it

## scope

- separate from PR #448 (column-width unification + picker + density)
- no layout, no spacing, no font sizes touched
- no new design tokens

## test plan

- [ ] open a chat with a markdown table → header lighter, borders softer, body cells readable but not screaming
- [ ] assistant prose with headings → headings clearly stand out vs body
- [ ] inline \`code\` snippets and **bold** spans visibly pop
- [ ] tool calls in turn → look passive when collapsed
- [ ] per-turn token usage line → still readable but recedes
- [ ] user message bubbles unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)