### PR TITLE
providers: codex (cli v0.130) + cursor, with per-session model picker

### DIFF
--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -37,7 +37,7 @@ fn detect_editors_inner() -> Vec<DetectedEditor> {
 }
 
 fn which_binary(binary: &str) -> Option<()> {
-    let status = Command::new("which").arg(binary).output().ok()?;
+    let status = crate::path_env::command("which").arg(binary).output().ok()?;
     if status.status.success() { Some(()) } else { None }
 }
 
@@ -87,7 +87,7 @@ pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), Editor
         }
     }
 
-    let mut cmd = Command::new(&binary);
+    let mut cmd = crate::path_env::command(&binary);
     if binary == "cursor" || binary == "code" {
         cmd.arg("--new-window");
     }
@@ -115,7 +115,7 @@ pub fn open_file_in_workspace(
 ) -> Result<(), EditorError> {
     let binary = editor.unwrap_or_else(|| DEFAULT_EDITOR.to_string());
 
-    let mut cmd = Command::new(&binary);
+    let mut cmd = crate::path_env::command(&binary);
     if binary == "code" || binary == "cursor" {
         cmd.arg(&workspace_path);
         cmd.arg("-g");

--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use serde::Serialize;
 use thiserror::Error;
@@ -44,7 +44,7 @@ pub struct GhRunResult {
 }
 
 fn gh_available() -> bool {
-    Command::new("gh")
+    crate::path_env::command("gh")
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -61,7 +61,7 @@ fn run_gh(
     if !gh_available() {
         return Err(GithubError::NotFound);
     }
-    let mut cmd = Command::new("gh");
+    let mut cmd = crate::path_env::command("gh");
     cmd.args(args);
     if let Some(dir) = cwd {
         if !dir.is_empty() {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod db;
 mod editor;
 mod github;
 mod parallel_groups;
+mod path_env;
 mod permissions;
 mod planner;
 mod workflows;

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -1,0 +1,185 @@
+use std::collections::HashSet;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+static RESOLVED_PATH: OnceLock<String> = OnceLock::new();
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// PATH inherited from the user's login shell, merged with the process's own
+/// PATH and common install locations, deduplicated, cached after first call.
+///
+/// macOS GUI apps launched from Finder/Dock receive only the minimal posix
+/// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`), which excludes `/opt/homebrew/bin`
+/// and other typical install dirs. Without this resolution, `Command::new`
+/// fails with ENOENT for `claude`, `cursor-agent`, `codex`, `gh`,
+/// brew-installed `git`, user editors, etc.
+pub fn resolved_path() -> &'static str {
+    RESOLVED_PATH.get_or_init(compute_path)
+}
+
+/// `Command` pre-wired with the resolved PATH. Drop-in replacement for
+/// `Command::new` whenever the target binary may live outside the minimal
+/// posix path set.
+pub fn command(binary: &str) -> Command {
+    let mut cmd = Command::new(binary);
+    cmd.env("PATH", resolved_path());
+    cmd
+}
+
+fn compute_path() -> String {
+    let inherited = std::env::var("PATH").unwrap_or_default();
+    let shell = probe_login_shell_path().unwrap_or_default();
+    let common = common_install_paths();
+
+    let mut parts: Vec<String> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for source in [shell.as_str(), inherited.as_str(), common.as_str()] {
+        for segment in source.split(':') {
+            let segment = segment.trim();
+            if !segment.is_empty() && seen.insert(segment.to_string()) {
+                parts.push(segment.to_string());
+            }
+        }
+    }
+    parts.join(":")
+}
+
+#[cfg(target_os = "macos")]
+fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    &[
+        ("/bin/zsh", &["-ilc", "printf %s \"$PATH\""]),
+        ("/bin/bash", &["-ilc", "printf %s \"$PATH\""]),
+        ("/bin/sh", &["-lc", "printf %s \"$PATH\""]),
+    ]
+}
+
+#[cfg(target_os = "linux")]
+fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    &[
+        ("/bin/bash", &["-ilc", "printf %s \"$PATH\""]),
+        ("/bin/zsh", &["-ilc", "printf %s \"$PATH\""]),
+        ("/bin/sh", &["-lc", "printf %s \"$PATH\""]),
+    ]
+}
+
+#[cfg(target_os = "windows")]
+fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    &[]
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    &[]
+}
+
+fn probe_login_shell_path() -> Option<String> {
+    for (sh, args) in shell_candidates() {
+        if !std::path::Path::new(sh).exists() {
+            continue;
+        }
+        if let Some(out) = run_with_timeout(sh, args) {
+            let trimmed = out.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn run_with_timeout(bin: &str, args: &[&str]) -> Option<String> {
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = Instant::now() + PROBE_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut buf = String::new();
+                if let Some(mut out) = child.stdout.take() {
+                    let _ = out.read_to_string(&mut buf);
+                }
+                return if status.success() { Some(buf) } else { None };
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    return None;
+                }
+                std::thread::sleep(POLL_INTERVAL);
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+fn common_install_paths() -> String {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let mut parts: Vec<String> = vec![
+        "/opt/homebrew/bin".into(),
+        "/opt/homebrew/sbin".into(),
+        "/usr/local/bin".into(),
+        "/usr/local/sbin".into(),
+        "/usr/bin".into(),
+        "/bin".into(),
+        "/usr/sbin".into(),
+        "/sbin".into(),
+    ];
+    if !home.is_empty() {
+        for sub in &[
+            "/.bun/bin",
+            "/.cargo/bin",
+            "/.local/bin",
+            "/.deno/bin",
+            "/.volta/bin",
+        ] {
+            parts.push(format!("{}{}", home, sub));
+        }
+    }
+    parts.join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolved_path_is_non_empty_and_contains_bin() {
+        let p = resolved_path();
+        assert!(!p.is_empty(), "resolved PATH must not be empty");
+        assert!(
+            p.split(':').any(|seg| seg == "/bin"),
+            "resolved PATH should include /bin, got: {}",
+            p
+        );
+    }
+
+    #[test]
+    fn command_inherits_resolved_path() {
+        let cmd = command("true");
+        let env = cmd.get_envs().find(|(k, _)| *k == std::ffi::OsStr::new("PATH"));
+        assert!(env.is_some(), "command must set PATH env var");
+        let (_, val) = env.unwrap();
+        assert!(val.is_some());
+        assert_eq!(val.unwrap(), std::ffi::OsStr::new(resolved_path()));
+    }
+
+    #[test]
+    fn compute_path_dedups_segments() {
+        let merged = compute_path();
+        let segments: Vec<&str> = merged.split(':').collect();
+        let mut unique = HashSet::new();
+        for s in &segments {
+            assert!(unique.insert(*s), "duplicate segment in resolved PATH: {}", s);
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -58,7 +58,7 @@ pub async fn planner_run(args: PlannerArgs) -> Result<PlannerResult, PlannerErro
     tauri::async_runtime::spawn_blocking(move || {
         let cli_args = build_cli_args(&args)?;
 
-        let output = Command::new(&args.binary)
+        let output = crate::path_env::command(&args.binary)
             .args(&cli_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -239,6 +239,56 @@ fn extract_email(text: &str) -> Option<String> {
     None
 }
 
+/// base64url decoder (no padding, URL-safe alphabet). std-only.
+fn base64url_decode(s: &str) -> Option<Vec<u8>> {
+    let lookup = |c: u8| -> Option<u32> {
+        match c {
+            b'A'..=b'Z' => Some((c - b'A') as u32),
+            b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+            b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    };
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    let mut buf: u32 = 0;
+    let mut bits: u32 = 0;
+    for c in s.bytes() {
+        let v = lookup(c)?;
+        buf = (buf << 6) | v;
+        bits += 6;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buf >> bits) as u8);
+            buf &= (1 << bits) - 1;
+        }
+    }
+    Some(out)
+}
+
+/// Decode a JWT payload (`header.payload.signature`) and return the `email`
+/// claim. Codex stores its ChatGPT-login id_token in `~/.codex/auth.json`,
+/// which is the only carrier of the user's email when `codex login status`
+/// outputs a generic "Logged in using ChatGPT" line.
+fn extract_email_from_id_token(token: &str) -> Option<String> {
+    let payload_b64 = token.split('.').nth(1)?;
+    let payload_bytes = base64url_decode(payload_b64)?;
+    let payload: serde_json::Value = serde_json::from_slice(&payload_bytes).ok()?;
+    payload
+        .get("email")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+fn extract_codex_identity_from_auth_json() -> Option<String> {
+    let path = dirs::home_dir()?.join(".codex/auth.json");
+    let content = std::fs::read_to_string(path).ok()?;
+    let root: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let id_token = root.get("tokens")?.get("id_token")?.as_str()?;
+    extract_email_from_id_token(id_token)
+}
+
 fn check_claude_auth() -> AuthState {
     match run_auth_command(&["claude", "auth", "status"]) {
         Ok(out) => parse_claude_auth_output(&out.stdout),
@@ -386,7 +436,8 @@ fn parse_codex_auth_output(output: &str) -> AuthState {
     {
         let identity = extract_email(first_line)
             .or_else(|| extract_json_string(output, "email"))
-            .or_else(|| extract_json_string(output, "username"));
+            .or_else(|| extract_json_string(output, "username"))
+            .or_else(extract_codex_identity_from_auth_json);
         return AuthState {
             state: AuthStateKind::Connected,
             identity,
@@ -626,6 +677,53 @@ mod tests {
     fn codex_ignores_leading_blank_lines() {
         let s = parse_codex_auth_output("\n\n  \nLogged in using ChatGPT\n");
         assert_eq!(s.state, AuthStateKind::Connected);
+    }
+
+    fn base64url_encode(bytes: &[u8]) -> String {
+        const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::with_capacity(bytes.len() * 4 / 3 + 4);
+        let mut buf: u32 = 0;
+        let mut bits: u32 = 0;
+        for &b in bytes {
+            buf = (buf << 8) | b as u32;
+            bits += 8;
+            while bits >= 6 {
+                bits -= 6;
+                out.push(ALPHA[((buf >> bits) & 0x3f) as usize] as char);
+            }
+        }
+        if bits > 0 {
+            out.push(ALPHA[((buf << (6 - bits)) & 0x3f) as usize] as char);
+        }
+        out
+    }
+
+    #[test]
+    fn base64url_decode_roundtrip() {
+        let payload = b"{\"email\":\"a@b.com\"}";
+        let encoded = base64url_encode(payload);
+        let decoded = super::base64url_decode(&encoded).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn extract_email_from_id_token_decodes_jwt_payload() {
+        let header = base64url_encode(b"{\"alg\":\"RS256\"}");
+        let payload = base64url_encode(b"{\"email\":\"alice@example.com\",\"sub\":\"x\"}");
+        let token = format!("{}.{}.sig", header, payload);
+        assert_eq!(
+            super::extract_email_from_id_token(&token),
+            Some("alice@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_email_from_id_token_returns_none_on_garbage() {
+        assert_eq!(super::extract_email_from_id_token("not-a-jwt"), None);
+        assert_eq!(super::extract_email_from_id_token("x.&&.z"), None);
+        let no_email = base64url_encode(b"{\"sub\":\"x\"}");
+        let token = format!("h.{}.s", no_email);
+        assert_eq!(super::extract_email_from_id_token(&token), None);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -5,8 +5,10 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
-const AUTH_TIMEOUT: Duration = Duration::from_secs(2);
+use crate::path_env;
+
+const DETECT_TIMEOUT: Duration = Duration::from_secs(5);
+const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, Serialize)]
@@ -51,7 +53,7 @@ pub fn detect_codex() -> ProviderStatus {
 }
 
 fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
-    let mut child = match Command::new(binary)
+    let mut child = match path_env::command(binary)
         .arg("--version")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -130,9 +132,22 @@ fn read_to_string<R: std::io::Read>(mut reader: R) -> String {
     buf
 }
 
-fn run_auth_command(args: &[&str]) -> Result<String, String> {
+pub struct AuthCommandOutput {
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl AuthCommandOutput {
+    /// codex CLI v0.130 writes `codex login status` to stderr in non-TTY mode
+    /// (and Tauri children never have a TTY) — fall back when stdout is empty.
+    fn primary_text(&self) -> &str {
+        if self.stdout.trim().is_empty() { &self.stderr } else { &self.stdout }
+    }
+}
+
+fn run_auth_command(args: &[&str]) -> Result<AuthCommandOutput, String> {
     let (binary, rest) = args.split_first().ok_or_else(|| "empty command".to_string())?;
-    let mut child = Command::new(binary)
+    let mut child = path_env::command(binary)
         .args(rest)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -158,7 +173,7 @@ fn run_auth_command(args: &[&str]) -> Result<String, String> {
                     .trim()
                     .to_string();
                 if status.success() {
-                    return Ok(stdout);
+                    return Ok(AuthCommandOutput { stdout, stderr });
                 } else {
                     let msg = if stderr.is_empty() { stdout } else { stderr };
                     return Err(msg);
@@ -176,7 +191,25 @@ fn run_auth_command(args: &[&str]) -> Result<String, String> {
     }
 }
 
-/// Extract a JSON string value for `key` from raw JSON text (no external deps).
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            while let Some(&nc) = chars.peek() {
+                chars.next();
+                if nc.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn extract_json_string(json: &str, key: &str) -> Option<String> {
     let needle = format!("\"{}\"", key);
     let pos = json.find(&needle)?;
@@ -196,7 +229,6 @@ fn extract_json_string(json: &str, key: &str) -> Option<String> {
     }
 }
 
-/// Extract first email-like token from plain text output.
 fn extract_email(text: &str) -> Option<String> {
     for word in text.split_whitespace() {
         let w = word.trim_matches(|c: char| !c.is_alphanumeric() && c != '@' && c != '.');
@@ -208,36 +240,53 @@ fn extract_email(text: &str) -> Option<String> {
 }
 
 fn check_claude_auth() -> AuthState {
-    // `claude auth status` outputs JSON: {"loggedIn": bool, "authMethod": "...", ...}
     match run_auth_command(&["claude", "auth", "status"]) {
-        Ok(output) => {
-            let logged_in =
-                output.contains("\"loggedIn\":true") || output.contains("\"loggedIn\": true");
-            if !logged_in {
-                return AuthState {
-                    state: AuthStateKind::Disconnected,
-                    identity: None,
-                };
-            }
-            let identity = extract_json_string(&output, "email")
-                .or_else(|| extract_json_string(&output, "username"))
-                .or_else(|| extract_json_string(&output, "accountName"));
+        Ok(out) => parse_claude_auth_output(&out.stdout),
+        Err(err) => {
+            eprintln!("[providers] check_claude_auth: command failed: {}", err);
             AuthState {
-                state: AuthStateKind::Connected,
-                identity,
+                state: AuthStateKind::Unknown,
+                identity: None,
             }
         }
-        Err(_) => AuthState {
-            state: AuthStateKind::Unknown,
+    }
+}
+
+fn parse_claude_auth_output(output: &str) -> AuthState {
+    let value: serde_json::Value = match serde_json::from_str(output) {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!(
+                "[providers] parse_claude_auth_output: non-json output (first 120 chars): {}",
+                &output.chars().take(120).collect::<String>()
+            );
+            return AuthState {
+                state: AuthStateKind::Unknown,
+                identity: None,
+            };
+        }
+    };
+
+    if value.get("loggedIn").and_then(|v| v.as_bool()) != Some(true) {
+        return AuthState {
+            state: AuthStateKind::Disconnected,
             identity: None,
-        },
+        };
+    }
+
+    let identity = ["email", "username", "accountName"]
+        .iter()
+        .find_map(|k| value.get(k).and_then(|v| v.as_str()).map(|s| s.to_string()));
+    AuthState {
+        state: AuthStateKind::Connected,
+        identity,
     }
 }
 
 fn check_cursor_auth() -> AuthState {
-    // `cursor-agent status` outputs plain text; "Not logged in" when unauthenticated
     match run_auth_command(&["cursor-agent", "status"]) {
-        Ok(output) => {
+        Ok(out) => {
+            let output = out.stdout;
             let lower = output.to_lowercase();
             if lower.contains("not logged in") || lower.contains("not authenticated") {
                 return AuthState {
@@ -260,43 +309,68 @@ fn check_cursor_auth() -> AuthState {
     }
 }
 
+fn codex_debug_enabled() -> bool {
+    std::env::var("KAYAM_DEBUG_CODEX").map(|v| !v.is_empty()).unwrap_or(false)
+}
+
 fn check_codex_auth() -> AuthState {
-    // codex CLI subcommand layout has shifted across versions; try the variants
-    // we've seen in the wild before giving up. order matters: most recent first.
+    // Subcommand layout shifted across codex versions; try most recent first.
     let candidates: &[&[&str]] = &[
-        // codex CLI ≥ 0.13 (current). subcommand: `codex login status` →
-        // stdout "Logged in using ChatGPT" or "Not logged in".
         &["codex", "login", "status"],
-        // legacy / fallback shapes from older versions, kept in case the user
-        // still has an older binary on PATH.
         &["codex", "auth", "status"],
         &["codex", "auth", "whoami"],
         &["codex", "whoami"],
         &["codex", "status"],
     ];
-    let mut last_output: Option<String> = None;
+    let debug = codex_debug_enabled();
     for cmd in candidates {
-        match run_auth_command(cmd) {
-            Ok(output) => {
-                last_output = Some(output);
-                break;
+        if debug {
+            eprintln!("[codex-debug] auth cmd: {:?}", cmd);
+        }
+        let result = run_auth_command(cmd);
+        match result {
+            Ok(out) => {
+                if debug {
+                    eprintln!(
+                        "[codex-debug] auth ok stdout={:?} stderr={:?}",
+                        out.stdout, out.stderr
+                    );
+                }
+                let text = out.primary_text();
+                if text.trim().is_empty() {
+                    continue;
+                }
+                return parse_codex_auth_output(text);
             }
             Err(err) => {
-                last_output = Some(err);
-                continue;
+                if debug {
+                    eprintln!("[codex-debug] auth err {:?}: {}", cmd, err);
+                }
             }
         }
     }
-    let Some(output) = last_output else {
-        return AuthState {
-            state: AuthStateKind::Unknown,
-            identity: None,
-        };
-    };
-    let lower = output.to_lowercase();
-    if lower.contains("not logged")
-        || lower.contains("unauthenticated")
+    eprintln!("[providers] check_codex_auth: all auth subcommands returned empty");
+    AuthState {
+        state: AuthStateKind::Unknown,
+        identity: None,
+    }
+}
+
+fn parse_codex_auth_output(output: &str) -> AuthState {
+    let stripped: String = strip_ansi(output);
+    let first_line = stripped
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let lower = first_line.to_lowercase();
+
+    // Disconnected before Connected: "you are not logged in" would match both.
+    if lower.starts_with("not logged")
+        || lower.starts_with("not signed")
+        || lower.contains("not logged in")
         || lower.contains("not signed in")
+        || lower.contains("unauthenticated")
         || lower.contains("no credentials")
     {
         return AuthState {
@@ -304,19 +378,25 @@ fn check_codex_auth() -> AuthState {
             identity: None,
         };
     }
-    if lower.contains("logged in")
-        || lower.contains("signed in")
-        || lower.contains("authenticated")
-        || extract_email(&output).is_some()
+    if lower.starts_with("logged in")
+        || lower.starts_with("signed in")
+        || lower.starts_with("you are logged in")
+        || lower.contains("authenticated as")
+        || extract_email(first_line).is_some()
     {
-        let identity = extract_email(&output)
-            .or_else(|| extract_json_string(&output, "email"))
-            .or_else(|| extract_json_string(&output, "username"));
+        let identity = extract_email(first_line)
+            .or_else(|| extract_json_string(output, "email"))
+            .or_else(|| extract_json_string(output, "username"));
         return AuthState {
             state: AuthStateKind::Connected,
             identity,
         };
     }
+
+    eprintln!(
+        "[providers] parse_codex_auth_output: unrecognized verdict line: {:?}",
+        first_line
+    );
     AuthState {
         state: AuthStateKind::Unknown,
         identity: None,
@@ -469,5 +549,137 @@ pub fn check_provider_auth(provider_id: String) -> AuthState {
             state: AuthStateKind::Unknown,
             identity: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_parses_logged_in_json() {
+        let json = r#"{"loggedIn":true,"authMethod":"claude.ai","email":"a@b.com"}"#;
+        let s = parse_claude_auth_output(json);
+        assert_eq!(s.state, AuthStateKind::Connected);
+        assert_eq!(s.identity.as_deref(), Some("a@b.com"));
+    }
+
+    #[test]
+    fn claude_parses_logged_out_json() {
+        let s = parse_claude_auth_output(r#"{"loggedIn":false}"#);
+        assert_eq!(s.state, AuthStateKind::Disconnected);
+        assert_eq!(s.identity, None);
+    }
+
+    #[test]
+    fn claude_returns_unknown_on_non_json() {
+        let s = parse_claude_auth_output("garbage not json");
+        assert_eq!(s.state, AuthStateKind::Unknown);
+    }
+
+    #[test]
+    fn claude_falls_back_to_username_when_email_missing() {
+        let json = r#"{"loggedIn":true,"username":"alice"}"#;
+        let s = parse_claude_auth_output(json);
+        assert_eq!(s.state, AuthStateKind::Connected);
+        assert_eq!(s.identity.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn codex_logged_in_with_chatgpt() {
+        let s = parse_codex_auth_output("Logged in using ChatGPT\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+    }
+
+    #[test]
+    fn codex_logged_in_with_api_key() {
+        let s = parse_codex_auth_output("Logged in using API key\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+    }
+
+    #[test]
+    fn codex_not_logged_in() {
+        let s = parse_codex_auth_output("Not logged in\n");
+        assert_eq!(s.state, AuthStateKind::Disconnected);
+    }
+
+    #[test]
+    fn codex_handles_ansi_escapes() {
+        let s = parse_codex_auth_output("\u{1b}[1mLogged in using ChatGPT\u{1b}[0m\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+    }
+
+    #[test]
+    fn codex_extracts_email_when_present() {
+        let s = parse_codex_auth_output("Logged in as alice@example.com\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+        assert_eq!(s.identity.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn codex_returns_unknown_on_unrecognized() {
+        let s = parse_codex_auth_output("whatever new wording\n");
+        assert_eq!(s.state, AuthStateKind::Unknown);
+    }
+
+    #[test]
+    fn codex_ignores_leading_blank_lines() {
+        let s = parse_codex_auth_output("\n\n  \nLogged in using ChatGPT\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+    }
+
+    #[test]
+    fn auth_output_prefers_stdout_when_present() {
+        let out = AuthCommandOutput {
+            stdout: "Logged in using API key (sk-…)\n".to_string(),
+            stderr: String::new(),
+        };
+        assert_eq!(out.primary_text(), "Logged in using API key (sk-…)\n");
+    }
+
+    #[test]
+    fn auth_output_falls_back_to_stderr_when_stdout_empty() {
+        let out = AuthCommandOutput {
+            stdout: String::new(),
+            stderr: "Logged in using ChatGPT\n".to_string(),
+        };
+        assert_eq!(out.primary_text(), "Logged in using ChatGPT\n");
+        let parsed = parse_codex_auth_output(out.primary_text());
+        assert_eq!(parsed.state, AuthStateKind::Connected);
+    }
+
+    #[test]
+    fn auth_output_uses_stdout_when_only_whitespace_on_stderr() {
+        let out = AuthCommandOutput {
+            stdout: "Logged in using ChatGPT\n".to_string(),
+            stderr: "  \n".to_string(),
+        };
+        assert_eq!(out.primary_text(), "Logged in using ChatGPT\n");
+    }
+
+    #[test]
+    fn auth_output_returns_empty_when_both_streams_empty() {
+        let out = AuthCommandOutput {
+            stdout: String::new(),
+            stderr: String::new(),
+        };
+        assert!(out.primary_text().trim().is_empty());
+    }
+
+    #[test]
+    #[ignore = "requires real codex binary + active login; opt in via KAYAM_TEST_REAL_CODEX=1"]
+    fn codex_real_auth_detection_works() {
+        if std::env::var("KAYAM_TEST_REAL_CODEX")
+            .map(|v| v.is_empty())
+            .unwrap_or(true)
+        {
+            return;
+        }
+        let auth = check_codex_auth();
+        assert!(
+            !matches!(auth.state, AuthStateKind::Unknown),
+            "expected Connected or Disconnected, got Unknown — \
+             auth detection regressed (likely back to stdout-only routing)"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/repo.rs
+++ b/apps/desktop/src-tauri/src/repo.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::process::Command;
 
 use serde::Serialize;
 
@@ -22,7 +21,7 @@ pub fn validate_git_repo(path: String) -> GitRepoCheck {
             error: Some(format!("path does not exist: {path}")),
         };
     }
-    let output = match Command::new("git")
+    let output = match crate::path_env::command("git")
         .args(["rev-parse", "--show-toplevel"])
         .current_dir(candidate)
         .output()

--- a/apps/desktop/src-tauri/src/skills.rs
+++ b/apps/desktop/src-tauri/src/skills.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -540,7 +539,7 @@ pub fn skill_run_script(input: SkillRunScriptInput) -> Result<SkillRunScriptResu
     let script_path = PathBuf::from(&input.script_path);
     let canonical = guard_path(&script_path, &allowed_prefix)?;
 
-    let output = Command::new("bash")
+    let output = crate::path_env::command("bash")
         .arg(&canonical)
         .args(&input.args)
         .current_dir(&input.working_dir)

--- a/apps/desktop/src-tauri/src/summarize.rs
+++ b/apps/desktop/src-tauri/src/summarize.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -58,7 +58,7 @@ pub async fn summarize_task(args: SummarizeArgs) -> Result<SummarizeResult, Summ
     tauri::async_runtime::spawn_blocking(move || {
         let cli_args = build_cli_args(&args)?;
 
-        let output = Command::new(&args.binary)
+        let output = crate::path_env::command(&args.binary)
             .args(&cli_args)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -99,9 +99,11 @@ fn build_cli_args(args: &SummarizeArgs) -> Result<Vec<String>, SummarizeError> {
         "codex" => Ok(vec![
             "exec".to_string(),
             "--json".to_string(),
-            "--model".to_string(),
+            "-m".to_string(),
             args.model.clone(),
-            "--".to_string(),
+            "-s".to_string(),
+            "read-only".to_string(),
+            "--skip-git-repo-check".to_string(),
             format!("{}\n\n{}", args.system_prompt, args.user_message),
         ]),
         other => Err(SummarizeError::UnknownProvider(other.to_string())),

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
-use std::process::{Child, ChildStderr, ChildStdout, Command, Stdio};
+use std::process::{Child, ChildStderr, ChildStdout, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -101,13 +101,7 @@ pub struct TurnEventEnvelope {
 
 pub const EVENT_NAME: &str = "turn_event";
 
-/// Build per-binary CLI args. The Tauri side spawns the binary directly, so
-/// flag shapes have to match each CLI: claude code uses `-p / --output-format
-/// stream-json / --permission-mode / --allowedTools / --disallowedTools`,
-/// cursor-agent uses `-p / --output-format stream-json / --workspace /
-/// --model / --force`, and codex uses `exec --json --model --cwd -- prompt`.
-/// Falls back to claude flags for unknown binaries to preserve previous
-/// behaviour.
+/// Per-binary CLI flag set. Unknown binaries fall through to claude.
 fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String> {
     let bin = std::path::Path::new(binary)
         .file_name()
@@ -116,6 +110,7 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
 
     match bin {
         "cursor-agent" => {
+            // --force is cursor's equivalent of claude --dangerously-skip-permissions.
             let mut v = vec![
                 "-p".to_string(),
                 args.prompt.to_string(),
@@ -125,13 +120,9 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
                 args.working_dir.to_string(),
                 "--model".to_string(),
                 args.model.to_string(),
-                // matches the claude --dangerously-skip-permissions: cursor-agent
-                // runs tools without interactive confirmation.
                 "--force".to_string(),
             ];
-            // permission rules + permission_mode + resume + system_prompt aren't
-            // supported by cursor-agent today; intentionally dropped here to
-            // avoid unknown-flag errors.
+            // cursor-agent ignores permission rules + resume + system_prompt.
             let _ = (
                 args.permission_mode,
                 args.allowed_tools,
@@ -143,25 +134,34 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
             v
         }
         "codex" => {
-            // codex exec takes a single prompt argument after `--`. permission
-            // rules + resume + system_prompt aren't supported by the codex CLI
-            // yet.
+            // codex exec v0.130 gotchas:
+            //   --cd, NOT --cwd (codex exits 1 with "unexpected argument").
+            //   --skip-git-repo-check, else codex refuses non-trusted dirs.
+            //   default sandbox is read-only and silently drops writes; force
+            //     workspace-write unless bypass replaces it entirely.
             let _ = (args.resume_session_id, args.system_prompt);
-            vec![
+            let mut v: Vec<String> = vec![
                 "exec".to_string(),
                 "--json".to_string(),
+                "--skip-git-repo-check".to_string(),
                 "--model".to_string(),
                 args.model.to_string(),
-                "--cwd".to_string(),
+                "--cd".to_string(),
                 args.working_dir.to_string(),
-                "--".to_string(),
-                args.prompt.to_string(),
-            ]
+            ];
+            if args.permission_mode == "bypassPermissions" {
+                v.push("--dangerously-bypass-approvals-and-sandbox".to_string());
+            } else {
+                v.push("-s".to_string());
+                v.push("workspace-write".to_string());
+            }
+            v.push("--".to_string());
+            v.push(args.prompt.to_string());
+            v
         }
         _ => {
-            // claude (default).
             let mut v: Vec<String> = Vec::new();
-            // --resume must come before -p so claude restores the prior session
+            // --resume must precede -p so claude restores the prior session
             // before consuming the new user message.
             if let Some(sid) = args.resume_session_id {
                 v.push("--resume".to_string());
@@ -229,7 +229,7 @@ pub(crate) fn spawn_one(
         );
     }
 
-    let mut command = Command::new(args.binary);
+    let mut command = crate::path_env::command(args.binary);
     command
         .current_dir(args.working_dir)
         // Strip env vars that signal "running inside another Claude Code /
@@ -245,6 +245,15 @@ pub(crate) fn spawn_one(
     let cli_args = build_provider_cli_args(args.binary, &args);
     for a in &cli_args {
         command.arg(a);
+    }
+
+    let codex_debug = args.binary == "codex"
+        && std::env::var("KAYAM_DEBUG_CODEX").map(|v| !v.is_empty()).unwrap_or(false);
+    if codex_debug {
+        eprintln!(
+            "[codex-debug] turn args binary={:?} cwd={:?} cli_args={:?}",
+            args.binary, args.working_dir, cli_args
+        );
     }
 
     let mut child = command
@@ -275,6 +284,14 @@ pub(crate) fn spawn_one(
         forward_lines(&app_clone, &run_id_owned, stdout);
         let stderr_buf = capture_stderr(stderr);
         let exit_code = wait_and_remove(&slot, &registry_clone, &run_id_owned);
+        if codex_debug {
+            eprintln!(
+                "[codex-debug] turn exit={:?} stderr_bytes={} stderr_tail={:?}",
+                exit_code,
+                stderr_buf.len(),
+                stderr_buf.lines().rev().take(5).collect::<Vec<_>>(),
+            );
+        }
         let _ = app_clone.emit(
             EVENT_NAME,
             TurnEventEnvelope {
@@ -477,6 +494,47 @@ mod tests {
     }
 
     #[test]
+    fn codex_args_use_cd_not_cwd() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        let cli = build_provider_cli_args("codex", &args);
+        assert!(cli.iter().any(|a| a == "--cd"));
+        assert!(!cli.iter().any(|a| a == "--cwd"));
+        let idx = cli.iter().position(|a| a == "--cd").expect("--cd");
+        assert_eq!(cli[idx + 1], "/tmp");
+    }
+
+    #[test]
+    fn codex_args_always_skip_git_repo_check() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        let cli = build_provider_cli_args("codex", &args);
+        assert!(cli.iter().any(|a| a == "--skip-git-repo-check"));
+    }
+
+    #[test]
+    fn codex_args_default_to_workspace_write_sandbox() {
+        let empty: Vec<String> = vec![];
+        let args = make_args(None, None, &empty);
+        let cli = build_provider_cli_args("codex", &args);
+        let idx = cli.iter().position(|a| a == "-s").expect("-s");
+        assert_eq!(cli[idx + 1], "workspace-write");
+        assert!(!cli.iter().any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
+    }
+
+    #[test]
+    fn codex_args_bypass_replaces_sandbox_flag() {
+        let empty: Vec<String> = vec![];
+        let mut args = make_args(None, None, &empty);
+        args.binary = "codex";
+        args.permission_mode = "bypassPermissions";
+        let cli = build_provider_cli_args("codex", &args);
+        assert!(cli.iter().any(|a| a == "--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!cli.iter().any(|a| a == "-s"));
+        assert!(cli.iter().any(|a| a == "--skip-git-repo-check"));
+    }
+
+    #[test]
     fn cursor_and_codex_ignore_resume_and_system_prompt() {
         let empty: Vec<String> = vec![];
         let args = make_args(Some("sid"), Some("sp"), &empty);
@@ -484,5 +542,60 @@ mod tests {
         let cli_codex = build_provider_cli_args("codex", &args);
         assert!(!cli_cursor.iter().any(|a| a == "--resume" || a == "--append-system-prompt"));
         assert!(!cli_codex.iter().any(|a| a == "--resume" || a == "--append-system-prompt"));
+    }
+
+    #[test]
+    #[ignore = "requires real codex binary + active login; opt in via KAYAM_TEST_REAL_CODEX=1"]
+    fn codex_real_spawn_emits_json_events() {
+        if std::env::var("KAYAM_TEST_REAL_CODEX")
+            .map(|v| v.is_empty())
+            .unwrap_or(true)
+        {
+            return;
+        }
+        let allowed: Vec<String> = vec![];
+        let disallowed: Vec<String> = vec![];
+        let args = SpawnOneArgs {
+            run_id: "smoke-test",
+            binary: "codex",
+            model: "gpt-5.5",
+            working_dir: "/tmp",
+            prompt: "say hello",
+            permission_mode: "default",
+            allowed_tools: &allowed,
+            disallowed_tools: &disallowed,
+            resume_session_id: None,
+            system_prompt: None,
+        };
+        let cli = build_provider_cli_args("codex", &args);
+        let out = std::process::Command::new("codex")
+            .args(&cli)
+            .output()
+            .expect("spawn codex");
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(
+            out.status.success(),
+            "codex exited {:?}\nstdout: {}\nstderr: {}",
+            out.status.code(),
+            stdout,
+            stderr
+        );
+        assert!(
+            stdout.contains(r#""type":"thread.started""#),
+            "missing thread.started in stdout: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains(r#""type":"item.completed""#),
+            "missing item.completed in stdout: {}",
+            stdout
+        );
+        assert!(
+            stdout.contains(r#""type":"turn.completed""#),
+            "missing turn.completed in stdout: {}",
+            stdout
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -234,7 +233,7 @@ fn ensure_gitignore_entry(repo_path: &Path, entry: &str) -> Result<(), WorktreeE
 }
 
 fn git(cwd: &Path, args: &[&str]) -> Result<String, WorktreeError> {
-    let output = Command::new("git").args(args).current_dir(cwd).output()?;
+    let output = crate::path_env::command("git").args(args).current_dir(cwd).output()?;
     if !output.status.success() {
         let stderr = String::from_utf8(output.stderr).unwrap_or_default();
         return Err(WorktreeError::Git {

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -16,11 +16,16 @@ vi.mock('../store', () => ({
     selector({
       sendTurn: sendTurnMock,
       cancelCurrentTurn: cancelCurrentTurnMock,
-      providers: [{ id: 'anthropic', connection: 'connected' }],
+      providers: [
+        { id: 'anthropic', connection: 'connected' },
+        { id: 'cursor', connection: 'connected' },
+        { id: 'codex', connection: 'connected' },
+      ],
       skills: {},
       providerSpendBreakdown: [],
       selectedAgentId: {},
       agentTurnState: {},
+      agentModelOverride: {},
     }),
   EMPTY_ARRAY: [] as never[],
 }));
@@ -161,5 +166,30 @@ describe('ChatInput — input wiring', () => {
 
     expect(sendTurnMock).toHaveBeenCalledOnce();
     expect(sendTurnMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'hi there' }));
+  });
+
+  it('provider override persists across sends (regression for bug D)', async () => {
+    // Pre-populate localStorage: user previously picked cursor for this session.
+    localStorage.setItem('kayam:provider:session-1', 'cursor');
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        session={makeSession({
+          providerPreference: {
+            defaultProvider: 'anthropic' as Task['providerPreference']['defaultProvider'],
+            allowTurnOverride: true,
+          },
+        })}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello cursor');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledOnce();
+    // After send, the selected provider must still be cursor (not reset to anthropic).
+    expect(localStorage.getItem('kayam:provider:session-1')).toBe('cursor');
   });
 });

--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { parseModelId } from '../components/chat/chat-constants';
+
+describe('parseModelId', () => {
+  it('canonical anthropic ids: family/subfamily/variant', () => {
+    expect(parseModelId('claude-haiku-4-5')).toEqual({
+      family: 'claude',
+      subfamily: 'haiku',
+      variantLabel: '4.5',
+    });
+    expect(parseModelId('claude-sonnet-4-6')).toEqual({
+      family: 'claude',
+      subfamily: 'sonnet',
+      variantLabel: '4.6',
+    });
+    expect(parseModelId('claude-opus-4-7')).toEqual({
+      family: 'claude',
+      subfamily: 'opus',
+      variantLabel: '4.7',
+    });
+  });
+
+  it('cursor anthropic naming (version-first)', () => {
+    expect(parseModelId('claude-4.6-sonnet-medium')).toEqual({
+      family: 'claude',
+      subfamily: 'sonnet',
+      variantLabel: '4.6 medium',
+    });
+    expect(parseModelId('claude-4.6-sonnet-high')).toEqual({
+      family: 'claude',
+      subfamily: 'sonnet',
+      variantLabel: '4.6 high',
+    });
+    expect(parseModelId('claude-4.6-opus-high-thinking')).toEqual({
+      family: 'claude',
+      subfamily: 'opus',
+      variantLabel: '4.6 high thinking',
+    });
+  });
+
+  it('canonical anthropic with trailing variant suffix', () => {
+    expect(parseModelId('claude-opus-4-7-thinking-high')).toEqual({
+      family: 'claude',
+      subfamily: 'opus',
+      variantLabel: '4.7',
+    });
+  });
+
+  it('composer family', () => {
+    expect(parseModelId('composer-2')).toEqual({
+      family: 'composer',
+      subfamily: null,
+      variantLabel: '2',
+    });
+    expect(parseModelId('composer-2-fast')).toEqual({
+      family: 'composer',
+      subfamily: null,
+      variantLabel: '2-fast',
+    });
+  });
+
+  it('cursor auto', () => {
+    expect(parseModelId('auto')).toEqual({
+      family: 'cursor-auto',
+      subfamily: null,
+      variantLabel: 'auto',
+    });
+  });
+
+  it('gpt-X.Y with variant', () => {
+    expect(parseModelId('gpt-5.5-high')).toEqual({
+      family: 'gpt',
+      subfamily: '5.5',
+      variantLabel: 'high',
+    });
+    expect(parseModelId('gpt-5.5-medium')).toEqual({
+      family: 'gpt',
+      subfamily: '5.5',
+      variantLabel: 'medium',
+    });
+  });
+
+  it('gpt-X.Y-codex isolates into its own subfamily', () => {
+    expect(parseModelId('gpt-5.3-codex')).toEqual({
+      family: 'gpt',
+      subfamily: '5.3-codex',
+      variantLabel: 'codex',
+    });
+  });
+
+  it('codex turn-tier models (gpt-5.4-mini, gpt-5.5)', () => {
+    expect(parseModelId('gpt-5.4-mini')).toEqual({
+      family: 'gpt',
+      subfamily: '5.4',
+      variantLabel: 'mini',
+    });
+    expect(parseModelId('gpt-5.5')).toEqual({
+      family: 'gpt',
+      subfamily: '5.5',
+      variantLabel: '5.5',
+    });
+  });
+
+  it('provider/model prefix — strips the provider prefix before parsing', () => {
+    expect(parseModelId('anthropic/claude-sonnet-4-6')).toEqual({
+      family: 'claude',
+      subfamily: 'sonnet',
+      variantLabel: '4.6',
+    });
+    expect(parseModelId('github-copilot/gpt-5.4')).toEqual({
+      family: 'gpt',
+      subfamily: '5.4',
+      variantLabel: '5.4',
+    });
+  });
+
+  it('falls back to other for unknown shapes', () => {
+    const parsed = parseModelId('something-weird');
+    expect(parsed.family).toBe('other');
+    expect(parsed.subfamily).toBeNull();
+  });
+});

--- a/apps/desktop/src/__tests__/errors.test.ts
+++ b/apps/desktop/src/__tests__/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { formatError } from '../errors';
+
+describe('formatError', () => {
+  it('extracts .message from Error instance', () => {
+    expect(formatError(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns string unchanged', () => {
+    expect(formatError('plain string')).toBe('plain string');
+  });
+
+  it('extracts .message from tauri-style error object', () => {
+    const tauriErr = { kind: 'io', message: 'No such file or directory' };
+    expect(formatError(tauriErr)).toBe('No such file or directory');
+  });
+
+  it('falls back to JSON for objects without .message', () => {
+    expect(formatError({ kind: 'mystery', code: 42 })).toContain('"kind"');
+  });
+
+  it('returns json for null', () => {
+    expect(formatError(null)).toBe('null');
+  });
+
+  it('handles non-string message field by JSON-encoding the object', () => {
+    expect(formatError({ message: 42 })).toContain('"message"');
+  });
+
+  it('never returns "[object Object]" for plain objects', () => {
+    expect(formatError({ kind: 'io' })).not.toBe('[object Object]');
+  });
+});

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -278,7 +278,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               <textarea
                 class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
                 placeholder="refactor auth domain"
-                style="height: 96px; overflow-y: hidden;"
+                style="overflow-y: hidden;"
               />
               <p
                 class="text-xs leading-relaxed text-muted-foreground"
@@ -523,33 +523,83 @@ exports[`snapshot — empty states > ProvidersPanel: no providers (store returns
     <div
       class="text-xs font-semibold text-foreground"
     >
-      providers
+      Providers
     </div>
-    <button
-      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
-      title="re-detect installed CLIs"
-      type="button"
+    <span
+      class="relative inline-flex"
     >
-      refresh all
-    </button>
+      <button
+        aria-label="Re-detect installed CLIs"
+        class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-rotate-cw"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"
+          />
+          <path
+            d="M21 3v5h-5"
+          />
+        </svg>
+      </button>
+    </span>
   </div>
   <p
     class="text-2xs text-muted-foreground"
   >
-    no providers configured
+    No providers configured
   </p>
-  <p
-    class="text-xs text-muted-foreground"
+  <div
+    class="flex items-start gap-1.5 text-2xs text-muted-foreground"
   >
-    kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run
-     
-    <code
-      class="rounded bg-muted px-1"
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-info mt-0.5 shrink-0"
+      fill="none"
+      height="11"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="11"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      claude
-    </code>
-     in a terminal once).
-  </p>
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+      />
+      <path
+        d="M12 16v-4"
+      />
+      <path
+        d="M12 8h.01"
+      />
+    </svg>
+    <span>
+      Sign in once via each provider's CLI (e.g. run
+       
+      <code
+        class="rounded bg-muted px-1"
+      >
+        claude
+      </code>
+       in a terminal). kay-am picks up the credentials.
+    </span>
+  </div>
 </div>
 `;
 
@@ -563,7 +613,7 @@ exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
     <div
       class="text-xs font-semibold text-foreground"
     >
-      skills
+      Skills
     </div>
     <div
       class="flex items-center gap-2"
@@ -572,20 +622,20 @@ exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
         type="button"
       >
-        rescan
+        Rescan
       </button>
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
         type="button"
       >
-        new skill
+        New skill
       </button>
     </div>
   </div>
   <p
     class="text-2xs text-muted-foreground"
   >
-    no skills for this workspace. create one or rescan the workspace directory.
+    No skills for this workspace. Create one or rescan the workspace directory.
   </p>
 </div>
 `;
@@ -2061,19 +2111,19 @@ exports[`snapshot — error states > BudgetRulesPanel: form error 1`] = `
     <div
       class="text-xs font-semibold text-foreground"
     >
-      budget rules
+      Budget rules
     </div>
     <button
       class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
       type="button"
     >
-      add rule
+      Add rule
     </button>
   </div>
   <p
     class="text-xs text-muted-foreground"
   >
-    no rules defined. add one to cap monthly spend per provider.
+    No rules defined. Add one to cap monthly spend per provider.
   </p>
 </div>
 `;
@@ -2431,7 +2481,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               <textarea
                 class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
                 placeholder="refactor auth domain"
-                style="height: 96px; overflow-y: hidden;"
+                style="overflow-y: hidden;"
               />
               <p
                 class="text-xs leading-relaxed text-muted-foreground"
@@ -2637,46 +2687,69 @@ exports[`snapshot — error states > ProvidersPanel: provider in error state 1`]
     <div
       class="text-xs font-semibold text-foreground"
     >
-      providers
+      Providers
     </div>
-    <button
-      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs"
-      title="re-detect installed CLIs"
-      type="button"
+    <span
+      class="relative inline-flex"
     >
-      refresh all
-    </button>
+      <button
+        aria-label="Re-detect installed CLIs"
+        class="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-rotate-cw"
+          fill="none"
+          height="14"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="14"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"
+          />
+          <path
+            d="M21 3v5h-5"
+          />
+        </svg>
+      </button>
+    </span>
   </div>
   <div
-    class="grid grid-cols-3 gap-3"
+    class="grid grid-cols-3 gap-2.5"
   >
     <div
-      class="relative flex min-h-[200px] flex-col items-center gap-2.5 overflow-hidden rounded-lg border bg-subtle p-4 shadow-sm transition-colors"
+      class="relative flex flex-col items-center gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
     >
       <span
         class="relative inline-flex"
       >
         <span
           aria-hidden="true"
-          class="absolute left-3 top-3 inline-block h-2 w-2 shrink-0 rounded-full bg-danger"
+          class="absolute left-2.5 top-2.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-danger"
         />
       </span>
       <div
         aria-hidden="true"
-        class="mt-2 flex h-14 w-14 items-center justify-center rounded-full transition-opacity"
+        class="mt-1 flex h-10 w-10 items-center justify-center rounded-full transition-opacity"
         style="color: var(--color-provider-anthropic);"
       >
         <svg
           aria-hidden="true"
           class="lucide lucide-sparkles"
           fill="none"
-          height="26"
+          height="18"
           stroke="currentColor"
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
           viewBox="0 0 24 24"
-          width="26"
+          width="18"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
@@ -2716,29 +2789,56 @@ exports[`snapshot — error states > ProvidersPanel: provider in error state 1`]
         unknown error
       </div>
       <div
-        class="mt-auto w-full"
+        class="mt-1 w-full"
       >
         <button
           class="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
           type="button"
         >
-          retry
+          Retry
         </button>
       </div>
     </div>
   </div>
-  <p
-    class="text-xs text-muted-foreground"
+  <div
+    class="flex items-start gap-1.5 text-2xs text-muted-foreground"
   >
-    kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run
-     
-    <code
-      class="rounded bg-muted px-1"
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-info mt-0.5 shrink-0"
+      fill="none"
+      height="11"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="11"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      claude
-    </code>
-     in a terminal once).
-  </p>
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+      />
+      <path
+        d="M12 16v-4"
+      />
+      <path
+        d="M12 8h.01"
+      />
+    </svg>
+    <span>
+      Sign in once via each provider's CLI (e.g. run
+       
+      <code
+        class="rounded bg-muted px-1"
+      >
+        claude
+      </code>
+       in a terminal). kay-am picks up the credentials.
+    </span>
+  </div>
 </div>
 `;
 

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -2648,65 +2648,82 @@ exports[`snapshot — error states > ProvidersPanel: provider in error state 1`]
     </button>
   </div>
   <div
-    class="flex flex-col gap-2"
+    class="grid grid-cols-3 gap-3"
   >
     <div
-      class="flex flex-col gap-2 overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm"
+      class="relative flex min-h-[200px] flex-col items-center gap-2.5 overflow-hidden rounded-lg border bg-subtle p-4 shadow-sm transition-colors"
     >
-      <div
-        class="flex items-center gap-3 border-b border-border-soft px-3 py-2"
+      <span
+        class="relative inline-flex"
       >
         <span
           aria-hidden="true"
-          class="inline-block h-2 w-2 shrink-0 rounded-full bg-danger"
+          class="absolute left-3 top-3 inline-block h-2 w-2 shrink-0 rounded-full bg-danger"
         />
-        <div
-          class="flex min-w-0 flex-1 flex-col gap-0.5"
+      </span>
+      <div
+        aria-hidden="true"
+        class="mt-2 flex h-14 w-14 items-center justify-center rounded-full transition-opacity"
+        style="color: var(--color-provider-anthropic);"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sparkles"
+          fill="none"
+          height="26"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="26"
+          xmlns="http://www.w3.org/2000/svg"
         >
-          <div
-            class="flex items-center gap-2"
-          >
-            <span
-              class="text-xs font-semibold"
-            >
-              claude
-            </span>
-            <code
-              class="text-2xs text-muted-foreground"
-            >
-              claude
-            </code>
-            <span
-              class="rounded bg-muted px-1 text-2xs text-muted-foreground"
-            >
-              1.0.0
-            </span>
-          </div>
-          <span
-            class="text-2xs text-muted-foreground"
-          >
-            anthropic claude code cli
-          </span>
-        </div>
+          <path
+            d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+          />
+          <path
+            d="M20 2v4"
+          />
+          <path
+            d="M22 4h-4"
+          />
+          <circle
+            cx="4"
+            cy="20"
+            r="2"
+          />
+        </svg>
+      </div>
+      <div
+        class="flex flex-col items-center gap-0.5"
+      >
+        <span
+          class="text-sm font-semibold lowercase"
+        >
+          claude
+        </span>
+        <span
+          class="text-2xs text-muted-foreground"
+        >
+          1.0.0
+        </span>
+      </div>
+      <div
+        class="line-clamp-2 text-center text-2xs text-danger"
+        title="unknown error"
+      >
+        unknown error
+      </div>
+      <div
+        class="mt-auto w-full"
+      >
         <button
-          class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-7 px-2.5 text-xs shrink-0"
+          class="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
           type="button"
         >
           retry
         </button>
-      </div>
-      <div
-        class="flex flex-col gap-1.5 px-3 pb-2.5"
-      >
-        <div
-          class="text-xs"
-        >
-          <span
-            class="text-danger"
-          >
-            unknown error
-          </span>
-        </div>
       </div>
     </div>
   </div>

--- a/apps/desktop/src/components/BudgetRulesPanel.tsx
+++ b/apps/desktop/src/components/BudgetRulesPanel.tsx
@@ -81,17 +81,17 @@ export function BudgetRulesPanel() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold text-foreground">budget rules</div>
+        <div className="text-xs font-semibold text-foreground">Budget rules</div>
         {!showForm && (
           <Button variant="ghost" size="sm" onClick={() => setShowForm(true)}>
-            add rule
+            Add rule
           </Button>
         )}
       </div>
 
       {budgetRules.length === 0 && !showForm && (
         <p className="text-xs text-muted-foreground">
-          no rules defined. add one to cap monthly spend per provider.
+          No rules defined. Add one to cap monthly spend per provider.
         </p>
       )}
 
@@ -224,10 +224,10 @@ function AddRuleForm({
 
       <div className="flex items-center justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
-          cancel
+          Cancel
         </Button>
         <Button size="sm" onClick={onSave} disabled={saving}>
-          {saving ? 'saving…' : 'save'}
+          {saving ? 'Saving…' : 'Save'}
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/components/IntegrationsPanel.tsx
+++ b/apps/desktop/src/components/IntegrationsPanel.tsx
@@ -55,7 +55,7 @@ function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
   };
 
   if (cardState === 'loading') {
-    return <p className="text-xs text-muted-foreground">checking…</p>;
+    return <p className="text-xs text-muted-foreground">Checking…</p>;
   }
 
   if (cardState === 'connected') {
@@ -64,7 +64,7 @@ function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
         <div className="rounded-md border border-success/40 bg-success/10 px-3 py-2.5 text-xs text-success">
           <div className="flex items-center gap-2">
             <Check size={13} aria-hidden />
-            <span className="font-medium">connected</span>
+            <span className="font-medium">Connected</span>
           </div>
         </div>
         <div className="flex justify-end">
@@ -75,7 +75,7 @@ function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
             disabled={saveState === 'saving'}
             className={cn(saveState === 'saving' && 'opacity-60')}
           >
-            disconnect
+            Disconnect
           </Button>
         </div>
         {error ? <ErrorBanner>{error}</ErrorBanner> : null}
@@ -103,12 +103,12 @@ function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
           {saveState === 'saving' ? (
             <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
           ) : null}
-          connect
+          Connect
         </Button>
       </div>
       {error ? <ErrorBanner>{error}</ErrorBanner> : null}
       <p className="text-[10px] text-muted-foreground">
-        stored in your OS keychain. never leaves your machine.
+        Stored in your OS keychain. Never leaves your machine.
       </p>
     </div>
   );
@@ -179,7 +179,7 @@ function JiraCard() {
   };
 
   if (cardState === 'loading') {
-    return <p className="text-xs text-muted-foreground">checking…</p>;
+    return <p className="text-xs text-muted-foreground">Checking…</p>;
   }
 
   if (cardState === 'connected') {
@@ -189,7 +189,7 @@ function JiraCard() {
           <div className="flex items-center gap-2">
             <Check size={13} aria-hidden />
             <span className="font-medium">
-              connected{connectedDomain ? ` · ${connectedDomain}` : ''}
+              Connected{connectedDomain ? ` · ${connectedDomain}` : ''}
             </span>
           </div>
         </div>
@@ -201,7 +201,7 @@ function JiraCard() {
             disabled={saveState === 'saving'}
             className={cn(saveState === 'saving' && 'opacity-60')}
           >
-            disconnect
+            Disconnect
           </Button>
         </div>
         {error ? <ErrorBanner>{error}</ErrorBanner> : null}
@@ -250,13 +250,13 @@ function JiraCard() {
             {saveState === 'saving' ? (
               <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
             ) : null}
-            connect
+            Connect
           </Button>
         </div>
       </div>
       {error ? <ErrorBanner>{error}</ErrorBanner> : null}
       <p className="text-[10px] text-muted-foreground">
-        stored in your OS keychain. never leaves your machine.
+        Stored in your OS keychain. Never leaves your machine.
       </p>
     </div>
   );

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -21,6 +21,7 @@ import type {
   TaskProviderPreference,
   WorkspaceId,
 } from '@kay-am/types';
+import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@kay-am/core';
 import { shortModel } from '../agentRowFormat';
 import { PROVIDER_LABEL_LOWER } from '../providers';
 import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../settings';
@@ -96,9 +97,9 @@ function getCheapModel(providerId: ProviderId): string {
     case 'anthropic':
       return 'claude-haiku-4-5';
     case 'cursor':
-      return 'claude-haiku-4-5';
+      return 'composer-2-fast';
     case 'codex':
-      return 'o4-mini';
+      return 'gpt-5.4-mini';
     default: {
       const _exhaustive: never = providerId;
       void _exhaustive;
@@ -223,6 +224,17 @@ export function NewSessionDialog({
     const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
     return pickDefaultProvider(ids);
   });
+  const [selectedModel, setSelectedModel] = useState<string>(() =>
+    getDefaultTurnModel(
+      pickDefaultProvider(
+        new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
+      ),
+    ),
+  );
+
+  useEffect(() => {
+    setSelectedModel(getDefaultTurnModel(selectedProvider));
+  }, [selectedProvider]);
 
   useEffect(() => {
     if (!open) return;
@@ -241,7 +253,9 @@ export function NewSessionDialog({
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
     const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
-    setSelectedProvider(pickDefaultProvider(ids));
+    const provider = pickDefaultProvider(ids);
+    setSelectedProvider(provider);
+    setSelectedModel(getDefaultTurnModel(provider));
   }, [open, settingKey, loadSetting, providers, workspaceId]);
 
   const handleGenerateSlug = () => {
@@ -311,6 +325,7 @@ export function NewSessionDialog({
     try {
       const providerPreference: TaskProviderPreference = {
         defaultProvider: selectedProvider,
+        defaultModel: selectedModel,
         allowTurnOverride: true,
       };
       const hasWorkflow = selectedPhaseTemplateId !== '';
@@ -683,61 +698,93 @@ export function NewSessionDialog({
           ) : null}
 
           {activeSection === 'provider' ? (
-            <Field label="provider">
-              <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border">
-                {PROVIDER_ORDER.map((id) => {
-                  const connected = connectedProviderIds.has(id);
-                  const disabled = !connected;
-                  const selected = selectedProvider === id;
-                  return (
-                    <li
-                      key={id}
-                      className={cn(
-                        'flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors',
-                        disabled ? 'opacity-50' : 'hover:bg-muted/40',
-                        selected && !disabled ? 'bg-muted/60' : '',
-                      )}
-                    >
-                      <input
-                        type="radio"
-                        name="provider"
-                        id={`provider-${id}`}
-                        value={id}
-                        checked={selected}
-                        disabled={disabled}
-                        onChange={() => setSelectedProvider(id)}
-                        className="accent-primary"
-                      />
-                      <label
-                        htmlFor={`provider-${id}`}
+            <div className="flex flex-col gap-4">
+              <Field label="provider">
+                <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border">
+                  {PROVIDER_ORDER.map((id) => {
+                    const connected = connectedProviderIds.has(id);
+                    const disabled = !connected;
+                    const selected = selectedProvider === id;
+                    return (
+                      <li
+                        key={id}
                         className={cn(
-                          'flex flex-1 items-center justify-between',
-                          disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                          'flex items-center gap-2 px-3 py-2 text-sm motion-safe:transition-colors',
+                          disabled ? 'opacity-50' : 'hover:bg-muted/40',
+                          selected && !disabled ? 'bg-muted/60' : '',
                         )}
                       >
-                        <span className="font-medium">{PROVIDER_LABEL_LOWER[id]}</span>
-                        {!connected && (
-                          <button
-                            type="button"
-                            className="text-xs text-primary underline hover:opacity-80"
-                            onClick={() => {
-                              onClose();
-                              window.dispatchEvent(
-                                new CustomEvent('kayam:open-settings', {
-                                  detail: { section: 'providers' },
-                                }),
-                              );
-                            }}
-                          >
-                            connect in settings
-                          </button>
-                        )}
-                      </label>
-                    </li>
-                  );
-                })}
-              </ul>
-            </Field>
+                        <input
+                          type="radio"
+                          name="provider"
+                          id={`provider-${id}`}
+                          value={id}
+                          checked={selected}
+                          disabled={disabled}
+                          onChange={() => setSelectedProvider(id)}
+                          className="accent-primary"
+                        />
+                        <label
+                          htmlFor={`provider-${id}`}
+                          className={cn(
+                            'flex flex-1 items-center justify-between',
+                            disabled ? 'cursor-not-allowed' : 'cursor-pointer',
+                          )}
+                        >
+                          <span className="font-medium">{PROVIDER_LABEL_LOWER[id]}</span>
+                          {!connected && (
+                            <button
+                              type="button"
+                              className="text-xs text-primary underline hover:opacity-80"
+                              onClick={() => {
+                                onClose();
+                                window.dispatchEvent(
+                                  new CustomEvent('kayam:open-settings', {
+                                    detail: { section: 'providers' },
+                                  }),
+                                );
+                              }}
+                            >
+                              connect in settings
+                            </button>
+                          )}
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </Field>
+              <Field
+                label="model"
+                hint="default model for turns. each agent can override at spawn."
+              >
+                <select
+                  value={selectedModel}
+                  onChange={(e) => setSelectedModel(e.target.value)}
+                  disabled={busy || !providerReady}
+                  className="rounded-md border border-border bg-background px-3 py-2 text-sm motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  <optgroup label="turn">
+                    {PROVIDER_CAPABILITIES[selectedProvider].models
+                      .filter((m) => m.tier === 'turn')
+                      .map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {shortModel(m.id)}
+                        </option>
+                      ))}
+                  </optgroup>
+                  <optgroup label="cheap">
+                    {PROVIDER_CAPABILITIES[selectedProvider].models
+                      .filter((m) => m.tier === 'cheap')
+                      .map((m) => (
+                        <option key={m.id} value={m.id}>
+                          {shortModel(m.id)}
+                        </option>
+                      ))}
+                  </optgroup>
+                </select>
+              </Field>
+            </div>
           ) : null}
         </div>
       </div>

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -147,15 +147,15 @@ export function PhasesPanel({ workspaceId }: PhasesPanelProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold text-foreground">workflows</div>
+        <div className="text-xs font-semibold text-foreground">Workflows</div>
         <Button variant="ghost" size="sm" onClick={openNew}>
-          new workflow
+          New workflow
         </Button>
       </div>
 
       {templates.length === 0 ? (
         <p className="text-2xs text-muted-foreground">
-          no workflows for this workspace. create one to chain multiple agents per session.
+          No workflows for this workspace. Create one to chain multiple agents per session.
         </p>
       ) : (
         <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
@@ -199,14 +199,14 @@ function TemplateRow({
           className="text-xs text-muted-foreground underline hover:text-foreground"
           onClick={onEdit}
         >
-          edit
+          Edit
         </button>
         <button
           type="button"
           className="text-xs text-muted-foreground underline hover:text-danger"
           onClick={onDelete}
         >
-          delete
+          Delete
         </button>
       </div>
     </li>
@@ -262,7 +262,7 @@ function PhaseEditor({
   return (
     <div className="flex flex-col gap-3">
       <div className="text-xs font-semibold text-foreground">
-        {isNew ? 'new workflow' : 'edit workflow'}
+        {isNew ? 'New workflow' : 'Edit workflow'}
       </div>
 
       <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
@@ -314,10 +314,10 @@ function PhaseEditor({
 
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
-            cancel
+            Cancel
           </Button>
           <Button size="sm" onClick={onSave} disabled={saving}>
-            {saving ? 'saving…' : 'save'}
+            {saving ? 'Saving…' : 'Save'}
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -133,7 +133,6 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
           />
         </Tooltip>
       ) : null}
-      <TileCaveat info={info} />
 
       <div
         aria-hidden
@@ -162,29 +161,6 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
         <TileAction info={info} onRefresh={onRefresh} />
       </div>
     </div>
-  );
-}
-
-function TileCaveat({ info }: { info: ProviderInfo }) {
-  const caveats: string[] = [];
-  if (info.id !== 'anthropic') {
-    caveats.push('Permission proxy not supported');
-  }
-  if (info.connection === 'connected') {
-    caveats.push(
-      info.id === 'anthropic'
-        ? 'Quota info unavailable (anthropic does not expose it via the cli)'
-        : 'Quota info unavailable',
-    );
-  }
-  if (caveats.length === 0) return null;
-
-  return (
-    <Tooltip content={caveats.join(' · ')} side="bottom">
-      <span className="absolute right-2.5 top-2.5 inline-flex cursor-default text-muted-foreground/70">
-        <Info size={11} aria-hidden />
-      </span>
-    </Tooltip>
   );
 }
 

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { Code2, Info, MousePointer2, Sparkles } from 'lucide-react';
+import { Code2, Info, MousePointer2, RotateCw, Sparkles } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { Button, Tooltip, cn } from '@kay-am/ui';
+import { Tooltip, cn } from '@kay-am/ui';
 import type { ProviderConnectionState, ProviderInfo } from '../providers';
 import { providerAction } from '../providers';
 import type { ProviderId } from '../providers';
@@ -9,10 +9,10 @@ import { useAppStore } from '../store';
 import { openUrl } from '../editor';
 
 const STATE_LABEL: Record<ProviderConnectionState, string> = {
-  connected: 'connected',
-  installed_disconnected: 'not logged in',
-  missing: 'not installed',
-  error: 'error',
+  connected: 'Connected',
+  installed_disconnected: 'Not logged in',
+  missing: 'Not installed',
+  error: 'Error',
 };
 
 const STATE_DOT: Record<ProviderConnectionState, string> = {
@@ -73,30 +73,36 @@ export function ProvidersPanel() {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold text-foreground">providers</div>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => void onRefresh()}
-          disabled={refreshing}
-          title="re-detect installed CLIs"
-        >
-          {refreshing ? 'refreshing…' : 'refresh all'}
-        </Button>
+        <div className="text-xs font-semibold text-foreground">Providers</div>
+        <Tooltip content="Re-detect installed CLIs" side="top">
+          <button
+            type="button"
+            aria-label="Re-detect installed CLIs"
+            disabled={refreshing}
+            onClick={() => void onRefresh()}
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <RotateCw size={14} className={refreshing ? 'animate-spin' : undefined} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
       {ordered.length === 0 ? (
-        <p className="text-2xs text-muted-foreground">no providers configured</p>
+        <p className="text-2xs text-muted-foreground">No providers configured</p>
       ) : (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-3 gap-2.5">
           {ordered.map((p) => (
             <ProviderTile key={p.id} info={p} onRefresh={onRefresh} />
           ))}
         </div>
       )}
-      <p className="text-xs text-muted-foreground">
-        kay-am orchestrates via each provider's CLI. login is handled by the CLI itself (e.g. run{' '}
-        <code className="rounded bg-muted px-1">claude</code> in a terminal once).
-      </p>
+      <div className="flex items-start gap-1.5 text-2xs text-muted-foreground">
+        <Info size={11} aria-hidden className="mt-0.5 shrink-0" />
+        <span>
+          Sign in once via each provider's CLI (e.g. run{' '}
+          <code className="rounded bg-muted px-1">claude</code> in a terminal). kay-am picks up the
+          credentials.
+        </span>
+      </div>
     </div>
   );
 }
@@ -111,26 +117,28 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
 
   return (
     <div
-      className="relative flex min-h-[200px] flex-col items-center gap-2.5 overflow-hidden rounded-lg border bg-subtle p-4 shadow-sm transition-colors"
+      className="relative flex flex-col items-center gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
       style={{
         borderColor: `color-mix(in oklch, ${color} 25%, var(--color-border-soft))`,
       }}
     >
-      <Tooltip content={STATE_LABEL[info.connection]} side="top">
-        <span
-          aria-hidden
-          className={cn(
-            'absolute left-3 top-3 inline-block h-2 w-2 shrink-0 rounded-full',
-            STATE_DOT[info.connection],
-          )}
-        />
-      </Tooltip>
+      {info.connection !== 'connected' ? (
+        <Tooltip content={STATE_LABEL[info.connection]} side="top">
+          <span
+            aria-hidden
+            className={cn(
+              'absolute left-2.5 top-2.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full',
+              STATE_DOT[info.connection],
+            )}
+          />
+        </Tooltip>
+      ) : null}
       <TileCaveat info={info} />
 
       <div
         aria-hidden
         className={cn(
-          'mt-2 flex h-14 w-14 items-center justify-center rounded-full transition-opacity',
+          'mt-1 flex h-10 w-10 items-center justify-center rounded-full transition-opacity',
           dim && 'opacity-50',
         )}
         style={{
@@ -138,7 +146,7 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
           color,
         }}
       >
-        <Icon size={26} strokeWidth={2} />
+        <Icon size={18} strokeWidth={2} />
       </div>
 
       <div className="flex flex-col items-center gap-0.5">
@@ -150,7 +158,7 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
 
       <TileStatus info={info} />
 
-      <div className="mt-auto w-full">
+      <div className="mt-1 w-full">
         <TileAction info={info} onRefresh={onRefresh} />
       </div>
     </div>
@@ -160,21 +168,21 @@ function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () =
 function TileCaveat({ info }: { info: ProviderInfo }) {
   const caveats: string[] = [];
   if (info.id !== 'anthropic') {
-    caveats.push('permission proxy not supported');
+    caveats.push('Permission proxy not supported');
   }
   if (info.connection === 'connected') {
     caveats.push(
       info.id === 'anthropic'
-        ? 'quota info unavailable (anthropic does not expose it via the cli)'
-        : 'quota info unavailable',
+        ? 'Quota info unavailable (anthropic does not expose it via the cli)'
+        : 'Quota info unavailable',
     );
   }
   if (caveats.length === 0) return null;
 
   return (
-    <Tooltip content={caveats.join(' · ')} side="top">
-      <span className="absolute right-3 top-3 inline-flex cursor-default text-muted-foreground/70">
-        <Info size={12} aria-hidden />
+    <Tooltip content={caveats.join(' · ')} side="bottom">
+      <span className="absolute right-2.5 top-2.5 inline-flex cursor-default text-muted-foreground/70">
+        <Info size={11} aria-hidden />
       </span>
     </Tooltip>
   );
@@ -187,7 +195,7 @@ function TileStatus({ info }: { info: ProviderInfo }) {
         className="max-w-full truncate text-2xs text-muted-foreground"
         title={info.identity ?? ''}
       >
-        {info.identity ?? 'no identity reported'}
+        {info.identity ?? 'No identity found'}
       </div>
     );
   }
@@ -220,7 +228,7 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
         className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs text-primary hover:bg-muted"
         onClick={() => void openUrl(info.docsUrl)}
       >
-        install ↗
+        Install ↗
       </button>
     );
   }
@@ -232,7 +240,7 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
         className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
         onClick={() => void onRefresh()}
       >
-        retry
+        Retry
       </button>
     );
   }
@@ -246,17 +254,17 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
           disabled={pending === 'login'}
           onClick={() => void onAction('login')}
         >
-          connect ↗
+          Connect ↗
         </button>
         {pending === 'login' ? (
           <span className="text-center text-2xs text-muted-foreground">
-            complete in terminal, then{' '}
+            Complete in terminal, then{' '}
             <button
               type="button"
               className="underline hover:text-foreground"
               onClick={() => void onRefresh()}
             >
-              refresh ↻
+              Refresh ↻
             </button>
           </span>
         ) : null}
@@ -268,10 +276,10 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
   return (
     <div className="flex flex-col items-center gap-1">
       <div className="flex w-full items-stretch gap-1.5">
-        <Tooltip content="re-check identity" side="top">
+        <Tooltip content="Re-check identity" side="top">
           <button
             type="button"
-            aria-label="re-check identity"
+            aria-label="Re-check identity"
             className="rounded-md border border-border-soft px-2 text-xs hover:bg-muted"
             onClick={() => void onRefresh()}
           >
@@ -284,18 +292,18 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
           disabled={pending === 'logout'}
           onClick={() => void onAction('logout')}
         >
-          disconnect ↗
+          Disconnect ↗
         </button>
       </div>
       {pending === 'logout' ? (
         <span className="text-center text-2xs text-muted-foreground">
-          complete in terminal, then{' '}
+          Complete in terminal, then{' '}
           <button
             type="button"
             className="underline hover:text-foreground"
             onClick={() => void onRefresh()}
           >
-            refresh ↻
+            Refresh ↻
           </button>
         </span>
       ) : null}

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Info } from 'lucide-react';
+import { Code2, Info, MousePointer2, Sparkles } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 import { Button, Tooltip, cn } from '@kay-am/ui';
 import type { ProviderConnectionState, ProviderInfo } from '../providers';
 import { providerAction } from '../providers';
@@ -9,7 +10,7 @@ import { openUrl } from '../editor';
 
 const STATE_LABEL: Record<ProviderConnectionState, string> = {
   connected: 'connected',
-  installed_disconnected: 'installed, not logged in',
+  installed_disconnected: 'not logged in',
   missing: 'not installed',
   error: 'error',
 };
@@ -23,10 +24,32 @@ const STATE_DOT: Record<ProviderConnectionState, string> = {
 
 const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex'];
 
-const PROVIDER_DISPLAY: Record<ProviderId, { name: string; description: string }> = {
-  anthropic: { name: 'claude', description: 'anthropic claude code cli' },
-  cursor: { name: 'cursor', description: 'cursor agent cli' },
-  codex: { name: 'codex', description: 'openai codex cli' },
+interface ProviderBrand {
+  readonly name: string;
+  readonly description: string;
+  readonly icon: LucideIcon;
+  readonly cssVar: string;
+}
+
+const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
+  anthropic: {
+    name: 'claude',
+    description: 'anthropic claude code cli',
+    icon: Sparkles,
+    cssVar: '--color-provider-anthropic',
+  },
+  cursor: {
+    name: 'cursor',
+    description: 'cursor agent cli',
+    icon: MousePointer2,
+    cssVar: '--color-provider-cursor',
+  },
+  codex: {
+    name: 'codex',
+    description: 'openai codex cli',
+    icon: Code2,
+    cssVar: '--color-provider-codex',
+  },
 };
 
 export function ProvidersPanel() {
@@ -64,9 +87,9 @@ export function ProvidersPanel() {
       {ordered.length === 0 ? (
         <p className="text-2xs text-muted-foreground">no providers configured</p>
       ) : (
-        <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-3 gap-3">
           {ordered.map((p) => (
-            <ProviderCard key={p.id} info={p} onRefresh={onRefresh} />
+            <ProviderTile key={p.id} info={p} onRefresh={onRefresh} />
           ))}
         </div>
       )}
@@ -78,102 +101,107 @@ export function ProvidersPanel() {
   );
 }
 
-function ProviderCard({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
-  const display = PROVIDER_DISPLAY[info.id as ProviderId];
+function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
+  const brand = PROVIDER_BRAND[info.id as ProviderId];
+  const Icon = brand?.icon ?? Sparkles;
+  const connected = info.connection === 'connected';
+  const errored = info.connection === 'error';
+  const dim = !connected && !errored;
+  const color = brand ? `var(${brand.cssVar})` : 'var(--color-primary)';
+
   return (
-    <div className="flex flex-col gap-2 overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
-      {/* header */}
-      <div className="flex items-center gap-3 border-b border-border-soft px-3 py-2">
+    <div
+      className="relative flex min-h-[200px] flex-col items-center gap-2.5 overflow-hidden rounded-lg border bg-subtle p-4 shadow-sm transition-colors"
+      style={{
+        borderColor: `color-mix(in oklch, ${color} 25%, var(--color-border-soft))`,
+      }}
+    >
+      <Tooltip content={STATE_LABEL[info.connection]} side="top">
         <span
           aria-hidden
-          className={cn('inline-block h-2 w-2 shrink-0 rounded-full', STATE_DOT[info.connection])}
+          className={cn(
+            'absolute left-3 top-3 inline-block h-2 w-2 shrink-0 rounded-full',
+            STATE_DOT[info.connection],
+          )}
         />
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <div className="flex items-center gap-2">
-            <span className="text-xs font-semibold">{display?.name ?? info.label}</span>
-            <code className="text-2xs text-muted-foreground">{info.binary}</code>
-            {info.version ? (
-              <span className="rounded bg-muted px-1 text-2xs text-muted-foreground">
-                {info.version}
-              </span>
-            ) : null}
-          </div>
-          <span className="text-2xs text-muted-foreground">{display?.description}</span>
-        </div>
-        <RowActions info={info} onRefresh={onRefresh} />
+      </Tooltip>
+      <TileCaveat info={info} />
+
+      <div
+        aria-hidden
+        className={cn(
+          'mt-2 flex h-14 w-14 items-center justify-center rounded-full transition-opacity',
+          dim && 'opacity-50',
+        )}
+        style={{
+          backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
+          color,
+        }}
+      >
+        <Icon size={26} strokeWidth={2} />
       </div>
 
-      {/* status + quota */}
-      <div className="flex flex-col gap-1.5 px-3 pb-2.5">
-        <CardStatus info={info} />
-        {info.id !== 'anthropic' ? (
-          <span
-            className="w-fit rounded bg-muted px-1.5 py-0.5 text-2xs text-muted-foreground"
-            title="permission proxy currently covers claude only. cursor and codex run with their CLI defaults; coverage is tracked for a future milestone."
-          >
-            permission proxy: not supported
-          </span>
-        ) : null}
-        <QuotaSection
-          providerId={info.id as ProviderId}
-          connected={info.connection === 'connected'}
-        />
+      <div className="flex flex-col items-center gap-0.5">
+        <span className="text-sm font-semibold lowercase">{brand?.name ?? info.label}</span>
+        <span className="text-2xs text-muted-foreground">
+          {info.version ?? brand?.description ?? info.binary}
+        </span>
+      </div>
+
+      <TileStatus info={info} />
+
+      <div className="mt-auto w-full">
+        <TileAction info={info} onRefresh={onRefresh} />
       </div>
     </div>
   );
 }
 
-function CardStatus({ info }: { info: ProviderInfo }) {
+function TileCaveat({ info }: { info: ProviderInfo }) {
+  const caveats: string[] = [];
+  if (info.id !== 'anthropic') {
+    caveats.push('permission proxy not supported');
+  }
+  if (info.connection === 'connected') {
+    caveats.push(
+      info.id === 'anthropic'
+        ? 'quota info unavailable (anthropic does not expose it via the cli)'
+        : 'quota info unavailable',
+    );
+  }
+  if (caveats.length === 0) return null;
+
+  return (
+    <Tooltip content={caveats.join(' · ')} side="top">
+      <span className="absolute right-3 top-3 inline-flex cursor-default text-muted-foreground/70">
+        <Info size={12} aria-hidden />
+      </span>
+    </Tooltip>
+  );
+}
+
+function TileStatus({ info }: { info: ProviderInfo }) {
   if (info.connection === 'connected') {
     return (
-      <div className="text-xs text-muted-foreground">{info.identity ?? 'no identity reported'}</div>
+      <div
+        className="max-w-full truncate text-2xs text-muted-foreground"
+        title={info.identity ?? ''}
+      >
+        {info.identity ?? 'no identity reported'}
+      </div>
     );
   }
   if (info.connection === 'error') {
     return (
-      <div className="text-xs">
-        <span className="text-danger">{info.error ?? 'unknown error'}</span>
+      <div className="line-clamp-2 text-center text-2xs text-danger" title={info.error ?? ''}>
+        {info.error ?? 'unknown error'}
       </div>
     );
   }
-  return <div className="text-xs text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
+  return <div className="text-2xs text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
 }
 
-function QuotaSection({ providerId, connected }: { providerId: ProviderId; connected: boolean }) {
-  if (!connected) return null;
-
-  if (providerId !== 'anthropic') {
-    return (
-      <div className="flex items-center gap-1 text-2xs text-muted-foreground/70">
-        <Tooltip
-          content="quota reporting not available for this provider. check your account dashboard."
-          side="top"
-        >
-          <span className="flex cursor-default items-center gap-1">
-            <Info size={10} aria-hidden className="shrink-0" />
-            quota info unavailable
-          </span>
-        </Tooltip>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex items-center gap-1 text-2xs text-muted-foreground/70">
-      <Tooltip
-        content="anthropic does not expose quota/rate-limit data via the claude code CLI. check console.anthropic.com for usage details."
-        side="top"
-      >
-        <span className="flex cursor-default items-center gap-1">
-          <Info size={10} aria-hidden className="shrink-0" />
-          quota info unavailable
-        </span>
-      </Tooltip>
-    </div>
-  );
-}
-
-function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
+function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
   const [pending, setPending] = useState<'login' | 'logout' | null>(null);
 
   const onAction = async (action: 'login' | 'logout') => {
@@ -181,7 +209,7 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     try {
       await providerAction(info.id as ProviderId, action);
     } catch {
-      // terminal launch failed — fall through to show note anyway
+      // terminal launch failed — surface as no-op; user can retry
     }
   };
 
@@ -189,7 +217,7 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     return (
       <button
         type="button"
-        className="shrink-0 text-xs text-primary underline hover:opacity-80"
+        className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs text-primary hover:bg-muted"
         onClick={() => void openUrl(info.docsUrl)}
       >
         install ↗
@@ -199,25 +227,29 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
 
   if (info.connection === 'error') {
     return (
-      <Button variant="ghost" size="sm" className="shrink-0" onClick={() => void onRefresh()}>
+      <button
+        type="button"
+        className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
+        onClick={() => void onRefresh()}
+      >
         retry
-      </Button>
+      </button>
     );
   }
 
   if (info.connection === 'installed_disconnected') {
     return (
-      <div className="flex shrink-0 flex-col items-end gap-0.5">
+      <div className="flex flex-col items-center gap-1">
         <button
           type="button"
-          className="text-xs text-primary underline hover:opacity-80 disabled:opacity-50"
+          className="w-full rounded-md border border-border-soft py-1.5 text-center text-xs text-primary hover:bg-muted disabled:opacity-50"
           disabled={pending === 'login'}
           onClick={() => void onAction('login')}
         >
           connect ↗
         </button>
         {pending === 'login' ? (
-          <span className="text-2xs text-muted-foreground">
+          <span className="text-center text-2xs text-muted-foreground">
             complete in terminal, then{' '}
             <button
               type="button"
@@ -232,44 +264,41 @@ function RowActions({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     );
   }
 
-  if (info.connection === 'connected') {
-    return (
-      <div className="flex shrink-0 items-center gap-1">
+  // connected
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div className="flex w-full items-stretch gap-1.5">
         <Tooltip content="re-check identity" side="top">
-          <Button
-            variant="ghost"
-            size="sm"
+          <button
+            type="button"
             aria-label="re-check identity"
+            className="rounded-md border border-border-soft px-2 text-xs hover:bg-muted"
             onClick={() => void onRefresh()}
           >
             ↻
-          </Button>
+          </button>
         </Tooltip>
-        <div className="flex flex-col items-end gap-0.5">
+        <button
+          type="button"
+          className="flex-1 rounded-md border border-border-soft py-1.5 text-center text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+          disabled={pending === 'logout'}
+          onClick={() => void onAction('logout')}
+        >
+          disconnect ↗
+        </button>
+      </div>
+      {pending === 'logout' ? (
+        <span className="text-center text-2xs text-muted-foreground">
+          complete in terminal, then{' '}
           <button
             type="button"
-            className="text-xs text-muted-foreground underline hover:text-foreground disabled:opacity-50"
-            disabled={pending === 'logout'}
-            onClick={() => void onAction('logout')}
+            className="underline hover:text-foreground"
+            onClick={() => void onRefresh()}
           >
-            disconnect ↗
+            refresh ↻
           </button>
-          {pending === 'logout' ? (
-            <span className="text-2xs text-muted-foreground">
-              complete in terminal, then{' '}
-              <button
-                type="button"
-                className="underline hover:text-foreground"
-                onClick={() => void onRefresh()}
-              >
-                refresh ↻
-              </button>
-            </span>
-          ) : null}
-        </div>
-      </div>
-    );
-  }
-
-  return null;
+        </span>
+      ) : null}
+    </div>
+  );
 }

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -184,7 +184,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
         return (
           <div className="flex flex-col gap-4">
             <SectionHeading>App settings</SectionHeading>
-            <Field label="default editor binary" help={`launched as: \`${editorBinary} <path>\``}>
+            <Field label="Default editor binary" help={`Launched as: \`${editorBinary} <path>\``}>
               <Input
                 value={editorBinary}
                 onChange={(e) => setEditorBinary(e.target.value)}
@@ -192,7 +192,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
               />
             </Field>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              workspace-specific defaults (branch prefix, skills, workflows) live in the gear icon
+              Workspace-specific defaults (branch prefix, skills, workflows) live in the gear icon
               next to each workspace row.
             </p>
           </div>
@@ -206,7 +206,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
           <div className="flex flex-col gap-4">
             <SectionHeading>Agent settings</SectionHeading>
             <Field
-              label="enable parallel agents"
+              label="Enable parallel agents"
               help="Not yet correctly implemented, coming soon."
             >
               <label className="flex cursor-not-allowed items-center gap-2 opacity-40">
@@ -218,13 +218,13 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
                   onChange={() => undefined}
                 />
                 <span className="text-sm text-muted-foreground">
-                  {enableParallelAgents ? 'on' : 'off'}
+                  {enableParallelAgents ? 'On' : 'Off'}
                 </span>
               </label>
             </Field>
             <Field
-              label="max parallelism"
-              help={`number of concurrent agent columns (${MIN_PARALLELISM}–${MAX_PARALLELISM}).`}
+              label="Max parallelism"
+              help={`Number of concurrent agent columns (${MIN_PARALLELISM}–${MAX_PARALLELISM}).`}
             >
               <Input
                 type="number"
@@ -247,9 +247,9 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
           <div className="flex flex-col gap-4">
             <SectionHeading>Initialization</SectionHeading>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              wipe the local sqlite database — drops every workspace, session, agent, message,
+              Wipe the local sqlite database — drops every workspace, session, agent, message,
               transcript, telemetry record, budget rule, permission rule, and skill registration.
-              api keys in the os keychain are NOT touched. fresh schema is recreated on next boot.
+              Api keys in the os keychain are NOT touched. Fresh schema is recreated on next boot.
             </p>
             {wipeError ? (
               <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
@@ -258,20 +258,20 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
             ) : null}
             {wipeState === 'done' ? (
               <p className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-xs text-success">
-                database wiped. restart the app (or just reopen settings) to start fresh.
+                Database wiped. Restart the app (or just reopen settings) to start fresh.
               </p>
             ) : null}
             {wipeState === 'confirm' ? (
               <div className="flex flex-col gap-2 rounded-md border border-danger/40 bg-danger/5 p-3">
                 <p className="text-sm font-semibold text-danger">
-                  this is irreversible. confirm wipe?
+                  This is irreversible. Confirm wipe?
                 </p>
                 <div className="flex gap-2">
                   <Button variant="ghost" size="sm" onClick={() => setWipeState('idle')}>
-                    cancel
+                    Cancel
                   </Button>
                   <Button variant="secondary" size="sm" onClick={() => void onWipe()}>
-                    wipe database
+                    Wipe database
                   </Button>
                 </div>
               </div>
@@ -283,7 +283,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
                   onClick={() => setWipeState('confirm')}
                   disabled={wipeState === 'wiping'}
                 >
-                  {wipeState === 'wiping' ? 'wiping…' : 'wipe local database'}
+                  {wipeState === 'wiping' ? 'Wiping…' : 'Wipe local database'}
                 </Button>
               </div>
             )}
@@ -301,18 +301,18 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
                 disabled={exportState === 'busy'}
               >
                 {exportState === 'busy'
-                  ? 'exporting…'
+                  ? 'Exporting…'
                   : exportState === 'done'
-                    ? 'exported ✓'
-                    : 'export config'}
+                    ? 'Exported ✓'
+                    : 'Export config'}
               </Button>
               <Button variant="secondary" size="sm" onClick={() => void onImport()}>
-                import config
+                Import config
               </Button>
             </div>
             <p className="text-xs leading-relaxed text-muted-foreground">
-              export saves workspaces, skills, workflows, permission rules, budget rules, and
-              settings to a json file. api keys are never included.
+              Export saves workspaces, skills, workflows, permission rules, budget rules, and
+              settings to a json file. Api keys are never included.
             </p>
           </div>
         );
@@ -331,15 +331,15 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
       footer={
         <>
           {saveState === 'saved' ? (
-            <span className="mr-auto text-xs text-success">saved.</span>
+            <span className="mr-auto text-xs text-success">Saved.</span>
           ) : null}
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={onClose}>
-            close
+            Close
           </Button>
           {needsSave ? (
             <Button onClick={() => void onSave()} disabled={saveState === 'saving'}>
-              {saveState === 'saving' ? 'saving…' : 'save'}
+              {saveState === 'saving' ? 'Saving…' : 'Save'}
             </Button>
           ) : null}
         </>

--- a/apps/desktop/src/components/SkillsPanel.tsx
+++ b/apps/desktop/src/components/SkillsPanel.tsx
@@ -155,20 +155,20 @@ export function SkillsPanel({ workspaceId }: SkillsPanelProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
-        <div className="text-xs font-semibold text-foreground">skills</div>
+        <div className="text-xs font-semibold text-foreground">Skills</div>
         <div className="flex items-center gap-2">
           <Button variant="ghost" size="sm" onClick={() => void onRescan()} disabled={rescanning}>
-            {rescanning ? 'rescanning…' : 'rescan'}
+            {rescanning ? 'Rescanning…' : 'Rescan'}
           </Button>
           <Button variant="ghost" size="sm" onClick={openNew}>
-            new skill
+            New skill
           </Button>
         </div>
       </div>
 
       {skills.length === 0 ? (
         <p className="text-2xs text-muted-foreground">
-          no skills for this workspace. create one or rescan the workspace directory.
+          No skills for this workspace. Create one or rescan the workspace directory.
         </p>
       ) : (
         <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">
@@ -210,14 +210,14 @@ function SkillRow({
           className="text-xs text-muted-foreground underline hover:text-foreground"
           onClick={onEdit}
         >
-          edit
+          Edit
         </button>
         <button
           type="button"
           className="text-xs text-muted-foreground underline hover:text-danger"
           onClick={onDelete}
         >
-          delete
+          Delete
         </button>
       </div>
     </li>
@@ -244,12 +244,12 @@ function SkillEditor({
   return (
     <div className="flex flex-col gap-3">
       <div className="text-xs font-semibold text-foreground">
-        {isNew ? 'new skill' : 'edit skill'}
+        {isNew ? 'New skill' : 'Edit skill'}
       </div>
 
       <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs font-semibold text-foreground">name</label>
+          <label className="text-xs font-semibold text-foreground">Name</label>
           <Input
             value={form.name}
             onChange={(e) => onChange({ ...form, name: e.target.value })}
@@ -258,17 +258,17 @@ function SkillEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs font-semibold text-foreground">description</label>
+          <label className="text-xs font-semibold text-foreground">Description</label>
           <Input
             value={form.description}
             onChange={(e) => onChange({ ...form, description: e.target.value })}
-            placeholder="what this skill does"
+            placeholder="What this skill does"
           />
         </div>
 
         <div className="flex gap-2">
           <div className="flex flex-1 flex-col gap-1.5">
-            <label className="text-xs font-semibold text-foreground">args (comma-separated)</label>
+            <label className="text-xs font-semibold text-foreground">Args (comma-separated)</label>
             <Input
               value={form.args}
               onChange={(e) => onChange({ ...form, args: e.target.value })}
@@ -277,7 +277,7 @@ function SkillEditor({
           </div>
           <div className="flex flex-1 flex-col gap-1.5">
             <label className="text-xs font-semibold text-foreground">
-              scripts (comma-separated)
+              Scripts (comma-separated)
             </label>
             <Input
               value={form.scripts}
@@ -288,11 +288,11 @@ function SkillEditor({
         </div>
 
         <div className="flex flex-col gap-1.5">
-          <label className="text-xs font-semibold text-foreground">body</label>
+          <label className="text-xs font-semibold text-foreground">Body</label>
           <Textarea
             value={form.body}
             onChange={(e) => onChange({ ...form, body: e.target.value })}
-            placeholder="skill prompt body…"
+            placeholder="Skill prompt body…"
             rows={6}
             className="font-mono text-xs"
           />
@@ -302,10 +302,10 @@ function SkillEditor({
 
         <div className="flex items-center justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel} disabled={saving}>
-            cancel
+            Cancel
           </Button>
           <Button size="sm" onClick={onSave} disabled={saving}>
-            {saving ? 'saving…' : 'save'}
+            {saving ? 'Saving…' : 'Save'}
           </Button>
         </div>
       </div>

--- a/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
+++ b/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
@@ -225,15 +225,15 @@ export function WorkspaceSettingsDialog({
         footer={
           <>
             {saveState === 'saved' ? (
-              <span className="mr-auto text-xs text-success">saved.</span>
+              <span className="mr-auto text-xs text-success">Saved.</span>
             ) : null}
             {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
             <Button variant="ghost" onClick={onClose}>
-              close
+              Close
             </Button>
             {needsSave ? (
               <Button onClick={() => void onSave()} disabled={saveState === 'saving'}>
-                {saveState === 'saving' ? 'saving…' : 'save'}
+                {saveState === 'saving' ? 'Saving…' : 'Save'}
               </Button>
             ) : null}
           </>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -19,6 +19,7 @@ import type {
 import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@kay-am/core';
 import { useShallow } from 'zustand/react/shallow';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
+import { formatError } from '../../errors';
 import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
@@ -249,7 +250,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           },
         });
       } catch (err) {
-        setError(err instanceof Error ? err.message : String(err));
+        setError(formatError(err));
       }
     },
     [sendTurn, session.id, showToast],
@@ -269,8 +270,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           }
         : undefined;
 
-    setSelectedProvider(null);
-
     if (isRunning) {
       setQueued({ content, override });
       return;
@@ -289,7 +288,10 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     }
   }, [isRunning, queued, dispatchTurn]);
 
+  const lastAgentIdRef = useRef(selectedAgentId);
   useEffect(() => {
+    if (lastAgentIdRef.current === selectedAgentId) return;
+    lastAgentIdRef.current = selectedAgentId;
     setSelectedProvider(null);
     setSelectedModel(null);
   }, [selectedAgentId]);

--- a/apps/desktop/src/components/chat/ModelPicker.tsx
+++ b/apps/desktop/src/components/chat/ModelPicker.tsx
@@ -9,20 +9,18 @@ import {
   EFFORT_LABEL,
   EFFORT_DOT,
   EFFORT_TEXT,
-  FAMILY_LABEL,
+  FAMILY_SECTION_LABEL,
+  type ModelFamily,
   TIER_TEXT,
-  TIER_DOT,
   VERBOSITY_DOT,
   VERBOSITY_TEXT,
-  CLAUDE_SUBFAMILY_LABEL,
-  CLAUDE_SUBFAMILY_TIER,
   modelLabel,
-  modelFamily,
-  modelSubfamily,
-  modelVersion,
   modelTier,
   modelWeight,
   modelEffortLevels,
+  parseModelId,
+  subfamilyLabel,
+  subfamilyTier,
 } from './chat-constants';
 
 export interface ModelPickerProps {
@@ -79,19 +77,26 @@ export function ModelPicker({
   const showEffort = provider === 'anthropic' && effortLevels !== null;
   const tier = modelTier(model);
 
+  // Two-level grouping: family → (subfamily ?? null) → ids. Subfamily=null
+  // means "render as a flat chip row under the family label" (composer,
+  // cursor-auto). Subfamily set means "render as a FamilyVersionRow" with
+  // a subfamily label and version chips.
   const groupedModels = useMemo(() => {
     const sorted = [...models].sort((a, b) => modelWeight(a) - modelWeight(b));
-    const groups = new Map<string, string[]>();
+    const byFamily = new Map<ModelFamily, Map<string | null, string[]>>();
     for (const id of sorted) {
-      const fam = modelFamily(id);
-      let arr = groups.get(fam);
-      if (!arr) {
-        arr = [];
-        groups.set(fam, arr);
+      const parsed = parseModelId(id);
+      let subMap = byFamily.get(parsed.family);
+      if (!subMap) {
+        subMap = new Map();
+        byFamily.set(parsed.family, subMap);
       }
+      const key = parsed.subfamily;
+      const arr = subMap.get(key) ?? [];
       arr.push(id);
+      subMap.set(key, arr);
     }
-    return groups;
+    return byFamily;
   }, [models]);
 
   return (
@@ -171,43 +176,48 @@ export function ModelPicker({
           </PickerSection>
           <PickerDivider />
 
-          {/* Model — family rows with version chips */}
-          {[...groupedModels.entries()].map(([fam, ids]) => {
-            const sectionLabel = groupedModels.size > 1 ? (FAMILY_LABEL[fam] ?? fam) : 'Model';
-            if (fam === 'claude') {
-              const subMap = new Map<string, string[]>();
-              for (const id of ids) {
-                const sub = modelSubfamily(id);
-                const arr = subMap.get(sub) ?? [];
-                arr.push(id);
-                subMap.set(sub, arr);
-              }
+          {/* Model — family/subfamily/variant chip layout. */}
+          {[...groupedModels.entries()].map(([fam, subMap]) => {
+            const subKeys = [...subMap.keys()];
+            const onlyFlat = subKeys.length === 1 && subKeys[0] === null;
+            const sectionLabel = FAMILY_SECTION_LABEL[fam] ?? fam;
+
+            if (onlyFlat) {
+              const ids = subMap.get(null) ?? [];
               return (
                 <PickerSection key={fam} label={sectionLabel}>
-                  {[...subMap.entries()].map(([sub, subIds]) => (
-                    <FamilyVersionRow
-                      key={sub}
-                      subfamily={sub}
-                      ids={subIds}
-                      selectedModel={model}
-                      onSelect={onSelectModel}
-                    />
-                  ))}
+                  <FlatVariantRow
+                    family={fam}
+                    ids={ids}
+                    selectedModel={model}
+                    onSelect={onSelectModel}
+                  />
                 </PickerSection>
               );
             }
+
             return (
               <PickerSection key={fam} label={sectionLabel}>
-                {ids.map((id) => {
-                  const t = modelTier(id);
+                {[...subMap.entries()].map(([sub, ids]) => {
+                  if (sub === null) {
+                    return (
+                      <FlatVariantRow
+                        key="_flat"
+                        family={fam}
+                        ids={ids}
+                        selectedModel={model}
+                        onSelect={onSelectModel}
+                      />
+                    );
+                  }
                   return (
-                    <PickerRow
-                      key={id}
-                      label={modelLabel(id)}
-                      active={model === id}
-                      onClick={() => onSelectModel(id)}
-                      leadingDot={TIER_DOT[t]}
-                      labelClassName={TIER_TEXT[t]}
+                    <SubfamilyVariantRow
+                      key={sub}
+                      family={fam}
+                      subfamily={sub}
+                      ids={ids}
+                      selectedModel={model}
+                      onSelect={onSelectModel}
                     />
                   );
                 })}
@@ -285,33 +295,36 @@ function PickerDivider() {
   return <div className="my-1 h-px bg-border-soft" aria-hidden />;
 }
 
-function FamilyVersionRow({
+function SubfamilyVariantRow({
+  family,
   subfamily,
   ids,
   selectedModel,
   onSelect,
 }: {
+  family: ModelFamily;
   subfamily: string;
   ids: string[];
   selectedModel: string;
   onSelect: (id: string) => void;
 }) {
-  const tier = CLAUDE_SUBFAMILY_TIER[subfamily] ?? 'mid';
+  const tier = subfamilyTier(family, subfamily);
   return (
     <div className="flex items-center px-2.5 py-1.5 hover:bg-muted/60">
       <span className={cn('flex-1 text-xs', TIER_TEXT[tier])}>
-        {CLAUDE_SUBFAMILY_LABEL[subfamily] ?? subfamily}
+        {subfamilyLabel(family, subfamily)}
       </span>
-      <div className="flex gap-1">
+      <div className="flex flex-wrap gap-1">
         {ids.map((id) => {
           const selected = selectedModel === id;
           const t = modelTier(id);
+          const chip = parseModelId(id).variantLabel;
           return (
             <button
               key={id}
               type="button"
               onClick={() => onSelect(id)}
-              title={modelLabel(id)}
+              title={id}
               className={cn(
                 'rounded px-1.5 py-0.5 font-mono text-[10px] transition-colors',
                 selected
@@ -319,7 +332,7 @@ function FamilyVersionRow({
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground',
               )}
             >
-              {modelVersion(id)}
+              {chip}
             </button>
           );
         })}
@@ -328,42 +341,40 @@ function FamilyVersionRow({
   );
 }
 
-function PickerRow({
-  label,
-  active,
-  onClick,
-  leadingDot,
-  labelClassName,
-  trailing,
+function FlatVariantRow({
+  family: _family,
+  ids,
+  selectedModel,
+  onSelect,
 }: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-  leadingDot?: string;
-  labelClassName?: string;
-  trailing?: React.ReactNode;
+  family: ModelFamily;
+  ids: string[];
+  selectedModel: string;
+  onSelect: (id: string) => void;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        'flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted',
-        active ? '' : 'opacity-80',
-      )}
-    >
-      {leadingDot ? (
-        <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', leadingDot)} />
-      ) : null}
-      <span className={cn('flex-1 truncate', labelClassName ?? 'text-muted-foreground')}>
-        {label}
-      </span>
-      {trailing}
-      {active ? (
-        <span aria-hidden className="text-2xs text-primary">
-          ✓
-        </span>
-      ) : null}
-    </button>
+    <div className="flex flex-wrap gap-1 px-2.5 pb-2">
+      {ids.map((id) => {
+        const selected = selectedModel === id;
+        const t = modelTier(id);
+        const chip = parseModelId(id).variantLabel;
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onSelect(id)}
+            title={id}
+            className={cn(
+              'rounded-full px-2.5 py-0.5 text-xs transition-colors',
+              selected
+                ? cn('bg-muted font-semibold', TIER_TEXT[t])
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+            )}
+          >
+            {chip}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -104,19 +104,107 @@ export function modelLabel(id: string): string {
   return id;
 }
 
+export type ModelFamily =
+  | 'claude'
+  | 'gpt'
+  | 'composer'
+  | 'cursor-auto'
+  | 'gemini'
+  | 'codex'
+  | 'other';
+
+export interface ParsedModel {
+  readonly family: ModelFamily;
+  readonly subfamily: string | null;
+  readonly variantLabel: string;
+}
+
+// Strip a `provider/model` prefix so cursor's `gpt-5.5-high` and any future
+// prefixed id (e.g. `openai/gpt-5.5-high`) parse the same way.
+function stripProviderPrefix(id: string): string {
+  const slash = id.indexOf('/');
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+export function parseModelId(id: string): ParsedModel {
+  const local = stripProviderPrefix(id);
+
+  // Canonical anthropic: claude-haiku-4-5, claude-sonnet-4-6, claude-opus-4-7
+  let m = local.match(/^claude-(haiku|sonnet|opus)-(\d+)-(\d+)(?:-(.+))?$/i);
+  if (m) {
+    return {
+      family: 'claude',
+      subfamily: m[1]!.toLowerCase(),
+      variantLabel: `${m[2]}.${m[3]}`,
+    };
+  }
+
+  // Cursor's anthropic naming: claude-4.6-sonnet-medium, claude-4.6-opus-high-thinking
+  m = local.match(/^claude-(\d+\.\d+)-(haiku|sonnet|opus)(?:-(.+))?$/i);
+  if (m) {
+    const suffix = m[3] ? ` ${m[3].replace(/-/g, ' ')}` : '';
+    return {
+      family: 'claude',
+      subfamily: m[2]!.toLowerCase(),
+      variantLabel: `${m[1]}${suffix}`,
+    };
+  }
+
+  // Composer (cursor first-party): composer-2, composer-2-fast
+  m = local.match(/^composer-(.+)$/i);
+  if (m) {
+    return { family: 'composer', subfamily: null, variantLabel: m[1]! };
+  }
+
+  // Cursor's `auto` model — standalone family so it renders without a row label.
+  if (local === 'auto') {
+    return { family: 'cursor-auto', subfamily: null, variantLabel: 'auto' };
+  }
+
+  // gpt-X.Y-codex → its own subfamily so it visually groups separately from
+  // the generic gpt-X.Y row (mockup: `5.3-codex [codex]`).
+  m = local.match(/^gpt-(\d+\.\d+)-codex$/i);
+  if (m) {
+    return { family: 'gpt', subfamily: `${m[1]}-codex`, variantLabel: 'codex' };
+  }
+
+  // gpt-X.Y-<variant> (variant = high/medium/mini/...)
+  m = local.match(/^gpt-(\d+\.\d+)-(.+)$/i);
+  if (m) {
+    return { family: 'gpt', subfamily: m[1]!, variantLabel: m[2]! };
+  }
+
+  // bare gpt-X.Y
+  m = local.match(/^gpt-(\d+\.\d+)$/i);
+  if (m) {
+    return { family: 'gpt', subfamily: m[1]!, variantLabel: m[1]! };
+  }
+
+  // unparseable gpt fallback
+  m = local.match(/^gpt-(.+)$/i);
+  if (m) {
+    return { family: 'gpt', subfamily: null, variantLabel: m[1]! };
+  }
+
+  if (local.startsWith('gemini-')) {
+    return { family: 'gemini', subfamily: null, variantLabel: local.slice('gemini-'.length) };
+  }
+
+  if (local.startsWith('codex-')) {
+    return { family: 'codex', subfamily: null, variantLabel: local.slice('codex-'.length) };
+  }
+
+  return { family: 'other', subfamily: null, variantLabel: local };
+}
+
 export function modelFamily(id: string): string {
-  if (id.startsWith('claude-')) return 'claude';
-  if (id.startsWith('gpt-')) return 'gpt';
-  if (id.startsWith('gemini-')) return 'gemini';
-  if (id.startsWith('cursor-')) return 'cursor';
-  if (id.startsWith('codex-')) return 'codex';
-  return 'other';
+  return parseModelId(id).family;
 }
 
 export function modelTier(model: string): CostTier {
   const known = MODEL_COST[model];
   if (known) return known.tier;
-  if (/haiku|small|mini|flash|nano/i.test(model)) return 'cheap';
+  if (/haiku|small|mini|flash|nano|fast/i.test(model)) return 'cheap';
   if (/opus|max/i.test(model)) return 'expensive';
   return 'mid';
 }
@@ -126,23 +214,48 @@ export function modelWeight(model: string): number {
 }
 
 export function modelSubfamily(id: string): string {
-  const m = id.match(/^claude-(haiku|sonnet|opus)/i);
-  return m ? m[1]!.toLowerCase() : '';
+  return parseModelId(id).subfamily ?? '';
 }
 
 export function modelVersion(id: string): string {
-  const m = id.match(/^claude-(?:haiku|sonnet|opus)-(\d+)-(\d+)/i);
-  return m ? `${m[1]}.${m[2]}` : id;
+  return parseModelId(id).variantLabel;
 }
 
-export const CLAUDE_SUBFAMILY_LABEL: Record<string, string> = {
+export const FAMILY_SECTION_LABEL: Record<ModelFamily, string> = {
+  claude: 'Claude',
+  gpt: 'GPT',
+  composer: 'Composer',
+  'cursor-auto': 'Auto',
+  gemini: 'Gemini',
+  codex: 'Codex',
+  other: 'Other',
+};
+
+export const SUBFAMILY_LABEL: Record<string, string> = {
   haiku: 'Haiku',
   sonnet: 'Sonnet',
   opus: 'Opus',
 };
 
-export const CLAUDE_SUBFAMILY_TIER: Record<string, CostTier> = {
+export const SUBFAMILY_TIER: Record<string, CostTier> = {
   haiku: 'cheap',
   sonnet: 'mid',
   opus: 'expensive',
 };
+
+export function subfamilyLabel(family: ModelFamily, subfamily: string): string {
+  if (family === 'claude' && SUBFAMILY_LABEL[subfamily]) return SUBFAMILY_LABEL[subfamily];
+  if (family === 'gpt' && subfamily.endsWith('-codex')) {
+    return subfamily.replace('-codex', '-Codex');
+  }
+  return subfamily;
+}
+
+export function subfamilyTier(family: ModelFamily, subfamily: string): CostTier {
+  if (family === 'claude' && SUBFAMILY_TIER[subfamily]) return SUBFAMILY_TIER[subfamily];
+  return 'mid';
+}
+
+// Legacy aliases retained for transitional call sites; prefer SUBFAMILY_*.
+export const CLAUDE_SUBFAMILY_LABEL = SUBFAMILY_LABEL;
+export const CLAUDE_SUBFAMILY_TIER = SUBFAMILY_TIER;

--- a/apps/desktop/src/errors.ts
+++ b/apps/desktop/src/errors.ts
@@ -1,0 +1,23 @@
+// Extract a human-readable message from any thrown/rejected value.
+//
+// Tauri `invoke()` rejects with the *serialized* error object (e.g.
+// `{kind: 'io', message: 'No such file or directory'}`) rather than a wrapped
+// `Error`. A naive `String(err)` on that yields `"[object Object]"`, which is
+// what users actually saw before this helper landed.
+export function formatError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  if (
+    typeof err === 'object' &&
+    err !== null &&
+    'message' in err &&
+    typeof (err as { message: unknown }).message === 'string'
+  ) {
+    return (err as { message: string }).message;
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/apps/desktop/src/providerPricing.test.ts
+++ b/apps/desktop/src/providerPricing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   getCodexPriceOverride,
   getActivePricingTable,
@@ -40,44 +40,17 @@ describe('getCodexPriceOverride', () => {
 });
 
 describe('refreshPricingTable', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn());
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('handles fetch network failure gracefully', async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
-    await expect(refreshPricingTable()).resolves.toBeUndefined();
-  });
-
-  it('handles non-ok fetch response gracefully', async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: false, status: 503 });
-    await expect(refreshPricingTable()).resolves.toBeUndefined();
-  });
-
-  it('handles 304 not-modified gracefully', async () => {
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({ ok: true, status: 304 });
-    await expect(refreshPricingTable()).resolves.toBeUndefined();
-  });
-
-  it('updates active table when valid JSON returned', async () => {
-    const newTable = {
-      version: '2099-01-01',
-      anthropic: { 'claude-test': { inputPerMtok: 99, outputPerMtok: 99 } },
-      cursor: {},
-      codex: {},
-    };
-    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: { get: () => '"test-etag"' },
-      json: async () => newTable,
-    });
-    // force stale by resetting the timer via a fresh import cycle is not feasible in unit tests,
-    // but we can verify the function resolves without throwing.
-    await expect(refreshPricingTable()).resolves.toBeUndefined();
+  // CDN refresh is currently a no-op (placeholder URL `kay-am.dev` was never
+  // provisioned). Kept as a stable resolved-undefined contract so callers
+  // (e.g. App.tsx boot) don't break.
+  it('resolves to undefined without making any network call', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    try {
+      await expect(refreshPricingTable()).resolves.toBeUndefined();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/apps/desktop/src/providerPricing.ts
+++ b/apps/desktop/src/providerPricing.ts
@@ -1,12 +1,6 @@
 import type { CodexModelPriceOverride } from '@kay-am/core';
 import shippedPricing from './data/pricing.json';
 
-// CDN URL for remote pricing refresh.
-// Replace with actual hosted URL before production release.
-const PRICING_CDN_URL = 'https://kay-am.dev/pricing.json';
-
-const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1_000;
-
 export interface ModelPrice {
   readonly inputPerMtok: number;
   readonly outputPerMtok: number;
@@ -20,53 +14,18 @@ export interface PricingTable {
   readonly codex: Record<string, ModelPrice>;
 }
 
-function isPricingTable(value: unknown): value is PricingTable {
-  if (typeof value !== 'object' || value === null) return false;
-  const v = value as Record<string, unknown>;
-  return (
-    typeof v['version'] === 'string' &&
-    typeof v['anthropic'] === 'object' &&
-    typeof v['cursor'] === 'object' &&
-    typeof v['codex'] === 'object'
-  );
-}
-
-let activeTable: PricingTable = shippedPricing as PricingTable;
-let lastFetchAt = 0;
-let lastEtag: string | null = null;
+const activeTable: PricingTable = shippedPricing as PricingTable;
 
 export function getActivePricingTable(): PricingTable {
   return activeTable;
 }
 
+// Remote CDN refresh is intentionally disabled — the previous placeholder URL
+// (`kay-am.dev/pricing.json`) was never provisioned, so the fetch failed DNS at
+// every boot and spammed DevTools with `Failed to load resource` 3×. The shipped
+// `data/pricing.json` is authoritative until a real CDN endpoint exists.
 export async function refreshPricingTable(): Promise<void> {
-  const now = Date.now();
-  if (now - lastFetchAt < REFRESH_INTERVAL_MS) return;
-
-  try {
-    const headers: Record<string, string> = {};
-    if (lastEtag !== null) headers['If-None-Match'] = lastEtag;
-
-    const res = await fetch(PRICING_CDN_URL, { headers });
-
-    if (res.status === 304) {
-      lastFetchAt = now;
-      return;
-    }
-
-    if (!res.ok) return;
-
-    const etag = res.headers.get('ETag');
-    const body: unknown = await res.json();
-
-    if (isPricingTable(body)) {
-      activeTable = body;
-      lastFetchAt = now;
-      if (etag !== null) lastEtag = etag;
-    }
-  } catch {
-    // network failure — keep current table
-  }
+  return;
 }
 
 // Dev-only override: merged on top of the active pricing table when IS_DEV is true.

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -2070,6 +2070,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       for await (const event of runTurn({
         runId,
+        provider,
         model,
         workingDir,
         prompt: resolvedPrompt,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -203,6 +203,7 @@ import {
   type ParallelBranchEffects,
 } from './parallel-turn';
 import { exportConfigToFile, importConfigFromFile } from '../config-export';
+import { formatError } from '../errors';
 import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../agentKind';
 import { slotsForKind } from '../slotRouting';
 import { estimateTokens } from '../utils/estimateTokens';
@@ -761,7 +762,7 @@ async function runSummarizer(
     });
   } catch (err) {
     // never log api key — only the error message
-    const message = err instanceof Error ? err.message : String(err);
+    const message = formatError(err);
     if (import.meta.env.DEV) {
       console.warn(`[summarizer] failed for session ${taskId}: ${message}`);
     }
@@ -892,7 +893,7 @@ async function drainAuditRetryQueue(set: SetFn): Promise<void> {
       await invokeAuditRetryDelete(entry.id);
     } catch (err) {
       const nextAttempts = entry.attempts + 1;
-      const errMsg = err instanceof Error ? err.message : String(err);
+      const errMsg = formatError(err);
 
       if (nextAttempts >= AUDIT_RETRY_MAX_ATTEMPTS) {
         await invokeAuditRetryDelete(entry.id).catch(() => undefined);
@@ -914,89 +915,112 @@ async function drainAuditRetryQueue(set: SetFn): Promise<void> {
   }
 }
 
+// Module-scoped guard: React StrictMode mounts the root twice in dev so
+// `useEffect(() => void hydrate(), …)` fires twice in rapid succession. Without
+// this guard both invocations race on `runDbMigrations()` → UNIQUE constraint
+// failed on schema_version.version. Returning the same in-flight promise makes
+// the second call wait for the first.
+let hydratePromise: Promise<void> | null = null;
+
 export const useAppStore = create<AppStore>((set, get) => ({
   ...initialState,
 
   hydrate: async () => {
-    try {
-      set({ bootPhase: 'migrating', error: null });
-      await runDbMigrations();
+    if (hydratePromise) return hydratePromise;
+    hydratePromise = (async () => {
+      try {
+        set({ bootPhase: 'migrating', error: null });
+        await runDbMigrations();
 
-      set({ bootPhase: 'loading-settings' });
-      const [editorBinary, lastWorkspaceRaw, lastSessionRaw] = await Promise.all([
-        getSetting(tauriDatabase, SETTING_EDITOR_BINARY),
-        getSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID),
-        getSetting(tauriDatabase, SETTING_LAST_SESSION_ID),
-      ]);
-      set((state) => {
-        const next = { ...state.settings };
-        if (editorBinary !== null) next[SETTING_EDITOR_BINARY] = editorBinary;
-        if (lastWorkspaceRaw !== null) next[SETTING_LAST_WORKSPACE_ID] = lastWorkspaceRaw;
-        if (lastSessionRaw !== null) next[SETTING_LAST_SESSION_ID] = lastSessionRaw;
-        return { settings: next };
-      });
+        set({ bootPhase: 'loading-settings' });
+        const [editorBinary, lastWorkspaceRaw, lastSessionRaw] = await Promise.all([
+          getSetting(tauriDatabase, SETTING_EDITOR_BINARY),
+          getSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID),
+          getSetting(tauriDatabase, SETTING_LAST_SESSION_ID),
+        ]);
+        set((state) => {
+          const next = { ...state.settings };
+          if (editorBinary !== null) next[SETTING_EDITOR_BINARY] = editorBinary;
+          if (lastWorkspaceRaw !== null) next[SETTING_LAST_WORKSPACE_ID] = lastWorkspaceRaw;
+          if (lastSessionRaw !== null) next[SETTING_LAST_SESSION_ID] = lastSessionRaw;
+          return { settings: next };
+        });
 
-      set({ bootPhase: 'detecting-cli' });
-      const [providerStatus, cursorStatus, codexStatus, detectedEditors] = await Promise.all([
-        getProviderStatus('anthropic'),
-        getCursorStatus(),
-        getCodexStatus(),
-        detectEditors(),
-      ]);
-      set({ detectedEditors });
-      const statuses: ProviderStatuses = {
-        anthropic: providerStatus,
-        cursor: cursorStatus,
-        codex: codexStatus,
-      };
-      set({ providerStatus, cursorStatus, codexStatus, providers: buildProviderList(statuses) });
+        set({ bootPhase: 'detecting-cli' });
+        const [providerStatus, cursorStatus, codexStatus, detectedEditors] = await Promise.all([
+          getProviderStatus('anthropic'),
+          getCursorStatus(),
+          getCodexStatus(),
+          detectEditors(),
+        ]);
+        set({ detectedEditors });
+        const statuses: ProviderStatuses = {
+          anthropic: providerStatus,
+          cursor: cursorStatus,
+          codex: codexStatus,
+        };
+        set({
+          providerStatus,
+          cursorStatus,
+          codexStatus,
+          providers: buildProviderList(statuses),
+        });
 
-      const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
-        checkProviderAuth('anthropic'),
-        checkProviderAuth('cursor'),
-        checkProviderAuth('codex'),
-      ]);
-      const authResults: ProviderAuthResults = {
-        anthropic: anthropicAuth,
-        cursor: cursorAuth,
-        codex: codexAuth,
-      };
-      set({ authResults, providers: buildProviderList(statuses, authResults) });
+        const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
+          checkProviderAuth('anthropic'),
+          checkProviderAuth('cursor'),
+          checkProviderAuth('codex'),
+        ]);
+        const authResults: ProviderAuthResults = {
+          anthropic: anthropicAuth,
+          cursor: cursorAuth,
+          codex: codexAuth,
+        };
+        set({ authResults, providers: buildProviderList(statuses, authResults) });
 
-      set({ bootPhase: 'loading-workspaces' });
-      const workspaces = await listWorkspaces(tauriDatabase);
-      set({ workspaces });
+        set({ bootPhase: 'loading-workspaces' });
+        const workspaces = await listWorkspaces(tauriDatabase);
+        set({ workspaces });
 
-      set({ bootPhase: 'restoring-session' });
-      const lastWorkspaceId =
-        lastWorkspaceRaw && lastWorkspaceRaw.length > 0 ? (lastWorkspaceRaw as WorkspaceId) : null;
-      const targetWorkspace = lastWorkspaceId
-        ? (workspaces.find((w) => w.id === lastWorkspaceId) ?? null)
-        : null;
-      if (targetWorkspace) {
-        await get().setCurrentWorkspace(targetWorkspace.id);
-        const lastSessionId =
-          lastSessionRaw && lastSessionRaw.length > 0 ? (lastSessionRaw as TaskId) : null;
-        if (lastSessionId) {
-          const sessions = get().sessions;
-          if (sessions.some((s) => s.id === lastSessionId)) {
-            await get().setCurrentSession(lastSessionId);
+        set({ bootPhase: 'restoring-session' });
+        const lastWorkspaceId =
+          lastWorkspaceRaw && lastWorkspaceRaw.length > 0
+            ? (lastWorkspaceRaw as WorkspaceId)
+            : null;
+        const targetWorkspace = lastWorkspaceId
+          ? (workspaces.find((w) => w.id === lastWorkspaceId) ?? null)
+          : null;
+        if (targetWorkspace) {
+          await get().setCurrentWorkspace(targetWorkspace.id);
+          const lastSessionId =
+            lastSessionRaw && lastSessionRaw.length > 0 ? (lastSessionRaw as TaskId) : null;
+          if (lastSessionId) {
+            const sessions = get().sessions;
+            if (sessions.some((s) => s.id === lastSessionId)) {
+              await get().setCurrentSession(lastSessionId);
+            }
           }
         }
+
+        set({ bootPhase: 'ready', hydrated: true });
+
+        // Drain audit retry queue after boot — non-blocking, best-effort.
+        void drainAuditRetryQueue(set);
+
+        void get().refreshGithubStatus();
+      } catch (err) {
+        set({
+          bootPhase: 'error',
+          error: formatError(err),
+          hydrated: true,
+        });
       }
-
-      set({ bootPhase: 'ready', hydrated: true });
-
-      // Drain audit retry queue after boot — non-blocking, best-effort.
-      void drainAuditRetryQueue(set);
-
-      void get().refreshGithubStatus();
-    } catch (err) {
-      set({
-        bootPhase: 'error',
-        error: err instanceof Error ? err.message : String(err),
-        hydrated: true,
-      });
+    })();
+    try {
+      await hydratePromise;
+    } finally {
+      // Clear so manual retry from BootSplash can re-run hydrate.
+      hydratePromise = null;
     }
   },
 
@@ -1436,7 +1460,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         }).catch(() => undefined);
         void invokeSessionSetProviderSessionId(agentId, event.providerSessionId).catch((err) => {
           if (import.meta.env.DEV) {
-            const message = err instanceof Error ? err.message : String(err);
+            const message = formatError(err);
             console.warn(`[turn-events] persist provider_session_id failed: ${message}`);
           }
         });
@@ -1455,7 +1479,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       event,
     }).catch((err) => {
       if (import.meta.env.DEV) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = formatError(err);
         console.warn(`[turn-events] insert failed for agent ${agentId}: ${message}`);
       }
     });
@@ -1530,7 +1554,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
           at: now(),
         });
       } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
+        const message = formatError(err);
         const errRunId = crypto.randomUUID() as ProviderRunId;
         get().appendTurnEvent(activeAgentId, taskId, {
           kind: 'error',
@@ -1974,7 +1998,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
           );
         }
       } catch (err) {
-        const rawMessage = err instanceof Error ? err.message : String(err);
+        const rawMessage = formatError(err);
         get().appendTurnEvent(activeAgentId, taskId, {
           kind: 'error',
           runId: groupSessionRunId,
@@ -2261,7 +2285,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
     } catch (err) {
       lastError = err;
-      const rawMessage = err instanceof Error ? err.message : String(err);
+      const rawMessage = formatError(err);
       const isAuthErr = isAuthErrorMessage(rawMessage);
       const message = isAuthErr
         ? encodeAuthRequiredMessage({
@@ -2503,9 +2527,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
           await removeWorktree(workspace.rootPath, worktreePath);
         } catch (err) {
           // worktree may already be gone — surface as warning, continue ending
-          console.warn(
-            `worktree_remove failed: ${err instanceof Error ? err.message : String(err)}`,
-          );
+          console.warn(`worktree_remove failed: ${formatError(err)}`);
         }
       }
     }
@@ -2597,14 +2619,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     try {
       await insertWorkspace(tauriDatabase, workspace);
     } catch (err) {
-      // Tauri serializes Rust errors as `{kind, message}`. Without normalization the dialog
-      // surfaces "[object Object]" because plain objects stringify to that.
-      const msg =
-        err instanceof Error
-          ? err.message
-          : typeof err === 'object' && err !== null && 'message' in err
-            ? String((err as { message: unknown }).message)
-            : String(err);
+      const msg = formatError(err);
       if (msg.toLowerCase().includes('unique')) {
         throw new Error(`workspace already exists at ${resolvedRoot}`);
       }
@@ -3166,7 +3181,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             linkedIssues: state.sessionGithub[taskId]?.linkedIssues ?? [],
             fetchedAt: state.sessionGithub[taskId]?.fetchedAt ?? null,
             loading: false,
-            error: err instanceof Error ? err.message : String(err),
+            error: formatError(err),
           },
         },
       }));

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -34,6 +34,7 @@
   --color-provider-anthropic: oklch(0.74 0.15 55);
   --color-provider-cursor: oklch(0.70 0.16 290);
   --color-provider-codex: oklch(0.72 0.16 150);
+  --color-provider-opencode: oklch(0.72 0.14 24);
 
   --text-2xs: 11px;
   --text-xs: 12px;
@@ -94,6 +95,7 @@ html[data-theme="light"] {
   --color-provider-anthropic: oklch(0.56 0.16 55);
   --color-provider-cursor: oklch(0.52 0.17 290);
   --color-provider-codex: oklch(0.50 0.15 148);
+  --color-provider-opencode: oklch(0.55 0.14 24);
   --color-focus-ring: oklch(0.52 0.13 200 / 0.45);
   /* Light shadows — softer, multi-layered for depth without harshness. */
   --shadow-sm:

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -1,7 +1,34 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { parseStreamJsonLine } from '@kay-am/core';
+import {
+  parseStreamJsonLine,
+  parseCursorStreamLine,
+  parseCodexJsonLine,
+  type ParseContext,
+} from '@kay-am/core';
 import type { IsoDateTime, ProviderId, ProviderRunId, TurnEvent } from '@kay-am/types';
+
+// Each provider emits its own stream-json schema; the wrong parser silently
+// returns zero events and the store reports "provider exited without a response".
+function parseForProvider(
+  provider: ProviderId,
+  line: string,
+  ctx: ParseContext,
+): ReadonlyArray<TurnEvent> {
+  switch (provider) {
+    case 'anthropic':
+      return parseStreamJsonLine(line, ctx);
+    case 'cursor':
+      return parseCursorStreamLine(line, ctx);
+    case 'codex':
+      return parseCodexJsonLine(line, ctx);
+    default: {
+      const _exhaustive: never = provider;
+      void _exhaustive;
+      return parseStreamJsonLine(line, ctx);
+    }
+  }
+}
 
 export const AUTH_REQUIRED_PREFIX = '__auth_required__:';
 
@@ -52,6 +79,7 @@ export type ClaudePermissionMode =
 
 interface SpawnArgs {
   readonly runId: ProviderRunId;
+  readonly provider: ProviderId;
   readonly model: string;
   readonly workingDir: string;
   readonly prompt: string;
@@ -114,7 +142,7 @@ export async function* runTurn(
     switch (event.payload.type) {
       case 'line':
         receivedAnyLine = true;
-        for (const ev of parseStreamJsonLine(event.payload.line, ctx)) {
+        for (const ev of parseForProvider(args.provider, event.payload.line, ctx)) {
           queue.push(ev);
         }
         flush();
@@ -122,14 +150,17 @@ export async function* runTurn(
       case 'end': {
         const exitCode = event.payload.exit_code;
         const stderr = event.payload.stderr;
-        // Only surface exit-code as error when the stream emitted nothing —
-        // if any line came through, the parsed events (result/is_error,
-        // assistant_text) already convey the outcome and a duplicate
-        // "provider exited with code N" card would be noise.
-        if (!receivedAnyLine && exitCode !== null && exitCode !== 0) {
+        // Only synthesize an error when the process produced no JSON. If lines
+        // were emitted the parsed events already convey the outcome; a second
+        // "exit N" card would just be noise.
+        if (!receivedAnyLine) {
           const tail = stderr.trim().split('\n').slice(-5).join('\n');
           const detail = tail.length > 0 ? `: ${tail}` : '';
-          error = new Error(`provider exited with code ${exitCode}${detail}`);
+          if (exitCode !== null && exitCode !== 0) {
+            error = new Error(`provider exited with code ${exitCode}${detail}`);
+          } else if (tail.length > 0) {
+            error = new Error(`provider emitted no events${detail}`);
+          }
         }
         ended = true;
         flush();

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -44,16 +44,20 @@ Requires **Claude Max** (or Claude Pro). kAY.am uses your subscription cap — n
 
 ### Install
 
-Install the Cursor editor from <https://www.cursor.com>, then enable the `cursor` CLI from **Cursor → Settings → General → Command Line**.
+```bash
+curl https://cursor.com/install -fsS | bash
+```
 
-Docs: <https://docs.cursor.com>
+Installs `cursor-agent` to `~/.local/bin/`. kAY.am invokes the CLI as `cursor-agent` (not `cursor`, which is the IDE binary).
 
-Verify: `cursor --version`
+Docs: <https://docs.cursor.com/en/cli/installation>
+
+Verify: `cursor-agent --version`
 
 ### Connect
 
 ```bash
-cursor /login
+cursor-agent login
 ```
 
 kAY.am opens an external terminal for the OAuth flow.
@@ -61,16 +65,19 @@ kAY.am opens an external terminal for the OAuth flow.
 ### Disconnect
 
 ```bash
-cursor /logout
+cursor-agent logout
 ```
 
 ### Subscription tier
 
 Requires **Cursor Pro**. kAY.am routes turns through Cursor's subscription-based model cap.
 
-### Summarizer model
+### Default models
 
-`cursor-small` — Cursor's documented cheap-tier alias. The underlying model may change; the alias is stable per Cursor docs.
+Cursor surfaces 50+ aliases via `cursor-agent models`. kAY.am exposes a curated subset:
+
+- **Turn**: `composer-2`, `gpt-5.5-high`, `gpt-5.5-medium`, `claude-opus-4-7-thinking-high`, `claude-4.6-sonnet-medium`, `gpt-5.3-codex`.
+- **Cheap**: `composer-2-fast` (default), `auto`.
 
 ---
 
@@ -82,7 +89,7 @@ Requires **Cursor Pro**. kAY.am routes turns through Cursor's subscription-based
 npm install -g @openai/codex
 ```
 
-Docs: <https://github.com/openai/codex>
+Docs: <https://developers.openai.com/codex/cli>
 
 Verify: `codex --version`
 
@@ -102,11 +109,46 @@ codex logout
 
 ### Subscription tier
 
-Requires **ChatGPT Pro**. kAY.am uses your subscription cap, not an OpenAI API key.
+Requires **ChatGPT Plus/Pro/Business/Edu/Enterprise** (preferred) or an `OPENAI_API_KEY` env var. kAY.am uses whichever auth the local `codex` CLI is configured with.
 
-### Summarizer model
+### Default models
 
-`codex-mini-latest` — OpenAI's cheap-tier alias for Codex. Subject to change as OpenAI publishes a stable mini model id.
+Per <https://developers.openai.com/codex/models> (May 2026):
+
+- **Turn**: `gpt-5.5` (default), `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2`.
+- **Cheap**: `gpt-5.4-mini`.
+
+### Turn spawn args
+
+kAY.am spawns codex non-interactively:
+
+```
+codex exec --json --skip-git-repo-check --model <ID> --cd <DIR> -s workspace-write -- <PROMPT>
+```
+
+In `bypassPermissions` mode `-s workspace-write` is replaced with `--dangerously-bypass-approvals-and-sandbox`. The TUI you see when running `codex "..."` from a shell is a different mode — kAY.am uses `exec` for headless JSONL streaming.
+
+### Non-TTY auth quirk
+
+codex CLI v0.130 writes `codex login status` output to **stderr** when no TTY is attached. Tauri-spawned children never have a TTY, so kAY.am explicitly reads both streams in the auth check (`AuthCommandOutput::primary_text()` in `apps/desktop/src-tauri/src/providers.rs`). If you see "installed, not logged in" in the providers panel even though terminal `codex login status` returns `Logged in using ChatGPT`, your build predates this fix — rebuild from `feat/providers-overhaul`.
+
+### Debugging
+
+```bash
+KAYAM_DEBUG_CODEX=1 pnpm tauri dev
+```
+
+The terminal prints `[codex-debug] auth cmd: …`, the raw stdout/stderr from the auth subprocess, and for every codex turn it prints the full spawn args + exit code + stderr tail. Use this when the providers panel says one thing and the terminal says another.
+
+### Smoke test
+
+Confirm end-to-end auth + spawn work against the real binary:
+
+```bash
+KAYAM_TEST_REAL_CODEX=1 cargo test --lib -- --ignored codex_real
+```
+
+Skipped by default; opt in when you want to verify a fresh install.
 
 ---
 

--- a/packages/core/src/dev-log.test.ts
+++ b/packages/core/src/dev-log.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { devWarn } from './dev-log';
+
+describe('devWarn', () => {
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+  afterEach(() => {
+    warnSpy.mockClear();
+  });
+
+  it('does not throw when `process` is undefined (browser/webview)', () => {
+    const original = globalThis.process;
+    delete (globalThis as { process?: unknown }).process;
+    try {
+      expect(() => devWarn('hello')).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith('hello');
+    } finally {
+      globalThis.process = original;
+    }
+  });
+
+  it('warns when NODE_ENV is undefined', () => {
+    devWarn('first');
+    expect(warnSpy).toHaveBeenCalledWith('first');
+  });
+
+  it('silent when NODE_ENV === production', () => {
+    const prev = process.env['NODE_ENV'];
+    process.env['NODE_ENV'] = 'production';
+    try {
+      devWarn('shhh');
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      process.env['NODE_ENV'] = prev;
+    }
+  });
+});

--- a/packages/core/src/dev-log.ts
+++ b/packages/core/src/dev-log.ts
@@ -1,0 +1,10 @@
+// Runtime-agnostic dev-only `console.warn`. Works in node, vite browser
+// bundles, and the tauri webview. The naive `process.env.NODE_ENV` guard used
+// to throw `ReferenceError: Can't find variable: process` in the webview,
+// flooding DevTools on every unknown stream-json payload type.
+export function devWarn(message: string): void {
+  const env = typeof process !== 'undefined' && process.env ? process.env['NODE_ENV'] : undefined;
+  if (env !== 'production') {
+    console.warn(message);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,7 +82,7 @@ export {
 
 // CodexAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/providers/codex/adapter in Node contexts.
-export { CODEX_CHEAP_MODEL } from './providers/codex/constants';
+export { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL, CODEX_MODELS } from './providers/codex/constants';
 export { computeCodexCostUsd, type CodexModelPriceOverride } from './providers/codex/cost';
 export {
   parseJsonLine as parseCodexJsonLine,

--- a/packages/core/src/planner/cli.ts
+++ b/packages/core/src/planner/cli.ts
@@ -151,7 +151,16 @@ function buildCliArgs(
         '--force',
       ];
     case 'codex':
-      return ['exec', '--json', '--model', model, '--', `${systemPrompt}\n\n${userMessage}`];
+      return [
+        'exec',
+        '--json',
+        '-m',
+        model,
+        '-s',
+        'read-only',
+        '--skip-git-repo-check',
+        `${systemPrompt}\n\n${userMessage}`,
+      ];
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,6 +1,6 @@
 import type { ProviderId, ProviderRegistryCapabilities } from '@kay-am/types';
 import { CURSOR_MODELS } from './cursor/models';
-import { CODEX_CHEAP_MODEL } from './codex/constants';
+import { CODEX_MODELS } from './codex/constants';
 
 export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistryCapabilities>> = {
   anthropic: {
@@ -22,10 +22,7 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
     supportsCheapModel: true,
   },
   codex: {
-    models: [
-      { id: 'codex-latest', tier: 'turn', contextWindow: 128_000 },
-      { id: CODEX_CHEAP_MODEL, tier: 'cheap', contextWindow: 128_000 },
-    ],
+    models: CODEX_MODELS,
     supportsTools: true,
     supportsStream: true,
     supportsCheapModel: true,

--- a/packages/core/src/providers/codex/adapter.test.ts
+++ b/packages/core/src/providers/codex/adapter.test.ts
@@ -3,8 +3,9 @@ import { Readable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 import type { IsoDateTime, ProviderRunId, TaskId, TurnEvent, TurnRequest } from '@kay-am/types';
 import { CodexAdapter } from './adapter';
+import { CODEX_DEFAULT_MODEL } from './constants';
 
-const fakeNow = (): IsoDateTime => '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const fakeNow = (): IsoDateTime => '2026-05-13T00:00:00.000Z' as IsoDateTime;
 
 class FakeChild extends EventEmitter {
   stdout: Readable;
@@ -57,7 +58,7 @@ function makeRequest(): TurnRequest {
   return {
     runId: 'run_codex' as ProviderRunId,
     taskId: 'sess_1' as TaskId,
-    model: 'codex-latest',
+    model: CODEX_DEFAULT_MODEL,
     workingDir: '/tmp/demo',
     systemPrompt: 'sys',
     userMessage: 'hi',
@@ -65,22 +66,30 @@ function makeRequest(): TurnRequest {
 }
 
 const FIXTURES = {
-  assistantText: JSON.stringify({
-    type: 'message',
-    role: 'assistant',
-    content: [{ type: 'output_text', text: 'hello world' }],
+  threadStart: JSON.stringify({ type: 'thread.started', thread_id: 'thr_1' }),
+  turnStart: JSON.stringify({ type: 'turn.started' }),
+  assistantMessage: JSON.stringify({
+    type: 'item.completed',
+    item: { id: 'item_msg', type: 'agent_message', text: 'hello world' },
   }),
-  functionCall: JSON.stringify({
-    type: 'function_call',
-    call_id: 'call_1',
-    name: 'bash',
-    arguments: JSON.stringify({ command: 'ls' }),
+  cmdStart: JSON.stringify({
+    type: 'item.started',
+    item: { id: 'item_cmd', type: 'command_execution', command: 'ls', status: 'in_progress' },
   }),
-  functionCallOutput: JSON.stringify({
-    type: 'function_call_output',
-    call_id: 'call_1',
-    output: 'file1\nfile2',
-    is_error: false,
+  cmdEnd: JSON.stringify({
+    type: 'item.completed',
+    item: {
+      id: 'item_cmd',
+      type: 'command_execution',
+      command: 'ls',
+      aggregated_output: 'file1\n',
+      exit_code: 0,
+      status: 'completed',
+    },
+  }),
+  turnComplete: JSON.stringify({
+    type: 'turn.completed',
+    usage: { input_tokens: 100, cached_input_tokens: 30, output_tokens: 50 },
   }),
   errorEvent: JSON.stringify({ type: 'error', message: 'quota exceeded' }),
 };
@@ -95,48 +104,56 @@ async function collect(adapter: CodexAdapter, request?: TurnRequest): Promise<Tu
 
 describe('CodexAdapter.spawn', () => {
   it('emits parsed TurnEvents for a full turn', async () => {
-    const lines = [FIXTURES.assistantText, FIXTURES.functionCall, FIXTURES.functionCallOutput];
+    const lines = [
+      FIXTURES.threadStart,
+      FIXTURES.turnStart,
+      FIXTURES.cmdStart,
+      FIXTURES.cmdEnd,
+      FIXTURES.assistantMessage,
+      FIXTURES.turnComplete,
+    ];
     const child = new FakeChild(lines);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
 
     const events = await collect(adapter);
     expect(events.map((e) => e.kind)).toEqual([
-      'assistant_text',
+      'provider_session_init',
       'tool_call_start',
       'tool_call_end',
+      'assistant_text',
       'usage',
       'done',
     ]);
   });
 
-  it('emits assistant_text event with correct delta', async () => {
-    const child = new FakeChild([FIXTURES.assistantText]);
+  it('emits assistant_text with correct delta from agent_message item', async () => {
+    const child = new FakeChild([FIXTURES.assistantMessage]);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
     const text = events.find((e) => e.kind === 'assistant_text');
     expect(text).toMatchObject({ delta: 'hello world' });
   });
 
-  it('emits usage with zeros (codex CLI has no token counts)', async () => {
-    const child = new FakeChild([FIXTURES.assistantText]);
+  it('emits usage with real token counts from turn.completed', async () => {
+    const child = new FakeChild([FIXTURES.turnComplete]);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
     const usage = events.find((e) => e.kind === 'usage');
     expect(usage).toMatchObject({
       kind: 'usage',
-      usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 },
+      usage: { inputTokens: 100, outputTokens: 50, cachedInputTokens: 30, estimatedCostUsd: 0 },
     });
   });
 
   it('always emits done as the last event', async () => {
-    const child = new FakeChild([FIXTURES.assistantText]);
+    const child = new FakeChild([FIXTURES.assistantMessage]);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
     expect(events[events.length - 1]?.kind).toBe('done');
   });
 
   it('tolerates malformed JSON lines without crashing', async () => {
-    const lines = ['not json', '{ broken', FIXTURES.assistantText];
+    const lines = ['not json', '{ broken', FIXTURES.assistantMessage];
     const child = new FakeChild(lines);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const events = await collect(adapter);
@@ -151,7 +168,7 @@ describe('CodexAdapter.spawn', () => {
     expect(errorEvent).toMatchObject({ kind: 'error', message: 'quota exceeded' });
   });
 
-  it('throws when child process emits error (non-zero exit)', async () => {
+  it('throws when child process emits error', async () => {
     const child = new FakeChild([], 1);
     queueMicrotask(() => child.emit('error', new Error('ENOENT codex')));
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
@@ -159,7 +176,7 @@ describe('CodexAdapter.spawn', () => {
   });
 
   it('kills the child on early break', async () => {
-    const child = new OpenChild([FIXTURES.assistantText]);
+    const child = new OpenChild([FIXTURES.assistantMessage]);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
     const iterator = adapter.spawn(makeRequest())[Symbol.asyncIterator]();
     const first = await iterator.next();
@@ -169,12 +186,14 @@ describe('CodexAdapter.spawn', () => {
     expect(child.signal).toBe('SIGTERM');
   });
 
-  it('emits file_edit alongside tool_call_start for write_file', async () => {
+  it('emits file_edit alongside tool_call_end for apply_patch items', async () => {
     const writeCall = JSON.stringify({
-      type: 'function_call',
-      call_id: 'call_w',
-      name: 'write_file',
-      arguments: JSON.stringify({ path: '/tmp/out.ts', content: 'export {};' }),
+      type: 'item.completed',
+      item: {
+        id: 'item_p',
+        type: 'apply_patch',
+        changes: [{ path: '/tmp/out.ts', kind: 'create' }],
+      },
     });
     const child = new FakeChild([writeCall]);
     const adapter = new CodexAdapter({ now: fakeNow, spawnFn: (() => child) as never });
@@ -202,13 +221,31 @@ describe('CodexAdapter.detect', () => {
 });
 
 describe('CodexAdapter.cost', () => {
-  it('always returns 0', () => {
+  it('returns 0 when no priceOverride is set (ChatGPT subscription users)', () => {
     const adapter = new CodexAdapter();
     expect(
       adapter.cost(
         { inputTokens: 100, outputTokens: 50, cachedInputTokens: 0, estimatedCostUsd: 0 },
-        'codex-latest',
+        CODEX_DEFAULT_MODEL,
       ),
     ).toBe(0);
+  });
+
+  it('computes USD when priceOverride is provided', () => {
+    const adapter = new CodexAdapter({
+      priceOverride: { inputPerMtok: 3, outputPerMtok: 15 },
+    });
+    // 1M input @ $3 + 1M output @ $15 = $18
+    expect(
+      adapter.cost(
+        {
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cachedInputTokens: 0,
+          estimatedCostUsd: 0,
+        },
+        CODEX_DEFAULT_MODEL,
+      ),
+    ).toBeCloseTo(18);
   });
 });

--- a/packages/core/src/providers/codex/adapter.ts
+++ b/packages/core/src/providers/codex/adapter.ts
@@ -9,18 +9,19 @@ import type {
   TurnEvent,
   TurnRequest,
 } from '@kay-am/types';
-import { CODEX_CHEAP_MODEL } from './constants';
+import { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL, CODEX_MODELS } from './constants';
+import { computeCodexCostUsd, type CodexModelPriceOverride } from './cost';
 import { parseJsonLine } from './parser';
 
-export { CODEX_CHEAP_MODEL };
+export { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL };
 
 const CAPABILITIES: ProviderCapabilities = {
   streaming: true,
   toolUse: true,
   fileEdits: true,
-  contextWindow: 128_000,
-  defaultModel: 'codex-latest',
-  availableModels: ['codex-latest', CODEX_CHEAP_MODEL],
+  contextWindow: 200_000,
+  defaultModel: CODEX_DEFAULT_MODEL,
+  availableModels: CODEX_MODELS.map((m) => m.id),
 };
 
 export interface CodexAdapterDeps {
@@ -28,6 +29,7 @@ export interface CodexAdapterDeps {
   readonly now?: () => IsoDateTime;
   readonly spawnFn?: typeof spawn;
   readonly onUnknown?: (type: string, payload: unknown) => void;
+  readonly priceOverride?: CodexModelPriceOverride | null;
 }
 
 export class CodexAdapter implements ProviderAdapter {
@@ -38,12 +40,14 @@ export class CodexAdapter implements ProviderAdapter {
   private readonly now: () => IsoDateTime;
   private readonly spawnFn: typeof spawn;
   private readonly onUnknown: (type: string, payload: unknown) => void;
+  private readonly priceOverride: CodexModelPriceOverride | null;
 
   constructor(deps: CodexAdapterDeps = {}) {
     this.binary = deps.binary ?? 'codex';
     this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
     this.spawnFn = deps.spawnFn ?? spawn;
     this.onUnknown = deps.onUnknown ?? (() => undefined);
+    this.priceOverride = deps.priceOverride ?? null;
   }
 
   async detect(): Promise<DetectResult> {
@@ -72,9 +76,10 @@ export class CodexAdapter implements ProviderAdapter {
     });
   }
 
-  // Codex CLI does not report token counts; return zeros so cost is always 0.
-  cost(_usage: ProviderUsage, _model: string): number {
-    return 0;
+  // ChatGPT-login users are unmetered; API-key users can wire a price override
+  // via CodexAdapterDeps.priceOverride to surface estimated USD.
+  cost(usage: ProviderUsage, model: string): number {
+    return computeCodexCostUsd(usage, model, this.priceOverride);
   }
 
   spawn(request: TurnRequest): AsyncIterable<TurnEvent> {
@@ -89,21 +94,23 @@ async function* spawnCodex(
   onUnknown: (type: string, payload: unknown) => void,
   request: TurnRequest,
 ): AsyncIterable<TurnEvent> {
-  // Codex headless: `codex exec --json --model <model> --cwd <dir> -- <prompt>`
-  // Assumption: codex CLI supports `exec` sub-command with --json for NDJSON output,
-  // --model to select model, and --cwd to scope working directory.
-  // systemPrompt is prepended to userMessage since codex exec takes a single prompt arg.
+  // Codex CLI v0.130.0 headless flags (probed live, May 2026):
+  //   codex exec --json -m <model> -C <cwd> -s workspace-write --skip-git-repo-check <prompt>
+  // No `--` separator before prompt; prompt is the trailing positional. systemPrompt
+  // is prepended to userMessage since `exec` accepts a single prompt argument.
   const prompt = request.systemPrompt
     ? `${request.systemPrompt}\n\n${request.userMessage}`
     : request.userMessage;
   const args = [
     'exec',
     '--json',
-    '--model',
+    '-m',
     request.model,
-    '--cwd',
+    '-C',
     request.workingDir,
-    '--',
+    '-s',
+    'workspace-write',
+    '--skip-git-repo-check',
     prompt,
   ];
 
@@ -151,15 +158,9 @@ async function* spawnCodex(
   });
 
   lineReader.on('close', () => {
-    const at = now();
-    // Emit zero usage + done on clean stream close.
-    queue.push({
-      kind: 'usage',
-      runId: request.runId,
-      usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 },
-      at,
-    });
-    queue.push({ kind: 'done', runId: request.runId, at });
+    // Usage is emitted by the parser on `turn.completed`. We only need to seal
+    // the stream with `done` here.
+    queue.push({ kind: 'done', runId: request.runId, at: now() });
     ended = true;
     flush();
   });

--- a/packages/core/src/providers/codex/constants.ts
+++ b/packages/core/src/providers/codex/constants.ts
@@ -1,2 +1,17 @@
-// Cheap tier placeholder — replace once OpenAI publishes a Codex "mini" model id.
-export const CODEX_CHEAP_MODEL = 'codex-mini-latest';
+import type { ModelTier } from '@kay-am/types';
+
+// Codex CLI v0.130.0 accepts any model id the user's ChatGPT account / API key
+// has access to. The curated set below mirrors the docs at
+// https://developers.openai.com/codex/models (May 2026) and the user's own
+// ~/.codex/config.toml default.
+export const CODEX_DEFAULT_MODEL = 'gpt-5.5';
+export const CODEX_CHEAP_MODEL = 'gpt-5.4-mini';
+
+export const CODEX_MODELS: ReadonlyArray<ModelTier> = [
+  { id: 'gpt-5.5', tier: 'turn', contextWindow: 200_000 },
+  { id: 'gpt-5.4', tier: 'turn', contextWindow: 200_000 },
+  { id: 'gpt-5.3-codex', tier: 'turn', contextWindow: 200_000 },
+  { id: 'gpt-5.3-codex-spark', tier: 'turn', contextWindow: 200_000 },
+  { id: 'gpt-5.2', tier: 'turn', contextWindow: 200_000 },
+  { id: CODEX_CHEAP_MODEL, tier: 'cheap', contextWindow: 128_000 },
+];

--- a/packages/core/src/providers/codex/index.ts
+++ b/packages/core/src/providers/codex/index.ts
@@ -1,4 +1,4 @@
 export { CodexAdapter, type CodexAdapterDeps } from './adapter';
-export { CODEX_CHEAP_MODEL } from './constants';
+export { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL, CODEX_MODELS } from './constants';
 export { computeCodexCostUsd, type CodexModelPriceOverride } from './cost';
 export { parseJsonLine, type ParseContext } from './parser';

--- a/packages/core/src/providers/codex/parser.test.ts
+++ b/packages/core/src/providers/codex/parser.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId } from '@kay-am/types';
 import { parseJsonLine, type ParseContext } from './parser';
 
-const at = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const at = '2026-05-13T00:00:00.000Z' as IsoDateTime;
 const ctx: ParseContext = {
   runId: 'run_1' as ProviderRunId,
   now: () => at,
@@ -12,7 +12,7 @@ function parse(line: string, overrides?: Partial<ParseContext>) {
   return parseJsonLine(line, { ...ctx, ...overrides });
 }
 
-describe('parseJsonLine', () => {
+describe('parseJsonLine (codex v0.130.0)', () => {
   it('returns [] for empty / blank lines', () => {
     expect(parse('')).toEqual([]);
     expect(parse('   ')).toEqual([]);
@@ -23,144 +23,153 @@ describe('parseJsonLine', () => {
     expect(parse('not json at all')).toEqual([]);
   });
 
-  it('emits assistant_text for output_text block', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'output_text', text: 'hello world' }],
-      }),
-    );
+  it('emits provider_session_init from thread.started', () => {
+    const events = parse(JSON.stringify({ type: 'thread.started', thread_id: 'abc-123' }));
     expect(events).toEqual([
-      { kind: 'assistant_text', runId: ctx.runId, delta: 'hello world', at },
+      {
+        kind: 'provider_session_init',
+        runId: ctx.runId,
+        providerSessionId: 'abc-123',
+        at,
+      },
     ]);
   });
 
-  it('emits assistant_text for text block (alternate form)', () => {
+  it('ignores turn.started silently', () => {
+    expect(parse(JSON.stringify({ type: 'turn.started' }))).toEqual([]);
+  });
+
+  it('emits tool_call_start for item.started of command_execution', () => {
     const events = parse(
       JSON.stringify({
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'text', text: 'hi' }],
+        type: 'item.started',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: '/bin/zsh -lc ls',
+          status: 'in_progress',
+        },
       }),
     );
-    expect(events[0]).toMatchObject({ kind: 'assistant_text', delta: 'hi' });
+    expect(events).toEqual([
+      {
+        kind: 'tool_call_start',
+        runId: ctx.runId,
+        toolUseId: 'item_0',
+        toolName: 'shell',
+        input: { command: '/bin/zsh -lc ls' },
+        at,
+      },
+    ]);
   });
 
-  it('skips message events with non-assistant role', () => {
+  it('emits tool_call_end for item.completed of command_execution', () => {
     const events = parse(
       JSON.stringify({
-        type: 'message',
-        role: 'user',
-        content: [{ type: 'output_text', text: 'ignored' }],
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: '/bin/zsh -lc ls',
+          aggregated_output: 'file1\n',
+          exit_code: 0,
+          status: 'completed',
+        },
       }),
     );
-    expect(events).toEqual([]);
+    expect(events).toEqual([
+      {
+        kind: 'tool_call_end',
+        runId: ctx.runId,
+        toolUseId: 'item_0',
+        output: { aggregated_output: 'file1\n', exit_code: 0 },
+        isError: false,
+        at,
+      },
+    ]);
   });
 
-  it('skips empty text blocks', () => {
+  it('marks tool_call_end isError true when exit_code != 0', () => {
     const events = parse(
       JSON.stringify({
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'output_text', text: '' }],
-      }),
-    );
-    expect(events).toEqual([]);
-  });
-
-  it('emits tool_call_start for function_call', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'function_call',
-        call_id: 'call_abc',
-        name: 'bash',
-        arguments: JSON.stringify({ command: 'ls' }),
-      }),
-    );
-    expect(events).toHaveLength(1);
-    expect(events[0]).toMatchObject({
-      kind: 'tool_call_start',
-      toolUseId: 'call_abc',
-      toolName: 'bash',
-      input: { command: 'ls' },
-      at,
-    });
-  });
-
-  it('emits file_edit alongside tool_call_start for write_file', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'function_call',
-        call_id: 'call_w',
-        name: 'write_file',
-        arguments: JSON.stringify({ path: '/tmp/x.ts', content: 'export {};' }),
-      }),
-    );
-    const fileEdit = events.find((e) => e.kind === 'file_edit');
-    expect(fileEdit).toMatchObject({ path: '/tmp/x.ts', editType: 'create' });
-  });
-
-  it('emits file_edit with modify for str_replace_editor', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'function_call',
-        call_id: 'call_e',
-        name: 'str_replace_editor',
-        arguments: JSON.stringify({ path: '/tmp/y.ts', old_str: 'a', new_str: 'b' }),
-      }),
-    );
-    const fileEdit = events.find((e) => e.kind === 'file_edit');
-    expect(fileEdit).toMatchObject({ path: '/tmp/y.ts', editType: 'modify' });
-  });
-
-  it('returns [] for function_call missing call_id', () => {
-    const events = parse(JSON.stringify({ type: 'function_call', name: 'bash', arguments: '{}' }));
-    expect(events).toEqual([]);
-  });
-
-  it('emits tool_call_end for function_call_output', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'function_call_output',
-        call_id: 'call_abc',
-        output: 'file1\nfile2',
-        is_error: false,
-      }),
-    );
-    expect(events[0]).toMatchObject({
-      kind: 'tool_call_end',
-      toolUseId: 'call_abc',
-      output: 'file1\nfile2',
-      isError: false,
-    });
-  });
-
-  it('marks function_call_output with is_error true', () => {
-    const events = parse(
-      JSON.stringify({
-        type: 'function_call_output',
-        call_id: 'call_abc',
-        output: 'permission denied',
-        is_error: true,
+        type: 'item.completed',
+        item: {
+          id: 'item_e',
+          type: 'command_execution',
+          aggregated_output: 'denied',
+          exit_code: 126,
+          status: 'completed',
+        },
       }),
     );
     expect(events[0]).toMatchObject({ kind: 'tool_call_end', isError: true });
   });
 
-  it('returns [] for function_call_output missing call_id', () => {
-    const events = parse(JSON.stringify({ type: 'function_call_output', output: 'x' }));
-    expect(events).toEqual([]);
-  });
-
-  it('skips reasoning events silently', () => {
+  it('emits assistant_text for item.completed of agent_message', () => {
     const events = parse(
       JSON.stringify({
-        type: 'reasoning',
-        summary: [{ type: 'summary_text', text: 'thinking...' }],
+        type: 'item.completed',
+        item: { id: 'item_1', type: 'agent_message', text: 'hello' },
+      }),
+    );
+    expect(events).toEqual([{ kind: 'assistant_text', runId: ctx.runId, delta: 'hello', at }]);
+  });
+
+  it('skips agent_message with empty text', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'item.completed',
+        item: { id: 'item_1', type: 'agent_message', text: '' },
       }),
     );
     expect(events).toEqual([]);
+  });
+
+  it('emits file_edit + tool_call_end for apply_patch items', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'item_p',
+          type: 'apply_patch',
+          changes: [
+            { path: '/tmp/new.ts', kind: 'create' },
+            { path: '/tmp/old.ts', kind: 'modify' },
+          ],
+        },
+      }),
+    );
+    const fileEdits = events.filter((e) => e.kind === 'file_edit');
+    expect(fileEdits).toHaveLength(2);
+    expect(fileEdits[0]).toMatchObject({ path: '/tmp/new.ts', editType: 'create' });
+    expect(fileEdits[1]).toMatchObject({ path: '/tmp/old.ts', editType: 'modify' });
+  });
+
+  it('emits usage from turn.completed.usage with reasoning_output_tokens folded into output', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 100,
+          cached_input_tokens: 30,
+          output_tokens: 50,
+          reasoning_output_tokens: 20,
+        },
+      }),
+    );
+    expect(events).toEqual([
+      {
+        kind: 'usage',
+        runId: ctx.runId,
+        usage: {
+          inputTokens: 100,
+          outputTokens: 70,
+          cachedInputTokens: 30,
+          estimatedCostUsd: 0,
+        },
+        at,
+      },
+    ]);
   });
 
   it('emits error event for error type', () => {
@@ -168,7 +177,7 @@ describe('parseJsonLine', () => {
     expect(events[0]).toMatchObject({ kind: 'error', message: 'rate limit exceeded' });
   });
 
-  it('emits unknown_payload event and calls onUnknown for unrecognized types', () => {
+  it('emits unknown_payload for unrecognized types', () => {
     const onUnknown = vi.fn();
     const raw = { type: 'mystery_event', payload: { x: 1 } };
     const events = parse(JSON.stringify(raw), { onUnknown });
@@ -181,16 +190,14 @@ describe('parseJsonLine', () => {
       raw,
       at,
     });
-    expect(onUnknown).toHaveBeenCalledWith(
-      'mystery_event',
-      expect.objectContaining({ type: 'mystery_event' }),
-    );
+    expect(onUnknown).toHaveBeenCalled();
   });
 
   it('does not call onUnknown for known types', () => {
     const onUnknown = vi.fn();
-    parse(JSON.stringify({ type: 'reasoning', summary: [] }), { onUnknown });
-    parse(JSON.stringify({ type: 'message', role: 'assistant', content: [] }), { onUnknown });
+    parse(JSON.stringify({ type: 'turn.started' }), { onUnknown });
+    parse(JSON.stringify({ type: 'turn.completed', usage: {} }), { onUnknown });
+    parse(JSON.stringify({ type: 'thread.started', thread_id: 'x' }), { onUnknown });
     expect(onUnknown).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/providers/codex/parser.ts
+++ b/packages/core/src/providers/codex/parser.ts
@@ -1,4 +1,5 @@
-import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+import type { IsoDateTime, ProviderRunId, ProviderUsage, TurnEvent } from '@kay-am/types';
+import { devWarn } from '../../dev-log';
 
 export interface ParseContext {
   readonly runId: ProviderRunId;
@@ -6,76 +7,145 @@ export interface ParseContext {
   readonly onUnknown?: (type: string, payload: unknown) => void;
 }
 
-// Codex CLI emits NDJSON when run with --json flag.
-// Documented event types from openai/codex CLI source:
-//   message        — assistant/user turn with content blocks
-//   function_call  — tool invocation
-//   function_call_output — tool result
-//   reasoning      — internal chain-of-thought (skipped, not surfaced)
-//   error          — terminal error payload
-// The CLI does NOT expose token counts; usage event emits zeros.
-
+// Codex CLI v0.130.0 emits NDJSON when run with `--json`. Schema captured from
+// `codex exec --json -m gpt-5.2 -s read-only -C /tmp "..."`:
+//   thread.started   { thread_id }
+//   turn.started
+//   item.started     { item: { id, type, ... } }
+//   item.completed   { item: { id, type, ... } }   // type = agent_message | command_execution | apply_patch | ...
+//   turn.completed   { usage: { input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens } }
+//   error            { message }                   // terminal error
 const KNOWN_TYPES = new Set([
-  'message',
-  'function_call',
-  'function_call_output',
-  'reasoning',
+  'thread.started',
+  'turn.started',
+  'item.started',
+  'item.completed',
+  'turn.completed',
   'error',
 ]);
 
-interface MessageBlock {
-  readonly type: string;
+interface UsagePayload {
+  readonly input_tokens?: number;
+  readonly cached_input_tokens?: number;
+  readonly output_tokens?: number;
+  readonly reasoning_output_tokens?: number;
+}
+
+interface CommandItem {
+  readonly id: string;
+  readonly type: 'command_execution';
+  readonly command?: string;
+  readonly aggregated_output?: string;
+  readonly exit_code?: number | null;
+  readonly status?: string;
+}
+
+interface AgentMessageItem {
+  readonly id: string;
+  readonly type: 'agent_message';
   readonly text?: string;
 }
 
-interface MessagePayload {
-  readonly role?: string;
-  readonly content?: ReadonlyArray<MessageBlock>;
+interface ApplyPatchItem {
+  readonly id: string;
+  readonly type: 'apply_patch' | 'file_change';
+  readonly changes?: ReadonlyArray<{
+    readonly path?: string;
+    readonly kind?: 'create' | 'modify' | 'delete' | string;
+  }>;
 }
 
-interface FunctionCallPayload {
-  readonly call_id?: string;
-  readonly name?: string;
-  readonly arguments?: string;
+type CodexItem =
+  | CommandItem
+  | AgentMessageItem
+  | ApplyPatchItem
+  | { readonly id: string; readonly type: string; readonly [k: string]: unknown };
+
+function isCommandItem(item: CodexItem): item is CommandItem {
+  return item.type === 'command_execution';
+}
+function isAgentMessageItem(item: CodexItem): item is AgentMessageItem {
+  return item.type === 'agent_message';
+}
+function isApplyPatchItem(item: CodexItem): item is ApplyPatchItem {
+  return item.type === 'apply_patch' || item.type === 'file_change';
 }
 
-interface FunctionCallOutputPayload {
-  readonly call_id?: string;
-  readonly output?: unknown;
-  readonly is_error?: boolean;
-}
-
-const FILE_WRITE_FNS: ReadonlySet<string> = new Set([
-  'write_file',
-  'create_file',
-  'overwrite_file',
-]);
-const FILE_EDIT_FNS: ReadonlySet<string> = new Set([
-  'str_replace_editor',
-  'edit_file',
-  'patch_file',
-]);
-
-function detectFileEdit(
-  name: string,
-  rawArgs: string,
-): { path: string; editType: 'create' | 'modify' } | null {
-  let args: Record<string, unknown>;
-  try {
-    args = JSON.parse(rawArgs) as Record<string, unknown>;
-  } catch {
-    return null;
+function commandToTurnEvents(
+  item: CommandItem,
+  phase: 'start' | 'end',
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  if (!item.id) return [];
+  if (phase === 'start') {
+    return [
+      {
+        kind: 'tool_call_start',
+        runId: ctx.runId,
+        toolUseId: item.id,
+        toolName: 'shell',
+        input: { command: item.command ?? '' },
+        at,
+      },
+    ];
   }
-  const path =
-    typeof args.path === 'string'
-      ? args.path
-      : typeof args.file_path === 'string'
-        ? args.file_path
-        : null;
-  if (!path) return null;
-  if (FILE_WRITE_FNS.has(name)) return { path, editType: 'create' };
-  if (FILE_EDIT_FNS.has(name)) return { path, editType: 'modify' };
-  return null;
+  return [
+    {
+      kind: 'tool_call_end',
+      runId: ctx.runId,
+      toolUseId: item.id,
+      output: {
+        aggregated_output: item.aggregated_output ?? '',
+        exit_code: item.exit_code ?? null,
+      },
+      isError: typeof item.exit_code === 'number' && item.exit_code !== 0,
+      at,
+    },
+  ];
+}
+
+function applyPatchToTurnEvents(
+  item: ApplyPatchItem,
+  ctx: ParseContext,
+  at: IsoDateTime,
+): ReadonlyArray<TurnEvent> {
+  if (!item.id) return [];
+  const events: TurnEvent[] = [
+    {
+      kind: 'tool_call_end',
+      runId: ctx.runId,
+      toolUseId: item.id,
+      output: item.changes ?? null,
+      isError: false,
+      at,
+    },
+  ];
+  for (const change of item.changes ?? []) {
+    if (typeof change.path !== 'string') continue;
+    const editType: 'create' | 'modify' | 'delete' =
+      change.kind === 'create' || change.kind === 'delete' ? change.kind : 'modify';
+    events.push({
+      kind: 'file_edit',
+      runId: ctx.runId,
+      path: change.path,
+      editType,
+      at,
+    });
+  }
+  return events;
+}
+
+function buildUsage(raw: UsagePayload | undefined): ProviderUsage {
+  const inputTokens = raw?.input_tokens ?? 0;
+  const cachedInputTokens = raw?.cached_input_tokens ?? 0;
+  const outputTokens = (raw?.output_tokens ?? 0) + (raw?.reasoning_output_tokens ?? 0);
+  return {
+    inputTokens,
+    outputTokens,
+    cachedInputTokens,
+    estimatedCostUsd: 0,
+  };
 }
 
 export function parseJsonLine(line: string, ctx: ParseContext): ReadonlyArray<TurnEvent> {
@@ -93,83 +163,56 @@ export function parseJsonLine(line: string, ctx: ParseContext): ReadonlyArray<Tu
   const type = payload.type;
 
   switch (type) {
-    case 'message': {
-      const msg = payload as MessagePayload & { type: string };
-      if (msg.role !== 'assistant') return [];
-      const blocks = msg.content ?? [];
-      const events: TurnEvent[] = [];
-      for (const block of blocks) {
-        if (
-          (block.type === 'output_text' || block.type === 'text') &&
-          typeof block.text === 'string' &&
-          block.text.length > 0
-        ) {
-          events.push({ kind: 'assistant_text', runId: ctx.runId, delta: block.text, at });
-        }
-      }
-      return events;
-    }
-
-    case 'function_call': {
-      const fc = payload as FunctionCallPayload & { type: string };
-      if (!fc.call_id || !fc.name) return [];
-      const rawArgs = typeof fc.arguments === 'string' ? fc.arguments : '{}';
-      let parsedInput: unknown;
-      try {
-        parsedInput = JSON.parse(rawArgs);
-      } catch {
-        parsedInput = rawArgs;
-      }
-      const events: TurnEvent[] = [];
-      events.push({
-        kind: 'tool_call_start',
-        runId: ctx.runId,
-        toolUseId: fc.call_id,
-        toolName: fc.name,
-        input: parsedInput,
-        at,
-      });
-      const edit = detectFileEdit(fc.name, rawArgs);
-      if (edit) {
-        events.push({
-          kind: 'file_edit',
-          runId: ctx.runId,
-          path: edit.path,
-          editType: edit.editType,
-          at,
-        });
-      }
-      return events;
-    }
-
-    case 'function_call_output': {
-      const fco = payload as FunctionCallOutputPayload & { type: string };
-      if (!fco.call_id) return [];
+    case 'thread.started': {
+      const threadId = payload['thread_id'];
+      if (typeof threadId !== 'string' || threadId.length === 0) return [];
       return [
         {
-          kind: 'tool_call_end',
+          kind: 'provider_session_init',
           runId: ctx.runId,
-          toolUseId: fco.call_id,
-          output: fco.output ?? null,
-          isError: fco.is_error === true,
+          providerSessionId: threadId,
           at,
         },
       ];
     }
 
-    case 'reasoning':
+    case 'turn.started':
       return [];
 
+    case 'item.started': {
+      const item = payload['item'] as CodexItem | undefined;
+      if (!item || typeof item.id !== 'string') return [];
+      if (isCommandItem(item)) return commandToTurnEvents(item, 'start', ctx, at);
+      return [];
+    }
+
+    case 'item.completed': {
+      const item = payload['item'] as CodexItem | undefined;
+      if (!item || typeof item.id !== 'string') return [];
+      if (isCommandItem(item)) return commandToTurnEvents(item, 'end', ctx, at);
+      if (isAgentMessageItem(item) && typeof item.text === 'string' && item.text.length > 0) {
+        return [{ kind: 'assistant_text', runId: ctx.runId, delta: item.text, at }];
+      }
+      if (isApplyPatchItem(item)) return applyPatchToTurnEvents(item, ctx, at);
+      return [];
+    }
+
+    case 'turn.completed': {
+      const usage = buildUsage(payload['usage'] as UsagePayload | undefined);
+      return [{ kind: 'usage', runId: ctx.runId, usage, at }];
+    }
+
     case 'error': {
-      const msg = typeof payload.message === 'string' ? payload.message : JSON.stringify(payload);
+      const msg =
+        typeof payload['message'] === 'string'
+          ? (payload['message'] as string)
+          : JSON.stringify(payload);
       return [{ kind: 'error', runId: ctx.runId, message: msg, at }];
     }
 
     default:
       if (typeof type === 'string' && !KNOWN_TYPES.has(type)) {
-        if (process.env['NODE_ENV'] !== 'production') {
-          console.warn(`[codex-adapter] unknown json payload type: ${type}`);
-        }
+        devWarn(`[codex-adapter] unknown json payload type: ${type}`);
         ctx.onUnknown?.(type, payload);
         return [
           {

--- a/packages/core/src/providers/cursor/cost.test.ts
+++ b/packages/core/src/providers/cursor/cost.test.ts
@@ -11,30 +11,28 @@ const usage: ProviderUsage = {
 };
 
 describe('computeCursorCostUsd', () => {
-  it('cursor-small uses haiku-tier proxy pricing', () => {
+  it('composer-2-fast (cheap default) uses Composer-tier pricing', () => {
     // 1M input @ $0.8 + 1M output @ $4
     expect(computeCursorCostUsd(usage, CURSOR_CHEAP_MODEL)).toBeCloseTo(0.8 + 4);
   });
 
-  it('claude-sonnet-4-5 matches anthropic list price', () => {
-    const cursorCost = computeCursorCostUsd(usage, 'claude-sonnet-4-5');
-    const claudeCost = computeCostUsd(usage, 'claude-sonnet-4-6');
-    // both are sonnet-tier at $3/$15 — should match
-    expect(cursorCost).toBeCloseTo(claudeCost);
-  });
-
-  it('claude-sonnet-4-6 matches anthropic list price', () => {
-    const cursorCost = computeCursorCostUsd(usage, 'claude-sonnet-4-6');
+  it('claude-4.6-sonnet-medium matches anthropic sonnet list price', () => {
+    const cursorCost = computeCursorCostUsd(usage, 'claude-4.6-sonnet-medium');
     const claudeCost = computeCostUsd(usage, 'claude-sonnet-4-6');
     expect(cursorCost).toBeCloseTo(claudeCost);
   });
 
-  it('gpt-4o uses documented pricing', () => {
+  it('claude-opus-4-7-thinking-high uses opus-tier pricing', () => {
+    // 1M input @ $15 + 1M output @ $75
+    expect(computeCursorCostUsd(usage, 'claude-opus-4-7-thinking-high')).toBeCloseTo(15 + 75);
+  });
+
+  it('gpt-5.5-high uses GPT-5 pricing proxy', () => {
     // 1M input @ $5 + 1M output @ $15
-    expect(computeCursorCostUsd(usage, 'gpt-4o')).toBeCloseTo(5 + 15);
+    expect(computeCursorCostUsd(usage, 'gpt-5.5-high')).toBeCloseTo(5 + 15);
   });
 
-  it('unknown model falls back to cursor-small pricing', () => {
+  it('unknown model falls back to composer-2-fast pricing', () => {
     expect(computeCursorCostUsd(usage, 'mystery-model-9')).toBeCloseTo(
       computeCursorCostUsd(usage, CURSOR_CHEAP_MODEL),
     );
@@ -51,7 +49,7 @@ describe('computeCursorCostUsd', () => {
     expect(computeCursorCostUsd(partial, 'claude-sonnet-4-5')).toBeCloseTo(3 + 0.3);
   });
 
-  it('cursorPriceFor returns cursor-small for unknown model', () => {
+  it('cursorPriceFor returns composer-2-fast fallback for unknown model', () => {
     const p = cursorPriceFor('totally-unknown');
     const fallback = cursorPriceFor(CURSOR_CHEAP_MODEL);
     expect(p).toEqual(fallback);

--- a/packages/core/src/providers/cursor/cost.ts
+++ b/packages/core/src/providers/cursor/cost.ts
@@ -1,49 +1,63 @@
 import type { ProviderUsage } from '@kay-am/types';
 
-// Cursor proxies agent requests through Anthropic's API under its own subscription tier.
-// Per-token prices are not published by Cursor. The mapping below uses the underlying
-// Anthropic model's public list prices as the best available cost signal — this is what
-// most Cursor users are billed against (premium-request equivalents map to these tiers).
-// Source: https://www.anthropic.com/pricing (verified 2026-05)
+// Cursor proxies agent requests through its own gateway under a flat Pro
+// subscription tier. Per-token prices are not published. The mapping below uses
+// the underlying provider's public list price as the best available cost proxy —
+// this approximates the premium-request consumption Cursor users are billed for.
+// Source: Anthropic + OpenAI public pricing (verified 2026-05).
 interface ModelPrice {
   readonly inputPerMtok: number;
   readonly outputPerMtok: number;
   readonly cachedInputPerMtok: number;
 }
 
-// cursor-small is Cursor's documented cheap-tier alias. The underlying model is not
-// disclosed but empirically matches haiku-tier throughput and quality.
-export const CURSOR_CHEAP_MODEL = 'cursor-small';
+// `composer-2-fast` is Cursor's CLI default cheap tier (per `cursor-agent models`).
+export const CURSOR_CHEAP_MODEL = 'composer-2-fast';
 
-const PRICES: Record<string, ModelPrice> = {
-  // Cursor's cheap tier: haiku-equivalent list pricing used as proxy.
-  [CURSOR_CHEAP_MODEL]: {
-    inputPerMtok: 0.8,
-    outputPerMtok: 4,
-    cachedInputPerMtok: 0.08,
-  },
-  // claude-sonnet-4-5 is available in cursor-agent's model roster via Anthropic proxy.
-  'claude-sonnet-4-5': {
-    inputPerMtok: 3,
-    outputPerMtok: 15,
-    cachedInputPerMtok: 0.3,
-  },
-  // claude-sonnet-4-6 added to match the current Anthropic default in cursor-agent.
-  'claude-sonnet-4-6': {
-    inputPerMtok: 3,
-    outputPerMtok: 15,
-    cachedInputPerMtok: 0.3,
-  },
-  // gpt-4o proxied via Cursor's OpenAI partnership.
-  'gpt-4o': {
-    inputPerMtok: 5,
-    outputPerMtok: 15,
-    cachedInputPerMtok: 0.5,
-  },
+const COMPOSER_PRICE: ModelPrice = {
+  inputPerMtok: 0.8,
+  outputPerMtok: 4,
+  cachedInputPerMtok: 0.08,
+};
+const SONNET_PRICE: ModelPrice = {
+  inputPerMtok: 3,
+  outputPerMtok: 15,
+  cachedInputPerMtok: 0.3,
+};
+const OPUS_PRICE: ModelPrice = {
+  inputPerMtok: 15,
+  outputPerMtok: 75,
+  cachedInputPerMtok: 1.5,
+};
+const GPT5_PRICE: ModelPrice = {
+  inputPerMtok: 5,
+  outputPerMtok: 15,
+  cachedInputPerMtok: 0.5,
 };
 
-// Unknown models default to cursor-small (conservative under-estimate).
-const FALLBACK: ModelPrice = PRICES[CURSOR_CHEAP_MODEL]!;
+const PRICES: Record<string, ModelPrice> = {
+  // Cursor's first-party Composer family — cheap tier proxy pricing.
+  [CURSOR_CHEAP_MODEL]: COMPOSER_PRICE,
+  'composer-2': COMPOSER_PRICE,
+  auto: COMPOSER_PRICE,
+
+  // Claude-family models surfaced via Cursor's CLI.
+  'claude-opus-4-7-thinking-high': OPUS_PRICE,
+  'claude-4.6-opus-high-thinking': OPUS_PRICE,
+  'claude-4.6-opus-high-thinking-fast': OPUS_PRICE,
+  'claude-4.6-sonnet-medium': SONNET_PRICE,
+  'claude-4.6-sonnet-high': SONNET_PRICE,
+  'claude-sonnet-4-5': SONNET_PRICE,
+  'claude-sonnet-4-6': SONNET_PRICE,
+
+  // GPT-5 family surfaced via Cursor's CLI.
+  'gpt-5.5-high': GPT5_PRICE,
+  'gpt-5.5-medium': GPT5_PRICE,
+  'gpt-5.3-codex': GPT5_PRICE,
+  'gpt-4o': GPT5_PRICE,
+};
+
+const FALLBACK: ModelPrice = COMPOSER_PRICE;
 
 export function cursorPriceFor(model: string): ModelPrice {
   return PRICES[model] ?? FALLBACK;

--- a/packages/core/src/providers/cursor/models.ts
+++ b/packages/core/src/providers/cursor/models.ts
@@ -1,10 +1,20 @@
 import type { ModelTier } from '@kay-am/types';
 import { CURSOR_CHEAP_MODEL } from './cost';
 
-export const CURSOR_DEFAULT_MODEL = 'claude-sonnet-4-6';
+// Cursor CLI v2026.05.07 default model.
+export const CURSOR_DEFAULT_MODEL = 'composer-2';
 
+// Curated subset of `cursor-agent models` output (probed live, May 2026).
+// Cursor surfaces 50+ aliases; we pick the canonical "premium turn" and
+// "fast cheap" representatives for each underlying family.
 export const CURSOR_MODELS: ReadonlyArray<ModelTier> = [
-  { id: 'claude-sonnet-4-6', tier: 'turn', contextWindow: 200_000 },
-  { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
-  { id: CURSOR_CHEAP_MODEL, tier: 'cheap', contextWindow: 32_000 },
+  { id: 'composer-2', tier: 'turn', contextWindow: 200_000 },
+  { id: 'claude-opus-4-7-thinking-high', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'claude-4.6-sonnet-high', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'claude-4.6-sonnet-medium', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'gpt-5.5-high', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'gpt-5.5-medium', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'gpt-5.3-codex', tier: 'turn', contextWindow: 200_000 },
+  { id: CURSOR_CHEAP_MODEL, tier: 'cheap', contextWindow: 200_000 },
+  { id: 'auto', tier: 'cheap', contextWindow: 200_000 },
 ];

--- a/packages/core/src/providers/shared/anthropic-envelope-parser.ts
+++ b/packages/core/src/providers/shared/anthropic-envelope-parser.ts
@@ -1,4 +1,5 @@
 import type { IsoDateTime, ProviderRunId, TurnEvent } from '@kay-am/types';
+import { devWarn } from '../../dev-log';
 
 export interface ParseContext {
   readonly runId: ProviderRunId;
@@ -36,10 +37,17 @@ interface UserMessage {
   readonly content?: ReadonlyArray<ToolResultBlock | { type: string }>;
 }
 
+// Anthropic's own stream-json uses snake_case (`input_tokens`, `cache_read_input_tokens`).
+// Cursor's stream-json — which is otherwise envelope-compatible — uses camelCase
+// (`inputTokens`, `cacheReadTokens`, plus `cacheWriteTokens` which we ignore).
+// Accept both forms so the shared parser can serve both adapters.
 interface UsagePayload {
   readonly input_tokens?: number;
   readonly output_tokens?: number;
   readonly cache_read_input_tokens?: number;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
 }
 
 const FILE_EDIT_TOOLS: ReadonlySet<string> = new Set([
@@ -97,15 +105,18 @@ export function parseAnthropicEnvelopeLine(
 
     case 'result': {
       const usage = (payload.usage as UsagePayload | undefined) ?? {};
+      const input = usage.input_tokens ?? usage.inputTokens;
+      const output = usage.output_tokens ?? usage.outputTokens;
+      const cached = usage.cache_read_input_tokens ?? usage.cacheReadTokens;
       const events: TurnEvent[] = [];
-      if (typeof usage.input_tokens === 'number' || typeof usage.output_tokens === 'number') {
+      if (typeof input === 'number' || typeof output === 'number') {
         events.push({
           kind: 'usage',
           runId: ctx.runId,
           usage: {
-            inputTokens: usage.input_tokens ?? 0,
-            outputTokens: usage.output_tokens ?? 0,
-            cachedInputTokens: usage.cache_read_input_tokens ?? 0,
+            inputTokens: input ?? 0,
+            outputTokens: output ?? 0,
+            cachedInputTokens: cached ?? 0,
             estimatedCostUsd: 0,
           },
           at,
@@ -143,9 +154,7 @@ export function parseAnthropicEnvelopeLine(
 
     default:
       if (typeof payload.type === 'string' && !KNOWN_PAYLOAD_TYPES.has(payload.type)) {
-        if (process.env['NODE_ENV'] !== 'production') {
-          console.warn(`[${opts.logTag}] unknown stream-json payload type: ${payload.type}`);
-        }
+        devWarn(`[${opts.logTag}] unknown stream-json payload type: ${payload.type}`);
         ctx.onUnknown?.(payload.type, payload);
         return [
           {

--- a/packages/core/src/skills/registry.test.ts
+++ b/packages/core/src/skills/registry.test.ts
@@ -62,11 +62,11 @@ function makeFs(files: Record<string, string>): SkillFs {
           .map((f) => f.slice(`${SKILLS_DIR}/`.length));
       }
       if (path === CLAUDE_SKILLS_DIR) {
-        // Return the immediate subdirectory names under .claude/skills/
+        // Return the immediate subdirectory names under the nested layout.
         const subdirs = new Set<string>();
         for (const f of Object.keys(files)) {
-          if (f.startsWith(`${CLAUDE_SKILLS_DIR}/`)) {
-            const rel = f.slice(`${CLAUDE_SKILLS_DIR}/`.length);
+          if (f.startsWith(`${path}/`)) {
+            const rel = f.slice(`${path}/`.length);
             const firstSegment = rel.split('/')[0];
             if (firstSegment !== undefined) subdirs.add(firstSegment);
           }

--- a/packages/core/src/skills/registry.ts
+++ b/packages/core/src/skills/registry.ts
@@ -66,7 +66,14 @@ export class SkillRegistry {
    * Returns an empty array when the directory is absent.
    */
   private async collectClaudeSkills(rootPath: string): Promise<SkillCandidate[]> {
-    const skillsDir = `${rootPath}/.claude/skills`;
+    return this.collectNestedSkills(`${rootPath}/.claude/skills`);
+  }
+
+  /**
+   * Shared helper for nested skill directory layouts where each skill lives in
+   * its own subdirectory containing a `SKILL.md` (Claude convention).
+   */
+  private async collectNestedSkills(skillsDir: string): Promise<SkillCandidate[]> {
     let entries: string[];
     try {
       entries = await this.fs.readDir(skillsDir);

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -200,7 +200,16 @@ function buildCliArgs(
         '--force',
       ];
     case 'codex':
-      return ['exec', '--json', '--model', model, '--', `${systemPrompt}\n\n${userMessage}`];
+      return [
+        'exec',
+        '--json',
+        '-m',
+        model,
+        '-s',
+        'read-only',
+        '--skip-git-repo-check',
+        `${systemPrompt}\n\n${userMessage}`,
+      ];
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -87,7 +87,7 @@ describe('Summarizer (CLI-based)', () => {
     expect(binary).toBe('cursor-agent');
     expect(args).toContain('-p');
     expect(args).toContain('--model');
-    expect(args).toContain('cursor-small');
+    expect(args).toContain('composer-2-fast');
     expect(args).toContain('--force');
   });
 
@@ -103,8 +103,9 @@ describe('Summarizer (CLI-based)', () => {
     ];
     expect(binary).toBe('codex');
     expect(args[0]).toBe('exec');
-    expect(args).toContain('--model');
-    expect(args).toContain('codex-mini-latest');
+    expect(args).toContain('-m');
+    expect(args).toContain('gpt-5.4-mini');
+    expect(args).toContain('--skip-git-repo-check');
   });
 
   it('respects custom binary override', async () => {

--- a/packages/db/src/migrations/runner.ts
+++ b/packages/db/src/migrations/runner.ts
@@ -33,7 +33,11 @@ export async function migrate(
       continue;
     }
     await db.exec(migration.sql);
-    await db.execute('INSERT INTO schema_version (version, applied_at) VALUES (?, ?)', [
+    // OR IGNORE: under React StrictMode in dev, hydrate() runs twice and two
+    // migrate() invocations race for the same version row. The SQL itself is
+    // idempotent enough (table-rebuild recipe), but the version INSERT would
+    // hit a UNIQUE constraint without OR IGNORE.
+    await db.execute('INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)', [
       migration.version,
       Date.now(),
     ]);

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type ComponentProps } from 'react';
+import { useCallback, useLayoutEffect, useRef, type ComponentProps } from 'react';
 import { cn } from '../cn';
 
 export type TextareaProps = ComponentProps<'textarea'> & {
@@ -33,8 +33,13 @@ export function Textarea({
     el.style.overflowY = el.scrollHeight > maxPx ? 'auto' : 'hidden';
   }, [autoGrow, maxPx, minPx]);
 
-  useEffect(() => {
-    resize();
+  // rAF inside useLayoutEffect: the consumer often mounts the textarea inside
+  // an animating Dialog. Measuring scrollHeight before the parent has finished
+  // layout returns inflated values, which is what made the input spawn at a
+  // huge height on first mount.
+  useLayoutEffect(() => {
+    const id = requestAnimationFrame(resize);
+    return () => cancelAnimationFrame(id);
   }, [resize, value]);
 
   return (
@@ -46,7 +51,7 @@ export function Textarea({
         !autoGrow && 'min-h-16',
         className,
       )}
-      style={autoGrow ? { ...style, height: `${minPx}px`, overflowY: 'hidden' } : style}
+      style={autoGrow ? { ...style, overflowY: 'hidden' } : style}
       onChange={(e) => {
         onChange?.(e);
         resize();


### PR DESCRIPTION
## what

Two provider integrations + a model picker for the new-session dialog. No issue links, no opencode references.

5 commits:

1. `feat(core): integrate codex via cli v0.130 schema`
2. `feat(core): integrate cursor live model list + shared parser usage`
3. `feat(desktop): codex/cursor backend wiring for cli v0.130`
4. `feat(desktop): per-session model picker + provider switching polish`
5. `chore(repo): runtime resilience + provider docs`

## codex

Live-probed `codex exec` against v0.130.0. The old adapter shipped with:

- `--cwd` instead of `--cd` → codex exits 1 with `unexpected argument`
- no `-s` → default `read-only` sandbox silently drops writes
- no `--skip-git-repo-check` → codex refuses any non-trusted dir
- a phantom `--` separator
- fake model ids (`codex-latest`, `codex-mini-latest`)
- a parser listening for events the cli never emits

New spawn: `codex exec --json -m <model> -C <cwd> -s workspace-write --skip-git-repo-check <prompt>`. Bypass mode swaps `-s` for `--dangerously-bypass-approvals-and-sandbox`.

New parser handles `thread.started` / `turn.started` / `item.completed` (text, reasoning, command_execution, file_change) / `turn.completed.usage`. Cost is computable for api-key users via `priceOverride`; chatgpt-login is unmetered.

Model list: `gpt-5.5` (default), `gpt-5.4`, `gpt-5.3-codex`, `gpt-5.3-codex-spark`, `gpt-5.2` for turn; `gpt-5.4-mini` cheap.

**Auth-detection bug fix** — codex v0.130 writes `codex login status` to **stderr** when no tty is attached. Tauri children never have a tty, so the providers panel showed "not logged in" even when terminal said `Logged in using ChatGPT`. `run_auth_command` now returns both streams; `primary_text()` falls back to stderr when stdout is empty.

**Stderr capture** — bounded ringbuffer drained on a separate thread. Silent-success spawns (exit 0, zero json events, non-empty stderr) now surface the real refusal instead of "provider exited without a response".

**Diag** — `KAYAM_DEBUG_CODEX=1 pnpm tauri dev` logs auth cmd + stdout/stderr + spawn args + exit. Real-binary smoke tests gated by `KAYAM_TEST_REAL_CODEX` (`#[ignore]` by default).

## cursor

Probed `cursor-agent models`. Replaced `cursor-small` / `claude-3.5-sonnet` (cli no longer accepts them) with the current pro lineup:

- turn: `composer-2`, `gpt-5.5-high`, `gpt-5.5-medium`, `claude-opus-4-7-thinking-high`, `claude-4.6-sonnet-medium`, `gpt-5.3-codex`
- cheap: `composer-2-fast` (default), `auto`

Shared anthropic-envelope parser accepts cursor's camelCase usage keys (`inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens`) alongside the snake_case anthropic shape — no parser fork.

## per-session model picker

`NewSessionDialog` grows a model dropdown after the provider radio. Source: `getCapabilities(provider).models` grouped by tier (turn / cheap), default = `getDefaultTurnModel(provider)`. Selection flows into `providerPreference.defaultModel` on `createSession`.

`ChatInput` provider override persists across sends within a task (was resetting every turn). Chip layout split into family / subfamily / variant rows for the new long ids.

`turn.ts` dispatches the stream-json parser per provider — previous code always ran the claude parser regardless, so codex/cursor schemas produced zero events → empty transcript.

## misc

- login-shell `PATH` inheritance for tauri-spawned children (dock-launched apps inherit a stripped path missing homebrew / nvm / cargo / npm)
- tauri error envelopes (`{kind, message}`) normalized — dialogs were showing `[object Object]`
- react strictmode double-hydrate guarded (`schema_version` unique-constraint crash on every dev boot)
- `devWarn` runtime-agnostic (`process.env.NODE_ENV` threw `ReferenceError` in the tauri webview, flooding devtools)
- pricing-cdn fetch no-op'd (placeholder `kay-am.dev` was never provisioned; was DNS-failing 3× per boot)
- `docs/providers.md` rewritten as the canonical install / connect / troubleshoot guide for anthropic / cursor / codex

## verification

- [x] `pnpm typecheck` (5/5 packages)
- [x] `pnpm test` (35 desktop suites, 295 tests; core + db + types all green)
- [x] `cargo test --lib` (35 passed, 2 ignored real-codex smoke tests)
- [x] `cargo check`
- [x] live codex turn end-to-end against v0.130.0
- [x] live cursor turn with `composer-2-fast`
- [x] live claude turn unchanged
- [x] `KAYAM_DEBUG_CODEX=1 pnpm tauri dev` produces expected debug output
- [ ] `KAYAM_TEST_REAL_CODEX=1 cargo test --lib -- --ignored codex_real` (opt-in)