### PR TITLE
docs: tighten README — cleaner layout diagram, less repetition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,192 +2,157 @@
 
 **AI workspace orchestrator. Local-first. Provider-agnostic.**
 
-kAY.am sits between you and your AI agents. It doesn't replace your editor or your terminal — it commands them.
+kAY.am sits between you and your AI agents. It doesn't replace your editor or your terminal — it commands them. One workspace per repo. One session per goal. N agents per session, each with its own chat and provider, sharing the same context. Routing across Anthropic, OpenAI, and Cursor based on priority and budget. Real-time cost. Skills for the repeatable.
 
-Manage workspaces. Open sessions per goal. Spawn N agents per session, each with its own chat, sharing the session's context. Route work across providers (Anthropic, OpenAI, Cursor, ...) based on priority and budget. See cost in real time. Automate the repeatable with skills.
+> **Status**: per-agent chat model live · sidebar-first IA (no header / footer chrome) · v1.0 next — see [ROADMAP.md](./ROADMAP.md).
 
-> **Status**: per-agent chat model live. Sidebar-first IA (no header / footer chrome). v1.0 next — see [ROADMAP.md](./ROADMAP.md).
+---
 
 ## Why
 
-- AI sessions today are monolithic threads. Context bloats, costs blur, work blends together.
-- Switching providers means switching tools. No layer compares them, balances them, or routes work intelligently.
-- Local skills and workflows are locked into vendor ecosystems.
+| Problem                                                         | kAY.am                                  |
+| --------------------------------------------------------------- | --------------------------------------- |
+| AI sessions are monolithic threads. Context bloats, costs blur. | One session = one goal, scoped context. |
+| Switching providers means switching tools. No layer compares.   | Provider-agnostic routing + budget.     |
+| Local skills and workflows are locked into vendor ecosystems.   | Skills live with the workspace.         |
 
-kAY.am is the missing orchestration layer.
+## Principles
+
+- **Local-first, local-only.** No backend. No telemetry. Your machine, your keys, your data.
+- **Provider-agnostic.** No lock-in.
+- **Context is expensive.** Never send more than needed.
+- **Sessions are goals, not threads.**
+- **Each agent owns its chat.** Sessions share context, not history.
+- **Automate the repeatable.**
+
+Full product vision in [VISION.md](./VISION.md).
 
 ## Mental model
 
 ```
-Workspace               registered git repo
-└── Session             a goal, its own worktree + branch + shared context
-    ├── ContextPanel    auto-populated by the LLM after every turn
-    └── Agent (n)       independent chat, own provider/model, spawned at will
+Workspace                a registered git repo
+└── Session              one goal · own worktree · own branch · shared context
+    ├── ContextPanel     auto-populated by the LLM after every turn
+    └── Agent (×N)       independent chat · own provider/model
 ```
 
-- **Workspace** = a local git repository you registered. Sessions are scoped to it.
-- **Session** = one goal. Owns the git worktree, the branch, the context panel slots, the budget. Auto-spawns one default agent on creation.
-- **Agent** = an independent chat thread inside a session. Spawn as many as you want, switch between them by clicking in the sidebar. Every agent reads the same shared session context; the summarizer keeps it fresh after each turn.
-- **Workflow** _(optional, beta)_ = a preset that pre-spawns N named agents (e.g. scout → planner → implementer → reviewer) at session creation. Free-form spawn always available.
+- **Workspace** — a local git repo you registered. Sessions are scoped to it.
+- **Session** — one goal. Owns the worktree, the branch, the context panel, the budget. Auto-spawns `agent 1` on creation.
+- **Agent** — an independent chat thread inside a session. Spawn as many as you want. Switch via sidebar. All agents read the same shared context; the summarizer refreshes it after each turn.
+- **Workflow** _(beta)_ — a preset that pre-spawns N role-named agents at session creation (e.g. scout → planner → implementer → reviewer). Free-form spawn always available.
 
-## Principles
-
-- **Local-first, local-only.** No backend. No telemetry. No data collection. Your machine, your keys, your data.
-- **Provider-agnostic.** No lock-in.
-- **Context is expensive.** Never send more than needed.
-- **Sessions are goals, not threads.** Structure work by intent.
-- **Each agent owns its chat.** Sessions only share context, not conversation history.
-- **Automate the repeatable.**
-
-See [VISION.md](./VISION.md) for the full product vision.
+---
 
 ## Stack
 
