### PR TITLE
feat(desktop): redesign boot splash with character + 500ms min per phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Hover an agent row and click the **pencil** icon to rename it inline.
 
 Sidebar footer shows the providers chip (one dot per provider, color-coded) and the telemetry pill (`$session · $workspace`). Click the pill for a per-model breakdown.
 
-The **bell icon** in the sidebar top opens the alert center for budget thresholds and other warnings.
+The **bell icon** in the sidebar top opens the notification center for budget thresholds and other warnings.
 
 ### 9. Archive or end the session
 
@@ -177,7 +177,7 @@ Sidebar kebab menu → **archive** moves a session out of the active list (still
 
 Two scopes:
 
-- **Global** (sidebar top → ⚙) — App / Providers / Budget / Agent / Permissions / Initialization / Advanced. Beta chips mark sections whose behaviour is not yet validated. **Initialization → Wipe local database** drops every workspace / session / agent / message in `~/.kay-am/data.db` and re-runs migrations on next boot. API keys in the OS keychain are not touched.
+- **Global** (sidebar top → ⚙) — App / Providers / Budget / Agent / Github / Advanced / Initialization. Beta chips mark sections whose behaviour is not yet validated. **Initialization → Wipe local database** drops every workspace / session / agent / message in `~/.kay-am/data.db` and re-runs migrations on next boot. API keys in the OS keychain are not touched.
 - **Per-workspace** (workspace row → ⚙ icon on hover) — General (branch prefix), Skills, Workflows (beta). Per-workspace settings stay scoped — the global dialog never shows them.
 
 ## Roadmap & contributing

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,15 @@ import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessionSlots } 
 import { refreshPricingTable } from './providerPricing';
 
 const CONTEXT_PANEL_KEY = (id: TaskId): string => `kayam:context-panel-open:${id}`;
