### PR TITLE
feat(desktop): polish round 2 — casing, mode chip, models, sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Hover an agent row and click the **pencil** icon to rename it inline.
 
 Sidebar footer shows the providers chip (one dot per provider, color-coded) and the telemetry pill (`$session · $workspace`). Click the pill for a per-model breakdown.
 
-The **bell icon** in the sidebar top opens the alert center for budget thresholds and other warnings.
+The **bell icon** in the sidebar top opens the notification center for budget thresholds and other warnings.
 
 ### 9. Archive or end the session
 
@@ -177,7 +177,7 @@ Sidebar kebab menu → **archive** moves a session out of the active list (still
 
 Two scopes:
 
-- **Global** (sidebar top → ⚙) — App / Providers / Budget / Agent / Permissions / Initialization / Advanced. Beta chips mark sections whose behaviour is not yet validated. **Initialization → Wipe local database** drops every workspace / session / agent / message in `~/.kay-am/data.db` and re-runs migrations on next boot. API keys in the OS keychain are not touched.
+- **Global** (sidebar top → ⚙) — App / Providers / Budget / Agent / Github / Advanced / Initialization. Beta chips mark sections whose behaviour is not yet validated. **Initialization → Wipe local database** drops every workspace / session / agent / message in `~/.kay-am/data.db` and re-runs migrations on next boot. API keys in the OS keychain are not touched.
 - **Per-workspace** (workspace row → ⚙ icon on hover) — General (branch prefix), Skills, Workflows (beta). Per-workspace settings stay scoped — the global dialog never shows them.
 
 ## Roadmap & contributing

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,15 @@ import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessionSlots } 
 import { refreshPricingTable } from './providerPricing';
 
 const CONTEXT_PANEL_KEY = (id: TaskId): string => `kayam:context-panel-open:${id}`;