-- **Tauri 2** + **React 19** + **TypeScript 5** + **Vite 6**
-- **Tailwind CSS v4** for styling
-- **Zustand** for state
-- **SQLite** for local persistence (config + transcripts only — never sent anywhere)
-- Monorepo: **pnpm workspaces** + **Turborepo**
-
-## Project structure
+**Tauri 2** · **React 19** · **TypeScript 5** · **Vite 6** · **Tailwind v4** · **Zustand** · **SQLite** (local, never sent anywhere) · **pnpm workspaces** + **Turborepo**.
 
 ```
 kay-am/
-├── apps/desktop/     # Tauri 2 desktop app
+├── apps/desktop/        Tauri 2 desktop app
 └── packages/
-    ├── ui/           # Shared React components (AppShell, Dialog, Markdown, …)
-    ├── core/         # Business logic (workflows, providers, budget, context)
-    ├── db/           # SQLite schema + queries
-    └── types/        # Shared TypeScript types
+    ├── ui/              shared React components
+    ├── core/            workflows · providers · budget · context
+    ├── db/              SQLite schema + queries
+    └── types/           shared TypeScript types
 ```
 
-## Development
+## Layout
 
-### Supported providers
+Two columns. Floating sidebar left, chat + context panel right. No top header, no bottom footer — both fold into the sidebar.
 
-kAY.am orchestrates sessions through locally installed CLI tools. All three require an active subscription — kAY.am uses the subscription cap, not API tokens.
+```
+┌─────────────────────────┬───────────────────────────────┬──────────────┐
+│ kAY.am          🔔  ⚙   │ goal · branch · open in code  │              │
+│                         │                               │              │
+│ WORKSPACES              │                               │              │
+│  • app-web              │                               │  Context     │
+│                         │                               │  Panel       │
+│ SESSIONS    (app-web)   │       Agent's chat            │              │
+│  • refactor auth        │       (streaming)             │  shared      │
+│                         │                               │  across      │
+│ AGENTS      2 agents    │                               │  agents      │
+│  ▣ agent 1  ← selected  │                               │              │
+│  ▢ agent 2              │                               │  (collap-    │
+│  + spawn agent          │                               │   sible)     │
+│                         │ ┌───────────────────────────┐ │              │
+│                         │ │ Message Claude…        ▶  │ │              │
+│                         │ └───────────────────────────┘ │              │
+│ ⓟ providers   3 / 3     │  [Claude] [Opus 4.7] [Med]   │              │
+│ $0.20 session · $1.40   │                               │              │
+└─────────────────────────┴───────────────────────────────┴──────────────┘
+   sidebar (floating)            chat (central)              context
+```
 
-| Provider               | CLI install                                      | Required subscription   |
+- **Sidebar top** — brand · alerts bell · settings (⌘,).
+- **Sidebar middle** — workspaces → sessions → agents.
+- **Sidebar footer** — providers chip · cost telemetry pill (click for per-model breakdown).
+- **Right rail** — shared context panel for the current session, collapsible.
+
+---
+
+## Providers
+
+kAY.am orchestrates through locally installed CLIs. Each uses the **subscription cap**, not API tokens.
+
+| Provider               | CLI install                                      | Subscription            |
 | ---------------------- | ------------------------------------------------ | ----------------------- |
