### PR TITLE
fix(desktop): suggested-action cta auto-sends kickoff prompt

### DIFF
--- a/apps/desktop/src/spawnFromNextAction.ts
+++ b/apps/desktop/src/spawnFromNextAction.ts
@@ -4,7 +4,12 @@ import { AGENT_KIND_DEFAULTS, type AgentKind } from './agentKind';
 
 export type SpawnAgentFn = (
   taskId: TaskId,
-  args: { name?: string; model?: string; effort?: 'low' | 'medium' | 'high' },
+  args: {
+    name?: string;
+    model?: string;
+    effort?: 'low' | 'medium' | 'high';
+    initialPrompt?: string;
+  },
 ) => Promise<unknown>;
 
 export function spawnKindForAction(action: NextAction): AgentKind | null {
@@ -20,6 +25,21 @@ export function spawnKindForAction(action: NextAction): AgentKind | null {
   }
 }
 
+function kickoffPromptFor(action: NextAction): string {
+  switch (action.id) {
+    case 'spawn_planner':
+      return 'plan the next steps based on the current context.';
+    case 'spawn_implementer':
+      return 'implement based on the latest plan.';
+    case 'spawn_debugger': {
+      const topic = action.payload?.topic?.trim();
+      return topic ? `debug ${topic}.` : 'debug the current failure.';
+    }
+    default:
+      return '';
+  }
+}
+
 export async function spawnFromNextAction(
   action: NextAction,
   taskId: TaskId,
@@ -28,10 +48,12 @@ export async function spawnFromNextAction(
   const kind = spawnKindForAction(action);
   if (!kind) return false;
   const defaults = AGENT_KIND_DEFAULTS[kind];
+  const initialPrompt = kickoffPromptFor(action);
   await spawnAgent(taskId, {
     name: action.label,
     model: defaults.model,
     effort: defaults.effort,
+    ...(initialPrompt ? { initialPrompt } : {}),
   });
   return true;
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -386,7 +386,13 @@ export interface AppActions {
   selectAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
   spawnAgent(
     taskId: TaskId,
-    args: { stepId?: StepId; name?: string; model?: string; effort?: string },
+    args: {
+      stepId?: StepId;
+      name?: string;
+      model?: string;
+      effort?: string;
+      initialPrompt?: string;
+    },
   ): Promise<SessionId>;
   renameAgent(taskId: TaskId, agentId: SessionId, name: string): Promise<void>;
   deleteAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
@@ -1885,9 +1891,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (contextPreamble.length > 0) {
       resolvedPrompt = `${contextPreamble}\n\n${resolvedPrompt}`;
     }
-    const verbosityHint = verbosityDirective(
-      phaseDefinition?.verbosity ?? readVerbosity(taskId),
-    );
+    const verbosityHint = verbosityDirective(phaseDefinition?.verbosity ?? readVerbosity(taskId));
     resolvedPrompt = `${verbosityHint}\n\n${resolvedPrompt}`;
 
     let assistantText = '';
@@ -2623,8 +2627,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
         agentModelOverride: { ...s.agentModelOverride, [inserted.id]: args.model },
       }),
     }));
-    if (stepPromptPrefix.length > 0) {
-      void get().sendTurn({ taskId, content: stepPromptPrefix });
+    const kickoff = stepPromptPrefix.length > 0 ? stepPromptPrefix : (args.initialPrompt ?? '');
+    if (kickoff.length > 0) {
+      void get().sendTurn({ taskId, content: kickoff });
     }
     return inserted.id;
   },


### PR DESCRIPTION
## Summary

Clicking a suggested-action CTA (e.g. "start debug on file X") spawned the agent correctly but didn't send any message — the chat sat idle waiting for the user to type.

## Root cause

\`spawnFromNextAction\` called \`spawnAgent\` without an \`initialPrompt\`. \`spawnAgent\` only auto-sends a turn when there's a \`stepPromptPrefix\` (workflow-step path); the next-action path had no such prefix → no kick-off message.

## Fix

- \`spawnAgent\` args extended with optional \`initialPrompt\`. When no step prefix is present, \`initialPrompt\` is used as the kickoff content.
- \`spawnFromNextAction\` derives a kickoff prompt per action kind:
  - planner → "plan the next steps based on the current context."
  - implementer → "implement based on the latest plan."
  - debugger → \`debug <topic>.\` (or "debug the current failure." when no topic).

## Files

- \`apps/desktop/src/store/store.ts\` — args type + kickoff fallback after stepPrefix
- \`apps/desktop/src/spawnFromNextAction.ts\` — \`kickoffPromptFor\` + wire to \`initialPrompt\`

## Test plan

- [ ] click "start debug on …" CTA → new session spawns AND agent receives the debug prompt automatically
- [ ] click "plan next steps" / "implement" CTAs → same auto-start
- [ ] workflow-step spawns still use their \`promptPrefix\` (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)