### PR TITLE
feat(desktop): theme system soft+cream, sidebar icons, Legenda

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -516,6 +516,56 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     <div
       class="ml-auto flex items-center gap-0.5"
     >
+      <button
+        aria-label="switch to light mode"
+        class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title="switch to light mode"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sun"
+          fill="none"
+          height="13"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="13"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="4"
+          />
+          <path
+            d="M12 2v2"
+          />
+          <path
+            d="M12 20v2"
+          />
+          <path
+            d="m4.93 4.93 1.41 1.41"
+          />
+          <path
+            d="m17.66 17.66 1.41 1.41"
+          />
+          <path
+            d="M2 12h2"
+          />
+          <path
+            d="M20 12h2"
+          />
+          <path
+            d="m6.34 17.66-1.41 1.41"
+          />
+          <path
+            d="m19.07 4.93-1.41 1.41"
+          />
+        </svg>
+      </button>
       <div
         aria-label="alerts"
         aria-live="polite"
@@ -622,11 +672,28 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
       class="flex flex-col px-2"
     >
       <header
-        class="flex items-baseline justify-between gap-2 pb-1.5"
+        class="flex items-center justify-between gap-2 pb-1.5"
       >
         <span
-          class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
+          class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-folder-open text-primary"
+            fill="none"
+            height="11"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="11"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m6 14 1.5-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.54 6a2 2 0 0 1-1.95 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H18a2 2 0 0 1 2 2v2"
+            />
+          </svg>
           Workspaces
         </span>
       </header>
@@ -682,8 +749,28 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
         class="flex items-center justify-between gap-2 pb-1.5"
       >
         <span
-          class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
+          class="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
         >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-messages-square text-info"
+            fill="none"
+            height="11"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="11"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16 10a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 14.286V4a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"
+            />
+            <path
+              d="M20 9a2 2 0 0 1 2 2v10.286a.71.71 0 0 1-1.212.502l-2.202-2.202A2 2 0 0 0 17.172 19H10a2 2 0 0 1-2-2v-1"
+            />
+          </svg>
           Sessions
         </span>
         <div
@@ -1306,6 +1393,55 @@ workspace: $0"
               </svg>
               <span>
                 Tips
+              </span>
+            </button>
+            <button
+              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-palette"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 22a1 1 0 0 1 0-20 10 9 0 0 1 10 9 5 5 0 0 1-5 5h-2.25a1.75 1.75 0 0 0-1.4 2.8l.3.4a1.75 1.75 0 0 1-1.4 2.8z"
+                />
+                <circle
+                  cx="13.5"
+                  cy="6.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+                <circle
+                  cx="17.5"
+                  cy="10.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+                <circle
+                  cx="6.5"
+                  cy="12.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+                <circle
+                  cx="8.5"
+                  cy="7.5"
+                  fill="currentColor"
+                  r=".5"
+                />
+              </svg>
+              <span>
+                Legenda
               </span>
             </button>
           </nav>

--- a/apps/desktop/src/components/GuideDialog.tsx
+++ b/apps/desktop/src/components/GuideDialog.tsx
@@ -1,13 +1,13 @@
 import { useState } from 'react';
 import { Button, Dialog, cn } from '@kay-am/ui';
-import { BookOpen, Bot, Coins, GitBranch, Lightbulb, MessagesSquare, Wrench } from 'lucide-react';
+import { BookOpen, Bot, Coins, GitBranch, Lightbulb, MessagesSquare, Palette, Wrench } from 'lucide-react';
 
 interface GuideDialogProps {
   open: boolean;
   onClose: () => void;
 }
 
-type Section = 'overview' | 'session' | 'turn' | 'tools' | 'tokens' | 'agents' | 'tips';
+type Section = 'overview' | 'session' | 'turn' | 'tools' | 'tokens' | 'agents' | 'tips' | 'legenda';
 
 interface NavItem {
   id: Section;
@@ -23,6 +23,7 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'tokens', label: 'Tokens & cost', icon: <Coins size={14} aria-hidden /> },
   { id: 'agents', label: 'Agents', icon: <Bot size={14} aria-hidden /> },
   { id: 'tips', label: 'Tips', icon: <Lightbulb size={14} aria-hidden /> },
