### PR TITLE
feat(desktop,core): gate next-action card + offer phase-aware option set

### DIFF
--- a/apps/desktop/src/components/NextActionChips.tsx
+++ b/apps/desktop/src/components/NextActionChips.tsx
@@ -15,11 +15,7 @@ export interface NextActionChipsProps {
 }
 
 function isSpawnAction(action: NextAction): boolean {
-  return (
-    action.id === 'spawn_planner' ||
-    action.id === 'spawn_implementer' ||
-    action.id === 'spawn_debugger'
-  );
+  return spawnKindForAction(action) !== null;
 }
 
 export function NextActionChips({ taskId, workflowBound, className }: NextActionChipsProps) {
@@ -42,24 +38,16 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
     setError(null);
     setPendingAction(null);
     try {
-      switch (action.id) {
-        case 'spawn_planner':
-        case 'spawn_implementer':
-        case 'spawn_debugger': {
-          const defaults = AGENT_KIND_DEFAULTS[action.kind];
-          await spawnAgent(taskId, {
-            name: action.label,
-            model: defaults.model,
-            effort: defaults.effort,
-          });
-          break;
-        }
-        case 'open_pr':
-          await createPrForSession(taskId);
-          break;
-        case 'merge_pr':
-          // No-op until #415 lands the merge action on the store.
-          break;
+      const kind = spawnKindForAction(action);
+      if (kind) {
+        const defaults = AGENT_KIND_DEFAULTS[kind];
+        await spawnAgent(taskId, {
+          name: action.label,
+          model: defaults.model,
+          effort: defaults.effort,
+        });
+      } else if (action.id === 'open_pr') {
+        await createPrForSession(taskId);
       }
       clearSessionNextActions(taskId);
     } catch (err) {

--- a/apps/desktop/src/spawn-from-next-action.ts
+++ b/apps/desktop/src/spawn-from-next-action.ts
@@ -14,12 +14,20 @@ export type SpawnAgentFn = (
 
 export function spawnKindForAction(action: NextAction): AgentKind | null {
   switch (action.id) {
+    case 'spawn_scout':
+      return 'scout';
     case 'spawn_planner':
       return 'planner';
     case 'spawn_implementer':
       return 'implementer';
     case 'spawn_debugger':
       return 'debugger';
+    case 'spawn_reviewer':
+      return 'reviewer';
+    case 'spawn_tester':
+      return 'reviewer';
+    case 'spawn_docs':
+      return 'docs';
     default:
       return null;
   }
@@ -27,6 +35,8 @@ export function spawnKindForAction(action: NextAction): AgentKind | null {
 
 function kickoffPromptFor(action: NextAction): string {
   switch (action.id) {
+    case 'spawn_scout':
+      return 'explore the current scope and surface what is still unclear before planning.';
     case 'spawn_planner':
       return 'plan the next steps based on the current context.';
     case 'spawn_implementer':
@@ -35,6 +45,12 @@ function kickoffPromptFor(action: NextAction): string {
       const topic = action.payload?.topic?.trim();
       return topic ? `debug ${topic}.` : 'debug the current failure.';
     }
+    case 'spawn_reviewer':
+      return 'review the latest changes for correctness, style, and edge cases.';
+    case 'spawn_tester':
+      return 'write tests covering the latest changes. include unit and edge cases.';
+    case 'spawn_docs':
+      return 'document the latest changes. update relevant readme or guides.';
     default:
       return '';
   }

--- a/packages/core/src/summarizer/next-actions.test.ts
+++ b/packages/core/src/summarizer/next-actions.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { ContextSlot } from '@kay-am/types';
 import type { ContextSlotDelta, SummarizeInput } from './client';
-import { inferNextActions, type NextActionsPrState } from './next-actions';
+import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
+
+const LOCKED_GOAL = 'add caching layer to the auth module';
 
 function buildInput(
   turnOutput: string,
@@ -14,106 +16,191 @@ function delta(upserts: Array<{ key: string; value: string }> = []): ContextSlot
   return { upserts: upserts as ContextSlotDelta['upserts'] };
 }
 
-describe('inferNextActions', () => {
-  it('suggests planner after scout-only turn', () => {
+function slots(map: Record<string, string>, opts: { withGoal?: boolean } = {}): ContextSlot[] {
+  const out: ContextSlot[] = [];
+  if (opts.withGoal !== false && map.goal === undefined) {
+    out.push({ key: 'goal', value: LOCKED_GOAL, enabled: true });
+  }
+  for (const [key, value] of Object.entries(map)) {
+    out.push({ key, value, enabled: true });
+  }
+  return out;
+}
+
+function findById<T extends NextAction['id']>(
+  actions: ReadonlyArray<NextAction>,
+  id: T,
+): Extract<NextAction, { id: T }> | undefined {
+  return actions.find((a) => a.id === id) as Extract<NextAction, { id: T }> | undefined;
+}
+
+describe('inferNextActions — trigger gating', () => {
+  it('returns [] when open_questions slot has content (still refining)', () => {
+    const actions = inferNextActions({
+      input: buildInput('here is a draft plan'),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: 'which db driver?' }),
+    });
+    expect(actions).toEqual([]);
+  });
+
+  it('returns [] when goal is empty (still framing)', () => {
+    const actions = inferNextActions({
+      input: buildInput('drafted a plan'),
+      delta: delta(),
+      slotsAfter: slots({ goal: '' }, { withGoal: false }),
+    });
+    expect(actions).toEqual([]);
+  });
+
+  it('returns [] when goal is very short (still framing)', () => {
+    const actions = inferNextActions({
+      input: buildInput('drafted a plan'),
+      delta: delta(),
+      slotsAfter: slots({ goal: 'fix it' }, { withGoal: false }),
+    });
+    expect(actions).toEqual([]);
+  });
+
+  it('surfaces actions once goal is locked and no open questions remain', () => {
+    const actions = inferNextActions({
+      input: buildInput('drafted a plan for the new caching layer'),
+      delta: delta(),
+      slotsAfter: slots({}),
+    });
+    expect(actions.length).toBeGreaterThan(0);
+  });
+});
+
+describe('inferNextActions — option set after each phase', () => {
+  it('after scout turn → plan + refine scope', () => {
     const actions = inferNextActions({
       input: buildInput('explored the auth module and mapped its dependencies'),
       delta: delta([{ key: 'last_output_summary', value: 'investigated auth code paths' }]),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    expect(actions).toHaveLength(1);
-    expect(actions[0]).toEqual({ id: 'spawn_planner', label: 'start plan', kind: 'planner' });
+    expect(findById(actions, 'spawn_planner')).toBeDefined();
+    expect(findById(actions, 'spawn_scout')).toBeDefined();
   });
 
-  it('suggests implementer after plan turn', () => {
+  it('after plan turn → implement + refine plan', () => {
     const actions = inferNextActions({
       input: buildInput('drafted a plan for the new caching layer'),
       delta: delta([{ key: 'last_output_summary', value: 'planned caching design' }]),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    expect(actions.find((a) => a.id === 'spawn_implementer')).toBeDefined();
+    expect(findById(actions, 'spawn_implementer')).toBeDefined();
+    expect(findById(actions, 'spawn_planner')).toBeDefined();
   });
 
-  it('suggests open_pr after implementation turn', () => {
+  it('after implementation turn → review + tests + open pr', () => {
     const actions = inferNextActions({
-      input: buildInput('implemented the new endpoint and added tests'),
-      delta: delta([{ key: 'last_output_summary', value: 'wrote handler + tests' }]),
-      slotsAfter: [],
+      input: buildInput('implemented the new endpoint'),
+      delta: delta([{ key: 'last_output_summary', value: 'wrote handler' }]),
+      slotsAfter: slots({}),
     });
-    expect(actions.find((a) => a.id === 'open_pr')).toBeDefined();
+    expect(findById(actions, 'spawn_reviewer')).toBeDefined();
+    expect(findById(actions, 'spawn_tester')).toBeDefined();
+    expect(findById(actions, 'open_pr')).toBeDefined();
   });
 
-  it('does not suggest open_pr if PR already mentioned', () => {
+  it('after implementation that already mentions tests → review + open pr (no extra test chip)', () => {
+    const actions = inferNextActions({
+      input: buildInput('implemented endpoint and added unit tests'),
+      delta: delta(),
+      slotsAfter: slots({}),
+    });
+    expect(findById(actions, 'spawn_reviewer')).toBeDefined();
+    expect(findById(actions, 'spawn_tester')).toBeUndefined();
+    expect(findById(actions, 'open_pr')).toBeDefined();
+  });
+
+  it('after implementation when PR already exists → suggests neither open_pr nor a new impl chip', () => {
     const actions = inferNextActions({
       input: buildInput('implemented and opened pr #42'),
       delta: delta(),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    expect(actions.find((a) => a.id === 'open_pr')).toBeUndefined();
+    expect(findById(actions, 'open_pr')).toBeUndefined();
   });
+});
 
-  it('suggests debugger when bug mentioned with topic', () => {
+describe('inferNextActions — bug + pr-state branches', () => {
+  it('suggests debug + tests when bug mentioned', () => {
     const actions = inferNextActions({
       input: buildInput('found a bug in auth/session.ts where tokens leak across requests'),
       delta: delta(),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    const debug = actions.find((a) => a.id === 'spawn_debugger');
+    const debug = findById(actions, 'spawn_debugger');
     expect(debug).toBeDefined();
-    if (debug && debug.id === 'spawn_debugger') {
-      expect(debug.payload?.topic).toMatch(/auth\/session\.ts/);
-      expect(debug.label).toContain('start debug on');
-    }
+    expect(debug?.payload?.topic).toMatch(/auth\/session\.ts/);
+    expect(findById(actions, 'spawn_tester')).toBeDefined();
   });
 
-  it('caps at 2 actions', () => {
-    const actions = inferNextActions({
-      input: buildInput(
-        'scouted the code, drafted a plan, implemented the change, and found a regression',
-      ),
-      delta: delta(),
-      slotsAfter: [],
-    });
-    expect(actions.length).toBeLessThanOrEqual(2);
-  });
-
-  it('returns merge_pr when PR open + checks green', () => {
+  it('returns merge_pr only when PR open + checks green', () => {
     const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: true };
     const actions = inferNextActions({
-      input: buildInput('CI passed'),
+      input: buildInput('ci passed'),
       delta: delta(),
-      slotsAfter: [],
+      slotsAfter: slots({}),
       prState,
     });
-    expect(actions.find((a) => a.id === 'merge_pr')).toBeDefined();
+    expect(actions).toEqual([{ id: 'merge_pr', label: 'merge pr' }]);
   });
 
-  it('returns empty when nothing matches', () => {
+  it('returns debug + tests when PR open + checks failing', () => {
+    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: false };
+    const actions = inferNextActions({
+      input: buildInput('ci red'),
+      delta: delta(),
+      slotsAfter: slots({}),
+      prState,
+    });
+    expect(findById(actions, 'spawn_debugger')).toBeDefined();
+    expect(findById(actions, 'spawn_tester')).toBeDefined();
+  });
+
+  it('pr-state branches override the refinement gate', () => {
+    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: true };
+    const actions = inferNextActions({
+      input: buildInput('ci passed'),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: 'still unclear' }),
+      prState,
+    });
+    expect(actions).toEqual([{ id: 'merge_pr', label: 'merge pr' }]);
+  });
+});
+
+describe('inferNextActions — invariants', () => {
+  it('caps at 3 actions', () => {
+    const actions = inferNextActions({
+      input: buildInput(
+        'scouted the code, drafted a plan, implemented the change, found a regression',
+      ),
+      delta: delta(),
+      slotsAfter: slots({}),
+    });
+    expect(actions.length).toBeLessThanOrEqual(3);
+  });
+
+  it('returns a generic plan + refine fallback when goal locked and nothing else fires', () => {
     const actions = inferNextActions({
       input: buildInput('hello world'),
       delta: delta(),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    expect(actions).toHaveLength(0);
+    expect(findById(actions, 'spawn_planner')).toBeDefined();
+    expect(findById(actions, 'spawn_scout')).toBeDefined();
   });
 
-  it('reads delta upsert values too', () => {
+  it('reads delta upsert values to detect impl phase', () => {
     const actions = inferNextActions({
       input: buildInput(''),
       delta: delta([{ key: 'last_output_summary', value: 'finished implementation of feature X' }]),
-      slotsAfter: [],
+      slotsAfter: slots({}),
     });
-    expect(actions.find((a) => a.id === 'open_pr')).toBeDefined();
-  });
-
-  it('skips open_pr when prState already has open pr (even without text mention)', () => {
-    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: false };
-    const actions = inferNextActions({
-      input: buildInput('finished implementation'),
-      delta: delta(),
-      slotsAfter: [],
-      prState,
-    });
-    expect(actions.find((a) => a.id === 'open_pr')).toBeUndefined();
+    expect(findById(actions, 'open_pr')).toBeDefined();
   });
 });

--- a/packages/core/src/summarizer/next-actions.ts
+++ b/packages/core/src/summarizer/next-actions.ts
@@ -2,6 +2,7 @@ import type { ContextSlot } from '@kay-am/types';
 import type { ContextSlotDelta, SummarizeInput } from './client';
 
 export type NextAction =
+  | { readonly id: 'spawn_scout'; readonly label: string; readonly kind: 'scout' }
   | { readonly id: 'spawn_planner'; readonly label: string; readonly kind: 'planner' }
   | { readonly id: 'spawn_implementer'; readonly label: string; readonly kind: 'implementer' }
   | {
@@ -10,6 +11,9 @@ export type NextAction =
       readonly kind: 'debugger';
       readonly payload?: { readonly topic?: string };
     }
+  | { readonly id: 'spawn_reviewer'; readonly label: string; readonly kind: 'reviewer' }
+  | { readonly id: 'spawn_tester'; readonly label: string; readonly kind: 'reviewer' }
+  | { readonly id: 'spawn_docs'; readonly label: string; readonly kind: 'docs' }
   | { readonly id: 'open_pr'; readonly label: string }
   | { readonly id: 'merge_pr'; readonly label: string };
 
@@ -34,49 +38,107 @@ const IMPL_PATTERN =
 const PR_PATTERN = /\b(pull\s+request|\bpr\b|opened\s+pr|created\s+pr)\b/i;
 const BUG_PATTERN =
   /\b(bug|error|failing|failure|regression|broken|crash(?:ed|ing)?|exception|stack\s*trace)\b/i;
+const TEST_PATTERN = /\b(test(?:ed|ing|s)?|spec(?:s)?|unit\s+test|coverage)\b/i;
+const DOCS_PATTERN = /\b(doc(?:s|ument|umented|umentation)?|readme|changelog|guide|reference)\b/i;
 
-const MAX_ACTIONS = 2;
+const GOAL_MIN_CHARS = 12;
+const MAX_ACTIONS = 3;
 
-// PR-state-driven actions take precedence over text heuristics: if the user already
-// has an open PR with green checks, the summary text might still mention "implement"
-// from earlier work — surfacing "open pr" then would be wrong.
+// Trigger gating uses slot state instead of regex: card should appear only at
+// natural hand-off boundaries. If goal is still ambiguous or open questions are
+// pending, the user is mid-refinement — let them keep talking, do not surface
+// "spawn a new agent" chips.
 export function inferNextActions(input: InferNextActionsInput): ReadonlyArray<NextAction> {
-  const actions: NextAction[] = [];
-
   const summary = collectSummaryText(input);
+  const slots = mapSlots(input.slotsAfter);
+  const goal = slots.goal ?? '';
+  const openQuestions = slots.open_questions ?? '';
+  const decisions = slots.decisions ?? '';
+  const lastOutput = slots.last_output_summary ?? '';
 
-  if (input.prState?.hasOpenPr && input.prState.checksGreen) {
-    actions.push({ id: 'merge_pr', label: 'merge pr' });
+  const prOpen = input.prState?.hasOpenPr === true;
+  const prGreen = prOpen && input.prState?.checksGreen === true;
+  const prFailing = prOpen && input.prState?.checksGreen === false;
+
+  // PR-state branches are unconditional: they override the refinement gate
+  // because they describe a concrete next step the user can act on regardless
+  // of slot freshness.
+  if (prGreen) {
+    return [{ id: 'merge_pr', label: 'merge pr' }];
+  }
+  if (prFailing) {
+    return capActions([
+      bugAction(summary) ?? { id: 'spawn_debugger', label: 'start debug', kind: 'debugger' },
+      { id: 'spawn_tester', label: 'write tests', kind: 'reviewer' },
+    ]);
+  }
+
+  const refining = openQuestions.trim().length > 0 || goal.trim().length < GOAL_MIN_CHARS;
+  if (refining) {
+    return [];
   }
 
   if (BUG_PATTERN.test(summary)) {
-    const topic = extractBugTopic(summary);
-    actions.push({
+    const debug = bugAction(summary) ?? {
       id: 'spawn_debugger',
-      label: topic ? `start debug on ${topic}` : 'start debug',
+      label: 'start debug',
       kind: 'debugger',
-      ...(topic ? { payload: { topic } } : {}),
-    });
+    };
+    return capActions([debug, { id: 'spawn_tester', label: 'write tests', kind: 'reviewer' }]);
   }
 
-  const mentionsImpl = IMPL_PATTERN.test(summary);
-  const mentionsPlan = PLAN_PATTERN.test(summary);
+  const mentionsImpl = IMPL_PATTERN.test(summary) || IMPL_PATTERN.test(lastOutput);
+  const mentionsPlan = PLAN_PATTERN.test(summary) || PLAN_PATTERN.test(decisions);
   const mentionsScout = SCOUT_PATTERN.test(summary);
-  const mentionsPr = PR_PATTERN.test(summary) || input.prState?.hasOpenPr === true;
+  const mentionsPr = PR_PATTERN.test(summary) || prOpen;
+  const mentionsTests = TEST_PATTERN.test(summary);
+  const mentionsDocs = DOCS_PATTERN.test(summary);
 
   if (mentionsImpl && !mentionsPr) {
-    actions.push({ id: 'open_pr', label: 'open pr' });
-  } else if (mentionsPlan && !mentionsImpl) {
-    actions.push({
-      id: 'spawn_implementer',
-      label: 'start implementation',
-      kind: 'implementer',
-    });
-  } else if (mentionsScout && !mentionsPlan && !mentionsImpl) {
-    actions.push({ id: 'spawn_planner', label: 'start plan', kind: 'planner' });
+    const post: NextAction[] = [
+      { id: 'spawn_reviewer', label: 'review changes', kind: 'reviewer' },
+    ];
+    if (!mentionsTests) {
+      post.push({ id: 'spawn_tester', label: 'write tests', kind: 'reviewer' });
+    }
+    post.push({ id: 'open_pr', label: 'open pr' });
+    return capActions(post);
   }
 
-  return dedupeById(actions).slice(0, MAX_ACTIONS);
+  if (mentionsPlan && !mentionsImpl) {
+    return capActions([
+      { id: 'spawn_implementer', label: 'start implementation', kind: 'implementer' },
+      { id: 'spawn_planner', label: 'refine plan', kind: 'planner' },
+    ]);
+  }
+
+  if (mentionsScout && !mentionsPlan && !mentionsImpl) {
+    return capActions([
+      { id: 'spawn_planner', label: 'start plan', kind: 'planner' },
+      { id: 'spawn_scout', label: 'keep exploring', kind: 'scout' },
+    ]);
+  }
+
+  if (mentionsDocs && mentionsImpl) {
+    return capActions([{ id: 'spawn_docs', label: 'write docs', kind: 'docs' }]);
+  }
+
+  // Goal locked, no obvious phase hint — offer the safest forward step: plan.
+  // Pair with refine so the user can deepen scope instead if the goal is
+  // locked but still shallow.
+  return capActions([
+    { id: 'spawn_planner', label: 'start plan', kind: 'planner' },
+    { id: 'spawn_scout', label: 'refine scope', kind: 'scout' },
+  ]);
+}
+
+function mapSlots(slots: ReadonlyArray<ContextSlot>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const slot of slots) {
+    if (!slot.enabled) continue;
+    out[slot.key] = slot.value ?? '';
+  }
+  return out;
 }
 
 function collectSummaryText(input: InferNextActionsInput): string {
@@ -90,8 +152,18 @@ function collectSummaryText(input: InferNextActionsInput): string {
   return parts.join('\n');
 }
 
+function bugAction(text: string): NextAction | null {
+  const topic = extractBugTopic(text);
+  if (!topic) return null;
+  return {
+    id: 'spawn_debugger',
+    label: `start debug on ${topic}`,
+    kind: 'debugger',
+    payload: { topic },
+  };
+}
+
 function extractBugTopic(text: string): string | undefined {
-  // Prefer a quoted snippet right after the bug term, else the next ~6 words.
   const quoted = /\b(?:bug|error|regression|failure)[^"'`]*["'`]([^"'`]{2,60})["'`]/i.exec(text);
   if (quoted?.[1]) return quoted[1].trim();
   const inline =
@@ -100,6 +172,10 @@ function extractBugTopic(text: string): string | undefined {
     );
   if (inline?.[1]) return inline[1].trim();
   return undefined;
+}
+
+function capActions(actions: ReadonlyArray<NextAction>): ReadonlyArray<NextAction> {
+  return dedupeById(actions).slice(0, MAX_ACTIONS);
 }
 
 function dedupeById(actions: ReadonlyArray<NextAction>): NextAction[] {


### PR DESCRIPTION
## Summary

The 'next agent / suggested action' card used to fire on every summarizer pass and almost always offered only 'start implementation'. Now it stays hidden during refinement and presents a small phase-aware option set (plan / refine / implement / review / test / write docs / debug / open pr / merge pr).

## Before vs after

- **Before**: card rendered after every turn the summarizer touched; the dominant path landed on `spawn_implementer` because any 'plan/design/proposed' phrasing without an 'impl' word fired that single branch.
- **After**: card stays hidden while the user is still refining (open questions present or goal still vague); when it shows, the buttons reflect the detected phase and include reasonable alternatives.

## Trigger logic

Gating in `inferNextActions` (`packages/core/src/summarizer/next-actions.ts`):

- if `prState.checksGreen` → unconditional `merge_pr` (overrides the gate)
- if `prState.checksFailing` → unconditional `[debug, tests]` (overrides the gate)
- else if `open_questions` slot has any non-empty content → return `[]` (mid-refinement)
- else if `goal` slot is shorter than 12 chars → return `[]` (goal still ambiguous)
- else → run phase detection on summary text + relevant slots

These signals are read straight off the existing post-summarizer slot state — no new pipeline, no LLM call.

## Option set

Cap at 3 actions, deduped by id. Existing types: `open_pr`, `merge_pr`, `spawn_planner`, `spawn_implementer`, `spawn_debugger`. New types added: `spawn_scout` (refine), `spawn_reviewer` (review), `spawn_tester` (write tests), `spawn_docs` (write docs). New `kind` values map to the existing `AgentKind` palette/defaults — no new agent kinds.

Phase-aware rules (cheap regex over summary + slot values):

- bug mentioned → `[debug(<topic>?), write tests]`
- impl mentioned and no PR yet → `[review changes, write tests*, open pr]` (skip tester chip if the impl turn already mentioned tests)
- plan mentioned and no impl → `[start implementation, refine plan]`
- scout mentioned, no plan, no impl → `[start plan, keep exploring]`
- docs + impl mentioned → `[write docs]`
- fallback (goal locked, nothing else matched) → `[start plan, refine scope]`

PR-state branches override the refinement gate so users can still merge or pivot to debug when CI is decisive.

## Files touched

- `packages/core/src/summarizer/next-actions.ts` — gating + phase rules + new action variants
- `packages/core/src/summarizer/next-actions.test.ts` — rewrote tests around new contract
- `apps/desktop/src/spawn-from-next-action.ts` — added kind + kickoff prompt mapping for new variants
- `apps/desktop/src/components/NextActionChips.tsx` — switched action handler to `spawnKindForAction` + `id` so it stays exhaustive as the union grows

## Judgment calls

- Goal-min-chars threshold (12) is a heuristic. Picked low enough that 'fix it' is gated but 'add caching layer' is not. Tune later if it feels off.
- The generic fallback always fires when goal is locked but no phase keywords match. Alternative: also gate this on 'no decisions yet' or 'last_output_summary empty'. Kept simple for now; user can confirm if the fallback feels too eager.
- 'spawn_tester' and 'spawn_reviewer' both map to the `reviewer` AgentKind (same model + effort). Distinct ids let us label them separately ('review changes' vs 'write tests') and give them different kickoff prompts.
- `merge_pr` chip remains a no-op when clicked (matches pre-existing TODO around store integration). Out of scope for this PR.

## Test plan

- [ ] create a session, state a 2-word goal, see no chips (goal still vague)
- [ ] state a real goal, see [plan, refine scope] in fallback
- [ ] answer assistant clarifying questions → after summarizer, see [plan, refine] (no chips while open_questions populated)
- [ ] ask for a plan, see [implement, refine plan]
- [ ] complete an implementation turn, see [review, tests, open pr]
- [ ] open a PR with failing CI, see [debug, tests]
- [ ] open a PR with green CI, see [merge pr] only