+const SIDEBAR_COLLAPSED_KEY = 'kayam:sidebar-collapsed';
+
+function readSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
 
 function readPersistedContextOpen(id: TaskId, fallback: boolean): boolean {
   try {
@@ -48,6 +57,18 @@ export function App() {
   );
   const [endOpen, setEndOpen] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
+  const toggleSidebarCollapsed = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState<boolean>(false);
   const [contextHydratedFor, setContextHydratedFor] = useState<TaskId | null>(null);
@@ -110,7 +131,14 @@ export function App() {
   return (
     <ToastProvider>
       <AppShell
-        leftSidebar={<WorkspacesSidebar onOpenSettings={() => setSettingsOpen(true)} />}
+        leftSidebar={
+          <WorkspacesSidebar
+            onOpenSettings={() => setSettingsOpen(true)}
+            collapsed={sidebarCollapsed}
+            onToggleCollapsed={toggleSidebarCollapsed}
+          />
+        }
+        leftSidebarCollapsed={sidebarCollapsed}
         main={
           error ? (
             <p className="p-6 text-sm text-danger">init error: {error}</p>

--- a/apps/desktop/src/components/SessionSettingsDialog.tsx
+++ b/apps/desktop/src/components/SessionSettingsDialog.tsx
@@ -22,13 +22,13 @@ interface NavItem {
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'general', label: 'GENERAL', icon: <Bot size={14} aria-hidden /> },
-  { id: 'budget', label: 'BUDGET', icon: <DollarSign size={14} aria-hidden /> },
+  { id: 'general', label: 'General', icon: <Bot size={14} aria-hidden /> },
+  { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden /> },
 ];
 
 const DANGER_NAV: NavItem = {
   id: 'danger',
-  label: 'DELETE',
+  label: 'Delete',
   icon: <Trash2 size={14} aria-hidden />,
 };
 
@@ -129,9 +129,7 @@ export function SessionSettingsDialog({
       case 'general':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              SESSION
-            </div>
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">Session</div>
             <Field
               label="name"
               hint="display name for the session in the sidebar. to update the actual goal text the agent reads, use the context panel on the right."
@@ -172,8 +170,8 @@ export function SessionSettingsDialog({
       case 'budget':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              SOFT CAP
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
+              Soft cap
             </div>
             <Field
               label="cap (usd)"
@@ -211,9 +209,7 @@ export function SessionSettingsDialog({
         return (
           <div className="flex flex-col gap-5">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
-                DANGER ZONE
-              </div>
+              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                 permanent actions on this session.
               </p>

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -45,13 +45,13 @@ interface NavItem {
 // global settings only — per-workspace skills + workflows live in
 // WorkspaceSettingsDialog (the gear icon next to a workspace row).
 const NAV_ITEMS: NavItem[] = [
-  { id: 'app', label: 'APP', icon: <FolderCode size={14} aria-hidden /> },
-  { id: 'providers', label: 'PROVIDERS', icon: <Cpu size={14} aria-hidden /> },
-  { id: 'budget', label: 'BUDGET', icon: <DollarSign size={14} aria-hidden />, beta: true },
-  { id: 'agent', label: 'AGENT', icon: <Bot size={14} aria-hidden />, beta: true },
-  { id: 'github', label: 'GITHUB', icon: <GitFork size={14} aria-hidden /> },
-  { id: 'initialization', label: 'INITIALIZATION', icon: <Trash2 size={14} aria-hidden /> },
-  { id: 'advanced', label: 'ADVANCED', icon: <FileDown size={14} aria-hidden /> },
+  { id: 'app', label: 'App', icon: <FolderCode size={14} aria-hidden /> },
+  { id: 'providers', label: 'Providers', icon: <Cpu size={14} aria-hidden /> },
+  { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden />, beta: true },
+  { id: 'agent', label: 'Agent', icon: <Bot size={14} aria-hidden />, beta: true },
+  { id: 'github', label: 'Github', icon: <GitFork size={14} aria-hidden /> },
+  { id: 'initialization', label: 'Initialization', icon: <Trash2 size={14} aria-hidden /> },
+  { id: 'advanced', label: 'Advanced', icon: <FileDown size={14} aria-hidden /> },
 ];
 
 function isNavSection(value: string | undefined): value is NavSection {
@@ -183,7 +183,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'app':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>APP SETTINGS</SectionHeading>
+            <SectionHeading>App settings</SectionHeading>
             <Field label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>
               <Input
                 value={editorBinary}
@@ -204,7 +204,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'agent':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>AGENT SETTINGS</SectionHeading>
+            <SectionHeading>Agent settings</SectionHeading>
             <Field
               label="enable parallel agents"
               help="Not yet correctly implemented, coming soon."
@@ -245,7 +245,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'initialization':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>INITIALIZATION</SectionHeading>
+            <SectionHeading>Initialization</SectionHeading>
             <p className="text-xs leading-relaxed text-muted-foreground">
               wipe the local sqlite database — drops every workspace, session, agent, message,
               transcript, telemetry record, budget rule, permission rule, and skill registration.
@@ -292,7 +292,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'advanced':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>CONFIG BACKUP</SectionHeading>
+            <SectionHeading>Config backup</SectionHeading>
             <div className="flex gap-2">
               <Button
                 variant="secondary"
@@ -396,9 +396,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-      {children}
-    </div>
+    <div className="text-xs font-semibold tracking-wide text-muted-foreground">{children}</div>
   );
 }
 

--- a/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
+++ b/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
@@ -25,14 +25,14 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { id: 'general', label: 'GENERAL', icon: <FolderCode size={14} aria-hidden /> },
-  { id: 'skills', label: 'SKILLS', icon: <Zap size={14} aria-hidden /> },
-  { id: 'phases', label: 'WORKFLOWS', icon: <GitBranch size={14} aria-hidden />, beta: true },
+  { id: 'general', label: 'General', icon: <FolderCode size={14} aria-hidden /> },
+  { id: 'skills', label: 'Skills', icon: <Zap size={14} aria-hidden /> },
+  { id: 'phases', label: 'Workflows', icon: <GitBranch size={14} aria-hidden />, beta: true },
 ];
 
 const DANGER_NAV: NavItem = {
   id: 'danger',
-  label: 'DISCONNECT',
+  label: 'Disconnect',
   icon: <Unplug size={14} aria-hidden />,
 };
 
@@ -132,8 +132,8 @@ export function WorkspaceSettingsDialog({
       case 'general':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              WORKSPACE DEFAULTS
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
+              Workspace defaults
             </div>
             <div className="flex flex-col gap-1.5">
               <div className="text-xs font-semibold text-foreground">branch prefix</div>
@@ -156,9 +156,7 @@ export function WorkspaceSettingsDialog({
         return (
           <div className="flex flex-col gap-5">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
-                DANGER ZONE
-              </div>
+              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                 irreversible workspace actions.
               </p>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -196,7 +196,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
 
   if (sidebarCollapsed) {
     return (
-      <div className="flex h-full min-h-0 flex-col items-center gap-1 px-1 py-2">
+      <div className="flex h-full min-h-0 flex-col items-center px-1 py-2.5">
         <button
           type="button"
           onClick={toggleSidebarCollapsed}
@@ -206,7 +206,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
         >
           <KayAmLogo iconOnly />
         </button>
-        <div className="mt-auto flex flex-col items-center gap-1">
+        <div className="mt-auto flex flex-col items-center gap-2 border-t border-border-soft pt-3">
           <button
             type="button"
             onClick={toggleTheme}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -83,6 +83,8 @@ import { useThemeStore } from '../theme';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
 }
 
 const PROVIDER_SHORT: Record<ProviderId, string> = {
@@ -102,31 +104,11 @@ const PROVIDER_FILTER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor
 
 type SessionSort = 'updated' | 'alpha';
 
-const SIDEBAR_COLLAPSED_KEY = 'kayam:sidebar-collapsed';
-
-function useSidebarCollapsed(): [boolean, () => void] {
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
-    } catch {
-      return false;
-    }
-  });
-  const toggle = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  }, []);
-  return [collapsed, toggle];
-}
-
-export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
+export function WorkspacesSidebar({
+  onOpenSettings,
+  collapsed: sidebarCollapsed,
+  onToggleCollapsed: toggleSidebarCollapsed,
+}: WorkspacesSidebarProps) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
   const sessions = useSessions();
@@ -177,8 +159,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const [archivedMap, archive, unarchive] = useArchivedTasks();
   const activeSessions = filteredSessions.filter((s) => !archivedMap[s.id]);
   const archivedSessions = filteredSessions.filter((s) => archivedMap[s.id]);
-
-  const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
 
   const toggleStateFilter = (kind: TurnState['kind']) => {
     const next = sidebarStateFilter.includes(kind)

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -334,6 +334,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         ) : null}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
+            <PermissionModePicker session={session} />
             {queued ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-2xs text-primary">
                 queued
@@ -352,9 +353,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
               </span>
             ) : null}
           </div>
-          <ProviderUsagePill provider={effectiveProvider} />
           <div className="flex items-center gap-2">
-            <PermissionModePicker session={session} />
+            <ProviderUsagePill provider={effectiveProvider} />
             <ModelPicker
               providers={providerCandidates}
               models={modelCandidates}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -434,6 +434,7 @@ export function ChatView({ session }: ChatViewProps) {
         title="worktree diff"
         loader={diffLoader}
         workingDir={worktreePath ?? undefined}
+        jumpToFile={diffJumpFile ?? undefined}
       />
     </div>
   );

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -21,7 +21,7 @@ const OPUS_EFFORT: ReadonlyArray<EffortLevel> = ['low', 'medium', 'high', 'extra
 
 export function modelEffortLevels(model: string): ReadonlyArray<EffortLevel> | null {
   if (/claude-opus/i.test(model)) return OPUS_EFFORT;
-  if (/claude-sonnet|claude-haiku/i.test(model)) return SONNET_EFFORT;
+  if (/claude-sonnet/i.test(model)) return SONNET_EFFORT;
   return null;
 }
 
@@ -55,9 +55,10 @@ export const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'cursor-small': { weight: 4, tier: 'cheap' },
   'claude-haiku-4-5': { weight: 5, tier: 'cheap' },
   'codex-mini-latest': { weight: 6, tier: 'cheap' },
-  'claude-sonnet-4-5': { weight: 15, tier: 'mid' },
+  'claude-sonnet-4-5': { weight: 14, tier: 'mid' },
   'claude-sonnet-4-6': { weight: 15, tier: 'mid' },
   'codex-latest': { weight: 20, tier: 'mid' },
+  'claude-opus-4-6': { weight: 60, tier: 'expensive' },
   'claude-opus-4-7': { weight: 75, tier: 'expensive' },
 };
 

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -6,7 +6,9 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
   anthropic: {
     models: [
       { id: 'claude-opus-4-7', tier: 'turn', contextWindow: 1_000_000 },
+      { id: 'claude-opus-4-6', tier: 'turn', contextWindow: 200_000 },
       { id: 'claude-sonnet-4-6', tier: 'turn', contextWindow: 200_000 },
+      { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
       { id: 'claude-haiku-4-5', tier: 'cheap', contextWindow: 200_000 },
     ],
     supportsTools: true,

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { cn } from '../cn';
 
 export interface AppShellProps {
   leftSidebar: ReactNode;
+  leftSidebarCollapsed?: boolean;
   main: ReactNode;
   rightSidebar: ReactNode;
   rightSidebarCollapsed?: boolean;
@@ -13,6 +14,7 @@ const LEFT_SIDEBAR_MIN = 220;
 const LEFT_SIDEBAR_MAX = 480;
 const LEFT_SIDEBAR_DEFAULT = 280;
 const LEFT_SIDEBAR_STORAGE_KEY = 'kayam:left-sidebar-width';
+const LEFT_RAIL_WIDTH = 68;
 
 const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;
@@ -31,6 +33,7 @@ function readPersistedWidth(key: string, def: number, min: number, max: number):
 
 function buildLayout(opts: {
   collapsed: boolean;
+  leftCollapsed: boolean;
   hasRightSidebar: boolean;
   leftWidthPx: number;
   rightWidthPx: number;
@@ -38,8 +41,8 @@ function buildLayout(opts: {
   templateAreas: string;
   templateColumns: string;
 } {
-  const { collapsed, hasRightSidebar, leftWidthPx, rightWidthPx } = opts;
-  const leftCol = `${leftWidthPx}px`;
+  const { collapsed, leftCollapsed, hasRightSidebar, leftWidthPx, rightWidthPx } = opts;
+  const leftCol = `${leftCollapsed ? LEFT_RAIL_WIDTH : leftWidthPx}px`;
   if (!hasRightSidebar) {
     return {
       templateAreas: `"left lhandle main"`,
@@ -56,6 +59,7 @@ function buildLayout(opts: {
 
 export function AppShell({
   leftSidebar,
+  leftSidebarCollapsed = false,
   main,
   rightSidebar,
   rightSidebarCollapsed = false,
@@ -155,6 +159,7 @@ export function AppShell({
 
   const layout = buildLayout({
     collapsed: rightSidebarCollapsed,
+    leftCollapsed: leftSidebarCollapsed,
     hasRightSidebar,
     leftWidthPx: leftWidth,
     rightWidthPx: rightWidth,


### PR DESCRIPTION
## Summary

- **Modal casing**: nav labels + section headings → sentence case (remove `uppercase` CSS class). Looks cleaner, less shouty.
- **Mode chip left**: `PermissionModePicker` moved to left side of chat input bar; model picker stays right — `space-between` layout.
- **Haiku effort**: removed from `modelEffortLevels` — Haiku doesn't support extended thinking / effort levels.
- **Legacy Claude models**: added `claude-opus-4-6` (expensive tier, opus effort levels) and `claude-sonnet-4-5` (mid tier, sonnet effort levels) to capabilities + cost table.
- **Collapsed sidebar**: hairline `border-t` separator above bottom icon group + `gap-2` spacing → less naked whitespace when collapsed.
- **Diff jump-to-file bug**: the non-split-view `DiffViewerDialog` was missing `jumpToFile` prop — clicking a modified file in chat always opened file index 0.
- **README**: removed stale "Permissions" from settings list, "alert center" → "notification center".

## Test plan

- [ ] Open settings dialog — nav labels sentence case, section headings not uppercase
- [ ] Open workspace/session settings — same casing check
- [ ] Chat input — mode chip appears on far left, model picker on right
- [ ] Select Haiku in model picker — no effort section shown
- [ ] Select Sonnet 4.5 / Opus 4.6 — appear in list with correct effort levels
- [ ] Collapse sidebar — separator visible above bottom icons, even spacing
- [ ] Click a modified file in chat transcript — diff viewer opens on correct file

🤖 Generated with [Claude Code](https://claude.com/claude-code)