### PR TITLE
feat(desktop): model picker, rail sidebar, esc fullscreen fix

### DIFF
--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -54,20 +54,24 @@ pub struct PlannerResult {
 }
 
 #[tauri::command]
-pub fn planner_run(args: PlannerArgs) -> Result<PlannerResult, PlannerError> {
-    let cli_args = build_cli_args(&args)?;
+pub async fn planner_run(args: PlannerArgs) -> Result<PlannerResult, PlannerError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cli_args = build_cli_args(&args)?;
 
-    let output = Command::new(&args.binary)
-        .args(&cli_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
+        let output = Command::new(&args.binary)
+            .args(&cli_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?;
 
-    Ok(PlannerResult {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        exit_code: output.status.code(),
+        Ok(PlannerResult {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.status.code(),
+        })
     })
+    .await
+    .map_err(|e| PlannerError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?
 }
 
 fn build_cli_args(args: &PlannerArgs) -> Result<Vec<String>, PlannerError> {

--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -54,20 +54,24 @@ pub struct SummarizeResult {
 }
 
 #[tauri::command]
-pub fn summarize_task(args: SummarizeArgs) -> Result<SummarizeResult, SummarizeError> {
-    let cli_args = build_cli_args(&args)?;
+pub async fn summarize_task(args: SummarizeArgs) -> Result<SummarizeResult, SummarizeError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let cli_args = build_cli_args(&args)?;
 
-    let output = Command::new(&args.binary)
-        .args(&cli_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()?;
+        let output = Command::new(&args.binary)
+            .args(&cli_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?;
 
-    Ok(SummarizeResult {
-        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-        exit_code: output.status.code(),
+        Ok(SummarizeResult {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.status.code(),
+        })
     })
+    .await
+    .map_err(|e| SummarizeError::Io(std::io::Error::new(std::io::ErrorKind::Other, e.to_string())))?
 }
 
 fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -88,6 +88,19 @@ export function App() {
     return () => window.removeEventListener('kayam:open-settings', handler);
   }, []);
 
+  // Prevent macOS from exiting native fullscreen on ESC. Calling
+  // preventDefault at the capture phase marks the event as handled in
+  // WKWebView before it reaches the native responder chain. Dialogs and
+  // dropdowns still receive the keydown and close normally via their own
+  // listeners.
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') e.preventDefault();
+    };
+    document.addEventListener('keydown', onEsc, { capture: true });
+    return () => document.removeEventListener('keydown', onEsc, { capture: true });
+  }, []);
+
   useEffect(() => {
     if (!currentSession) {
       setContextOpen(false);

--- a/apps/desktop/src/__tests__/a11y/smoke.test.tsx
+++ b/apps/desktop/src/__tests__/a11y/smoke.test.tsx
@@ -135,7 +135,9 @@ describe('a11y smoke — BootSplash', () => {
 
 describe('a11y smoke — WorkspacesSidebar', () => {
   it('no violations (no workspace selected)', async () => {
-    const { container } = render(<WorkspacesSidebar onOpenSettings={vi.fn()} />);
+    const { container } = render(
+      <WorkspacesSidebar onOpenSettings={vi.fn()} collapsed={false} onToggleCollapsed={vi.fn()} />,
+    );
     const { violations } = await runA11yCheck(container);
     expect(violations).toHaveLength(0);
   });

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -161,7 +161,9 @@ describe('snapshot — empty states', () => {
   });
 
   it('WorkspacesSidebar: no workspace selected', () => {
-    const { container } = render(<WorkspacesSidebar onOpenSettings={vi.fn()} />);
+    const { container } = render(
+      <WorkspacesSidebar onOpenSettings={vi.fn()} collapsed={false} onToggleCollapsed={vi.fn()} />,
+    );
     expect(container.firstChild).toMatchSnapshot();
   });
 

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -207,6 +207,7 @@ export function ContextPanel({
                     taskId={session.id}
                     slotKey={key}
                     slot={slot}
+                    isSummarizing={summarizer.status === 'running'}
                     onCommit={(value) => void upsertSessionSlot(session.id, key, value)}
                   />
                 );
@@ -305,6 +306,37 @@ function PrStateIcon({ state }: { state: PullRequestStateKind }) {
 
 function openInBrowser(url: string) {
   openUrl(url).catch(() => window.open(url, '_blank'));
+}
+
+function SlotSkeleton({ emphasis }: { emphasis?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 rounded-md px-2.5 py-2 bg-subtle',
+        emphasis ? 'gap-2.5' : 'gap-1.5',
+      )}
+      aria-hidden
+    >
+      <div
+        className={cn(
+          'animate-pulse rounded bg-muted/70',
+          emphasis ? 'h-3.5 w-3/4' : 'h-2.5 w-4/5',
+        )}
+      />
+      <div
+        className={cn(
+          'animate-pulse rounded bg-muted/70',
+          emphasis ? 'h-3.5 w-full' : 'h-2.5 w-full',
+        )}
+      />
+      <div
+        className={cn(
+          'animate-pulse rounded bg-muted/70',
+          emphasis ? 'h-3.5 w-1/2' : 'h-2.5 w-2/3',
+        )}
+      />
+    </div>
+  );
 }
 
 function PrSkeleton() {
@@ -575,10 +607,11 @@ interface SlotRowProps {
   taskId: TaskId;
   slotKey: SlotKey;
   slot: ContextSlot | undefined;
+  isSummarizing?: boolean;
   onCommit: (value: string) => void;
 }
 
-function SlotRow({ taskId, slotKey, slot, onCommit }: SlotRowProps) {
+function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: SlotRowProps) {
   const value = slot?.value ?? '';
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -652,6 +685,8 @@ function SlotRow({ taskId, slotKey, slot, onCommit }: SlotRowProps) {
           autoGrow
           maxRows={12}
         />
+      ) : isSummarizing ? (
+        <SlotSkeleton emphasis={meta?.emphasis} />
       ) : !hasValue ? (
         <button
           type="button"

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -8,7 +8,6 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
-  DollarSign,
   FolderOpen,
   FolderPlus,
   Gauge,
@@ -191,142 +190,179 @@ export function WorkspacesSidebar({
     const sortedRails = [...currentSessionRuns].sort((a, b) => a.ordinal - b.ordinal);
     const railBtn =
       'rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
-    const sectionIcon = 'mb-1 shrink-0 opacity-50';
 
     return (
-      <div className="flex h-full min-h-0 flex-col items-center overflow-hidden px-1.5 py-2.5">
-        {/* Logo / expand */}
-        <button
-          type="button"
-          onClick={toggleSidebarCollapsed}
-          title="expand sidebar"
-          aria-label="expand sidebar"
-          className={railBtn}
-        >
-          <KayAmLogo iconOnly />
-        </button>
-
-        {/* Workspaces */}
-        <div className="mt-4 flex w-full flex-col items-center gap-0.5">
-          <FolderOpen size={10} aria-hidden className={cn(sectionIcon, 'text-primary')} />
-          {filteredWorkspaces.map((ws) => (
-            <button
-              key={ws.id}
-              type="button"
-              title={ws.name}
-              onClick={() => void setCurrentWorkspace(ws.id)}
-              className={cn(
-                'w-full truncate rounded-md px-1 py-0.5 text-center text-[9px] font-semibold uppercase tracking-wide transition-colors',
-                ws.id === currentWorkspace?.id
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-              )}
-            >
-              {ws.name.slice(0, 5)}
-            </button>
-          ))}
+      <div className="flex h-full min-h-0 flex-col">
+        {/* Header — same height as expanded */}
+        <div className="flex shrink-0 items-center justify-center gap-1.5 px-2 py-2">
+          <button
+            type="button"
+            onClick={toggleSidebarCollapsed}
+            title="expand sidebar"
+            aria-label="expand sidebar"
+            className={railBtn}
+          >
+            <KayAmLogo iconOnly />
+          </button>
         </div>
 
-        {/* Sessions */}
-        <div className="mt-4 flex w-full flex-col items-center gap-0.5">
-          <MessagesSquare size={10} aria-hidden className={cn(sectionIcon, 'text-info')} />
-          {activeSessions.slice(0, 7).map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              title={s.goal}
-              onClick={() => void setCurrentSession(s.id as TaskId)}
-              className={cn(
-                'flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-[9px] transition-colors',
-                s.id === currentSession?.id
-                  ? 'bg-muted text-foreground'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
-              )}
-            >
-              <span
-                aria-hidden
-                className={cn(
-                  'h-1 w-1 shrink-0 rounded-full',
-                  s.id === currentSession?.id ? 'bg-primary' : 'bg-muted-foreground/30',
-                )}
-              />
-              <span className="flex-1 truncate font-medium">{s.goal.slice(0, 5)}</span>
-            </button>
-          ))}
-        </div>
-
-        {/* Agents — only if current session has runs */}
-        {currentSession && sortedRails.length > 0 ? (
-          <div className="mt-4 flex w-full flex-col items-center gap-0.5">
-            <Bot size={10} aria-hidden className={cn(sectionIcon, 'text-success')} />
-            {sortedRails.map((run) => {
-              const kind = inferAgentKindFromName(run.name);
-              const isSelected = run.id === currentSelectedAgentId;
-              return (
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+          {/* Workspaces — same vertical position as expanded */}
+          <section className="flex flex-col px-1.5">
+            <header className="flex items-center justify-center pb-1.5">
+              <FolderOpen size={11} aria-hidden className="text-primary" />
+            </header>
+            <div className="flex flex-col gap-0.5">
+              {filteredWorkspaces.map((ws) => (
                 <button
-                  key={run.id}
+                  key={ws.id}
                   type="button"
-                  title={`${run.name} — ${run.status}`}
-                  onClick={() => void selectAgent(currentSession.id, run.id)}
+                  title={ws.name}
+                  onClick={() => void setCurrentWorkspace(ws.id)}
                   className={cn(
-                    'w-full rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide transition-colors',
-                    AGENT_KIND_PALETTE[kind].bg,
-                    AGENT_KIND_PALETTE[kind].fg,
-                    isSelected ? 'ring-1 ring-inset ring-white/20' : '',
+                    'w-full truncate rounded-md px-1 py-0.5 text-center text-[9px] font-semibold uppercase tracking-wide transition-colors',
+                    ws.id === currentWorkspace?.id
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
                   )}
                 >
-                  {AGENT_KIND_PALETTE[kind].label}
+                  {ws.name.slice(0, 5)}
                 </button>
-              );
-            })}
+              ))}
+            </div>
+          </section>
+
+          {/* Sessions — mt-8 matching expanded */}
+          <section className="mt-8 flex flex-col px-1.5">
+            <header className="flex items-center justify-center pb-1.5">
+              <MessagesSquare size={11} aria-hidden className="text-info" />
+            </header>
+            <div className="flex flex-col gap-0.5">
+              {activeSessions.slice(0, 7).map((s) => {
+                const isActive = s.id === currentSession?.id;
+                if (isActive) {
+                  return (
+                    <button
+                      key={s.id}
+                      type="button"
+                      onClick={toggleSidebarCollapsed}
+                      title={s.goal}
+                      className="flex flex-col gap-0.5 rounded-md bg-muted px-1.5 py-1 text-left transition-colors hover:bg-muted/80"
+                    >
+                      <span className="line-clamp-2 text-[9px] font-medium leading-tight text-foreground">
+                        {s.goal}
+                      </span>
+                      <div className="flex items-center gap-1.5 text-[8px] text-muted-foreground">
+                        {sortedRails.length > 0 ? (
+                          <span
+                            className="inline-flex items-center gap-0.5 tabular-nums"
+                            title={`${sortedRails.length} agent${sortedRails.length === 1 ? '' : 's'}`}
+                          >
+                            <Users size={8} aria-hidden />
+                            {sortedRails.length}
+                          </span>
+                        ) : null}
+                        {sessionCost !== null && sessionCost > 0 ? (
+                          <CostBadge
+                            value={sessionCost}
+                            title={`$${sessionCost.toFixed(4)}`}
+                            className="text-[8px]"
+                          />
+                        ) : null}
+                      </div>
+                    </button>
+                  );
+                }
+                return (
+                  <button
+                    key={s.id}
+                    type="button"
+                    title={s.goal}
+                    onClick={() => void setCurrentSession(s.id as TaskId)}
+                    className="flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-[9px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+                  >
+                    <span
+                      aria-hidden
+                      className="h-1 w-1 shrink-0 rounded-full bg-muted-foreground/30"
+                    />
+                    <span className="flex-1 truncate font-medium">{s.goal.slice(0, 5)}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          {/* Agents — mt-8 matching expanded */}
+          {currentSession && sortedRails.length > 0 ? (
+            <section className="mt-8 flex flex-col px-1.5 pb-3">
+              <header className="flex items-center justify-center pb-1.5">
+                <Bot size={11} aria-hidden className="text-success" />
+              </header>
+              <div className="flex flex-col gap-0.5">
+                {sortedRails.map((run) => {
+                  const kind = inferAgentKindFromName(run.name);
+                  const isSelected = run.id === currentSelectedAgentId;
+                  return (
+                    <button
+                      key={run.id}
+                      type="button"
+                      title={`${run.name} — ${run.status}`}
+                      onClick={() => void selectAgent(currentSession.id, run.id)}
+                      className={cn(
+                        'w-full rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide transition-colors',
+                        AGENT_KIND_PALETTE[kind].bg,
+                        AGENT_KIND_PALETTE[kind].fg,
+                        isSelected ? 'ring-1 ring-inset ring-white/20' : '',
+                      )}
+                    >
+                      {AGENT_KIND_PALETTE[kind].label}
+                    </button>
+                  );
+                })}
+                <button
+                  type="button"
+                  title="spawn free agent"
+                  onClick={() => void spawnAgent(currentSession.id, {})}
+                  className="mt-0.5 w-full rounded border border-dashed border-border-soft py-0.5 text-[9px] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+                >
+                  +
+                </button>
+              </div>
+            </section>
+          ) : null}
+        </div>
+
+        {/* Footer — matches expanded sidebar */}
+        <div className="flex shrink-0 flex-col items-center gap-1.5 px-2 pb-2 pt-1.5">
+          <div className="flex items-center gap-0.5">
             <button
               type="button"
-              title="spawn free agent"
-              onClick={() => void spawnAgent(currentSession.id, {})}
-              className="mt-0.5 w-full rounded border border-dashed border-border-soft py-0.5 text-[9px] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+              onClick={toggleTheme}
+              title={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
+              aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
+              className={railBtn}
             >
-              +
+              {theme === 'dark' ? <Sun size={13} aria-hidden /> : <Moon size={13} aria-hidden />}
+            </button>
+            <button
+              type="button"
+              onClick={() => setGuideOpen(true)}
+              title="getting started — guide"
+              aria-label="open getting started guide"
+              className={railBtn}
+            >
+              <HelpCircle size={13} aria-hidden />
+            </button>
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              title="settings (⌘,)"
+              aria-label="open settings"
+              className={railBtn}
+            >
+              <Settings size={13} aria-hidden />
             </button>
           </div>
-        ) : null}
-
-        {/* Footer */}
-        <div className="mt-auto flex flex-col items-center gap-2 border-t border-border-soft pt-3">
-          {sessionCost !== null && sessionCost > 0 ? (
-            <span
-              title={`$${sessionCost.toFixed(4)} session cost`}
-              className="p-1.5 text-muted-foreground/60"
-            >
-              <DollarSign size={13} aria-hidden />
-            </span>
-          ) : null}
-          <button
-            type="button"
-            onClick={toggleTheme}
-            title={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-            aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-            className={railBtn}
-          >
-            {theme === 'dark' ? <Sun size={13} aria-hidden /> : <Moon size={13} aria-hidden />}
-          </button>
-          <button
-            type="button"
-            onClick={() => setGuideOpen(true)}
-            title="getting started — guide"
-            aria-label="open getting started guide"
-            className={railBtn}
-          >
-            <HelpCircle size={13} aria-hidden />
-          </button>
-          <button
-            type="button"
-            onClick={onOpenSettings}
-            title="settings (⌘,)"
-            aria-label="open settings"
-            className={railBtn}
-          >
-            <Settings size={13} aria-hidden />
-          </button>
         </div>
         <GuideDialog open={guideOpen} onClose={() => setGuideOpen(false)} />
       </div>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronDown,
   ChevronLeft,
   ChevronRight,
+  DollarSign,
   FolderOpen,
   FolderPlus,
   Gauge,
@@ -156,6 +157,18 @@ export function WorkspacesSidebar({
   const theme = useThemeStore((s) => s.theme);
   const toggleTheme = useThemeStore((s) => s.toggleTheme);
 
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const currentSessionRuns = useAppStore((s) =>
+    currentSession
+      ? (s.sessionPhaseRuns[currentSession.id] ?? (EMPTY_ARRAY as ReadonlyArray<Session>))
+      : (EMPTY_ARRAY as ReadonlyArray<Session>),
+  );
+  const currentSelectedAgentId = useAppStore((s) =>
+    currentSession ? (s.selectedAgentId[currentSession.id] ?? null) : null,
+  );
+  const sessionCost = useAppStore((s) => s.sessionSummary?.estimatedCostUsd ?? null);
+
   const [archivedMap, archive, unarchive] = useArchivedTasks();
   const activeSessions = filteredSessions.filter((s) => !archivedMap[s.id]);
   const archivedSessions = filteredSessions.filter((s) => archivedMap[s.id]);
@@ -175,24 +188,124 @@ export function WorkspacesSidebar({
   };
 
   if (sidebarCollapsed) {
+    const sortedRails = [...currentSessionRuns].sort((a, b) => a.ordinal - b.ordinal);
+    const railBtn =
+      'rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground';
+    const sectionIcon = 'mb-1 shrink-0 opacity-50';
+
     return (
-      <div className="flex h-full min-h-0 flex-col items-center px-1 py-2.5">
+      <div className="flex h-full min-h-0 flex-col items-center overflow-hidden px-1.5 py-2.5">
+        {/* Logo / expand */}
         <button
           type="button"
           onClick={toggleSidebarCollapsed}
           title="expand sidebar"
           aria-label="expand sidebar"
-          className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          className={railBtn}
         >
           <KayAmLogo iconOnly />
         </button>
+
+        {/* Workspaces */}
+        <div className="mt-4 flex w-full flex-col items-center gap-0.5">
+          <FolderOpen size={10} aria-hidden className={cn(sectionIcon, 'text-primary')} />
+          {filteredWorkspaces.map((ws) => (
+            <button
+              key={ws.id}
+              type="button"
+              title={ws.name}
+              onClick={() => void setCurrentWorkspace(ws.id)}
+              className={cn(
+                'w-full truncate rounded-md px-1 py-0.5 text-center text-[9px] font-semibold uppercase tracking-wide transition-colors',
+                ws.id === currentWorkspace?.id
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+              )}
+            >
+              {ws.name.slice(0, 5)}
+            </button>
+          ))}
+        </div>
+
+        {/* Sessions */}
+        <div className="mt-4 flex w-full flex-col items-center gap-0.5">
+          <MessagesSquare size={10} aria-hidden className={cn(sectionIcon, 'text-info')} />
+          {activeSessions.slice(0, 7).map((s) => (
+            <button
+              key={s.id}
+              type="button"
+              title={s.goal}
+              onClick={() => void setCurrentSession(s.id as TaskId)}
+              className={cn(
+                'flex w-full items-center gap-1 rounded-md px-1 py-0.5 text-[9px] transition-colors',
+                s.id === currentSession?.id
+                  ? 'bg-muted text-foreground'
+                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  'h-1 w-1 shrink-0 rounded-full',
+                  s.id === currentSession?.id ? 'bg-primary' : 'bg-muted-foreground/30',
+                )}
+              />
+              <span className="flex-1 truncate font-medium">{s.goal.slice(0, 5)}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* Agents — only if current session has runs */}
+        {currentSession && sortedRails.length > 0 ? (
+          <div className="mt-4 flex w-full flex-col items-center gap-0.5">
+            <Bot size={10} aria-hidden className={cn(sectionIcon, 'text-success')} />
+            {sortedRails.map((run) => {
+              const kind = inferAgentKindFromName(run.name);
+              const isSelected = run.id === currentSelectedAgentId;
+              return (
+                <button
+                  key={run.id}
+                  type="button"
+                  title={`${run.name} — ${run.status}`}
+                  onClick={() => void selectAgent(currentSession.id, run.id)}
+                  className={cn(
+                    'w-full rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide transition-colors',
+                    AGENT_KIND_PALETTE[kind].bg,
+                    AGENT_KIND_PALETTE[kind].fg,
+                    isSelected ? 'ring-1 ring-inset ring-white/20' : '',
+                  )}
+                >
+                  {AGENT_KIND_PALETTE[kind].label}
+                </button>
+              );
+            })}
+            <button
+              type="button"
+              title="spawn free agent"
+              onClick={() => void spawnAgent(currentSession.id, {})}
+              className="mt-0.5 w-full rounded border border-dashed border-border-soft py-0.5 text-[9px] text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+            >
+              +
+            </button>
+          </div>
+        ) : null}
+
+        {/* Footer */}
         <div className="mt-auto flex flex-col items-center gap-2 border-t border-border-soft pt-3">
+          {sessionCost !== null && sessionCost > 0 ? (
+            <span
+              title={`$${sessionCost.toFixed(4)} session cost`}
+              className="p-1.5 text-muted-foreground/60"
+            >
+              <DollarSign size={13} aria-hidden />
+            </span>
+          ) : null}
           <button
             type="button"
             onClick={toggleTheme}
             title={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
             aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className={railBtn}
           >
             {theme === 'dark' ? <Sun size={13} aria-hidden /> : <Moon size={13} aria-hidden />}
           </button>
@@ -201,7 +314,7 @@ export function WorkspacesSidebar({
             onClick={() => setGuideOpen(true)}
             title="getting started — guide"
             aria-label="open getting started guide"
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className={railBtn}
           >
             <HelpCircle size={13} aria-hidden />
           </button>
@@ -210,7 +323,7 @@ export function WorkspacesSidebar({
             onClick={onOpenSettings}
             title="settings (⌘,)"
             aria-label="open settings"
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            className={railBtn}
           >
             <Settings size={13} aria-hidden />
           </button>

--- a/apps/desktop/src/components/chat/ModelPicker.tsx
+++ b/apps/desktop/src/components/chat/ModelPicker.tsx
@@ -14,8 +14,12 @@ import {
   TIER_DOT,
   VERBOSITY_DOT,
   VERBOSITY_TEXT,
+  CLAUDE_SUBFAMILY_LABEL,
+  CLAUDE_SUBFAMILY_TIER,
   modelLabel,
   modelFamily,
+  modelSubfamily,
+  modelVersion,
   modelTier,
   modelWeight,
   modelEffortLevels,
@@ -132,48 +136,68 @@ export function ModelPicker({
       {open ? (
         <div
           role="dialog"
-          aria-label="model & effort"
-          className="absolute bottom-full right-0 z-30 mb-1.5 w-64 overflow-hidden rounded-lg bg-background py-1.5 text-xs shadow-lg ring-1 ring-border-soft"
+          aria-label="model picker"
+          className="absolute bottom-full right-0 z-30 mb-1.5 w-64 overflow-hidden rounded-lg bg-background py-2 text-xs shadow-lg ring-1 ring-border-soft"
         >
-          <PickerSection label="provider">
-            {providers.map((id) => {
-              const isConnected = connectedProviders.includes(id);
-              return (
-                <PickerRow
-                  key={id}
-                  label={PROVIDER_LABEL[id]}
-                  active={provider === id}
-                  onClick={() => onSelectProvider(id)}
-                  labelClassName={isConnected ? PROVIDER_TEXT[id] : 'text-muted-foreground/60'}
-                  trailing={
-                    !isConnected ? (
-                      <span className="text-2xs text-warning">connect ↗</span>
-                    ) : undefined
-                  }
-                />
-              );
-            })}
-          </PickerSection>
-          <PickerDivider />
-          {groupedModels.size <= 1 ? (
-            <PickerSection label="model · cheapest first">
-              {[...groupedModels.values()].flat().map((id) => {
-                const t = modelTier(id);
+          {/* Provider */}
+          <PickerSection label="Provider">
+            <div className="flex flex-wrap gap-1 px-2.5 pb-2">
+              {providers.map((id) => {
+                const isConnected = connectedProviders.includes(id);
+                const active = provider === id;
                 return (
-                  <PickerRow
+                  <button
                     key={id}
-                    label={modelLabel(id)}
-                    active={model === id}
-                    onClick={() => onSelectModel(id)}
-                    leadingDot={TIER_DOT[t]}
-                    labelClassName={TIER_TEXT[t]}
-                  />
+                    type="button"
+                    onClick={() => onSelectProvider(id)}
+                    title={isConnected ? undefined : 'not connected'}
+                    className={cn(
+                      'rounded-full px-2.5 py-0.5 transition-colors',
+                      active
+                        ? cn('bg-muted font-semibold', PROVIDER_TEXT[id])
+                        : isConnected
+                          ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                          : 'text-muted-foreground/35 hover:bg-muted/50',
+                    )}
+                  >
+                    {PROVIDER_LABEL[id]}
+                    {!isConnected ? (
+                      <span className="ml-0.5 text-[9px] text-warning">↗</span>
+                    ) : null}
+                  </button>
                 );
               })}
-            </PickerSection>
-          ) : (
-            [...groupedModels.entries()].map(([fam, ids]) => (
-              <PickerSection key={fam} label={FAMILY_LABEL[fam] ?? fam}>
+            </div>
+          </PickerSection>
+          <PickerDivider />
+
+          {/* Model — family rows with version chips */}
+          {[...groupedModels.entries()].map(([fam, ids]) => {
+            const sectionLabel = groupedModels.size > 1 ? (FAMILY_LABEL[fam] ?? fam) : 'Model';
+            if (fam === 'claude') {
+              const subMap = new Map<string, string[]>();
+              for (const id of ids) {
+                const sub = modelSubfamily(id);
+                const arr = subMap.get(sub) ?? [];
+                arr.push(id);
+                subMap.set(sub, arr);
+              }
+              return (
+                <PickerSection key={fam} label={sectionLabel}>
+                  {[...subMap.entries()].map(([sub, subIds]) => (
+                    <FamilyVersionRow
+                      key={sub}
+                      subfamily={sub}
+                      ids={subIds}
+                      selectedModel={model}
+                      onSelect={onSelectModel}
+                    />
+                  ))}
+                </PickerSection>
+              );
+            }
+            return (
+              <PickerSection key={fam} label={sectionLabel}>
                 {ids.map((id) => {
                   const t = modelTier(id);
                   return (
@@ -188,37 +212,57 @@ export function ModelPicker({
                   );
                 })}
               </PickerSection>
-            ))
-          )}
-          {showEffort && effortLevels ? (
-            <>
-              <PickerDivider />
-              <PickerSection label="effort">
-                {effortLevels.map((level) => (
-                  <PickerRow
-                    key={level}
-                    label={EFFORT_LABEL[level]}
-                    leadingDot={EFFORT_DOT[level]}
-                    active={effort === level}
-                    onClick={() => onSelectEffort(level)}
-                    labelClassName={EFFORT_TEXT[level]}
-                  />
-                ))}
-              </PickerSection>
-            </>
-          ) : null}
+            );
+          })}
           <PickerDivider />
-          <PickerSection label="verbosity">
-            {VERBOSITY_LEVELS.map((level) => (
-              <PickerRow
-                key={level}
-                label={VERBOSITY_LABEL[level]}
-                leadingDot={VERBOSITY_DOT[level]}
-                active={verbosity === level}
-                onClick={() => onSelectVerbosity(level)}
-                labelClassName={VERBOSITY_TEXT[level]}
-              />
-            ))}
+
+          {/* Effort — always visible */}
+          <PickerSection label="Effort">
+            {showEffort && effortLevels ? (
+              <div className="flex flex-wrap gap-1 px-2.5 pb-2">
+                {effortLevels.map((level) => (
+                  <button
+                    key={level}
+                    type="button"
+                    onClick={() => onSelectEffort(level)}
+                    className={cn(
+                      'rounded px-2 py-0.5 transition-colors',
+                      effort === level
+                        ? cn('bg-muted font-semibold', EFFORT_TEXT[level])
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                    )}
+                  >
+                    {EFFORT_LABEL[level]}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <p className="px-2.5 pb-2 text-2xs italic text-muted-foreground/50">
+                not available for this model
+              </p>
+            )}
+          </PickerSection>
+          <PickerDivider />
+
+          {/* Verbosity */}
+          <PickerSection label="Verbosity">
+            <div className="flex flex-wrap gap-1 px-2.5 pb-2">
+              {VERBOSITY_LEVELS.map((level) => (
+                <button
+                  key={level}
+                  type="button"
+                  onClick={() => onSelectVerbosity(level)}
+                  className={cn(
+                    'rounded px-2 py-0.5 transition-colors',
+                    verbosity === level
+                      ? cn('bg-muted font-semibold', VERBOSITY_TEXT[level])
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  {VERBOSITY_LABEL[level]}
+                </button>
+              ))}
+            </div>
           </PickerSection>
         </div>
       ) : null}
@@ -229,7 +273,7 @@ export function ModelPicker({
 function PickerSection({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col">
-      <div className="px-2.5 pb-0.5 pt-1 text-2xs uppercase tracking-wide text-muted-foreground/70">
+      <div className="px-2.5 pb-0.5 pt-1 text-2xs tracking-wide text-muted-foreground/70">
         {label}
       </div>
       {children}
@@ -239,6 +283,49 @@ function PickerSection({ label, children }: { label: string; children: React.Rea
 
 function PickerDivider() {
   return <div className="my-1 h-px bg-border-soft" aria-hidden />;
+}
+
+function FamilyVersionRow({
+  subfamily,
+  ids,
+  selectedModel,
+  onSelect,
+}: {
+  subfamily: string;
+  ids: string[];
+  selectedModel: string;
+  onSelect: (id: string) => void;
+}) {
+  const tier = CLAUDE_SUBFAMILY_TIER[subfamily] ?? 'mid';
+  return (
+    <div className="flex items-center px-2.5 py-1.5 hover:bg-muted/60">
+      <span className={cn('flex-1 text-xs', TIER_TEXT[tier])}>
+        {CLAUDE_SUBFAMILY_LABEL[subfamily] ?? subfamily}
+      </span>
+      <div className="flex gap-1">
+        {ids.map((id) => {
+          const selected = selectedModel === id;
+          const t = modelTier(id);
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => onSelect(id)}
+              title={modelLabel(id)}
+              className={cn(
+                'rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors',
+                selected
+                  ? cn('bg-muted font-semibold', TIER_TEXT[t])
+                  : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+              )}
+            >
+              {modelVersion(id)}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
 }
 
 function PickerRow({

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -124,3 +124,25 @@ export function modelTier(model: string): CostTier {
 export function modelWeight(model: string): number {
   return MODEL_COST[model]?.weight ?? 10;
 }
+
+export function modelSubfamily(id: string): string {
+  const m = id.match(/^claude-(haiku|sonnet|opus)/i);
+  return m ? m[1]!.toLowerCase() : '';
+}
+
+export function modelVersion(id: string): string {
+  const m = id.match(/^claude-(?:haiku|sonnet|opus)-(\d+)-(\d+)/i);
+  return m ? `${m[1]}.${m[2]}` : id;
+}
+
+export const CLAUDE_SUBFAMILY_LABEL: Record<string, string> = {
+  haiku: 'Haiku',
+  sonnet: 'Sonnet',
+  opus: 'Opus',
+};
+
+export const CLAUDE_SUBFAMILY_TIER: Record<string, CostTier> = {
+  haiku: 'cheap',
+  sonnet: 'mid',
+  opus: 'expensive',
+};

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -14,7 +14,7 @@ const LEFT_SIDEBAR_MIN = 220;
 const LEFT_SIDEBAR_MAX = 480;
 const LEFT_SIDEBAR_DEFAULT = 280;
 const LEFT_SIDEBAR_STORAGE_KEY = 'kayam:left-sidebar-width';
-const LEFT_RAIL_WIDTH = 68;
+const LEFT_RAIL_WIDTH = 80;
 
 const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;


### PR DESCRIPTION
## Summary

- **model picker redesign**: provider/model/effort/verbosity as horizontal chip rows; claude models grouped by Haiku/Sonnet/Opus subfamily with version chips (4.5, 4.6, 4.7); effort always shown, grayed out with "not available" message when unsupported
- **collapsed sidebar rail (80px)**: workspace chips with abbreviated names + tooltip, session chips with status dot, agent kind chips (SCOUT/PLAN/IMPL), cost icon in footer; rail width bumped 68→80 in AppShell
- **esc fullscreen fix**: capture-phase `e.preventDefault()` on ESC prevents macOS native fullscreen exit without blocking React dialog/dropdown close

## Depends on

Chains from `feat/bootsplash-redesign` (PR #478).

## Test plan

- [ ] Open model picker — provider row shows colored chips, Claude models grouped by subfamily with version buttons
- [ ] Switch between Haiku/Sonnet/Opus — effort section shows correct levels or "not available" message
- [ ] Collapse sidebar — see workspace/session/agent chips with truncated names; hover for full name tooltip
- [ ] Enter native macOS fullscreen — press ESC, window stays fullscreen; open a dialog, ESC closes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)