### PR TITLE
chore(desktop): copy polish — cta casing, typos, tone alignment

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -457,7 +457,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
             class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
             type="button"
           >
-            cancel
+            Cancel
           </button>
           <button
             class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
@@ -465,7 +465,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
             title="complete: goal, provider"
             type="button"
           >
-            create session
+            Create session
           </button>
         </div>
       </div>
@@ -930,7 +930,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
                 />
               </svg>
             </span>
-            add workspace
+            Add workspace
           </button>
         </li>
       </ul>
@@ -979,9 +979,9 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             <button
               aria-expanded="false"
               aria-haspopup="menu"
-              aria-label="Sort sessions"
+              aria-label="sort sessions"
               class="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-              title="Sort: recent"
+              title="sort: recent"
               type="button"
             >
               <svg
@@ -1086,7 +1086,7 @@ workspace: $0"
               class="text-sm font-semibold tracking-tight text-foreground"
               id="_r_0_-title"
             >
-              pricing
+              Pricing
             </h2>
           </div>
           <button
@@ -1199,7 +1199,7 @@ workspace: $0"
             class="text-sm font-semibold tracking-tight text-foreground"
             id="_r_1_-title"
           >
-            add workspace
+            Add workspace
           </h2>
           <p
             class="text-xs leading-relaxed text-muted-foreground"
@@ -1285,7 +1285,7 @@ workspace: $0"
                   class="inline-flex items-center justify-center gap-1.5 rounded-md border font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-muted text-foreground hover:bg-muted/70 border-border h-8 px-3 text-sm"
                   type="button"
                 >
-                  browse
+                  Browse
                 </button>
               </div>
               <p
@@ -1304,14 +1304,14 @@ workspace: $0"
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
           type="button"
         >
-          cancel
+          Cancel
         </button>
         <button
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
           disabled=""
           type="button"
         >
-          add workspace
+          Add workspace
         </button>
       </footer>
     </div>
@@ -1638,7 +1638,7 @@ workspace: $0"
                 />
               </svg>
               <span>
-                Legenda
+                Legend
               </span>
             </button>
           </nav>
@@ -1745,7 +1745,7 @@ workspace: $0"
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
           type="button"
         >
-          close
+          Close
         </button>
       </footer>
     </div>
