### PR TITLE
feat(desktop): add integrations panel for github, gitlab, jira, linear

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost"
+      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://api.linear.app https://gitlab.com https://*.atlassian.net"
     }
   },
   "bundle": {

--- a/apps/desktop/src/components/GithubPanel.tsx
+++ b/apps/desktop/src/components/GithubPanel.tsx
@@ -5,7 +5,7 @@ import { useAppStore } from '../store';
 
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
-export function GithubPanel() {
+export function GithubPanel({ hideSectionHeader }: { hideSectionHeader?: boolean } = {}) {
   const status = useAppStore((s) => s.githubStatus);
   const refreshStatus = useAppStore((s) => s.refreshGithubStatus);
   const setPat = useAppStore((s) => s.setGithubPat);
@@ -47,10 +47,12 @@ export function GithubPanel() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center gap-2">
-        <GithubIcon size={16} aria-hidden className="text-muted-foreground" />
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-foreground">GitHub</h2>
-      </div>
+      {!hideSectionHeader ? (
+        <div className="flex items-center gap-2">
+          <GithubIcon size={16} aria-hidden className="text-muted-foreground" />
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-foreground">GitHub</h2>
+        </div>
+      ) : null}
 
       {status === null ? (
         <p className="text-xs text-muted-foreground">checking gh status…</p>

--- a/apps/desktop/src/components/IntegrationsPanel.tsx
+++ b/apps/desktop/src/components/IntegrationsPanel.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useState } from 'react';
+import { Check, Loader2, AlertCircle } from 'lucide-react';
+import { Button, Input, cn } from '@kay-am/ui';
+import { setSecret, deleteSecret, hasSecret, getSecret } from '../secrets';
+import { GithubPanel } from './GithubPanel';
+
+type CardState = 'loading' | 'connected' | 'disconnected';
+type SaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+// ─── generic single-token card ────────────────────────────────────────────────
+
+interface TokenCardProps {
+  secretKey: string;
+  label: string;
+  placeholder: string;
+  hint: string;
+}
+
+function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
+  const [cardState, setCardState] = useState<CardState>('loading');
+  const [token, setToken] = useState('');
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void hasSecret(secretKey).then((has) => setCardState(has ? 'connected' : 'disconnected'));
+  }, [secretKey]);
+
+  const onConnect = async () => {
+    if (!token.trim()) return;
+    setSaveState('saving');
+    setError(null);
+    try {
+      await setSecret(secretKey, token.trim());
+      setToken('');
+      setCardState('connected');
+      setSaveState('saved');
+    } catch (err) {
+      setSaveState('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onDisconnect = async () => {
+    setSaveState('saving');
+    setError(null);
+    try {
+      await deleteSecret(secretKey);
+      setCardState('disconnected');
+      setSaveState('idle');
+    } catch (err) {
+      setSaveState('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (cardState === 'loading') {
+    return <p className="text-xs text-muted-foreground">checking…</p>;
+  }
+
+  if (cardState === 'connected') {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success">
+          <div className="flex items-center gap-2">
+            <Check size={13} aria-hidden />
+            <span className="font-medium">connected</span>
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void onDisconnect()}
+            disabled={saveState === 'saving'}
+            className={cn(saveState === 'saving' && 'opacity-60')}
+          >
+            disconnect
+          </Button>
+        </div>
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p>
+      <div className="flex items-center gap-2">
+        <Input
+          type="password"
+          placeholder={placeholder}
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          className="flex-1 font-mono text-xs"
+          aria-label={label}
+        />
+        <Button
+          size="sm"
+          onClick={() => void onConnect()}
+          disabled={saveState === 'saving' || !token.trim()}
+        >
+          {saveState === 'saving' ? (
+            <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
+          ) : null}
+          connect
+        </Button>
+      </div>
+      {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+      <p className="text-[10px] text-muted-foreground">
+        stored in your OS keychain. never leaves your machine.
+      </p>
+    </div>
+  );
+}
+
+// ─── jira card (domain + email + token) ───────────────────────────────────────
+
+const JIRA_KEY_DOMAIN = 'integration.jira.domain';
+const JIRA_KEY_EMAIL = 'integration.jira.email';
+const JIRA_KEY_TOKEN = 'integration.jira.token';
+
+function JiraCard() {
+  const [cardState, setCardState] = useState<CardState>('loading');
+  const [domain, setDomain] = useState('');
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [connectedDomain, setConnectedDomain] = useState<string | null>(null);
+  const [saveState, setSaveState] = useState<SaveState>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      const has = await hasSecret(JIRA_KEY_TOKEN);
+      if (has) {
+        const d = await getSecret(JIRA_KEY_DOMAIN);
+        setConnectedDomain(d ?? null);
+        setCardState('connected');
+      } else {
+        setCardState('disconnected');
+      }
+    })();
+  }, []);
+
+  const onConnect = async () => {
+    if (!domain.trim() || !email.trim() || !token.trim()) return;
+    setSaveState('saving');
+    setError(null);
+    try {
+      await setSecret(JIRA_KEY_DOMAIN, domain.trim());
+      await setSecret(JIRA_KEY_EMAIL, email.trim());
+      await setSecret(JIRA_KEY_TOKEN, token.trim());
+      setConnectedDomain(domain.trim());
+      setDomain('');
+      setEmail('');
+      setToken('');
+      setCardState('connected');
+      setSaveState('saved');
+    } catch (err) {
+      setSaveState('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const onDisconnect = async () => {
+    setSaveState('saving');
+    setError(null);
+    try {
+      await deleteSecret(JIRA_KEY_DOMAIN);
+      await deleteSecret(JIRA_KEY_EMAIL);
+      await deleteSecret(JIRA_KEY_TOKEN);
+      setConnectedDomain(null);
+      setCardState('disconnected');
+      setSaveState('idle');
+    } catch (err) {
+      setSaveState('error');
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  if (cardState === 'loading') {
+    return <p className="text-xs text-muted-foreground">checking…</p>;
+  }
+
+  if (cardState === 'connected') {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success">
+          <div className="flex items-center gap-2">
+            <Check size={13} aria-hidden />
+            <span className="font-medium">
+              connected{connectedDomain ? ` · ${connectedDomain}` : ''}
+            </span>
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => void onDisconnect()}
+            disabled={saveState === 'saving'}
+            className={cn(saveState === 'saving' && 'opacity-60')}
+          >
+            disconnect
+          </Button>
+        </div>
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+      </div>
+    );
+  }
+
+  const canConnect = domain.trim() && email.trim() && token.trim();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-xs leading-relaxed text-muted-foreground">
+        Jira Cloud API token — generate one at{' '}
+        <span className="font-mono text-[10px]">id.atlassian.com → security → API tokens</span>.
+      </p>
+      <div className="flex flex-col gap-2">
+        <Input
+          placeholder="yourcompany.atlassian.net"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          className="font-mono text-xs"
+          aria-label="Jira domain"
+        />
+        <Input
+          type="email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="text-xs"
+          aria-label="Atlassian account email"
+        />
+        <div className="flex items-center gap-2">
+          <Input
+            type="password"
+            placeholder="ATATT3x…"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            className="flex-1 font-mono text-xs"
+            aria-label="Jira API token"
+          />
+          <Button
+            size="sm"
+            onClick={() => void onConnect()}
+            disabled={saveState === 'saving' || !canConnect}
+          >
+            {saveState === 'saving' ? (
+              <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
+            ) : null}
+            connect
+          </Button>
+        </div>
+      </div>
+      {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+      <p className="text-[10px] text-muted-foreground">
+        stored in your OS keychain. never leaves your machine.
+      </p>
+    </div>
+  );
+}
+
+// ─── section wrapper ───────────────────────────────────────────────────────────
+
+function IntegrationSection({
+  icon,
+  name,
+  children,
+}: {
+  icon: React.ReactNode;
+  name: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        {icon}
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-foreground">{name}</h2>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function Divider() {
+  return <div className="border-t border-border" />;
+}
+
+function ErrorBanner({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+      <div className="flex items-center gap-2">
+        <AlertCircle size={12} aria-hidden />
+        <span>{children}</span>
+      </div>
+    </div>
+  );
+}
+
+// ─── svgs for brand icons (minimal inline) ────────────────────────────────────
+
+function GitLabIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className="text-muted-foreground"
+    >
+      <path d="M22.65 14.39L12 22.13 1.35 14.39a.84.84 0 0 1-.3-.94l1.22-3.78 2.44-7.51A.42.42 0 0 1 4.82 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.49h8.1l2.44-7.51A.42.42 0 0 1 18.6 2a.43.43 0 0 1 .58 0 .42.42 0 0 1 .11.18l2.44 7.51 1.22 3.78a.84.84 0 0 1-.3.92z" />
+    </svg>
+  );
+}
+
+function JiraIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className="text-muted-foreground"
+    >
+      <path d="M11.571 11.429 6 5.857l5.571-5.572L17.143 6l-5.572 5.429zm.858.857L18 18l-5.571 5.571L6.857 18l5.572-5.714z" />
+    </svg>
+  );
+}
+
+function LinearIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className="text-muted-foreground"
+    >
+      <path d="M3.374 5.268a.7.7 0 0 1 .99-.99l15.358 15.358a.7.7 0 0 1-.99.99L3.374 5.268zM2.5 8.25A5.75 5.75 0 0 1 14.197 4.09l-9.11 9.11A5.75 5.75 0 0 1 2.5 8.25zm8.803 11.16A5.75 5.75 0 0 0 19.91 11.1l-8.607 8.31z" />
+    </svg>
+  );
+}
+
+// ─── public panel ─────────────────────────────────────────────────────────────
+
+export function IntegrationsPanel() {
+  return (
+    <div className="flex flex-col gap-5">
+      <IntegrationSection
+        icon={
+          <svg
+            width={14}
+            height={14}
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden
+            className="text-muted-foreground"
+          >
+            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0 1 12 6.844a9.59 9.59 0 0 1 2.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.02 10.02 0 0 0 22 12.017C22 6.484 17.522 2 12 2z" />
+          </svg>
+        }
+        name="GitHub"
+      >
+        <GithubPanel hideSectionHeader />
+      </IntegrationSection>
+
+      <Divider />
+
+      <IntegrationSection icon={<GitLabIcon />} name="GitLab">
+        <TokenCard
+          secretKey="integration.gitlab.token"
+          label="GitLab personal access token"
+          placeholder="glpat-…"
+          hint="Personal access token with api or read_api scope — Settings → Access Tokens."
+        />
+      </IntegrationSection>
+
+      <Divider />
+
+      <IntegrationSection icon={<JiraIcon />} name="Jira">
+        <JiraCard />
+      </IntegrationSection>
+
+      <Divider />
+
+      <IntegrationSection icon={<LinearIcon />} name="Linear">
+        <TokenCard
+          secretKey="integration.linear.token"
+          label="Linear API key"
+          placeholder="lin_api_…"
+          hint="Personal API key — Settings → API → Personal API keys → New key."
+        />
+      </IntegrationSection>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -26,6 +26,7 @@ import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../settings';
 import { EMPTY_ARRAY, useAppStore } from '../store';
 import { PlannerWidget } from './PlannerWidget';
 import { fetchGithubIssue, parseGithubIssueUrl } from '../github';
+import { fetchIssueFromUrl, type IssueData } from '../integrations';
 import { useToast } from './Toast';
 
 interface NewSessionDialogProps {
@@ -155,7 +156,31 @@ async function generateBranchSlug(goal: string, providerId: ProviderId): Promise
     .join('-');
 }
 
-const LINEAR_FEATURE_FLAG = false;
+async function generateGoalFromIssue(issue: IssueData, providerId: ProviderId): Promise<string> {
+  const systemPrompt =
+    'You are a goal extractor for AI coding sessions. Given a task or issue, write a concise goal in 2-4 sentences, imperative form (e.g. "Refactor the auth middleware to..."). Output ONLY the goal text, nothing else.';
+  const userMessage = `Title: ${issue.title}\n\nDescription:\n${issue.body}`.slice(0, 4000);
+  const result = await invoke<SummarizeTaskResult>('summarize_task', {
+    args: {
+      providerId,
+      model: getCheapModel(providerId),
+      binary: getDefaultBinary(providerId),
+      userMessage,
+      systemPrompt,
+    },
+  });
+  if ((result.exitCode ?? 0) !== 0) {
+    throw new Error(`goal generation failed: ${result.stderr}`);
+  }
+  const raw = result.stdout.trim();
+  try {
+    const parsed = JSON.parse(raw) as { result?: string };
+    if (typeof parsed.result === 'string') return parsed.result.trim();
+  } catch {
+    // not json, use raw
+  }
+  return raw;
+}
 
 export function NewSessionDialog({
   open,
@@ -243,13 +268,27 @@ export function NewSessionDialog({
   const handleIssueUrl = async (value: string) => {
     setIssueUrl(value);
     setIssueError(null);
-    const parsed = parseGithubIssueUrl(value);
-    if (!parsed) return;
+
+    const githubParsed = parseGithubIssueUrl(value);
+    const hasMatch =
+      githubParsed !== null ||
+      value.includes('linear.app') ||
+      value.includes('gitlab.com') ||
+      value.includes('atlassian.net');
+    if (!hasMatch) return;
+
     setIssueFetching(true);
     try {
-      const issue = await fetchGithubIssue(parsed.repoSlug, parsed.number);
-      const fullGoal = issue.body ? `${issue.title}\n\n${issue.body}` : issue.title;
-      setGoal(fullGoal);
+      let issueData: IssueData | null = null;
+      if (githubParsed) {
+        const gh = await fetchGithubIssue(githubParsed.repoSlug, githubParsed.number);
+        issueData = { service: 'github', title: gh.title, body: gh.body, url: gh.url };
+      } else {
+        issueData = await fetchIssueFromUrl(value);
+      }
+      if (!issueData) return;
+      const goal = await generateGoalFromIssue(issueData, selectedProvider);
+      setGoal(goal);
     } catch (err) {
       setIssueError(formatError(err));
     } finally {
@@ -453,14 +492,7 @@ export function NewSessionDialog({
               )}
             >
               {s.icon}
-              <span className="flex-1">
-                {s.label}
-                {s.required ? (
-                  <span aria-hidden className="ml-0.5 text-warning">
-                    *
-                  </span>
-                ) : null}
-              </span>
+              <span className="flex-1">{s.label}</span>
               {s.ready ? (
                 <Check size={11} className="text-success" aria-label="filled" />
               ) : s.required ? (
@@ -477,17 +509,16 @@ export function NewSessionDialog({
         <div className="min-w-0 flex-1 overflow-y-auto pl-4">
           {activeSection === 'goal' ? (
             <div className="flex flex-col gap-4">
-              <Field label="issue link" hint="paste a GitHub issue URL or owner/repo#number.">
-                {LINEAR_FEATURE_FLAG ? (
-                  <p className="rounded-md border border-dashed border-border-soft bg-subtle px-3 py-2 text-xs text-muted-foreground">
-                    Linear integration coming soon.
-                  </p>
-                ) : null}
+              <Field
+                label="issue link"
+                labelSuffix={<BetaChip />}
+                hint="paste a GitHub, GitLab, Jira, or Linear issue URL — goal will be generated automatically."
+              >
                 <div className="relative">
                   <Input
                     value={issueUrl}
                     onChange={(e) => void handleIssueUrl(e.target.value)}
-                    placeholder="https://github.com/owner/repo/issues/42"
+                    placeholder="github.com/…/issues/42 · linear.app/…/TEAM-1 · jira · gitlab"
                     disabled={issueFetching || busy}
                   />
                   {issueFetching ? (
@@ -701,19 +732,32 @@ export function NewSessionDialog({
 
 function Field({
   label,
+  labelSuffix,
   hint,
   children,
 }: {
   label: string;
+  labelSuffix?: React.ReactNode;
   hint?: string;
   children: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="text-xs font-semibold text-foreground">{label}</span>
+      <span className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+        {label}
+        {labelSuffix}
+      </span>
       {children}
       {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
     </div>
+  );
+}
+
+function BetaChip() {
+  return (
+    <span className="rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning">
+      beta
+    </span>
   );
 }
 

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import { Bot, Cpu, DollarSign, FileDown, FolderCode, GitFork, Trash2 } from 'lucide-react';
+import { Bot, Cpu, DollarSign, FileDown, FolderCode, Link2, Trash2 } from 'lucide-react';
 import { Button, Dialog, Input } from '@kay-am/ui';
 import { ProvidersPanel } from './ProvidersPanel';
 import { BudgetRulesPanel } from './BudgetRulesPanel';
-import { GithubPanel } from './GithubPanel';
+import { IntegrationsPanel } from './IntegrationsPanel';
 import { ImportConfigDialog } from './ImportConfigDialog';
 import type { ConfigBundleImportResult } from '@kay-am/types';
 import {
@@ -31,7 +31,7 @@ type NavSection =
   | 'providers'
   | 'budget'
   | 'agent'
-  | 'github'
+  | 'integrations'
   | 'initialization'
   | 'advanced';
 
@@ -49,7 +49,7 @@ const NAV_ITEMS: NavItem[] = [
   { id: 'providers', label: 'Providers', icon: <Cpu size={14} aria-hidden /> },
   { id: 'budget', label: 'Budget', icon: <DollarSign size={14} aria-hidden />, beta: true },
   { id: 'agent', label: 'Agent', icon: <Bot size={14} aria-hidden />, beta: true },
-  { id: 'github', label: 'Github', icon: <GitFork size={14} aria-hidden /> },
+  { id: 'integrations', label: 'Integrations', icon: <Link2 size={14} aria-hidden /> },
   { id: 'initialization', label: 'Initialization', icon: <Trash2 size={14} aria-hidden /> },
   { id: 'advanced', label: 'Advanced', icon: <FileDown size={14} aria-hidden /> },
 ];
@@ -60,7 +60,7 @@ function isNavSection(value: string | undefined): value is NavSection {
     value === 'providers' ||
     value === 'budget' ||
     value === 'agent' ||
-    value === 'github' ||
+    value === 'integrations' ||
     value === 'initialization' ||
     value === 'advanced'
   );
@@ -240,8 +240,8 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
             </Field>
           </div>
         );
-      case 'github':
-        return <GithubPanel />;
+      case 'integrations':
+        return <IntegrationsPanel />;
       case 'initialization':
         return (
           <div className="flex flex-col gap-4">

--- a/apps/desktop/src/integrations.ts
+++ b/apps/desktop/src/integrations.ts
@@ -1,0 +1,162 @@
+import { getSecret } from './secrets';
+
+export interface IssueData {
+  readonly title: string;
+  readonly body: string;
+  readonly url: string;
+  readonly service: 'github' | 'gitlab' | 'jira' | 'linear';
+}
+
+// ─── Linear ────────────────────────────────────────────────────────────────────
+
+export function parseLinearIssueUrl(input: string): string | null {
+  const trimmed = input.trim();
+  const urlMatch = trimmed.match(/linear\.app\/[^/]+\/issue\/([A-Z]+-\d+)/i);
+  if (urlMatch) return urlMatch[1]!.toUpperCase();
+  return null;
+}
+
+export async function fetchLinearIssue(issueId: string): Promise<IssueData> {
+  const token = await getSecret('integration.linear.token');
+  if (!token)
+    throw new Error('Linear not connected — add your API key in Settings → Integrations.');
+
+  const query = `{ issue(id: "${issueId}") { title description url } }`;
+  const res = await fetch('https://api.linear.app/graphql', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: token,
+    },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!res.ok) throw new Error(`Linear API error: ${res.status} ${res.statusText}`);
+
+  const json = (await res.json()) as {
+    data?: { issue?: { title: string; description?: string | null; url: string } };
+    errors?: ReadonlyArray<{ message: string }>;
+  };
+  if (json.errors?.length) throw new Error(`Linear: ${json.errors[0]!.message}`);
+
+  const issue = json.data?.issue;
+  if (!issue) throw new Error(`Linear issue ${issueId} not found.`);
+
+  return {
+    service: 'linear',
+    title: issue.title,
+    body: issue.description ?? '',
+    url: issue.url,
+  };
+}
+
+// ─── GitLab ────────────────────────────────────────────────────────────────────
+
+export function parseGitLabIssueUrl(input: string): { projectPath: string; iid: number } | null {
+  const trimmed = input.trim();
+  const match = trimmed.match(/gitlab\.com\/(.+?)\/-\/issues\/(\d+)/);
+  if (match) return { projectPath: match[1]!, iid: parseInt(match[2]!, 10) };
+  return null;
+}
+
+export async function fetchGitLabIssue(projectPath: string, iid: number): Promise<IssueData> {
+  const token = await getSecret('integration.gitlab.token');
+  if (!token) throw new Error('GitLab not connected — add your token in Settings → Integrations.');
+
+  const encoded = encodeURIComponent(projectPath);
+  const res = await fetch(`https://gitlab.com/api/v4/projects/${encoded}/issues/${iid}`, {
+    headers: { 'PRIVATE-TOKEN': token },
+  });
+
+  if (!res.ok) throw new Error(`GitLab API error: ${res.status} ${res.statusText}`);
+
+  const issue = (await res.json()) as {
+    title: string;
+    description?: string | null;
+    web_url: string;
+  };
+
+  return {
+    service: 'gitlab',
+    title: issue.title,
+    body: issue.description ?? '',
+    url: issue.web_url,
+  };
+}
+
+// ─── Jira ──────────────────────────────────────────────────────────────────────
+
+export function parseJiraIssueUrl(input: string): string | null {
+  const trimmed = input.trim();
+  const urlMatch = trimmed.match(/atlassian\.net\/browse\/([A-Z]+-\d+)/i);
+  if (urlMatch) return urlMatch[1]!.toUpperCase();
+  return null;
+}
+
+export async function fetchJiraIssue(issueKey: string): Promise<IssueData> {
+  const [token, email, domain] = await Promise.all([
+    getSecret('integration.jira.token'),
+    getSecret('integration.jira.email'),
+    getSecret('integration.jira.domain'),
+  ]);
+  if (!token || !email || !domain)
+    throw new Error('Jira not connected — add your credentials in Settings → Integrations.');
+
+  const auth = btoa(`${email}:${token}`);
+  const res = await fetch(`https://${domain}/rest/api/3/issue/${issueKey}`, {
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!res.ok) throw new Error(`Jira API error: ${res.status} ${res.statusText}`);
+
+  const issue = (await res.json()) as {
+    key: string;
+    fields: {
+      summary: string;
+      description?: JiraDocNode | string | null;
+    };
+  };
+
+  return {
+    service: 'jira',
+    title: issue.fields.summary,
+    body: extractJiraDocText(issue.fields.description),
+    url: `https://${domain}/browse/${issueKey}`,
+  };
+}
+
+interface JiraDocNode {
+  type?: string;
+  text?: string;
+  content?: JiraDocNode[];
+}
+
+function extractJiraDocText(doc: JiraDocNode | string | null | undefined): string {
+  if (!doc) return '';
+  if (typeof doc === 'string') return doc;
+  const parts: string[] = [];
+  const walk = (node: JiraDocNode) => {
+    if (node.text) parts.push(node.text);
+    for (const child of node.content ?? []) walk(child);
+  };
+  walk(doc);
+  return parts.join(' ').trim();
+}
+
+// ─── unified detector ──────────────────────────────────────────────────────────
+
+export async function fetchIssueFromUrl(input: string): Promise<IssueData | null> {
+  const linear = parseLinearIssueUrl(input);
+  if (linear) return fetchLinearIssue(linear);
+
+  const gitlab = parseGitLabIssueUrl(input);
+  if (gitlab) return fetchGitLabIssue(gitlab.projectPath, gitlab.iid);
+
+  const jira = parseJiraIssueUrl(input);
+  if (jira) return fetchJiraIssue(jira);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Create IntegrationsPanel component grouping all external provider connections (GitHub, GitLab, Jira, Linear)
- Add integrations.ts with URL parsers and fetch functions for GitLab, Jira, Linear APIs
- Extend NewSessionDialog to auto-populate goal from issue data via cheap model
- All integration URLs now generate session goals automatically
- Update CSP in tauri.conf.json to allow integration API domains
- Remove yellow required asterisks from Goal/Provider fields
- Add Beta badge to issue link field

## Test plan

- Connect each integration in Settings → Integrations
- Paste an issue URL in "New Session" dialog
- Verify goal is auto-populated from issue data
- Verify branch slug is auto-generated from goal