### PR TITLE
chore(repo): drop refactor prompt scratchpad gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,3 @@ coverage/
 .claude/launch.json
 .claude/scheduled_tasks.lock
 .kay-am/
-REFACTOR_PROMPT.md


### PR DESCRIPTION
## Summary

- the \`REFACTOR_PROMPT.md\` scratchpad has served its purpose (n-bro's local cleanup brief during the v1.0 wave) and the file is being removed locally
- with the file gone, the \`.gitignore\` entry is dead weight

## Test plan

- [x] \`pnpm test\` — full turbo cache hit, all green
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm knip\` — exit 0 strict
- [x] \`pnpm build\` — clean

Refs #495