### PR TITLE
feat(desktop): per-step model+effort override in planner ui

### DIFF
--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -383,26 +383,36 @@ export function NewSessionDialog({
 
               {workflowMode === 'custom' ? (
                 <div className="mt-3 flex flex-col gap-3">
-                  <div className="rounded-md border border-border-soft bg-subtle px-3 py-3">
-                    <div className="mb-1 flex items-center gap-1.5 text-xs font-semibold text-foreground">
-                      <Sparkles size={12} aria-hidden /> design with planner
-                    </div>
-                    <PlannerWidget
-                      workspaceId={workspaceId}
-                      providerId={selectedProvider}
-                      initialTheme={goal}
-                      onWorkflowReady={(workflowId) => {
-                        setSelectedPhaseTemplateId(workflowId);
-                      }}
-                    />
-                  </div>
                   {selectedPhaseTemplateId !== '' ? (
-                    <WorkflowPreview
-                      template={
-                        phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null
-                      }
-                    />
-                  ) : null}
+                    <>
+                      <WorkflowPreview
+                        template={
+                          phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null
+                        }
+                      />
+                      <button
+                        type="button"
+                        onClick={() => setSelectedPhaseTemplateId('')}
+                        className="flex items-center gap-1 self-start text-2xs text-muted-foreground underline hover:text-foreground"
+                      >
+                        <Sparkles size={10} aria-hidden /> re-design with planner
+                      </button>
+                    </>
+                  ) : (
+                    <div className="rounded-md border border-border-soft bg-subtle px-3 py-3">
+                      <div className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                        <Sparkles size={12} aria-hidden /> design with planner
+                      </div>
+                      <PlannerWidget
+                        workspaceId={workspaceId}
+                        providerId={selectedProvider}
+                        initialTheme={goal}
+                        onWorkflowReady={(workflowId) => {
+                          setSelectedPhaseTemplateId(workflowId);
+                        }}
+                      />
+                    </div>
+                  )}
                 </div>
               ) : null}
 
