### PR TITLE
feat(desktop): notifications system — toasts + persistent feed (#466)

### DIFF
--- a/apps/desktop/src/__tests__/a11y/smoke.test.tsx
+++ b/apps/desktop/src/__tests__/a11y/smoke.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../store', () => ({
   useAppStore: vi.fn((selector: (s: unknown) => unknown) => {
     const state = {
       budgetAlerts: [],
+      notifications: [],
       providers: [],
       skills: {},
       settings: {},
@@ -31,6 +32,9 @@ vi.mock('../../store', () => ({
       providerSpendBreakdown: [],
       loadBudgetAlerts: vi.fn(),
       dismissBudgetAlert: vi.fn(),
+      loadNotifications: vi.fn(),
+      markNotificationsRead: vi.fn(),
+      clearNotifications: vi.fn(),
       refreshProviders: vi.fn(),
       loadSkills: vi.fn(),
       saveSkill: vi.fn(),
@@ -82,7 +86,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render } from '@testing-library/react';
 import type { WorkspaceId } from '@kay-am/types';
 import { runA11yCheck } from './utils';
-import { AlertCenter } from '../../components/AlertCenter';
+import { NotificationCenter } from '../../components/NotificationCenter';
 import { BootSplash } from '../../components/BootSplash';
 import { SettingsDialog } from '../../components/SettingsDialog';
 import { WorkspacesSidebar } from '../../components/WorkspacesSidebar';
@@ -95,9 +99,9 @@ afterEach(cleanup);
 
 const WS_ID = 'ws-test' as WorkspaceId;
 
-describe('a11y smoke — AlertCenter', () => {
+describe('a11y smoke — NotificationCenter', () => {
   it('no violations (empty state)', async () => {
-    const { container } = render(<AlertCenter />);
+    const { container } = render(<NotificationCenter />);
     const { violations } = await runA11yCheck(container);
     expect(violations).toHaveLength(0);
   });

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1,44 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`snapshot — empty states > AlertCenter: no alerts 1`] = `
-<div
-  aria-label="alerts"
-  aria-live="polite"
-  role="region"
->
-  <span
-    class="relative inline-flex"
-  >
-    <button
-      aria-label="alert center"
-      class="relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs motion-safe:transition-colors text-muted-foreground hover:bg-muted/60"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="lucide lucide-bell"
-        fill="none"
-        height="13"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        width="13"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M10.268 21a2 2 0 0 0 3.464 0"
-        />
-        <path
-          d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
-        />
-      </svg>
-    </button>
-  </span>
-</div>
-`;
-
 exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
 <dialog
   aria-describedby="_r_3_-desc"
@@ -156,60 +117,6 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               />
               <path
                 d="M12 17h.01"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-git-branch"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M15 6a9 9 0 0 0-9 9V3"
-              />
-              <circle
-                cx="18"
-                cy="6"
-                r="3"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Branch
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
               />
             </svg>
           </button>
@@ -341,23 +248,51 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           class="min-w-0 flex-1 overflow-y-auto pl-4"
         >
           <div
-            class="flex flex-col gap-1.5"
+            class="flex flex-col gap-4"
           >
-            <span
-              class="text-xs font-semibold text-foreground"
+            <div
+              class="flex flex-col gap-1.5"
             >
-              goal
-            </span>
-            <textarea
-              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-              placeholder="refactor auth domain"
-              style="height: 96px; overflow-y: hidden;"
-            />
-            <p
-              class="text-xs leading-relaxed text-muted-foreground"
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                issue link
+              </span>
+              <div
+                class="relative"
+              >
+                <input
+                  class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
+                  placeholder="https://github.com/owner/repo/issues/42"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                paste a GitHub issue URL or owner/repo#number.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-1.5"
             >
-              what the session should accomplish.
-            </p>
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                goal
+              </span>
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+                placeholder="refactor auth domain"
+                style="height: 96px; overflow-y: hidden;"
+              />
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                what the session should accomplish.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -365,51 +300,147 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
-      <span
-        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      <div
+        class="flex w-full flex-col gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-triangle-alert"
-          fill="none"
-          height="12"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="12"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="flex items-center gap-2"
         >
-          <path
-            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-          />
-          <path
-            d="M12 9v4"
-          />
-          <path
-            d="M12 17h.01"
-          />
-        </svg>
-        complete: goal, provider
-      </span>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
-        type="button"
-      >
-        cancel
-      </button>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
-        disabled=""
-        title="complete: goal, provider"
-        type="button"
-      >
-        create session
-      </button>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-git-branch shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 6a9 9 0 0 0-9 9V3"
+            />
+            <circle
+              cx="18"
+              cy="6"
+              r="3"
+            />
+            <circle
+              cx="6"
+              cy="18"
+              r="3"
+            />
+          </svg>
+          <div
+            class="flex min-w-0 flex-1 items-center gap-1"
+          >
+            <span
+              class="shrink-0 text-xs text-muted-foreground"
+            >
+              kay
+              /
+            </span>
+            <input
+              aria-label="branch slug"
+              class="w-full rounded-md border-border text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-primary/40 disabled:opacity-50 h-6 min-w-0 flex-1 border-0 bg-transparent px-1 py-0 text-xs font-mono focus-visible:ring-0 focus-visible:ring-offset-0"
+              placeholder="branch-slug"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-triangle-alert"
+              fill="none"
+              height="12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
+            complete: 
+            goal, provider
+          </span>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
+            disabled=""
+            title="complete: goal, provider"
+            type="button"
+          >
+            create session
+          </button>
+        </div>
+      </div>
     </footer>
   </div>
 </dialog>
+`;
+
+exports[`snapshot — empty states > NotificationCenter: no notifications 1`] = `
+<div
+  aria-label="notifications"
+  aria-live="polite"
+  role="region"
+>
+  <span
+    class="relative inline-flex"
+  >
+    <button
+      aria-label="notifications"
+      class="relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs motion-safe:transition-colors text-muted-foreground hover:bg-muted/60"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-bell"
+        fill="none"
+        height="13"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="13"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M10.268 21a2 2 0 0 0 3.464 0"
+        />
+        <path
+          d="M3.262 15.326A1 1 0 0 0 4 17h16a1 1 0 0 0 .74-1.673C19.41 13.956 18 12.499 18 8A6 6 0 0 0 6 8c0 4.499-1.411 5.956-2.738 7.326"
+        />
+      </svg>
+    </button>
+  </span>
+</div>
 `;
 
 exports[`snapshot — empty states > ProvidersPanel: no providers (store returns []) 1`] = `
@@ -509,9 +540,55 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     class="flex shrink-0 items-center gap-1.5 px-2 py-2"
   >
     <span
-      class="px-1 text-sm font-semibold tracking-tight"
+      class="flex items-center gap-1.5 px-1"
     >
-      kAY.am
+      <svg
+        aria-hidden="true"
+        class="shrink-0 text-foreground"
+        fill="none"
+        height="18"
+        viewBox="0 0 18 18"
+        width="18"
+      >
+        <circle
+          cx="9"
+          cy="9"
+          fill="currentColor"
+          opacity="0.9"
+          r="3.5"
+        />
+        <circle
+          cx="9"
+          cy="9"
+          opacity="0.35"
+          r="7.5"
+          stroke="currentColor"
+          stroke-width="1.2"
+        />
+        <line
+          opacity="0.2"
+          stroke="currentColor"
+          stroke-width="1"
+          x1="9"
+          x2="9"
+          y1="1"
+          y2="17"
+        />
+        <line
+          opacity="0.2"
+          stroke="currentColor"
+          stroke-width="1"
+          x1="1"
+          x2="17"
+          y1="9"
+          y2="9"
+        />
+      </svg>
+      <span
+        class="text-sm font-semibold tracking-tight text-foreground"
+      >
+        kAY.am
+      </span>
     </span>
     <div
       class="ml-auto flex items-center gap-0.5"
@@ -567,7 +644,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
         </svg>
       </button>
       <div
-        aria-label="alerts"
+        aria-label="notifications"
         aria-live="polite"
         role="region"
       >
@@ -575,7 +652,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
           class="relative inline-flex"
         >
           <button
-            aria-label="alert center"
+            aria-label="notifications"
             class="relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs motion-safe:transition-colors text-muted-foreground hover:bg-muted/60"
             type="button"
           >
@@ -660,6 +737,30 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             cx="12"
             cy="12"
             r="3"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="collapse sidebar"
+        class="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        title="collapse sidebar"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-left"
+          fill="none"
+          height="13"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="13"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 18-6-6 6-6"
           />
         </svg>
       </button>
@@ -2110,60 +2211,6 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="lucide lucide-git-branch"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M15 6a9 9 0 0 0-9 9V3"
-              />
-              <circle
-                cx="18"
-                cy="6"
-                r="3"
-              />
-              <circle
-                cx="6"
-                cy="18"
-                r="3"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Branch
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
               class="lucide lucide-dollar-sign"
               fill="none"
               height="13"
@@ -2286,23 +2333,51 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           class="min-w-0 flex-1 overflow-y-auto pl-4"
         >
           <div
-            class="flex flex-col gap-1.5"
+            class="flex flex-col gap-4"
           >
-            <span
-              class="text-xs font-semibold text-foreground"
+            <div
+              class="flex flex-col gap-1.5"
             >
-              goal
-            </span>
-            <textarea
-              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-              placeholder="refactor auth domain"
-              style="height: 96px; overflow-y: hidden;"
-            />
-            <p
-              class="text-xs leading-relaxed text-muted-foreground"
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                issue link
+              </span>
+              <div
+                class="relative"
+              >
+                <input
+                  class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
+                  placeholder="https://github.com/owner/repo/issues/42"
+                  type="text"
+                  value=""
+                />
+              </div>
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                paste a GitHub issue URL or owner/repo#number.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-1.5"
             >
-              what the session should accomplish.
-            </p>
+              <span
+                class="text-xs font-semibold text-foreground"
+              >
+                goal
+              </span>
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+                placeholder="refactor auth domain"
+                style="height: 96px; overflow-y: hidden;"
+              />
+              <p
+                class="text-xs leading-relaxed text-muted-foreground"
+              >
+                what the session should accomplish.
+              </p>
+            </div>
           </div>
         </div>
       </div>
@@ -2310,73 +2385,108 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
     <footer
       class="flex shrink-0 items-center justify-end gap-2 border-t border-border-soft bg-subtle px-6 py-3"
     >
-      <span
-        class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+      <div
+        class="flex w-full flex-col gap-2"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-triangle-alert"
-          fill="none"
-          height="12"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="12"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="flex items-center gap-2"
         >
-          <path
-            d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-          />
-          <path
-            d="M12 9v4"
-          />
-          <path
-            d="M12 17h.01"
-          />
-        </svg>
-        complete: goal, provider
-      </span>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
-        type="button"
-      >
-        cancel
-      </button>
-      <button
-        class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
-        disabled=""
-        title="complete: goal, provider"
-        type="button"
-      >
-        create session
-      </button>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-git-branch shrink-0 text-muted-foreground"
+            fill="none"
+            height="13"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="13"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 6a9 9 0 0 0-9 9V3"
+            />
+            <circle
+              cx="18"
+              cy="6"
+              r="3"
+            />
+            <circle
+              cx="6"
+              cy="18"
+              r="3"
+            />
+          </svg>
+          <div
+            class="flex min-w-0 flex-1 items-center gap-1"
+          >
+            <span
+              class="shrink-0 text-xs text-muted-foreground"
+            >
+              kay
+              /
+            </span>
+            <input
+              aria-label="branch slug"
+              class="w-full rounded-md border-border text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-primary/40 disabled:opacity-50 h-6 min-w-0 flex-1 border-0 bg-transparent px-1 py-0 text-xs font-mono focus-visible:ring-0 focus-visible:ring-offset-0"
+              placeholder="branch-slug"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="mr-auto inline-flex items-center gap-1 text-xs text-warning"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-triangle-alert"
+              fill="none"
+              height="12"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="12"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+              />
+              <path
+                d="M12 9v4"
+              />
+              <path
+                d="M12 17h.01"
+              />
+            </svg>
+            complete: 
+            goal, provider
+          </span>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
+            type="button"
+          >
+            cancel
+          </button>
+          <button
+            class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
+            disabled=""
+            title="complete: goal, provider"
+            type="button"
+          >
+            create session
+          </button>
+        </div>
+      </div>
     </footer>
   </div>
 </dialog>
-`;
-
-exports[`snapshot — error states > PermissionsPanel: form error (workspace scope) 1`] = `
-<div
-  class="flex flex-col gap-3"
->
-  <div
-    class="flex items-center justify-between"
-  >
-    <div
-      class="text-xs font-semibold text-foreground"
-    >
-      permission rules
-    </div>
-    <button
-      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
-      type="button"
-    >
-      add rule
-    </button>
-  </div>
-</div>
 `;
 
 exports[`snapshot — error states > ProvidersPanel: provider in error state 1`] = `

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -15,6 +15,7 @@ vi.mock('../../store', () => ({
   useAppStore: vi.fn((selector: (s: unknown) => unknown) => {
     const state = {
       budgetAlerts: [],
+      notifications: [],
       providers: [],
       skills: {},
       settings: {},
@@ -25,6 +26,9 @@ vi.mock('../../store', () => ({
       sessionSummary: null,
       loadBudgetAlerts: vi.fn(),
       dismissBudgetAlert: vi.fn(),
+      loadNotifications: vi.fn(),
+      markNotificationsRead: vi.fn(),
+      clearNotifications: vi.fn(),
       refreshProviders: vi.fn(),
       loadSkills: vi.fn(),
       saveSkill: vi.fn(),
@@ -90,7 +94,7 @@ function mockStore(partial: Partial<AppStore>): void {
     selector(partial as AppStore),
   );
 }
-import { AlertCenter } from '../../components/AlertCenter';
+import { NotificationCenter } from '../../components/NotificationCenter';
 import { BootSplash } from '../../components/BootSplash';
 import { NewSessionDialog } from '../../components/NewSessionDialog';
 import { EndSessionDialog } from '../../components/EndSessionDialog';
@@ -180,8 +184,8 @@ describe('snapshot — empty states', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('AlertCenter: no alerts', () => {
-    const { container } = render(<AlertCenter />);
+  it('NotificationCenter: no notifications', () => {
+    const { container } = render(<NotificationCenter />);
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -26,6 +26,7 @@ import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../settings';
 import { EMPTY_ARRAY, useAppStore } from '../store';
 import { PlannerWidget } from './PlannerWidget';
 import { fetchGithubIssue, parseGithubIssueUrl } from '../github';
+import { useToast } from './Toast';
 
 interface NewSessionDialogProps {
   open: boolean;
@@ -165,6 +166,7 @@ export function NewSessionDialog({
   const createSession = useAppStore((s) => s.createSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const { showToast } = useToast();
   const providers = useAppStore((s) => s.providers);
   const settingKey = settingBranchPrefix(workspaceId);
   const phaseTemplates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? EMPTY_ARRAY);
@@ -292,7 +294,7 @@ export function NewSessionDialog({
       if (softCapRaw.trim().length > 0 && !isNaN(parsedCap) && parsedCap > 0) {
         await setSessionBudget(session.id as TaskId, parsedCap);
       }
-      // TODO (@ak): fire "session created" success toast when toast system lands (#notifications)
+      showToast('success', `session created: ${session.goal}`);
       reset();
       onClose();
     } catch (err) {

--- a/apps/desktop/src/components/NotificationCenter.tsx
+++ b/apps/desktop/src/components/NotificationCenter.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Bell, CheckCircle, AlertCircle, AlertTriangle, Info, X, Trash2 } from 'lucide-react';
+import { Tooltip, cn } from '@kay-am/ui';
+import type { Notification, NotificationSeverity } from '@kay-am/db';
+import { useAppStore } from '../store';
+
+function severityIcon(severity: NotificationSeverity, size = 13) {
+  switch (severity) {
+    case 'success':
+      return <CheckCircle size={size} aria-hidden />;
+    case 'warning':
+      return <AlertTriangle size={size} aria-hidden />;
+    case 'error':
+      return <AlertCircle size={size} aria-hidden />;
+    default:
+      return <Info size={size} aria-hidden />;
+  }
+}
+
+function severityClass(severity: NotificationSeverity): string {
+  switch (severity) {
+    case 'success':
+      return 'text-success';
+    case 'warning':
+      return 'text-warning';
+    case 'error':
+      return 'text-danger';
+    default:
+      return 'text-info';
+  }
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+const DROPDOWN_WIDTH = 320;
+const VIEWPORT_MARGIN = 8;
+
+export function NotificationCenter() {
+  const notifications = useAppStore((s) => s.notifications);
+  const loadNotifications = useAppStore((s) => s.loadNotifications);
+  const markNotificationsRead = useAppStore((s) => s.markNotificationsRead);
+  const clearNotifications = useAppStore((s) => s.clearNotifications);
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    void loadNotifications();
+  }, [loadNotifications]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const updatePosition = () => {
+      const el = triggerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const desiredLeft = rect.right - DROPDOWN_WIDTH;
+      const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
+      const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
+      setCoords({ top: rect.bottom + 6, left });
+    };
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
+
+  const handleOpen = () => {
+    setOpen((v) => !v);
+    if (!open) {
+      void markNotificationsRead();
+    }
+  };
+
+  const unread = notifications.filter((n) => !n.read).length;
+
+  return (
+    <div role="region" aria-label="notifications" aria-live="polite">
+      <Tooltip content="notifications" side="bottom">
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={handleOpen}
+          className={cn(
+            'relative flex items-center gap-1.5 rounded-md px-2 py-1 text-xs motion-safe:transition-colors',
+            open ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/60',
+          )}
+          aria-label={`notifications${unread > 0 ? `, ${unread} unread` : ''}`}
+        >
+          <Bell size={13} aria-hidden />
+          {unread > 0 && (
+            <span className="absolute -right-1 -top-1 flex h-4 w-4 items-center justify-center rounded-full bg-warning text-2xs font-bold leading-none text-warning-foreground">
+              {unread > 9 ? '9+' : unread}
+            </span>
+          )}
+        </button>
+      </Tooltip>
+
+      {open && coords
+        ? createPortal(
+            <>
+              <div className="fixed inset-0 z-30" onClick={() => setOpen(false)} aria-hidden />
+              <div
+                className="fixed z-40 w-80 overflow-hidden rounded-lg border border-border bg-background shadow-lg"
+                style={{ top: coords.top, left: coords.left }}
+              >
+                <div className="flex items-center justify-between border-b border-border-soft px-3 py-2">
+                  <span className="text-xs font-semibold text-foreground">notifications</span>
+                  <div className="flex items-center gap-2">
+                    {notifications.length > 0 && (
+                      <Tooltip content="clear all" side="left">
+                        <button
+                          type="button"
+                          onClick={() => void clearNotifications()}
+                          className="text-muted-foreground hover:text-danger"
+                          aria-label="clear all notifications"
+                        >
+                          <Trash2 size={12} aria-hidden />
+                        </button>
+                      </Tooltip>
+                    )}
+                    <Tooltip content="close" side="left">
+                      <button
+                        type="button"
+                        onClick={() => setOpen(false)}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label="close notifications"
+                      >
+                        <X size={13} aria-hidden />
+                      </button>
+                    </Tooltip>
+                  </div>
+                </div>
+
+                {notifications.length === 0 ? (
+                  <p className="px-3 py-4 text-center text-xs text-muted-foreground">
+                    no notifications
+                  </p>
+                ) : (
+                  <ul className="max-h-80 overflow-y-auto divide-y divide-border-soft">
+                    {notifications.map((n) => (
+                      <NotificationItem key={n.id} notification={n} />
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+}
+
+interface NotificationItemProps {
+  notification: Notification;
+}
+
+function NotificationItem({ notification: n }: NotificationItemProps) {
+  return (
+    <li className={cn('flex items-start gap-2 px-3 py-2.5', !n.read && 'bg-muted/40')}>
+      <span className={cn('mt-0.5 shrink-0', severityClass(n.severity))}>
+        {severityIcon(n.severity)}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-medium text-foreground leading-snug">{n.title}</p>
+        {n.body && (
+          <p className="mt-0.5 text-xs text-muted-foreground leading-snug truncate">{n.body}</p>
+        )}
+        <p className="mt-0.5 text-2xs text-muted-foreground/70">{relativeTime(n.ts)}</p>
+      </div>
+    </li>
+  );
+}

--- a/apps/desktop/src/components/Toast.tsx
+++ b/apps/desktop/src/components/Toast.tsx
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useRef, useState } f
 import { X } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 
-export type ToastKind = 'warning' | 'error' | 'success';
+export type ToastKind = 'info' | 'warning' | 'error' | 'success';
 
 export interface ToastItem {
   readonly id: string;
@@ -101,7 +101,9 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
           ? 'border-danger/30 bg-background text-danger'
           : toast.kind === 'success'
             ? 'border-success/30 bg-background text-success'
-            : 'border-warning/30 bg-background text-warning',
+            : toast.kind === 'info'
+              ? 'border-info/30 bg-background text-info'
+              : 'border-warning/30 bg-background text-warning',
       )}
       role="alert"
     >

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -33,7 +33,7 @@ import { WorkspaceSettingsDialog } from './WorkspaceSettingsDialog';
 import { SessionSettingsDialog } from './SessionSettingsDialog';
 import { GuideDialog } from './GuideDialog';
 import { ProvidersChip } from './ProvidersChip';
-import { AlertCenter } from './AlertCenter';
+import { NotificationCenter } from './NotificationCenter';
 import { TelemetryPill } from './TelemetryPill';
 import type {
   ProviderId,
@@ -254,7 +254,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
           >
             {theme === 'dark' ? <Sun size={13} aria-hidden /> : <Moon size={13} aria-hidden />}
           </button>
-          <AlertCenter />
+          <NotificationCenter />
           <button
             type="button"
             onClick={() => setGuideOpen(true)}

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -80,6 +80,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -73,6 +73,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -69,6 +69,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.next-actions.test.ts
+++ b/apps/desktop/src/store/store.next-actions.test.ts
@@ -110,6 +110,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -85,6 +85,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -78,6 +78,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -143,6 +143,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -58,6 +58,13 @@ import {
   listDiffCommentsForTask,
   resolveDiffComment as dbResolveDiffComment,
   deleteDiffComment as dbDeleteDiffComment,
+  insertNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  clearAllNotifications,
+  type Notification,
+  type NotificationKind,
+  type NotificationSeverity,
   type TelemetrySummary,
   type ProviderTelemetrySummary,
 } from '@kay-am/db';
@@ -286,6 +293,7 @@ export interface AppState {
   readonly volatilePermissionAllows: ReadonlySet<string>;
   readonly agentModelOverride: Readonly<Record<SessionId, string>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
+  readonly notifications: ReadonlyArray<Notification>;
 }
 
 export interface SessionGithubState {
@@ -432,6 +440,16 @@ export interface AppActions {
   ): Promise<void>;
   resolveDiffComment(taskId: TaskId, commentId: string): Promise<void>;
   deleteDiffComment(taskId: TaskId, commentId: string): Promise<void>;
+  loadNotifications(): Promise<void>;
+  emitNotification(
+    kind: NotificationKind,
+    severity: NotificationSeverity,
+    title: string,
+    body?: string,
+    opts?: { sessionId?: TaskId; workspaceId?: WorkspaceId },
+  ): Promise<void>;
+  markNotificationsRead(): Promise<void>;
+  clearNotifications(): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -486,6 +504,7 @@ const initialState: AppState = {
   volatilePermissionAllows: new Set<string>(),
   agentModelOverride: {},
   diffComments: {},
+  notifications: [],
 };
 
 function buildProviderSpendBreakdown(
@@ -737,6 +756,9 @@ async function runSummarizer(
       sessionNextActions: { ...state.sessionNextActions, [taskId]: result.nextActions },
       providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
     }));
+    void get().emitNotification('summarizer-success', 'info', 'context summarized', undefined, {
+      sessionId: taskId,
+    });
   } catch (err) {
     // never log api key — only the error message
     const message = err instanceof Error ? err.message : String(err);
@@ -756,6 +778,9 @@ async function runSummarizer(
           },
         },
       };
+    });
+    void get().emitNotification('error', 'error', 'summarizer failed', message, {
+      sessionId: taskId,
     });
   }
 }
@@ -1357,6 +1382,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (firstStepPromptPrefix.length > 0) {
       void get().sendTurn({ taskId: session.id, content: firstStepPromptPrefix });
     }
+
+    void get().emitNotification(
+      'session-created',
+      'success',
+      `session created: ${session.goal}`,
+      undefined,
+      { sessionId: session.id, workspaceId: session.workspaceId },
+    );
 
     return { session, worktree };
   },
@@ -2403,6 +2436,39 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
+  loadNotifications: async () => {
+    const notifications = await listNotifications(tauriDatabase);
+    set({ notifications });
+  },
+
+  emitNotification: async (kind, severity, title, body, opts) => {
+    const n: Notification = {
+      id: crypto.randomUUID(),
+      ts: new Date().toISOString() as IsoDateTime,
+      kind,
+      title,
+      body: body ?? null,
+      severity,
+      sessionId: opts?.sessionId ?? null,
+      workspaceId: opts?.workspaceId ?? null,
+      read: false,
+    };
+    await insertNotification(tauriDatabase, n);
+    set((state) => ({ notifications: [n, ...state.notifications] }));
+  },
+
+  markNotificationsRead: async () => {
+    await markAllNotificationsRead(tauriDatabase);
+    set((state) => ({
+      notifications: state.notifications.map((n) => (n.read ? n : { ...n, read: true })),
+    }));
+  },
+
+  clearNotifications: async () => {
+    await clearAllNotifications(tauriDatabase);
+    set({ notifications: [] });
+  },
+
   toggleSessionSlot: async (taskId, key, enabled) => {
     const existing = get().sessionSlots[taskId] ?? [];
     const prev = existing.find((s) => s.key === key);
@@ -2636,6 +2702,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }));
       throw err;
     }
+    void get().emitNotification(
+      'workspace-deleted',
+      'info',
+      `workspace deleted: ${workspace.name}`,
+      sessions.length > 0
+        ? `${sessions.length} session${sessions.length === 1 ? '' : 's'} removed`
+        : undefined,
+    );
   },
 
   refreshProviderSpendBreakdown: async (workspaceId) => {
@@ -2955,6 +3029,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
         }
       }
     }
+    const sessionGoal = session.goal;
+    const sessionWorkspaceId = session.workspaceId;
     await deleteSessionFromDb(tauriDatabase, taskId);
     set((state) => {
       const nextWorktrees = { ...state.sessionWorktrees };
@@ -2973,6 +3049,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
         transcripts: nextTranscripts,
       };
     });
+    void get().emitNotification(
+      'session-deleted',
+      'info',
+      `session deleted: ${sessionGoal}`,
+      undefined,
+      { workspaceId: sessionWorkspaceId },
+    );
   },
 
   setSidebarWorkspaceSearch: (query) => set({ sidebarWorkspaceSearch: query }),
@@ -3187,6 +3270,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
       model: defaults.model,
       effort: defaults.effort,
     });
+    void get().emitNotification(
+      'agent-auto-spawn',
+      'info',
+      `agent auto-spawned: ${next.name}`,
+      undefined,
+      { sessionId: taskId },
+    );
   },
 
   createPrForSession: async (taskId) => {
@@ -3199,9 +3289,21 @@ export const useAppStore = create<AppStore>((set, get) => ({
       cwd: workspace.rootPath,
     });
     if (res.exitCode !== 0) {
-      throw new Error(res.stderr.trim() || `gh pr create exited with ${res.exitCode}`);
+      const errMsg = res.stderr.trim() || `gh pr create exited with ${res.exitCode}`;
+      void get().emitNotification('error', 'error', 'PR creation failed', errMsg, {
+        sessionId: taskId,
+        workspaceId: workspace.id,
+      });
+      throw new Error(errMsg);
     }
     await get().refreshSessionPr(taskId, { force: true });
+    void get().emitNotification(
+      'pr-created',
+      'success',
+      `PR created for: ${session.goal}`,
+      undefined,
+      { sessionId: taskId, workspaceId: workspace.id },
+    );
   },
 }));
 

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -68,6 +68,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -56,6 +56,10 @@ vi.mock('@kay-am/db', () => ({
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),
   listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
 }));
 
 vi.mock('../providers', () => ({

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -108,3 +108,12 @@ export {
   resolveDiffComment,
   deleteDiffComment,
 } from './queries/diff-comment';
+export {
+  insertNotification,
+  listNotifications,
+  markAllNotificationsRead,
+  clearAllNotifications,
+  type Notification,
+  type NotificationKind,
+  type NotificationSeverity,
+} from './queries/notification';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -23,6 +23,7 @@ import { m022TaskAutorun } from './m022-task-autorun';
 import { m023StepEffort } from './m023-step-effort';
 import { m024SessionProviderSessionId } from './m024-session-provider-session-id';
 import { m025TaskTitleUserEdited } from './m025-task-title-user-edited';
+import { m026Notifications } from './m026-notifications';
 
 export interface Migration {
   readonly version: number;
@@ -55,4 +56,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 23, sql: m023StepEffort },
   { version: 24, sql: m024SessionProviderSessionId },
   { version: 25, sql: m025TaskTitleUserEdited },
+  { version: 26, sql: m026Notifications },
 ];

--- a/packages/db/src/migrations/m026-notifications.ts
+++ b/packages/db/src/migrations/m026-notifications.ts
@@ -1,0 +1,13 @@
+export const m026Notifications = /* sql */ `
+CREATE TABLE IF NOT EXISTS notifications (
+  id TEXT PRIMARY KEY NOT NULL,
+  ts TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT,
+  severity TEXT NOT NULL DEFAULT 'info',
+  session_id TEXT,
+  workspace_id TEXT,
+  read INTEGER NOT NULL DEFAULT 0
+);
+`;

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -1,0 +1,81 @@
+import type { IsoDateTime, TaskId, WorkspaceId } from '@kay-am/types';
+import type { Database } from '../client';
+
+export type NotificationSeverity = 'success' | 'info' | 'warning' | 'error';
+export type NotificationKind =
+  | 'session-created'
+  | 'session-deleted'
+  | 'summarizer-success'
+  | 'agent-auto-spawn'
+  | 'pr-created'
+  | 'workspace-deleted'
+  | 'error';
+
+export interface Notification {
+  readonly id: string;
+  readonly ts: IsoDateTime;
+  readonly kind: NotificationKind;
+  readonly title: string;
+  readonly body: string | null;
+  readonly severity: NotificationSeverity;
+  readonly sessionId: TaskId | null;
+  readonly workspaceId: WorkspaceId | null;
+  readonly read: boolean;
+}
+
+interface NotificationRow {
+  id: string;
+  ts: string;
+  kind: string;
+  title: string;
+  body: string | null;
+  severity: string;
+  session_id: string | null;
+  workspace_id: string | null;
+  read: number;
+}
+
+function toNotification(row: NotificationRow): Notification {
+  return {
+    id: row.id,
+    ts: row.ts as IsoDateTime,
+    kind: row.kind as NotificationKind,
+    title: row.title,
+    body: row.body,
+    severity: row.severity as NotificationSeverity,
+    sessionId: row.session_id ? (row.session_id as TaskId) : null,
+    workspaceId: row.workspace_id ? (row.workspace_id as WorkspaceId) : null,
+    read: row.read !== 0,
+  };
+}
+
+export async function insertNotification(db: Database, n: Notification): Promise<void> {
+  await db.execute(
+    `INSERT INTO notifications (id, ts, kind, title, body, severity, session_id, workspace_id, read)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      n.id,
+      n.ts,
+      n.kind,
+      n.title,
+      n.body ?? null,
+      n.severity,
+      n.sessionId ?? null,
+      n.workspaceId ?? null,
+      n.read ? 1 : 0,
+    ],
+  );
+}
+
+export async function listNotifications(db: Database): Promise<ReadonlyArray<Notification>> {
+  const rows = await db.select<NotificationRow>('SELECT * FROM notifications ORDER BY ts DESC');
+  return rows.map(toNotification);
+}
+
+export async function markAllNotificationsRead(db: Database): Promise<void> {
+  await db.execute('UPDATE notifications SET read = 1 WHERE read = 0');
+}
+
+export async function clearAllNotifications(db: Database): Promise<void> {
+  await db.execute('DELETE FROM notifications');
+}


### PR DESCRIPTION
## Summary

- **DB**: `m026` migration adds `notifications` table; queries: insert, list, markAllRead, clearAll
- **NotificationCenter**: `AlertCenter.tsx` renamed/rewritten — bell dropdown shows infinite chronological feed from DB, severity icons (lucide `CheckCircle/Info/AlertTriangle/AlertCircle`) + theme tokens (`text-success/info/warning/danger`), mark-as-read on open, clear-all action
- **Toast**: extended `ToastKind` with `'info'` + `border-info/30 text-info` treatment
- **Store emit points**: session-created, session-deleted, summarizer-success, summarizer-error, agent-auto-spawn (workflow autoRun), pr-created, pr-error, workspace-deleted
- **TODO wired**: session-created toast in `NewSessionDialog` (was `TODO (@ak)` since #469)

## Test plan

- [ ] typecheck passes (`pnpm -F desktop typecheck`)
- [ ] all 280 tests pass (`pnpm -F desktop test`)
- [ ] Bell shows unread badge after creating a session, drops to 0 on open
- [ ] Clear-all empties the feed and persists across reload
- [ ] Success toast appears on session create; error toast appears on PR fail

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)