### PR TITLE
fix(desktop): ctx bar uses cumulative tokens, not cache_read

### DIFF
--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1792,7 +1792,7 @@ function AgentRow({
               <span aria-hidden>·</span>
               <AgentLifetime run={run} />
             </div>
-            <ContextWindowBar telemetry={telemetry} agentId={run.id} aggregate={aggregate} />
+            <ContextWindowBar telemetry={telemetry} aggregate={aggregate} />
           </div>
         </div>
       </div>
@@ -1856,45 +1856,30 @@ function AgentLifetime({ run }: { run: Session }) {
 
 function ContextWindowBar({
   telemetry,
-  agentId,
   aggregate,
 }: {
   telemetry: TelemetryRecord | null;
-  agentId: SessionId;
   aggregate: AgentAggregate | null;
 }) {
-  // Last 'usage' event surfaces cachedInputTokens — telemetry table doesn't
-  // persist that field, so we read it live from the transcript. Falls back to
-  // 0 cached when no usage event has been seen yet.
-  const cachedFromTranscript = useAppStore((s) => {
-    const events = s.transcripts[agentId];
-    if (!events) return 0;
-    for (let i = events.length - 1; i >= 0; i -= 1) {
-      const ev = events[i];
-      if (ev && ev.kind === 'usage') return ev.usage.cachedInputTokens;
-    }
-    return 0;
-  });
   if (!telemetry) return null;
   const window = findContextWindow(telemetry.model);
   if (!window) return null;
-  // Next-turn context size ≈ what the LLM will receive: latest turn's
-  // uncached input (telemetry) + cached prefix (system prompt + history
-  // already cached server-side). Output is the response, not input — excluded.
-  const latestInput = telemetry.inputTokens;
-  const used = latestInput + cachedFromTranscript;
-  // Aggregate input across all turns is a coarser fallback when the latest
-  // record happens to undercount (e.g. cache miss reset). We surface it in
-  // the tooltip for transparency but don't conflate it with the bar value.
-  const cumulativeInput = aggregate?.inputTokens ?? latestInput;
+  // Conversation size proxy: sum of per-turn uncached input deltas + assistant
+  // output across the session. Each turn's `inputTokens` is the *new* tokens
+  // added (the cached prefix isn't double-counted), and each `outputTokens`
+  // becomes part of history for the next turn. Avoids the `cache_read` trap:
+  // claude-code's per-turn `cache_read_input_tokens` sums every sub-call in a
+  // tool loop, so adding it would multiply by the number of iterations.
+  const cumulativeInput = aggregate?.inputTokens ?? telemetry.inputTokens;
+  const cumulativeOutput = aggregate?.outputTokens ?? telemetry.outputTokens;
+  const used = cumulativeInput + cumulativeOutput;
   const pct = Math.min(1, used / window);
   const tone =
     pct >= 0.9 ? 'bg-danger' : pct >= 0.75 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
   const windowLabel = window >= 1_000_000 ? `${window / 1_000_000}M` : `${window / 1_000}k`;
   const tooltip =
     `context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)\n` +
-    `latest turn: ${latestInput.toLocaleString()} new + ${cachedFromTranscript.toLocaleString()} cached\n` +
-    `cumulative input across turns: ${cumulativeInput.toLocaleString()}`;
+    `cumulative input: ${cumulativeInput.toLocaleString()} · output: ${cumulativeOutput.toLocaleString()}`;
   return (
     <div className="flex flex-col gap-0.5" title={tooltip}>
       <div className="flex items-center justify-between text-[9px] uppercase tracking-wide text-muted-foreground/60">


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced by #454.

### Root cause
PR #454 set `used = latestInput + cachedFromTranscript` where `cachedFromTranscript` reads `usage.cachedInputTokens` from the latest \`usage\` event. That field maps to claude-code's \`cache_read_input_tokens\` in the \`result\` envelope — which **sums every sub-LLM call in a tool-use loop**. With N tool iterations the cached read multiplies by N, easily blowing past the context window (observed: 994K / 200K = 100% on a haiku agent with 186 input / 6.8k output).

### Fix
Use \`aggregate.inputTokens + aggregate.outputTokens\` as the conversation-size proxy:
- \`aggregate.inputTokens\`: cumulative per-turn uncached input deltas — the cached prefix is never double-counted.
- \`aggregate.outputTokens\`: cumulative assistant output — becomes part of history for the next turn.

This drops the live-transcript scan and the \`agentId\` prop on \`ContextWindowBar\`.

## Files

- \`apps/desktop/src/components/WorkspacesSidebar.tsx\` — \`ContextWindowBar\` rewritten

## Test plan

- [ ] open agent with tool-heavy turns → CTX no longer overshoots window
- [ ] CTX grows turn-over-turn proportionally to conversation
- [ ] tooltip shows cumulative input + output split

🤖 Generated with [Claude Code](https://claude.com/claude-code)