+  { id: 'legenda', label: 'Legenda', icon: <Palette size={14} aria-hidden /> },
 ];
 
 export function GuideDialog({ open, onClose }: GuideDialogProps) {
@@ -323,6 +324,64 @@ function Content({ section }: { section: Section }) {
           />
         </Article>
       );
+
+    case 'legenda':
+      return (
+        <Article heading="Legenda" intro="color meanings used throughout the interface.">
+          <H3>Status dots — sessions & agents</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-muted-foreground/50', label: 'pending', desc: 'not yet started' },
+              { dot: 'bg-info', label: 'running', desc: 'active turn in progress' },
+              { dot: 'bg-success', label: 'completed', desc: 'ended successfully' },
+              { dot: 'bg-danger', label: 'failed', desc: 'ended with error' },
+              { dot: 'bg-muted-foreground/30', label: 'skipped', desc: 'bypassed by workflow logic' },
+            ]}
+          />
+          <H3>Edit types — transcript</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-primary', label: 'create', desc: 'new file or resource added' },
+              { dot: 'bg-muted-foreground/60', label: 'modify', desc: 'existing file changed' },
+              { dot: 'bg-danger', label: 'delete', desc: 'file or resource removed' },
+            ]}
+          />
+          <H3>Context window bar — CTX fill level</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-success', label: '< 50%', desc: 'comfortable — plenty of context remaining' },
+              { dot: 'bg-info', label: '50–75%', desc: 'moderate — monitor closely' },
+              { dot: 'bg-warning', label: '75–90%', desc: 'high — consider summarising soon' },
+              { dot: 'bg-danger', label: '≥ 90%', desc: 'critical — start a new session' },
+            ]}
+          />
+          <H3>Verbosity — output density</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-success', label: 'essential', desc: 'bare minimum — one-liners only' },
+              { dot: 'bg-success/70', label: 'minimal', desc: 'brief but complete' },
+              { dot: 'bg-info', label: 'normal', desc: 'standard prose with rationale' },
+              { dot: 'bg-warning', label: 'detailed', desc: 'extra context and reasoning' },
+              { dot: 'bg-danger', label: 'verbose', desc: 'full long-form with alternatives' },
+            ]}
+          />
+          <H3>Permission mode — tool access</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-danger', label: 'bypass', desc: 'all tools used freely — no prompts' },
+              { dot: 'bg-warning', label: 'edits', desc: 'file edits allowed; bash asks first' },
+              { dot: 'bg-blue-500', label: 'default', desc: 'writes and runs ask for approval' },
+              { dot: 'bg-slate-400', label: 'plan', desc: 'no tool calls executed — read-only' },
+            ]}
+          />
+          <H3>Auto badge</H3>
+          <LegendaGrid
+            rows={[
+              { dot: 'bg-amber-400', label: 'AUTO', desc: 'autorun mode — next action fires without user confirmation' },
+            ]}
+          />
+        </Article>
+      );
   }
 }
 
