### PR TITLE
chore(repo): drop what comments, keep why

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -4,10 +4,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { IsoDateTime, ProviderRunId, Task } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before imports that transitively pull the mocked modules
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before imports that transitively pull the mocked modules.
 const sendTurnMock = vi.fn(async () => undefined);
 const cancelCurrentTurnMock = vi.fn();
 
@@ -55,15 +52,8 @@ vi.mock('@kay-am/core', () => ({
   })),
 }));
 
-// ---------------------------------------------------------------------------
-// Import component AFTER mocks are in place
-// ---------------------------------------------------------------------------
-
+// Import component AFTER mocks are in place.
 import { ChatInput } from '../components/chat/ChatInput';
-
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
 
 function makeSession(overrides: Partial<Task> = {}): Task {
   return {
@@ -89,10 +79,6 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('ChatInput — input wiring', () => {
   it('typed characters appear in the textarea', async () => {

--- a/apps/desktop/src/__tests__/chat-view-split.test.ts
+++ b/apps/desktop/src/__tests__/chat-view-split.test.ts
@@ -2,19 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { ProviderRunId, TurnEvent, IsoDateTime } from '@kay-am/types';
 import { detectParallelRunIds, filterEventsByRunId } from '../components/chat/transcript-items';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const AT = '2026-01-01T00:00:00.000Z' as IsoDateTime;
 
 function makeEvent(runId: string, delta = 'text'): TurnEvent {
   return { kind: 'assistant_text', runId: runId as ProviderRunId, delta, at: AT };
 }
-
-// ---------------------------------------------------------------------------
-// detectParallelRunIds
-// ---------------------------------------------------------------------------
 
 describe('detectParallelRunIds', () => {
   it('returns [] when events is empty', () => {
@@ -64,10 +56,6 @@ describe('detectParallelRunIds', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// filterEventsByRunId
-// ---------------------------------------------------------------------------
-
 describe('filterEventsByRunId', () => {
   it('returns only events matching the given runId', () => {
     const events = [
@@ -92,10 +80,6 @@ describe('filterEventsByRunId', () => {
     expect(filterEventsByRunId(events, 'run-a' as ProviderRunId)).toHaveLength(3);
   });
 });
-
-// ---------------------------------------------------------------------------
-// isSplitView derivation (flag guard)
-// ---------------------------------------------------------------------------
 
 describe('isSplitView derivation', () => {
   function isSplitView(flagOn: boolean, events: ReadonlyArray<TurnEvent>): boolean {
@@ -132,10 +116,6 @@ describe('isSplitView derivation', () => {
     expect(isSplitView(true, events)).toBe(true);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Column event filtering (correct per-column isolation)
-// ---------------------------------------------------------------------------
 
 describe('per-column event isolation', () => {
   it('each column sees only its own events', () => {

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -65,10 +65,6 @@ function makeSession(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-// ---------------------------------------------------------------------------
-// Snapshot — rail (collapsed) vs expanded
-// ---------------------------------------------------------------------------
-
 describe('snapshot — ContextPanel variants', () => {
   it('collapsed: renders rail button, not slot content', () => {
     const { container } = render(
@@ -84,10 +80,6 @@ describe('snapshot — ContextPanel variants', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 });
-
-// ---------------------------------------------------------------------------
-// Rail semantics
-// ---------------------------------------------------------------------------
 
 describe('ContextPanel rail — a11y attributes', () => {
   it('has role=button', () => {
@@ -108,10 +100,6 @@ describe('ContextPanel rail — a11y attributes', () => {
     expect(document.activeElement).toBe(rail);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Keyboard interaction
-// ---------------------------------------------------------------------------
 
 describe('ContextPanel rail — keyboard', () => {
   it('Enter key calls onExpand', async () => {
@@ -141,10 +129,6 @@ describe('ContextPanel rail — keyboard', () => {
     expect(onExpand).toHaveBeenCalledOnce();
   });
 });
-
-// ---------------------------------------------------------------------------
-// Persistence — collapsed state survives toggle cycle
-// ---------------------------------------------------------------------------
 
 describe('ContextPanel — persistence contract', () => {
   it('collapsed=false: rail button present in DOM but visually hidden', () => {

--- a/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
@@ -95,10 +95,6 @@ function makeSession(overrides: Partial<Task> = {}): Task {
   } as Task;
 }
 
-// ---------------------------------------------------------------------------
-// EndSessionDialog
-// ---------------------------------------------------------------------------
-
 describe('keyboard — EndSessionDialog', () => {
   it('Escape key triggers onClose', async () => {
     const onClose = vi.fn();
@@ -141,10 +137,6 @@ describe('keyboard — EndSessionDialog', () => {
     expect(second?.tagName.toLowerCase()).toBe('button');
   });
 });
-
-// ---------------------------------------------------------------------------
-// NewSessionDialog
-// ---------------------------------------------------------------------------
 
 describe('keyboard — NewSessionDialog', () => {
   it('renders without crash when open (multiple textbox inputs present)', () => {
@@ -203,10 +195,6 @@ describe('keyboard — NewSessionDialog', () => {
     expect(createBtn).toBeDefined();
   });
 });
-
-// ---------------------------------------------------------------------------
-// SlashCommandPopover — arrow/tab navigation
-// ---------------------------------------------------------------------------
 
 describe('keyboard — SlashCommandPopover arrow / tab navigation', () => {
   const items = [

--- a/apps/desktop/src/__tests__/merge-dialog.test.tsx
+++ b/apps/desktop/src/__tests__/merge-dialog.test.tsx
@@ -6,10 +6,6 @@ import { MergeDialog, SKIP_SENTINEL } from '../components/chat/MergeDialog';
 
 afterEach(cleanup);
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const RUN_A = 'run-a' as ProviderRunId;
 const RUN_B = 'run-b' as ProviderRunId;
 
@@ -22,31 +18,17 @@ const TWO_CONFLICTS = [
   { file: 'src/bar.ts', runIds: [RUN_A, RUN_B] as ReadonlyArray<ProviderRunId> },
 ];
 
-// ---------------------------------------------------------------------------
-// Renders
-// ---------------------------------------------------------------------------
-
 describe('MergeDialog — rendering', () => {
   it('renders file path in mono font', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     expect(screen.getByText('src/foo.ts')).toBeDefined();
   });
 
   it('renders a radio for each runId + skip option', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     const radios = screen.getAllByRole('radio');
     // 2 runIds + 1 skip = 3
@@ -55,50 +37,29 @@ describe('MergeDialog — rendering', () => {
 
   it('renders all files when multiple conflicts', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={TWO_CONFLICTS}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={TWO_CONFLICTS} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     expect(screen.getByText('src/foo.ts')).toBeDefined();
     expect(screen.getByText('src/bar.ts')).toBeDefined();
   });
 
   it('renders empty-state message when no conflicts', () => {
-    render(
-      <MergeDialog open={true} conflicts={[]} onResolve={vi.fn()} onCancel={vi.fn()} />,
-    );
+    render(<MergeDialog open={true} conflicts={[]} onResolve={vi.fn()} onCancel={vi.fn()} />);
     expect(screen.getByText('no conflicts detected.')).toBeDefined();
   });
 
   it('renders diff preview placeholder', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     expect(screen.getByText(/diff preview.*follow-on/i)).toBeDefined();
   });
 });
 
-// ---------------------------------------------------------------------------
-// Confirm button gate
-// ---------------------------------------------------------------------------
-
 describe('MergeDialog — confirm button gate', () => {
   it('confirm disabled before any pick', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     const confirm = screen.getByRole('button', { name: /confirm/i });
     expect(confirm.hasAttribute('disabled')).toBe(true);
@@ -106,12 +67,7 @@ describe('MergeDialog — confirm button gate', () => {
 
   it('confirm enabled after picking a winner for all files', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     const radios = screen.getAllByRole('radio');
     fireEvent.click(radios[0]!); // pick run-a
@@ -121,12 +77,7 @@ describe('MergeDialog — confirm button gate', () => {
 
   it('confirm disabled when only one of two files is resolved', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={TWO_CONFLICTS}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={TWO_CONFLICTS} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     // pick run-a for first file only (radio index 0)
     const radios = screen.getAllByRole('radio');
@@ -137,12 +88,7 @@ describe('MergeDialog — confirm button gate', () => {
 
   it('confirm enabled after picking skip for all files', () => {
     render(
-      <MergeDialog
-        open={true}
-        conflicts={TWO_CONFLICTS}
-        onResolve={vi.fn()}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={TWO_CONFLICTS} onResolve={vi.fn()} onCancel={vi.fn()} />,
     );
     const radios = screen.getAllByRole('radio');
     // Each conflict has 3 radios: run-a, run-b, skip. Total = 6.
@@ -156,29 +102,18 @@ describe('MergeDialog — confirm button gate', () => {
   it('confirm enabled when no conflicts (edge case: always resolved)', () => {
     // With 0 conflicts the button stays disabled because
     // "allResolved = conflicts.length > 0 && ..." guards the empty state.
-    render(
-      <MergeDialog open={true} conflicts={[]} onResolve={vi.fn()} onCancel={vi.fn()} />,
-    );
+    render(<MergeDialog open={true} conflicts={[]} onResolve={vi.fn()} onCancel={vi.fn()} />);
     const confirm = screen.getByRole('button', { name: /confirm/i });
     // empty conflicts → allResolved = false → disabled
     expect(confirm.hasAttribute('disabled')).toBe(true);
   });
 });
 
-// ---------------------------------------------------------------------------
-// onResolve payload
-// ---------------------------------------------------------------------------
-
 describe('MergeDialog — onResolve payload', () => {
   it('calls onResolve with correct runId pick', () => {
     const onResolve = vi.fn();
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={onResolve}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={onResolve} onCancel={vi.fn()} />,
     );
     const radios = screen.getAllByRole('radio');
     fireEvent.click(radios[0]!); // run-a
@@ -190,12 +125,7 @@ describe('MergeDialog — onResolve payload', () => {
   it('calls onResolve with SKIP_SENTINEL when skip selected', () => {
     const onResolve = vi.fn();
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={onResolve}
-        onCancel={vi.fn()}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={onResolve} onCancel={vi.fn()} />,
     );
     const radios = screen.getAllByRole('radio');
     fireEvent.click(radios[2]!); // skip
@@ -224,20 +154,11 @@ describe('MergeDialog — onResolve payload', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Cancel handler
-// ---------------------------------------------------------------------------
-
 describe('MergeDialog — cancel', () => {
   it('invokes onCancel when cancel button is clicked', () => {
     const onCancel = vi.fn();
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={onCancel}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={onCancel} />,
     );
     fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onCancel).toHaveBeenCalledOnce();
@@ -264,20 +185,11 @@ describe('MergeDialog — cancel', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Escape closes dialog
-// ---------------------------------------------------------------------------
-
 describe('MergeDialog — escape', () => {
   it('calls onCancel when escape key fires a close event on the dialog', () => {
     const onCancel = vi.fn();
     render(
-      <MergeDialog
-        open={true}
-        conflicts={ONE_CONFLICT}
-        onResolve={vi.fn()}
-        onCancel={onCancel}
-      />,
+      <MergeDialog open={true} conflicts={ONE_CONFLICT} onResolve={vi.fn()} onCancel={onCancel} />,
     );
     // The Dialog primitive listens for the native `close` event on <dialog>.
     // happy-dom fires that event when Escape is pressed on an open modal.

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -14,10 +14,7 @@ import type {
 } from '@kay-am/types';
 import type { MergeResult } from '@kay-am/core';
 
-// ---------------------------------------------------------------------------
 // Module mocks — hoisted before subject imports.
-// ---------------------------------------------------------------------------
-
 // Tauri invoke — stubbed per-test.
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 
@@ -76,16 +73,8 @@ vi.mock('../turn', () => ({
 // orchestration logic is exercised end-to-end. Only the Tauri surface is mocked.
 // detectConflicts + resolveConflicts stay real too.
 
-// ---------------------------------------------------------------------------
-// Subject under test.
-// ---------------------------------------------------------------------------
-
 import { runParallelBranch } from '../store/parallel-turn';
 import type { ParallelBranchInputs, ParallelBranchEffects } from '../store/parallel-turn';
-
-// ---------------------------------------------------------------------------
-// Helpers.
-// ---------------------------------------------------------------------------
 
 const NOW = '2026-05-07T00:00:00.000Z' as IsoDateTime;
 const SESSION_ID = 'ses-1' as TaskId;
@@ -221,10 +210,6 @@ function wirePhaseRunSpies(
   phaseRunListSpy.mockImplementation(async () => insertedPhaseRuns.slice());
 }
 
-// ---------------------------------------------------------------------------
-// Tests.
-// ---------------------------------------------------------------------------
-
 describe('parallel e2e — fan-out/fan-in', () => {
   beforeEach(() => {
     parallelPhaseGroupCreateSpy.mockReset();
@@ -254,10 +239,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
-
-  // -------------------------------------------------------------------------
-  // Happy path: 3 parallel runs, all succeed.
-  // -------------------------------------------------------------------------
 
   it('happy path: 3 runs complete → transcript has events from all runIds, group marked complete', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
@@ -333,10 +314,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
     expect(phaseTransitions).toHaveLength(1);
   });
 
-  // -------------------------------------------------------------------------
-  // Error path: 1 of 3 runs fails.
-  // -------------------------------------------------------------------------
-
   it('error path: 1 of 3 runs fails → partial merge proceeds, anyFailed=true, group still completes', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
     wirePhaseRunSpies(insertedPhaseRuns);
@@ -391,10 +368,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
     expect(seenRunIds.has(idC as ProviderRunId)).toBe(false);
   });
 
-  // -------------------------------------------------------------------------
-  // All-fail path: no runs succeed → group NOT marked complete.
-  // -------------------------------------------------------------------------
-
   it('all-fail path: all 3 runs fail → allFailed=true, group completedAt not set', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
     wirePhaseRunSpies(insertedPhaseRuns);
@@ -422,11 +395,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
     // Group NOT marked complete when all fail.
     expect(parallelPhaseGroupUpdateCompletedAtSpy).not.toHaveBeenCalled();
   });
-
-  // -------------------------------------------------------------------------
-  // Transcript event ordering: events from each runId arrive interleaved
-  // but each lane sees only its own events when filtered.
-  // -------------------------------------------------------------------------
 
   it('transcript multi-lane: interleaved events remain correctly tagged per runId', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
@@ -477,10 +445,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
     for (const e of laneC) expect(e.runId).toBe(idC as ProviderRunId);
   });
 
-  // -------------------------------------------------------------------------
-  // Cancel mid-flight: cancelGroup propagates to all N runIds.
-  // -------------------------------------------------------------------------
-
   it('cancel mid-flight: spawn throws → cancelGroup teardown, listener unlistened', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
     wirePhaseRunSpies(insertedPhaseRuns);
@@ -507,10 +471,6 @@ describe('parallel e2e — fan-out/fan-in', () => {
     // No completedAt set on failure path.
     expect(parallelPhaseGroupUpdateCompletedAtSpy).not.toHaveBeenCalled();
   });
-
-  // -------------------------------------------------------------------------
-  // Parallelism cap: maxParallelism=2 with 3 defs → only 2 spawned.
-  // -------------------------------------------------------------------------
 
   it('maxParallelism cap: only 2 runs spawned when maxParallelism=2', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];

--- a/apps/desktop/src/__tests__/parallel-spawn.test.ts
+++ b/apps/desktop/src/__tests__/parallel-spawn.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-// ---------------------------------------------------------------------------
-// Module mocks — factories must not reference outer-scope variables
-// (vi.mock is hoisted before variable initialization)
-// ---------------------------------------------------------------------------
-
+// Module mocks — factories must not reference outer-scope variables (vi.mock
+// is hoisted before variable initialization).
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
@@ -13,18 +10,11 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(),
 }));
 
-// ---------------------------------------------------------------------------
-// Subject under test (imported after mocks are registered)
-// ---------------------------------------------------------------------------
-
+// Imported after mocks are registered.
 import { invoke } from '@tauri-apps/api/core';
 import { invokeParallelPhaseRunSpawn, type ParallelSpawnArgs } from '../turn';
 
 const invokeMock = vi.mocked(invoke);
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('invokeParallelPhaseRunSpawn', () => {
   beforeEach(() => {

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -143,10 +143,6 @@ function makeProviderInfo(overrides: Partial<ProviderInfo> = {}): ProviderInfo {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Empty states
-// ---------------------------------------------------------------------------
-
 describe('snapshot — empty states', () => {
   it('SkillsPanel: no skills', () => {
     const { container } = render(<SkillsPanel workspaceId={WS_ID} />);
@@ -189,10 +185,6 @@ describe('snapshot — empty states', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 });
-
-// ---------------------------------------------------------------------------
-// Error states
-// ---------------------------------------------------------------------------
 
 describe('snapshot — error states', () => {
   it('App init error — BootSplash with error message', () => {

--- a/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
+++ b/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId, SessionId, TaskId, WorkspaceId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before store import.
 vi.mock('../../turn', () => ({
   runTurn: vi.fn(),
   cancelTurn: vi.fn(),
@@ -118,10 +115,6 @@ vi.mock('../../providerPricing', () => ({
   refreshPricingTable: vi.fn(() => Promise.resolve()),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const TASK_ID = 'sess-1' as TaskId;
 const WORKSPACE_ID = 'ws-1' as WorkspaceId;
 const AGENT_ID = 'agent-1' as SessionId;
@@ -145,10 +138,6 @@ function buildSession() {
     updatedAt: AT,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('resolvePermissionRequest', () => {
   let useAppStore: (typeof import('../../store/store'))['useAppStore'];

--- a/apps/desktop/src/__tests__/store/unknown-payload.test.ts
+++ b/apps/desktop/src/__tests__/store/unknown-payload.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId, SessionId, TaskId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before store import.
 vi.mock('../../turn', () => ({
   runTurn: vi.fn(),
   cancelTurn: vi.fn(),
@@ -114,10 +111,6 @@ vi.mock('../../providerPricing', () => ({
   getCodexPriceOverride: vi.fn(() => null),
   refreshPricingTable: vi.fn(() => Promise.resolve()),
 }));
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 const TASK_ID = 'sess-1' as TaskId;
 const AGENT_ID = 'agent-1' as SessionId;

--- a/apps/desktop/src/components/IntegrationsPanel.tsx
+++ b/apps/desktop/src/components/IntegrationsPanel.tsx
@@ -7,8 +7,6 @@ import { GithubPanel } from './GithubPanel';
 type CardState = 'loading' | 'connected' | 'disconnected';
 type SaveState = 'idle' | 'saving' | 'saved' | 'error';
 
-// ─── generic single-token card ────────────────────────────────────────────────
-
 interface TokenCardProps {
   secretKey: string;
   label: string;
@@ -113,8 +111,6 @@ function TokenCard({ secretKey, label, placeholder, hint }: TokenCardProps) {
     </div>
   );
 }
-
-// ─── jira card (domain + email + token) ───────────────────────────────────────
 
 const JIRA_KEY_DOMAIN = 'integration.jira.domain';
 const JIRA_KEY_EMAIL = 'integration.jira.email';
@@ -262,8 +258,6 @@ function JiraCard() {
   );
 }
 
-// ─── section wrapper ───────────────────────────────────────────────────────────
-
 function IntegrationSection({
   icon,
   name,
@@ -298,8 +292,6 @@ function ErrorBanner({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
-
-// ─── svgs for brand icons (minimal inline) ────────────────────────────────────
 
 function GitLabIcon({ size = 14 }: { size?: number }) {
   return (
@@ -345,8 +337,6 @@ function LinearIcon({ size = 14 }: { size?: number }) {
     </svg>
   );
 }
-
-// ─── public panel ─────────────────────────────────────────────────────────────
 
 export function IntegrationsPanel() {
   return (

--- a/apps/desktop/src/components/ProvidersPanel.tsx
+++ b/apps/desktop/src/components/ProvidersPanel.tsx
@@ -248,7 +248,6 @@ function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => 
     );
   }
 
-  // connected
   return (
     <div className="flex flex-col items-center gap-1">
       <div className="flex w-full items-stretch gap-1.5">

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -219,7 +219,6 @@ export function ChatView({ session }: ChatViewProps) {
     [rawMergeConflicts],
   );
 
-  // Derive terminal runStatuses for the current session's phaseRuns.
   const terminalRunStatuses = useMemo(
     () =>
       phaseRuns

--- a/apps/desktop/src/components/chat/MergeDialog.tsx
+++ b/apps/desktop/src/components/chat/MergeDialog.tsx
@@ -95,10 +95,6 @@ export function MergeDialog({ open, conflicts, onResolve, onCancel }: MergeDialo
   );
 }
 
-// ---------------------------------------------------------------------------
-// ConflictRow
-// ---------------------------------------------------------------------------
-
 interface ConflictRowProps {
   conflict: MergeConflict;
   pick: MergeResolution | undefined;

--- a/apps/desktop/src/integrations.ts
+++ b/apps/desktop/src/integrations.ts
@@ -7,8 +7,6 @@ export interface IssueData {
   readonly service: 'github' | 'gitlab' | 'jira' | 'linear';
 }
 
-// ─── Linear ────────────────────────────────────────────────────────────────────
-
 function parseLinearIssueUrl(input: string): string | null {
   const trimmed = input.trim();
   const urlMatch = trimmed.match(/linear\.app\/[^/]+\/issue\/([A-Z]+-\d+)/i);
@@ -50,8 +48,6 @@ async function fetchLinearIssue(issueId: string): Promise<IssueData> {
   };
 }
 
-// ─── GitLab ────────────────────────────────────────────────────────────────────
-
 function parseGitLabIssueUrl(input: string): { projectPath: string; iid: number } | null {
   const trimmed = input.trim();
   const match = trimmed.match(/gitlab\.com\/(.+?)\/-\/issues\/(\d+)/);
@@ -83,8 +79,6 @@ async function fetchGitLabIssue(projectPath: string, iid: number): Promise<Issue
     url: issue.web_url,
   };
 }
-
-// ─── Jira ──────────────────────────────────────────────────────────────────────
 
 function parseJiraIssueUrl(input: string): string | null {
   const trimmed = input.trim();
@@ -145,8 +139,6 @@ function extractJiraDocText(doc: JiraDocNode | string | null | undefined): strin
   walk(doc);
   return parts.join(' ').trim();
 }
-
-// ─── unified detector ──────────────────────────────────────────────────────────
 
 export async function fetchIssueFromUrl(input: string): Promise<IssueData | null> {
   const linear = parseLinearIssueUrl(input);

--- a/apps/desktop/src/permissions.ts
+++ b/apps/desktop/src/permissions.ts
@@ -14,10 +14,6 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Raw row shapes returned by rust commands
-// ---------------------------------------------------------------------------
-
 interface RawPermissionRuleRow {
   readonly id: string;
   readonly scope: string;
@@ -44,10 +40,6 @@ interface RawPermissionAuditRow {
   readonly requestedAt: string;
   readonly decidedAt: string;
 }
-
-// ---------------------------------------------------------------------------
-// Row → domain converters
-// ---------------------------------------------------------------------------
 
 function rowToPermissionRule(row: RawPermissionRuleRow): PermissionRule {
   return {
@@ -86,10 +78,6 @@ function rowToAuditEntry(row: RawPermissionAuditRow): PermissionAuditEntry {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Payload interfaces
-// ---------------------------------------------------------------------------
-
 export interface PermissionRuleUpsertPayload {
   readonly id?: PermissionRuleId;
   readonly scope: PermissionRuleScope;
@@ -115,10 +103,7 @@ export interface PermissionAuditInsertPayload {
   readonly decidedAt: IsoDateTime;
 }
 
-// ---------------------------------------------------------------------------
-// Permission rule commands (#176)
-// ---------------------------------------------------------------------------
-
+// Permission rule commands (#176).
 export async function invokePermissionRuleList(args: {
   scope: PermissionRuleScope;
   workspaceId?: WorkspaceId;
@@ -150,10 +135,7 @@ export async function invokePermissionRuleUpsert(
   return rowToPermissionRule(row);
 }
 
-// ---------------------------------------------------------------------------
-// Permission audit commands (#177)
-// ---------------------------------------------------------------------------
-
+// Permission audit commands (#177).
 export async function invokePermissionAuditInsert(
   input: PermissionAuditInsertPayload,
 ): Promise<PermissionAuditEntry> {
@@ -175,9 +157,7 @@ export async function invokePermissionAuditInsert(
   return rowToAuditEntry(row);
 }
 
-// ---------------------------------------------------------------------------
-// Permission audit retry queue (#196)
-// ---------------------------------------------------------------------------
+// Permission audit retry queue (#196).
 
 interface RawAuditRetryRow {
   readonly id: string;

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -17,10 +17,6 @@ import type {
 } from '@kay-am/types';
 import type { ProviderId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Raw row shapes returned by rust commands
-// ---------------------------------------------------------------------------
-
 interface RawPhaseDefinitionRow {
   readonly id: string;
   readonly workflowId: string;
@@ -54,10 +50,6 @@ interface RawPhaseRunRow {
   readonly completedAt: string | null;
   readonly providerSessionId: string | null;
 }
-
-// ---------------------------------------------------------------------------
-// Row → domain converters
-// ---------------------------------------------------------------------------
 
 function rowToDefinition(row: RawPhaseDefinitionRow): Step {
   return {
@@ -99,10 +91,7 @@ function rowToPhaseRun(row: RawPhaseRunRow): Session {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Phase template commands (#155)
-// ---------------------------------------------------------------------------
-
+// Phase template commands (#155).
 export async function invokePhaseTemplateList(workspaceId: WorkspaceId): Promise<Workflow[]> {
   const rows = await invoke<RawPhaseTemplateRow[]>('workflow_list', { workspaceId });
   return rows.map(rowToTemplate);
@@ -149,10 +138,7 @@ export async function invokePhaseTemplateDelete(id: WorkflowId): Promise<void> {
   return invoke<void>('workflow_delete', { id });
 }
 
-// ---------------------------------------------------------------------------
-// Phase run commands (#156)
-// ---------------------------------------------------------------------------
-
+// Phase run commands (#156).
 export async function invokePhaseRunList(taskId: TaskId): Promise<Session[]> {
   const rows = await invoke<RawPhaseRunRow[]>('session_list_for_task', { taskId });
   return rows.map(rowToPhaseRun);
@@ -224,10 +210,7 @@ export async function invokeSessionSetProviderSessionId(
   });
 }
 
-// ---------------------------------------------------------------------------
-// Parallel phase group commands (#207)
-// ---------------------------------------------------------------------------
-
+// Parallel phase group commands (#207).
 interface RawParallelPhaseGroupRow {
   readonly id: string;
   readonly taskId: string;

--- a/apps/desktop/src/skills.ts
+++ b/apps/desktop/src/skills.ts
@@ -28,10 +28,6 @@ export async function resolveSkillInvocation(
   return { resolvedPrompt, skillName: input.skill.name, args: input.args };
 }
 
-// ---------------------------------------------------------------------------
-// Internal shape returned by rust commands
-// ---------------------------------------------------------------------------
-
 interface RawSkillRow {
   readonly id: string;
   readonly workspaceId: string;
@@ -58,10 +54,7 @@ function rowToSkill(row: RawSkillRow): Skill {
   };
 }
 
-// ---------------------------------------------------------------------------
-// CRUD wrappers (#132)
-// ---------------------------------------------------------------------------
-
+// CRUD wrappers (#132).
 export async function invokeSkillList(workspaceId: WorkspaceId): Promise<Skill[]> {
   const rows = await invoke<RawSkillRow[]>('skill_list', { workspaceId });
   return rows.map(rowToSkill);
@@ -101,10 +94,7 @@ export async function invokeSkillRescan(workspaceId: WorkspaceId): Promise<Skill
   return rows.map(rowToSkill);
 }
 
-// ---------------------------------------------------------------------------
-// Invoke (#133)
-// ---------------------------------------------------------------------------
-
+// Invoke (#133).
 interface SkillInvokeArgs {
   readonly skillId: SkillId;
   readonly args: ReadonlyArray<string>;
@@ -138,7 +128,6 @@ async function invokeSkillInvoke(args: SkillInvokeArgs): Promise<SkillInvokeResu
 
   const workspaceRoot = args.workspaceRoot;
 
-  // Script runner delegates to rust `skill_run_script` command.
   const tauriRunner: SkillScriptRunner = {
     async runScript(
       scriptPath: string,

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -39,10 +39,6 @@ import {
 } from '../phases';
 import { invokeParallelPhaseRunSpawn, cancelTurn } from '../turn';
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
-
 export interface ParallelBranchInputs {
   readonly session: Task;
   readonly orchestratingAgentId: SessionId;
@@ -70,10 +66,6 @@ export interface ParallelBranchResult {
   readonly allFailed: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// Detection helpers
-// ---------------------------------------------------------------------------
-
 export interface ParallelDetection {
   readonly currentDef: Step;
   readonly groupDefs: ReadonlyArray<Step>;
@@ -98,12 +90,9 @@ export function detectParallelGroup(
   return { currentDef, groupDefs: siblings };
 }
 
-// ---------------------------------------------------------------------------
-// Listener — multiplexes turn_event envelopes to per-runId callbacks.
-// Single global listener, routed by runId — avoids N independent listeners
-// (each subscribing to the same Tauri channel) which would be wasteful.
-// ---------------------------------------------------------------------------
-
+// Multiplexes turn_event envelopes to per-runId callbacks. Single global
+// listener routed by runId — N independent listeners on the same Tauri
+// channel would be wasteful.
 interface RawTurnEnvelope {
   readonly runId: string;
   readonly type: 'line' | 'end' | 'error';
@@ -156,12 +145,9 @@ async function startMultiplexedTurnListener(now: () => IsoDateTime): Promise<Mul
   };
 }
 
-// ---------------------------------------------------------------------------
 // Scheduler deps factory — design (b): pre-batch via invokeParallelPhaseRunSpawn,
 // scheduler.spawnRun resolves on per-runId 'end' envelope. Aligns with T2 (#208)
 // batched spawn design and keeps the scheduler purely an await-only orchestrator.
-// ---------------------------------------------------------------------------
-
 interface BuildSchedulerDepsArgs {
   readonly listener: MultiplexedListener;
   readonly settleHandlers: Map<
@@ -196,10 +182,6 @@ function buildSchedulerDeps(args: BuildSchedulerDepsArgs): SchedulerDeps {
     },
   };
 }
-
-// ---------------------------------------------------------------------------
-// Main entry — orchestrates the parallel branch end-to-end.
-// ---------------------------------------------------------------------------
 
 export interface RunParallelBranchDeps {
   readonly now: () => IsoDateTime;
@@ -376,7 +358,6 @@ export async function runParallelBranch(
 
     const merge = await awaitMerge(handle);
 
-    // Update each phase_run row with terminal status.
     for (let i = 0; i < cappedDefs.length; i++) {
       const def = cappedDefs[i]!;
       const runId = runIds[i]!;
@@ -392,7 +373,6 @@ export async function runParallelBranch(
     }
     await effects.refreshPhaseRuns(session.id);
 
-    // Conflict detection + auto-resolve.
     // Auto-resolution path only — manual MergeDialog wiring is deferred. Reason:
     // surfacing conflicts to the user requires emitting MergeResult into ChatView
     // state (currently a TODO placeholder in MergeDialog). Default to the group's

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -9,10 +9,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before store import.
 const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
 
@@ -145,10 +142,6 @@ vi.mock('../providerPricing', () => ({
   refreshPricingTable: vi.fn(() => Promise.resolve()),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const SESSION_ID = 'session-1' as TaskId;
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const NOW: IsoDateTime = '2026-05-07T00:00:00.000Z' as IsoDateTime;
@@ -196,10 +189,6 @@ function makeRetryEntry(overrides: { id?: string; payloadJson?: string; attempts
 async function* emptyStream(): AsyncIterable<TurnEvent> {
   // intentionally empty
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('audit retry queue — sendTurn enqueue on failure', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, Task, TaskId, WorkspaceId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before store import.
 const cancelTurnSpy = vi.fn();
 
 vi.mock('../turn', () => ({
@@ -132,10 +129,6 @@ vi.mock('../providerPricing', () => ({
   refreshPricingTable: vi.fn(() => Promise.resolve()),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const SESSION_ID = 'session-end-1' as TaskId;
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const NOW: IsoDateTime = '2026-05-08T00:00:00.000Z' as IsoDateTime;
@@ -170,10 +163,6 @@ async function importStore() {
   const mod = await import('./store');
   return mod.useAppStore;
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('endSession — happy path', () => {
   beforeEach(() => {
@@ -211,7 +200,6 @@ describe('endSession — happy path', () => {
 
   it('marks session ended when session has persisted turns (non-empty)', async () => {
     const useAppStore = await importStore();
-    // Task has turns in transcript (non-empty state)
     useAppStore.setState({
       sessions: [buildSession('idle')],
       sessionWorktrees: { [SESSION_ID]: [WORKTREE_PATH] },
@@ -311,7 +299,6 @@ describe('endSession — Tauri error propagation (#242)', () => {
       ],
     });
 
-    // Should not throw
     await expect(useAppStore.getState().endSession(SESSION_ID)).resolves.toBeUndefined();
 
     const session = useAppStore.getState().sessions.find((s) => s.id === SESSION_ID);

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -15,10 +15,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
 // Module mocks — hoisted before importing the store.
-// ---------------------------------------------------------------------------
-
 const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
 const invokeParallelPhaseRunSpawnSpy = vi.fn();
@@ -154,10 +151,6 @@ vi.mock('../repo', () => ({
   validateGitRepo: vi.fn(),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const SESSION_ID = 'session-1' as TaskId;
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const TEMPLATE_ID = 'template-1' as WorkflowId;
@@ -268,10 +261,6 @@ function setupSession(
   });
 }
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe('sendTurn — parallel agents branch', () => {
   beforeEach(() => {
     runTurnSpy.mockReset();
@@ -358,7 +347,6 @@ describe('sendTurn — parallel agents branch', () => {
     expect(invokeParallelPhaseRunSpawnSpy).toHaveBeenCalledTimes(2);
     expect(parallelPhaseGroupCreateSpy).toHaveBeenCalledOnce();
 
-    // Pull runIds from the spawn calls and emit 'end' for each.
     const allCalls = invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
       [{ runs: ReadonlyArray<{ runId: ProviderRunId }> }]
     >;
@@ -369,9 +357,7 @@ describe('sendTurn — parallel agents branch', () => {
 
     await turnPromise;
 
-    // Merge completion was persisted.
     expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
-    // Both phase runs were inserted then updated.
     expect(phaseRunInsertSpy).toHaveBeenCalledTimes(2);
     expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(2);
   });
@@ -411,7 +397,6 @@ describe('sendTurn — parallel agents branch', () => {
 
     await turnPromise;
 
-    // Mixed result: at least one completed → group completedAt is set.
     expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -12,10 +12,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — these MUST be hoisted before importing the store
-// ---------------------------------------------------------------------------
-
+// Module mocks — these MUST be hoisted before importing the store.
 const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
 
@@ -140,10 +137,6 @@ vi.mock('../repo', () => ({
   validateGitRepo: vi.fn(),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const SESSION_ID = 'session-1' as TaskId;
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 
@@ -185,10 +178,6 @@ function buildRule(overrides: Partial<PermissionRule>): PermissionRule {
 async function* emptyStream(): AsyncIterable<TurnEvent> {
   // emit nothing — turn ends immediately
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('sendTurn — permission proxy integration', () => {
   beforeEach(async () => {

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, Task, TaskId, WorkspaceId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — must be hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — must be hoisted before store import.
 vi.mock('../turn', () => ({
   runTurn: vi.fn(),
   cancelTurn: vi.fn(),
@@ -157,10 +154,6 @@ vi.mock('@tauri-apps/api/core', () => ({
   })),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const TASK_ID = 'task-queue-test' as TaskId;
 const WORKSPACE_ID = 'ws-1' as WorkspaceId;
 const NOW: IsoDateTime = '2026-05-10T00:00:00.000Z' as IsoDateTime;
@@ -185,10 +178,6 @@ async function importStore() {
   const mod = await import('./store');
   return mod;
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('summarizer queue — coalescing and no-stack', () => {
   beforeEach(() => {
@@ -237,14 +226,12 @@ describe('summarizer queue — coalescing and no-stack', () => {
     };
     summarizerQueues.set(TASK_ID, queue);
 
-    // Simulate 4 additional triggers arriving while in-flight.
     for (let i = 1; i <= 4; i++) {
       if (queue.inFlight) {
         queue.queued = { turnInput: `input-${i}`, turnOutput: `output-${i}` };
       }
     }
 
-    // Only the last coalesced entry should survive.
     expect(queue.queued?.turnInput).toBe('input-4');
 
     // Now simulate in-flight completing: the queued entry fires → 1 more call.
@@ -253,11 +240,9 @@ describe('summarizer queue — coalescing and no-stack', () => {
     firstResolve();
     await Promise.resolve();
 
-    // Queue should now have queued=null after drain.
     expect(callsBefore).toBeLessThanOrEqual(2);
     expect(state).toBeDefined(); // store is live
 
-    // Cleanup
     summarizerQueues.delete(TASK_ID);
   });
 
@@ -270,7 +255,6 @@ describe('summarizer queue — coalescing and no-stack', () => {
     const { summarizerQueues: sq } = await import('./store');
     sq.clear();
 
-    // No in-flight: queue starts empty, inFlight=false.
     const queue = {
       inFlight: false,
       queued: null as null | { turnInput: string; turnOutput: string },
@@ -299,7 +283,6 @@ describe('summarizer queue — coalescing and no-stack', () => {
     };
     sq.set(TASK_ID, queue);
 
-    // Simulate 10 rapid calls while in-flight.
     for (let i = 0; i < 10; i++) {
       if (queue.inFlight) {
         queue.queued = { turnInput: `t${i}`, turnOutput: `o${i}` };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -533,11 +533,8 @@ function mergeSlots(
 
 type SetFn = (partial: Partial<AppStore> | ((state: AppStore) => Partial<AppStore>)) => void;
 
-// ---------------------------------------------------------------------------
 // Summarizer queue — one per task, max one in-flight + one queued (coalesced).
 // Prevents stacking when the user iterates faster than the summarizer completes.
-// ---------------------------------------------------------------------------
-
 interface SummarizerQueueEntry {
   readonly turnInput: string;
   readonly turnOutput: string;
@@ -1857,8 +1854,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
     }
 
-    // ---- Parallel-agents branch -----------------------------------------
-    // Triggered iff: enableParallelAgents on + phaseTemplate active + current
+    // Parallel-agents branch — triggered iff: enableParallelAgents on + phaseTemplate active + current
     // phase has parallelGroup with >= 2 siblings (already resolved above).
     // Pre-flight: aggregate cost = single-run estimate × N. Existing single-run
     // pre-flight is the routing decision itself (resolveProviderForTurn already
@@ -2016,8 +2012,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
       return;
     }
-    // ---- /Parallel-agents branch ----------------------------------------
-
     void refreshPricingTable();
 
     // ContextPanel acts as the Task's shared memory: prepend the serialized

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -11,10 +11,7 @@ import type {
   WorkspaceId,
 } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before subject import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before subject import.
 const runTurnSpy = vi.fn();
 
 vi.mock('../turn', () => ({
@@ -132,10 +129,6 @@ vi.mock('../worktree', () => ({
 }));
 
 vi.mock('../repo', () => ({ validateGitRepo: vi.fn() }));
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
 
 const WS_ID = 'ws-1' as WorkspaceId;
 const WORKFLOW_ID = 'wf-refactor' as WorkflowId;
@@ -257,10 +250,6 @@ function wirePhaseSpies() {
     },
   );
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('createSession — workflow stepper seeding (#424)', () => {
   beforeEach(() => {

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -1,10 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IsoDateTime, ProviderRunId, Task, TaskId, WorkspaceId } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Module mocks — hoisted before store import
-// ---------------------------------------------------------------------------
-
+// Module mocks — hoisted before store import.
 const cancelTurnSpy = vi.fn();
 
 vi.mock('../turn', () => ({
@@ -111,10 +108,6 @@ vi.mock('../repo', () => ({
   validateGitRepo: vi.fn(),
 }));
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const WS_A = 'workspace-a' as WorkspaceId;
 const WS_B = 'workspace-b' as WorkspaceId;
 const SESSION_IDLE = 'session-idle' as TaskId;
@@ -153,10 +146,6 @@ function buildRunningSession(id: TaskId, wsId: WorkspaceId, runId: ProviderRunId
     updatedAt: NOW,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('setCurrentWorkspace — session-scoped state cleanup', () => {
   beforeEach(() => {

--- a/apps/desktop/src/turn.ts
+++ b/apps/desktop/src/turn.ts
@@ -199,10 +199,6 @@ export async function cancelTurn(runId: ProviderRunId): Promise<void> {
   await invoke('turn_cancel', { runId });
 }
 
-// ---------------------------------------------------------------------------
-// Parallel phase run spawn
-// ---------------------------------------------------------------------------
-
 interface ParallelRunSpec {
   readonly runId: ProviderRunId;
   /** Worktree path from C3 worktree helper. */

--- a/packages/core/src/context/auto-populate.ts
+++ b/packages/core/src/context/auto-populate.ts
@@ -4,14 +4,10 @@ import { ContextEngine } from './engine';
 import { extractMarkers, mergeIntoSlot, removeFromSlot } from './extractors';
 import type { SlotKey } from './slots';
 
-// ---------------------------------------------------------------------------
 // Glue layer between turn output (files touched + assistant text markers)
-// and the persistent ContextPanel slots.
-//
-// Called by the desktop store at the end of every turn. Purposefully thin:
-// the heavy logic lives in extractors.ts and ContextEngine; this fn only
-// orchestrates load → merge → upsert per slot.
-// ---------------------------------------------------------------------------
+// and the persistent ContextPanel slots. Called by the desktop store at the
+// end of every turn. Thin on purpose: heavy logic lives in extractors.ts and
+// ContextEngine; this fn orchestrates load → merge → upsert per slot.
 
 export interface AutoPopulateInput {
   readonly db: Database;

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -1,12 +1,8 @@
 import type { TurnEvent } from '@kay-am/types';
 
-// ---------------------------------------------------------------------------
-// Extractors that turn raw turn output into ContextPanel updates.
-//
-// Each exported fn is pure — caller is responsible for persisting the result
-// via the ContextEngine. This split keeps the extractors trivially testable
-// and lets the store decide when to flush (after each turn vs on demand).
-// ---------------------------------------------------------------------------
+// Extractors that turn raw turn output into ContextPanel updates. Each
+// exported fn is pure — caller persists via the ContextEngine. Split kept
+// extractors trivially testable and lets the store decide when to flush.
 
 /**
  * Collect the unique file paths an agent touched during a turn from its

--- a/packages/core/src/permissions/matcher.ts
+++ b/packages/core/src/permissions/matcher.ts
@@ -21,7 +21,6 @@ function globToRegex(glob: string): RegExp {
       pattern += '[^:/]*';
       i += 1;
     } else {
-      // escape regex metachar
       pattern += ch!.replace(REGEX_METACHARS, '\\$&');
       i += 1;
     }
@@ -54,7 +53,6 @@ export function parseToolPattern(pattern: string): ToolMatcher {
   const parenIdx = pattern.indexOf('(');
 
   if (parenIdx === -1) {
-    // bare tool name or wildcard `*`
     const tool = pattern.trim();
     if (tool === '*') {
       return { matches: () => true };

--- a/packages/core/src/providers/cursor/adapter.test.ts
+++ b/packages/core/src/providers/cursor/adapter.test.ts
@@ -118,7 +118,6 @@ async function collect(adapter: CursorAdapter): Promise<ReadonlyArray<TurnEvent>
   return events;
 }
 
-// --- text stream ---
 describe('CursorAdapter — text stream', () => {
   it('emits assistant_text, usage, done for a basic text turn', async () => {
     const lines = [FIXTURES.init, FIXTURES.assistantText, FIXTURES.resultSuccess];
@@ -131,7 +130,6 @@ describe('CursorAdapter — text stream', () => {
   });
 });
 
-// --- tool use ---
 describe('CursorAdapter — tool use', () => {
   it('emits tool_call_start + tool_call_end for a bash tool round-trip', async () => {
     const lines = [
@@ -163,7 +161,6 @@ describe('CursorAdapter — tool use', () => {
   });
 });
 
-// --- usage ---
 describe('CursorAdapter — usage', () => {
   it('maps input/output/cached token fields into ProviderUsage', async () => {
     const child = new FakeChild([FIXTURES.resultSuccess]);
@@ -177,7 +174,6 @@ describe('CursorAdapter — usage', () => {
   });
 });
 
-// --- malformed JSON ---
 describe('CursorAdapter — malformed JSON', () => {
   it('tolerates malformed lines without crashing the stream', async () => {
     const lines = ['this is not json', '{ broken', FIXTURES.assistantText, FIXTURES.resultSuccess];
@@ -219,7 +215,6 @@ describe('CursorAdapter — malformed JSON', () => {
   });
 });
 
-// --- non-zero exit / error ---
 describe('CursorAdapter — non-zero exit', () => {
   it('emits an error event when result subtype is error', async () => {
     const child = new FakeChild([FIXTURES.assistantText, FIXTURES.resultError]);
@@ -253,7 +248,6 @@ describe('CursorAdapter — non-zero exit', () => {
   });
 });
 
-// --- detect ---
 describe('CursorAdapter.detect', () => {
   it('returns available with parsed version on exit 0', async () => {
     const child = new FakeChild(['1.0.0']);

--- a/packages/core/src/scheduler/__tests__/orchestration.test.ts
+++ b/packages/core/src/scheduler/__tests__/orchestration.test.ts
@@ -20,10 +20,6 @@ import {
   type SchedulerDeps,
 } from '../index';
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
 const rid = (id: string) => id as ProviderRunId;
 const iso = (s: string) => s as IsoDateTime;
 
@@ -53,10 +49,6 @@ function makeRun(index: number, runId: string = `run-${index}`): ParallelSession
     completedAt: null,
   };
 }
-
-// ---------------------------------------------------------------------------
-// Scenario 1 — happy path: 3 runs, no conflict, last_write_wins merge
-// ---------------------------------------------------------------------------
 
 describe('orchestration — happy path: 3 runs, no conflict, last_write_wins', () => {
   it('fan-out completes, merge has 3 success statuses, detectConflicts returns 0', async () => {
@@ -106,10 +98,6 @@ describe('orchestration — happy path: 3 runs, no conflict, last_write_wins', (
     expect(resolutions).toHaveLength(0);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Scenario 2 — 1 run fails, 2 complete; partial merge
-// ---------------------------------------------------------------------------
 
 describe('orchestration — 1 run fails, 2 complete', () => {
   it('MergeResult includes failure; resolveConflicts only considers completed runs', async () => {
@@ -164,10 +152,6 @@ describe('orchestration — 1 run fails, 2 complete', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Scenario 3 — all 3 fail; resolveConflicts on empty completed → []
-// ---------------------------------------------------------------------------
-
 describe('orchestration — all 3 runs fail', () => {
   it('MergeResult has 3 failures; resolveConflicts with no completed returns empty', async () => {
     const runs = [makeRun(0, 'run-a'), makeRun(1, 'run-b'), makeRun(2, 'run-c')];
@@ -196,10 +180,6 @@ describe('orchestration — all 3 runs fail', () => {
     expect(resolutions).toHaveLength(0);
   });
 });
-
-// ---------------------------------------------------------------------------
-// Scenario 4 — conflict detected, last_write_wins: 2 of 3 touch same file
-// ---------------------------------------------------------------------------
 
 describe('orchestration — conflict detected, last_write_wins', () => {
   it('picks later completedAt; deterministic tie-break via runId', async () => {
@@ -277,10 +257,6 @@ describe('orchestration — conflict detected, last_write_wins', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Scenario 5 — conflict, manual strategy, missing pick → ManualResolutionRequiredError
-// ---------------------------------------------------------------------------
-
 describe('orchestration — manual strategy, missing pick throws ManualResolutionRequiredError', () => {
   it('throws with the conflicted file in unresolvedFiles when no manualPicks provided', async () => {
     const runs = [makeRun(0, 'run-a'), makeRun(1, 'run-b')];
@@ -325,10 +301,6 @@ describe('orchestration — manual strategy, missing pick throws ManualResolutio
     }
   });
 });
-
-// ---------------------------------------------------------------------------
-// Scenario 6 — cancel mid-flight: cancelRun called for all runIds
-// ---------------------------------------------------------------------------
 
 describe('orchestration — cancel mid-flight', () => {
   it('cancelGroup calls cancelRun for all 3 runIds; awaitMerge still resolves', async () => {

--- a/packages/core/src/scheduler/__tests__/scheduler.test.ts
+++ b/packages/core/src/scheduler/__tests__/scheduler.test.ts
@@ -53,8 +53,6 @@ function makeDoneTurnEvent(runId: string): TurnEvent {
   return { kind: 'done', runId: runId as ProviderRunId, at: NOW };
 }
 
-// --- happy path: 3 runs all complete ---
-
 describe('fanOut + awaitMerge — 3-run happy path', () => {
   it('returns MergeResult with completed status for all runs', async () => {
     const runs = [makeRun(0), makeRun(1), makeRun(2)];
@@ -82,8 +80,6 @@ describe('fanOut + awaitMerge — 3-run happy path', () => {
     expect(spawnRun).toHaveBeenCalledTimes(3);
   });
 });
-
-// --- partial failure: 1 fails, 2 complete ---
 
 describe('fanOut + awaitMerge — partial failure', () => {
   it('includes failed run in result without cancelling siblings', async () => {
@@ -117,8 +113,6 @@ describe('fanOut + awaitMerge — partial failure', () => {
   });
 });
 
-// --- all fail: empty success set ---
-
 describe('fanOut + awaitMerge — all fail', () => {
   it('returns MergeResult with all runs failed', async () => {
     const runs = [makeRun(0), makeRun(1)];
@@ -140,8 +134,6 @@ describe('fanOut + awaitMerge — all fail', () => {
   });
 });
 
-// --- spawnRun rejects unexpectedly ---
-
 describe('fanOut + awaitMerge — unexpected rejection', () => {
   it('treats thrown error as failed run', async () => {
     const runs = [makeRun(0, 'run-0')];
@@ -159,8 +151,6 @@ describe('fanOut + awaitMerge — unexpected rejection', () => {
     expect(result.runStatuses[0]?.error).toBe('crash');
   });
 });
-
-// --- cancelGroup propagates to all run ids ---
 
 describe('cancelGroup', () => {
   it('calls cancelRun for every run in the handle', async () => {
@@ -182,8 +172,6 @@ describe('cancelGroup', () => {
     expect(cancelRun).toHaveBeenCalledWith('run-2' as ProviderRunId);
   });
 });
-
-// --- onProgress receives events tagged with correct runId ---
 
 describe('onProgress', () => {
   it('delivers events with correct runId to subscriber', async () => {

--- a/packages/core/src/scheduler/conflict.ts
+++ b/packages/core/src/scheduler/conflict.ts
@@ -86,7 +86,6 @@ export async function resolveConflicts(
     return resolveManual(conflicts, manualPicks ?? {});
   }
 
-  // synthesizer_driven
   return resolveSynthesizer(conflicts, synthesize);
 }
 

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -86,19 +86,15 @@ function ctxStyleForTag(tag: string): CtxTagStyle {
   return { ...CTX_DEFAULT, label: stripped || tag };
 }
 
-// ---------------------------------------------------------------------------
-// Minimal markdown renderer for assistant output.
-//
-// Handwritten in lieu of a dependency: react-markdown pulls a 30-package
-// remark/rehype subtree, marked has XSS surface, and LLMs only ever produce
-// a small subset of CommonMark — fenced code, headings, lists (ordered +
-// unordered, flat), blockquotes, horizontal rules, gfm-style pipe tables,
-// paragraphs, plus inline emphasis / code / links. We also recognise the
-// agent's <<ctx-*>>...</ctx-*>> markers and render them as labelled blocks.
-//
-// Inline rendering operates on plain strings only; we never dangerouslySetHTML
-// so any unmatched delimiter just shows literal characters.
-// ---------------------------------------------------------------------------
+// Minimal markdown renderer for assistant output. Handwritten in lieu of a
+// dependency: react-markdown pulls a 30-package remark/rehype subtree, marked
+// has XSS surface, and LLMs only ever produce a small subset of CommonMark —
+// fenced code, headings, lists (ordered + unordered, flat), blockquotes,
+// horizontal rules, gfm-style pipe tables, paragraphs, plus inline emphasis /
+// code / links. We also recognise the agent's <<ctx-*>>...</ctx-*>> markers
+// and render them as labelled blocks. Inline rendering operates on plain
+// strings only; we never dangerouslySetHTML so any unmatched delimiter just
+// shows literal characters.
 
 interface MarkdownProps {
   readonly text: string;
@@ -276,7 +272,6 @@ function parseBlocks(input: string): ReadonlyArray<Block> {
         const m = (lines[i] ?? '').match(re);
         if (!m) break;
         // Indent depth (number of leading spaces) is currently unused — flat lists only.
-        // Future: nest based on indent.
         items.push({ content: m[2]!.trim(), children: [] });
         i++;
       }
@@ -314,12 +309,10 @@ function parseBlocks(input: string): ReadonlyArray<Block> {
   return blocks;
 }
 
-// ---------------------------------------------------------------------------
-// Inline rendering — bold, italic, inline code, links.
-// We tokenize manually instead of using regex with backreferences, which keeps
-// nested emphasis predictable and means an unmatched delimiter renders as a
-// literal char rather than swallowing the rest of the line.
-// ---------------------------------------------------------------------------
+// Inline rendering — bold, italic, inline code, links. We tokenize manually
+// instead of using regex with backreferences, which keeps nested emphasis
+// predictable and means an unmatched delimiter renders as a literal char
+// rather than swallowing the rest of the line.
 
 function renderInline(input: string, keyPrefix: string): ReactNode {
   const out: ReactNode[] = [];
@@ -481,10 +474,6 @@ function renderInline(input: string, keyPrefix: string): ReactNode {
   flush();
   return out.length === 1 ? out[0] : <>{out}</>;
 }
-
-// ---------------------------------------------------------------------------
-// Block rendering
-// ---------------------------------------------------------------------------
 
 function renderBlock(block: Block, idx: number): ReactNode {
   const key = `b-${idx}`;


### PR DESCRIPTION
## Summary

- Sweeps banner / separator comments (`// ---- Foo ----`, `// === section ===`) when adjacent code (function/type names, `describe`/`it`) already conveys the section
- Drops rephrasing comments that restate the next line
- Keeps WHY comments — vendor quirks, hidden constraints, issue refs (#155, #156, #196, #207, #208, #414, #415, #424, #461), JSDoc on exported contracts, magic-number meaning, empty-catch intent

## Scope

- 36 files touched across `apps/desktop`, `packages/core`, `packages/ui`
- Strictly TS/TSX only — no Rust, no config, no markdown
- `~357` line-comment lines removed; net `-485` lines (some banner blocks flattened to single comments preserving the WHY content)

## Files most touched

- `apps/desktop/src/store/parallel-turn.ts` — collapsed 4 banner blocks; kept all in-function WHY
- `apps/desktop/src/store/store.ts` — flattened one banner, kept ~30 WHY comments
- `apps/desktop/src/__tests__/parallel-e2e.test.ts` — dropped scenario banners that duplicated `it()` titles
- `apps/desktop/src/permissions.ts` / `phases.ts` / `skills.ts` — collapsed `Raw row shapes` / `commands` banners; preserved issue refs inline
- `apps/desktop/src/integrations.ts` — dropped per-service banner separators
- `packages/ui/src/components/Markdown.tsx` — flattened 3 banner blocks; kept WHY rationale
- `packages/core/src/scheduler/__tests__/*` — dropped `// --- happy path ---` separators that duplicated `describe()` strings

## Intentionally kept despite looking redundant

- `// ignore` and `// intentionally empty` on empty `catch` / generator bodies — signal intent; not just structure
- `// Module mocks — hoisted before store import.` in test files — vitest hoisting is a real constraint, not narration
- Per-regex pattern labels in `apps/desktop/src/components/chat/chat-constants.ts` (e.g. `// Canonical anthropic: claude-haiku-4-5`) — examples of input shape, load-bearing for readers
- Per-construct labels in `packages/ui/src/components/Markdown.tsx` (e.g. `// Fenced code block.`) — the parser has many branches; labels aid scanning

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 302/302 desktop, 529 + 7 skipped core, 10/10 ui, 14/14 db
- [x] `pnpm knip` exit 0
- [x] `pnpm build` clean
- [x] No Rust / config / markdown / CSS touched

Closes #515