### PR TITLE
fix(desktop): files counter from transcript, phase pill per-agent, ctx incl. cached

### DIFF
--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -39,6 +39,7 @@ vi.mock('../store', () => ({
   useSlotHistory: vi.fn().mockReturnValue([]),
   useSessionNextActions: vi.fn().mockReturnValue([]),
   useDiffComments: vi.fn().mockReturnValue([]),
+  useFilesTouched: vi.fn().mockReturnValue({ paths: [], count: 0 }),
 }));
 
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -35,6 +35,7 @@ import {
   EMPTY_ARRAY,
   useAppStore,
   useDiffComments,
+  useFilesTouched,
   useSessionSlots,
   useSlotHistory,
   useSummarizerStatus,
@@ -90,11 +91,8 @@ export function ContextPanel({
 
   const visibleSlotKeys = useMemo(() => SLOT_KEYS.filter((k) => k !== 'files_touched'), []);
 
-  const filesTouchedCount = useMemo(() => {
-    const slot = slotsByKey.get('files_touched');
-    if (!slot || slot.value.length === 0) return 0;
-    return slot.value.split('\n').filter((l) => l.trim().length > 0).length;
-  }, [slotsByKey]);
+  const filesTouched = useFilesTouched(session.id);
+  const filesTouchedCount = filesTouched.count;
 
   const [filesDiffOpen, setFilesDiffOpen] = useState(false);
   const [filesDiffJumpToNotes, setFilesDiffJumpToNotes] = useState(false);

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1772,7 +1772,7 @@ function AgentRow({
               <span aria-hidden>·</span>
               <AgentLifetime run={run} />
             </div>
-            <ContextWindowBar telemetry={telemetry} />
+            <ContextWindowBar telemetry={telemetry} agentId={run.id} aggregate={aggregate} />
           </div>
         </div>
       </div>
@@ -1834,20 +1834,49 @@ function AgentLifetime({ run }: { run: Session }) {
   );
 }
 
-function ContextWindowBar({ telemetry }: { telemetry: TelemetryRecord | null }) {
+function ContextWindowBar({
+  telemetry,
+  agentId,
+  aggregate,
+}: {
+  telemetry: TelemetryRecord | null;
+  agentId: SessionId;
+  aggregate: AgentAggregate | null;
+}) {
+  // Last 'usage' event surfaces cachedInputTokens — telemetry table doesn't
+  // persist that field, so we read it live from the transcript. Falls back to
+  // 0 cached when no usage event has been seen yet.
+  const cachedFromTranscript = useAppStore((s) => {
+    const events = s.transcripts[agentId];
+    if (!events) return 0;
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const ev = events[i];
+      if (ev && ev.kind === 'usage') return ev.usage.cachedInputTokens;
+    }
+    return 0;
+  });
   if (!telemetry) return null;
   const window = findContextWindow(telemetry.model);
   if (!window) return null;
-  const used = telemetry.inputTokens;
+  // Next-turn context size ≈ what the LLM will receive: latest turn's
+  // uncached input (telemetry) + cached prefix (system prompt + history
+  // already cached server-side). Output is the response, not input — excluded.
+  const latestInput = telemetry.inputTokens;
+  const used = latestInput + cachedFromTranscript;
+  // Aggregate input across all turns is a coarser fallback when the latest
+  // record happens to undercount (e.g. cache miss reset). We surface it in
+  // the tooltip for transparency but don't conflate it with the bar value.
+  const cumulativeInput = aggregate?.inputTokens ?? latestInput;
   const pct = Math.min(1, used / window);
   const tone =
     pct >= 0.9 ? 'bg-danger' : pct >= 0.75 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
   const windowLabel = window >= 1_000_000 ? `${window / 1_000_000}M` : `${window / 1_000}k`;
+  const tooltip =
+    `context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)\n` +
+    `latest turn: ${latestInput.toLocaleString()} new + ${cachedFromTranscript.toLocaleString()} cached\n` +
+    `cumulative input across turns: ${cumulativeInput.toLocaleString()}`;
   return (
-    <div
-      className="flex flex-col gap-0.5"
-      title={`context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)`}
-    >
+    <div className="flex flex-col gap-0.5" title={tooltip}>
       <div className="flex items-center justify-between text-[9px] uppercase tracking-wide text-muted-foreground/60">
         <span>ctx</span>
         <span className="font-mono">

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -125,16 +125,21 @@ const STATUS_DOT: Record<SessionStatus, string> = {
 
 function PhaseProgressPill({ taskId }: { taskId: TaskId }) {
   const runs = useAppStore((s) => s.sessionPhaseRuns[taskId] ?? EMPTY_ARRAY);
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[taskId] ?? null);
 
   if (runs.length === 0) return null;
 
   const sorted = runs.slice().sort((a, b) => a.ordinal - b.ordinal);
+  const selectedIdx = selectedAgentId ? sorted.findIndex((r) => r.id === selectedAgentId) : -1;
   const activeIdx = sorted.findIndex((r) => r.status === 'running');
   const lastCompletedIdx = sorted.reduce(
     (acc: number, r: Session, i: number) => (r.status === 'completed' ? i : acc),
     -1,
   );
-  const displayIdx = activeIdx >= 0 ? activeIdx : lastCompletedIdx;
+  // Selected agent takes priority — pill reflects the agent the user is
+  // looking at, not workflow-wide running state. Falls back to running, then
+  // last completed when no agent is selected (e.g. fresh task).
+  const displayIdx = selectedIdx >= 0 ? selectedIdx : activeIdx >= 0 ? activeIdx : lastCompletedIdx;
   const current = displayIdx >= 0 ? sorted[displayIdx] : sorted[0];
 
   if (!current) return null;

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -18,6 +18,7 @@ export {
   useCurrentSession,
   useCurrentWorkspace,
   useDiffComments,
+  useFilesTouched,
   useSessionSlots,
   useSessionNextActions,
   useSlotHistory,
@@ -25,6 +26,7 @@ export {
   useSummarizerStatus,
   useWorkspaces,
 } from './selectors';
+export type { FilesTouched } from './selectors';
 export { selectTranscript, useTranscript } from './transcript';
 
 export const EMPTY_ARRAY: readonly never[] = [];

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,13 +1,20 @@
+import { useMemo } from 'react';
 import type {
   ContextSlot,
   ContextSlotHistoryEntry,
   DiffComment,
   Task,
   TaskId,
-  Workspace,
 } from '@kay-am/types';
+import type { Workspace } from '@kay-am/types';
 import type { NextAction } from '@kay-am/core';
 import { useAppStore, type AppState, type SummarizerSessionStatus } from './store';
+
+function toRelPath(absPath: string, workingDir: string | null): string {
+  if (!workingDir) return absPath;
+  const root = workingDir.endsWith('/') ? workingDir : `${workingDir}/`;
+  return absPath.startsWith(root) ? absPath.slice(root.length) : absPath;
+}
 
 export const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
 export const selectCurrentWorkspace = (state: AppState): Workspace | null =>
@@ -54,3 +61,43 @@ const EMPTY_COMMENTS: ReadonlyArray<DiffComment> = [];
 
 export const useDiffComments = (taskId: TaskId | null): ReadonlyArray<DiffComment> =>
   useAppStore((s) => (taskId ? (s.diffComments[taskId] ?? EMPTY_COMMENTS) : EMPTY_COMMENTS));
+
+export interface FilesTouched {
+  readonly paths: ReadonlyArray<string>;
+  readonly count: number;
+}
+
+const EMPTY_FILES_TOUCHED: FilesTouched = { paths: [], count: 0 };
+
+/**
+ * Distinct files edited across every agent of a task, derived from `file_edit`
+ * transcript events. Slot-based 'files_touched' lags until the summarizer
+ * runs — this gives a live count regardless of summarizer state.
+ *
+ * Selectors return raw slices so Zustand's Object.is check is stable; the
+ * derived list is memoized in React.
+ */
+export const useFilesTouched = (taskId: TaskId | null): FilesTouched => {
+  const phaseRuns = useAppStore((s) => (taskId ? (s.sessionPhaseRuns[taskId] ?? null) : null));
+  const transcripts = useAppStore((s) => s.transcripts);
+  const workingDir = useAppStore((s) =>
+    taskId ? ((s.sessionWorktrees[taskId] ?? [])[0] ?? null) : null,
+  );
+  return useMemo(() => {
+    if (!phaseRuns || phaseRuns.length === 0) return EMPTY_FILES_TOUCHED;
+    const seen = new Set<string>();
+    const ordered: string[] = [];
+    for (const run of phaseRuns) {
+      const events = transcripts[run.id] ?? [];
+      for (const ev of events) {
+        if (ev.kind !== 'file_edit') continue;
+        const rel = toRelPath(ev.path, workingDir);
+        if (seen.has(rel)) continue;
+        seen.add(rel);
+        ordered.push(rel);
+      }
+    }
+    if (ordered.length === 0) return EMPTY_FILES_TOUCHED;
+    return { paths: ordered, count: ordered.length };
+  }, [phaseRuns, transcripts, workingDir]);
+};


### PR DESCRIPTION
## Summary

3 bugs in the chat header + sidebar.

### #1 — files counter showed "1" when 3 files modified
Root cause: count derived from `files_touched` context slot written by summarizer; if summary hadn't run / captured only one file, count was wrong.
Fix: new `useFilesTouched(taskId)` selector walks every phase-run agent transcript, dedups `file_edit` paths. Slot left populated as legacy fallback, no longer consulted for display.

### #2 — header "4/4" stuck regardless of selected agent
Root cause: `displayIdx` derived from workflow state (running → last-completed), ignoring `selectedAgentId`.
Fix: priority `selectedIdx > activeIdx > lastCompletedIdx`. Denominator = all phase runs (incl. ad-hoc), so spawning 7 with 4-step workflow naturally shows "7/4". Status dots row unchanged (workflow progress still visible).

### #3 — CTX % too low
Root cause: `used = telemetry.inputTokens` — that's only the uncached portion of the latest turn, missing the cached prefix (system prompt + history).
Fix: scan transcript backward for latest `usage` event → read `usage.cachedInputTokens`. `used = latestInput + cachedFromTranscript`. Output excluded. Tooltip exposes per-turn split + aggregate cumulative.
Trade-off: cached count is in-memory only — accurate while agent is loaded, undercounts immediately after hot restart until next turn. Persistent fix would require `cachedInputTokens` in `TelemetryRecord` + DB migration (out of scope).

## Files

- `apps/desktop/src/store/selectors.ts` — `useFilesTouched`
- `apps/desktop/src/store/index.ts` — re-export
- `apps/desktop/src/components/ContextPanel.tsx` — use selector
- `apps/desktop/src/components/chat/ChatHeader.tsx` — phase pill honors selected agent
- `apps/desktop/src/components/WorkspacesSidebar.tsx` — `ContextWindowBar` cached tokens

## Test plan

- [ ] modify 3 files in a session → counter shows 3
- [ ] select agent 2/4 → header shows 2/4
- [ ] spawn 7 agents on 4-step workflow → 7/4
- [ ] CTX % grows turn over turn as cache populates
- [ ] CTX tooltip shows both per-turn split + aggregate

🤖 Generated with [Claude Code](https://claude.com/claude-code)