### PR TITLE
fix(desktop): resolve linear issues by team key + number

### DIFF
--- a/apps/desktop/src/integrations.ts
+++ b/apps/desktop/src/integrations.ts
@@ -7,38 +7,54 @@ export interface IssueData {
   readonly service: 'github' | 'gitlab' | 'jira' | 'linear';
 }
 
-function parseLinearIssueUrl(input: string): string | null {
-  const trimmed = input.trim();
-  const urlMatch = trimmed.match(/linear\.app\/[^/]+\/issue\/([A-Z]+-\d+)/i);
-  if (urlMatch) return urlMatch[1]!.toUpperCase();
-  return null;
+interface LinearIssueRef {
+  readonly identifier: string;
+  readonly teamKey: string;
+  readonly number: number;
 }
 
-async function fetchLinearIssue(issueId: string): Promise<IssueData> {
+function parseLinearIssueUrl(input: string): LinearIssueRef | null {
+  const trimmed = input.trim();
+  const urlMatch = trimmed.match(/linear\.app\/[^/]+\/issue\/([A-Za-z]+)-(\d+)/);
+  if (!urlMatch) return null;
+  const teamKey = urlMatch[1]!.toUpperCase();
+  const number = parseInt(urlMatch[2]!, 10);
+  return { identifier: `${teamKey}-${number}`, teamKey, number };
+}
+
+async function fetchLinearIssue(ref: LinearIssueRef): Promise<IssueData> {
   const token = await getSecret('integration.linear.token');
   if (!token)
     throw new Error('Linear not connected — add your API key in Settings → Integrations.');
 
-  const query = `{ issue(id: "${issueId}") { title description url } }`;
+  const query = `query($team: String!, $number: Float!) {
+    issues(filter: { team: { key: { eq: $team } }, number: { eq: $number } }, first: 1) {
+      nodes { title description url }
+    }
+  }`;
   const res = await fetch('https://api.linear.app/graphql', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: token,
     },
-    body: JSON.stringify({ query }),
+    body: JSON.stringify({ query, variables: { team: ref.teamKey, number: ref.number } }),
   });
 
   if (!res.ok) throw new Error(`Linear API error: ${res.status} ${res.statusText}`);
 
   const json = (await res.json()) as {
-    data?: { issue?: { title: string; description?: string | null; url: string } };
+    data?: {
+      issues?: {
+        nodes?: ReadonlyArray<{ title: string; description?: string | null; url: string }>;
+      };
+    };
     errors?: ReadonlyArray<{ message: string }>;
   };
   if (json.errors?.length) throw new Error(`Linear: ${json.errors[0]!.message}`);
 
-  const issue = json.data?.issue;
-  if (!issue) throw new Error(`Linear issue ${issueId} not found.`);
+  const issue = json.data?.issues?.nodes?.[0];
+  if (!issue) throw new Error(`Linear issue ${ref.identifier} not found.`);
 
   return {
     service: 'linear',


### PR DESCRIPTION
## Summary

`fetchLinearIssue` was calling `issue(id: "TEAM-NUM")` against Linear's root GraphQL `issue` field. While Linear's docs claim this field accepts either a UUID or the human identifier, in practice many workspaces / API versions reject the identifier with the literal error `"Entity Not Found"` — which is what the user has been seeing every time they paste a Linear URL.

Switching to the unambiguous `issues(filter: { team: { key: { eq } }, number: { eq } })` connection — which is documented and stable — resolves the lookup reliably.

## Repro

1. Configure a Linear personal API key in Settings → Integrations.
2. Open the new-session dialog and paste any `https://linear.app/<ws>/issue/<TEAM>-<NUM>/<slug>` URL into the "issue link" field.
3. Observe error banner: `Linear: Entity Not Found`.

## Fix

`apps/desktop/src/integrations.ts`:

- `parseLinearIssueUrl` now returns `{ identifier, teamKey, number }` instead of a bare string, by splitting the captured `TEAM-NUM` group at the dash.
- `fetchLinearIssue` accepts that ref and issues a parameterised GraphQL query:

  ```graphql
  query($team: String!, $number: Float!) {
    issues(filter: { team: { key: { eq: $team } }, number: { eq: $number } }, first: 1) {
      nodes { title description url }
    }
  }
  ```

- Response shape and error path updated accordingly. No new deps, no other files touched.

## Test plan

- [ ] Paste a full URL with slug: `https://linear.app/foo/issue/ENG-123/some-slug` → goal populates.
- [ ] Paste a URL without slug: `https://linear.app/foo/issue/ENG-123` → goal populates.
- [ ] Paste a URL with query string: `https://linear.app/foo/issue/ENG-123/slug?notification_id=x` → goal populates.
- [ ] Paste a markdown-wrapped URL: `[ENG-123](https://linear.app/foo/issue/ENG-123/slug)` → goal populates.
- [ ] Paste a lowercase URL path: `https://linear.app/foo/issue/eng-123` → goal populates (team key normalised to upper-case).
- [ ] Paste a real non-existent issue from a connected workspace → error banner shows `Linear issue ENG-9999 not found.`
- [ ] Paste a URL from a workspace the token does NOT belong to → error banner still surfaces a clear message (Linear will return either an empty result → "not found", or its own auth/scope error).
- [ ] Disconnect Linear in Settings, retry paste → error banner shows the existing `"Linear not connected"` message.

## Notes

Plain-id paste (e.g. typing `ENG-123` without the URL) remains unsupported because `NewSessionDialog.handleIssueUrl` short-circuits on the absence of the `linear.app` substring — out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)