+const SIDEBAR_COLLAPSED_KEY = 'kayam:sidebar-collapsed';
+
+function readSidebarCollapsed(): boolean {
+  try {
+    return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
 
 function readPersistedContextOpen(id: TaskId, fallback: boolean): boolean {
   try {
@@ -48,6 +57,18 @@ export function App() {
   );
   const [endOpen, setEndOpen] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(readSidebarCollapsed);
+  const toggleSidebarCollapsed = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }, []);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [contextOpen, setContextOpen] = useState<boolean>(false);
   const [contextHydratedFor, setContextHydratedFor] = useState<TaskId | null>(null);
@@ -110,7 +131,14 @@ export function App() {
   return (
     <ToastProvider>
       <AppShell
-        leftSidebar={<WorkspacesSidebar onOpenSettings={() => setSettingsOpen(true)} />}
+        leftSidebar={
+          <WorkspacesSidebar
+            onOpenSettings={() => setSettingsOpen(true)}
+            collapsed={sidebarCollapsed}
+            onToggleCollapsed={toggleSidebarCollapsed}
+          />
+        }
+        leftSidebarCollapsed={sidebarCollapsed}
         main={
           error ? (
             <p className="p-6 text-sm text-danger">init error: {error}</p>

--- a/apps/desktop/src/components/BootSplash.tsx
+++ b/apps/desktop/src/components/BootSplash.tsx
@@ -1,17 +1,16 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { BootPhase } from '../store';
 import { openUrl } from '../editor';
-import { cn as uiCn } from '@kay-am/ui';
 
 const PHASE_LABEL: Record<BootPhase, string> = {
   pending: 'starting…',
-  migrating: 'running database migrations…',
-  'loading-settings': 'loading settings…',
-  'detecting-cli': 'detecting claude cli…',
-  'loading-workspaces': 'loading workspaces…',
-  'restoring-session': 'restoring last session…',
-  ready: 'ready.',
-  error: 'boot error',
+  migrating: 'running migrations',
+  'loading-settings': 'loading settings',
+  'detecting-cli': 'detecting providers',
+  'loading-workspaces': 'loading workspaces',
+  'restoring-session': 'restoring session',
+  ready: 'ready',
+  error: 'error',
 };
 
 const PHASE_ORDER: ReadonlyArray<BootPhase> = [
@@ -22,6 +21,8 @@ const PHASE_ORDER: ReadonlyArray<BootPhase> = [
   'restoring-session',
 ];
 
+const MIN_PHASE_MS = 500;
+
 const GITHUB_NEW_ISSUE_URL =
   'https://github.com/kay-am/kay-am/issues/new?template=bug_report.md&labels=bug%2Cboot&title=Boot+failure';
 
@@ -30,6 +31,144 @@ interface BootSplashProps {
   error: string | null;
   onRetry?: () => void;
   onSkipProviderDetection?: () => void;
+}
+
+function useDisplayPhase(realPhase: BootPhase): BootPhase {
+  const [displayPhase, setDisplayPhase] = useState<BootPhase>(realPhase);
+  const queueRef = useRef<BootPhase[]>([]);
+  const scheduledRef = useRef(false);
+
+  const drain = useRef<() => void>(() => undefined);
+  drain.current = () => {
+    const next = queueRef.current.shift();
+    if (next === undefined) {
+      scheduledRef.current = false;
+      return;
+    }
+    setDisplayPhase(next);
+    setTimeout(() => drain.current(), MIN_PHASE_MS);
+  };
+
+  useEffect(() => {
+    queueRef.current.push(realPhase);
+    if (!scheduledRef.current) {
+      scheduledRef.current = true;
+      drain.current();
+    }
+  }, [realPhase]);
+
+  return displayPhase;
+}
+
+export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: BootSplashProps) {
+  const displayPhase = useDisplayPhase(phase);
+  const idx = PHASE_ORDER.indexOf(displayPhase);
+  const total = PHASE_ORDER.length;
+  const progressPct =
+    displayPhase === 'ready'
+      ? 100
+      : displayPhase === 'pending'
+        ? 0
+        : Math.round(((idx + 1) / total) * 100);
+
+  return (
+    <div className="relative flex h-screen flex-col items-center justify-center gap-10 overflow-hidden bg-background text-foreground">
+      {/* ambient glow */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+        style={{
+          background:
+            'radial-gradient(ellipse 60% 40% at 50% 30%, oklch(from var(--color-primary) l c h / 0.12) 0%, transparent 70%)',
+        }}
+      />
+
+      {/* logo + wordmark */}
+      <div className="flex flex-col items-center gap-4">
+        <div className="relative flex h-20 w-20 items-center justify-center">
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-[22px] motion-safe:animate-ping"
+            style={{ background: 'oklch(from var(--color-primary) l c h / 0.10)' }}
+          />
+          <div
+            className="relative flex h-full w-full items-center justify-center rounded-[22px] bg-subtle shadow-lg ring-1 ring-border-soft"
+            style={{ boxShadow: '0 0 40px oklch(from var(--color-primary) l c h / 0.15)' }}
+          >
+            <span className="text-3xl font-bold tracking-tighter text-foreground">k</span>
+          </div>
+        </div>
+        <div className="flex flex-col items-center gap-0.5">
+          <span className="text-lg font-bold tracking-tight">kAY.am</span>
+          <span className="text-[11px] tracking-widest text-muted-foreground/60 uppercase">
+            ai workspace orchestrator
+          </span>
+        </div>
+      </div>
+
+      {/* step list + progress */}
+      <div className="flex w-64 flex-col gap-4">
+        <ul className="flex flex-col gap-1 font-mono text-[11px]">
+          {PHASE_ORDER.map((p, i) => {
+            const done = displayPhase === 'ready' || i < idx;
+            const active = i === idx && displayPhase !== 'ready' && displayPhase !== 'pending';
+            return (
+              <li key={p} className="flex items-center gap-2.5">
+                <span
+                  className={
+                    done ? 'text-success' : active ? 'text-primary' : 'text-muted-foreground/25'
+                  }
+                >
+                  {done ? '✓' : active ? '›' : '·'}
+                </span>
+                <span
+                  className={
+                    done
+                      ? 'text-success/70'
+                      : active
+                        ? 'text-foreground'
+                        : 'text-muted-foreground/25'
+                  }
+                >
+                  {PHASE_LABEL[p]}
+                  {active ? <BlinkCursor /> : null}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="relative h-[3px] w-full overflow-hidden rounded-full bg-muted/40">
+            <div
+              className="absolute inset-y-0 left-0 rounded-full bg-primary motion-safe:transition-all motion-safe:duration-700"
+              style={{
+                width: `${progressPct}%`,
+                boxShadow: '0 0 8px oklch(from var(--color-primary) l c h / 0.6)',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <BootErrorRecovery
+          error={error}
+          phase={phase}
+          onRetry={onRetry}
+          onSkipProviderDetection={onSkipProviderDetection}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function BlinkCursor() {
+  return (
+    <span aria-hidden className="ml-0.5 inline-block w-[5px] motion-safe:animate-pulse">
+      _
+    </span>
+  );
 }
 
 function BootErrorRecovery({
@@ -58,37 +197,35 @@ function BootErrorRecovery({
 
   const category =
     phase === 'migrating'
-      ? 'database migration'
+      ? 'migration'
       : phase === 'loading-settings'
-        ? 'settings load'
+        ? 'settings'
         : phase === 'detecting-cli'
           ? 'cli detection'
           : phase === 'loading-workspaces'
             ? 'workspace load'
             : phase === 'restoring-session'
               ? 'session restore'
-              : 'initialization';
+              : 'init';
 
   return (
     <div
       role="alert"
-      className="flex w-72 flex-col gap-3 rounded-lg border border-danger/30 bg-danger/5 p-4"
+      className="flex w-64 flex-col gap-3 rounded-lg border border-danger/30 bg-danger/5 p-4 font-mono text-[11px]"
     >
       <div className="flex flex-col gap-1">
-        <span className="text-xs font-semibold uppercase tracking-wide text-danger">
-          {category} failed
-        </span>
-        <p className="text-xs text-danger/80">{error}</p>
+        <span className="text-danger">✗ {category} failed</span>
+        <p className="leading-relaxed text-danger/70">{error}</p>
       </div>
 
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-1.5">
         {onRetry ? (
           <button
             type="button"
             onClick={onRetry}
-            className="rounded-md border border-danger/30 bg-background px-3 py-1.5 text-xs font-medium text-danger motion-safe:transition-colors hover:bg-danger/10"
+            className="rounded border border-danger/30 bg-background px-3 py-1.5 text-danger motion-safe:transition-colors hover:bg-danger/10"
           >
-            retry
+            › retry
           </button>
         ) : null}
 
@@ -96,115 +233,28 @@ function BootErrorRecovery({
           <button
             type="button"
             onClick={onSkipProviderDetection}
-            className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted"
+            className="rounded border border-border px-3 py-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted"
           >
-            skip provider detection
+            › skip provider detection
           </button>
         ) : null}
 
         <button
           type="button"
           onClick={openLogs}
-          className="rounded-md border border-border px-3 py-1.5 text-xs text-muted-foreground motion-safe:transition-colors hover:bg-muted"
+          className="rounded border border-border px-3 py-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted"
         >
-          open logs
+          › open logs
         </button>
 
         <button
           type="button"
           onClick={openIssue}
-          className="text-left text-xs text-muted-foreground underline-offset-2 hover:underline"
+          className="text-left text-muted-foreground/60 underline-offset-2 hover:underline"
         >
           report on github ↗
         </button>
       </div>
-    </div>
-  );
-}
-
-export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: BootSplashProps) {
-  const idx = PHASE_ORDER.indexOf(phase);
-  const total = PHASE_ORDER.length;
-  const progressPct = phase === 'ready' ? 100 : Math.max(0, (idx / total) * 100);
-
-  return (
-    <div className="relative flex h-screen flex-col items-center justify-center gap-6 overflow-hidden bg-background text-foreground">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10"
-        style={{
-          background:
-            'radial-gradient(ellipse at 50% 35%, oklch(from var(--color-primary) l c h / 0.10) 0%, transparent 55%)',
-        }}
-      />
-
-      <div className="flex flex-col items-center gap-3">
-        <div
-          aria-hidden
-          className="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-subtle ring-1 ring-border-soft"
-        >
-          <span
-            className="absolute inset-0 rounded-2xl motion-safe:animate-ping"
-            style={{ background: 'oklch(from var(--color-primary) l c h / 0.15)' }}
-          />
-          <span className="relative font-semibold tracking-tight text-foreground">k</span>
-        </div>
-        <div className="text-base font-semibold tracking-tight">kAY.am</div>
-      </div>
-
-      <div className="flex w-80 flex-col gap-2">
-        <div className="flex items-center justify-between text-2xs uppercase tracking-[0.08em] text-muted-foreground">
-          <span>{PHASE_LABEL[phase]}</span>
-          <span className="font-mono text-muted-foreground/70">{Math.round(progressPct)}%</span>
-        </div>
-        <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted/60">
-          <div
-            className="h-full rounded-full bg-primary motion-safe:transition-all motion-safe:duration-500"
-            style={{ width: `${progressPct}%` }}
-          />
-        </div>
-        <ul className="mt-2 flex flex-col gap-0.5">
-          {PHASE_ORDER.map((p, i) => {
-            const done = i < idx || phase === 'ready';
-            const active = i === idx && phase !== 'ready';
-            return (
-              <li
-                key={p}
-                className={uiCn(
-                  'flex items-center gap-2 text-2xs',
-                  done
-                    ? 'text-success/80'
-                    : active
-                      ? 'text-foreground'
-                      : 'text-muted-foreground/40',
-                )}
-              >
-                <span
-                  aria-hidden
-                  className={uiCn(
-                    'inline-block h-1.5 w-1.5 rounded-full',
-                    done
-                      ? 'bg-success'
-                      : active
-                        ? 'bg-primary motion-safe:animate-pulse'
-                        : 'bg-muted-foreground/30',
-                  )}
-                />
-                <span className="truncate">{PHASE_LABEL[p]}</span>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-
-      {error ? (
-        <BootErrorRecovery
-          error={error}
-          phase={phase}
-          onRetry={onRetry}
-          onSkipProviderDetection={onSkipProviderDetection}
-        />
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/components/GuideDialog.tsx
+++ b/apps/desktop/src/components/GuideDialog.tsx
@@ -1,6 +1,15 @@
 import { useState } from 'react';
 import { Button, Dialog, cn } from '@kay-am/ui';
-import { BookOpen, Bot, Coins, GitBranch, Lightbulb, MessagesSquare, Palette, Wrench } from 'lucide-react';
+import {
+  BookOpen,
+  Bot,
+  Coins,
+  GitBranch,
+  Lightbulb,
+  MessagesSquare,
+  Palette,
+  Wrench,
+} from 'lucide-react';
 
 interface GuideDialogProps {
   open: boolean;
@@ -335,7 +344,11 @@ function Content({ section }: { section: Section }) {
               { dot: 'bg-info', label: 'running', desc: 'active turn in progress' },
               { dot: 'bg-success', label: 'completed', desc: 'ended successfully' },
               { dot: 'bg-danger', label: 'failed', desc: 'ended with error' },
-              { dot: 'bg-muted-foreground/30', label: 'skipped', desc: 'bypassed by workflow logic' },
+              {
+                dot: 'bg-muted-foreground/30',
+                label: 'skipped',
+                desc: 'bypassed by workflow logic',
+              },
             ]}
           />
           <H3>Edit types — transcript</H3>
@@ -349,7 +362,11 @@ function Content({ section }: { section: Section }) {
           <H3>Context window bar — CTX fill level</H3>
           <LegendaGrid
             rows={[
-              { dot: 'bg-success', label: '< 50%', desc: 'comfortable — plenty of context remaining' },
+              {
+                dot: 'bg-success',
+                label: '< 50%',
+                desc: 'comfortable — plenty of context remaining',
+              },
               { dot: 'bg-info', label: '50–75%', desc: 'moderate — monitor closely' },
               { dot: 'bg-warning', label: '75–90%', desc: 'high — consider summarising soon' },
               { dot: 'bg-danger', label: '≥ 90%', desc: 'critical — start a new session' },
@@ -358,10 +375,8 @@ function Content({ section }: { section: Section }) {
           <H3>Verbosity — output density</H3>
           <LegendaGrid
             rows={[
-              { dot: 'bg-success', label: 'essential', desc: 'bare minimum — one-liners only' },
-              { dot: 'bg-success/70', label: 'minimal', desc: 'brief but complete' },
+              { dot: 'bg-success', label: 'brief', desc: 'bare minimum — one-liners only' },
               { dot: 'bg-info', label: 'normal', desc: 'standard prose with rationale' },
-              { dot: 'bg-warning', label: 'detailed', desc: 'extra context and reasoning' },
               { dot: 'bg-danger', label: 'verbose', desc: 'full long-form with alternatives' },
             ]}
           />
@@ -377,7 +392,11 @@ function Content({ section }: { section: Section }) {
           <H3>Auto badge</H3>
           <LegendaGrid
             rows={[
-              { dot: 'bg-amber-400', label: 'AUTO', desc: 'autorun mode — next action fires without user confirmation' },
+              {
+                dot: 'bg-amber-400',
+                label: 'AUTO',
+                desc: 'autorun mode — next action fires without user confirmation',
+              },
             ]}
           />
         </Article>

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -22,7 +22,7 @@ interface PlannerWidgetProps {
   onWorkflowReady: (workflowId: WorkflowId) => void;
 }
 
-const DEFAULT_VERBOSITY: VerbosityLevel = 'essential';
+const DEFAULT_VERBOSITY: VerbosityLevel = 'normal';
 
 export function PlannerWidget({
   workspaceId,
@@ -68,7 +68,10 @@ export function PlannerWidget({
       const now = new Date().toISOString() as Workflow['createdAt'];
       const workflowId = `wf_planner_${crypto.randomUUID()}` as WorkflowId;
       const steps: ReadonlyArray<Step> = plan.steps.map((s, ordinal) => {
-        const o = overrides[ordinal] ?? { ...defaultsForRole(s.role), verbosity: DEFAULT_VERBOSITY };
+        const o = overrides[ordinal] ?? {
+          ...defaultsForRole(s.role),
+          verbosity: DEFAULT_VERBOSITY,
+        };
         return {
           id: `step_planner_${crypto.randomUUID()}` as StepId,
           workflowId,
@@ -157,9 +160,7 @@ export function PlannerWidget({
                   {ov ? (
                     <StepOverrideRow
                       values={ov}
-                      onChange={(next) =>
-                        setOverrides((prev) => ({ ...prev, [i]: next }))
-                      }
+                      onChange={(next) => setOverrides((prev) => ({ ...prev, [i]: next }))}
                     />
                   ) : null}
                 </li>
@@ -174,4 +175,3 @@ export function PlannerWidget({
     </div>
   );
 }
-

--- a/apps/desktop/src/components/SessionSettingsDialog.tsx
+++ b/apps/desktop/src/components/SessionSettingsDialog.tsx
@@ -22,13 +22,13 @@ interface NavItem {
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'general', label: 'GENERAL', icon: <Bot size={14} aria-hidden /> },
-  { id: 'budget', label: 'BUDGET', icon: <DollarSign size={14} aria-hidden /> },
+  { id: 'general', label: 'General', icon: <Bot size={14} aria-hidden /> },
+  { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden /> },
 ];
 
 const DANGER_NAV: NavItem = {
   id: 'danger',
-  label: 'DELETE',
+  label: 'Delete',
   icon: <Trash2 size={14} aria-hidden />,
 };
 
@@ -129,9 +129,7 @@ export function SessionSettingsDialog({
       case 'general':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              SESSION
-            </div>
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">Session</div>
             <Field
               label="name"
               hint="display name for the session in the sidebar. to update the actual goal text the agent reads, use the context panel on the right."
@@ -172,8 +170,8 @@ export function SessionSettingsDialog({
       case 'budget':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              SOFT CAP
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
+              Soft cap
             </div>
             <Field
               label="cap (usd)"
@@ -211,9 +209,7 @@ export function SessionSettingsDialog({
         return (
           <div className="flex flex-col gap-5">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
-                DANGER ZONE
-              </div>
+              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                 permanent actions on this session.
               </p>

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -45,13 +45,13 @@ interface NavItem {
 // global settings only — per-workspace skills + workflows live in
 // WorkspaceSettingsDialog (the gear icon next to a workspace row).
 const NAV_ITEMS: NavItem[] = [
-  { id: 'app', label: 'APP', icon: <FolderCode size={14} aria-hidden /> },
-  { id: 'providers', label: 'PROVIDERS', icon: <Cpu size={14} aria-hidden /> },
-  { id: 'budget', label: 'BUDGET', icon: <DollarSign size={14} aria-hidden />, beta: true },
-  { id: 'agent', label: 'AGENT', icon: <Bot size={14} aria-hidden />, beta: true },
-  { id: 'github', label: 'GITHUB', icon: <GitFork size={14} aria-hidden /> },
-  { id: 'initialization', label: 'INITIALIZATION', icon: <Trash2 size={14} aria-hidden /> },
-  { id: 'advanced', label: 'ADVANCED', icon: <FileDown size={14} aria-hidden /> },
+  { id: 'app', label: 'App', icon: <FolderCode size={14} aria-hidden /> },
+  { id: 'providers', label: 'Providers', icon: <Cpu size={14} aria-hidden /> },
+  { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden />, beta: true },
+  { id: 'agent', label: 'Agent', icon: <Bot size={14} aria-hidden />, beta: true },
+  { id: 'github', label: 'Github', icon: <GitFork size={14} aria-hidden /> },
+  { id: 'initialization', label: 'Initialization', icon: <Trash2 size={14} aria-hidden /> },
+  { id: 'advanced', label: 'Advanced', icon: <FileDown size={14} aria-hidden /> },
 ];
 
 function isNavSection(value: string | undefined): value is NavSection {
@@ -183,7 +183,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'app':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>APP SETTINGS</SectionHeading>
+            <SectionHeading>App settings</SectionHeading>
             <Field label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>
               <Input
                 value={editorBinary}
@@ -204,7 +204,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'agent':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>AGENT SETTINGS</SectionHeading>
+            <SectionHeading>Agent settings</SectionHeading>
             <Field
               label="enable parallel agents"
               help="Not yet correctly implemented, coming soon."
@@ -245,7 +245,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'initialization':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>INITIALIZATION</SectionHeading>
+            <SectionHeading>Initialization</SectionHeading>
             <p className="text-xs leading-relaxed text-muted-foreground">
               wipe the local sqlite database — drops every workspace, session, agent, message,
               transcript, telemetry record, budget rule, permission rule, and skill registration.
@@ -292,7 +292,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       case 'advanced':
         return (
           <div className="flex flex-col gap-4">
-            <SectionHeading>CONFIG BACKUP</SectionHeading>
+            <SectionHeading>Config backup</SectionHeading>
             <div className="flex gap-2">
               <Button
                 variant="secondary"
@@ -396,9 +396,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
 
 function SectionHeading({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-      {children}
-    </div>
+    <div className="text-xs font-semibold tracking-wide text-muted-foreground">{children}</div>
   );
 }
 

--- a/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
+++ b/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
@@ -25,14 +25,14 @@ interface NavItem {
 }
 
 const NAV_ITEMS: NavItem[] = [
-  { id: 'general', label: 'GENERAL', icon: <FolderCode size={14} aria-hidden /> },
-  { id: 'skills', label: 'SKILLS', icon: <Zap size={14} aria-hidden /> },
-  { id: 'phases', label: 'WORKFLOWS', icon: <GitBranch size={14} aria-hidden />, beta: true },
+  { id: 'general', label: 'General', icon: <FolderCode size={14} aria-hidden /> },
+  { id: 'skills', label: 'Skills', icon: <Zap size={14} aria-hidden /> },
+  { id: 'phases', label: 'Workflows', icon: <GitBranch size={14} aria-hidden />, beta: true },
 ];
 
 const DANGER_NAV: NavItem = {
   id: 'danger',
-  label: 'DISCONNECT',
+  label: 'Disconnect',
   icon: <Unplug size={14} aria-hidden />,
 };
 
@@ -132,8 +132,8 @@ export function WorkspaceSettingsDialog({
       case 'general':
         return (
           <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-              WORKSPACE DEFAULTS
+            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
+              Workspace defaults
             </div>
             <div className="flex flex-col gap-1.5">
               <div className="text-xs font-semibold text-foreground">branch prefix</div>
@@ -156,9 +156,7 @@ export function WorkspaceSettingsDialog({
         return (
           <div className="flex flex-col gap-5">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-wide text-danger">
-                DANGER ZONE
-              </div>
+              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
               <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                 irreversible workspace actions.
               </p>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -196,7 +196,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
 
   if (sidebarCollapsed) {
     return (
-      <div className="flex h-full min-h-0 flex-col items-center gap-1 px-1 py-2">
+      <div className="flex h-full min-h-0 flex-col items-center px-1 py-2.5">
         <button
           type="button"
           onClick={toggleSidebarCollapsed}
@@ -206,7 +206,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
         >
           <KayAmLogo iconOnly />
         </button>
-        <div className="mt-auto flex flex-col items-center gap-1">
+        <div className="mt-auto flex flex-col items-center gap-2 border-t border-border-soft pt-3">
           <button
             type="button"
             onClick={toggleTheme}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -83,6 +83,8 @@ import { useThemeStore } from '../theme';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
 }
 
 const PROVIDER_SHORT: Record<ProviderId, string> = {
@@ -102,31 +104,11 @@ const PROVIDER_FILTER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor
 
 type SessionSort = 'updated' | 'alpha';
 
-const SIDEBAR_COLLAPSED_KEY = 'kayam:sidebar-collapsed';
-
-function useSidebarCollapsed(): [boolean, () => void] {
-  const [collapsed, setCollapsed] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
-    } catch {
-      return false;
-    }
-  });
-  const toggle = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      try {
-        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
-      } catch {
-        // ignore
-      }
-      return next;
-    });
-  }, []);
-  return [collapsed, toggle];
-}
-
-export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
+export function WorkspacesSidebar({
+  onOpenSettings,
+  collapsed: sidebarCollapsed,
+  onToggleCollapsed: toggleSidebarCollapsed,
+}: WorkspacesSidebarProps) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
   const sessions = useSessions();
@@ -177,8 +159,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   const [archivedMap, archive, unarchive] = useArchivedTasks();
   const activeSessions = filteredSessions.filter((s) => !archivedMap[s.id]);
   const archivedSessions = filteredSessions.filter((s) => archivedMap[s.id]);
-
-  const [sidebarCollapsed, toggleSidebarCollapsed] = useSidebarCollapsed();
 
   const toggleStateFilter = (kind: TurnState['kind']) => {
     const next = sidebarStateFilter.includes(kind)

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -334,6 +334,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         ) : null}
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
+            <PermissionModePicker session={session} />
             {queued ? (
               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-2xs text-primary">
                 queued
@@ -352,9 +353,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
               </span>
             ) : null}
           </div>
-          <ProviderUsagePill provider={effectiveProvider} />
           <div className="flex items-center gap-2">
-            <PermissionModePicker session={session} />
+            <ProviderUsagePill provider={effectiveProvider} />
             <ModelPicker
               providers={providerCandidates}
               models={modelCandidates}

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -434,6 +434,7 @@ export function ChatView({ session }: ChatViewProps) {
         title="worktree diff"
         loader={diffLoader}
         workingDir={worktreePath ?? undefined}
+        jumpToFile={diffJumpFile ?? undefined}
       />
     </div>
   );

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -21,7 +21,7 @@ const OPUS_EFFORT: ReadonlyArray<EffortLevel> = ['low', 'medium', 'high', 'extra
 
 export function modelEffortLevels(model: string): ReadonlyArray<EffortLevel> | null {
   if (/claude-opus/i.test(model)) return OPUS_EFFORT;
-  if (/claude-sonnet|claude-haiku/i.test(model)) return SONNET_EFFORT;
+  if (/claude-sonnet/i.test(model)) return SONNET_EFFORT;
   return null;
 }
 
@@ -55,9 +55,10 @@ export const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'cursor-small': { weight: 4, tier: 'cheap' },
   'claude-haiku-4-5': { weight: 5, tier: 'cheap' },
   'codex-mini-latest': { weight: 6, tier: 'cheap' },
-  'claude-sonnet-4-5': { weight: 15, tier: 'mid' },
+  'claude-sonnet-4-5': { weight: 14, tier: 'mid' },
   'claude-sonnet-4-6': { weight: 15, tier: 'mid' },
   'codex-latest': { weight: 20, tier: 'mid' },
+  'claude-opus-4-6': { weight: 60, tier: 'expensive' },
   'claude-opus-4-7': { weight: 75, tier: 'expensive' },
 };
 

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -84,18 +84,14 @@ export const TIER_DOT: Record<CostTier, string> = {
 };
 
 export const VERBOSITY_DOT: Record<VerbosityLevel, string> = {
-  essential: 'bg-success',
-  minimal: 'bg-success/70',
+  brief: 'bg-success',
   normal: 'bg-info',
-  detailed: 'bg-warning',
   verbose: 'bg-danger',
 };
 
 export const VERBOSITY_TEXT: Record<VerbosityLevel, string> = {
-  essential: 'text-success',
-  minimal: 'text-success/85',
+  brief: 'text-success',
   normal: 'text-info',
-  detailed: 'text-warning',
   verbose: 'text-danger',
 };
 

--- a/apps/desktop/src/components/overrides/StepOverrideRow.tsx
+++ b/apps/desktop/src/components/overrides/StepOverrideRow.tsx
@@ -1,10 +1,6 @@
 import { cn } from '@kay-am/ui';
 import type { AgentEffort } from '@kay-am/types';
-import {
-  VERBOSITY_LEVELS,
-  VERBOSITY_LABEL,
-  type VerbosityLevel,
-} from '../../verbosity';
+import { VERBOSITY_LEVELS, VERBOSITY_LABEL, type VerbosityLevel } from '../../verbosity';
 import {
   EFFORT_LEVELS,
   EFFORT_LABEL,
@@ -44,10 +40,8 @@ const EFFORT_SHORT: Record<AgentEffort, string> = {
 };
 
 const VERBOSITY_SHORT: Record<VerbosityLevel, string> = {
-  essential: 'ess',
-  minimal: 'min',
+  brief: 'brf',
   normal: 'norm',
-  detailed: 'det',
   verbose: 'verb',
 };
 

--- a/apps/desktop/src/verbosity.ts
+++ b/apps/desktop/src/verbosity.ts
@@ -1,25 +1,29 @@
 import type { TaskId } from '@kay-am/types';
 
-export const VERBOSITY_LEVELS = ['essential', 'minimal', 'normal', 'detailed', 'verbose'] as const;
+export const VERBOSITY_LEVELS = ['brief', 'normal', 'verbose'] as const;
 export type VerbosityLevel = (typeof VERBOSITY_LEVELS)[number];
 
 export const VERBOSITY_LABEL: Record<VerbosityLevel, string> = {
-  essential: 'Essential',
-  minimal: 'Minimal',
+  brief: 'Brief',
   normal: 'Normal',
-  detailed: 'Detailed',
   verbose: 'Verbose',
 };
 
 const STORAGE_PREFIX = 'kayam:verbosity:';
-const DEFAULT_LEVEL: VerbosityLevel = 'essential';
+const DEFAULT_LEVEL: VerbosityLevel = 'normal';
+
+const LEGACY_MAP: Record<string, VerbosityLevel> = {
+  essential: 'brief',
+  minimal: 'brief',
+  detailed: 'verbose',
+};
 
 export function readVerbosity(taskId: TaskId): VerbosityLevel {
   try {
     const raw = localStorage.getItem(`${STORAGE_PREFIX}${taskId}`);
-    if (raw && (VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) {
-      return raw as VerbosityLevel;
-    }
+    if (!raw) return DEFAULT_LEVEL;
+    if ((VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) return raw as VerbosityLevel;
+    if (raw in LEGACY_MAP) return LEGACY_MAP[raw]!;
   } catch {
     // ignore
   }
@@ -35,14 +39,10 @@ export function writeVerbosity(taskId: TaskId, level: VerbosityLevel): void {
 }
 
 const VERBOSITY_DIRECTIVE: Record<VerbosityLevel, string> = {
-  essential:
-    'Output verbosity: ESSENTIAL. Output only what is strictly required to answer or act. No preambles, no recaps, no explanations unless asked. Single short sentence per update; one-line end-of-turn.',
-  minimal:
-    'Output verbosity: MINIMAL. Brief but complete. Skip narration and pleasantries. Short paragraphs only when needed.',
+  brief:
+    'Output verbosity: BRIEF. Output only what is strictly required to answer or act. No preambles, no recaps, no explanations unless asked. Single short sentence per update; one-line end-of-turn.',
   normal:
     'Output verbosity: NORMAL. Standard prose. Include rationale when non-obvious; avoid filler.',
-  detailed:
-    'Output verbosity: DETAILED. Provide additional context and rationale where it aids the reader. Still no filler or pleasantries.',
   verbose:
     'Output verbosity: VERBOSE. Include reasoning, alternatives considered, and trade-offs. Long-form is acceptable.',
 };

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -6,7 +6,9 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
   anthropic: {
     models: [
       { id: 'claude-opus-4-7', tier: 'turn', contextWindow: 1_000_000 },
+      { id: 'claude-opus-4-6', tier: 'turn', contextWindow: 200_000 },
       { id: 'claude-sonnet-4-6', tier: 'turn', contextWindow: 200_000 },
+      { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
       { id: 'claude-haiku-4-5', tier: 'cheap', contextWindow: 200_000 },
     ],
     supportsTools: true,

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -38,7 +38,7 @@ export type Step = Readonly<{
   providerOverride?: ProviderId;
   modelOverride?: string;
   effort?: AgentEffort;
-  verbosity?: 'essential' | 'minimal' | 'normal' | 'detailed' | 'verbose';
+  verbosity?: 'brief' | 'normal' | 'verbose';
   parallelGroup?: number;
 }>;
 

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { cn } from '../cn';
 
 export interface AppShellProps {
   leftSidebar: ReactNode;
+  leftSidebarCollapsed?: boolean;
   main: ReactNode;
   rightSidebar: ReactNode;
   rightSidebarCollapsed?: boolean;
@@ -13,6 +14,7 @@ const LEFT_SIDEBAR_MIN = 220;
 const LEFT_SIDEBAR_MAX = 480;
 const LEFT_SIDEBAR_DEFAULT = 280;
 const LEFT_SIDEBAR_STORAGE_KEY = 'kayam:left-sidebar-width';
+const LEFT_RAIL_WIDTH = 68;
 
 const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;
@@ -31,6 +33,7 @@ function readPersistedWidth(key: string, def: number, min: number, max: number):
 
 function buildLayout(opts: {
   collapsed: boolean;
+  leftCollapsed: boolean;
   hasRightSidebar: boolean;
   leftWidthPx: number;
   rightWidthPx: number;
@@ -38,8 +41,8 @@ function buildLayout(opts: {
   templateAreas: string;
   templateColumns: string;
 } {
-  const { collapsed, hasRightSidebar, leftWidthPx, rightWidthPx } = opts;
-  const leftCol = `${leftWidthPx}px`;
+  const { collapsed, leftCollapsed, hasRightSidebar, leftWidthPx, rightWidthPx } = opts;
+  const leftCol = `${leftCollapsed ? LEFT_RAIL_WIDTH : leftWidthPx}px`;
   if (!hasRightSidebar) {
     return {
       templateAreas: `"left lhandle main"`,
@@ -56,6 +59,7 @@ function buildLayout(opts: {
 
 export function AppShell({
   leftSidebar,
+  leftSidebarCollapsed = false,
   main,
   rightSidebar,
   rightSidebarCollapsed = false,
@@ -155,6 +159,7 @@ export function AppShell({
 
   const layout = buildLayout({
     collapsed: rightSidebarCollapsed,
+    leftCollapsed: leftSidebarCollapsed,
     hasRightSidebar,
     leftWidthPx: leftWidth,
     rightWidthPx: rightWidth,


### PR DESCRIPTION
## Summary
- Larger logo (80×80, rounded-[22px]) with glow ring and ambient radial gradient
- Wordmark + "ai workspace orchestrator" tagline in small caps
- Monospace step list with `✓` / `›` / `·` indicators and blinking cursor on active step
- Thicker progress bar (3px) with primary color glow — no percentage number
- Error panel matches mono aesthetic: `✗ category failed` + `›` prefixed buttons
- **500ms minimum display per phase**: `useDisplayPhase` hook queues real phase transitions and drains at 500ms intervals, so even instant boots feel deliberate

## Test plan
- [ ] App launches — each step visible for ~500ms before advancing
- [ ] All 5 phases show `›` while active, `✓` when done
- [ ] Boot error path shows new error panel correctly
- [ ] Progress bar fills smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)