### PR TITLE
feat(desktop): wrap app in an error boundary

### DIFF
--- a/apps/desktop/src/components/ErrorBoundary.test.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+afterEach(cleanup);
+
+function Boom({ throwNow }: { throwNow: boolean }): null {
+  if (throwNow) throw new Error('kaboom');
+  return null;
+}
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    render(
+      <ErrorBoundary>
+        <p>safe content</p>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('safe content')).toBeDefined();
+  });
+
+  it('renders the recovery alert when a child throws', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    render(
+      <ErrorBoundary>
+        <Boom throwNow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByRole('alert')).toBeDefined();
+    expect(screen.getByText(/something went wrong/i)).toBeDefined();
+    expect(screen.getByText(/kaboom/)).toBeDefined();
+    consoleError.mockRestore();
+  });
+
+  it('exposes a reload button that calls window.location.reload', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const reload = vi.fn();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...window.location, reload },
+    });
+    render(
+      <ErrorBoundary>
+        <Boom throwNow />
+      </ErrorBoundary>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /reload/i }));
+    expect(reload).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+});

--- a/apps/desktop/src/components/ErrorBoundary.tsx
+++ b/apps/desktop/src/components/ErrorBoundary.tsx
@@ -1,0 +1,66 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  readonly children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  readonly error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[error-boundary]', error, info.componentStack);
+  }
+
+  reset = (): void => {
+    this.setState({ error: null });
+  };
+
+  reload = (): void => {
+    window.location.reload();
+  };
+
+  override render(): ReactNode {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div
+        role="alert"
+        className="flex h-screen w-screen flex-col items-center justify-center bg-background p-6 text-foreground"
+      >
+        <div className="flex max-w-md flex-col gap-4 rounded-lg border border-danger/40 bg-subtle p-6 shadow-md">
+          <h1 className="text-base font-semibold tracking-tight">something went wrong</h1>
+          <p className="text-sm text-muted-foreground">
+            kAY.am hit a runtime error and stopped rendering. your data is safe — sessions, agents,
+            and providers are all persisted to disk. reload to recover.
+          </p>
+          <pre className="overflow-auto rounded bg-muted px-3 py-2 text-xs text-danger">
+            {this.state.error.message}
+          </pre>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={this.reload}
+              className="rounded bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground hover:opacity-90"
+            >
+              reload
+            </button>
+            <button
+              type="button"
+              onClick={this.reset}
+              className="rounded border border-border px-3 py-1.5 text-xs font-semibold text-foreground hover:bg-muted"
+            >
+              try again
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { bootstrapTheme } from './theme';
 import { migrateLegacyStorageKeys } from './storage-keys';
 import './styles.css';
@@ -13,6 +14,8 @@ if (!container) throw new Error('root element not found');
 
 createRoot(container).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary

- adds \`apps/desktop/src/components/ErrorBoundary.tsx\` — class component that catches downstream errors and renders a recovery panel (reload / try again) with the error message inline
- wraps \`<App />\` in \`main.tsx\` inside \`<StrictMode>\` so a render-time exception no longer blanks the WebView
- \`componentDidCatch\` forwards the error + component stack to \`console.error\` for DevTools
- three tests: happy path, error render, reload click

## Test plan

- [x] \`pnpm test\` — 298/298
- [x] \`pnpm typecheck\` — clean (\`override\` modifiers added on class members)
- [x] \`pnpm knip\` — exit 0
- [x] \`pnpm build\` — clean

Refs #508