### PR TITLE
feat(desktop): block agent spawn when open questions are unresolved

### DIFF
--- a/apps/desktop/src/components/NextActionChips.tsx
+++ b/apps/desktop/src/components/NextActionChips.tsx
@@ -3,7 +3,7 @@ import { ArrowRight } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import type { NextAction } from '@kay-am/core';
 import type { TaskId } from '@kay-am/types';
-import { useAppStore, useSessionNextActions } from '../store';
+import { useAppStore, useSessionNextActions, useSessionSlots } from '../store';
 import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE } from '../agentKind';
 import { spawnKindForAction } from '../spawnFromNextAction';
 
@@ -13,20 +13,33 @@ export interface NextActionChipsProps {
   readonly className?: string;
 }
 
+function isSpawnAction(action: NextAction): boolean {
+  return (
+    action.id === 'spawn_planner' ||
+    action.id === 'spawn_implementer' ||
+    action.id === 'spawn_debugger'
+  );
+}
+
 export function NextActionChips({ taskId, workflowBound, className }: NextActionChipsProps) {
   const actions = useSessionNextActions(taskId);
+  const slots = useSessionSlots(taskId);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const createPrForSession = useAppStore((s) => s.createPrForSession);
   const clearSessionNextActions = useAppStore((s) => s.clearSessionNextActions);
   const [busyId, setBusyId] = useState<NextAction['id'] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<NextAction | null>(null);
+
+  const hasOpenQuestions =
+    (slots.find((s) => s.key === 'open_questions')?.value?.trim().length ?? 0) > 0;
 
   if (workflowBound || actions.length === 0) return null;
 
-  const onClick = async (action: NextAction) => {
-    if (busyId) return;
+  const executeAction = async (action: NextAction) => {
     setBusyId(action.id);
     setError(null);
+    setPendingAction(null);
     try {
       switch (action.id) {
         case 'spawn_planner':
@@ -56,6 +69,15 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
     }
   };
 
+  const onClick = async (action: NextAction) => {
+    if (busyId) return;
+    if (hasOpenQuestions && isSpawnAction(action)) {
+      setPendingAction(action);
+      return;
+    }
+    await executeAction(action);
+  };
+
   return (
     <section
       className={cn('flex flex-col gap-1.5', className)}
@@ -76,6 +98,29 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
           />
         ))}
       </div>
+      {pendingAction ? (
+        <div className="rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
+          <p className="mb-2 font-medium text-foreground">
+            open questions need resolution before spawning an agent.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPendingAction(null)}
+              className="rounded bg-warning px-2 py-0.5 text-[10px] font-semibold text-warning-foreground hover:opacity-90"
+            >
+              resolve first
+            </button>
+            <button
+              type="button"
+              onClick={() => void executeAction(pendingAction)}
+              className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
+            >
+              force spawn
+            </button>
+          </div>
+        </div>
+      ) : null}
       {error ? (
         <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-[10px] text-danger">
           {error}

--- a/apps/desktop/src/components/WorkflowNextStepCta.tsx
+++ b/apps/desktop/src/components/WorkflowNextStepCta.tsx
@@ -8,7 +8,12 @@ import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE, inferAgentKindFromName } from 
 export interface WorkflowNextStepCtaProps {
   readonly workflow: Workflow;
   readonly runs: ReadonlyArray<Session>;
-  readonly onAdvance: (step: Step, model: string, verbosity: VerbosityLevel | undefined) => void | Promise<void>;
+  readonly onAdvance: (
+    step: Step,
+    model: string,
+    verbosity: VerbosityLevel | undefined,
+  ) => void | Promise<void>;
+  readonly hasOpenQuestions?: boolean;
   readonly className?: string;
 }
 
@@ -41,61 +46,93 @@ export function WorkflowNextStepCta({
   workflow,
   runs,
   onAdvance,
+  hasOpenQuestions = false,
   className,
 }: WorkflowNextStepCtaProps) {
   const [busy, setBusy] = useState(false);
+  const [pendingConfirm, setPendingConfirm] = useState(false);
   const next = useMemo(() => pickNextWorkflowStep(workflow, runs), [workflow, runs]);
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
   const defaults = AGENT_KIND_DEFAULTS[kind];
   const palette = AGENT_KIND_PALETTE[kind];
   if (!next) return null;
   const stepVerbosity = next.verbosity;
-  const onClick = async () => {
+  const doAdvance = async () => {
     if (busy) return;
     setBusy(true);
+    setPendingConfirm(false);
     try {
       await onAdvance(next, defaults.model, stepVerbosity);
     } finally {
       setBusy(false);
     }
   };
+  const onClick = () => {
+    if (hasOpenQuestions) {
+      setPendingConfirm(true);
+    } else {
+      void doAdvance();
+    }
+  };
   return (
-    <button
-      type="button"
-      onClick={() => void onClick()}
-      disabled={busy}
-      data-testid="workflow-next-step-cta"
-      title={`model: ${defaults.model} · effort: ${defaults.effort}${stepVerbosity ? ` · verbosity: ${stepVerbosity}` : ''}`}
-      className={cn(
-        'group flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
-        className,
-      )}
-      aria-label={`Start ${next.name} (${defaults.model}, ${defaults.effort} effort${stepVerbosity ? `, ${stepVerbosity} verbosity` : ''})`}
-    >
-      <span className="flex items-center gap-1.5">
-        <span className="text-2xs uppercase tracking-wide opacity-70">start</span>
-        <span className="font-semibold">{next.name}</span>
-        <span
-          className={cn(
-            'rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
-            palette.bg,
-            palette.fg,
-          )}
-          aria-hidden
-        >
-          {palette.label}
+    <div className={cn('flex flex-col gap-1.5', className)}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={busy}
+        data-testid="workflow-next-step-cta"
+        title={`model: ${defaults.model} · effort: ${defaults.effort}${stepVerbosity ? ` · verbosity: ${stepVerbosity}` : ''}`}
+        className="group flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/10 px-2.5 py-1.5 text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60"
+        aria-label={`Start ${next.name} (${defaults.model}, ${defaults.effort} effort${stepVerbosity ? `, ${stepVerbosity} verbosity` : ''})`}
+      >
+        <span className="flex items-center gap-1.5">
+          <span className="text-2xs uppercase tracking-wide opacity-70">start</span>
+          <span className="font-semibold">{next.name}</span>
+          <span
+            className={cn(
+              'rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
+              palette.bg,
+              palette.fg,
+            )}
+            aria-hidden
+          >
+            {palette.label}
+          </span>
         </span>
-      </span>
-      <span className="flex items-center gap-1.5">
-        <span className="text-[10px] font-normal opacity-60">
-          {defaults.model.split('-').slice(1, 3).join('-')}
+        <span className="flex items-center gap-1.5">
+          <span className="text-[10px] font-normal opacity-60">
+            {defaults.model.split('-').slice(1, 3).join('-')}
+          </span>
+          <ArrowRight
+            size={13}
+            aria-hidden
+            className="transition-transform group-hover:translate-x-0.5"
+          />
         </span>
-        <ArrowRight
-          size={13}
-          aria-hidden
-          className="transition-transform group-hover:translate-x-0.5"
-        />
-      </span>
-    </button>
+      </button>
+      {pendingConfirm ? (
+        <div className="rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
+          <p className="mb-2 font-medium text-foreground">
+            open questions need resolution before spawning an agent.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPendingConfirm(false)}
+              className="rounded bg-warning px-2 py-0.5 text-[10px] font-semibold text-warning-foreground hover:opacity-90"
+            >
+              resolve first
+            </button>
+            <button
+              type="button"
+              onClick={() => void doAdvance()}
+              className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
+            >
+              force spawn
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -55,6 +55,7 @@ import {
   useCurrentSession,
   useCurrentWorkspace,
   useSessionNextActions,
+  useSessionSlots,
   useSessions,
   useWorkspaces,
 } from '../store';
@@ -1285,6 +1286,9 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const workflow = task.workflowId
     ? (phaseTemplates.find((t) => t.id === task.workflowId) ?? null)
     : null;
+  const slots = useSessionSlots(task.id);
+  const hasOpenQuestions =
+    (slots.find((s) => s.key === 'open_questions')?.value?.trim().length ?? 0) > 0;
   const [spawnError, setSpawnError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<SessionId | null>(null);
 
@@ -1438,6 +1442,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
             workflow={workflow}
             runs={sorted}
             onAdvance={(step, model) => onSpawn(step.id, model)}
+            hasOpenQuestions={hasOpenQuestions}
           />
         </div>
       ) : null}
@@ -1457,10 +1462,14 @@ interface SpawnAgentControlProps {
 
 function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps) {
   const [open, setOpen] = useState(false);
+  const [pendingSuggestion, setPendingSuggestion] = useState<NextAction | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const nextActions = useSessionNextActions(taskId);
+  const slots = useSessionSlots(taskId);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const clearSessionNextActions = useAppStore((s) => s.clearSessionNextActions);
+  const hasOpenQuestions =
+    (slots.find((s) => s.key === 'open_questions')?.value?.trim().length ?? 0) > 0;
 
   useEffect(() => {
     if (!open) return;
@@ -1478,10 +1487,19 @@ function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps
 
   const suggestions = workflow ? [] : nextActions;
 
-  const onPickSuggestion = async (action: NextAction) => {
-    setOpen(false);
+  const executeSuggestion = async (action: NextAction) => {
+    setPendingSuggestion(null);
     const did = await spawnFromNextAction(action, taskId, spawnAgent);
     if (did) clearSessionNextActions(taskId);
+  };
+
+  const onPickSuggestion = (action: NextAction) => {
+    setOpen(false);
+    if (hasOpenQuestions) {
+      setPendingSuggestion(action);
+      return;
+    }
+    void executeSuggestion(action);
   };
 
   return (
@@ -1555,6 +1573,29 @@ function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps
               ))}
             </>
           ) : null}
+        </div>
+      ) : null}
+      {pendingSuggestion ? (
+        <div className="mt-1.5 rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
+          <p className="mb-2 font-medium text-foreground">
+            open questions need resolution before spawning an agent.
+          </p>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => setPendingSuggestion(null)}
+              className="rounded bg-warning px-2 py-0.5 text-[10px] font-semibold text-warning-foreground hover:opacity-90"
+            >
+              resolve first
+            </button>
+            <button
+              type="button"
+              onClick={() => void executeSuggestion(pendingSuggestion)}
+              className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
+            >
+              force spawn
+            </button>
+          </div>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- intercept spawn actions on `WorkflowNextStepCta`, `NextActionChips`, and `SpawnAgentControl` suggested-next when `open_questions` slot has content
- show inline confirmation: **resolve first** (dismiss) or **force spawn** (proceed anyway)
- manual spawns (+ free agent, from-workflow steps) bypass the guard intentionally

## Test plan
- [ ] session with open questions → click workflow CTA → confirmation appears
- [ ] confirm "resolve first" → dialog dismisses, no spawn
- [ ] confirm "force spawn" → agent spawns normally
- [ ] session without open questions → click CTA → spawns immediately (no dialog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)