### PR TITLE
feat(desktop): context-mgmt followups (m4 token estimate, m5 sliding window, m6 slot routing)

### DIFF
--- a/apps/desktop/src/slotRouting.test.ts
+++ b/apps/desktop/src/slotRouting.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { SLOT_KEYS } from '@kay-am/core';
+import { AGENT_KIND_SLOTS, slotsForKind } from './slotRouting';
+
+describe('AGENT_KIND_SLOTS', () => {
+  it('only references valid slot keys', () => {
+    const valid = new Set<string>(SLOT_KEYS);
+    for (const [, slots] of Object.entries(AGENT_KIND_SLOTS)) {
+      if (!slots) continue;
+      for (const k of slots) expect(valid.has(k)).toBe(true);
+    }
+  });
+
+  it('planner drops files_touched', () => {
+    expect(AGENT_KIND_SLOTS.planner).toBeDefined();
+    expect(AGENT_KIND_SLOTS.planner).not.toContain('files_touched');
+  });
+
+  it('debugger drops open_questions', () => {
+    expect(AGENT_KIND_SLOTS.debugger).toBeDefined();
+    expect(AGENT_KIND_SLOTS.debugger).not.toContain('open_questions');
+  });
+
+  it('generic has no entry → fallback (all slots)', () => {
+    expect(slotsForKind('generic')).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/slotRouting.ts
+++ b/apps/desktop/src/slotRouting.ts
@@ -1,0 +1,17 @@
+import type { SlotKey } from '@kay-am/core';
+import type { AgentKind } from './agentKind';
+
+// slots each kind actually consumes. missing kinds get all slots (fallback).
+// reduces preamble bloat → cheaper turns + less noise.
+export const AGENT_KIND_SLOTS: Partial<Record<AgentKind, ReadonlyArray<SlotKey>>> = {
+  planner: ['goal', 'open_questions', 'decisions', 'last_output_summary'],
+  implementer: ['goal', 'decisions', 'files_touched', 'last_output_summary'],
+  debugger: ['goal', 'files_touched', 'last_output_summary'],
+  reviewer: ['goal', 'files_touched', 'last_output_summary'],
+  scout: ['goal', 'last_output_summary'],
+  docs: ['goal', 'last_output_summary'],
+};
+
+export function slotsForKind(kind: AgentKind): ReadonlyArray<SlotKey> | undefined {
+  return AGENT_KIND_SLOTS[kind];
+}

--- a/apps/desktop/src/store/preamble.test.ts
+++ b/apps/desktop/src/store/preamble.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import type { ContextSlot, IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from './preamble';
+
+const NOW = '2026-05-11T00:00:00.000Z' as IsoDateTime;
+const RUN = 'run-1' as ProviderRunId;
+
+function slot(key: string, value: string): ContextSlot {
+  return { key, value, enabled: true };
+}
+
+describe('buildContextPreamble', () => {
+  it('emits marker hint even with no slots', () => {
+    const out = buildContextPreamble([]);
+    expect(out).toContain('context handoff protocol');
+    expect(out).not.toContain('## shared context');
+  });
+
+  it('renders shared context block when slots present', () => {
+    const out = buildContextPreamble([slot('goal', 'ship m4-m6')]);
+    expect(out).toContain('## shared context');
+    expect(out).toContain('ship m4-m6');
+  });
+
+  it('slotFilter drops slots not in allow-list', () => {
+    const slots = [slot('goal', 'g'), slot('files_touched', 'a.ts'), slot('decisions', 'd')];
+    const out = buildContextPreamble(slots, ['goal', 'decisions']);
+    expect(out).toContain('goal');
+    expect(out).toContain('## decisions');
+    expect(out).not.toContain('a.ts');
+  });
+
+  it('empty filter result → no shared context block', () => {
+    const out = buildContextPreamble([slot('open_questions', 'q?')], ['goal']);
+    expect(out).not.toContain('## shared context');
+    expect(out).toContain('context handoff protocol');
+  });
+});
+
+describe('buildPriorTurnsBlock', () => {
+  it('empty transcripts → empty string', () => {
+    expect(buildPriorTurnsBlock([], 1000)).toBe('');
+  });
+
+  it('only tool events (no text) → empty string', () => {
+    const events: TurnEvent[] = [
+      {
+        kind: 'tool_call_start',
+        runId: RUN,
+        toolUseId: 't1',
+        toolName: 'Bash',
+        input: {},
+        at: NOW,
+      },
+    ];
+    expect(buildPriorTurnsBlock(events, 1000)).toBe('');
+  });
+
+  it('groups assistant deltas, preserves chronological order', () => {
+    const events: TurnEvent[] = [
+      { kind: 'user_text', runId: RUN, text: 'hello', at: NOW },
+      { kind: 'assistant_text', runId: RUN, delta: 'hi ', at: NOW },
+      { kind: 'assistant_text', runId: RUN, delta: 'there', at: NOW },
+      { kind: 'user_text', runId: RUN, text: 'bye', at: NOW },
+    ];
+    const out = buildPriorTurnsBlock(events, 1000);
+    expect(out).toContain('prior turns');
+    expect(out.indexOf('hello')).toBeLessThan(out.indexOf('hi there'));
+    expect(out.indexOf('hi there')).toBeLessThan(out.indexOf('bye'));
+  });
+
+  it('drops oldest first when over budget', () => {
+    const longText = 'x'.repeat(4000); // ≈1000 tokens each
+    const events: TurnEvent[] = [
+      { kind: 'user_text', runId: RUN, text: `old-${longText}`, at: NOW },
+      { kind: 'user_text', runId: RUN, text: `mid-${longText}`, at: NOW },
+      { kind: 'user_text', runId: RUN, text: `new-${longText}`, at: NOW },
+    ];
+    const out = buildPriorTurnsBlock(events, 1500);
+    expect(out).toContain('new-');
+    expect(out).not.toContain('old-');
+  });
+
+  it('budget too small for any turn → empty', () => {
+    const events: TurnEvent[] = [
+      { kind: 'user_text', runId: RUN, text: 'x'.repeat(4000), at: NOW },
+    ];
+    expect(buildPriorTurnsBlock(events, 10)).toBe('');
+  });
+});
+
+describe('getModelContextWindow', () => {
+  it('known claude model → 1_000_000', () => {
+    expect(getModelContextWindow('claude-opus-4-7')).toBe(1_000_000);
+  });
+
+  it('unknown model → null', () => {
+    expect(getModelContextWindow('some-custom-model')).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/preamble.ts
+++ b/apps/desktop/src/store/preamble.ts
@@ -1,0 +1,79 @@
+import { serializeSlots, type SlotKey, PROVIDER_CAPABILITIES } from '@kay-am/core';
+import type { ContextSlot, TurnEvent } from '@kay-am/types';
+import { estimateTokens } from '../utils/estimateTokens';
+
+const CONTEXT_MARKER_HINT =
+  '## context handoff protocol\n' +
+  'when you reach a durable design decision, wrap it as `<<ctx-decision>>your decision<</ctx-decision>>`.\n' +
+  'when you have an open question that the user must answer before continuing, wrap it as `<<ctx-question>>your question<</ctx-question>>`.\n' +
+  'when an open question listed in the shared context above has just been answered (by the user, or because work has clarified it), wrap it as `<<ctx-resolved>>the original question text<</ctx-resolved>>` — the orchestrator removes matching lines from open_questions. emit one resolved marker per question; reuse the original phrasing closely so the substring match succeeds.\n' +
+  "the orchestrator parses these markers and persists them to this task's shared context panel — every other agent in this task will see them automatically. don't repeat what's already in the shared context above.";
+
+export function buildContextPreamble(
+  sharedSlots: ReadonlyArray<ContextSlot>,
+  slotFilter?: ReadonlyArray<SlotKey>,
+): string {
+  const parts: string[] = [];
+  const filtered = slotFilter
+    ? sharedSlots.filter((s) => (slotFilter as ReadonlyArray<string>).includes(s.key))
+    : sharedSlots;
+  const rendered = filtered.length > 0 ? serializeSlots(filtered) : '';
+  if (rendered.length > 0) {
+    parts.push(
+      '## shared context (already loaded by orchestrator — do not re-derive)\n' + rendered,
+    );
+  }
+  parts.push(CONTEXT_MARKER_HINT);
+  return parts.join('\n\n');
+}
+
+const PRIOR_TURNS_HEADER = '## prior turns (this conversation, most recent last)';
+
+// codex/cursor are stateless per-invocation. inject recent user/assistant text
+// so they keep working memory. claude uses --resume (M1) so skip there.
+export function buildPriorTurnsBlock(
+  transcripts: ReadonlyArray<TurnEvent>,
+  maxTokens: number,
+): string {
+  type Line = { role: 'user' | 'assistant'; text: string };
+  const grouped: Line[] = [];
+  let pendingAssistant = '';
+  for (const ev of transcripts) {
+    if (ev.kind === 'user_text') {
+      if (pendingAssistant.length > 0) {
+        grouped.push({ role: 'assistant', text: pendingAssistant });
+        pendingAssistant = '';
+      }
+      grouped.push({ role: 'user', text: ev.text });
+    } else if (ev.kind === 'assistant_text') {
+      pendingAssistant += ev.delta;
+    }
+  }
+  if (pendingAssistant.length > 0) grouped.push({ role: 'assistant', text: pendingAssistant });
+
+  if (grouped.length === 0) return '';
+
+  const kept: string[] = [];
+  let budget = maxTokens;
+  for (let i = grouped.length - 1; i >= 0; i--) {
+    const line = grouped[i]!;
+    const text = line.text.trim();
+    if (text.length === 0) continue;
+    const formatted = `${line.role}: ${text}`;
+    const cost = estimateTokens(formatted);
+    if (cost > budget) break;
+    budget -= cost;
+    kept.push(formatted);
+  }
+  if (kept.length === 0) return '';
+  kept.reverse();
+  return `${PRIOR_TURNS_HEADER}\n${kept.join('\n\n')}`;
+}
+
+export function getModelContextWindow(model: string): number | null {
+  for (const caps of Object.values(PROVIDER_CAPABILITIES)) {
+    const m = caps.models.find((x) => x.id === model);
+    if (m) return m.contextWindow;
+  }
+  return null;
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -8,7 +8,6 @@ import {
   buildStepPrompt,
   currentStep,
   findReusableSession,
-  serializeSlots,
   parseSlashCommand,
   resolveConflicts,
   resolveSettings,
@@ -197,6 +196,8 @@ import {
 } from './parallel-turn';
 import { exportConfigToFile, importConfigFromFile } from '../config-export';
 import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../agentKind';
+import { slotsForKind } from '../slotRouting';
+import { estimateTokens } from '../utils/estimateTokens';
 
 export type BootPhase =
   | 'pending'
@@ -208,7 +209,7 @@ export type BootPhase =
   | 'ready'
   | 'error';
 
-export type SystemAlertKind = 'audit-retry-corrupt' | 'audit-retry-exhausted';
+export type SystemAlertKind = 'audit-retry-corrupt' | 'audit-retry-exhausted' | 'context-soft-cap';
 
 export interface SystemAlert {
   readonly id: string;
@@ -217,24 +218,7 @@ export interface SystemAlert {
   readonly createdAt: string;
 }
 
-const CONTEXT_MARKER_HINT =
-  '## context handoff protocol\n' +
-  'when you reach a durable design decision, wrap it as `<<ctx-decision>>your decision<</ctx-decision>>`.\n' +
-  'when you have an open question that the user must answer before continuing, wrap it as `<<ctx-question>>your question<</ctx-question>>`.\n' +
-  'when an open question listed in the shared context above has just been answered (by the user, or because work has clarified it), wrap it as `<<ctx-resolved>>the original question text<</ctx-resolved>>` — the orchestrator removes matching lines from open_questions. emit one resolved marker per question; reuse the original phrasing closely so the substring match succeeds.\n' +
-  "the orchestrator parses these markers and persists them to this task's shared context panel — every other agent in this task will see them automatically. don't repeat what's already in the shared context above.";
-
-function buildContextPreamble(sharedSlotsRendered: string): string {
-  const parts: string[] = [];
-  if (sharedSlotsRendered.length > 0) {
-    parts.push(
-      '## shared context (already loaded by orchestrator — do not re-derive)\n' +
-        sharedSlotsRendered,
-    );
-  }
-  parts.push(CONTEXT_MARKER_HINT);
-  return parts.join('\n\n');
-}
+import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from './preamble';
 
 function toRelPath(absPath: string, workingDir: string): string {
   if (!workingDir) return absPath;
@@ -1955,30 +1939,66 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // stale set from two turns ago. Capped at 2s to keep the UI responsive.
     await waitForSummarizerSettled(taskId, 2000);
     const sharedSlots = get().sessionSlots[taskId] ?? [];
-    const sharedSlotsRendered = sharedSlots.length > 0 ? serializeSlots(sharedSlots) : '';
-    const contextPreamble = buildContextPreamble(sharedSlotsRendered);
+
+    // M1: read the agent row once here; used by M5 (provider-id check) and M3 below.
+    const agentRowEarly =
+      (get().sessionPhaseRuns[taskId] ?? []).find((s) => s.id === activeAgentId) ?? null;
+    const earlyAgentKind = inferAgentKindFromName(agentRowEarly?.name ?? '');
+    const slotFilter = slotsForKind(earlyAgentKind);
+    const contextPreamble = buildContextPreamble(sharedSlots, slotFilter);
     if (contextPreamble.length > 0) {
       resolvedPrompt = `${contextPreamble}\n\n${resolvedPrompt}`;
     }
+
+    // M5: codex/cursor have no native --resume. inject recent turn text so
+    // they keep working memory. claude skips — duplicating context wastes tokens.
+    const needsTextHistory = provider === 'cursor' || provider === 'codex';
+    if (needsTextHistory) {
+      const priorTranscripts = get().transcripts[activeAgentId] ?? [];
+      const priorTurns = buildPriorTurnsBlock(priorTranscripts, 8000);
+      if (priorTurns.length > 0) {
+        resolvedPrompt = `${priorTurns}\n\n${resolvedPrompt}`;
+      }
+    }
+
     const verbosityHint = verbosityDirective(phaseDefinition?.verbosity ?? readVerbosity(taskId));
     resolvedPrompt = `${verbosityHint}\n\n${resolvedPrompt}`;
+
+    // M4: soft-cap warning. heuristic only — exact tokenization requires wasm.
+    const estimated = estimateTokens(resolvedPrompt);
+    const ctxWindow = getModelContextWindow(model);
+    if (ctxWindow !== null) {
+      const ratio = estimated / ctxWindow;
+      if (ratio >= 0.85) {
+        const pct = Math.round(ratio * 100);
+        const msg = `ctx estimate: ${estimated.toLocaleString()} / ${ctxWindow.toLocaleString()} (${pct}%) — consider /compact`;
+        if (import.meta.env.DEV) console.warn(msg);
+        set((state) => ({
+          systemAlerts: [
+            ...state.systemAlerts,
+            {
+              id: crypto.randomUUID(),
+              kind: 'context-soft-cap' as const,
+              message: msg,
+              createdAt: now(),
+            },
+          ],
+        }));
+      }
+    }
 
     let assistantText = '';
     let lastError: unknown = null;
     const filesTouchedThisTurn = new Set<string>();
 
     // M1: thread the per-agent provider session id so claude `--resume`s and
-    // keeps prior-turn context across one-shot CLI invocations. Read from the
-    // freshly loaded sessionPhaseRuns rather than a stale snapshot.
-    const agentRow =
-      (get().sessionPhaseRuns[taskId] ?? []).find((s) => s.id === activeAgentId) ?? null;
-    const resumeSessionId = agentRow?.providerSessionId;
+    // keeps prior-turn context across one-shot CLI invocations.
+    const resumeSessionId = agentRowEarly?.providerSessionId;
 
     // M3: per-kind system prompt — biases planner/implementer/debugger toward
     // their role. Only claude consumes it today; other providers ignore the
     // arg downstream.
-    const agentKind = inferAgentKindFromName(agentRow?.name ?? '');
-    const kindSystemPrompt = AGENT_KIND_DEFAULTS[agentKind].systemPrompt;
+    const kindSystemPrompt = AGENT_KIND_DEFAULTS[earlyAgentKind].systemPrompt;
 
     try {
       for await (const event of runTurn({

--- a/apps/desktop/src/utils/estimateTokens.test.ts
+++ b/apps/desktop/src/utils/estimateTokens.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { estimateTokens } from './estimateTokens';
+
+describe('estimateTokens', () => {
+  it('empty string → 0', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('short text rounds up', () => {
+    expect(estimateTokens('a')).toBe(1);
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcde')).toBe(2);
+  });
+
+  it('long text scales by chars/4', () => {
+    const text = 'x'.repeat(4000);
+    expect(estimateTokens(text)).toBe(1000);
+  });
+});

--- a/apps/desktop/src/utils/estimateTokens.ts
+++ b/apps/desktop/src/utils/estimateTokens.ts
@@ -1,0 +1,5 @@
+// 1 token ≈ 4 chars for english/code. real tokenizer needs wasm dep,
+// out of scope per project policy. heuristic is enough for soft-cap warnings.
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}


### PR DESCRIPTION
## Summary

Follow-ups to [#457](https://github.com/akhayam99/kay-am/pull/457). Three remaining items from the context-mgmt audit:

- **M4 (alto)** — pre-flight token estimate vs model `contextWindow`. Warns via new `context-soft-cap` system alert when prompt ≥85% of window. Heuristic 1 tok ≈ 4 chars (no wasm dep). Non-blocking.
- **M5 (utile)** — sliding window text injection for codex/cursor (still stateless every turn — claude got `--resume` in #457). Walks transcript backward, packs `user:` / `assistant:` lines until 8k token budget, prepends to preamble. Skipped for claude (would dupe `--resume` context).
- **M6 (utile)** — `AGENT_KIND_SLOTS` filter table. Planner skips `files_touched`, debugger skips `open_questions`, scout/docs keep only `goal + last_output_summary`. Reduces preamble bloat for specialized agents.

## Changes

- new `apps/desktop/src/utils/estimateTokens.ts` — heuristic estimator
- new `apps/desktop/src/slotRouting.ts` — `AGENT_KIND_SLOTS` per-kind filter
- new `apps/desktop/src/store/preamble.ts` — extracted `buildContextPreamble` (now takes `slots + slotFilter?`), new `buildPriorTurnsBlock`, new `getModelContextWindow` walking `PROVIDER_CAPABILITIES`
- `apps/desktop/src/store/store.ts` — wired all three into `sendTurn`; added `context-soft-cap` to `SystemAlertKind`; deduped agent-row lookup so M3 + M5 share it

## Notes / deviations

- **Slot keys**: actual `SlotKey` values in `packages/core/src/context/slots.ts` are `goal | files_touched | decisions | open_questions | last_output_summary` (not the names guessed in the audit). `AGENT_KIND_SLOTS` rewritten against real keys.
- **Toast**: `useToast` is React-context only — store can't consume it. Used existing `systemAlerts` pipeline with new kind, consistent with `audit-retry-*` precedent. `console.warn` in DEV preserved.

## Test plan

- [x] `pnpm typecheck` — clean across all packages
- [x] `pnpm test` — 279 passed (18 new: estimator sanity, prior-turns block empty/mixed/over-budget, slot routing per kind, preamble with filter)
- [ ] manual: spawn debugger agent, observe preamble has no `open_questions` slot (M6)
- [ ] manual: spawn codex/cursor session, send 2 turns referencing turn 1 → verify memory carries via prior-turns block (M5)
- [ ] manual: craft a ~170k char prompt against sonnet (200k window) → verify system alert fires (M4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)