### PR TITLE
feat(desktop): workflow override UI — verbosity + compact segmented controls

### DIFF
--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -541,6 +541,7 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
         {sortedSteps.map((step, i) => {
           const model = step.modelOverride ? shortModel(step.modelOverride) : null;
           const effort = step.effort ?? null;
+          const verbosity = step.verbosity ?? null;
           return (
             <li
               key={step.id}
@@ -548,9 +549,9 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
             >
               <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
               <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
-              {model || effort ? (
+              {model || effort || verbosity ? (
                 <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-                  {[model, effort].filter(Boolean).join(' · ')}
+                  {[model, effort, verbosity ? `v:${verbosity}` : null].filter(Boolean).join(' · ')}
                 </span>
               ) : null}
             </li>

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, Textarea, cn } from '@kay-am/ui';
+import { Button, Textarea } from '@kay-am/ui';
 import { PlannerClient, type PlannerOutput, defaultsForRole } from '@kay-am/core';
 import type {
   AgentEffort,
@@ -11,8 +11,9 @@ import type {
   WorkflowId,
   WorkspaceId,
 } from '@kay-am/types';
+import type { VerbosityLevel } from '../verbosity';
 import { useAppStore } from '../store';
-import { shortModel } from '../agentRowFormat';
+import { StepOverrideRow, type StepOverrideValues } from './overrides/StepOverrideRow';
 
 interface PlannerWidgetProps {
   workspaceId: WorkspaceId;
@@ -21,13 +22,7 @@ interface PlannerWidgetProps {
   onWorkflowReady: (workflowId: WorkflowId) => void;
 }
 
-const SELECTABLE_MODELS = ['claude-haiku-4-5', 'claude-sonnet-4-6', 'claude-opus-4-7'] as const;
-const SELECTABLE_EFFORTS: AgentEffort[] = ['low', 'medium', 'high', 'extra-high', 'max'];
-
-interface StepOverride {
-  model: string;
-  effort: AgentEffort;
-}
+const DEFAULT_VERBOSITY: VerbosityLevel = 'essential';
 
 export function PlannerWidget({
   workspaceId,
@@ -39,7 +34,7 @@ export function PlannerWidget({
   const [theme, setTheme] = useState(initialTheme);
   const [busy, setBusy] = useState(false);
   const [plan, setPlan] = useState<PlannerOutput | null>(null);
-  const [overrides, setOverrides] = useState<Record<number, StepOverride>>({});
+  const [overrides, setOverrides] = useState<Record<number, StepOverrideValues>>({});
   const [error, setError] = useState<string | null>(null);
 
   const onPlan = async () => {
@@ -52,10 +47,10 @@ export function PlannerWidget({
       const client = new PlannerClient({ providerId, invokeFn: invoke });
       const result = await client.plan({ theme: theme.trim() });
       setPlan(result.output);
-      const initial: Record<number, StepOverride> = {};
+      const initial: Record<number, StepOverrideValues> = {};
       result.output.steps.forEach((s, i) => {
         const d = defaultsForRole(s.role);
-        initial[i] = { model: d.model, effort: d.effort };
+        initial[i] = { model: d.model, effort: d.effort, verbosity: DEFAULT_VERBOSITY };
       });
       setOverrides(initial);
     } catch (err) {
@@ -73,7 +68,7 @@ export function PlannerWidget({
       const now = new Date().toISOString() as Workflow['createdAt'];
       const workflowId = `wf_planner_${crypto.randomUUID()}` as WorkflowId;
       const steps: ReadonlyArray<Step> = plan.steps.map((s, ordinal) => {
-        const o = overrides[ordinal] ?? defaultsForRole(s.role);
+        const o = overrides[ordinal] ?? { ...defaultsForRole(s.role), verbosity: DEFAULT_VERBOSITY };
         return {
           id: `step_planner_${crypto.randomUUID()}` as StepId,
           workflowId,
@@ -81,7 +76,8 @@ export function PlannerWidget({
           name: s.name,
           promptPrefix: s.promptPrefix,
           modelOverride: o.model,
-          effort: o.effort,
+          effort: o.effort as AgentEffort,
+          verbosity: o.verbosity,
         };
       });
       const workflow: Workflow = {
@@ -159,46 +155,12 @@ export function PlannerWidget({
                     </p>
                   ) : null}
                   {ov ? (
-                    <div className="mt-2 flex items-center gap-1.5">
-                      <select
-                        value={ov.model}
-                        onChange={(e) =>
-                          setOverrides((prev) => ({
-                            ...prev,
-                            [i]: { ...ov, model: e.target.value },
-                          }))
-                        }
-                        className={cn(
-                          'rounded border border-border-soft bg-background px-1.5 py-0.5 text-2xs text-foreground',
-                          'focus:outline-none focus:ring-1 focus:ring-primary',
-                        )}
-                      >
-                        {SELECTABLE_MODELS.map((m) => (
-                          <option key={m} value={m}>
-                            {shortModel(m)}
-                          </option>
-                        ))}
-                      </select>
-                      <select
-                        value={ov.effort}
-                        onChange={(e) =>
-                          setOverrides((prev) => ({
-                            ...prev,
-                            [i]: { ...ov, effort: e.target.value as AgentEffort },
-                          }))
-                        }
-                        className={cn(
-                          'rounded border border-border-soft bg-background px-1.5 py-0.5 text-2xs text-foreground',
-                          'focus:outline-none focus:ring-1 focus:ring-primary',
-                        )}
-                      >
-                        {SELECTABLE_EFFORTS.map((ef) => (
-                          <option key={ef} value={ef}>
-                            {ef}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
+                    <StepOverrideRow
+                      values={ov}
+                      onChange={(next) =>
+                        setOverrides((prev) => ({ ...prev, [i]: next }))
+                      }
+                    />
                   ) : null}
                 </li>
               );
@@ -212,3 +174,4 @@ export function PlannerWidget({
     </div>
   );
 }
+

--- a/apps/desktop/src/components/WorkflowNextStepCta.tsx
+++ b/apps/desktop/src/components/WorkflowNextStepCta.tsx
@@ -2,12 +2,13 @@ import { useMemo, useState } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import type { Session, Step, Workflow } from '@kay-am/types';
+import type { VerbosityLevel } from '../verbosity';
 import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE, inferAgentKindFromName } from '../agentKind';
 
 export interface WorkflowNextStepCtaProps {
   readonly workflow: Workflow;
   readonly runs: ReadonlyArray<Session>;
-  readonly onAdvance: (step: Step, model: string) => void | Promise<void>;
+  readonly onAdvance: (step: Step, model: string, verbosity: VerbosityLevel | undefined) => void | Promise<void>;
   readonly className?: string;
 }
 
@@ -48,11 +49,12 @@ export function WorkflowNextStepCta({
   const defaults = AGENT_KIND_DEFAULTS[kind];
   const palette = AGENT_KIND_PALETTE[kind];
   if (!next) return null;
+  const stepVerbosity = next.verbosity;
   const onClick = async () => {
     if (busy) return;
     setBusy(true);
     try {
-      await onAdvance(next, defaults.model);
+      await onAdvance(next, defaults.model, stepVerbosity);
     } finally {
       setBusy(false);
     }
@@ -63,12 +65,12 @@ export function WorkflowNextStepCta({
       onClick={() => void onClick()}
       disabled={busy}
       data-testid="workflow-next-step-cta"
-      title={`model: ${defaults.model} · effort: ${defaults.effort}`}
+      title={`model: ${defaults.model} · effort: ${defaults.effort}${stepVerbosity ? ` · verbosity: ${stepVerbosity}` : ''}`}
       className={cn(
         'group flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
         className,
       )}
-      aria-label={`Start ${next.name} (${defaults.model}, ${defaults.effort} effort)`}
+      aria-label={`Start ${next.name} (${defaults.model}, ${defaults.effort} effort${stepVerbosity ? `, ${stepVerbosity} verbosity` : ''})`}
     >
       <span className="flex items-center gap-1.5">
         <span className="text-2xs uppercase tracking-wide opacity-70">start</span>

--- a/apps/desktop/src/components/overrides/StepOverrideRow.tsx
+++ b/apps/desktop/src/components/overrides/StepOverrideRow.tsx
@@ -1,0 +1,145 @@
+import { cn } from '@kay-am/ui';
+import type { AgentEffort } from '@kay-am/types';
+import {
+  VERBOSITY_LEVELS,
+  VERBOSITY_LABEL,
+  type VerbosityLevel,
+} from '../../verbosity';
+import {
+  EFFORT_LEVELS,
+  EFFORT_LABEL,
+  EFFORT_TEXT,
+  VERBOSITY_TEXT,
+  modelLabel,
+} from '../chat/chat-constants';
+
+export const STEP_SELECTABLE_MODELS = [
+  'claude-haiku-4-5',
+  'claude-sonnet-4-5',
+  'claude-sonnet-4-6',
+  'claude-opus-4-7',
+] as const;
+
+export type StepSelectableModel = (typeof STEP_SELECTABLE_MODELS)[number];
+
+export interface StepOverrideValues {
+  readonly model: string;
+  readonly effort: AgentEffort;
+  readonly verbosity: VerbosityLevel;
+}
+
+interface StepOverrideRowProps {
+  readonly values: StepOverrideValues;
+  readonly onChange: (next: StepOverrideValues) => void;
+}
+
+const EFFORT_SEGMENT: ReadonlyArray<AgentEffort> = ['low', 'medium', 'high', 'extra-high', 'max'];
+
+const EFFORT_SHORT: Record<AgentEffort, string> = {
+  low: 'low',
+  medium: 'med',
+  high: 'high',
+  'extra-high': 'x-hi',
+  max: 'max',
+};
+
+const VERBOSITY_SHORT: Record<VerbosityLevel, string> = {
+  essential: 'ess',
+  minimal: 'min',
+  normal: 'norm',
+  detailed: 'det',
+  verbose: 'verb',
+};
+
+export function StepOverrideRow({ values, onChange }: StepOverrideRowProps) {
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1.5">
+      <OverrideGroup label="model">
+        <select
+          value={values.model}
+          onChange={(e) => onChange({ ...values, model: e.target.value })}
+          className={cn(
+            'rounded border border-border-soft bg-background px-1.5 py-0.5 text-2xs text-foreground',
+            'focus:outline-none focus:ring-1 focus:ring-primary/60',
+          )}
+        >
+          {STEP_SELECTABLE_MODELS.map((m) => (
+            <option key={m} value={m}>
+              {modelLabel(m)}
+            </option>
+          ))}
+        </select>
+      </OverrideGroup>
+
+      <OverrideGroup label="effort">
+        <SegmentedControl<AgentEffort>
+          options={EFFORT_SEGMENT}
+          value={values.effort}
+          getLabel={(v) => EFFORT_SHORT[v]}
+          getActiveClass={(v) => EFFORT_TEXT[v]}
+          onChange={(v) => onChange({ ...values, effort: v })}
+        />
+      </OverrideGroup>
+
+      <OverrideGroup label="verbosity">
+        <SegmentedControl<VerbosityLevel>
+          options={[...VERBOSITY_LEVELS]}
+          value={values.verbosity}
+          getLabel={(v) => VERBOSITY_SHORT[v]}
+          getActiveClass={(v) => VERBOSITY_TEXT[v]}
+          onChange={(v) => onChange({ ...values, verbosity: v })}
+        />
+      </OverrideGroup>
+    </div>
+  );
+}
+
+function OverrideGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <span className="flex items-center gap-1">
+      <span className="text-2xs text-muted-foreground/70">{label}</span>
+      {children}
+    </span>
+  );
+}
+
+function SegmentedControl<T extends string>({
+  options,
+  value,
+  getLabel,
+  getActiveClass,
+  onChange,
+}: {
+  options: ReadonlyArray<T>;
+  value: T;
+  getLabel: (v: T) => string;
+  getActiveClass: (v: T) => string;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <span className="inline-flex rounded border border-border-soft bg-subtle">
+      {options.map((opt) => {
+        const active = opt === value;
+        return (
+          <button
+            key={opt}
+            type="button"
+            onClick={() => onChange(opt)}
+            title={`${opt}`}
+            className={cn(
+              'px-1.5 py-0.5 text-2xs transition-colors first:rounded-l last:rounded-r',
+              active
+                ? cn('bg-background font-semibold shadow-sm', getActiveClass(opt))
+                : 'text-muted-foreground/60 hover:text-foreground',
+            )}
+          >
+            {getLabel(opt)}
+          </button>
+        );
+      })}
+    </span>
+  );
+}
+
+export const EFFORT_LEVELS_PLANNER = EFFORT_LEVELS;
+export { EFFORT_LABEL, VERBOSITY_LABEL };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1885,7 +1885,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (contextPreamble.length > 0) {
       resolvedPrompt = `${contextPreamble}\n\n${resolvedPrompt}`;
     }
-    const verbosityHint = verbosityDirective(readVerbosity(taskId));
+    const verbosityHint = verbosityDirective(
+      phaseDefinition?.verbosity ?? readVerbosity(taskId),
+    );
     resolvedPrompt = `${verbosityHint}\n\n${resolvedPrompt}`;
 
     let assistantText = '';

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -38,6 +38,7 @@ export type Step = Readonly<{
   providerOverride?: ProviderId;
   modelOverride?: string;
   effort?: AgentEffort;
+  verbosity?: 'essential' | 'minimal' | 'normal' | 'detailed' | 'verbose';
   parallelGroup?: number;
 }>;
 


### PR DESCRIPTION
## Summary

- add verbosity selector to workflow step overrides (prefilled + custom planner)
- new `StepOverrideRow` component: compact inline row, model dropdown + effort/verbosity segmented controls
- verbosity propagated to spawn: `Step.verbosity` honored over task default in `store.ts:1888`
- WorkflowPreview shows `v:<level>` badge per step

## Files

- `packages/types/src/workflow.ts` — `verbosity` field on `Step`
- `apps/desktop/src/components/overrides/StepOverrideRow.tsx` — new compact row
- `apps/desktop/src/components/PlannerWidget.tsx` — uses StepOverrideRow
- `apps/desktop/src/components/WorkflowNextStepCta.tsx` — passes verbosity
- `apps/desktop/src/components/NewSessionDialog.tsx` — preview badge
- `apps/desktop/src/store/store.ts` — verbosity resolution

## Test plan

- [ ] open NewSessionDialog → select preset → override row compact
- [ ] override verbosity per step → spawn → verbosity directive applied
- [ ] custom planner: edit step → segmented controls work for effort + verbosity
- [ ] preview shows v: badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)