-| **Anthropic (Claude)** | `npm install -g @anthropic-ai/claude-code`       | Claude Max / Claude Pro |
+| **Anthropic (Claude)** | `npm i -g @anthropic-ai/claude-code`             | Claude Max / Claude Pro |
 | **Cursor**             | [cursor.com](https://www.cursor.com) desktop app | Cursor Pro              |
-| **OpenAI (Codex)**     | `npm install -g @openai/codex`                   | ChatGPT Pro             |
+| **OpenAI (Codex)**     | `npm i -g @openai/codex`                         | ChatGPT Pro             |
 
-Connect a provider: `<cli> /login` (Claude / Cursor) or `<cli> login` (Codex). See [docs/providers.md](./docs/providers.md) for full install, connect/disconnect, multi-account, and troubleshooting guidance.
+Connect: `<cli> /login` (Claude / Cursor) or `<cli> login` (Codex). Full guide: [docs/providers.md](./docs/providers.md).
 
-### Prerequisites
+## Prerequisites
 
-- **Node.js** ≥ 20 and **pnpm** ≥ 9
-- **Rust** toolchain (`rustup`) — required by Tauri 2; install from <https://rustup.rs>. After installing, make sure `cargo` is on your shell `PATH` — `rustup` writes the env to `$HOME/.cargo/env`, which most shells don't auto-source. Either add `source "$HOME/.cargo/env"` to your `~/.zshrc` / `~/.bashrc`, or restart your terminal after install. Verify with `cargo --version` (Tauri shells out to `cargo metadata` and will fail with `os error 2` if it's missing).
-- Platform Tauri prereqs — see <https://v2.tauri.app/start/prerequisites/>
-- At least one **provider CLI** on `PATH` — see [Supported providers](#supported-providers) above. The summarizer reuses the active provider's cheap-tier model via its CLI — no separate API token required.
+- **Node** ≥ 20 · **pnpm** ≥ 9
+- **Rust** toolchain — install from <https://rustup.rs>, then ensure `cargo` is on `PATH` (`source "$HOME/.cargo/env"` in your shell rc, or restart the terminal). Tauri shells out to `cargo metadata` and fails with `os error 2` if it's missing.
+- Platform Tauri prereqs — <https://v2.tauri.app/start/prerequisites/>
+- At least one **provider CLI** on `PATH`. The summarizer reuses the active provider's cheap-tier model — no separate API token.
 
-### Quickstart
+## Quickstart
 
 ```bash
 pnpm install
-pnpm tauri:dev      # launches the desktop app in dev mode
+pnpm tauri:dev          # launches the desktop app in dev
 ```
 
-Useful commands:
+| Command            | What it does                        |
+| ------------------ | ----------------------------------- |
+| `pnpm typecheck`   | `tsc --noEmit` across the monorepo  |
+| `pnpm test`        | vitest across packages              |
+| `pnpm build`       | vite build (frontend)               |
+| `pnpm tauri:build` | package the desktop app             |
+| `pnpm format`      | prettier across `ts/tsx/js/json/md` |
 
-```bash
-pnpm typecheck      # tsc --noEmit across the monorepo (turbo)
-pnpm test           # vitest across packages
-pnpm build          # vite build (frontend only)
-pnpm lint           # placeholder; lint runs in CI
-```
+---
 
-## Layout at a glance
+## First run
 
-The shell is two columns: a **floating sidebar** on the left, the **chat + context panel** on the right. There is no separate top header or bottom footer — both rolled into the sidebar.
+1. **Boot** — `pnpm tauri:dev`, wait for the splash to reach _ready_.
+2. **Connect a provider** — ⚙ (⌘,) → **Providers** → connect ≥1 of Claude / Cursor / Codex.
+3. **Add a workspace** — sidebar **Workspaces** → **add workspace…** → pick a local git repo.
+4. **Create a session** — sidebar **Sessions** → **add session** → set a goal, optionally pick a **workflow** (beta).
+5. **Talk to agent 1** — auto-spawned on session creation. Type → enter. Watch the transcript stream, the cost pill tick, and a `worktree-{slug}` directory appear next to your repo.
+6. **Spawn more agents** — **Agents** block → **+ spawn agent**. Click any row to switch. Hover + pencil to rename.
+7. **Open in editor** — **Open in code** button in the chat header opens the worktree in your default editor (or pick from a dropdown if you have multiple detected).
+8. **Watch cost + alerts** — providers chip + telemetry pill in the sidebar footer. 🔔 in the top bar opens the notification center for budget thresholds.
+9. **Archive / end** — sidebar kebab → **archive** (keeps it inspectable) or **⌘.** to end the active session (cleans the worktree, keeps the branch).
 
-```
-┌─ floating sidebar ──┐  ┌──────────────────────────────────────┐
-│ kAY.am   🔔  ⚙       │  │  ChatHeader (goal · branch · open in code) │
-│ ─                    │  │                                      │
-│ Workspaces           │  │                                      │
-│   • app-web          │  │   Agent's chat                       │
-│ ─                    │  │                                      │
-│ Sessions  app-web ⇅  │  │                                      │
-│   • refactor auth    │  │                                      │
-│ Agents    2 agents   │  │                                      │
-│   ▣ agent 1 (sel)    │  │                                      │
-│   ▢ agent 2          │  │                                      │
-│   + spawn agent      │  │   ┌──────────────────────┐           │
-│ ─                    │  │   │ Message Claude…   ▶  │           │
-│ ⓟ providers (3/3)    │  │   └──────────────────────┘           │
-│ $0.20 · $1.40 total  │  │   [Claude] [Opus 4.7] [Medium]       │
-└──────────────────────┘  └──────────────────────────────────────┘
-                                                    ContextPanel ▸
-```
-
-- **Sidebar top**: brand, alerts bell, settings (⌘,).
-- **Sidebar middle**: workspaces → sessions → agents, separated by dividers.
-- **Sidebar footer**: providers connection chip, then the cost telemetry pill.
-- **Right rail**: shared context panel for the current session (collapsible).
-
-## Getting started
-
-### 1. Boot splash → ready
-
-Launch `pnpm tauri:dev`. Wait for the splash screen to reach _ready_.
-
-### 2. Connect a provider
-
-Sidebar top-right: **settings (⌘,)** → **Providers** → connect at least one of Anthropic / Cursor / Codex (see [Supported providers](#supported-providers)).
-
-### 3. Add your first workspace
-
-Sidebar **Workspaces** section → **add workspace…** → pick a local git repo. kAY.am runs every session inside an isolated worktree alongside the repo.
-
-### 4. Create your first session
-
-Sidebar **Sessions** section → **add session** → set a goal (e.g. "Refactor auth domain"), tweak the branch prefix, optionally pick a **workflow** (beta) to pre-spawn role-named agents.
-
-A default **agent 1** is auto-spawned when the session is created — the chat is immediately ready.
-
-### 5. First turn
-
-The chat is the central pane. Type a message → enter. You'll see streamed assistant text in agent 1's transcript, the cost meter ticking in the sidebar footer, and a `worktree-{slug}` directory created next to your repo root.
-
-### 6. Spawn another agent
-
-Sidebar **Agents** block → **+ spawn agent** → either pick `+ free agent` (no role) or one of the workflow steps if a workflow is attached.
-
-The new agent gets its own empty chat. Click any agent in the sidebar to switch the chat view to that agent's history. The right-side context panel stays the same — it's shared across all agents in the session and auto-populated by the LLM after each turn.
-
-Hover an agent row and click the **pencil** icon to rename it inline.
-
-### 7. Open the worktree in your editor
-
-`Open in code` button in the chat header opens the active worktree in your default editor. If you have multiple editors detected, pick from the dropdown.
-
-### 8. Monitor cost + alerts
-
-Sidebar footer shows the providers chip (one dot per provider, color-coded) and the telemetry pill (`$session · $workspace`). Click the pill for a per-model breakdown.
-
-The **bell icon** in the sidebar top opens the notification center for budget thresholds and other warnings.
-
-### 9. Archive or end the session
-
-Sidebar kebab menu → **archive** moves a session out of the active list (still inspectable under "archived"). **⌘.** ends the active session and cleans up the worktree while preserving the branch.
+---
 
 ## Settings
 
-Two scopes:
-
-- **Global** (sidebar top → ⚙) — App / Providers / Budget / Agent / Github / Advanced / Initialization. Beta chips mark sections whose behaviour is not yet validated. **Initialization → Wipe local database** drops every workspace / session / agent / message in `~/.kay-am/data.db` and re-runs migrations on next boot. API keys in the OS keychain are not touched.
-- **Per-workspace** (workspace row → ⚙ icon on hover) — General (branch prefix), Skills, Workflows (beta). Per-workspace settings stay scoped — the global dialog never shows them.
+- **Global** (⚙ top of sidebar) — App / Providers / Budget / Agent / Github / Advanced / Initialization. Beta chips mark unvalidated sections. **Initialization → Wipe local database** drops every workspace/session/agent/message in `~/.kay-am/data.db` and re-runs migrations on next boot. OS-keychain API keys are untouched.
+- **Per-workspace** (workspace row → ⚙ on hover) — General (branch prefix), Skills, Workflows (beta). Scoped — never bleeds into the global dialog.
 
 ## Roadmap & contributing
 
-- [ROADMAP.md](./ROADMAP.md) — milestones and the active issue list
-- [CONVENTIONS.md](./CONVENTIONS.md) — monorepo conventions
-- [CLAUDE.md](./CLAUDE.md) — project rules (also enforced via `lefthook` + `commitlint` on commit)
+- [ROADMAP.md](./ROADMAP.md) — milestones and active issues.
+- [CONVENTIONS.md](./CONVENTIONS.md) — monorepo conventions.
+- [CLAUDE.md](./CLAUDE.md) — project rules (enforced via `lefthook` + `commitlint`).
 
-- Conventional commits (`type(scope): subject`), all-lowercase subjects.
-- Branch protection on `main`. PR-only.
+Conventional commits, lowercase subjects. `main` is protected — PR only.
 
 ## License
 


### PR DESCRIPTION
## Summary

- rewrote README intro, principles, mental model and getting-started for less verbosity and clearer reading flow
- redrew the ASCII layout diagram: three balanced columns (sidebar · chat · context) instead of the lopsided two-box version
- collapsed overlapping sections (Mental model + Layout + Getting started no longer repeat the same facts)
- added compact tables for **Why**, **commands**, and **providers**
- preserved all factual claims: stack versions, providers, prereqs (rustup PATH note), scripts, settings scopes

## Test plan

- [ ] visual scan of rendered README on GitHub
- [ ] prettier --check passes (formatted via `prettier --write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)