@@ -530,6 +540,7 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <ol className="flex flex-col gap-1">
         {sortedSteps.map((step, i) => {
           const model = step.modelOverride ? shortModel(step.modelOverride) : null;
+          const effort = step.effort ?? null;
           return (
             <li
               key={step.id}
@@ -537,9 +548,9 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
             >
               <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
               <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
-              {model ? (
-                <span className="rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-                  {model}
+              {model || effort ? (
+                <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
+                  {[model, effort].filter(Boolean).join(' · ')}
                 </span>
               ) : null}
             </li>

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -1,15 +1,32 @@
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { Button, Textarea, cn } from '@kay-am/ui';
-import { PlannerClient, type PlannerOutput } from '@kay-am/core';
-import type { ProviderId, Step, StepId, Workflow, WorkflowId, WorkspaceId } from '@kay-am/types';
+import { PlannerClient, type PlannerOutput, defaultsForRole } from '@kay-am/core';
+import type {
+  AgentEffort,
+  ProviderId,
+  Step,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@kay-am/types';
 import { useAppStore } from '../store';
+import { shortModel } from '../agentRowFormat';
 
 interface PlannerWidgetProps {
   workspaceId: WorkspaceId;
   providerId: ProviderId;
   initialTheme: string;
   onWorkflowReady: (workflowId: WorkflowId) => void;
+}
+
+const SELECTABLE_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-7'] as const;
+const SELECTABLE_EFFORTS: AgentEffort[] = ['low', 'medium', 'high', 'extra-high', 'max'];
+
+interface StepOverride {
+  model: string;
+  effort: AgentEffort;
 }
 
 export function PlannerWidget({
@@ -22,17 +39,25 @@ export function PlannerWidget({
   const [theme, setTheme] = useState(initialTheme);
   const [busy, setBusy] = useState(false);
   const [plan, setPlan] = useState<PlannerOutput | null>(null);
+  const [overrides, setOverrides] = useState<Record<number, StepOverride>>({});
   const [error, setError] = useState<string | null>(null);
 
   const onPlan = async () => {
     if (theme.trim().length === 0) return;
     setError(null);
     setPlan(null);
+    setOverrides({});
     setBusy(true);
     try {
       const client = new PlannerClient({ providerId, invokeFn: invoke });
       const result = await client.plan({ theme: theme.trim() });
       setPlan(result.output);
+      const initial: Record<number, StepOverride> = {};
+      result.output.steps.forEach((s, i) => {
+        const d = defaultsForRole(s.role);
+        initial[i] = { model: d.model, effort: d.effort };
+      });
+      setOverrides(initial);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -47,13 +72,18 @@ export function PlannerWidget({
     try {
       const now = new Date().toISOString() as Workflow['createdAt'];
       const workflowId = `wf_planner_${crypto.randomUUID()}` as WorkflowId;
-      const steps: ReadonlyArray<Step> = plan.steps.map((s, ordinal) => ({
-        id: `step_planner_${crypto.randomUUID()}` as StepId,
-        workflowId,
-        ordinal,
-        name: s.name,
-        promptPrefix: s.promptPrefix,
-      }));
+      const steps: ReadonlyArray<Step> = plan.steps.map((s, ordinal) => {
+        const o = overrides[ordinal] ?? defaultsForRole(s.role);
+        return {
+          id: `step_planner_${crypto.randomUUID()}` as StepId,
+          workflowId,
+          ordinal,
+          name: s.name,
+          promptPrefix: s.promptPrefix,
+          modelOverride: o.model,
+          effort: o.effort,
+        };
+      });
       const workflow: Workflow = {
         id: workflowId,
         workspaceId,
@@ -66,6 +96,7 @@ export function PlannerWidget({
       await savePhaseTemplate(workflow);
       onWorkflowReady(workflowId);
       setPlan(null);
+      setOverrides({});
       setTheme('');
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -75,9 +106,8 @@ export function PlannerWidget({
   };
 
   return (
-    <div className="flex flex-col gap-2 rounded-md bg-subtle p-3">
+    <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-foreground">design with planner</span>
         <span className="text-2xs text-muted-foreground">cheap-tier · {providerId}</span>
       </div>
       <Textarea
@@ -101,7 +131,7 @@ export function PlannerWidget({
         </p>
       ) : null}
       {plan ? (
-        <div className="flex flex-col gap-2 rounded-md bg-background p-3">
+        <div className="flex flex-col gap-2 rounded-md border border-border-soft bg-background p-3">
           <div>
             <div className="text-sm font-semibold">{plan.workflowName}</div>
             {plan.reasoning ? (
@@ -111,21 +141,68 @@ export function PlannerWidget({
             ) : null}
           </div>
           <ol className="flex flex-col gap-1.5">
-            {plan.steps.map((s, i) => (
-              <li key={`${i}-${s.name}`} className={cn('rounded-md bg-subtle px-2.5 py-1.5')}>
-                <div className="flex items-center justify-between gap-2 text-xs">
-                  <span className="font-medium">
-                    {i + 1}. {s.name}
-                  </span>
-                  <span className="rounded-full bg-muted px-1.5 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
-                    {s.role}
-                  </span>
-                </div>
-                <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
-                  {s.expectedOutput}
-                </p>
-              </li>
-            ))}
+            {plan.steps.map((s, i) => {
+              const ov = overrides[i];
+              return (
+                <li key={`${i}-${s.name}`} className="rounded-md bg-subtle px-2.5 py-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="pt-0.5 text-xs font-medium">
+                      {i + 1}. {s.name}
+                    </span>
+                    <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
+                      {s.role}
+                    </span>
+                  </div>
+                  {s.expectedOutput ? (
+                    <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+                      {s.expectedOutput}
+                    </p>
+                  ) : null}
+                  {ov ? (
+                    <div className="mt-2 flex items-center gap-1.5">
+                      <select
+                        value={ov.model}
+                        onChange={(e) =>
+                          setOverrides((prev) => ({
+                            ...prev,
+                            [i]: { ...ov, model: e.target.value },
+                          }))
+                        }
+                        className={cn(
+                          'rounded border border-border-soft bg-background px-1.5 py-0.5 text-2xs text-foreground',
+                          'focus:outline-none focus:ring-1 focus:ring-primary',
+                        )}
+                      >
+                        {SELECTABLE_MODELS.map((m) => (
+                          <option key={m} value={m}>
+                            {shortModel(m)}
+                          </option>
+                        ))}
+                      </select>
+                      <select
+                        value={ov.effort}
+                        onChange={(e) =>
+                          setOverrides((prev) => ({
+                            ...prev,
+                            [i]: { ...ov, effort: e.target.value as AgentEffort },
+                          }))
+                        }
+                        className={cn(
+                          'rounded border border-border-soft bg-background px-1.5 py-0.5 text-2xs text-foreground',
+                          'focus:outline-none focus:ring-1 focus:ring-primary',
+                        )}
+                      >
+                        {SELECTABLE_EFFORTS.map((ef) => (
+                          <option key={ef} value={ef}>
+                            {ef}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
           </ol>
           <Button size="sm" onClick={onSave} disabled={busy}>
             {busy ? 'saving…' : 'use this workflow'}

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -1,33 +1,6 @@
-import type { ProviderId } from '@kay-am/types';
+import type { AgentEffort, AgentRole, ProviderId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Per-role agent defaults.
-//
-// Each agent in a Task is assigned a "role" (the chip the user sees in the
-// sidebar). The role drives sensible default routing — the user shouldn't
-// have to pick a model for every spawn, but can override when needed. These
-// defaults are intentionally conservative: cheap models for read-heavy work,
-// stronger models for design-heavy work.
-//
-// Effort is included as a hint (used as a UI default in the spawn dialog and
-// passed to claude --effort when the provider supports it). Storing effort
-// on Step itself is deferred to a follow-up PR; for now the seeder only
-// applies provider + model.
-// ---------------------------------------------------------------------------
-
-export type AgentRole =
-  | 'scout'
-  | 'planner'
-  | 'implementer'
-  | 'reviewer'
-  | 'investigator'
-  | 'product'
-  | 'architect'
-  | 'tester'
-  | 'explorer'
-  | 'custom';
-
-export type AgentEffort = 'low' | 'medium' | 'high' | 'extra-high' | 'max';
+export type { AgentEffort, AgentRole } from '@kay-am/types';
 
 export interface RoleDefaults {
   readonly provider: ProviderId;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -20,6 +20,7 @@ import { m019TaskPermissionMode } from './m019-task-permission-mode';
 import { m020DiffComments } from './m020-diff-comments';
 import { m021DiffCommentLine } from './m021-diff-comment-line';
 import { m022TaskAutorun } from './m022-task-autorun';
+import { m023StepEffort } from './m023-step-effort';
 
 export interface Migration {
   readonly version: number;
@@ -49,4 +50,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 20, sql: m020DiffComments },
   { version: 21, sql: m021DiffCommentLine },
   { version: 22, sql: m022TaskAutorun },
+  { version: 23, sql: m023StepEffort },
 ];

--- a/packages/db/src/migrations/m023-step-effort.ts
+++ b/packages/db/src/migrations/m023-step-effort.ts
@@ -1,0 +1,3 @@
+export const m023StepEffort = /* sql */ `
+ALTER TABLE steps ADD COLUMN effort TEXT;
+`;

--- a/packages/db/src/queries/workflow.ts
+++ b/packages/db/src/queries/workflow.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentEffort,
   IsoDateTime,
   ProviderId,
   Step,
@@ -26,6 +27,7 @@ interface StepRow {
   prompt_prefix: string;
   provider_override: string | null;
   model_override: string | null;
+  effort: string | null;
 }
 
 function toStep(row: StepRow): Step {
@@ -37,6 +39,7 @@ function toStep(row: StepRow): Step {
     promptPrefix: row.prompt_prefix,
     ...(row.provider_override && { providerOverride: row.provider_override as ProviderId }),
     ...(row.model_override && { modelOverride: row.model_override }),
+    ...(row.effort && { effort: row.effort as AgentEffort }),
   };
 }
 
@@ -109,8 +112,8 @@ export async function upsertWorkflow(db: Database, workflow: Workflow): Promise<
   for (const step of workflow.steps) {
     await db.execute(
       `INSERT INTO steps
-        (id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        (id, workflow_id, ordinal, name, prompt_prefix, provider_override, model_override, effort)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         step.id,
         workflow.id,
@@ -119,6 +122,7 @@ export async function upsertWorkflow(db: Database, workflow: Workflow): Promise<
         step.promptPrefix,
         step.providerOverride ?? null,
         step.modelOverride ?? null,
+        step.effort ?? null,
       ],
     );
   }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -57,6 +57,8 @@ export type {
 } from './budget';
 export type { TelemetrySummary, TelemetryPeriodSummary } from './telemetry-period';
 export type {
+  AgentEffort,
+  AgentRole,
   ParallelMergeStrategy,
   ParallelGroup,
   ParallelSession,

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -11,6 +11,20 @@ import type {
 } from './ids';
 import type { ProviderId } from './provider-registry';
 
+export type AgentEffort = 'low' | 'medium' | 'high' | 'extra-high' | 'max';
+
+export type AgentRole =
+  | 'scout'
+  | 'planner'
+  | 'implementer'
+  | 'reviewer'
+  | 'investigator'
+  | 'product'
+  | 'architect'
+  | 'tester'
+  | 'explorer'
+  | 'custom';
+
 export type SessionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 
 export type ParallelMergeStrategy = 'last_write_wins' | 'manual' | 'synthesizer_driven';
@@ -23,6 +37,7 @@ export type Step = Readonly<{
   promptPrefix: string;
   providerOverride?: ProviderId;
   modelOverride?: string;
+  effort?: AgentEffort;
   parallelGroup?: number;
 }>;
 


### PR DESCRIPTION
## Summary

- Move `AgentEffort` (and `AgentRole`) types from `@kay-am/core` to `@kay-am/types` to break circular dep
- Add `effort?: AgentEffort` field to `Step` type + DB column migration
- Surface model + effort per step in `PlannerWidget` plan review, with inline per-step overrides (model select + effort select)
- Populate `step.modelOverride` and `step.effort` from `defaultsForRole` at save time
- UI cleanup in `NewSessionDialog` custom workflow section: remove redundant outer card, collapse planner after workflow saved

## Test plan

- [ ] Plan a custom workflow — each step shows model + effort derived from role
- [ ] Override model/effort on a step before saving — `WorkflowPreview` reflects override
- [ ] Leave defaults — `WorkflowPreview` shows role-derived model + effort
- [ ] Re-design flow — "re-design" resets to planner, new plan can be saved
- [ ] Existing workflows (no effort column) load without error (nullable column)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
