### PR TITLE
chore(repo): sweep knip-flagged dead exports and types

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,8 +20,6 @@
     "@kay-am/ui": "workspace:*",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.2.0",
-    "@tauri-apps/plugin-shell": "^2.2.0",
-    "@tauri-apps/plugin-sql": "^2.2.0",
     "lucide-react": "^1.14.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/desktop/src/budget.ts
+++ b/apps/desktop/src/budget.ts
@@ -36,20 +36,9 @@ export async function invokeBudgetAlertDismiss(id: string): Promise<void> {
   return invoke<void>('budget_alert_dismiss', { id });
 }
 
-export async function invokeBudgetEmitAlerts(input: {
-  provider: ProviderName;
-  taskId: string;
-}): Promise<BudgetAlert[]> {
-  return invoke<BudgetAlert[]>('budget_emit_alerts', { input });
-}
-
 export async function invokeCheckProviderBudget(
   provider: ProviderName,
   period: BudgetPeriod,
 ): Promise<BudgetCheckResult> {
   return invoke<BudgetCheckResult>('check_provider_budget', { provider, period });
-}
-
-export async function invokeCheckSessionBudget(taskId: string): Promise<BudgetCheckResult> {
-  return invoke<BudgetCheckResult>('check_task_budget', { taskId });
 }

--- a/apps/desktop/src/components/chat/PermissionModePicker.tsx
+++ b/apps/desktop/src/components/chat/PermissionModePicker.tsx
@@ -12,7 +12,7 @@ interface ModeMeta {
   readonly text: string;
 }
 
