### PR TITLE
feat(desktop): persist per-session provider+model selection

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -36,6 +36,8 @@ const RUNNING_KINDS = new Set(['starting', 'running']);
 const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
 
 const EFFORT_STORAGE_PREFIX = 'kayam:effort:';
+const MODEL_STORAGE_PREFIX = 'kayam:model:';
+const PROVIDER_STORAGE_PREFIX = 'kayam:provider:';
 
 function readEffort(taskId: TaskId): EffortLevel {
   try {
@@ -50,6 +52,49 @@ function readEffort(taskId: TaskId): EffortLevel {
 function writeEffort(taskId: TaskId, level: EffortLevel): void {
   try {
     localStorage.setItem(`${EFFORT_STORAGE_PREFIX}${taskId}`, level);
+  } catch {
+    // ignore
+  }
+}
+
+function readModel(taskId: TaskId): string | null {
+  try {
+    return localStorage.getItem(`${MODEL_STORAGE_PREFIX}${taskId}`);
+  } catch {
+    return null;
+  }
+}
+
+function writeModel(taskId: TaskId, model: string | null): void {
+  try {
+    if (model === null) {
+      localStorage.removeItem(`${MODEL_STORAGE_PREFIX}${taskId}`);
+    } else {
+      localStorage.setItem(`${MODEL_STORAGE_PREFIX}${taskId}`, model);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function readProvider(taskId: TaskId): ProviderId | null {
+  try {
+    const raw = localStorage.getItem(`${PROVIDER_STORAGE_PREFIX}${taskId}`);
+    const valid: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+    if (raw && valid.includes(raw as ProviderId)) return raw as ProviderId;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function writeProvider(taskId: TaskId, provider: ProviderId | null): void {
+  try {
+    if (provider === null) {
+      localStorage.removeItem(`${PROVIDER_STORAGE_PREFIX}${taskId}`);
+    } else {
+      localStorage.setItem(`${PROVIDER_STORAGE_PREFIX}${taskId}`, provider);
+    }
   } catch {
     // ignore
   }
@@ -95,8 +140,12 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const { showToast } = useToast();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [selectedProvider, setSelectedProvider] = useState<ProviderId | null>(null);
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [selectedProvider, setSelectedProviderState] = useState<ProviderId | null>(() =>
+    readProvider(session.id),
+  );
+  const [selectedModel, setSelectedModelState] = useState<string | null>(() =>
+    readModel(session.id),
+  );
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
@@ -165,6 +214,16 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const setVerbosity = (level: VerbosityLevel) => {
     setVerbosityState(level);
     writeVerbosity(session.id, level);
+  };
+
+  const setSelectedProvider = (id: ProviderId | null) => {
+    setSelectedProviderState(id);
+    writeProvider(session.id, id);
+  };
+
+  const setSelectedModel = (id: string | null) => {
+    setSelectedModelState(id);
+    writeModel(session.id, id);
   };
 
   const onSelectProvider = (id: ProviderId) => {

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -48,7 +48,14 @@ interface ColumnProps {
   onOpenDiff: (filePath: string) => void;
 }
 
-function ParallelColumn({ runId, index, events, workingDir, onRefreshAuth, onOpenDiff }: ColumnProps) {
+function ParallelColumn({
+  runId,
+  index,
+  events,
+  workingDir,
+  onRefreshAuth,
+  onOpenDiff,
+}: ColumnProps) {
   const columnEvents = useMemo(() => filterEventsByRunId(events, runId), [events, runId]);
   const items = useMemo(() => reduceTranscript(columnEvents), [columnEvents]);
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
@@ -284,7 +291,11 @@ export function ChatView({ session }: ChatViewProps) {
             session ended — no further turns. branch preserved.
           </div>
         ) : (
-          <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
+          <ChatInput
+            key={session.id}
+            session={session}
+            providerDisconnected={isProviderDisconnected}
+          />
         )}
         <DiffViewerDialog
           open={diffJumpFile !== null}
@@ -410,7 +421,11 @@ export function ChatView({ session }: ChatViewProps) {
           session ended — no further turns. branch preserved.
         </div>
       ) : (
-        <ChatInput session={session} providerDisconnected={isProviderDisconnected} />
+        <ChatInput
+          key={session.id}
+          session={session}
+          providerDisconnected={isProviderDisconnected}
+        />
       )}
       <DiffViewerDialog
         open={diffJumpFile !== null}


### PR DESCRIPTION
## Summary

Provider + model dropdowns now persist per-session via localStorage. Consistent with the existing effort/verbosity pattern.

- `kayam:provider:<taskId>` + `kayam:model:<taskId>` keys
- `<ChatInput key={session.id}>` forces remount on session switch → state stays clean per-session

## Test plan

- [ ] manual: open session A, pick cursor+sonnet → switch to session B → switch back → verify cursor+sonnet still selected
- [ ] manual: new session → defaults restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)