### PR TITLE
feat(desktop): render context panel slots as markdown

### DIFF
--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -21,7 +21,7 @@ import {
   Activity,
   type LucideIcon,
 } from 'lucide-react';
-import { ScrollArea, Textarea, Dialog, Button, cn } from '@kay-am/ui';
+import { ScrollArea, Textarea, Dialog, Button, Markdown, cn } from '@kay-am/ui';
 import { SLOT_KEYS, SLOT_LABELS, type SlotKey, detectRepoSlug } from '@kay-am/core';
 import type {
   ContextSlot,
@@ -573,6 +573,12 @@ interface SlotMeta {
   readonly emptyLabel: string;
 }
 
+const MARKDOWN_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>([
+  'open_questions',
+  'decisions',
+  'last_output_summary',
+]);
+
 const SLOT_META: Record<Exclude<SlotKey, 'files_touched'>, SlotMeta> = {
   goal: {
     icon: Target,
@@ -628,6 +634,7 @@ function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: Slo
   const meta = slotKey === 'files_touched' ? null : SLOT_META[slotKey];
   const Icon = meta?.icon;
   const hasValue = value.length > 0;
+  const renderAsMarkdown = MARKDOWN_SLOTS.has(slotKey);
 
   useEffect(() => {
     if (!editing) setDraft(value);
@@ -686,9 +693,9 @@ function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: Slo
               commit();
             }
           }}
-          className="text-xs"
+          className="font-mono text-xs"
           autoGrow
-          maxRows={12}
+          maxRows={16}
         />
       ) : isSummarizing ? (
         <SlotSkeleton emphasis={meta?.emphasis} />
@@ -700,12 +707,31 @@ function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: Slo
         >
           {meta?.emptyLabel ?? 'empty — click to edit'}
         </button>
+      ) : renderAsMarkdown ? (
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => setEditing(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setEditing(true);
+            }
+          }}
+          className={cn(
+            'cursor-text rounded-md border border-transparent px-2.5 py-2 text-left leading-relaxed hover:border-border-soft hover:bg-muted/40 focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15',
+            'bg-subtle',
+            meta?.tintedWhenNonEmpty,
+          )}
+        >
+          <Markdown text={value} className="text-[13px] text-foreground" />
+        </div>
       ) : (
         <button
           type="button"
           onClick={() => setEditing(true)}
           className={cn(
-            'whitespace-pre-wrap break-all rounded-md border border-transparent px-2.5 py-2 text-left leading-relaxed hover:border-border-soft hover:bg-muted/40',
+            'whitespace-pre-wrap break-words rounded-md border border-transparent px-2.5 py-2 text-left leading-relaxed hover:border-border-soft hover:bg-muted/40',
             meta?.emphasis ? 'bg-subtle text-sm font-medium' : 'bg-subtle text-xs',
             meta?.tintedWhenNonEmpty,
           )}
@@ -716,6 +742,7 @@ function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: Slo
 
       <SlotHistoryDialog
         label={SLOT_LABELS[slotKey]}
+        renderAsMarkdown={renderAsMarkdown}
         open={historyOpen}
         entries={history}
         onRestore={restore}
@@ -727,13 +754,21 @@ function SlotRow({ taskId, slotKey, slot, isSummarizing = false, onCommit }: Slo
 
 interface SlotHistoryDialogProps {
   label: string;
+  renderAsMarkdown: boolean;
   open: boolean;
   entries: ReadonlyArray<ContextSlotHistoryEntry>;
   onRestore: (entry: ContextSlotHistoryEntry) => void;
   onClose: () => void;
 }
 
-function SlotHistoryDialog({ label, open, entries, onRestore, onClose }: SlotHistoryDialogProps) {
+function SlotHistoryDialog({
+  label,
+  renderAsMarkdown,
+  open,
+  entries,
+  onRestore,
+  onClose,
+}: SlotHistoryDialogProps) {
   return (
     <Dialog open={open} onClose={onClose} title={`history — ${label}`} size="xl">
       {entries.length === 0 ? (
@@ -768,9 +803,15 @@ function SlotHistoryDialog({ label, open, entries, onRestore, onClose }: SlotHis
                   restore
                 </button>
               </div>
-              <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground line-clamp-4">
-                {entry.value}
-              </p>
+              {renderAsMarkdown ? (
+                <div className="max-h-40 overflow-hidden text-xs leading-relaxed text-foreground">
+                  <Markdown text={entry.value} className="text-xs" />
+                </div>
+              ) : (
+                <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground line-clamp-4">
+                  {entry.value}
+                </p>
+              )}
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

- read mode for `decisions`, `open_questions`, `last_output_summary` now renders Markdown using the same `@kay-am/ui` `Markdown` component the chat transcript uses (no new dependency)
- edit mode is still a plain `<textarea>` (no toolbar, no preview) with a monospace font so the raw Markdown source is editable verbatim

## Before vs after

| slot | before | after |
| --- | --- | --- |
| `goal` | plain `text-sm font-medium` line | unchanged — it's a short single-line phrase |
| `decisions` | wall of plain text (`whitespace-pre-wrap break-all`) | Markdown: bullets, headings, inline `code`, links |
| `open_questions` | same wall, warning-tinted | Markdown rendering, warning border preserved |
| `last_output_summary` | same wall | Markdown rendering |
| slot history dialog entries | plain `<p>` w/ `line-clamp-4` | Markdown for the same three slots, scroll-clipped to `max-h-40` |

Also flipped `break-all` → `break-words` on the (still-plain) `goal` block so long words wrap on word boundaries.

## Markdown library

Reused the existing **`Markdown` component** at `packages/ui/src/components/Markdown.tsx`, already exported by `@kay-am/ui` and consumed by `apps/desktop/src/components/chat/TranscriptCards.tsx` (assistant message rendering). It's a handwritten parser — no new npm package, no new transitive deps. Sanitisation matches: no `dangerouslySetInnerHTML`, link schemes restricted to `http(s)`/`mailto`.

## Edit UX

- click on the rendered Markdown block → enters edit mode
- `<textarea>` (monospace, `autoGrow`, `maxRows={16}`) shows the raw value verbatim
- **blur** saves
- **Esc** discards the draft
- **Cmd/Ctrl + Enter** saves explicitly
- no canonicalisation on save — the textarea value is persisted as-is
- read-mode block uses `role="button"` + `tabIndex={0}` + Enter/Space handlers (we can't nest interactive markdown content like links/tables inside a `<button>`)

## Test plan

- [ ] open a task with summarizer output containing markdown headings, bullets, links
- [ ] confirm `decisions`, `open_questions`, `last_output_summary` render as formatted markdown (not raw text)
- [ ] confirm `goal` still renders as before
- [ ] click each markdown slot → textarea opens with raw markdown source in monospace
- [ ] type something, blur → value persists; raw text round-trips, no autoformat
- [ ] Esc inside textarea → discards changes
- [ ] Cmd/Ctrl+Enter → saves explicitly
- [ ] tab into a markdown slot → focus ring shows, Enter/Space opens editor
- [ ] open slot history → entries render markdown for the same three slots
- [ ] very long single-word string in `goal` → wraps on word boundary, no horizontal scroll