### PR TITLE
feat(desktop): resume claude session, summarizer barrier, role prompts

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -99,6 +99,7 @@ pub fn run() {
       workflows::session_list_for_task,
       workflows::session_insert,
       workflows::session_update_status,
+      workflows::session_set_provider_session_id,
       parallel_groups::parallel_group_create,
       parallel_groups::parallel_group_list,
       parallel_groups::parallel_group_get,

--- a/apps/desktop/src-tauri/src/parallel_groups.rs
+++ b/apps/desktop/src-tauri/src/parallel_groups.rs
@@ -442,6 +442,8 @@ pub fn parallel_session_spawn(
                 permission_mode: &permission_mode,
                 allowed_tools: &args.allowed_tools,
                 disallowed_tools: &args.disallowed_tools,
+                resume_session_id: None,
+                system_prompt: None,
             },
         )?;
         run_ids.push(run_id);

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -70,6 +70,14 @@ pub struct SpawnArgs {
     pub disallowed_tools: Vec<String>,
     #[serde(default)]
     pub permission_mode: Option<String>,
+    // claude-only: when Some, spawn carries `--resume <id>` so the CLI restores
+    // the prior conversation instead of starting fresh. Ignored by codex/cursor.
+    #[serde(default)]
+    pub resume_session_id: Option<String>,
+    // claude-only: when Some, spawn carries `--append-system-prompt <prompt>`.
+    // Used to bias planner/implementer/debugger agents toward their role.
+    #[serde(default)]
+    pub system_prompt: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -121,15 +129,24 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 // runs tools without interactive confirmation.
                 "--force".to_string(),
             ];
-            // permission rules + permission_mode aren't supported by cursor-agent
-            // today; intentionally dropped here to avoid unknown-flag errors.
-            let _ = (args.permission_mode, args.allowed_tools, args.disallowed_tools);
+            // permission rules + permission_mode + resume + system_prompt aren't
+            // supported by cursor-agent today; intentionally dropped here to
+            // avoid unknown-flag errors.
+            let _ = (
+                args.permission_mode,
+                args.allowed_tools,
+                args.disallowed_tools,
+                args.resume_session_id,
+                args.system_prompt,
+            );
             v.shrink_to_fit();
             v
         }
         "codex" => {
             // codex exec takes a single prompt argument after `--`. permission
-            // rules aren't supported by the codex CLI yet.
+            // rules + resume + system_prompt aren't supported by the codex CLI
+            // yet.
+            let _ = (args.resume_session_id, args.system_prompt);
             vec![
                 "exec".to_string(),
                 "--json".to_string(),
@@ -143,7 +160,14 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
         }
         _ => {
             // claude (default).
-            let mut v = vec![
+            let mut v: Vec<String> = Vec::new();
+            // --resume must come before -p so claude restores the prior session
+            // before consuming the new user message.
+            if let Some(sid) = args.resume_session_id {
+                v.push("--resume".to_string());
+                v.push(sid.to_string());
+            }
+            v.extend([
                 "-p".to_string(),
                 args.prompt.to_string(),
                 "--output-format".to_string(),
@@ -153,7 +177,11 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 args.model.to_string(),
                 "--permission-mode".to_string(),
                 args.permission_mode.to_string(),
-            ];
+            ]);
+            if let Some(sp) = args.system_prompt {
+                v.push("--append-system-prompt".to_string());
+                v.push(sp.to_string());
+            }
             if !args.allowed_tools.is_empty() {
                 v.push("--allowedTools".to_string());
                 v.push(args.allowed_tools.join(","));
@@ -177,6 +205,8 @@ pub struct SpawnOneArgs<'a> {
     pub permission_mode: &'a str,
     pub allowed_tools: &'a [String],
     pub disallowed_tools: &'a [String],
+    pub resume_session_id: Option<&'a str>,
+    pub system_prompt: Option<&'a str>,
 }
 
 /// Spawns one child process, registers it in the registry, and starts the
@@ -285,6 +315,8 @@ pub fn turn_spawn(
             permission_mode: &permission_mode,
             allowed_tools: &args.allowed_tools,
             disallowed_tools: &args.disallowed_tools,
+            resume_session_id: args.resume_session_id.as_deref(),
+            system_prompt: args.system_prompt.as_deref(),
         },
     )
 }