@@ -2190,13 +2190,13 @@ exports[`snapshot — error states > EndSessionDialog: error state 1`] = `
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
         type="button"
       >
-        cancel
+        Cancel
       </button>
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-danger text-danger-foreground hover:bg-danger/90 h-8 px-3 text-sm"
         type="button"
       >
-        end session
+        End session
       </button>
     </footer>
   </div>
@@ -2660,7 +2660,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
             class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
             type="button"
           >
-            cancel
+            Cancel
           </button>
           <button
             class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
@@ -2668,7 +2668,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
             title="complete: goal, provider"
             type="button"
           >
-            create session
+            Create session
           </button>
         </div>
       </div>

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -490,7 +490,7 @@ function GitHubSection({ session }: { session: Task }) {
               className="h-5 gap-0.5 px-1.5 text-[10px]"
             >
               <Plus size={10} aria-hidden />
-              open pr
+              Open PR
             </Button>
           </div>
         )}
@@ -825,7 +825,7 @@ function SummarizerBadge({
       ? `last error: ${error}`
       : lastUpdate
         ? `last update: ${lastUpdate}`
-        : 'summarizer running — keep typing, the app is not blocked';
+        : 'summarizer running — input is not blocked';
   return (
     <span
       title={tooltip}

--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -467,7 +467,7 @@ function NotesFooter({ openCount, spawning, onPropose }: NotesFooterProps) {
         ) : (
           <Sparkles size={11} aria-hidden />
         )}
-        propose fixes
+        Propose fixes
       </button>
     </div>
   );
@@ -898,7 +898,7 @@ function FileDiffPane({
               className="flex items-center gap-1 rounded-sm px-1 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
             >
               <MessageSquarePlus size={10} aria-hidden />
-              add file note
+              Add file note
             </button>
           </div>
         ) : null}
@@ -1048,7 +1048,7 @@ function InlineComposer({
             onClick={onCancel}
             className="rounded-sm px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
           >
-            cancel
+            Cancel
           </button>
           <button
             type="button"
@@ -1056,7 +1056,7 @@ function InlineComposer({
             disabled={trimmed.length === 0}
             className="inline-flex items-center gap-1 rounded-sm bg-foreground px-2 py-0.5 text-[10px] font-medium text-background hover:opacity-80 disabled:opacity-30"
           >
-            send
+            Send
           </button>
         </div>
       </div>

--- a/apps/desktop/src/components/EndSessionDialog.tsx
+++ b/apps/desktop/src/components/EndSessionDialog.tsx
@@ -51,10 +51,10 @@ export function EndSessionDialog({ session, open, onClose }: EndSessionDialogPro
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={onClose} disabled={busy}>
-            cancel
+            Cancel
           </Button>
           <Button variant="danger" onClick={() => void onConfirm()} disabled={busy}>
-            {busy ? 'ending…' : 'end session'}
+            {busy ? 'Ending…' : 'End session'}
           </Button>
         </>
       }

--- a/apps/desktop/src/components/GithubPanel.tsx
+++ b/apps/desktop/src/components/GithubPanel.tsx
@@ -130,7 +130,7 @@ function Absent({
           {save === 'saving' ? (
             <Loader2 size={12} className="mr-1 animate-spin" aria-hidden />
           ) : null}
-          connect
+          Connect
         </Button>
       </div>
       {error ? (
@@ -180,7 +180,7 @@ function Connected({
           disabled={save === 'saving'}
           className={cn(save === 'saving' && 'opacity-60')}
         >
-          disconnect
+          Disconnect
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/components/GuideDialog.tsx
+++ b/apps/desktop/src/components/GuideDialog.tsx
@@ -32,7 +32,7 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'tokens', label: 'Tokens & cost', icon: <Coins size={14} aria-hidden /> },
   { id: 'agents', label: 'Agents', icon: <Bot size={14} aria-hidden /> },
   { id: 'tips', label: 'Tips', icon: <Lightbulb size={14} aria-hidden /> },
-  { id: 'legenda', label: 'Legenda', icon: <Palette size={14} aria-hidden /> },
+  { id: 'legenda', label: 'Legend', icon: <Palette size={14} aria-hidden /> },
 ];
 
 export function GuideDialog({ open, onClose }: GuideDialogProps) {
@@ -49,7 +49,7 @@ export function GuideDialog({ open, onClose }: GuideDialogProps) {
       fullScreenOnSmall
       footer={
         <Button variant="ghost" onClick={onClose}>
-          close
+          Close
         </Button>
       }
     >
@@ -244,7 +244,7 @@ function Content({ section }: { section: Section }) {
           <P>
             each model has a hard ceiling on how many tokens fit in one call (Opus 4.7 1M, Sonnet
             4.6 / Haiku 4.5 200k, gpt-4o 128k). the bar under each agent shows how full the current
-            context is. above 75% → the agent starts forgetting; consider summarising or starting a
+            context is. above 75% → the agent starts forgetting; consider summarizing or starting a
             new session.
           </P>
           <H3>Cost colors</H3>
@@ -295,7 +295,7 @@ function Content({ section }: { section: Section }) {
           <P>
             the second line on each agent shows:{' '}
             <Code>model · ↓ input · ↑ output · cost · ⏱ age</Code>. below it, a thin bar = context
-            window utilisation. tooltip on the bar gives exact numbers.
+            window utilization. tooltip on the bar gives exact numbers.
           </P>
         </Article>
       );
@@ -315,7 +315,7 @@ function Content({ section }: { section: Section }) {
               ],
               [
                 'use cheap models for navigation',
-                'haiku / cursor-small can grep, list, summarise in seconds at 1/15th the price. swap up only when reasoning gets hard.',
+                'haiku / cursor-small can grep, list, summarize in seconds at 1/15th the price. swap up only when reasoning gets hard.',
               ],
               [
                 "queue, don't cancel",
@@ -336,7 +336,7 @@ function Content({ section }: { section: Section }) {
 
     case 'legenda':
       return (
-        <Article heading="Legenda" intro="color meanings used throughout the interface.">
+        <Article heading="Legend" intro="color meanings used throughout the interface.">
           <H3>Status dots — sessions & agents</H3>
           <LegendaGrid
             rows={[
@@ -368,7 +368,7 @@ function Content({ section }: { section: Section }) {
                 desc: 'comfortable — plenty of context remaining',
               },
               { dot: 'bg-info', label: '50–75%', desc: 'moderate — monitor closely' },
-              { dot: 'bg-warning', label: '75–90%', desc: 'high — consider summarising soon' },
+              { dot: 'bg-warning', label: '75–90%', desc: 'high — consider summarizing soon' },
               { dot: 'bg-danger', label: '≥ 90%', desc: 'critical — start a new session' },
             ]}
           />

--- a/apps/desktop/src/components/ImportConfigDialog.tsx
+++ b/apps/desktop/src/components/ImportConfigDialog.tsx
@@ -10,10 +10,10 @@ interface ImportConfigDialogProps {
 
 export function ImportConfigDialog({ open, result, error, onClose }: ImportConfigDialogProps) {
   const title = error
-    ? 'import failed'
+    ? 'Import failed'
     : result?.ok
-      ? 'import complete'
-      : 'import validation errors';
+      ? 'Import complete'
+      : 'Import validation errors';
 
   return (
     <Dialog
@@ -21,10 +21,10 @@ export function ImportConfigDialog({ open, result, error, onClose }: ImportConfi
       onClose={onClose}
       title={title}
       description={
-        result?.ok ? 'config imported successfully.' : 'review the issues below before retrying.'
+        result?.ok ? 'Config imported successfully.' : 'Review the issues below before retrying.'
       }
       size="sm"
-      footer={<Button onClick={onClose}>close</Button>}
+      footer={<Button onClick={onClose}>Close</Button>}
     >
       {error ? (
         <p className="text-xs text-danger">{error}</p>

--- a/apps/desktop/src/components/NewSessionDialog.tsx
+++ b/apps/desktop/src/components/NewSessionDialog.tsx
@@ -482,7 +482,7 @@ export function NewSessionDialog({
               </span>
             ) : null}
             <Button variant="ghost" onClick={onClose} disabled={busy}>
-              cancel
+              Cancel
             </Button>
             <Button
               onClick={() => void onCreate()}
@@ -496,10 +496,10 @@ export function NewSessionDialog({
               {busy ? (
                 <>
                   <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
-                  creating…
+                  Creating…
                 </>
               ) : (
-                'create session'
+                'Create session'
               )}
             </Button>
           </div>
@@ -745,7 +745,7 @@ export function NewSessionDialog({
                                 );
                               }}
                             >
-                              connect in settings
+                              Connect in settings
                             </button>
                           )}
                         </label>

--- a/apps/desktop/src/components/OpenInEditorButton.tsx
+++ b/apps/desktop/src/components/OpenInEditorButton.tsx
@@ -69,7 +69,7 @@ export function OpenInEditorButton({
         onClick={() => void open(resolvedDefault)}
       >
         <FolderOpen size={12} aria-hidden />
-        open in {resolvedDefault}
+        Open in {resolvedDefault}
       </Button>
     );
   }

--- a/apps/desktop/src/components/PhasesPanel.tsx
+++ b/apps/desktop/src/components/PhasesPanel.tsx
@@ -392,7 +392,7 @@ function DefinitionEditor({
         <Textarea
           value={def.promptPrefix}
           onChange={(e) => onUpdate({ promptPrefix: e.target.value })}
-          placeholder="You are in the planning step. Your goal is to…"
+          placeholder="you are in the planning step. your goal is to…"
           rows={3}
           className="font-mono text-xs"
         />

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -121,7 +121,7 @@ export function PlannerWidget({
           planner returns a structured workflow you can review before saving.
         </p>
         <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
-          {busy && !plan ? 'planning…' : plan ? 're-plan' : 'generate plan'}
+          {busy && !plan ? 'Planning…' : plan ? 'Re-plan' : 'Generate plan'}
         </Button>
       </div>
       {error ? (
@@ -168,7 +168,7 @@ export function PlannerWidget({
             })}
           </ol>
           <Button size="sm" onClick={onSave} disabled={busy}>
-            {busy ? 'saving…' : 'use this workflow'}
+            {busy ? 'Saving…' : 'Use this workflow'}
           </Button>
         </div>
       ) : null}

--- a/apps/desktop/src/components/PricingDialog.tsx
+++ b/apps/desktop/src/components/PricingDialog.tsx
@@ -132,7 +132,7 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
   const workspaceCost = workspaceSummary?.estimatedCostUsd ?? 0;
 
   return (
-    <Dialog open={open} onClose={onClose} size="lg" title="pricing">
+    <Dialog open={open} onClose={onClose} size="lg" title="Pricing">
       <div className="flex flex-col gap-4 text-sm">
         <div className="grid grid-cols-2 gap-3">
           <CostStat label="current session" value={formatCost(sessionCost)} />

--- a/apps/desktop/src/components/SessionSettingsDialog.tsx
+++ b/apps/desktop/src/components/SessionSettingsDialog.tsx
@@ -146,7 +146,7 @@ export function SessionSettingsDialog({
                   onClick={() => void onSaveGoal()}
                   disabled={busy || goalDraft.trim() === session.goal.trim()}
                 >
-                  save
+                  Save
                 </Button>
               </div>
             </Field>
@@ -188,7 +188,7 @@ export function SessionSettingsDialog({
                   className="flex-1"
                 />
                 <Button variant="secondary" onClick={() => void onSaveCap()} disabled={busy}>
-                  save
+                  Save
                 </Button>
               </div>
             </Field>
@@ -238,12 +238,12 @@ export function SessionSettingsDialog({
                 {archived ? (
                   <>
                     <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
-                    unarchive
+                    Unarchive
                   </>
                 ) : (
                   <>
                     <Archive size={13} aria-hidden className="mr-1.5" />
-                    archive
+                    Archive
                   </>
                 )}
               </Button>
@@ -266,7 +266,7 @@ export function SessionSettingsDialog({
                 {!confirmDelete ? (
                   <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
                     <Trash2 size={13} aria-hidden className="mr-1.5" />
-                    delete
+                    Delete
                   </Button>
                 ) : null}
               </div>
@@ -279,7 +279,7 @@ export function SessionSettingsDialog({
                   </div>
                   <div className="flex items-center justify-end gap-2">
                     <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
-                      cancel
+                      Cancel
                     </Button>
                     {!archived ? (
                       <Button
@@ -292,11 +292,11 @@ export function SessionSettingsDialog({
                         disabled={busy}
                       >
                         <Archive size={13} aria-hidden className="mr-1.5" />
-                        archive instead
+                        Archive instead
                       </Button>
                     ) : null}
                     <Button variant="danger" onClick={() => void onDelete()} disabled={busy}>
-                      {busy ? 'deleting…' : 'confirm delete'}
+                      {busy ? 'Deleting…' : 'Confirm delete'}
                     </Button>
                   </div>
                 </>
@@ -320,7 +320,7 @@ export function SessionSettingsDialog({
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={onClose}>
-            close
+            Close
           </Button>
         </>
       }

--- a/apps/desktop/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/components/SettingsDialog.tsx
@@ -249,7 +249,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
             <p className="text-xs leading-relaxed text-muted-foreground">
               Wipe the local sqlite database — drops every workspace, session, agent, message,
               transcript, telemetry record, budget rule, permission rule, and skill registration.
-              Api keys in the os keychain are NOT touched. Fresh schema is recreated on next boot.
+              API keys in the OS keychain are not touched. Fresh schema is recreated on next boot.
             </p>
             {wipeError ? (
               <p className="rounded-md border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
@@ -312,7 +312,7 @@ export function SettingsDialog({ open, onClose, initialSection }: SettingsDialog
             </div>
             <p className="text-xs leading-relaxed text-muted-foreground">
               Export saves workspaces, skills, workflows, permission rules, budget rules, and
-              settings to a json file. Api keys are never included.
+              settings to a JSON file. API keys are never included.
             </p>
           </div>
         );

--- a/apps/desktop/src/components/ShortcutHelpDialog.tsx
+++ b/apps/desktop/src/components/ShortcutHelpDialog.tsx
@@ -23,7 +23,7 @@ export function ShortcutHelpDialog({ open, onClose }: ShortcutHelpDialogProps) {
     <Dialog
       open={open}
       onClose={onClose}
-      title="keyboard shortcuts"
+      title="Keyboard shortcuts"
       description="global shortcuts active anywhere in kAY.am."
       size="sm"
     >

--- a/apps/desktop/src/components/SkillsPanel.tsx
+++ b/apps/desktop/src/components/SkillsPanel.tsx
@@ -262,7 +262,7 @@ function SkillEditor({
           <Input
             value={form.description}
             onChange={(e) => onChange({ ...form, description: e.target.value })}
-            placeholder="What this skill does"
+            placeholder="what this skill does"
           />
         </div>
 
@@ -292,7 +292,7 @@ function SkillEditor({
           <Textarea
             value={form.body}
             onChange={(e) => onChange({ ...form, body: e.target.value })}
-            placeholder="Skill prompt body…"
+            placeholder="skill prompt body…"
             rows={6}
             className="font-mono text-xs"
           />

--- a/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
+++ b/apps/desktop/src/components/WorkspaceSettingsDialog.tsx
@@ -183,7 +183,7 @@ export function WorkspaceSettingsDialog({
                     disabled={disconnecting}
                   >
                     <Unplug size={13} aria-hidden className="mr-1.5" />
-                    disconnect
+                    Disconnect
                   </Button>
                 ) : null}
               </div>
@@ -195,14 +195,14 @@ export function WorkspaceSettingsDialog({
                     onClick={() => setConfirmDisconnect(false)}
                     disabled={disconnecting}
                   >
-                    cancel
+                    Cancel
                   </Button>
                   <Button
                     variant="danger"
                     onClick={() => void onDisconnect()}
                     disabled={disconnecting}
                   >
-                    {disconnecting ? 'disconnecting…' : 'confirm disconnect'}
+                    {disconnecting ? 'Disconnecting…' : 'Confirm disconnect'}
                   </Button>
                 </div>
               ) : null}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -222,7 +222,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
             ))}
             <li>
               <AddRow
-                label="add workspace"
+                label="Add workspace"
                 icon={<FolderPlus size={13} aria-hidden />}
                 onClick={() => setAddWorkspaceOpen(true)}
               />
@@ -362,8 +362,8 @@ function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
             setWsSettingsOpen(true);
           }}
           className="mr-1 shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-muted hover:text-foreground group-hover:text-muted-foreground"
-          title="Workspace settings (incl. disconnect)"
-          aria-label={`Settings for workspace ${workspace.name}`}
+          title="workspace settings (incl. disconnect)"
+          aria-label={`settings for workspace ${workspace.name}`}
         >
           <Settings2 size={12} aria-hidden />
         </button>
@@ -489,7 +489,7 @@ function SessionList({
         ))}
         <li>
           <AddRow
-            label="add session"
+            label="Add session"
             icon={<Plus size={13} aria-hidden />}
             onClick={onNewSession}
           />
@@ -565,8 +565,8 @@ function SortIconButton({
         className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         aria-haspopup="menu"
         aria-expanded={open}
-        title={`Sort: ${current.label}`}
-        aria-label="Sort sessions"
+        title={`sort: ${current.label}`}
+        aria-label="sort sessions"
       >
         <ArrowUpDown size={12} aria-hidden />
       </button>
@@ -1014,16 +1014,16 @@ function DeleteConfirmDialog({ sessionGoal, onConfirm, onCancel }: DeleteConfirm
     <Dialog
       open
       onClose={onCancel}
-      title="delete session?"
+      title="Delete session?"
       description={`"${sessionGoal}" will be permanently removed. worktree, transcripts, and audit logs will be deleted. this cannot be undone.`}
       size="sm"
       footer={
         <>
           <Button variant="ghost" onClick={onCancel}>
-            cancel
+            Cancel
           </Button>
           <Button variant="danger" onClick={onConfirm}>
-            delete
+            Delete
           </Button>
         </>
       }
@@ -1101,17 +1101,17 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
     <Dialog
       open={open}
       onClose={onClose}
-      title="add workspace"
+      title="Add workspace"
       description="point at a git repository on disk. each task creates its own worktree."
       size="lg"
       footer={
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={onClose} disabled={busy}>
-            cancel
+            Cancel
           </Button>
           <Button onClick={() => void onAdd()} disabled={path.length === 0 || busy}>
-            {busy ? 'adding…' : 'add workspace'}
+            {busy ? 'Adding…' : 'Add workspace'}
           </Button>
         </>
       }
@@ -1151,7 +1151,7 @@ function AddWorkspaceDialog({ open, onClose }: AddWorkspaceDialogProps) {
                   className="flex-1"
                 />
                 <Button variant="secondary" onClick={() => void onPick()} disabled={busy}>
-                  browse
+                  Browse
                 </Button>
               </div>
               <p className="text-xs leading-relaxed text-muted-foreground">
@@ -1512,7 +1512,7 @@ function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps
         aria-expanded={open}
       >
         <Plus size={13} aria-hidden />
-        spawn agent
+        Spawn agent
       </button>
       {open ? (
         <div
@@ -1672,7 +1672,7 @@ function AgentRow({
 }: AgentRowProps) {
   const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
   const titleParts = [
-    `Agent ${run.ordinal + 1}`,
+    `agent ${run.ordinal + 1}`,
     `status: ${run.status}`,
     isSelected ? 'selected — chat shows this agent' : 'click to switch chat to this agent',
     telemetry ? `provider: ${telemetry.provider}` : null,
@@ -1771,7 +1771,7 @@ function AgentRow({
                 className="rounded px-1 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="cancel"
               >
-                cancel
+                Cancel
               </button>
               <button
                 type="button"
@@ -1782,7 +1782,7 @@ function AgentRow({
                 className="rounded px-1 py-0.5 text-2xs font-medium text-danger transition-colors hover:bg-danger/10"
                 title="confirm delete"
               >
-                delete
+                Delete
               </button>
             </div>
           ) : (
@@ -2026,17 +2026,17 @@ export function BulkSessionDeleteDialog({
     <Dialog
       open={open}
       onClose={handleClose}
-      title="delete all sessions?"
+      title="Delete all sessions?"
       description={`disconnecting "${workspaceName}" will permanently remove all ${workspaceSessions.length} session${workspaceSessions.length === 1 ? '' : 's'} listed below. worktrees, transcripts, and audit logs will be deleted. this cannot be undone.`}
       size="sm"
       footer={
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
           <Button variant="ghost" onClick={handleClose} disabled={busy}>
-            cancel
+            Cancel
           </Button>
           <Button variant="danger" onClick={() => void onConfirm()} disabled={busy}>
-            {busy ? 'deleting…' : 'delete all & disconnect'}
+            {busy ? 'Deleting…' : 'Delete all & disconnect'}
           </Button>
         </>
       }

--- a/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
+++ b/apps/desktop/src/components/chat/AuthRequiredCallout.tsx
@@ -31,10 +31,10 @@ export function AuthRequiredCallout({ providerId, identity, onRefresh }: AuthReq
           ) : null}
           <div className="mt-2 flex gap-2">
             <Button size="sm" onClick={onConnect}>
-              connect now ↗
+              Connect now ↗
             </Button>
             <Button size="sm" variant="ghost" onClick={onRefresh}>
-              refresh status
+              Refresh status
             </Button>
           </div>
         </div>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -405,8 +405,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             <button
               type="button"
               onClick={() => void cancelCurrentTurn(session.id)}
-              title="Cancel turn"
-              aria-label="Cancel turn"
+              title="cancel turn"
+              aria-label="cancel turn"
               className="absolute bottom-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-danger transition-colors hover:bg-danger/10"
             >
               <Square size={16} aria-hidden fill="currentColor" />
@@ -416,8 +416,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
               type="button"
               onClick={() => void onSend()}
               disabled={!canSend}
-              title={sendDisabledTitle ?? (isRunning ? 'Queue message (enter)' : 'Send (enter)')}
-              aria-label={isRunning ? 'Queue message' : 'Send message'}
+              title={sendDisabledTitle ?? (isRunning ? 'queue message (enter)' : 'send (enter)')}
+              aria-label={isRunning ? 'queue message' : 'send message'}
               className="absolute bottom-3 right-3 inline-flex h-8 w-8 items-center justify-center rounded-md text-info transition-colors hover:bg-info/10 disabled:cursor-not-allowed disabled:text-muted-foreground/40 disabled:hover:bg-transparent"
             >
               <Send size={16} aria-hidden className="-translate-x-px" />

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -279,7 +279,7 @@ export function ChatView({ session }: ChatViewProps) {
               className="rounded border border-border bg-background px-3 py-1 text-xs motion-safe:transition-colors hover:bg-muted"
               onClick={() => setMergeDialogOpen(true)}
             >
-              merge
+              Merge
             </button>
           </div>
         ) : null}

--- a/apps/desktop/src/components/chat/MergeDialog.tsx
+++ b/apps/desktop/src/components/chat/MergeDialog.tsx
@@ -45,14 +45,14 @@ export function MergeDialog({ open, conflicts, onResolve, onCancel }: MergeDialo
     <Dialog
       open={open}
       onClose={handleCancel}
-      title="resolve merge conflicts"
+      title="Resolve merge conflicts"
       description="pick the winning version for each file, or skip to leave it unresolved."
       size="lg"
       closeOnBackdrop={false}
       footer={
         <>
           <Button variant="ghost" onClick={handleCancel}>
-            cancel
+            Cancel
           </Button>
           <Button
             variant="primary"
@@ -60,7 +60,7 @@ export function MergeDialog({ open, conflicts, onResolve, onCancel }: MergeDialo
             disabled={!allResolved}
             aria-disabled={!allResolved}
           >
-            confirm
+            Confirm
           </Button>
         </>
       }


### PR DESCRIPTION
## Summary

Closes #513.

Touches **22 files** in `apps/desktop/src/components/**`. ~94 strings changed. Snapshot file regenerated to reflect new button labels.

### Before → after (representative)

| before | after |
|---|---|
| `cancel` / `end session` (EndSessionDialog buttons) | `Cancel` / `End session` |
| `add workspace` (dialog title + button) | `Add workspace` |
| `'delete session?'` (DeleteConfirmDialog title) | `'Delete session?'` |
| `'pricing'` / `'keyboard shortcuts'` / `'resolve merge conflicts'` (dialog titles) | `'Pricing'` / `'Keyboard shortcuts'` / `'Resolve merge conflicts'` |
| `'planning…' / 're-plan' / 'generate plan'` (PlannerWidget) | `'Planning…' / 'Re-plan' / 'Generate plan'` |
| `connect now ↗` / `refresh status` (AuthRequiredCallout) | `Connect now ↗` / `Refresh status` |
| `Legenda` (Italian) | `Legend` |
| `summarising` / `utilisation` (British, GuideDialog) | `summarizing` / `utilization` |
| `Api keys in the os keychain are NOT touched.` | `API keys in the OS keychain are not touched.` |
| `summarizer running — keep typing, the app is not blocked` (verbose tooltip) | `summarizer running — input is not blocked` |
| `title="Cancel turn"` / `aria-label="Cancel turn"` (mixed case) | `title="cancel turn"` / `aria-label="cancel turn"` |
| `open pr` (ContextPanel CTA) | `Open PR` |
| `open in vscode` (OpenInEditorButton) | `Open in vscode` |

### Conventions applied

- **CTAs / dialog titles / menu items**: sentence case (`Save`, `Cancel`, `Add workspace`, `End session`, `Delete session?`).
- **Tooltips / aria-labels**: lowercase first word, proper nouns kept.
- **Body text & descriptions**: untouched where already terse and lowercase per README voice.
- **US English**: `summarize`, `utilization`, `behavior`, `color`.
- No `please / kindly / sorry / we / let's`. No trailing `!`. No trailing period on titles.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 295/295 desktop, snapshot regenerated for `empty-error-states.test.tsx.snap`
- [x] `pnpm knip` — exit 0
- [x] `pnpm build` — clean

## Notes

- Identifiers / function names / type names left untouched (per scope).
- `Section` id `'legenda'` kept (structural discriminator) — only the displayed label changed to `Legend`.
- Two markdown-style placeholder sentences in `ChatInput` kept sentence-cased (full prompts to the user) rather than forced-lowercase — matches the `'Sign in to send a message.'` family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)