-export const PERMISSION_MODES: ReadonlyArray<ModeMeta> = [
+const PERMISSION_MODES: ReadonlyArray<ModeMeta> = [
   {
     value: 'bypassPermissions',
     label: 'bypass',

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -51,7 +51,7 @@ export const EFFORT_TEXT: Record<EffortLevel, string> = {
 
 export type CostTier = 'cheap' | 'mid' | 'expensive';
 
-export const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
+const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'cursor-small': { weight: 4, tier: 'cheap' },
   'claude-haiku-4-5': { weight: 5, tier: 'cheap' },
   'codex-mini-latest': { weight: 6, tier: 'cheap' },
@@ -62,25 +62,10 @@ export const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'claude-opus-4-7': { weight: 75, tier: 'expensive' },
 };
 
-export const FAMILY_LABEL: Record<string, string> = {
-  claude: 'Claude',
-  gpt: 'GPT',
-  gemini: 'Gemini',
-  cursor: 'Cursor',
-  codex: 'Codex',
-  other: 'Other',
-};
-
 export const TIER_TEXT: Record<CostTier, string> = {
   cheap: 'text-success',
   mid: 'text-warning',
   expensive: 'text-danger',
-};
-
-export const TIER_DOT: Record<CostTier, string> = {
-  cheap: 'bg-success',
-  mid: 'bg-warning',
-  expensive: 'bg-danger',
 };
 
 export const VERBOSITY_DOT: Record<VerbosityLevel, string> = {
@@ -197,10 +182,6 @@ export function parseModelId(id: string): ParsedModel {
   return { family: 'other', subfamily: null, variantLabel: local };
 }
 
-export function modelFamily(id: string): string {
-  return parseModelId(id).family;
-}
-
 export function modelTier(model: string): CostTier {
   const known = MODEL_COST[model];
   if (known) return known.tier;
@@ -213,14 +194,6 @@ export function modelWeight(model: string): number {
   return MODEL_COST[model]?.weight ?? 10;
 }
 
-export function modelSubfamily(id: string): string {
-  return parseModelId(id).subfamily ?? '';
-}
-
-export function modelVersion(id: string): string {
-  return parseModelId(id).variantLabel;
-}
-
 export const FAMILY_SECTION_LABEL: Record<ModelFamily, string> = {
   claude: 'Claude',
   gpt: 'GPT',
@@ -231,13 +204,13 @@ export const FAMILY_SECTION_LABEL: Record<ModelFamily, string> = {
   other: 'Other',
 };
 
-export const SUBFAMILY_LABEL: Record<string, string> = {
+const SUBFAMILY_LABEL: Record<string, string> = {
   haiku: 'Haiku',
   sonnet: 'Sonnet',
   opus: 'Opus',
 };
 
-export const SUBFAMILY_TIER: Record<string, CostTier> = {
+const SUBFAMILY_TIER: Record<string, CostTier> = {
   haiku: 'cheap',
   sonnet: 'mid',
   opus: 'expensive',

--- a/apps/desktop/src/components/overrides/StepOverrideRow.tsx
+++ b/apps/desktop/src/components/overrides/StepOverrideRow.tsx
@@ -1,22 +1,14 @@
 import { cn } from '@kay-am/ui';
 import type { AgentEffort } from '@kay-am/types';
-import { VERBOSITY_LEVELS, VERBOSITY_LABEL, type VerbosityLevel } from '../../verbosity';
-import {
-  EFFORT_LEVELS,
-  EFFORT_LABEL,
-  EFFORT_TEXT,
-  VERBOSITY_TEXT,
-  modelLabel,
-} from '../chat/chat-constants';
+import { VERBOSITY_LEVELS, type VerbosityLevel } from '../../verbosity';
+import { EFFORT_TEXT, VERBOSITY_TEXT, modelLabel } from '../chat/chat-constants';
 
-export const STEP_SELECTABLE_MODELS = [
+const STEP_SELECTABLE_MODELS = [
   'claude-haiku-4-5',
   'claude-sonnet-4-5',
   'claude-sonnet-4-6',
   'claude-opus-4-7',
 ] as const;
-
-export type StepSelectableModel = (typeof STEP_SELECTABLE_MODELS)[number];
 
 export interface StepOverrideValues {
   readonly model: string;
@@ -134,6 +126,3 @@ function SegmentedControl<T extends string>({
     </span>
   );
 }
-
-export const EFFORT_LEVELS_PLANNER = EFFORT_LEVELS;
-export { EFFORT_LABEL, VERBOSITY_LABEL };

--- a/apps/desktop/src/config-export.ts
+++ b/apps/desktop/src/config-export.ts
@@ -1,14 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { save, open } from '@tauri-apps/plugin-dialog';
-import type { ConfigBundle, ConfigBundleImportResult } from '@kay-am/types';
-
-export async function invokeExportConfig(): Promise<ConfigBundle> {
-  return invoke<ConfigBundle>('export_config');
-}
-
-export async function invokeImportConfig(bundle: ConfigBundle): Promise<ConfigBundleImportResult> {
-  return invoke<ConfigBundleImportResult>('import_config', { bundle });
-}
+import type { ConfigBundleImportResult } from '@kay-am/types';
 
 export async function exportConfigToFile(): Promise<string | null> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);

--- a/apps/desktop/src/integrations.ts
+++ b/apps/desktop/src/integrations.ts
@@ -9,14 +9,14 @@ export interface IssueData {
 
 // ─── Linear ────────────────────────────────────────────────────────────────────
 
-export function parseLinearIssueUrl(input: string): string | null {
+function parseLinearIssueUrl(input: string): string | null {
   const trimmed = input.trim();
   const urlMatch = trimmed.match(/linear\.app\/[^/]+\/issue\/([A-Z]+-\d+)/i);
   if (urlMatch) return urlMatch[1]!.toUpperCase();
   return null;
 }
 
-export async function fetchLinearIssue(issueId: string): Promise<IssueData> {
+async function fetchLinearIssue(issueId: string): Promise<IssueData> {
   const token = await getSecret('integration.linear.token');
   if (!token)
     throw new Error('Linear not connected — add your API key in Settings → Integrations.');
@@ -52,14 +52,14 @@ export async function fetchLinearIssue(issueId: string): Promise<IssueData> {
 
 // ─── GitLab ────────────────────────────────────────────────────────────────────
 
-export function parseGitLabIssueUrl(input: string): { projectPath: string; iid: number } | null {
+function parseGitLabIssueUrl(input: string): { projectPath: string; iid: number } | null {
   const trimmed = input.trim();
   const match = trimmed.match(/gitlab\.com\/(.+?)\/-\/issues\/(\d+)/);
   if (match) return { projectPath: match[1]!, iid: parseInt(match[2]!, 10) };
   return null;
 }
 
-export async function fetchGitLabIssue(projectPath: string, iid: number): Promise<IssueData> {
+async function fetchGitLabIssue(projectPath: string, iid: number): Promise<IssueData> {
   const token = await getSecret('integration.gitlab.token');
   if (!token) throw new Error('GitLab not connected — add your token in Settings → Integrations.');
 
@@ -86,14 +86,14 @@ export async function fetchGitLabIssue(projectPath: string, iid: number): Promis
 
 // ─── Jira ──────────────────────────────────────────────────────────────────────
 
-export function parseJiraIssueUrl(input: string): string | null {
+function parseJiraIssueUrl(input: string): string | null {
   const trimmed = input.trim();
   const urlMatch = trimmed.match(/atlassian\.net\/browse\/([A-Z]+-\d+)/i);
   if (urlMatch) return urlMatch[1]!.toUpperCase();
   return null;
 }
 
-export async function fetchJiraIssue(issueKey: string): Promise<IssueData> {
+async function fetchJiraIssue(issueKey: string): Promise<IssueData> {
   const [token, email, domain] = await Promise.all([
     getSecret('integration.jira.token'),
     getSecret('integration.jira.email'),

--- a/apps/desktop/src/permissions.ts
+++ b/apps/desktop/src/permissions.ts
@@ -115,19 +115,6 @@ export interface PermissionAuditInsertPayload {
   readonly decidedAt: IsoDateTime;
 }
 
-export interface PermissionAuditQueryPayload {
-  readonly taskId?: TaskId;
-  readonly workspaceId?: WorkspaceId;
-  readonly fromAt?: IsoDateTime;
-  readonly toAt?: IsoDateTime;
-  readonly limit?: number;
-}
-
-export interface PermissionAuditClearScope {
-  readonly taskId?: TaskId;
-  readonly workspaceId?: WorkspaceId;
-}
-
 // ---------------------------------------------------------------------------
 // Permission rule commands (#176)
 // ---------------------------------------------------------------------------
@@ -143,13 +130,6 @@ export async function invokePermissionRuleList(args: {
     taskId: args.taskId ?? null,
   });
   return rows.map(rowToPermissionRule);
-}
-
-export async function invokePermissionRuleGet(
-  id: PermissionRuleId,
-): Promise<PermissionRule | null> {
-  const row = await invoke<RawPermissionRuleRow | null>('permission_rule_get', { id });
-  return row ? rowToPermissionRule(row) : null;
 }
 
 export async function invokePermissionRuleUpsert(
@@ -168,10 +148,6 @@ export async function invokePermissionRuleUpsert(
     },
   });
   return rowToPermissionRule(row);
-}
-
-export async function invokePermissionRuleDelete(id: PermissionRuleId): Promise<void> {
-  return invoke<void>('permission_rule_delete', { id });
 }
 
 // ---------------------------------------------------------------------------
@@ -197,30 +173,6 @@ export async function invokePermissionAuditInsert(
     },
   });
   return rowToAuditEntry(row);
-}
-
-export async function invokePermissionAuditList(
-  query: PermissionAuditQueryPayload,
-): Promise<ReadonlyArray<PermissionAuditEntry>> {
-  const rows = await invoke<RawPermissionAuditRow[]>('permission_audit_list', {
-    input: {
-      taskId: query.taskId ?? null,
-      workspaceId: query.workspaceId ?? null,
-      fromAt: query.fromAt ?? null,
-      toAt: query.toAt ?? null,
-      limit: query.limit ?? null,
-    },
-  });
-  return rows.map(rowToAuditEntry);
-}
-
-export async function invokePermissionAuditClear(scope: PermissionAuditClearScope): Promise<void> {
-  return invoke<void>('permission_audit_clear', {
-    input: {
-      taskId: scope.taskId ?? null,
-      workspaceId: scope.workspaceId ?? null,
-    },
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -277,51 +229,4 @@ export async function invokeAuditRetryUpdate(
 
 export async function invokeAuditRetryDelete(id: string): Promise<void> {
   return invoke<void>('permission_audit_retry_delete', { id });
-}
-
-// ---------------------------------------------------------------------------
-// Effective rules hook — for preflight banner
-// ---------------------------------------------------------------------------
-
-import { useEffect, useRef, useState } from 'react';
-
-export function useEffectivePermissionRules(args: {
-  taskId: TaskId | null;
-  workspaceId: WorkspaceId | null;
-  refreshKey?: number;
-}): ReadonlyArray<PermissionRule> {
-  const { taskId, workspaceId, refreshKey = 0 } = args;
-  const [rules, setRules] = useState<ReadonlyArray<PermissionRule>>([]);
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => {
-    if (!taskId || !workspaceId) {
-      setRules([]);
-      return;
-    }
-
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const [global, workspace, session] = await Promise.all([
-          invokePermissionRuleList({ scope: 'global' }),
-          invokePermissionRuleList({ scope: 'workspace', workspaceId }),
-          invokePermissionRuleList({ scope: 'task', taskId }),
-        ]);
-        if (!cancelled) setRules([...global, ...workspace, ...session]);
-      } catch {
-        // silent
-      }
-    };
-
-    void load();
-    timerRef.current = setInterval(() => void load(), 30000);
-
-    return () => {
-      cancelled = true;
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [taskId, workspaceId, refreshKey]);
-
-  return rules;
 }

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -108,11 +108,6 @@ export async function invokePhaseTemplateList(workspaceId: WorkspaceId): Promise
   return rows.map(rowToTemplate);
 }
 
-export async function invokePhaseTemplateGet(id: WorkflowId): Promise<Workflow | null> {
-  const row = await invoke<RawPhaseTemplateRow | null>('workflow_get', { id });
-  return row ? rowToTemplate(row) : null;
-}
-
 export interface PhaseDefinitionUpsertArgs {
   readonly id?: StepId;
   readonly ordinal: number;
@@ -274,24 +269,6 @@ export async function invokeParallelPhaseGroupCreate(
     },
   });
   return rowToParallelPhaseGroup(row);
-}
-
-export async function invokeParallelPhaseGroupList(taskId: TaskId): Promise<ParallelGroup[]> {
-  const rows = await invoke<RawParallelPhaseGroupRow[]>('parallel_group_list', {
-    taskId,
-  });
-  return rows.map(rowToParallelPhaseGroup);
-}
-
-export async function invokeParallelPhaseGroupGet(
-  id: ParallelGroupId,
-): Promise<ParallelGroup | null> {
-  const row = await invoke<RawParallelPhaseGroupRow | null>('parallel_group_get', { id });
-  return row != null ? rowToParallelPhaseGroup(row) : null;
-}
-
-export async function invokeParallelPhaseGroupDelete(id: ParallelGroupId): Promise<void> {
-  return invoke<void>('parallel_group_delete', { id });
 }
 
 export async function invokeParallelPhaseGroupUpdateCompletedAt(

--- a/apps/desktop/src/providerPricing.ts
+++ b/apps/desktop/src/providerPricing.ts
@@ -1,7 +1,7 @@
 import type { CodexModelPriceOverride } from '@kay-am/core';
 import shippedPricing from './data/pricing.json';
 
-export interface ModelPrice {
+interface ModelPrice {
   readonly inputPerMtok: number;
   readonly outputPerMtok: number;
   readonly cachedInputPerMtok?: number;
@@ -38,7 +38,7 @@ declare global {
 
 const IS_DEV = import.meta.env.DEV === true;
 
-export function priceForModel(
+function priceForModel(
   provider: 'anthropic' | 'cursor' | 'codex',
   model: string,
 ): ModelPrice | null {
@@ -65,11 +65,3 @@ export function getCodexPriceOverride(
       : {}),
   };
 }
-
-// Legacy compat: kept for existing callers that used to pass raw JSON string.
-export function parseProviderPricingConfig(_raw: string | null): unknown {
-  return {};
-}
-
-// Kept for ProviderPricingConfig shape compatibility in tests.
-export type ProviderPricingConfig = Record<string, never>;

--- a/apps/desktop/src/providers.ts
+++ b/apps/desktop/src/providers.ts
@@ -5,7 +5,7 @@ import type {
   ProviderId,
 } from '@kay-am/types';
 
-export type AuthStateKind = 'connected' | 'disconnected' | 'unknown';
+type AuthStateKind = 'connected' | 'disconnected' | 'unknown';
 
 export interface AuthState {
   readonly state: AuthStateKind;
@@ -53,12 +53,6 @@ const TAURI_GET_CMD: Record<ProviderId, string> = {
   codex: 'get_codex_status',
 };
 
-const TAURI_REFRESH_CMD: Record<ProviderId, string> = {
-  anthropic: 'refresh_provider_status',
-  cursor: 'refresh_cursor_status',
-  codex: 'refresh_codex_status',
-};
-
 const EMPTY_CAPABILITIES: ProviderInfoBase['capabilities'] = {
   models: [],
   supportsTools: false,
@@ -70,14 +64,8 @@ export async function getProviderStatus(id: ProviderId): Promise<ProviderStatus>
   return invoke<ProviderStatus>(TAURI_GET_CMD[id]);
 }
 
-export async function refreshProviderStatus(id: ProviderId): Promise<ProviderStatus> {
-  return invoke<ProviderStatus>(TAURI_REFRESH_CMD[id]);
-}
-
 export const getCursorStatus = (): Promise<ProviderStatus> => getProviderStatus('cursor');
-export const refreshCursorStatus = (): Promise<ProviderStatus> => refreshProviderStatus('cursor');
 export const getCodexStatus = (): Promise<ProviderStatus> => getProviderStatus('codex');
-export const refreshCodexStatus = (): Promise<ProviderStatus> => refreshProviderStatus('codex');
 
 export async function checkProviderAuth(providerId: ProviderId): Promise<AuthState> {
   return invoke<AuthState>('check_provider_auth', { providerId });

--- a/apps/desktop/src/skills.ts
+++ b/apps/desktop/src/skills.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { IsoDateTime, Skill, SkillFrontmatter, SkillId, WorkspaceId } from '@kay-am/types';
-import { parseSkillMarkdown, serializeSkillMarkdown, SkillExecutor } from '@kay-am/core';
+import { serializeSkillMarkdown, SkillExecutor } from '@kay-am/core';
 import type { SkillScriptRunner } from '@kay-am/core';
 
 export interface ResolveSkillInvocationArgs {
@@ -67,11 +67,6 @@ export async function invokeSkillList(workspaceId: WorkspaceId): Promise<Skill[]
   return rows.map(rowToSkill);
 }
 
-export async function invokeSkillGet(skillId: SkillId): Promise<Skill | null> {
-  const row = await invoke<RawSkillRow | null>('skill_get', { skillId });
-  return row ? rowToSkill(row) : null;
-}
-
 export interface SkillUpsertArgs {
   readonly workspaceId: WorkspaceId;
   readonly name: string;
@@ -110,7 +105,7 @@ export async function invokeSkillRescan(workspaceId: WorkspaceId): Promise<Skill
 // Invoke (#133)
 // ---------------------------------------------------------------------------
 
-export interface SkillInvokeArgs {
+interface SkillInvokeArgs {
   readonly skillId: SkillId;
   readonly args: ReadonlyArray<string>;
   readonly workingDir: string;
@@ -118,11 +113,11 @@ export interface SkillInvokeArgs {
   readonly workspaceRoot: string;
 }
 
-export interface SkillInvokeResult {
+interface SkillInvokeResult {
   readonly resolvedPrompt: string;
 }
 
-export async function invokeSkillInvoke(args: SkillInvokeArgs): Promise<SkillInvokeResult> {
+async function invokeSkillInvoke(args: SkillInvokeArgs): Promise<SkillInvokeResult> {
   const rawRow = await invoke<RawSkillRow | null>('skill_get', { skillId: args.skillId });
   if (!rawRow) {
     throw new Error(`skill not found: ${args.skillId}`);
@@ -172,8 +167,3 @@ export async function invokeSkillInvoke(args: SkillInvokeArgs): Promise<SkillInv
 
   return { resolvedPrompt };
 }
-
-// ---------------------------------------------------------------------------
-// Re-export parse helpers so callers don't need to depend on @kay-am/core directly
-// ---------------------------------------------------------------------------
-export { parseSkillMarkdown, serializeSkillMarkdown };

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -1,20 +1,6 @@
-export {
-  useAppStore,
-  type AppActions,
-  type AppState,
-  type BootPhase,
-  type ProviderSpendEntry,
-  type SummarizerSessionStatus,
-  type SystemAlert,
-  type SystemAlertKind,
-} from './store';
-export type { DetectedEditor } from '../editor';
+export { useAppStore, type BootPhase, type ProviderSpendEntry } from './store';
 
 export {
-  selectCurrentSession,
-  selectCurrentWorkspace,
-  selectSessions,
-  selectWorkspaces,
   useCurrentSession,
   useCurrentWorkspace,
   useDiffComments,
@@ -26,7 +12,6 @@ export {
   useSummarizerStatus,
   useWorkspaces,
 } from './selectors';
-export type { FilesTouched } from './selectors';
-export { selectTranscript, useTranscript } from './transcript';
+export { useTranscript } from './transcript';
 
 export const EMPTY_ARRAY: readonly never[] = [];

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -119,15 +119,13 @@ interface RunListenerState {
   collectedFiles: Set<string>;
 }
 
-export interface MultiplexedListener {
+interface MultiplexedListener {
   unlisten: () => Promise<void>;
   registerRun: (runId: ProviderRunId, state: RunListenerState) => void;
   filesTouchedByRun: (runId: ProviderRunId) => ReadonlyArray<string>;
 }
 
-export async function startMultiplexedTurnListener(
-  now: () => IsoDateTime,
-): Promise<MultiplexedListener> {
+async function startMultiplexedTurnListener(now: () => IsoDateTime): Promise<MultiplexedListener> {
   const states = new Map<string, RunListenerState>();
 
   const unlistenFn: UnlistenFn = await listen<RawTurnEnvelope>('turn_event', (event) => {
@@ -164,7 +162,7 @@ export async function startMultiplexedTurnListener(
 // batched spawn design and keeps the scheduler purely an await-only orchestrator.
 // ---------------------------------------------------------------------------
 
-export interface BuildSchedulerDepsArgs {
+interface BuildSchedulerDepsArgs {
   readonly listener: MultiplexedListener;
   readonly settleHandlers: Map<
     ProviderRunId,
@@ -175,7 +173,7 @@ export interface BuildSchedulerDepsArgs {
   >;
 }
 
-export function buildSchedulerDeps(args: BuildSchedulerDepsArgs): SchedulerDeps {
+function buildSchedulerDeps(args: BuildSchedulerDepsArgs): SchedulerDeps {
   const { settleHandlers } = args;
 
   return {

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -16,11 +16,11 @@ function toRelPath(absPath: string, workingDir: string | null): string {
   return absPath.startsWith(root) ? absPath.slice(root.length) : absPath;
 }
 
-export const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
-export const selectCurrentWorkspace = (state: AppState): Workspace | null =>
+const selectWorkspaces = (state: AppState): ReadonlyArray<Workspace> => state.workspaces;
+const selectCurrentWorkspace = (state: AppState): Workspace | null =>
   state.workspaces.find((w) => w.id === state.currentWorkspaceId) ?? null;
-export const selectSessions = (state: AppState): ReadonlyArray<Task> => state.sessions;
-export const selectCurrentSession = (state: AppState): Task | null =>
+const selectSessions = (state: AppState): ReadonlyArray<Task> => state.sessions;
+const selectCurrentSession = (state: AppState): Task | null =>
   state.sessions.find((s) => s.id === state.currentSessionId) ?? null;
 export const useWorkspaces = (): ReadonlyArray<Workspace> => useAppStore(selectWorkspaces);
 export const useCurrentWorkspace = (): Workspace | null => useAppStore(selectCurrentWorkspace);
@@ -62,7 +62,7 @@ const EMPTY_COMMENTS: ReadonlyArray<DiffComment> = [];
 export const useDiffComments = (taskId: TaskId | null): ReadonlyArray<DiffComment> =>
   useAppStore((s) => (taskId ? (s.diffComments[taskId] ?? EMPTY_COMMENTS) : EMPTY_COMMENTS));
 
-export interface FilesTouched {
+interface FilesTouched {
   readonly paths: ReadonlyArray<string>;
   readonly count: number;
 }

--- a/apps/desktop/src/store/transcript.ts
+++ b/apps/desktop/src/store/transcript.ts
@@ -4,7 +4,7 @@ import { useAppStore, type AppState } from './store';
 
 const EMPTY: ReadonlyArray<TurnEvent> = [];
 
-export const selectTranscript =
+const selectTranscript =
   (agentId: SessionId | null) =>
   (state: AppState): ReadonlyArray<TurnEvent> =>
     agentId ? (state.transcripts[agentId] ?? EMPTY) : EMPTY;

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -30,7 +30,7 @@ function parseForProvider(
   }
 }
 
-export const AUTH_REQUIRED_PREFIX = '__auth_required__:';
+const AUTH_REQUIRED_PREFIX = '__auth_required__:';
 
 export interface AuthRequiredPayload {
   readonly providerId: ProviderId;
@@ -70,12 +70,7 @@ export function isAuthErrorMessage(text: string): boolean {
 
 const EVENT_NAME = 'turn_event';
 
-export type ClaudePermissionMode =
-  | 'default'
-  | 'acceptEdits'
-  | 'bypassPermissions'
-  | 'dontAsk'
-  | 'plan';
+type ClaudePermissionMode = 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
 
 interface SpawnArgs {
   readonly runId: ProviderRunId;
@@ -95,11 +90,6 @@ type RawTurnEnvelope =
   | { runId: string; type: 'line'; line: string }
   | { runId: string; type: 'end'; exit_code: number | null; stderr: string }
   | { runId: string; type: 'error'; message: string };
-
-export interface TurnTermination {
-  readonly exitCode: number | null;
-  readonly stderr: string;
-}
 
 export async function* runTurn(
   args: SpawnArgs,
@@ -213,7 +203,7 @@ export async function cancelTurn(runId: ProviderRunId): Promise<void> {
 // Parallel phase run spawn
 // ---------------------------------------------------------------------------
 
-export interface ParallelRunSpec {
+interface ParallelRunSpec {
   readonly runId: ProviderRunId;
   /** Worktree path from C3 worktree helper. */
   readonly workingDir: string;

--- a/apps/desktop/src/worktree.ts
+++ b/apps/desktop/src/worktree.ts
@@ -7,13 +7,6 @@ export interface CreatedWorktree {
   readonly reused: boolean;
 }
 
-export interface WorktreeInfo {
-  readonly path: string;
-  readonly branch: string | null;
-  readonly head: string;
-  readonly isMain: boolean;
-}
-
 export interface CreateWorktreeArgs {
   readonly repoPath: string;
   readonly branchPrefix: string;
@@ -27,18 +20,6 @@ export async function createWorktree(args: CreateWorktreeArgs): Promise<CreatedW
 
 export async function removeWorktree(repoPath: string, worktreePath: string): Promise<void> {
   await invoke('worktree_remove', { repoPath, worktreePath });
-}
-
-export async function listWorktrees(repoPath: string): Promise<ReadonlyArray<WorktreeInfo>> {
-  return invoke<ReadonlyArray<WorktreeInfo>>('worktree_list', { repoPath });
-}
-
-export async function worktreeExists(
-  repoPath: string,
-  branchPrefix: string,
-  slug: string,
-): Promise<boolean> {
-  return invoke<boolean>('worktree_exists', { repoPath, branchPrefix, slug });
 }
 
 export async function worktreeDiff(worktreePath: string, base?: string): Promise<string> {

--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,8 @@
     },
     "apps/desktop": {
       "entry": ["src/**/*.test.{ts,tsx}"],
-      "project": ["src/**/*.{ts,tsx}"]
+      "project": ["src/**/*.{ts,tsx}"],
+      "ignoreDependencies": ["tailwindcss"]
     },
     "packages/core": {
       "entry": ["src/**/*.test.ts", "src/**/__tests__/**/*.test.ts"],

--- a/packages/core/src/budget/index.ts
+++ b/packages/core/src/budget/index.ts
@@ -1,3 +1,2 @@
 export { checkProviderBudget, checkTaskBudget, getPeriodWindow } from './checker';
-export { resolveProvider, type ResolveProviderInput } from './router';
 export { emitBudgetAlerts, getCurrentPeriodKey, type AlertEmitterDeps } from './alert-emitter';

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -2,4 +2,3 @@ export { PermissionEngine, type PermissionEngineDeps } from './engine';
 export { formatToolPattern, parseArgsMatcher, parseToolPattern, type ToolMatcher } from './matcher';
 export { buildClaudeFlags, type ClaudeFlagSet } from './claude-flags';
 export { PermissionAuditRecorder, type AuditRecorderDeps, type AuditQuery } from './audit';
-export { createPermissionDecisionEvent, createPermissionRequestEvent } from './events';

--- a/packages/core/src/providers/claude/index.ts
+++ b/packages/core/src/providers/claude/index.ts
@@ -1,3 +1,1 @@
 export { ClaudeAdapter, type ClaudeAdapterDeps } from './adapter';
-export { computeCostUsd, priceFor } from './cost';
-export { parseStreamJsonLine, type ParseContext } from './parser';

--- a/packages/core/src/providers/codex/adapter.ts
+++ b/packages/core/src/providers/codex/adapter.ts
@@ -9,11 +9,9 @@ import type {
   TurnEvent,
   TurnRequest,
 } from '@kay-am/types';
-import { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL, CODEX_MODELS } from './constants';
+import { CODEX_DEFAULT_MODEL, CODEX_MODELS } from './constants';
 import { computeCodexCostUsd, type CodexModelPriceOverride } from './cost';
 import { parseJsonLine } from './parser';
-
-export { CODEX_CHEAP_MODEL, CODEX_DEFAULT_MODEL };
 
 const CAPABILITIES: ProviderCapabilities = {
   streaming: true,

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -5,9 +5,9 @@ import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
 
-export type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
+type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
 
-export type ContextSlotDelta = Readonly<{
+type ContextSlotDelta = Readonly<{
   upserts: ReadonlyArray<ContextSlotDeltaUpsert>;
 }>;
 

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -4,8 +4,6 @@ import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
 
-export type { SlotKey };
-
 function getCheapModel(providerId: ProviderId): string {
   const caps = PROVIDER_CAPABILITIES[providerId];
   return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,7 +14,6 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "@kay-am/types": "workspace:*",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
     "tailwind-merge": "^2.5.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,12 +49,6 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.2.0
         version: 2.7.1
-      '@tauri-apps/plugin-shell':
-        specifier: ^2.2.0
-        version: 2.3.5
-      '@tauri-apps/plugin-sql':
-        specifier: ^2.2.0
-        version: 2.4.0
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.6)
@@ -163,9 +157,6 @@ importers:
 
   packages/ui:
     dependencies:
-      '@kay-am/types':
-        specifier: workspace:*
-        version: link:../types
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1838,18 +1829,6 @@ packages:
     resolution:
       {
         integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==,
-      }
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    resolution:
-      {
-        integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==,
-      }
-
-  '@tauri-apps/plugin-sql@2.4.0':
-    resolution:
-      {
-        integrity: sha512-SIICc5JlnK6OrBZzOw7MmhXHPlmASpt5zLWIu10WW4kLr5cDYOXHdV2MoCgYQkgZLQfyBYgF3SQa5XCisUiQkw==,
       }
 
   '@testing-library/dom@10.4.1':
@@ -4399,14 +4378,6 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-shell@2.3.5':
-    dependencies:
-      '@tauri-apps/api': 2.11.0
-
-  '@tauri-apps/plugin-sql@2.4.0':
     dependencies:
       '@tauri-apps/api': 2.11.0
 


### PR DESCRIPTION
## Summary

- Removed all 65 unused exports and 28 unused exported types knip flagged on `main`.
- Demoted re-exports to module-internal where the symbol is still consumed inside its own file; outright deleted when no caller exists anywhere.
- Cleaned three dead deps (`@tauri-apps/plugin-shell`, `@tauri-apps/plugin-sql` in `apps/desktop`; `@kay-am/types` in `packages/ui`) and added a `tailwindcss` ignore for the CSS `@import` false positive.

## Knip before / after

| Bucket                  | Before | After |
| ----------------------- | -----: | ----: |
| Unused exports          |     64 |     0 |
| Unused exported types   |     26 |     0 |
| Unused dependencies     |      3 |     0 |
| Unused devDependencies  |      1 |     0 (ignored — false positive) |

`pnpm knip` now exits 0 under full strict mode.

## Areas touched

- `apps/desktop/src/`: budget, config-export, integrations, permissions, phases, providerPricing, providers, skills, store/(index|selectors|transcript|parallel-turn), turn, worktree, plus chat-constants & PermissionModePicker.
- `packages/core/src/`: budget/index, permissions/index, providers/claude/index, providers/codex/adapter, summarizer/(cli|client).

No Tauri Rust commands touched; only the TS wrappers swept.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 295 desktop + 529 core passing
- [x] `pnpm build` succeeds
- [x] `pnpm knip` exits 0

Closes #502