### PR TITLE
chore(desktop): retire stale todos + drop unused shortcut export

### DIFF
--- a/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
@@ -252,11 +252,3 @@ describe('keyboard — SlashCommandPopover arrow / tab navigation', () => {
     expect(screen.getByText(/no skills/i)).toBeDefined();
   });
 });
-
-// ---------------------------------------------------------------------------
-// TODO (@ak): F1 / cmd+K command palette keyboard flow — not implemented yet.
-// Will be wired in the shortcut layer tracked in #245.
-// ---------------------------------------------------------------------------
-
-// TODO (@ak): cmd+, / cmd+/ / cmd+. shortcut layer — not implemented yet (#245).
-// Tests for those shortcuts should be added when the shortcut layer lands.

--- a/apps/desktop/src/components/NextActionChips.tsx
+++ b/apps/desktop/src/components/NextActionChips.tsx
@@ -57,8 +57,7 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
           await createPrForSession(taskId);
           break;
         case 'merge_pr':
-          // TODO (#425 follow-up): no merge action exists in the store yet.
-          // The chip stays a no-op so the user sees no failure.
+          // No-op until #415 lands the merge action on the store.
           break;
       }
       clearSessionNextActions(taskId);

--- a/apps/desktop/src/hooks/use-keyboard-shortcut.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcut.ts
@@ -1,23 +1,20 @@
 import { useEffect } from 'react';
 
-export type ShortcutScope = 'global' | 'dialog';
+type ShortcutScope = 'global' | 'dialog';
 
-export interface ShortcutOptions {
+interface ShortcutOptions {
   /** Prevent firing when focus is inside an input/textarea/select/contenteditable. */
   ignoreInInputs?: boolean;
   scope?: ShortcutScope;
 }
 
-export interface ShortcutCombo {
+interface ShortcutCombo {
   key: string;
   meta?: boolean;
   ctrl?: boolean;
   shift?: boolean;
   alt?: boolean;
 }
-
-/** Registry slot reserved for cmd+K command palette (#297, not yet implemented). */
-export const RESERVED_CMD_K: ShortcutCombo = { key: 'k', meta: true };
 
 function parseCombo(combo: string): ShortcutCombo {
   const parts = combo.toLowerCase().split('+');


### PR DESCRIPTION
## Summary

- updates the merge_pr chip comment to reference the still-open \`#415\` instead of the closed \`#425\`
- removes the unused \`RESERVED_CMD_K\` placeholder and demotes \`ShortcutScope\`/\`ShortcutCombo\`/\`ShortcutOptions\` to module-internal (cmd+K palette landed in \`#297\`)
- deletes the two stale TODO blocks at the bottom of \`navigation.test.tsx\` (their \`#245\` tracker closed when the shortcut layer shipped)

## Test plan

- [x] \`pnpm test\` — 295/295
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm knip --include files,duplicates,unlisted\` — exit 0

Closes #500