### PR TITLE
feat(desktop): providers cards, quota view, costs table, comments UI (#467)

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -165,60 +165,6 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-git-branch"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M15 6a9 9 0 0 0-9 9V3"
-              />
-              <circle
-                cx="18"
-                cy="6"
-                r="3"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Branch
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
               class="lucide lucide-dollar-sign"
               fill="none"
               height="13"
@@ -341,23 +287,51 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           class="min-w-0 flex-1 overflow-y-auto pl-4"
         >
           <div
-            class="flex flex-col gap-1.5"
+            class="flex flex-col gap-4"
           >
-            <span
-              class="text-xs font-semibold text-foreground"
+            <div
+              class="flex flex-col gap-1.5"
             >
-              goal
-            </span>
-            <textarea
-              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-              placeholder="refactor auth domain"
-              style="height: 96px; overflow-y: hidden;"
-            />
-            <p
-              class="text-xs leading-relaxed text-muted-foreground"
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                issue link
+              </span>
+              <div
+                class="relative"
+              >
+                <input
+                  class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
+                  placeholder="https://github.com/owner/repo/issues/42"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                paste a GitHub issue URL or owner/repo#number.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-1.5"
             >
-              what the session should accomplish.
-            </p>
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                goal
+              </span>
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+                placeholder="refactor auth domain"
+                style="height: 96px; overflow-y: hidden;"
+              />
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                what the session should accomplish.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -365,48 +339,105 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
-      <span
-        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      <div
+        class="flex w-full flex-col gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-triangle-alert"
-          fill="none"
-          height="12"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="12"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="flex items-center gap-2"
         >
-          <path
-            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-          />
-          <path
-            d="M12 9v4"
-          />
-          <path
-            d="M12 17h.01"
-          />
-        </svg>
-        complete: goal, provider
-      </span>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
-        type="button"
-      >
-        cancel
-      </button>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
-        disabled=""
-        title="complete: goal, provider"
-        type="button"
-      >
-        create session
-      </button>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-git-branch shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 6a9 9 0 0 0-9 9V3"
+            />
+            <circle
+              cx="18"
+              cy="6"
+              r="3"
+            />
+            <circle
+              cx="6"
+              cy="18"
+              r="3"
+            />
+          </svg>
+          <div
+            class="flex min-w-0 flex-1 items-center gap-1"
+          >
+            <span
+              class="shrink-0 text-xs text-muted-foreground"
+            >
+              kay
+              /
+            </span>
+            <input
+              aria-label="branch slug"
+              class="w-full rounded-md border-border text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-primary/40 disabled:opacity-50 h-6 min-w-0 flex-1 border-0 bg-transparent px-1 py-0 text-xs font-mono focus-visible:ring-0 focus-visible:ring-offset-0"
+              placeholder="branch-slug"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-triangle-alert"
+              fill="none"
+              height="12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
+            complete: 
+            goal, provider
+          </span>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
+            disabled=""
+            title="complete: goal, provider"
+            type="button"
+          >
+            create session
+          </button>
+        </div>
+      </div>
     </footer>
   </div>
 </dialog>
@@ -509,9 +540,55 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     class="flex shrink-0 items-center gap-1.5 px-2 py-2"
   >
     <span
-      class="px-1 text-sm font-semibold tracking-tight"
+      class="flex items-center gap-1.5 px-1"
     >
-      kAY.am
+      <svg
+        aria-hidden="true"
+        class="shrink-0 text-foreground"
+        fill="none"
+        height="18"
+        viewBox="0 0 18 18"
+        width="18"
+      >
+        <circle
+          cx="9"
+          cy="9"
+          fill="currentColor"
+          opacity="0.9"
+          r="3.5"
+        />
+        <circle
+          cx="9"
+          cy="9"
+          opacity="0.35"
+          r="7.5"
+          stroke="currentColor"
+          stroke-width="1.2"
+        />
+        <line
+          opacity="0.2"
+          stroke="currentColor"
+          stroke-width="1"
+          x1="9"
+          x2="9"
+          y1="1"
+          y2="17"
+        />
+        <line
+          opacity="0.2"
+          stroke="currentColor"
+          stroke-width="1"
+          x1="1"
+          x2="17"
+          y1="9"
+          y2="9"
+        />
+      </svg>
+      <span
+        class="text-sm font-semibold tracking-tight text-foreground"
+      >
+        kAY.am
+      </span>
     </span>
     <div
       class="ml-auto flex items-center gap-0.5"
@@ -660,6 +737,30 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             cx="12"
             cy="12"
             r="3"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="collapse sidebar"
+        class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title="collapse sidebar"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-left"
+          fill="none"
+          height="13"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="13"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 18-6-6 6-6"
           />
         </svg>
       </button>
@@ -970,10 +1071,10 @@ workspace: $0"
                 </div>
               </div>
               <div
-                class="max-h-72 overflow-y-auto"
+                class="max-h-72 overflow-y-auto rounded-md border border-border-soft"
               >
                 <p
-                  class="py-2 text-xs text-muted-foreground"
+                  class="py-2 text-center text-xs text-muted-foreground"
                 >
                   no recorded turns yet.
                 </p>
@@ -2110,60 +2211,6 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-git-branch"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M15 6a9 9 0 0 0-9 9V3"
-              />
-              <circle
-                cx="18"
-                cy="6"
-                r="3"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Branch
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
               class="lucide lucide-dollar-sign"
               fill="none"
               height="13"
@@ -2286,23 +2333,51 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           class="min-w-0 flex-1 overflow-y-auto pl-4"
         >
           <div
-            class="flex flex-col gap-1.5"
+            class="flex flex-col gap-4"
           >
-            <span
-              class="text-xs font-semibold text-foreground"
+            <div
+              class="flex flex-col gap-1.5"
             >
-              goal
-            </span>
-            <textarea
-              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-              placeholder="refactor auth domain"
-              style="height: 96px; overflow-y: hidden;"
-            />
-            <p
-              class="text-xs leading-relaxed text-muted-foreground"
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                issue link
+              </span>
+              <div
+                class="relative"
+              >
+                <input
+                  class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
+                  placeholder="https://github.com/owner/repo/issues/42"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                paste a GitHub issue URL or owner/repo#number.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-1.5"
             >
-              what the session should accomplish.
-            </p>
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                goal
+              </span>
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+                placeholder="refactor auth domain"
+                style="height: 96px; overflow-y: hidden;"
+              />
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                what the session should accomplish.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -2310,73 +2385,108 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
-      <span
-        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      <div
+        class="flex w-full flex-col gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-triangle-alert"
-          fill="none"
-          height="12"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="12"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="flex items-center gap-2"
         >
-          <path
-            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-          />
-          <path
-            d="M12 9v4"
-          />
-          <path
-            d="M12 17h.01"
-          />
-        </svg>
-        complete: goal, provider
-      </span>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
-        type="button"
-      >
-        cancel
-      </button>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
-        disabled=""
-        title="complete: goal, provider"
-        type="button"
-      >
-        create session
-      </button>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-git-branch shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 6a9 9 0 0 0-9 9V3"
+            />
+            <circle
+              cx="18"
+              cy="6"
+              r="3"
+            />
+            <circle
+              cx="6"
+              cy="18"
+              r="3"
+            />
+          </svg>
+          <div
+            class="flex min-w-0 flex-1 items-center gap-1"
+          >
+            <span
+              class="shrink-0 text-xs text-muted-foreground"
+            >
+              kay
+              /
+            </span>
+            <input
+              aria-label="branch slug"
+              class="w-full rounded-md border-border text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-primary/40 disabled:opacity-50 h-6 min-w-0 flex-1 border-0 bg-transparent px-1 py-0 text-xs font-mono focus-visible:ring-0 focus-visible:ring-offset-0"
+              placeholder="branch-slug"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-triangle-alert"
+              fill="none"
+              height="12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
+            complete: 
+            goal, provider
+          </span>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
+            disabled=""
+            title="complete: goal, provider"
+            type="button"
+          >
+            create session
+          </button>
+        </div>
+      </div>
     </footer>
   </div>
 </dialog>
-`;
-
-exports[`snapshot — error states > PermissionsPanel: form error (workspace scope) 1`] = `
-<div
-  class="flex flex-col gap-3"
->
-  <div
-    class="flex items-center justify-between"
-  >
-    <div
-      class="text-xs font-semibold text-foreground"
-    >
-      permission rules
-    </div>
-    <button
-      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
-      type="button"
-    >
-      add rule
-    </button>
-  </div>
-</div>
 `;
 
 exports[`snapshot — error states > ProvidersPanel: provider in error state 1`] = `
@@ -2399,38 +2509,57 @@ exports[`snapshot — error states > ProvidersPanel: provider in error state 1`]
       refresh all
     </button>
   </div>
-  <ul
-    class="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm"
+  <div
+    class="flex flex-col gap-2"
   >
-    <li
-      class="flex items-center gap-3 px-3 py-2.5 text-xs"
+    <div
+      class="flex flex-col gap-2 overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm"
     >
-      <span
-        aria-hidden="true"
-        class="inline-block h-2 w-2 shrink-0 rounded-full bg-danger"
-      />
       <div
-        class="flex min-w-0 flex-1 flex-col gap-0.5"
+        class="flex items-center gap-3 border-b border-border-soft px-3 py-2"
       >
+        <span
+          aria-hidden="true"
+          class="inline-block h-2 w-2 shrink-0 rounded-full bg-danger"
+        />
         <div
-          class="flex items-center gap-2"
+          class="flex min-w-0 flex-1 flex-col gap-0.5"
         >
-          <span
-            class="font-medium"
+          <div
+            class="flex items-center gap-2"
           >
-            claude
-          </span>
-          <code
+            <span
+              class="text-xs font-semibold"
+            >
+              claude
+            </span>
+            <code
+              class="text-2xs text-muted-foreground"
+            >
+              claude
+            </code>
+            <span
+              class="rounded bg-muted px-1 text-2xs text-muted-foreground"
+            >
+              1.0.0
+            </span>
+          </div>
+          <span
             class="text-2xs text-muted-foreground"
           >
-            claude
-          </code>
-          <span
-            class="rounded bg-muted px-1 text-2xs text-muted-foreground"
-          >
-            1.0.0
+            anthropic claude code cli
           </span>
         </div>
+        <button
+          class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs shrink-0"
+          type="button"
+        >
+          retry
+        </button>
+      </div>
+      <div
+        class="flex flex-col gap-1.5 px-3 pb-2.5"
+      >
         <div
           class="text-xs"
         >
@@ -2441,14 +2570,8 @@ exports[`snapshot — error states > ProvidersPanel: provider in error state 1`]
           </span>
         </div>
       </div>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs shrink-0"
-        type="button"
-      >
-        retry
-      </button>
-    </li>
-  </ul>
+    </div>
+  </div>
   <p
     class="text-xs text-muted-foreground"
   >

--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -186,6 +186,7 @@ export function DiffViewerDialog({
   const [error, setError] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarPref);
   const [activeAnchor, setActiveAnchor] = useState<DiffCommentAnchor | null>(null);
+  const [fileLevelComposerOpen, setFileLevelComposerOpen] = useState(false);
 
   const comments = useDiffComments(taskId ?? null);
   const loadDiffComments = useAppStore((s) => s.loadDiffComments);
@@ -283,6 +284,7 @@ export function DiffViewerDialog({
 
   useEffect(() => {
     setActiveAnchor(null);
+    setFileLevelComposerOpen(false);
   }, [selectedIdx]);
 
   const editorBinary = useAppStore(
@@ -335,6 +337,24 @@ export function DiffViewerDialog({
     setActiveAnchor(null);
   };
 
+  const handleAddFileLevelComment = async (body: string) => {
+    if (!selected || !taskId) return;
+    await addDiffComment(taskId, selected.path, body);
+    setFileLevelComposerOpen(false);
+  };
+
+  const handleSelectFile = (idx: number) => {
+    setSelectedIdx(idx);
+    setFileLevelComposerOpen(false);
+    setActiveAnchor(null);
+  };
+
+  const handleRailFileComment = (idx: number) => {
+    setSelectedIdx(idx);
+    setActiveAnchor(null);
+    setFileLevelComposerOpen(true);
+  };
+
   return (
     <Dialog
       open={open}
@@ -382,7 +402,8 @@ export function DiffViewerDialog({
                 <FileRail
                   files={files}
                   selectedIdx={selectedIdx}
-                  onSelect={setSelectedIdx}
+                  onSelect={handleSelectFile}
+                  onStartFileComment={taskId ? handleRailFileComment : undefined}
                   commentCounts={openCommentsByFile}
                 />
               ) : null}
@@ -393,10 +414,14 @@ export function DiffViewerDialog({
                     comments={selectedComments}
                     fileLevelComments={fileLevelComments}
                     activeAnchor={activeAnchor}
+                    fileLevelComposerOpen={fileLevelComposerOpen}
                     canComment={Boolean(taskId)}
                     onStartComment={(anchor) => setActiveAnchor(anchor)}
                     onCancelComment={() => setActiveAnchor(null)}
                     onSubmitComment={(anchor, body) => void handleAddComment(anchor, body)}
+                    onStartFileLevelComment={() => setFileLevelComposerOpen(true)}
+                    onCancelFileLevelComment={() => setFileLevelComposerOpen(false)}
+                    onSubmitFileLevelComment={(body) => void handleAddFileLevelComment(body)}
                     onResolve={(id) => taskId && void resolveDiffComment(taskId, id)}
                     onDelete={(id) => taskId && void deleteDiffComment(taskId, id)}
                   />
@@ -576,11 +601,13 @@ function FileRail({
   files,
   selectedIdx,
   onSelect,
+  onStartFileComment,
   commentCounts,
 }: {
   files: ReadonlyArray<FileDiff>;
   selectedIdx: number;
   onSelect: (i: number) => void;
+  onStartFileComment?: (i: number) => void;
   commentCounts: Map<string, number>;
 }) {
   const selectedRef = useRef<HTMLButtonElement>(null);
@@ -601,6 +628,7 @@ function FileRail({
               depth={0}
               selectedIdx={selectedIdx}
               onSelect={onSelect}
+              onStartFileComment={onStartFileComment}
               selectedRef={selectedRef}
               commentCounts={commentCounts}
             />
@@ -615,6 +643,7 @@ function TreeNodeView({
   depth,
   selectedIdx,
   onSelect,
+  onStartFileComment,
   selectedRef,
   commentCounts,
 }: {
@@ -622,6 +651,7 @@ function TreeNodeView({
   depth: number;
   selectedIdx: number;
   onSelect: (i: number) => void;
+  onStartFileComment?: (i: number) => void;
   selectedRef: React.RefObject<HTMLButtonElement | null>;
   commentCounts: Map<string, number>;
 }) {
@@ -633,39 +663,59 @@ function TreeNodeView({
     const isSelected = index === selectedIdx;
     const noteCount = commentCounts.get(file.path) ?? 0;
     return (
-      <button
-        ref={isSelected ? selectedRef : null}
-        type="button"
-        onClick={() => onSelect(index)}
-        title={file.path}
+      <div
         className={cn(
-          'relative flex w-full items-center gap-2 py-1 pr-2.5 text-left font-mono text-xs transition-colors',
+          'group relative flex w-full items-center gap-2 py-1 pr-1 font-mono text-xs transition-colors',
           isSelected
             ? 'border-l-2 border-primary bg-subtle text-foreground'
             : 'border-l-2 border-transparent text-muted-foreground/80 hover:bg-muted/30 hover:text-foreground',
         )}
         style={{ paddingLeft: 10 + indent }}
       >
-        <span
-          className={cn(
-            'w-3 shrink-0 text-center text-[10px] font-bold',
-            STATUS_COLOR[file.status],
-          )}
+        <button
+          ref={isSelected ? selectedRef : null}
+          type="button"
+          onClick={() => onSelect(index)}
+          title={file.path}
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
         >
-          {STATUS_GLYPH[file.status]}
-        </span>
-        <span className="min-w-0 flex-1 truncate">{node.name}</span>
-        {noteCount > 0 ? (
-          <span className="shrink-0 rounded-full bg-warning/15 px-1 text-[9px] font-medium text-warning">
-            {noteCount}
+          <span
+            className={cn(
+              'w-3 shrink-0 text-center text-[10px] font-bold',
+              STATUS_COLOR[file.status],
+            )}
+          >
+            {STATUS_GLYPH[file.status]}
           </span>
+          <span className="min-w-0 flex-1 truncate">{node.name}</span>
+          {noteCount > 0 ? (
+            <span className="shrink-0 rounded-full bg-warning/15 px-1 text-[9px] font-medium text-warning">
+              {noteCount}
+            </span>
+          ) : null}
+          <span className="shrink-0 text-[10px] tabular-nums">
+            {file.additions > 0 ? <span className="text-success">+{file.additions}</span> : null}
+            {file.additions > 0 && file.deletions > 0 ? (
+              <span className="opacity-40"> </span>
+            ) : null}
+            {file.deletions > 0 ? <span className="text-danger">−{file.deletions}</span> : null}
+          </span>
+        </button>
+        {onStartFileComment ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onStartFileComment(index);
+            }}
+            title="add file-level note"
+            aria-label="add file-level note"
+            className="mr-1 shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+          >
+            <MessageSquarePlus size={10} aria-hidden />
+          </button>
         ) : null}
-        <span className="shrink-0 text-[10px] tabular-nums">
-          {file.additions > 0 ? <span className="text-success">+{file.additions}</span> : null}
-          {file.additions > 0 && file.deletions > 0 ? <span className="opacity-40"> </span> : null}
-          {file.deletions > 0 ? <span className="text-danger">−{file.deletions}</span> : null}
-        </span>
-      </button>
+      </div>
     );
   }
 
@@ -693,6 +743,7 @@ function TreeNodeView({
               depth={depth + 1}
               selectedIdx={selectedIdx}
               onSelect={onSelect}
+              onStartFileComment={onStartFileComment}
               selectedRef={selectedRef}
               commentCounts={commentCounts}
             />
@@ -767,10 +818,14 @@ interface FileDiffPaneProps {
   comments: ReadonlyArray<DiffComment>;
   fileLevelComments: ReadonlyArray<DiffComment>;
   activeAnchor: DiffCommentAnchor | null;
+  fileLevelComposerOpen: boolean;
   canComment: boolean;
   onStartComment: (anchor: DiffCommentAnchor) => void;
   onCancelComment: () => void;
   onSubmitComment: (anchor: DiffCommentAnchor, body: string) => void;
+  onStartFileLevelComment: () => void;
+  onCancelFileLevelComment: () => void;
+  onSubmitFileLevelComment: (body: string) => void;
   onResolve: (id: string) => void;
   onDelete: (id: string) => void;
 }
@@ -780,10 +835,14 @@ function FileDiffPane({
   comments,
   fileLevelComments,
   activeAnchor,
+  fileLevelComposerOpen,
   canComment,
   onStartComment,
   onCancelComment,
   onSubmitComment,
+  onStartFileLevelComment,
+  onCancelFileLevelComment,
+  onSubmitFileLevelComment,
   onResolve,
   onDelete,
 }: FileDiffPaneProps) {
@@ -802,14 +861,45 @@ function FileDiffPane({
   return (
     <ScrollArea className="flex-1 overflow-auto">
       <div className="p-3">
-        {fileLevelComments.length > 0 ? (
+        {fileLevelComments.length > 0 || fileLevelComposerOpen ? (
           <div className="mb-3 flex flex-col gap-1.5">
-            <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-              file notes
-            </span>
+            <div className="flex items-center justify-between">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+                file notes
+              </span>
+              {canComment && !fileLevelComposerOpen ? (
+                <button
+                  type="button"
+                  onClick={onStartFileLevelComment}
+                  title="add file-level note"
+                  aria-label="add file-level note"
+                  className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  <MessageSquarePlus size={11} aria-hidden />
+                </button>
+              ) : null}
+            </div>
             {fileLevelComments.map((c) => (
               <CommentItem key={c.id} comment={c} onResolve={onResolve} onDelete={onDelete} />
             ))}
+            {fileLevelComposerOpen ? (
+              <InlineComposer
+                onSubmit={onSubmitFileLevelComment}
+                onCancel={onCancelFileLevelComment}
+              />
+            ) : null}
+          </div>
+        ) : canComment ? (
+          <div className="mb-3">
+            <button
+              type="button"
+              onClick={onStartFileLevelComment}
+              title="add file-level note"
+              className="flex items-center gap-1 rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <MessageSquarePlus size={10} aria-hidden />
+              add file note
+            </button>
           </div>
         ) : null}
         {file.binary ? (
@@ -856,7 +946,7 @@ function FileDiffPane({
                                 title="add comment on this line"
                                 aria-label="add comment on this line"
                                 className={cn(
-                                  'flex h-4 w-4 items-center justify-center rounded-sm bg-primary text-primary-foreground transition-opacity',
+                                  'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
                                   isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
                                 )}
                               >
@@ -928,43 +1018,47 @@ function InlineComposer({
   onCancel: () => void;
 }) {
   const [body, setBody] = useState('');
+  const trimmed = body.trim();
   return (
-    <div className="rounded-md border border-warning/30 bg-warning/5 p-2">
-      <Textarea
-        autoFocus
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        placeholder="add a note for the agent (cmd/ctrl+enter to save)…"
-        className="text-xs"
-        autoGrow
-        maxRows={6}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') {
-            e.preventDefault();
-            onCancel();
-          }
-          if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            if (body.trim().length > 0) onSubmit(body.trim());
-          }
-        }}
-      />
-      <div className="mt-1.5 flex justify-end gap-1">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="rounded-sm px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          cancel
-        </button>
-        <button
-          type="button"
-          onClick={() => body.trim().length > 0 && onSubmit(body.trim())}
-          disabled={body.trim().length === 0}
-          className="rounded-sm bg-primary px-2 py-0.5 text-[10px] font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-40"
-        >
-          save
-        </button>
+    <div className="flex gap-2 rounded-md border border-border-soft bg-background px-2 py-1.5 shadow-sm">
+      <MessageSquarePlus size={13} aria-hidden className="mt-0.5 shrink-0 text-muted-foreground" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <Textarea
+          autoFocus
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="note for the agent… (⌘↵ to save)"
+          className="text-xs"
+          autoGrow
+          maxRows={6}
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') {
+              e.preventDefault();
+              onCancel();
+            }
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              if (trimmed.length > 0) onSubmit(trimmed);
+            }
+          }}
+        />
+        <div className="flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-sm px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => trimmed.length > 0 && onSubmit(trimmed)}
+            disabled={trimmed.length === 0}
+            className="inline-flex items-center gap-1 rounded-sm bg-foreground px-2 py-0.5 text-[10px] font-medium text-background hover:opacity-80 disabled:opacity-30"
+          >
+            send
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/components/PricingDialog.tsx
+++ b/apps/desktop/src/components/PricingDialog.tsx
@@ -164,34 +164,48 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
             <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               by model
             </h3>
-            <table className="w-full table-fixed text-left text-xs">
-              <thead>
-                <tr className="text-muted-foreground">
-                  <th className="w-1/3 py-1 font-normal">provider · model</th>
-                  <th className="py-1 text-right font-normal">in tokens</th>
-                  <th className="py-1 text-right font-normal">out tokens</th>
-                  <th className="py-1 text-right font-normal">cost</th>
-                </tr>
-              </thead>
-              <tbody>
-                {modelBreakdown.map((entry) => (
-                  <tr
-                    key={`${entry.provider}//${entry.model}`}
-                    className="border-t border-border-soft"
-                  >
-                    <td className="py-1.5">
-                      <span className="mr-1 rounded bg-muted px-1 text-2xs uppercase text-muted-foreground">
-                        {entry.provider === 'anthropic' ? 'cl' : entry.provider.slice(0, 2)}
-                      </span>
-                      <span className="font-mono">{entry.model}</span>
-                    </td>
-                    <td className="py-1.5 text-right font-mono">{formatTokens(entry.tokensIn)}</td>
-                    <td className="py-1.5 text-right font-mono">{formatTokens(entry.tokensOut)}</td>
-                    <td className="py-1.5 text-right font-mono">{formatCost(entry.spentUsd)}</td>
+            <div className="overflow-hidden rounded-md border border-border-soft">
+              <table className="w-full table-fixed text-left text-xs">
+                <colgroup>
+                  <col className="w-[44%]" />
+                  <col className="w-[18%]" />
+                  <col className="w-[18%]" />
+                  <col className="w-[20%]" />
+                </colgroup>
+                <thead className="sticky top-0 z-10 bg-subtle">
+                  <tr className="border-b border-border-soft text-muted-foreground">
+                    <th className="px-2 py-1.5 text-left font-medium">provider · model</th>
+                    <th className="px-2 py-1.5 text-right font-medium">in</th>
+                    <th className="px-2 py-1.5 text-right font-medium">out</th>
+                    <th className="px-2 py-1.5 text-right font-medium">cost</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody className="divide-y divide-border-soft">
+                  {modelBreakdown.map((entry) => (
+                    <tr
+                      key={`${entry.provider}//${entry.model}`}
+                      className="transition-colors hover:bg-muted/40"
+                    >
+                      <td className="px-2 py-1.5">
+                        <span className="mr-1.5 rounded bg-muted px-1 py-0.5 text-2xs font-medium uppercase text-muted-foreground">
+                          {entry.provider === 'anthropic' ? 'cl' : entry.provider.slice(0, 2)}
+                        </span>
+                        <span className="font-mono text-foreground">{entry.model}</span>
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono tabular-nums text-muted-foreground">
+                        {formatTokens(entry.tokensIn)}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono tabular-nums text-muted-foreground">
+                        {formatTokens(entry.tokensOut)}
+                      </td>
+                      <td className="px-2 py-1.5 text-right font-mono tabular-nums font-medium text-foreground">
+                        {formatCost(entry.spentUsd)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </section>
         ) : null}
 
@@ -213,20 +227,22 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
               />
             </div>
           </div>
-          <div className="max-h-72 overflow-y-auto">
+          <div className="max-h-72 overflow-y-auto rounded-md border border-border-soft">
             {sorted.length === 0 ? (
-              <p className="py-2 text-xs text-muted-foreground">no recorded turns yet.</p>
+              <p className="py-2 text-center text-xs text-muted-foreground">
+                no recorded turns yet.
+              </p>
             ) : (
-              <ul className="flex flex-col">
+              <ul className="flex flex-col divide-y divide-border-soft">
                 {sorted.map((record) => (
                   <li
                     key={record.id}
-                    className="flex items-center justify-between gap-2 border-t border-border-soft py-1.5 text-xs"
+                    className="flex items-center justify-between gap-2 px-2 py-1.5 text-xs transition-colors hover:bg-muted/40"
                   >
-                    <span className="flex items-center gap-1 text-muted-foreground">
+                    <span className="flex items-center gap-1.5 text-muted-foreground">
                       <span
                         className={cn(
-                          'rounded px-1 text-2xs uppercase',
+                          'rounded px-1 py-0.5 text-2xs font-medium uppercase',
                           record.kind === 'summarizer'
                             ? 'bg-muted text-muted-foreground'
                             : 'bg-primary/10 text-primary',
@@ -239,11 +255,13 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
                           {record.provider === 'anthropic' ? 'claude' : record.provider}
                         </span>
                       ) : null}
-                      <span>
+                      <span className="font-mono tabular-nums">
                         {formatTokens(record.inputTokens)}↓ / {formatTokens(record.outputTokens)}↑
                       </span>
                     </span>
-                    <span className="font-mono">{formatCost(record.estimatedCostUsd)}</span>
+                    <span className="font-mono tabular-nums font-medium">
+                      {formatCost(record.estimatedCostUsd)}
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Info } from 'lucide-react';
 import { Button, Tooltip, cn } from '@kay-am/ui';
 import type { ProviderConnectionState, ProviderInfo } from '../providers';
 import { providerAction } from '../providers';
@@ -20,6 +21,14 @@ const STATE_DOT: Record<ProviderConnectionState, string> = {
   error: 'bg-danger',
 };
 
+const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex'];
+
+const PROVIDER_DISPLAY: Record<ProviderId, { name: string; description: string }> = {
+  anthropic: { name: 'claude', description: 'anthropic claude code cli' },
+  cursor: { name: 'cursor', description: 'cursor agent cli' },
+  codex: { name: 'codex', description: 'openai codex cli' },
+};
+
 export function ProvidersPanel() {
   const providers = useAppStore((s) => s.providers);
   const refreshProviders = useAppStore((s) => s.refreshProviders);
@@ -33,6 +42,10 @@ export function ProvidersPanel() {
       setRefreshing(false);
     }
   };
+
+  const ordered = PROVIDER_ORDER.map((id) => providers.find((p) => p.id === id)).filter(
+    (p): p is ProviderInfo => p !== undefined,
+  );
 
   return (
     <div className="flex flex-col gap-3">
@@ -48,14 +61,14 @@ export function ProvidersPanel() {
           {refreshing ? 'refreshing…' : 'refresh all'}
         </Button>
       </div>
-      {providers.length === 0 ? (
+      {ordered.length === 0 ? (
         <p className="text-2xs text-muted-foreground">no providers configured</p>
       ) : (
-        <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
-          {providers.map((p) => (
-            <ProviderRow key={p.id} info={p} onRefresh={onRefresh} />
+        <div className="flex flex-col gap-2">
+          {ordered.map((p) => (
+            <ProviderCard key={p.id} info={p} onRefresh={onRefresh} />
           ))}
-        </ul>
+        </div>
       )}
       <p className="text-xs text-muted-foreground">
         kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run{' '}
@@ -65,39 +78,52 @@ export function ProvidersPanel() {
   );
 }
 
-function ProviderRow({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
+function ProviderCard({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
+  const display = PROVIDER_DISPLAY[info.id as ProviderId];
   return (
-    <li className="flex items-center gap-3 px-3 py-2.5 text-xs">
-      <span
-        aria-hidden
-        className={cn('inline-block h-2 w-2 shrink-0 rounded-full', STATE_DOT[info.connection])}
-      />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{info.label}</span>
-          <code className="text-2xs text-muted-foreground">{info.binary}</code>
-          {info.version ? (
-            <span className="rounded bg-muted px-1 text-2xs text-muted-foreground">
-              {info.version}
-            </span>
-          ) : null}
-          {info.id !== 'anthropic' ? (
-            <span
-              className="rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground"
-              title="permission proxy currently covers claude only. cursor and codex run with their CLI defaults; coverage is tracked for a future milestone."
-            >
-              permission proxy: not supported
-            </span>
-          ) : null}
+    <div className="flex flex-col gap-2 overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
+      {/* header */}
+      <div className="flex items-center gap-3 border-b border-border-soft px-3 py-2">
+        <span
+          aria-hidden
+          className={cn('inline-block h-2 w-2 shrink-0 rounded-full', STATE_DOT[info.connection])}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-semibold">{display?.name ?? info.label}</span>
+            <code className="text-2xs text-muted-foreground">{info.binary}</code>
+            {info.version ? (
+              <span className="rounded bg-muted px-1 text-2xs text-muted-foreground">
+                {info.version}
+              </span>
+            ) : null}
+          </div>
+          <span className="text-2xs text-muted-foreground">{display?.description}</span>
         </div>
-        <RowStatus info={info} />
+        <RowActions info={info} onRefresh={onRefresh} />
       </div>
-      <RowActions info={info} onRefresh={onRefresh} />
-    </li>
+
+      {/* status + quota */}
+      <div className="flex flex-col gap-1.5 px-3 pb-2.5">
+        <CardStatus info={info} />
+        {info.id !== 'anthropic' ? (
+          <span
+            className="w-fit rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground"
+            title="permission proxy currently covers claude only. cursor and codex run with their CLI defaults; coverage is tracked for a future milestone."
+          >
+            permission proxy: not supported
+          </span>
+        ) : null}
+        <QuotaSection
+          providerId={info.id as ProviderId}
+          connected={info.connection === 'connected'}
+        />
+      </div>
+    </div>
   );
 }
 
-function RowStatus({ info }: { info: ProviderInfo }) {
+function CardStatus({ info }: { info: ProviderInfo }) {
   if (info.connection === 'connected') {
     return (
       <div className="text-xs text-muted-foreground">{info.identity ?? 'no identity reported'}</div>
@@ -111,6 +137,40 @@ function RowStatus({ info }: { info: ProviderInfo }) {
     );
   }
   return <div className="text-xs text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
+}
+
+function QuotaSection({ providerId, connected }: { providerId: ProviderId; connected: boolean }) {
+  if (!connected) return null;
+
+  if (providerId !== 'anthropic') {
+    return (
+      <div className="flex items-center gap-1 text-2xs text-muted-foreground/70">
+        <Tooltip
+          content="quota reporting not available for this provider. check your account dashboard."
+          side="top"
+        >
+          <span className="flex cursor-default items-center gap-1">
+            <Info size={10} aria-hidden className="shrink-0" />
+            quota info unavailable
+          </span>
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 text-2xs text-muted-foreground/70">
+      <Tooltip
+        content="anthropic does not expose quota/rate-limit data via the claude code CLI. check console.anthropic.com for usage details."
+        side="top"
+      >
+        <span className="flex cursor-default items-center gap-1">
+          <Info size={10} aria-hidden className="shrink-0" />
+          quota info unavailable
+        </span>
+      </Tooltip>
+    </div>
+  );
 }
 
 function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -97,24 +97,40 @@ interface FileEditBlockProps {
 
 function FileEditBlock({ path, editType, workingDir, onOpenDiff }: FileEditBlockProps) {
   const rel = displayPath(path, workingDir);
-  return (
-    <div className="group inline-flex w-fit max-w-full items-center gap-2 rounded-md border border-info/20 bg-info/5 px-2 py-1">
-      <FileEdit size={11} aria-hidden className="shrink-0 text-info" />
+  const inner = (
+    <>
+      <FileEdit size={11} aria-hidden className="shrink-0 text-muted-foreground" />
       <span className="text-2xs uppercase tracking-wide text-info/80">{EDIT_LABEL[editType]}</span>
       <code className="min-w-0 truncate font-mono text-xs text-foreground/80" title={path}>
         {rel}
       </code>
       {onOpenDiff ? (
-        <button
-          type="button"
-          onClick={() => onOpenDiff(path)}
-          title="open in files modal"
-          aria-label="open in files modal"
-          className="ml-auto shrink-0 rounded-sm p-0.5 text-info/60 opacity-0 transition-opacity hover:text-info group-hover:opacity-100"
-        >
-          <ArrowUpRight size={11} aria-hidden />
-        </button>
+        <ArrowUpRight
+          size={11}
+          aria-hidden
+          className="ml-auto shrink-0 text-info/60 opacity-0 transition-opacity group-hover:opacity-100"
+        />
       ) : null}
+    </>
+  );
+
+  if (onOpenDiff) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenDiff(path)}
+        title="open in files modal"
+        aria-label={`open ${rel} in files modal`}
+        className="group inline-flex w-fit max-w-full cursor-pointer items-center gap-2 rounded-md border border-info/20 bg-info/5 px-2 py-1 transition-colors hover:border-info/40 hover:bg-info/10"
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <div className="group inline-flex w-fit max-w-full items-center gap-2 rounded-md border border-info/20 bg-info/5 px-2 py-1">
+      {inner}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **ProvidersPanel**: refactored to 3 distinct cards (claude/cursor/codex), each with its own header row, status, and quota section. Quota shows "unavailable" with tooltip for all providers — none expose quota data via their CLI.
- **PricingDialog**: costs table now uses bordered layout, sticky `thead`, hover row highlight (`hover:bg-muted/40`), `tabular-nums` font, and `colgroup` for aligned columns. Turns list also bordered + hover.
- **DiffViewerDialog**: file rail rows show `MessageSquarePlus` icon on hover → opens file-level inline composer. `InlineComposer` refactored: icon + textarea + send/cancel, cleaner layout. Line-level comment icon recolored to `text-muted-foreground`.
- **TranscriptCards**: `FileEditBlock` entire card is now a `<button>` when `onOpenDiff` is provided — clicking anywhere triggers the diff CTA. Arrow icon still visible on hover.

## Test plan

- [x] typecheck passes
- [x] 280 tests pass (4 snapshots updated for ProvidersPanel/NewSessionDialog/WorkspacesSidebar)
- [ ] visually verify 3 provider cards render with correct status dots and quota tooltip
- [ ] open diff viewer, hover file in rail → comment icon appears → click → inline composer opens
- [ ] click file-edit card in chat transcript → diff modal opens
- [ ] open pricing dialog with session data → table aligned, hover rows highlight

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)