### PR TITLE
feat(desktop): centralise localStorage keys with kay-am prefix

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,8 +13,9 @@ import { WorkspacesSidebar } from './components/WorkspacesSidebar';
 import { useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
 import { useAppStore, useCurrentSession, useCurrentWorkspace, useSessionSlots } from './store';
 import { refreshPricingTable } from './providerPricing';
+import { STORAGE_PREFIXES } from './storage-keys';
 
-const CONTEXT_PANEL_KEY = (id: TaskId): string => `kayam:context-panel-open:${id}`;
+const CONTEXT_PANEL_KEY = (id: TaskId): string => `${STORAGE_PREFIXES.contextPanelOpen}${id}`;
 
 function readPersistedContextOpen(id: TaskId, fallback: boolean): boolean {
   try {

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -170,7 +170,7 @@ describe('ChatInput — input wiring', () => {
 
   it('provider override persists across sends (regression for bug D)', async () => {
     // Pre-populate localStorage: user previously picked cursor for this session.
-    localStorage.setItem('kayam:provider:session-1', 'cursor');
+    localStorage.setItem('kay-am:provider:session-1', 'cursor');
 
     const user = userEvent.setup();
     render(
@@ -190,6 +190,6 @@ describe('ChatInput — input wiring', () => {
 
     expect(sendTurnMock).toHaveBeenCalledOnce();
     // After send, the selected provider must still be cursor (not reset to anthropic).
-    expect(localStorage.getItem('kayam:provider:session-1')).toBe('cursor');
+    expect(localStorage.getItem('kay-am:provider:session-1')).toBe('cursor');
   });
 });

--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -28,6 +28,7 @@ import { openFileInWorkspace } from '../editor';
 import { DEFAULT_EDITOR_BINARY, SETTING_DEFAULT_EDITOR, SETTING_EDITOR_BINARY } from '../settings';
 import { useAppStore, useDiffComments } from '../store';
 import { AGENT_KIND_DEFAULTS } from '../agentKind';
+import { STORAGE_KEYS } from '../storage-keys';
 
 interface DiffViewerDialogProps {
   open: boolean;
@@ -60,7 +61,7 @@ const STATUS_COLOR: Record<FileDiffStatus, string> = {
   renamed: 'text-warning',
 };
 
-const SIDEBAR_PREF_KEY = 'kay-am:diff-sidebar-collapsed';
+const SIDEBAR_PREF_KEY = STORAGE_KEYS.diffSidebarCollapsed;
 
 type TreeNode =
   | {

--- a/apps/desktop/src/components/PricingDialog.tsx
+++ b/apps/desktop/src/components/PricingDialog.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Dialog, cn } from '@kay-am/ui';
 import { EMPTY_ARRAY, useAppStore } from '../store';
 import type { ProviderSpendEntry } from '../store';
+import { STORAGE_KEYS } from '../storage-keys';
 
 const formatCost = (usd: number): string => `$${usd.toFixed(4)}`;
 const formatTokens = (n: number): string =>
@@ -12,7 +13,7 @@ const formatTokens = (n: number): string =>
       : `${n}`;
 
 type SortKey = 'recent' | 'expensive';
-const SORT_KEY_STORAGE = 'pricing-sort-key';
+const SORT_KEY_STORAGE = STORAGE_KEYS.pricingSortKey;
 
 function spendColor(pct: number): string {
   if (pct >= 1) return 'bg-danger';

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -79,6 +79,7 @@ import {
 import { spawnFromNextAction, spawnKindForAction } from '../spawnFromNextAction';
 import { openUrl } from '../editor';
 import { useThemeStore } from '../theme';
+import { STORAGE_KEYS } from '../storage-keys';
 
 interface WorkspacesSidebarProps {
   onOpenSettings: () => void;
@@ -606,7 +607,7 @@ function sortSessions(list: ReadonlyArray<Task>, sort: SessionSort): ReadonlyArr
   return copy;
 }
 
-const ARCHIVED_KEY = 'kayam:archived-tasks';
+const ARCHIVED_KEY = STORAGE_KEYS.archivedTasks;
 
 function readArchivedSet(): Record<string, true> {
   try {

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -28,14 +28,15 @@ import { EFFORT_LEVELS, type EffortLevel } from './chat-constants';
 import { ProviderUsagePill } from './ProviderUsagePill';
 import { ModelPicker } from './ModelPicker';
 import { PermissionModePicker } from './PermissionModePicker';
+import { STORAGE_PREFIXES } from '../../storage-keys';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
 const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
 
-const EFFORT_STORAGE_PREFIX = 'kayam:effort:';
-const MODEL_STORAGE_PREFIX = 'kayam:model:';
-const PROVIDER_STORAGE_PREFIX = 'kayam:provider:';
+const EFFORT_STORAGE_PREFIX = STORAGE_PREFIXES.effort;
+const MODEL_STORAGE_PREFIX = STORAGE_PREFIXES.model;
+const PROVIDER_STORAGE_PREFIX = STORAGE_PREFIXES.provider;
 
 function readEffort(taskId: TaskId): EffortLevel {
   try {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -2,8 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
 import { bootstrapTheme } from './theme';
+import { migrateLegacyStorageKeys } from './storage-keys';
 import './styles.css';
 
+migrateLegacyStorageKeys();
 bootstrapTheme();
 
 const container = document.getElementById('root');

--- a/apps/desktop/src/storage-keys.test.ts
+++ b/apps/desktop/src/storage-keys.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { STORAGE_KEYS, STORAGE_PREFIXES, migrateLegacyStorageKeys } from './storage-keys';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('migrateLegacyStorageKeys', () => {
+  it('moves legacy direct keys to the new prefix', () => {
+    localStorage.setItem('kayam:theme', 'light');
+    localStorage.setItem('kayam:archived-tasks', '{"a":true}');
+    localStorage.setItem('pricing-sort-key', 'expensive');
+
+    migrateLegacyStorageKeys();
+
+    expect(localStorage.getItem('kayam:theme')).toBeNull();
+    expect(localStorage.getItem('kayam:archived-tasks')).toBeNull();
+    expect(localStorage.getItem('pricing-sort-key')).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEYS.theme)).toBe('light');
+    expect(localStorage.getItem(STORAGE_KEYS.archivedTasks)).toBe('{"a":true}');
+    expect(localStorage.getItem(STORAGE_KEYS.pricingSortKey)).toBe('expensive');
+  });
+
+  it('moves legacy prefixed keys (verbosity, effort, model, provider, context-panel-open)', () => {
+    localStorage.setItem('kayam:verbosity:session-1', 'brief');
+    localStorage.setItem('kayam:effort:session-1', 'low');
+    localStorage.setItem('kayam:model:session-1', 'claude-sonnet-4-6');
+    localStorage.setItem('kayam:provider:session-1', 'cursor');
+    localStorage.setItem('kayam:context-panel-open:session-1', '1');
+
+    migrateLegacyStorageKeys();
+
+    expect(localStorage.getItem(`${STORAGE_PREFIXES.verbosity}session-1`)).toBe('brief');
+    expect(localStorage.getItem(`${STORAGE_PREFIXES.effort}session-1`)).toBe('low');
+    expect(localStorage.getItem(`${STORAGE_PREFIXES.model}session-1`)).toBe('claude-sonnet-4-6');
+    expect(localStorage.getItem(`${STORAGE_PREFIXES.provider}session-1`)).toBe('cursor');
+    expect(localStorage.getItem(`${STORAGE_PREFIXES.contextPanelOpen}session-1`)).toBe('1');
+    expect(localStorage.getItem('kayam:verbosity:session-1')).toBeNull();
+  });
+
+  it('keeps the new key when both legacy and new exist (user already migrated)', () => {
+    localStorage.setItem('kayam:theme', 'light');
+    localStorage.setItem(STORAGE_KEYS.theme, 'dark');
+
+    migrateLegacyStorageKeys();
+
+    expect(localStorage.getItem(STORAGE_KEYS.theme)).toBe('dark');
+    expect(localStorage.getItem('kayam:theme')).toBeNull();
+  });
+
+  it('is a no-op when there are no legacy keys', () => {
+    localStorage.setItem(STORAGE_KEYS.theme, 'light');
+
+    migrateLegacyStorageKeys();
+
+    expect(localStorage.getItem(STORAGE_KEYS.theme)).toBe('light');
+    expect(localStorage.length).toBe(1);
+  });
+});

--- a/apps/desktop/src/storage-keys.ts
+++ b/apps/desktop/src/storage-keys.ts
@@ -1,0 +1,66 @@
+const PREFIX = 'kay-am:';
+
+export const STORAGE_KEYS = {
+  theme: `${PREFIX}theme`,
+  archivedTasks: `${PREFIX}archived-tasks`,
+  pricingSortKey: `${PREFIX}pricing-sort-key`,
+  diffSidebarCollapsed: `${PREFIX}diff-sidebar-collapsed`,
+} as const;
+
+export const STORAGE_PREFIXES = {
+  verbosity: `${PREFIX}verbosity:`,
+  effort: `${PREFIX}effort:`,
+  model: `${PREFIX}model:`,
+  provider: `${PREFIX}provider:`,
+  contextPanelOpen: `${PREFIX}context-panel-open:`,
+} as const;
+
+const LEGACY_KEY_MAP: Record<string, string> = {
+  'kayam:theme': STORAGE_KEYS.theme,
+  'kayam:archived-tasks': STORAGE_KEYS.archivedTasks,
+  'pricing-sort-key': STORAGE_KEYS.pricingSortKey,
+  'kayam:left-sidebar-width': 'kay-am:left-sidebar-width',
+  'kayam:right-sidebar-width': 'kay-am:right-sidebar-width',
+};
+
+const LEGACY_PREFIX_MAP: Record<string, string> = {
+  'kayam:verbosity:': STORAGE_PREFIXES.verbosity,
+  'kayam:effort:': STORAGE_PREFIXES.effort,
+  'kayam:model:': STORAGE_PREFIXES.model,
+  'kayam:provider:': STORAGE_PREFIXES.provider,
+  'kayam:context-panel-open:': STORAGE_PREFIXES.contextPanelOpen,
+};
+
+export function migrateLegacyStorageKeys(): void {
+  try {
+    const moves: Array<[string, string]> = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key) continue;
+      const directTarget = LEGACY_KEY_MAP[key];
+      if (directTarget) {
+        moves.push([key, directTarget]);
+        continue;
+      }
+      for (const [oldPrefix, newPrefix] of Object.entries(LEGACY_PREFIX_MAP)) {
+        if (key.startsWith(oldPrefix)) {
+          moves.push([key, `${newPrefix}${key.slice(oldPrefix.length)}`]);
+          break;
+        }
+      }
+    }
+    for (const [oldKey, newKey] of moves) {
+      if (localStorage.getItem(newKey) !== null) {
+        localStorage.removeItem(oldKey);
+        continue;
+      }
+      const value = localStorage.getItem(oldKey);
+      if (value !== null) {
+        localStorage.setItem(newKey, value);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // localStorage might be unavailable (private mode, quota); fail open.
+  }
+}

--- a/apps/desktop/src/theme.ts
+++ b/apps/desktop/src/theme.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
+import { STORAGE_KEYS } from './storage-keys';
 
 type Theme = 'dark' | 'light';
 
-const STORAGE_KEY = 'kayam:theme';
+const STORAGE_KEY = STORAGE_KEYS.theme;
 
 function readStoredTheme(): Theme {
   try {

--- a/apps/desktop/src/verbosity.ts
+++ b/apps/desktop/src/verbosity.ts
@@ -1,4 +1,5 @@
 import type { TaskId } from '@kay-am/types';
+import { STORAGE_PREFIXES } from './storage-keys';
 
 export const VERBOSITY_LEVELS = ['brief', 'normal', 'verbose'] as const;
 export type VerbosityLevel = (typeof VERBOSITY_LEVELS)[number];
@@ -9,7 +10,7 @@ export const VERBOSITY_LABEL: Record<VerbosityLevel, string> = {
   verbose: 'Verbose',
 };
 
-const STORAGE_PREFIX = 'kayam:verbosity:';
+const STORAGE_PREFIX = STORAGE_PREFIXES.verbosity;
 const DEFAULT_LEVEL: VerbosityLevel = 'normal';
 
 const LEGACY_MAP: Record<string, VerbosityLevel> = {

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -13,13 +13,13 @@ export interface AppShellProps {
 const LEFT_SIDEBAR_MIN = 220;
 const LEFT_SIDEBAR_MAX = 480;
 const LEFT_SIDEBAR_DEFAULT = 280;
-const LEFT_SIDEBAR_STORAGE_KEY = 'kayam:left-sidebar-width';
+const LEFT_SIDEBAR_STORAGE_KEY = 'kay-am:left-sidebar-width';
 const LEFT_RAIL_WIDTH = 80;
 
 const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;
 const RIGHT_SIDEBAR_DEFAULT = 340;
-const RIGHT_SIDEBAR_STORAGE_KEY = 'kayam:right-sidebar-width';
+const RIGHT_SIDEBAR_STORAGE_KEY = 'kay-am:right-sidebar-width';
 const RIGHT_RAIL_WIDTH = 44;
 
 function readPersistedWidth(key: string, def: number, min: number, max: number): number {


### PR DESCRIPTION
## Summary

- introduces \`apps/desktop/src/storage-keys.ts\` as the single source of truth — \`STORAGE_KEYS\` for direct entries and \`STORAGE_PREFIXES\` for per-session prefixes
- standardises on the \`kay-am:\` prefix (was a mix of \`kayam:\`, \`kay-am:\`, and bare \`pricing-sort-key\`)
- \`migrateLegacyStorageKeys()\` runs once at boot from \`main.tsx\`: it sweeps legacy keys onto the new prefix, prefers an existing new value when both are present, and fails open if localStorage is unavailable
- all call sites updated: \`theme\`, \`verbosity\`, \`App\` (context panel), \`WorkspacesSidebar\` (archived sessions), \`PricingDialog\` (sort key), \`DiffViewerDialog\` (sidebar collapsed), chat \`ChatInput\` (effort/model/provider), \`@kay-am/ui\` \`AppShell\` (left/right sidebar widths)
- four new tests cover direct keys, prefixed keys, the \"already migrated\" path, and the no-op path

## Out of scope

- the \`kayam:open-settings\` CustomEvent name kept as-is — events aren't persisted, so renaming is cosmetic; can follow up if we want full prefix consistency
- Intl helper consolidation + top-level ErrorBoundary remain for the rest of #508

## Test plan

- [x] \`pnpm test\` — 299/299 (4 new in \`storage-keys.test.ts\`)
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm knip\` — exit 0 (strict)
- [x] \`pnpm build\` — clean

Refs #508