### PR TITLE
chore(desktop): a11y baseline — icon-button labels, img alt, focus

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -344,6 +344,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
               value=""
             />
             <button
+              aria-label="generate branch name"
               class="shrink-0 rounded p-0.5 transition-colors cursor-not-allowed text-muted-foreground/30"
               disabled=""
               title="generate branch name"
@@ -2547,6 +2548,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
               value=""
             />
             <button
+              aria-label="generate branch name"
               class="shrink-0 rounded p-0.5 transition-colors cursor-not-allowed text-muted-foreground/30"
               disabled=""
               title="generate branch name"

--- a/apps/desktop/src/components/CommandPalette.tsx
+++ b/apps/desktop/src/components/CommandPalette.tsx
@@ -153,7 +153,8 @@ export function CommandPalette({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
-          className="w-full px-4 py-3 text-sm focus:outline-none bg-background border-b border-border"
+          aria-label="search workspaces, sessions, and actions"
+          className="w-full px-4 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] bg-background border-b border-border"
         />
         <ul ref={listRef} className="max-h-64 overflow-y-auto">
           {filteredItems.length === 0 ? (

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -454,6 +454,7 @@ export function NewSessionDialog({
                 onClick={handleGenerateSlug}
                 disabled={!goal.trim() || slugGenerating || busy}
                 title="generate branch name"
+                aria-label="generate branch name"
                 className={cn(
                   'shrink-0 rounded p-0.5 transition-colors',
                   goal.trim() && !slugGenerating && !busy

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -353,8 +353,9 @@ function DefinitionEditor({
             onClick={onMoveUp}
             disabled={ordinal === 0}
             title="move up"
+            aria-label="move step up"
           >
-            ↑
+            <span aria-hidden>↑</span>
           </button>
           <button
             type="button"
@@ -362,16 +363,18 @@ function DefinitionEditor({
             onClick={onMoveDown}
             disabled={ordinal === total - 1}
             title="move down"
+            aria-label="move step down"
           >
-            ↓
+            <span aria-hidden>↓</span>
           </button>
           <button
             type="button"
             className="text-xs text-muted-foreground hover:text-danger"
             onClick={onRemove}
             title="remove step"
+            aria-label="remove step"
           >
-            ×
+            <span aria-hidden>×</span>
           </button>
         </div>
       </div>

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -667,7 +667,7 @@ function FilterChip({ label, onRemove }: FilterChipProps) {
         className="hover:text-danger"
         aria-label={`remove filter ${label}`}
       >
-        <X size={9} />
+        <X size={9} aria-hidden />
       </button>
     </span>
   );


### PR DESCRIPTION
## Summary

- adds `aria-label` to icon-only buttons that previously relied on `title` alone (branch-slug generator in NewSessionDialog, move up/down/remove step glyphs in PhasesPanel, filter-chip remove in WorkspacesSidebar)
- marks decorative text glyphs (↑ ↓ ×) and the inner `<X />` icon `aria-hidden` so SRs read the button's accessible name and not the glyph
- restores the global `:focus-visible` ring on the command palette search input — was stripped by `focus:outline-none` without a replacement
- updates the empty/error snapshot to reflect the new `aria-label` on the branch-slug generator
- closes #511

No behavior changes. No img audit needed — none exist in the desktop tree. Toast / NotificationCenter already expose `role` + `aria-live="polite"`.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 295/295 pass
- [x] `pnpm knip` exit 0
- [x] `pnpm build` clean
- [x] axe smoke suite remains green (excluded from CI by config — see #331)

🤖 Generated with [Claude Code](https://claude.com/claude-code)