@@ -375,6 +434,26 @@ function List({ items }: { items: ReadonlyArray<readonly [string, string]> }) {
         <li key={term} className="flex flex-col gap-0.5">
           <span className="text-sm font-semibold text-foreground">{term}</span>
           <span className="text-sm leading-relaxed text-muted-foreground">{desc}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface LegendaRow {
+  readonly dot: string;
+  readonly label: string;
+  readonly desc: string;
+}
+
+function LegendaGrid({ rows }: { rows: ReadonlyArray<LegendaRow> }) {
+  return (
+    <ul className="flex flex-col gap-1">
+      {rows.map((row) => (
+        <li key={row.label} className="flex items-center gap-2.5">
+          <span aria-hidden className={cn('inline-block h-2 w-2 shrink-0 rounded-full', row.dot)} />
+          <span className="w-20 shrink-0 text-sm font-medium text-foreground">{row.label}</span>
+          <span className="text-sm text-muted-foreground">{row.desc}</span>
         </li>
       ))}
     </ul>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -4,6 +4,7 @@ import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
   ArrowRight,
   ArrowUpDown,
+  Bot,
   ChevronDown,
   ChevronRight,
   FolderOpen,
@@ -13,9 +14,12 @@ import {
   GitPullRequestArrow,
   GitPullRequestDraft,
   HelpCircle,
+  MessagesSquare,
+  Moon,
   Plus,
   Settings,
   Settings2,
+  Sun,
   Trash2,
   Users,
   Workflow as WorkflowIcon,
@@ -72,6 +76,7 @@ import {
 } from '../agentKind';
 import { spawnFromNextAction, spawnKindForAction } from '../spawnFromNextAction';
 import { openUrl } from '../editor';
+import { useThemeStore } from '../theme';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
@@ -139,6 +144,9 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
     return matchesState && matchesProvider;
   });
 
+  const theme = useThemeStore((s) => s.theme);
+  const toggleTheme = useThemeStore((s) => s.toggleTheme);
+
   const [archivedMap, archive, unarchive] = useArchivedTasks();
   const activeSessions = filteredSessions.filter((s) => !archivedMap[s.id]);
   const archivedSessions = filteredSessions.filter((s) => archivedMap[s.id]);
@@ -162,6 +170,15 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       <div className="flex shrink-0 items-center gap-1.5 px-2 py-2">
         <span className="px-1 text-sm font-semibold tracking-tight">kAY.am</span>
         <div className="ml-auto flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={toggleTheme}
+            title={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
+            aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
+            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {theme === 'dark' ? <Sun size={13} aria-hidden /> : <Moon size={13} aria-hidden />}
+          </button>
           <AlertCenter />
           <button
             type="button"
@@ -186,8 +203,9 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
 
       <ScrollArea className="max-h-[40%] shrink-0">
         <section className="flex flex-col px-2">
-          <header className="flex items-baseline justify-between gap-2 pb-1.5">
-            <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          <header className="flex items-center justify-between gap-2 pb-1.5">
+            <span className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              <FolderOpen size={11} aria-hidden className="text-primary" />
               Workspaces
             </span>
           </header>
@@ -214,7 +232,8 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       <ScrollArea className="mt-8 flex-1">
         <section className="flex flex-col px-2">
           <header className="flex items-center justify-between gap-2 pb-1.5">
-            <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            <span className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              <MessagesSquare size={11} aria-hidden className="text-info" />
               Sessions
             </span>
             <div className="flex items-center gap-1.5">
@@ -1344,7 +1363,8 @@ function AgentsSection({ task }: AgentsSectionProps) {
   return (
     <section className="mt-8 flex flex-col px-2 pb-3">
       <header className="flex items-center justify-between gap-2 pb-1.5">
-        <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        <span className="flex items-center gap-1.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          <Bot size={11} aria-hidden className="text-success" />
           Agents
         </span>
         <span className="truncate text-2xs text-muted-foreground/70">

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { bootstrapTheme } from './theme';
 import './styles.css';
+
+bootstrapTheme();
 
 const container = document.getElementById('root');
 if (!container) throw new Error('root element not found');

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -5,35 +5,30 @@
   --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
 
-  /* Neutrals: subtle cool tint instead of pure greys — page reads warmer +
-     less clinical. Sidebar and chat get a hair of separation via lightness. */
-  --color-background: oklch(0.16 0.008 260);
-  --color-foreground: oklch(0.94 0.006 90);
-  --color-subtle: oklch(0.20 0.010 260);
-  --color-muted: oklch(0.26 0.012 260);
-  --color-muted-foreground: oklch(0.66 0.018 260);
-  --color-border: oklch(0.32 0.015 260);
-  --color-border-soft: oklch(0.24 0.012 260);
+  /* Dark palette (default) — soft desaturated darks, lifted black base. */
+  --color-background: oklch(0.15 0.006 255);
+  --color-foreground: oklch(0.92 0.006 90);
+  --color-subtle: oklch(0.19 0.008 255);
+  --color-muted: oklch(0.24 0.010 255);
+  --color-muted-foreground: oklch(0.62 0.015 255);
+  --color-border: oklch(0.30 0.012 255);
+  --color-border-soft: oklch(0.22 0.010 255);
 
-  /* Brand accent — teal/cyan. Used for primary actions, selected states,
-     active dots. Distinctive vs anthropic-orange + openai-green so it
-     doesn't read as "we are X provider". */
-  --color-primary: oklch(0.78 0.13 200);
+  /* Brand accent — teal/cyan. */
+  --color-primary: oklch(0.74 0.11 200);
   --color-primary-foreground: oklch(0.13 0.02 200);
 
-  /* Semantics — chroma bumped from 0.025 → 0.16-0.20 so success/danger/
-     warning/info chips actually pop instead of blending into the grey. */
-  --color-danger: oklch(0.66 0.20 25);
-  --color-danger-foreground: oklch(0.16 0 0);
-  --color-warning: oklch(0.78 0.16 80);
-  --color-warning-foreground: oklch(0.16 0 0);
-  --color-success: oklch(0.72 0.16 150);
-  --color-success-foreground: oklch(0.16 0 0);
-  --color-info: oklch(0.72 0.14 240);
-  --color-info-foreground: oklch(0.16 0 0);
+  /* Semantic tokens — slightly softer chroma for dark mode. */
+  --color-danger: oklch(0.63 0.17 22);
+  --color-danger-foreground: oklch(0.15 0 0);
+  --color-warning: oklch(0.76 0.13 78);
+  --color-warning-foreground: oklch(0.15 0 0);
+  --color-success: oklch(0.69 0.13 148);
+  --color-success-foreground: oklch(0.15 0 0);
+  --color-info: oklch(0.69 0.11 238);
+  --color-info-foreground: oklch(0.15 0 0);
 
-  /* Per-provider accent — used on ProvidersChip dots + per-agent provider
-     hints. Anthropic = warm amber, Cursor = violet, OpenAI/Codex = green. */
+  /* Per-provider accent. */
   --color-provider-anthropic: oklch(0.74 0.15 55);
   --color-provider-cursor: oklch(0.70 0.16 290);
   --color-provider-codex: oklch(0.72 0.16 150);
@@ -62,6 +57,32 @@
   --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
 
   --color-focus-ring: oklch(0.78 0 0 / 0.5);
+}
+
+/* Light cream palette — applied when html[data-theme="light"]. */
+html[data-theme="light"] {
+  --color-background: oklch(0.97 0.012 80);
+  --color-foreground: oklch(0.22 0.010 60);
+  --color-subtle: oklch(0.94 0.014 80);
+  --color-muted: oklch(0.90 0.016 80);
+  --color-muted-foreground: oklch(0.46 0.018 60);
+  --color-border: oklch(0.80 0.020 80);
+  --color-border-soft: oklch(0.88 0.016 80);
+  --color-primary: oklch(0.52 0.13 200);
+  --color-primary-foreground: oklch(0.98 0.004 200);
+  --color-danger: oklch(0.52 0.19 22);
+  --color-danger-foreground: oklch(0.98 0 0);
+  --color-warning: oklch(0.56 0.15 78);
+  --color-warning-foreground: oklch(0.98 0 0);
+  --color-success: oklch(0.50 0.14 148);
+  --color-success-foreground: oklch(0.98 0 0);
+  --color-info: oklch(0.50 0.12 238);
+  --color-info-foreground: oklch(0.98 0 0);
+  --color-provider-anthropic: oklch(0.56 0.16 55);
+  --color-provider-cursor: oklch(0.52 0.17 290);
+  --color-provider-codex: oklch(0.50 0.15 148);
+  --color-focus-ring: oklch(0.52 0.13 200 / 0.45);
+  color-scheme: light;
 }
 
 html,

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+
+type Theme = 'dark' | 'light';
+
+const STORAGE_KEY = 'kayam:theme';
+
+function readStoredTheme(): Theme {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw === 'light') return 'light';
+  } catch {
+    // ignore
+  }
+  return 'dark';
+}
+
+function applyTheme(theme: Theme): void {
+  if (theme === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
+}
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set, get) => ({
+  theme: 'dark',
+  setTheme: (theme) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {
+      // ignore
+    }
+    applyTheme(theme);
+    set({ theme });
+  },
+  toggleTheme: () => {
+    const next: Theme = get().theme === 'dark' ? 'light' : 'dark';
+    get().setTheme(next);
+  },
+}));
+
+export function bootstrapTheme(): void {
+  const stored = readStoredTheme();
+  applyTheme(stored);
+  useThemeStore.setState({ theme: stored });
+}


### PR DESCRIPTION
## Summary

- new theme system: dark palette softened (reduced saturation, lifted blacks), light palette cream (`#f8f5ee`-ish, non bianco puro)
- theme toggle in sidebar header (sun/moon) → zustand slice + `localStorage` persist + bootstrap before mount
- sidebar section icons: `FolderOpen`/`MessagesSquare`/`Bot` per WORKSPACES/SESSIONS/AGENTS, colored via semantic tokens
- new Legenda tab in GuideDialog: maps colors for status dots, edit types, ctx levels, verbosity, permission mode, AUTO badge

## Files

- `apps/desktop/src/styles.css` — theme tokens (dark `@theme` + light `[data-theme="light"]`)
- `apps/desktop/src/theme.ts` — zustand slice + bootstrap
- `apps/desktop/src/main.tsx` — bootstrap call before `createRoot`
- `apps/desktop/src/components/WorkspacesSidebar.tsx` — toggle + section icons
- `apps/desktop/src/components/GuideDialog.tsx` — Legenda tab

## Test plan

- [ ] toggle theme → background+text adapt
- [ ] reload → theme persisted
- [ ] sidebar section icons render with correct semantic colors in both themes
- [ ] Legenda tab opens, swatches reflect active theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)