### PR TITLE
fix(desktop): auto-advance respects step.modelOverride and effort

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -3267,8 +3267,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     await get().spawnAgent(taskId, {
       name: next.name,
       stepId: next.id,
-      model: defaults.model,
-      effort: defaults.effort,
+      model: next.modelOverride ?? defaults.model,
+      effort: next.effort ?? defaults.effort,
     });
     void get().emitNotification(
       'agent-auto-spawn',


### PR DESCRIPTION
## Summary
- `maybeAutoAdvanceWorkflow` was always passing `AGENT_KIND_DEFAULTS[kind].model/effort` to `spawnAgent`, ignoring the per-step overrides the user set in PlannerWidget
- This caused `agentModelOverride[agentId]` to be set to the generic kind default, so `ChatInput` displayed and defaulted to the wrong model
- The actual turn execution was accidentally correct (because `phaseDefinition.modelOverride` takes priority in `sendTurn`), but the UI showed the wrong model and any manual turn without an explicit override would use the wrong default

## Fix
Pass `next.modelOverride ?? defaults.model` and `next.effort ?? defaults.effort` so spawned agents inherit the step's configured overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)