### PR TITLE
feat(desktop): transcript polish — relative paths, subtle edit blocks, hierarchy

### DIFF
--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -42,6 +42,8 @@ interface DiffViewerDialogProps {
   workingDir?: string;
   /** When true and the dialog opens, jump to the first file that has open comments. */
   jumpToFirstCommented?: boolean;
+  /** When set, jump to this file path after the diff loads. */
+  jumpToFile?: string;
 }
 
 const STATUS_GLYPH: Record<FileDiffStatus, string> = {
@@ -176,6 +178,7 @@ export function DiffViewerDialog({
   cwd,
   workingDir,
   jumpToFirstCommented = false,
+  jumpToFile,
 }: DiffViewerDialogProps) {
   const [files, setFiles] = useState<ReadonlyArray<FileDiff>>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
@@ -219,7 +222,10 @@ export function DiffViewerDialog({
         const parsed = parseUnifiedDiff(raw);
         setFiles(parsed);
         setLoading(false);
-        if (jumpToFirstCommented && openCommentsByFile.size > 0) {
+        if (jumpToFile) {
+          const idx = parsed.findIndex((f) => f.path === jumpToFile || jumpToFile.endsWith(f.path));
+          setSelectedIdx(idx >= 0 ? idx : 0);
+        } else if (jumpToFirstCommented && openCommentsByFile.size > 0) {
           const idx = parsed.findIndex((f) => openCommentsByFile.has(f.path));
           setSelectedIdx(idx >= 0 ? idx : 0);
         } else {
@@ -230,7 +236,7 @@ export function DiffViewerDialog({
         setError(err instanceof Error ? err.message : String(err));
         setLoading(false);
       });
-  }, [open, loader, repoSlug, prNumber, cwd, jumpToFirstCommented, openCommentsByFile]);
+  }, [open, loader, repoSlug, prNumber, cwd, jumpToFirstCommented, jumpToFile, openCommentsByFile]);
 
   useEffect(() => {
     if (open && taskId) void loadDiffComments(taskId);
@@ -678,11 +684,6 @@ function TreeNodeView({
           className={cn('shrink-0 transition-transform duration-150', expanded && 'rotate-90')}
         />
         <span className="min-w-0 flex-1 truncate font-mono">{node.name}</span>
-        <span className="shrink-0 text-[10px] tabular-nums opacity-60">
-          {node.additions > 0 ? <span className="text-success">+{node.additions}</span> : null}
-          {node.additions > 0 && node.deletions > 0 ? <span> </span> : null}
-          {node.deletions > 0 ? <span className="text-danger">−{node.deletions}</span> : null}
-        </span>
       </button>
       {expanded
         ? node.children.map((child, i) => (

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -59,7 +59,7 @@ export function ChatHeader({
   };
 
   return (
-    <div className="px-10 py-2.5">
+    <div className="sticky top-0 z-10 border-b border-border/30 bg-background px-10 py-2.5 shadow-[0_4px_8px_-6px_rgb(0_0_0_/_0.12)]">
       <div className="mx-auto flex w-full max-w-[880px] items-center gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -8,6 +8,8 @@ import { AuthRequiredCallout } from './AuthRequiredCallout';
 import { ChatHeader } from './ChatHeader';
 import { ChatInput } from './ChatInput';
 import { MergeDialog, type MergeConflict, type MergeResolution } from './MergeDialog';
+import { DiffViewerDialog } from '../DiffViewerDialog';
+import { worktreeDiff } from '../../worktree';
 
 interface ChatViewProps {
   session: Task;
@@ -41,10 +43,12 @@ interface ColumnProps {
   runId: ProviderRunId;
   index: number;
   events: ReturnType<typeof useTranscript>;
+  workingDir: string | null;
   onRefreshAuth: () => void;
+  onOpenDiff: (filePath: string) => void;
 }
 
-function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
+function ParallelColumn({ runId, index, events, workingDir, onRefreshAuth, onOpenDiff }: ColumnProps) {
   const columnEvents = useMemo(() => filterEventsByRunId(events, runId), [events, runId]);
   const items = useMemo(() => reduceTranscript(columnEvents), [columnEvents]);
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
@@ -65,7 +69,12 @@ function ParallelColumn({ runId, index, events, onRefreshAuth }: ColumnProps) {
             <ul className="flex flex-col gap-4">
               {items.map((item) => (
                 <li key={item.key}>
-                  <TranscriptCard item={item} onRefreshAuth={onRefreshAuth} />
+                  <TranscriptCard
+                    item={item}
+                    workingDir={workingDir}
+                    onRefreshAuth={onRefreshAuth}
+                    onOpenDiff={onOpenDiff}
+                  />
                 </li>
               ))}
             </ul>
@@ -182,6 +191,15 @@ export function ChatView({ session }: ChatViewProps) {
   };
 
   const [mergeDialogOpen, setMergeDialogOpen] = useState(false);
+  const [diffJumpFile, setDiffJumpFile] = useState<string | null>(null);
+  const diffLoader = useMemo(
+    () => (worktreePath ? () => worktreeDiff(worktreePath) : undefined),
+    [worktreePath],
+  );
+
+  const handleOpenDiff = (filePath: string) => {
+    setDiffJumpFile(filePath);
+  };
 
   // Derive MergeConflict[] from store — populated by parallel-turn scheduler
   // when manual resolution is required. Cast FileConflict to MergeConflict:
@@ -236,7 +254,9 @@ export function ChatView({ session }: ChatViewProps) {
               runId={runId}
               index={i}
               events={events}
+              workingDir={worktreePath}
               onRefreshAuth={() => void refreshProviders()}
+              onOpenDiff={handleOpenDiff}
             />
           ))}
         </div>
@@ -266,6 +286,15 @@ export function ChatView({ session }: ChatViewProps) {
         ) : (
           <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
         )}
+        <DiffViewerDialog
+          open={diffJumpFile !== null}
+          onClose={() => setDiffJumpFile(null)}
+          taskId={session.id}
+          title="worktree diff"
+          loader={diffLoader}
+          workingDir={worktreePath ?? undefined}
+          jumpToFile={diffJumpFile ?? undefined}
+        />
       </div>
     );
   }
@@ -345,7 +374,9 @@ export function ChatView({ session }: ChatViewProps) {
                         item={item}
                         taskId={session.id}
                         agentId={selectedAgentId}
+                        workingDir={worktreePath}
                         onRefreshAuth={() => void refreshProviders()}
+                        onOpenDiff={handleOpenDiff}
                       />
                     </li>,
                   );
@@ -381,6 +412,14 @@ export function ChatView({ session }: ChatViewProps) {
       ) : (
         <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
       )}
+      <DiffViewerDialog
+        open={diffJumpFile !== null}
+        onClose={() => setDiffJumpFile(null)}
+        taskId={session.id}
+        title="worktree diff"
+        loader={diffLoader}
+        workingDir={worktreePath ?? undefined}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Check, ChevronRight, Copy, Wrench } from 'lucide-react';
+import { ArrowUpRight, Check, ChevronRight, Copy, Wrench } from 'lucide-react';
 import { CopyButton, Markdown, cn } from '@kay-am/ui';
 import type { SessionId, TaskId } from '@kay-am/types';
 import type { TranscriptItem } from './transcript-items';
@@ -8,25 +8,30 @@ import { SkillInvocationCard } from './SkillInvocationCard';
 import { PhaseTransitionCard } from './PhaseTransitionCard';
 import { PermissionRequestCard } from './PermissionRequestCard';
 import { PermissionDecisionCard } from './PermissionDecisionCard';
+import { displayPath } from '../../utils/displayPath';
 
-const EDIT_TONE: Record<'create' | 'modify' | 'delete', string> = {
-  create: 'bg-primary/10 text-primary',
-  modify: 'bg-muted text-foreground',
-  delete: 'bg-danger/10 text-danger',
+const EDIT_DOT: Record<'create' | 'modify' | 'delete', string> = {
+  create: 'bg-primary',
+  modify: 'bg-muted-foreground',
+  delete: 'bg-danger',
 };
 
 interface TranscriptCardProps {
   readonly item: TranscriptItem;
   readonly taskId?: TaskId | null;
   readonly agentId?: SessionId | null;
+  readonly workingDir?: string | null;
   readonly onRefreshAuth?: () => void;
+  readonly onOpenDiff?: (filePath: string) => void;
 }
 
 export function TranscriptCard({
   item,
   taskId = null,
   agentId = null,
+  workingDir = null,
   onRefreshAuth,
+  onOpenDiff,
 }: TranscriptCardProps) {
   switch (item.kind) {
     case 'user_text':
@@ -37,15 +42,12 @@ export function TranscriptCard({
       return <ToolCall item={item} />;
     case 'file_edit':
       return (
-        <div
-          className={cn(
-            'inline-flex w-fit items-center gap-2 rounded-md border border-border px-2 py-1 text-xs',
-            EDIT_TONE[item.editType],
-          )}
-        >
-          <span className="font-medium uppercase tracking-wide">{item.editType}</span>
-          <code className="font-mono">{item.path}</code>
-        </div>
+        <FileEditBlock
+          path={item.path}
+          editType={item.editType}
+          workingDir={workingDir}
+          onOpenDiff={onOpenDiff}
+        />
       );
     case 'usage':
       return (
@@ -84,6 +86,37 @@ export function TranscriptCard({
     case 'permission_decision':
       return <PermissionDecisionCard item={item} taskId={taskId} agentId={agentId} />;
   }
+}
+
+interface FileEditBlockProps {
+  path: string;
+  editType: 'create' | 'modify' | 'delete';
+  workingDir?: string | null;
+  onOpenDiff?: (filePath: string) => void;
+}
+
+function FileEditBlock({ path, editType, workingDir, onOpenDiff }: FileEditBlockProps) {
+  const rel = displayPath(path, workingDir);
+  return (
+    <div className="group inline-flex w-fit max-w-full items-center gap-2 rounded-md border border-border/40 px-2 py-1">
+      <span className={cn('h-1.5 w-1.5 shrink-0 rounded-full', EDIT_DOT[editType])} />
+      <span className="text-2xs uppercase tracking-wide text-muted-foreground">{editType}</span>
+      <code className="min-w-0 truncate font-mono text-xs text-muted-foreground" title={path}>
+        {rel}
+      </code>
+      {onOpenDiff ? (
+        <button
+          type="button"
+          onClick={() => onOpenDiff(path)}
+          title="open in files modal"
+          aria-label="open in files modal"
+          className="ml-auto shrink-0 rounded-sm p-0.5 text-muted-foreground/50 opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+        >
+          <ArrowUpRight size={11} aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  );
 }
 
 function formatTokens(n: number): string {

--- a/apps/desktop/src/utils/displayPath.ts
+++ b/apps/desktop/src/utils/displayPath.ts
@@ -1,0 +1,5 @@
+export function displayPath(absPath: string, workingDir: string | null | undefined): string {
+  if (!workingDir) return absPath;
+  const root = workingDir.endsWith('/') ? workingDir : `${workingDir}/`;
+  return absPath.startsWith(root) ? absPath.slice(root.length) : absPath;
+}

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -422,17 +422,21 @@ function renderBlock(block: Block, idx: number): ReactNode {
     case 'list':
       if (block.ordered) {
         return (
-          <ol key={key} className="ml-5 list-decimal space-y-1">
+          <ol key={key} className="list-decimal space-y-1.5 pl-5">
             {block.items.map((item, j) => (
-              <li key={`${key}-${j}`}>{renderInline(item.content, `${key}-${j}`)}</li>
+              <li key={`${key}-${j}`} className="leading-relaxed">
+                {renderInline(item.content, `${key}-${j}`)}
+              </li>
             ))}
           </ol>
         );
       }
       return (
-        <ul key={key} className="ml-5 list-disc space-y-1">
+        <ul key={key} className="list-disc space-y-1.5 pl-5">
           {block.items.map((item, j) => (
-            <li key={`${key}-${j}`}>{renderInline(item.content, `${key}-${j}`)}</li>
+            <li key={`${key}-${j}`} className="leading-relaxed">
+              {renderInline(item.content, `${key}-${j}`)}
+            </li>
           ))}
         </ul>
       );


### PR DESCRIPTION
## Summary

- relative paths in CREATE/MODIFY/DELETE blocks (strip workingDir prefix via new `displayPath` util)
- subtle file_edit block: colored dot + muted mono path, no tinted background (Claude-inspired, custom)
- hover CTA on file_edit blocks → opens DiffViewerDialog anchored to that file (`jumpToFile` prop)
- DiffViewerDialog: folder rows no longer show `+N -M` counters (file rows only)
- Markdown bullet indentation: `pl-5 space-y-1.5 leading-relaxed`
- sticky chat header with subtle bottom shadow for scroll separation

## Files

- `apps/desktop/src/utils/displayPath.ts` — new shared util
- `apps/desktop/src/components/chat/TranscriptCards.tsx` — relative paths, subtle FileEditBlock, CTA
- `apps/desktop/src/components/chat/ChatView.tsx` — diff dialog state wire-up
- `apps/desktop/src/components/DiffViewerDialog.tsx` — `jumpToFile` prop, folder counters removed
- `packages/ui/src/components/Markdown.tsx` — bullet indent
- `apps/desktop/src/components/chat/ChatHeader.tsx` — sticky + shadow

## Test plan

- [ ] file_edit blocks show relative paths (worktree prefix stripped)
- [ ] hover on block → CTA visible, click → modal opens scrolled to file
- [ ] folder rows in modal show only file count, not aggregated diff
- [ ] bullets indent visibly in chat
- [ ] scrolling transcript fades softly under header

🤖 Generated with [Claude Code](https://claude.com/claude-code)