### PR TITLE
refactor(desktop,core): flatten ternary-in-ternary and dense conditions

### DIFF
--- a/apps/desktop/src/components/BootSplash.tsx
+++ b/apps/desktop/src/components/BootSplash.tsx
@@ -64,12 +64,11 @@ export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: B
   const displayPhase = useDisplayPhase(phase);
   const idx = PHASE_ORDER.indexOf(displayPhase);
   const total = PHASE_ORDER.length;
-  const progressPct =
-    displayPhase === 'ready'
-      ? 100
-      : displayPhase === 'pending'
-        ? 0
-        : Math.round(((idx + 1) / total) * 100);
+  const progressPct = (() => {
+    if (displayPhase === 'ready') return 100;
+    if (displayPhase === 'pending') return 0;
+    return Math.round(((idx + 1) / total) * 100);
+  })();
 
   return (
     <div className="relative flex h-screen flex-col items-center justify-center gap-10 overflow-hidden bg-background text-foreground">
@@ -112,24 +111,25 @@ export function BootSplash({ phase, error, onRetry, onSkipProviderDetection }: B
           {PHASE_ORDER.map((p, i) => {
             const done = displayPhase === 'ready' || i < idx;
             const active = i === idx && displayPhase !== 'ready' && displayPhase !== 'pending';
+            const iconClass = (() => {
+              if (done) return 'text-success';
+              if (active) return 'text-primary';
+              return 'text-muted-foreground/25';
+            })();
+            const iconGlyph = (() => {
+              if (done) return '✓';
+              if (active) return '›';
+              return '·';
+            })();
+            const labelClass = (() => {
+              if (done) return 'text-success/70';
+              if (active) return 'text-foreground';
+              return 'text-muted-foreground/25';
+            })();
             return (
               <li key={p} className="flex items-center gap-2.5">
-                <span
-                  className={
-                    done ? 'text-success' : active ? 'text-primary' : 'text-muted-foreground/25'
-                  }
-                >
-                  {done ? '✓' : active ? '›' : '·'}
-                </span>
-                <span
-                  className={
-                    done
-                      ? 'text-success/70'
-                      : active
-                        ? 'text-foreground'
-                        : 'text-muted-foreground/25'
-                  }
-                >
+                <span className={iconClass}>{iconGlyph}</span>
+                <span className={labelClass}>
                   {PHASE_LABEL[p]}
                   {active ? <BlinkCursor /> : null}
                 </span>

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -820,12 +820,11 @@ function SummarizerBadge({
     running: 'summarizing…',
     error: 'error',
   };
-  const tooltip =
-    status === 'error' && error
-      ? `last error: ${error}`
-      : lastUpdate
-        ? `last update: ${lastUpdate}`
-        : 'summarizer running — input is not blocked';
+  const tooltip = (() => {
+    if (status === 'error' && error) return `last error: ${error}`;
+    if (lastUpdate) return `last update: ${lastUpdate}`;
+    return 'summarizer running — input is not blocked';
+  })();
   return (
     <span
       title={tooltip}

--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -47,6 +47,12 @@ interface DiffViewerDialogProps {
   jumpToFile?: string;
 }
 
+const LINE_PREFIX: Record<DiffHunkLine['kind'], string> = {
+  add: '+',
+  del: '-',
+  context: ' ',
+};
+
 const STATUS_GLYPH: Record<FileDiffStatus, string> = {
   added: 'A',
   modified: 'M',
@@ -930,6 +936,7 @@ function FileDiffPane({
                       activeAnchor !== null &&
                       activeAnchor.side === anchor.side &&
                       activeAnchor.lineNumber === anchor.lineNumber;
+                    const linePrefix = LINE_PREFIX[line.kind];
                     return (
                       <Fragment key={`hunk-${hi}-line-${li}`}>
                         <tr
@@ -968,7 +975,7 @@ function FileDiffPane({
                               line.kind === 'del' && 'text-danger',
                             )}
                           >
-                            {line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' '}
+                            {linePrefix}
                             {line.text}
                           </td>
                         </tr>

--- a/apps/desktop/src/components/PlannerWidget.tsx
+++ b/apps/desktop/src/components/PlannerWidget.tsx
@@ -104,6 +104,12 @@ export function PlannerWidget({
     }
   };
 
+  const planButtonLabel = (() => {
+    if (busy && !plan) return 'Planning…';
+    if (plan) return 'Re-plan';
+    return 'Generate plan';
+  })();
+
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between gap-2">
@@ -121,7 +127,7 @@ export function PlannerWidget({
           planner returns a structured workflow you can review before saving.
         </p>
         <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
-          {busy && !plan ? 'Planning…' : plan ? 'Re-plan' : 'Generate plan'}
+          {planButtonLabel}
         </Button>
       </div>
       {error ? (

--- a/apps/desktop/src/components/PricingDialog.tsx
+++ b/apps/desktop/src/components/PricingDialog.tsx
@@ -5,12 +5,11 @@ import type { ProviderSpendEntry } from '../store';
 import { STORAGE_KEYS } from '../storage-keys';
 
 const formatCost = (usd: number): string => `$${usd.toFixed(4)}`;
-const formatTokens = (n: number): string =>
-  n >= 1_000_000
-    ? `${(n / 1_000_000).toFixed(2)}M`
-    : n >= 1_000
-      ? `${(n / 1_000).toFixed(1)}k`
-      : `${n}`;
+const formatTokens = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
+};
 
 type SortKey = 'recent' | 'expensive';
 const SORT_KEY_STORAGE = STORAGE_KEYS.pricingSortKey;

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -785,8 +785,12 @@ function SessionRow({
   const cap = budget?.softCapUsd ?? null;
   const pct = cap !== null && cap > 0 ? spent / cap : null;
 
-  const barColor =
-    pct === null ? '' : pct >= 1 ? 'bg-danger' : pct >= 0.8 ? 'bg-warning' : 'bg-muted-foreground';
+  const barColor = (() => {
+    if (pct === null) return '';
+    if (pct >= 1) return 'bg-danger';
+    if (pct >= 0.8) return 'bg-warning';
+    return 'bg-muted-foreground';
+  })();
 
   const onCapClick = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -1944,16 +1948,18 @@ function ContextWindowBar({
   const cumulativeOutput = aggregate?.outputTokens ?? telemetry.outputTokens;
   const used = cumulativeInput + cumulativeOutput;
   const pct = Math.min(1, used / window);
-  const barTone =
-    pct >= 0.9 ? 'bg-danger' : pct >= 0.75 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
-  const iconTone =
-    pct >= 0.9
-      ? 'text-danger'
-      : pct >= 0.75
-        ? 'text-warning'
-        : pct >= 0.5
-          ? 'text-info'
-          : 'text-success';
+  const barTone = (() => {
+    if (pct >= 0.9) return 'bg-danger';
+    if (pct >= 0.75) return 'bg-warning';
+    if (pct >= 0.5) return 'bg-info';
+    return 'bg-success';
+  })();
+  const iconTone = (() => {
+    if (pct >= 0.9) return 'text-danger';
+    if (pct >= 0.75) return 'text-warning';
+    if (pct >= 0.5) return 'text-info';
+    return 'text-success';
+  })();
   const windowLabel = window >= 1_000_000 ? `${window / 1_000_000}M` : `${window / 1_000}k`;
   const tooltip =
     `context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)\n` +

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -139,7 +139,11 @@ function PhaseProgressPill({ taskId }: { taskId: TaskId }) {
   // Selected agent takes priority — pill reflects the agent the user is
   // looking at, not workflow-wide running state. Falls back to running, then
   // last completed when no agent is selected (e.g. fresh task).
-  const displayIdx = selectedIdx >= 0 ? selectedIdx : activeIdx >= 0 ? activeIdx : lastCompletedIdx;
+  const displayIdx = (() => {
+    if (selectedIdx >= 0) return selectedIdx;
+    if (activeIdx >= 0) return activeIdx;
+    return lastCompletedIdx;
+  })();
   const current = displayIdx >= 0 ? sorted[displayIdx] : sorted[0];
 
   if (!current) return null;

--- a/apps/desktop/src/components/chat/ChatView.tsx
+++ b/apps/desktop/src/components/chat/ChatView.tsx
@@ -373,11 +373,13 @@ export function ChatView({ session }: ChatViewProps) {
                       lastDay = day;
                     }
                   }
+                  const itemSpacing = (() => {
+                    if (tightToTool) return 'mt-0.5';
+                    if (idx === 0) return '';
+                    return 'mt-4';
+                  })();
                   node.push(
-                    <li
-                      key={item.key}
-                      className={cn(tightToTool ? 'mt-0.5' : idx === 0 ? '' : 'mt-4')}
-                    >
+                    <li key={item.key} className={cn(itemSpacing)}>
                       <TranscriptCard
                         item={item}
                         taskId={session.id}

--- a/apps/desktop/src/components/chat/ModelPicker.tsx
+++ b/apps/desktop/src/components/chat/ModelPicker.tsx
@@ -150,20 +150,19 @@ export function ModelPicker({
               {providers.map((id) => {
                 const isConnected = connectedProviders.includes(id);
                 const active = provider === id;
+                const chipTone = (() => {
+                  if (active) return cn('bg-muted font-semibold', PROVIDER_TEXT[id]);
+                  if (isConnected)
+                    return 'text-muted-foreground hover:bg-muted hover:text-foreground';
+                  return 'text-muted-foreground/35 hover:bg-muted/50';
+                })();
                 return (
                   <button
                     key={id}
                     type="button"
                     onClick={() => onSelectProvider(id)}
                     title={isConnected ? undefined : 'not connected'}
-                    className={cn(
-                      'rounded-full px-2.5 py-0.5 transition-colors',
-                      active
-                        ? cn('bg-muted font-semibold', PROVIDER_TEXT[id])
-                        : isConnected
-                          ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                          : 'text-muted-foreground/35 hover:bg-muted/50',
-                    )}
+                    className={cn('rounded-full px-2.5 py-0.5 transition-colors', chipTone)}
                   >
                     {PROVIDER_LABEL[id]}
                     {!isConnected ? (

--- a/apps/desktop/src/components/chat/PermissionScopePicker.tsx
+++ b/apps/desktop/src/components/chat/PermissionScopePicker.tsx
@@ -67,6 +67,13 @@ export function PermissionScopePicker({
     deny: 'deny this request',
   };
 
+  const scopeTone = (scope: PermissionScope): string => {
+    if (scope === 'task')
+      return 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90';
+    if (scope === 'deny') return 'border-danger/40 text-danger hover:bg-danger/10';
+    return 'border-success/40 text-success hover:bg-success/10';
+  };
+
   return (
     <div className="mt-1.5 flex flex-wrap gap-1">
       {scopes.map((scope) => (
@@ -78,11 +85,7 @@ export function PermissionScopePicker({
           title={SCOPE_TITLES[scope]}
           className={cn(
             'rounded border px-2 py-0.5 text-2xs font-medium transition-colors',
-            scope === 'task'
-              ? 'border-transparent bg-primary text-primary-foreground hover:bg-primary/90'
-              : scope === 'deny'
-                ? 'border-danger/40 text-danger hover:bg-danger/10'
-                : 'border-success/40 text-success hover:bg-success/10',
+            scopeTone(scope),
             busy && 'cursor-not-allowed opacity-50',
           )}
         >

--- a/apps/desktop/src/components/chat/ProviderUsagePill.tsx
+++ b/apps/desktop/src/components/chat/ProviderUsagePill.tsx
@@ -14,8 +14,11 @@ export function ProviderUsagePill({ provider }: { provider: ProviderId }) {
   if (!entry || entry.capUsd === null || entry.capUsd <= 0) return null;
   const pctUsed = Math.max(0, Math.min(1, entry.pct));
   const pctRemaining = Math.round((1 - pctUsed) * 100);
-  const tone =
-    pctRemaining > 50 ? 'text-success' : pctRemaining > 20 ? 'text-warning' : 'text-danger';
+  const tone = (() => {
+    if (pctRemaining > 50) return 'text-success';
+    if (pctRemaining > 20) return 'text-warning';
+    return 'text-danger';
+  })();
   const reset = nextMonthlyResetLabel();
   const tooltip = `${provider}: $${entry.spentUsd.toFixed(2)} / $${entry.capUsd.toFixed(2)} used (${Math.round(pctUsed * 100)}%) · resets ${reset}`;
   return (

--- a/apps/desktop/src/components/chat/TranscriptCards.tsx
+++ b/apps/desktop/src/components/chat/TranscriptCards.tsx
@@ -214,11 +214,11 @@ function UserText({ text, at }: { text: string; at: string }) {
 function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' }> }) {
   const [open, setOpen] = useState(false);
   const running = !item.ended;
-  const accent = item.isError
-    ? 'text-danger'
-    : running
-      ? 'text-muted-foreground/70'
-      : 'text-muted-foreground';
+  const accent = (() => {
+    if (item.isError) return 'text-danger';
+    if (running) return 'text-muted-foreground/70';
+    return 'text-muted-foreground';
+  })();
 
   return (
     <div className="group">

--- a/apps/desktop/src/hooks/use-keyboard-shortcut.ts
+++ b/apps/desktop/src/hooks/use-keyboard-shortcut.ts
@@ -16,11 +16,17 @@ interface ShortcutCombo {
   alt?: boolean;
 }
 
+const KEY_ALIAS: Record<string, string> = {
+  comma: ',',
+  period: '.',
+  slash: '/',
+};
+
 function parseCombo(combo: string): ShortcutCombo {
   const parts = combo.toLowerCase().split('+');
   const key = parts[parts.length - 1] ?? '';
   return {
-    key: key === 'comma' ? ',' : key === 'period' ? '.' : key === 'slash' ? '/' : key,
+    key: KEY_ALIAS[key] ?? key,
     meta: parts.includes('cmd') || parts.includes('meta'),
     ctrl: parts.includes('ctrl'),
     shift: parts.includes('shift'),

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -130,7 +130,8 @@ async function startMultiplexedTurnListener(now: () => IsoDateTime): Promise<Mul
       }
     } else if (payload.type === 'end') {
       const exit = payload.exit_code ?? 0;
-      state.onSettle(exit === 0 ? 'completed' : 'failed', exit !== 0 ? payload.stderr : undefined);
+      const succeeded = exit === 0;
+      state.onSettle(succeeded ? 'completed' : 'failed', succeeded ? undefined : payload.stderr);
     } else if (payload.type === 'error') {
       state.onSettle('failed', payload.message ?? 'unknown error');
     }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -2161,12 +2161,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
         }
 
         if (event.kind === 'usage') {
-          const cost =
-            provider === 'codex'
-              ? computeCodexCostUsd(event.usage, model, getCodexPriceOverride(null, model))
-              : provider === 'cursor'
-                ? computeCursorCostUsd(event.usage, model)
-                : computeCostUsd(event.usage, model);
+          const cost = (() => {
+            if (provider === 'codex') {
+              return computeCodexCostUsd(event.usage, model, getCodexPriceOverride(null, model));
+            }
+            if (provider === 'cursor') return computeCursorCostUsd(event.usage, model);
+            return computeCostUsd(event.usage, model);
+          })();
           const record: TelemetryRecord = {
             id: crypto.randomUUID() as TelemetryRecordId,
             runId,

--- a/packages/core/src/settings/resolver.ts
+++ b/packages/core/src/settings/resolver.ts
@@ -13,19 +13,19 @@ export type ResolveSettingsInput = {
 export function resolveSettings(input: ResolveSettingsInput): ResolvedSettings {
   const { global: g, workspaceOverride: ws, sessionOverride: sess } = input;
 
+  // workflowId can be `null` (explicit "no workflow" override), so `??` cannot
+  // chain — first defined wins, including null.
+  const resolvedWorkflowId = (() => {
+    if (sess?.defaultWorkflowId !== undefined) return sess.defaultWorkflowId;
+    if (ws?.defaultWorkflowId !== undefined) return ws.defaultWorkflowId;
+    return g.defaultWorkflowId;
+  })();
+
   return {
     defaultProviderId: sess?.defaultProviderId ?? ws?.defaultProviderId ?? g.defaultProviderId,
-
-    defaultWorkflowId:
-      sess?.defaultWorkflowId !== undefined
-        ? sess.defaultWorkflowId
-        : ws?.defaultWorkflowId !== undefined
-          ? ws.defaultWorkflowId
-          : g.defaultWorkflowId,
-
+    defaultWorkflowId: resolvedWorkflowId,
     defaultBranchPrefix:
       sess?.defaultBranchPrefix ?? ws?.defaultBranchPrefix ?? g.defaultBranchPrefix,
-
     parallelEnabled: sess?.parallelEnabled ?? ws?.parallelEnabled ?? g.parallelEnabled,
   };
 }

--- a/packages/ui/src/components/CopyButton.tsx
+++ b/packages/ui/src/components/CopyButton.tsx
@@ -36,9 +36,15 @@ export function CopyButton({ value, label = 'text' }: CopyButtonProps) {
     window.setTimeout(() => setState('idle'), 1200);
   };
 
+  const buttonText = (() => {
+    if (state === 'copied') return `copied: ${label}`;
+    if (state === 'error') return 'copy failed';
+    return 'copy';
+  })();
+
   return (
     <Button variant="ghost" size="sm" onClick={() => void onCopy()} aria-label={`copy ${label}`}>
-      {state === 'copied' ? `copied: ${label}` : state === 'error' ? 'copy failed' : 'copy'}
+      {buttonText}
     </Button>
   );
 }

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -535,8 +535,11 @@ function renderBlock(block: Block, idx: number): ReactNode {
         </blockquote>
       );
     case 'table': {
-      const alignClass = (a: CellAlign | undefined): string =>
-        a === 'right' ? 'text-right' : a === 'center' ? 'text-center' : 'text-left';
+      const alignClass = (a: CellAlign | undefined): string => {
+        if (a === 'right') return 'text-right';
+        if (a === 'center') return 'text-center';
+        return 'text-left';
+      };
       return (
         <div key={key} className="overflow-x-auto">
           <table className="w-full border-collapse text-sm">


### PR DESCRIPTION
## Summary

Hunts down nested ternaries and multi-line predicate expressions in production TS/TSX (`apps/desktop/src`, `packages/core/src`, `packages/ui/src/components`). Pulls them into named consts, early returns, or `Record<>` lookups. Zero behavioural changes — full test suite stays green.

Closes #518.

## Patterns applied

- **Nested ternary → IIFE with early returns** for 3-way branches (tone classes, status icons, button labels).
- **Lookup `Record<>`** for stable key→value maps (line prefix in diff viewer, keyboard alias).
- **Named helper fn** when the same ternary recurs (scope styling).

## Before/after — three representative cases

### 1. `apps/desktop/src/components/WorkspacesSidebar.tsx` — bar colour cascade

```diff
- const barTone =
-   pct >= 0.9 ? 'bg-danger' : pct >= 0.75 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
+ const barTone = (() => {
+   if (pct >= 0.9) return 'bg-danger';
+   if (pct >= 0.75) return 'bg-warning';
+   if (pct >= 0.5) return 'bg-info';
+   return 'bg-success';
+ })();
```

### 2. `apps/desktop/src/components/DiffViewerDialog.tsx` — line glyph

```diff
+ const LINE_PREFIX: Record<DiffHunkLine['kind'], string> = {
+   add: '+',
+   del: '-',
+   context: ' ',
+ };
  ...
-   {line.kind === 'add' ? '+' : line.kind === 'del' ? '-' : ' '}
+   {LINE_PREFIX[line.kind]}
```

### 3. `apps/desktop/src/hooks/use-keyboard-shortcut.ts` — alias map

```diff
+ const KEY_ALIAS: Record<string, string> = {
+   comma: ',',
+   period: '.',
+   slash: '/',
+ };
  ...
-   key: key === 'comma' ? ',' : key === 'period' ? '.' : key === 'slash' ? '/' : key,
+   key: KEY_ALIAS[key] ?? key,
```

## Scope

18 files touched:

- `apps/desktop/src/components/{BootSplash,ContextPanel,DiffViewerDialog,PlannerWidget,PricingDialog,WorkspacesSidebar}.tsx`
- `apps/desktop/src/components/chat/{ChatHeader,ChatView,ModelPicker,PermissionScopePicker,ProviderUsagePill,TranscriptCards}.tsx`
- `apps/desktop/src/hooks/use-keyboard-shortcut.ts`
- `apps/desktop/src/store/{parallel-turn,store}.ts`
- `packages/core/src/settings/resolver.ts`
- `packages/ui/src/components/{CopyButton,Markdown}.tsx`

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 299 tests pass
- [x] `pnpm knip` exit 0
- [x] `pnpm build` clean