@@ -385,9 +417,72 @@ mod tests {
             permission_mode: "default",
             allowed_tools: &allowed,
             disallowed_tools: &disallowed,
+            resume_session_id: None,
+            system_prompt: None,
         };
         assert_eq!(args.run_id, "run-1");
         assert_eq!(args.binary, "echo");
         assert_eq!(args.allowed_tools, &["Bash".to_string()]);
+    }
+
+    fn make_args<'a>(
+        resume: Option<&'a str>,
+        system_prompt: Option<&'a str>,
+        empty: &'a [String],
+    ) -> SpawnOneArgs<'a> {
+        SpawnOneArgs {
+            run_id: "run-1",
+            binary: "claude",
+            model: "claude-3",
+            working_dir: "/tmp",
+            prompt: "hi",
+            permission_mode: "default",
+            allowed_tools: empty,
+            disallowed_tools: empty,
+            resume_session_id: resume,
+            system_prompt,
+        }
+    }
+
+    #[test]
+    fn claude_args_omit_resume_and_system_prompt_when_none() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        let cli = build_provider_cli_args("claude", &args);
+        assert!(!cli.contains(&"--resume".to_string()));
+        assert!(!cli.contains(&"--append-system-prompt".to_string()));
+    }
+
+    #[test]
+    fn claude_args_include_resume_before_prompt() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(Some("sess-abc"), None, &empty);
+        let cli = build_provider_cli_args("claude", &args);
+        let resume_idx = cli.iter().position(|a| a == "--resume").expect("--resume");
+        let p_idx = cli.iter().position(|a| a == "-p").expect("-p");
+        assert!(resume_idx < p_idx, "--resume must precede -p");
+        assert_eq!(cli[resume_idx + 1], "sess-abc");
+    }
+
+    #[test]
+    fn claude_args_include_system_prompt() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, Some("you are a planner"), &empty);
+        let cli = build_provider_cli_args("claude", &args);
+        let idx = cli
+            .iter()
+            .position(|a| a == "--append-system-prompt")
+            .expect("--append-system-prompt");
+        assert_eq!(cli[idx + 1], "you are a planner");
+    }
+
+    #[test]
+    fn cursor_and_codex_ignore_resume_and_system_prompt() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(Some("sid"), Some("sp"), &empty);
+        let cli_cursor = build_provider_cli_args("cursor-agent", &args);
+        let cli_codex = build_provider_cli_args("codex", &args);
+        assert!(!cli_cursor.iter().any(|a| a == "--resume" || a == "--append-system-prompt"));
+        assert!(!cli_codex.iter().any(|a| a == "--resume" || a == "--append-system-prompt"));
     }
 }

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -77,6 +77,8 @@ pub struct SessionRow {
     pub started_at: Option<String>,
     #[serde(rename = "completedAt")]
     pub completed_at: Option<String>,
+    #[serde(rename = "providerSessionId")]
+    pub provider_session_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -424,7 +426,8 @@ pub fn session_list_for_task(
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let mut stmt = conn.prepare(
         "SELECT id, task_id, step_id, ordinal, name, status,
-                provider_run_id, output_summary, started_at, completed_at
+                provider_run_id, output_summary, started_at, completed_at,
+                provider_session_id
          FROM sessions
          WHERE task_id = ?1
          ORDER BY ordinal ASC",
@@ -441,6 +444,7 @@ pub fn session_list_for_task(
             output_summary: row.get(7)?,
             started_at: row.get(8)?,
             completed_at: row.get(9)?,
+            provider_session_id: row.get(10)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -484,6 +488,7 @@ pub fn session_insert(
         output_summary: input.output_summary,
         started_at: input.started_at,
         completed_at: input.completed_at,
+        provider_session_id: None,
     })
 }
 
@@ -515,7 +520,8 @@ pub fn session_update_status(
     // Fetch updated row.
     let mut stmt = conn.prepare(
         "SELECT id, task_id, step_id, ordinal, name, status,
-                provider_run_id, output_summary, started_at, completed_at
+                provider_run_id, output_summary, started_at, completed_at,
+                provider_session_id
          FROM sessions
          WHERE id = ?1
          LIMIT 1",
@@ -532,12 +538,33 @@ pub fn session_update_status(
             output_summary: row.get(7)?,
             started_at: row.get(8)?,
             completed_at: row.get(9)?,
+            provider_session_id: row.get(10)?,
         })
     })?;
     match rows.next() {
         Some(r) => Ok(r.map_err(PhaseError::Db)?),
         None => Err(PhaseError::RunNotFound(input.id)),
     }
+}
+
+// Persists the provider-side session id captured from the CLI's `system` init
+// event (claude). Threaded back via `--resume <id>` on subsequent turns so the
+// provider retains full prior-turn context across one-shot invocations.
+#[tauri::command]
+pub fn session_set_provider_session_id(
+    state: State<'_, Db>,
+    id: String,
+    provider_session_id: String,
+) -> Result<(), PhaseError> {
+    let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
+    let affected = conn.execute(
+        "UPDATE sessions SET provider_session_id = ?2 WHERE id = ?1",
+        rusqlite::params![id, provider_session_id],
+    )?;
+    if affected == 0 {
+        return Err(PhaseError::RunNotFound(id));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/agentKind.ts
+++ b/apps/desktop/src/agentKind.ts
@@ -49,15 +49,38 @@ export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; lab
 
 export const AGENT_KIND_DEFAULTS: Record<
   AgentKind,
-  { model: string; effort: 'low' | 'medium' | 'high'; verbosity?: 'low' | 'medium' | 'high' }
+  {
+    model: string;
+    effort: 'low' | 'medium' | 'high';
+    verbosity?: 'low' | 'medium' | 'high';
+    // Optional role bias appended to the claude system prompt via
+    // `--append-system-prompt`. Kept short to avoid drowning the user prompt;
+    // only kinds with a sharp role have one.
+    systemPrompt?: string;
+  }
 > = {
   scout: { model: 'claude-haiku-4-5', effort: 'low' },
   docs: { model: 'claude-haiku-4-5', effort: 'low' },
   generic: { model: 'claude-haiku-4-5', effort: 'low' },
-  implementer: { model: 'claude-sonnet-4-5', effort: 'medium' },
-  debugger: { model: 'claude-sonnet-4-5', effort: 'medium' },
+  implementer: {
+    model: 'claude-sonnet-4-5',
+    effort: 'medium',
+    systemPrompt:
+      'you are an implementation agent. execute the plan precisely. write code, run tests, fix issues. do not re-plan unless blocked. report progress at key checkpoints.',
+  },
+  debugger: {
+    model: 'claude-sonnet-4-5',
+    effort: 'medium',
+    systemPrompt:
+      'you are a debugging agent. reproduce the failure, isolate the root cause, propose minimal fixes. prefer instrumentation over assumptions. report findings before patching.',
+  },
   reviewer: { model: 'claude-sonnet-4-5', effort: 'medium' },
-  planner: { model: 'claude-opus-4-5', effort: 'high' },
+  planner: {
+    model: 'claude-opus-4-5',
+    effort: 'high',
+    systemPrompt:
+      'you are a planning agent. analyze the goal, break it into ordered steps, identify risks and dependencies. do not implement — produce a plan the implementer agent will execute. be concise.',
+  },
 };
 
 const ROLE_TO_KIND: Record<string, AgentKind> = {

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -52,6 +52,7 @@ interface RawPhaseRunRow {
   readonly outputSummary: string | null;
   readonly startedAt: string | null;
   readonly completedAt: string | null;
+  readonly providerSessionId: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +95,7 @@ function rowToPhaseRun(row: RawPhaseRunRow): Session {
     ...(row.outputSummary != null && { outputSummary: row.outputSummary }),
     ...(row.startedAt != null && { startedAt: row.startedAt as IsoDateTime }),
     ...(row.completedAt != null && { completedAt: row.completedAt as IsoDateTime }),
+    ...(row.providerSessionId != null && { providerSessionId: row.providerSessionId }),
   };
 }
 
@@ -215,6 +217,16 @@ export async function invokePhaseRunUpdateStatus(
     },
   });
   return rowToPhaseRun(row);
+}
+
+export async function invokeSessionSetProviderSessionId(
+  id: SessionId,
+  providerSessionId: string,
+): Promise<void> {
+  await invoke<void>('session_set_provider_session_id', {
+    id,
+    providerSessionId,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -187,6 +187,7 @@ import {
   invokePhaseRunList,
   invokePhaseRunInsert,
   invokePhaseRunUpdateStatus,
+  invokeSessionSetProviderSessionId,
   type PhaseTemplateUpsertArgs,
 } from '../phases';
 import {
@@ -534,9 +535,32 @@ interface SummarizerQueueEntry {
 interface SummarizerTaskQueue {
   inFlight: boolean;
   queued: SummarizerQueueEntry | null;
+  // Resolves when the current cycle (inFlight + any drained queued run) settles.
+  // Tracked so `waitForSummarizerSettled` can `await` instead of polling.
+  // Optional so test fixtures can construct partial queues without managing
+  // the internal promise plumbing.
+  settled?: Promise<void> | null;
+  resolveSettled?: (() => void) | null;
 }
 
 export const summarizerQueues = new Map<TaskId, SummarizerTaskQueue>();
+
+// Awaits a pending summarizer cycle for `taskId` so the next preamble sees the
+// freshest slots. Resolves either when the cycle settles or after `timeoutMs`.
+// 2s default keeps the user-facing input from blocking forever if summarizer
+// stalls; staleness is preferable to indefinite UI freeze.
+export async function waitForSummarizerSettled(taskId: TaskId, timeoutMs: number): Promise<void> {
+  const queue = summarizerQueues.get(taskId);
+  if (!queue || (!queue.inFlight && queue.queued === null)) return;
+  const settled = queue.settled;
+  if (!settled) return;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  await Promise.race([settled, timeout]);
+  if (timer) clearTimeout(timer);
+}
 
 function scheduleIdle(fn: () => void): void {
   if (typeof requestIdleCallback === 'function') {
@@ -555,7 +579,7 @@ function enqueueSummarizer(
 ): void {
   let queue = summarizerQueues.get(taskId);
   if (!queue) {
-    queue = { inFlight: false, queued: null };
+    queue = { inFlight: false, queued: null, settled: null, resolveSettled: null };
     summarizerQueues.set(taskId, queue);
   }
 
@@ -567,6 +591,16 @@ function enqueueSummarizer(
 
   queue.inFlight = true;
   queue.queued = null;
+  queue.settled = new Promise<void>((resolve) => {
+    queue!.resolveSettled = resolve;
+  });
+
+  const resolveSettled = (q: SummarizerTaskQueue): void => {
+    const r = q.resolveSettled;
+    q.settled = null;
+    q.resolveSettled = null;
+    r?.();
+  };
 
   const run = (): void => {
     void runSummarizer(set, get, taskId, turnInput, turnOutput).finally(() => {
@@ -578,11 +612,15 @@ function enqueueSummarizer(
         scheduleIdle(() => {
           void runSummarizer(set, get, taskId, next.turnInput, next.turnOutput).finally(() => {
             const q2 = summarizerQueues.get(taskId);
-            if (q2) q2.inFlight = false;
+            if (q2) {
+              q2.inFlight = false;
+              resolveSettled(q2);
+            }
           });
         });
       } else {
         q.inFlight = false;
+        resolveSettled(q);
       }
     });
   };
@@ -1331,8 +1369,35 @@ export const useAppStore = create<AppStore>((set, get) => ({
           },
         };
       }
+      // M1: capture claude's session id from the `system` init event so the
+      // next turn for this agent can pass `--resume <id>`. Update in-memory
+      // sessionPhaseRuns + persist; tolerate transient DB failures (worst
+      // case: next turn starts fresh, no data loss).
+      if (event.kind === 'provider_session_init') {
+        const runs = state.sessionPhaseRuns[taskId] ?? [];
+        const updatedRuns = runs.map((s) =>
+          s.id === agentId ? { ...s, providerSessionId: event.providerSessionId } : s,
+        );
+        void insertTurnEvent(tauriDatabase, {
+          id: crypto.randomUUID(),
+          taskId,
+          agentId,
+          event,
+        }).catch(() => undefined);
+        void invokeSessionSetProviderSessionId(agentId, event.providerSessionId).catch((err) => {
+          if (import.meta.env.DEV) {
+            const message = err instanceof Error ? err.message : String(err);
+            console.warn(`[turn-events] persist provider_session_id failed: ${message}`);
+          }
+        });
+        return {
+          transcripts: updatedTranscripts,
+          sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: updatedRuns },
+        };
+      }
       return { transcripts: updatedTranscripts };
     });
+    if (event.kind === 'provider_session_init') return;
     void insertTurnEvent(tauriDatabase, {
       id: crypto.randomUUID(),
       taskId,
@@ -1885,6 +1950,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // this Task already learned, and (b) knows how to write back via
     // <<ctx-decision>> / <<ctx-question>> markers parsed in the auto-populate
     // step after the turn ends.
+    // Barrier: wait for any pending summarizer cycle for this task so the
+    // preamble reads the slots produced by the previous turn rather than the
+    // stale set from two turns ago. Capped at 2s to keep the UI responsive.
+    await waitForSummarizerSettled(taskId, 2000);
     const sharedSlots = get().sessionSlots[taskId] ?? [];
     const sharedSlotsRendered = sharedSlots.length > 0 ? serializeSlots(sharedSlots) : '';
     const contextPreamble = buildContextPreamble(sharedSlotsRendered);
@@ -1898,6 +1967,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
     let lastError: unknown = null;
     const filesTouchedThisTurn = new Set<string>();
 
+    // M1: thread the per-agent provider session id so claude `--resume`s and
+    // keeps prior-turn context across one-shot CLI invocations. Read from the
+    // freshly loaded sessionPhaseRuns rather than a stale snapshot.
+    const agentRow =
+      (get().sessionPhaseRuns[taskId] ?? []).find((s) => s.id === activeAgentId) ?? null;
+    const resumeSessionId = agentRow?.providerSessionId;
+
+    // M3: per-kind system prompt — biases planner/implementer/debugger toward
+    // their role. Only claude consumes it today; other providers ignore the
+    // arg downstream.
+    const agentKind = inferAgentKindFromName(agentRow?.name ?? '');
+    const kindSystemPrompt = AGENT_KIND_DEFAULTS[agentKind].systemPrompt;
+
     try {
       for await (const event of runTurn({
         runId,
@@ -1905,6 +1987,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
         workingDir,
         prompt: resolvedPrompt,
         binary: providerInfo?.binary,
+        ...(resumeSessionId !== undefined && { resumeSessionId }),
+        ...(kindSystemPrompt !== undefined && { systemPrompt: kindSystemPrompt }),
         ...claudeFlags,
       })) {
         get().appendTurnEvent(activeAgentId, taskId, event);

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -59,6 +59,8 @@ interface SpawnArgs {
   readonly allowedTools?: ReadonlyArray<string>;
   readonly disallowedTools?: ReadonlyArray<string>;
   readonly permissionMode?: ClaudePermissionMode;
+  readonly resumeSessionId?: string;
+  readonly systemPrompt?: string;
 }
 
 type RawTurnEnvelope =

--- a/packages/core/src/providers/claude/parser.test.ts
+++ b/packages/core/src/providers/claude/parser.test.ts
@@ -22,8 +22,18 @@ describe('parseStreamJsonLine', () => {
     expect(parse('{not json')).toEqual([]);
   });
 
-  it('ignores system events', () => {
+  it('ignores system events without session id', () => {
     expect(parse(JSON.stringify({ type: 'system', subtype: 'init' }))).toEqual([]);
+    expect(parse(JSON.stringify({ type: 'system', subtype: 'other' }))).toEqual([]);
+  });
+
+  it('emits provider_session_init for system init events with session_id', () => {
+    const events = parse(
+      JSON.stringify({ type: 'system', subtype: 'init', session_id: 'sess-123' }),
+    );
+    expect(events).toEqual([
+      { kind: 'provider_session_init', runId: ctx.runId, providerSessionId: 'sess-123', at },
+    ]);
   });
 
   it('emits assistant_text for text content blocks', () => {

--- a/packages/core/src/providers/shared/anthropic-envelope-parser.ts
+++ b/packages/core/src/providers/shared/anthropic-envelope-parser.ts
@@ -122,8 +122,24 @@ export function parseAnthropicEnvelopeLine(
       return events;
     }
 
-    case 'system':
+    case 'system': {
+      // Claude stream-json emits `{"type":"system","subtype":"init","session_id":"..."}`.
+      // Capture the session id so it can be threaded back via --resume; ignore
+      // other system subtypes for now.
+      const subtype = payload.subtype as string | undefined;
+      const sessionId = payload.session_id;
+      if (subtype === 'init' && typeof sessionId === 'string' && sessionId.length > 0) {
+        return [
+          {
+            kind: 'provider_session_init',
+            runId: ctx.runId,
+            providerSessionId: sessionId,
+            at,
+          },
+        ];
+      }
       return [];
+    }
 
     default:
       if (typeof payload.type === 'string' && !KNOWN_PAYLOAD_TYPES.has(payload.type)) {

--- a/packages/core/src/turn/reducer.ts
+++ b/packages/core/src/turn/reducer.ts
@@ -81,6 +81,7 @@ function applyTurnEvent(state: TurnState, turn: TurnEvent): TurnState {
     case 'permission_request':
     case 'permission_decision':
     case 'unknown_payload':
+    case 'provider_session_init':
       return state;
     default: {
       const _exhaustive: never = turn;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -21,6 +21,7 @@ import { m020DiffComments } from './m020-diff-comments';
 import { m021DiffCommentLine } from './m021-diff-comment-line';
 import { m022TaskAutorun } from './m022-task-autorun';
 import { m023StepEffort } from './m023-step-effort';
+import { m024SessionProviderSessionId } from './m024-session-provider-session-id';
 
 export interface Migration {
   readonly version: number;
@@ -51,4 +52,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 21, sql: m021DiffCommentLine },
   { version: 22, sql: m022TaskAutorun },
   { version: 23, sql: m023StepEffort },
+  { version: 24, sql: m024SessionProviderSessionId },
 ];

--- a/packages/db/src/migrations/m024-session-provider-session-id.ts
+++ b/packages/db/src/migrations/m024-session-provider-session-id.ts
@@ -1,0 +1,3 @@
+export const m024SessionProviderSessionId = /* sql */ `
+ALTER TABLE sessions ADD COLUMN provider_session_id TEXT;
+`;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -69,6 +69,15 @@ export type TurnEvent =
   | { kind: 'error'; runId: ProviderRunId; message: string; at: IsoDateTime }
   | { kind: 'done'; runId: ProviderRunId; at: IsoDateTime }
   | {
+      // Emitted on the provider's first `system` event of a turn (claude init).
+      // Carries the provider-side session id so the store can persist it per
+      // agent and pass `--resume <id>` on the next turn.
+      kind: 'provider_session_init';
+      runId: ProviderRunId;
+      providerSessionId: string;
+      at: IsoDateTime;
+    }
+  | {
       kind: 'skill_invocation';
       runId: ProviderRunId;
       skillName: string;

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -63,6 +63,10 @@ export type Session = Readonly<{
   outputSummary?: string;
   startedAt?: IsoDateTime;
   completedAt?: IsoDateTime;
+  // Provider-side conversation id captured from the CLI's `system` init event
+  // (currently only claude). Threaded back via `--resume` on subsequent turns
+  // so the provider keeps full prior-turn context across one-shot invocations.
+  providerSessionId?: string;
 }>;
 
 export type StepTransition = Readonly<{


### PR DESCRIPTION
## Summary

Three fixes to context management identified during the context-mgmt audit:

- **M1 (critical)** — capture claude `system`/`init` `session_id` per agent, persist (`sessions.provider_session_id`), pass `--resume <id>` on next spawn. Eliminates the "agent forgets everything between turns" failure mode — claude now keeps prior conversation across one-shot CLI invocations. No-op for codex/cursor.
- **M2 (critical)** — `waitForSummarizerSettled(taskId, 2000)` barrier before building the context preamble. Prevents next turn from prepending stale slots while the previous turn's summarizer is still in-flight. 2s timeout keeps UI responsive on summarizer stalls.
- **M3 (high)** — `--append-system-prompt` per agent kind. Planner/implementer/debugger now ship with concise role bias instructions in `AGENT_KIND_DEFAULTS`.

## Changes

- new `provider_session_init` TurnEvent kind, emitted by `anthropic-envelope-parser` on first claude `system`/`init` frame.
- new migration `m024-session-provider-session-id` (`ALTER TABLE sessions ADD COLUMN provider_session_id TEXT`).
- new tauri command `session_set_provider_session_id`.
- `SpawnArgs` / `SpawnOneArgs` extended with `resume_session_id` + `system_prompt`; claude CLI args branch pushes them.
- `appendTurnEvent` handles `provider_session_init` (in-memory + DB persist via new invoke).
- `enqueueSummarizer` tracks a `settled` promise per task; `sendTurn` awaits before preamble.
- `sendTurn` resolves agent kind from name → looks up `AGENT_KIND_DEFAULTS[kind].systemPrompt`, threads through `runTurn`.

## Test plan

- [x] `pnpm typecheck` — all 5 packages pass
- [x] `pnpm test` — core 535 + desktop 261 + db 14 + ui 10 all green
- [x] `cargo test --lib` — 13 tests pass (4 new: resume/system-prompt presence + absence + cross-provider no-op)
- [ ] manual: spawn planner agent, send turn 1, send turn 2 referencing turn 1 content → verify agent has memory (M1 working)
- [ ] manual: rapid-fire 2 turns → verify second turn's preamble has fresh slots (M2 working)
- [ ] manual: planner vs implementer behavior on identical prompt — planner should plan, implementer should execute (M3 working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)