### PR TITLE
feat(desktop,core): session plans as first-class artifact

### DIFF
--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../store', () => ({
       spawnAgent: vi.fn(),
       clearSessionNextActions: vi.fn(),
       loadDiffComments: vi.fn(),
+      sessionPlans: {},
     };
     return selector(state);
   }),

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../store', () => ({
       clearSessionNextActions: vi.fn(),
       loadDiffComments: vi.fn(),
       sessionPlans: {},
+      sessionPhaseRuns: {},
       loadSessionPlans: vi.fn(),
       setPlanStatus: vi.fn(),
       updatePlanBody: vi.fn(),

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -30,6 +30,10 @@ vi.mock('../store', () => ({
       clearSessionNextActions: vi.fn(),
       loadDiffComments: vi.fn(),
       sessionPlans: {},
+      loadSessionPlans: vi.fn(),
+      setPlanStatus: vi.fn(),
+      updatePlanBody: vi.fn(),
+      deletePlan: vi.fn(),
     };
     return selector(state);
   }),

--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -41,6 +41,8 @@ vi.mock('../store', () => ({
   useSessionNextActions: vi.fn().mockReturnValue([]),
   useDiffComments: vi.fn().mockReturnValue([]),
   useFilesTouched: vi.fn().mockReturnValue({ paths: [], count: 0 }),
+  useSessionPlans: vi.fn().mockReturnValue([]),
+  useMostRecentPlan: vi.fn().mockReturnValue(null),
 }));
 
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/apps/desktop/src/agent-kind.ts
+++ b/apps/desktop/src/agent-kind.ts
@@ -79,7 +79,7 @@ export const AGENT_KIND_DEFAULTS: Record<
     model: 'claude-opus-4-5',
     effort: 'high',
     systemPrompt:
-      'you are a planning agent. analyze the goal, break it into ordered steps, identify risks and dependencies. do not implement — produce a plan the implementer agent will execute. be concise.',
+      'you are a planning agent. analyze the goal, break it into ordered steps, identify risks and dependencies. do not implement — produce a plan the implementer agent will execute. be concise. wrap your final plan in <<plan>>...<</plan>> markers so it can be captured as a session artifact. the first line of the plan body is the title; the rest is markdown. emit exactly one plan block per turn.',
   },
 };
 

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -22,6 +22,7 @@ import {
   HelpCircle,
   Activity,
   ClipboardList,
+  Play,
   type LucideIcon,
 } from 'lucide-react';
 import { ScrollArea, Textarea, Dialog, Button, Markdown, cn } from '@kay-am/ui';
@@ -208,8 +209,6 @@ export function ContextPanel({
               </div>
             </header>
 
-            <NextActionChips taskId={session.id} workflowBound={session.workflowId !== undefined} />
-
             <PlansSection taskId={session.id} />
 
             <ul className="flex flex-col gap-6">
@@ -227,6 +226,8 @@ export function ContextPanel({
                 );
               })}
             </ul>
+
+            <NextActionChips taskId={session.id} workflowBound={session.workflowId !== undefined} />
           </div>
         </ScrollArea>
 
@@ -908,8 +909,10 @@ function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(planToSource(plan));
+  const [spawning, setSpawning] = useState(false);
   const setPlanStatus = useAppStore((s) => s.setPlanStatus);
   const updatePlanBody = useAppStore((s) => s.updatePlanBody);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
 
   useEffect(() => {
     if (!editing) setDraft(planToSource(plan));
@@ -926,6 +929,16 @@ function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
     if (next.title.length === 0) return;
     if (next.title === plan.title && next.bodyMd === plan.bodyMd) return;
     void updatePlanBody(taskId, plan.id, next.title, next.bodyMd);
+  };
+
+  const runPlan = async () => {
+    if (spawning) return;
+    setSpawning(true);
+    try {
+      await spawnAgent(taskId, { initialPrompt: plan.bodyMd });
+    } finally {
+      setSpawning(false);
+    }
   };
 
   const Chevron = expanded ? ChevronDown : ChevronRight;
@@ -955,6 +968,25 @@ function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
         </button>
       </div>
       <span className="text-2xs text-muted-foreground">by {agentName}</span>
+      {plan.status === 'active' ? (
+        <button
+          type="button"
+          onClick={() => void runPlan()}
+          disabled={spawning}
+          className={cn(
+            'inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-1 text-xs text-primary transition-colors hover:bg-primary/10',
+            spawning && 'cursor-not-allowed opacity-60',
+          )}
+          title="avvia nuovo agent che esegue questo piano"
+        >
+          {spawning ? (
+            <Loader2 size={11} aria-hidden className="animate-spin" />
+          ) : (
+            <Play size={11} aria-hidden />
+          )}
+          Avvia nuovo agent che esegue questo piano
+        </button>
+      ) : null}
       {expanded ? (
         editing ? (
           <Textarea

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -14,18 +14,24 @@ import {
   Loader2,
   Copy,
   X,
+  ChevronRight,
+  ChevronDown,
   FileEdit,
   Target,
   CheckCheck,
   HelpCircle,
   Activity,
+  ClipboardList,
   type LucideIcon,
 } from 'lucide-react';
-import { ScrollArea, Textarea, Dialog, Button, cn } from '@kay-am/ui';
+import { ScrollArea, Textarea, Dialog, Button, Markdown, cn } from '@kay-am/ui';
 import { SLOT_KEYS, SLOT_LABELS, type SlotKey, detectRepoSlug } from '@kay-am/core';
 import type {
   ContextSlot,
   ContextSlotHistoryEntry,
+  Plan,
+  PlanStatus,
+  Session,
   Task,
   TaskId,
   TelemetryRecord,
@@ -36,6 +42,7 @@ import {
   useAppStore,
   useDiffComments,
   useFilesTouched,
+  useSessionPlans,
   useSessionSlots,
   useSlotHistory,
   useSummarizerStatus,
@@ -202,6 +209,8 @@ export function ContextPanel({
             </header>
 
             <NextActionChips taskId={session.id} workflowBound={session.workflowId !== undefined} />
+
+            <PlansSection taskId={session.id} />
 
             <ul className="flex flex-col gap-6">
               {visibleSlotKeys.map((key) => {
@@ -848,4 +857,159 @@ function SummarizerBadge({
       {labels[status]}
     </span>
   );
+}
+
+const PLAN_STATUS_STYLE: Record<PlanStatus, string> = {
+  active: 'bg-success/10 text-success',
+  completed: 'bg-muted text-muted-foreground',
+  superseded: 'bg-warning/10 text-warning',
+};
+
+function PlansSection({ taskId }: { taskId: TaskId }) {
+  const plans = useSessionPlans(taskId);
+  const loadSessionPlans = useAppStore((s) => s.loadSessionPlans);
+  const agents = useAppStore(
+    (s) => s.sessionPhaseRuns[taskId] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
+  );
+
+  useEffect(() => {
+    void loadSessionPlans(taskId);
+  }, [taskId, loadSessionPlans]);
+
+  if (plans.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        <ClipboardList size={11} aria-hidden className="text-primary" />
+        plans
+      </span>
+      <ul className="flex flex-col gap-1.5">
+        {plans.map((plan) => (
+          <PlanRow
+            key={plan.id}
+            taskId={taskId}
+            plan={plan}
+            agentName={agents.find((a) => a.id === plan.agentId)?.name ?? 'unknown agent'}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+interface PlanRowProps {
+  readonly taskId: TaskId;
+  readonly plan: Plan;
+  readonly agentName: string;
+}
+
+function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(planToSource(plan));
+  const setPlanStatus = useAppStore((s) => s.setPlanStatus);
+  const updatePlanBody = useAppStore((s) => s.updatePlanBody);
+
+  useEffect(() => {
+    if (!editing) setDraft(planToSource(plan));
+  }, [plan, editing]);
+
+  const toggleStatus = () => {
+    const next: PlanStatus = plan.status === 'active' ? 'completed' : 'active';
+    void setPlanStatus(taskId, plan.id, next);
+  };
+
+  const commit = () => {
+    setEditing(false);
+    const next = parsePlanSource(draft);
+    if (next.title.length === 0) return;
+    if (next.title === plan.title && next.bodyMd === plan.bodyMd) return;
+    void updatePlanBody(taskId, plan.id, next.title, next.bodyMd);
+  };
+
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <li className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
+      <div className="flex items-start justify-between gap-2">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+          title={expanded ? 'collapse plan' : 'expand plan'}
+        >
+          <Chevron size={11} aria-hidden className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-xs font-medium text-foreground">{plan.title}</span>
+        </button>
+        <button
+          type="button"
+          onClick={toggleStatus}
+          title={`mark as ${plan.status === 'active' ? 'completed' : 'active'}`}
+          className={cn(
+            'shrink-0 rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
+            PLAN_STATUS_STYLE[plan.status],
+          )}
+        >
+          {plan.status}
+        </button>
+      </div>
+      <span className="text-2xs text-muted-foreground">by {agentName}</span>
+      {expanded ? (
+        editing ? (
+          <Textarea
+            autoFocus
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                setDraft(planToSource(plan));
+                setEditing(false);
+              }
+              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                commit();
+              }
+            }}
+            className="font-mono text-xs"
+            autoGrow
+            maxRows={24}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            title="edit plan source"
+            className="rounded-md border border-transparent px-1 py-1 text-left hover:border-border-soft hover:bg-muted/40"
+          >
+            <Markdown text={plan.bodyMd} className="text-xs" />
+          </button>
+        )
+      ) : null}
+    </li>
+  );
+}
+
+function planToSource(plan: Plan): string {
+  const head = plan.title.startsWith('#') ? plan.title : `# ${plan.title}`;
+  return plan.bodyMd.length > 0 ? `${head}\n\n${plan.bodyMd}` : head;
+}
+
+function parsePlanSource(raw: string): { title: string; bodyMd: string } {
+  const lines = raw.split('\n');
+  let firstIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if ((lines[i] ?? '').trim().length > 0) {
+      firstIdx = i;
+      break;
+    }
+  }
+  if (firstIdx === -1) return { title: '', bodyMd: '' };
+  const titleLine = (lines[firstIdx] ?? '').trim();
+  const title = titleLine.replace(/^#+\s*/, '').trim();
+  const restLines = lines.slice(firstIdx + 1);
+  const bodyMd = restLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
+  return { title, bodyMd };
 }

--- a/apps/desktop/src/plans.ts
+++ b/apps/desktop/src/plans.ts
@@ -1,0 +1,45 @@
+import type { Plan, PlanId, PlanStatus, SessionId, TaskId } from '@kay-am/types';
+import {
+  deletePlan as dbDeletePlan,
+  listPlansForSession as dbListPlansForSession,
+  updatePlanBody as dbUpdatePlanBody,
+  updatePlanStatus as dbUpdatePlanStatus,
+  upsertPlan as dbUpsertPlan,
+} from '@kay-am/db';
+import { tauriDatabase } from './db';
+
+export async function listPlansForSession(sessionId: TaskId): Promise<ReadonlyArray<Plan>> {
+  return dbListPlansForSession(tauriDatabase, sessionId);
+}
+
+export interface UpsertPlanArgs {
+  readonly sessionId: TaskId;
+  readonly agentId: SessionId;
+  readonly title: string;
+  readonly bodyMd: string;
+  readonly status?: PlanStatus;
+}
+
+export async function upsertPlan(args: UpsertPlanArgs): Promise<Plan> {
+  const id = crypto.randomUUID() as PlanId;
+  return dbUpsertPlan(tauriDatabase, {
+    id,
+    sessionId: args.sessionId,
+    agentId: args.agentId,
+    title: args.title,
+    bodyMd: args.bodyMd,
+    status: args.status ?? 'active',
+  });
+}
+
+export async function setPlanStatus(id: PlanId, status: PlanStatus): Promise<void> {
+  await dbUpdatePlanStatus(tauriDatabase, id, status);
+}
+
+export async function setPlanBody(id: PlanId, title: string, bodyMd: string): Promise<void> {
+  await dbUpdatePlanBody(tauriDatabase, id, title, bodyMd);
+}
+
+export async function deletePlan(id: PlanId): Promise<void> {
+  await dbDeletePlan(tauriDatabase, id);
+}

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -5,6 +5,8 @@ export {
   useCurrentWorkspace,
   useDiffComments,
   useFilesTouched,
+  useMostRecentPlan,
+  useSessionPlans,
   useSessionSlots,
   useSessionNextActions,
   useSlotHistory,

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -3,6 +3,7 @@ import type {
   ContextSlot,
   ContextSlotHistoryEntry,
   DiffComment,
+  Plan,
   Task,
   TaskId,
 } from '@kay-am/types';
@@ -61,6 +62,16 @@ const EMPTY_COMMENTS: ReadonlyArray<DiffComment> = [];
 
 export const useDiffComments = (taskId: TaskId | null): ReadonlyArray<DiffComment> =>
   useAppStore((s) => (taskId ? (s.diffComments[taskId] ?? EMPTY_COMMENTS) : EMPTY_COMMENTS));
+
+const EMPTY_PLANS: ReadonlyArray<Plan> = [];
+
+export const useSessionPlans = (taskId: TaskId | null): ReadonlyArray<Plan> =>
+  useAppStore((s) => (taskId ? (s.sessionPlans[taskId] ?? EMPTY_PLANS) : EMPTY_PLANS));
+
+export const useMostRecentPlan = (taskId: TaskId | null): Plan | null => {
+  const plans = useSessionPlans(taskId);
+  return plans[0] ?? null;
+};
 
 interface FilesTouched {
   readonly paths: ReadonlyArray<string>;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -85,6 +85,9 @@ import type {
   PermissionRequest,
   PermissionRequestId,
   PermissionRule,
+  Plan,
+  PlanId,
+  PlanStatus,
   Step,
   StepId,
   Session,
@@ -118,6 +121,7 @@ import {
   computeCostUsd,
   computeCodexCostUsd,
   computeCursorCostUsd,
+  extractPlanFromMarker,
   getPrForBranch,
   fetchLinkedIssues,
   detectRepoSlug,
@@ -205,6 +209,13 @@ import {
 import { exportConfigToFile, importConfigFromFile } from '../config-export';
 import { formatError } from '../errors';
 import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../agent-kind';
+import {
+  deletePlan as invokeDeletePlan,
+  listPlansForSession as invokeListPlansForSession,
+  setPlanBody as invokeSetPlanBody,
+  setPlanStatus as invokeSetPlanStatus,
+  upsertPlan as invokeUpsertPlan,
+} from '../plans';
 import { slotsForKind } from '../slot-routing';
 import { estimateTokens } from '../utils/estimate-tokens';
 
@@ -295,6 +306,7 @@ export interface AppState {
   readonly agentModelOverride: Readonly<Record<SessionId, string>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
   readonly notifications: ReadonlyArray<Notification>;
+  readonly sessionPlans: Readonly<Record<TaskId, ReadonlyArray<Plan>>>;
 }
 
 export interface SessionGithubState {
@@ -451,6 +463,10 @@ export interface AppActions {
   ): Promise<void>;
   markNotificationsRead(): Promise<void>;
   clearNotifications(): Promise<void>;
+  loadSessionPlans(taskId: TaskId): Promise<void>;
+  setPlanStatus(taskId: TaskId, planId: PlanId, status: PlanStatus): Promise<void>;
+  updatePlanBody(taskId: TaskId, planId: PlanId, title: string, bodyMd: string): Promise<void>;
+  deletePlan(taskId: TaskId, planId: PlanId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -506,6 +522,7 @@ const initialState: AppState = {
   agentModelOverride: {},
   diffComments: {},
   notifications: [],
+  sessionPlans: {},
 };
 
 function buildProviderSpendBreakdown(
@@ -780,6 +797,58 @@ async function runSummarizer(
     void get().emitNotification('error', 'error', 'summarizer failed', message, {
       sessionId: taskId,
     });
+  }
+}
+
+async function buildPlanKickoffSection(taskId: TaskId): Promise<string> {
+  try {
+    const plans = await invokeListPlansForSession(taskId);
+    const plan = plans[0];
+    if (!plan) return '';
+    if (plan.status === 'completed') {
+      return [
+        'The most recent plan in this session was completed and should NOT be re-executed. Provided for context only:',
+        '',
+        plan.bodyMd,
+      ].join('\n');
+    }
+    if (plan.status === 'superseded') return '';
+    return ['Active plan to execute:', '', plan.bodyMd].join('\n');
+  } catch {
+    return '';
+  }
+}
+
+function composeKickoff(planSection: string, baseKickoff: string): string {
+  if (planSection.length === 0) return baseKickoff;
+  if (baseKickoff.length === 0) return planSection;
+  return `${planSection}\n\n${baseKickoff}`;
+}
+
+async function capturePlanFromTurn(
+  set: SetFn,
+  taskId: TaskId,
+  agentId: SessionId,
+  assistantText: string,
+): Promise<void> {
+  try {
+    const extracted = extractPlanFromMarker(assistantText);
+    if (!extracted) return;
+    await invokeUpsertPlan({
+      sessionId: taskId,
+      agentId,
+      title: extracted.title,
+      bodyMd: extracted.bodyMd,
+      status: 'active',
+    });
+    const refreshed = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+    }));
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn(`[plan-capture] failed for session ${taskId}: ${formatError(err)}`);
+    }
   }
 }
 
@@ -1125,12 +1194,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setCurrentSession: async (id) => {
     set({ currentSessionId: id, sessionSummary: null });
     if (id) {
-      const [summary, telemetry, slots, agents, agentRunIds] = await Promise.all([
+      const safePlans = (): Promise<ReadonlyArray<Plan>> => {
+        try {
+          return invokeListPlansForSession(id).catch(() => [] as ReadonlyArray<Plan>);
+        } catch {
+          return Promise.resolve([] as ReadonlyArray<Plan>);
+        }
+      };
+      const [summary, telemetry, slots, agents, agentRunIds, plans] = await Promise.all([
         summarizeTaskTelemetry(tauriDatabase, id),
         listTelemetryForTask(tauriDatabase, id),
         listContextSlotsForTask(tauriDatabase, id),
         invokePhaseRunList(id),
         listAgentRunIdsForTask(tauriDatabase, id),
+        safePlans(),
       ]);
       // Pick the previously-selected agent if it still exists, else the
       // lowest-ordinal one (= default "agent 1" or first workflow step).
@@ -1194,6 +1271,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         },
         sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
         sessionSlots: { ...state.sessionSlots, [id]: slots },
+        sessionPlans: { ...state.sessionPlans, [id]: plans },
         agentRunHistory: { ...state.agentRunHistory, ...seededHistory },
         agentTurnState: { ...state.agentTurnState, ...seededTurnState },
       }));
@@ -2332,6 +2410,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     if (!lastError && assistantText.length > 0) {
       enqueueSummarizer(set, get, taskId, resolvedPrompt, assistantText);
+      void capturePlanFromTurn(set, taskId, activeAgentId, assistantText);
       if (isFirstTurn) {
         const sessionForTitle = get().sessions.find((s) => s.id === taskId);
         if (sessionForTitle && !sessionForTitle.titleUserEdited) {
@@ -2487,6 +2566,37 @@ export const useAppStore = create<AppStore>((set, get) => ({
   clearNotifications: async () => {
     await clearAllNotifications(tauriDatabase);
     set({ notifications: [] });
+  },
+
+  loadSessionPlans: async (taskId) => {
+    const plans = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: plans },
+    }));
+  },
+
+  setPlanStatus: async (taskId, planId, status) => {
+    await invokeSetPlanStatus(planId, status);
+    const refreshed = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+    }));
+  },
+
+  updatePlanBody: async (taskId, planId, title, bodyMd) => {
+    await invokeSetPlanBody(planId, title, bodyMd);
+    const refreshed = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+    }));
+  },
+
+  deletePlan: async (taskId, planId) => {
+    await invokeDeletePlan(planId);
+    const refreshed = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+    }));
   },
 
   toggleSessionSlot: async (taskId, key, enabled) => {
@@ -2856,7 +2966,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
         agentModelOverride: { ...s.agentModelOverride, [inserted.id]: args.model },
       }),
     }));
-    const kickoff = stepPromptPrefix.length > 0 ? stepPromptPrefix : (args.initialPrompt ?? '');
+    const baseKickoff = stepPromptPrefix.length > 0 ? stepPromptPrefix : (args.initialPrompt ?? '');
+    const planSection = await buildPlanKickoffSection(taskId);
+    const kickoff = composeKickoff(planSection, baseKickoff);
     if (kickoff.length > 0) {
       void get().sendTurn({ taskId, content: kickoff });
     }

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { TurnEvent } from '@kay-am/types';
-import { extractFilesTouched, extractMarkers, mergeIntoSlot } from './extractors';
+import {
+  extractFilesTouched,
+  extractMarkers,
+  extractPlanFromMarker,
+  mergeIntoSlot,
+} from './extractors';
 
 function fileEdit(path: string): TurnEvent {
   return {
@@ -89,6 +94,60 @@ line three<</ctx-decision>>`;
     expect(extractMarkers(text).decisions).toEqual(['x']);
     expect(extractMarkers(text).decisions).toEqual(['x']);
     expect(extractMarkers(text).decisions).toEqual(['x']);
+  });
+});
+
+describe('extractPlanFromMarker', () => {
+  it('returns null when no plan marker present', () => {
+    expect(extractPlanFromMarker('no plan here')).toBeNull();
+  });
+
+  it('extracts title from first non-empty line and body as markdown rest', () => {
+    const text = `prose before. <<plan>>migrate auth to oauth2
+- step 1: scaffolding
+- step 2: token exchange<</plan>>`;
+    expect(extractPlanFromMarker(text)).toEqual({
+      title: 'migrate auth to oauth2',
+      bodyMd: '- step 1: scaffolding\n- step 2: token exchange',
+    });
+  });
+
+  it('strips leading # from title', () => {
+    const text = `<<plan>>### refactor everything
+
+body line.<</plan>>`;
+    const out = extractPlanFromMarker(text);
+    expect(out?.title).toBe('refactor everything');
+    expect(out?.bodyMd).toBe('body line.');
+  });
+
+  it('falls back to title-as-body when body empty', () => {
+    const text = '<<plan>>only title<</plan>>';
+    expect(extractPlanFromMarker(text)).toEqual({
+      title: 'only title',
+      bodyMd: 'only title',
+    });
+  });
+
+  it('returns null when marker content is whitespace only', () => {
+    const text = '<<plan>>   \n  <</plan>>';
+    expect(extractPlanFromMarker(text)).toBeNull();
+  });
+
+  it('picks the LAST plan when multiple emitted in a turn', () => {
+    const text = `<<plan>>first
+body 1<</plan>>
+intermediate prose
+<<plan>>final
+body 2<</plan>>`;
+    expect(extractPlanFromMarker(text)?.title).toBe('final');
+  });
+
+  it('survives repeat calls (no leaked lastIndex)', () => {
+    const text = '<<plan>>x\nb<</plan>>';
+    expect(extractPlanFromMarker(text)?.title).toBe('x');
+    expect(extractPlanFromMarker(text)?.title).toBe('x');
+    expect(extractPlanFromMarker(text)?.title).toBe('x');
   });
 });
 

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -23,6 +23,7 @@ export function extractFilesTouched(events: ReadonlyArray<TurnEvent>): ReadonlyA
 const DECISION_RE = /<<ctx-decision>>([\s\S]*?)<<\/ctx-decision>>/g;
 const QUESTION_RE = /<<ctx-question>>([\s\S]*?)<<\/ctx-question>>/g;
 const RESOLVED_RE = /<<ctx-resolved>>([\s\S]*?)<<\/ctx-resolved>>/g;
+const PLAN_RE = /<<plan>>([\s\S]*?)<<\/plan>>/g;
 
 /**
  * Pull agent-emitted markers out of an assistant turn's full text. Agents
@@ -46,6 +47,47 @@ export function extractMarkers(assistantText: string): {
   const questions = extractAll(assistantText, QUESTION_RE);
   const resolved = extractAll(assistantText, RESOLVED_RE);
   return { decisions, questions, resolved };
+}
+
+/**
+ * Pull the most recent `<<plan>>...<</plan>>` block from an assistant turn.
+ * Planning agents wrap a Markdown body inside the marker — title is the first
+ * non-empty line (with leading `#` stripped); body is the rest. Returns null
+ * when no marker is present or its content is empty.
+ *
+ * If multiple plans appear in one turn (rare), the last one wins — agents are
+ * expected to emit one final plan per turn.
+ */
+export interface ExtractedPlan {
+  readonly title: string;
+  readonly bodyMd: string;
+}
+
+export function extractPlanFromMarker(assistantText: string): ExtractedPlan | null {
+  const matches = extractAll(assistantText, PLAN_RE);
+  if (matches.length === 0) return null;
+  const raw = matches[matches.length - 1]!;
+  return parsePlanBody(raw);
+}
+
+function parsePlanBody(raw: string): ExtractedPlan | null {
+  const lines = raw.split('\n');
+  let firstIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const ln = (lines[i] ?? '').trim();
+    if (ln.length > 0) {
+      firstIdx = i;
+      break;
+    }
+  }
+  if (firstIdx === -1) return null;
+  const titleLine = (lines[firstIdx] ?? '').trim();
+  const title = titleLine.replace(/^#+\s*/, '').trim();
+  if (title.length === 0) return null;
+  const restLines = lines.slice(firstIdx + 1);
+  let bodyMd = restLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
+  if (bodyMd.length === 0) bodyMd = title;
+  return { title, bodyMd };
 }
 
 function extractAll(text: string, re: RegExp): ReadonlyArray<string> {

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -8,7 +8,14 @@ export {
   SLOT_LABELS,
   type SlotKey,
 } from './slots';
-export { extractFilesTouched, extractMarkers, mergeIntoSlot, removeFromSlot } from './extractors';
+export {
+  extractFilesTouched,
+  extractMarkers,
+  extractPlanFromMarker,
+  mergeIntoSlot,
+  removeFromSlot,
+  type ExtractedPlan,
+} from './extractors';
 export {
   autoPopulateContext,
   type AutoPopulateInput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   autoPopulateContext,
   extractFilesTouched,
   extractMarkers,
+  extractPlanFromMarker,
   isSlotKey,
   mergeIntoSlot,
   removeFromSlot,
@@ -32,6 +33,7 @@ export {
   type AutoPopulateInput,
   type AutoPopulateResult,
   type ContextEngineDeps,
+  type ExtractedPlan,
   type SlotKey,
 } from './context';
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -117,3 +117,11 @@ export {
   type NotificationKind,
   type NotificationSeverity,
 } from './queries/notification';
+export {
+  listPlansForSession,
+  upsertPlan,
+  updatePlanStatus,
+  updatePlanBody,
+  deletePlan,
+  type UpsertPlanInput,
+} from './queries/plan';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -24,6 +24,7 @@ import { m023StepEffort } from './m023-step-effort';
 import { m024SessionProviderSessionId } from './m024-session-provider-session-id';
 import { m025TaskTitleUserEdited } from './m025-task-title-user-edited';
 import { m026Notifications } from './m026-notifications';
+import { m027SessionPlans } from './m027-session-plans';
 
 export interface Migration {
   readonly version: number;
@@ -57,4 +58,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 24, sql: m024SessionProviderSessionId },
   { version: 25, sql: m025TaskTitleUserEdited },
   { version: 26, sql: m026Notifications },
+  { version: 27, sql: m027SessionPlans },
 ];

--- a/packages/db/src/migrations/m027-session-plans.ts
+++ b/packages/db/src/migrations/m027-session-plans.ts
@@ -1,0 +1,17 @@
+export const m027SessionPlans = /* sql */ `
+CREATE TABLE IF NOT EXISTS session_plans (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body_md TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('active', 'completed', 'superseded')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (session_id, agent_id),
+  FOREIGN KEY (session_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_plans_session ON session_plans(session_id, updated_at DESC);
+`;

--- a/packages/db/src/queries/plan.test.ts
+++ b/packages/db/src/queries/plan.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from 'vitest';
+import type { PlanId, SessionId, TaskId } from '@kay-am/types';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from '../migrations/runner';
+import {
+  deletePlan,
+  listPlansForSession,
+  updatePlanBody,
+  updatePlanStatus,
+  upsertPlan,
+} from './plan';
+
+async function seedFixture() {
+  const db = makeTestDatabase();
+  await migrate(db);
+  const now = Date.now();
+  await db.execute(
+    `INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+    ['w1', 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    `INSERT INTO tasks (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    ['t1', 'w1', 'goal', 'idle', now, now],
+  );
+  await db.execute(
+    `INSERT INTO sessions (id, task_id, ordinal, name, status, parallel_index) VALUES (?, ?, ?, ?, ?, ?)`,
+    ['a1', 't1', 0, 'planner agent', 'pending', 0],
+  );
+  await db.execute(
+    `INSERT INTO sessions (id, task_id, ordinal, name, status, parallel_index) VALUES (?, ?, ?, ?, ?, ?)`,
+    ['a2', 't1', 1, 'second planner', 'pending', 0],
+  );
+  return db;
+}
+
+const taskId = 't1' as TaskId;
+const agentA1 = 'a1' as SessionId;
+const agentA2 = 'a2' as SessionId;
+
+describe('session_plans queries', () => {
+  it('upsertPlan inserts a new plan and listPlansForSession returns it', async () => {
+    const db = await seedFixture();
+    await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'first plan',
+      bodyMd: 'body',
+      status: 'active',
+    });
+    const plans = await listPlansForSession(db, taskId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0]!.title).toBe('first plan');
+    expect(plans[0]!.bodyMd).toBe('body');
+    expect(plans[0]!.status).toBe('active');
+    expect(plans[0]!.agentId).toBe(agentA1);
+  });
+
+  it('upsertPlan on conflict replaces body and status (same session+agent)', async () => {
+    const db = await seedFixture();
+    await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'v1',
+      bodyMd: 'b1',
+      status: 'active',
+    });
+    await upsertPlan(db, {
+      id: 'p2' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'v2',
+      bodyMd: 'b2',
+      status: 'active',
+    });
+    const plans = await listPlansForSession(db, taskId);
+    expect(plans).toHaveLength(1);
+    expect(plans[0]!.title).toBe('v2');
+    expect(plans[0]!.bodyMd).toBe('b2');
+  });
+
+  it('different agents create separate rows (session has many plans, one per agent)', async () => {
+    const db = await seedFixture();
+    await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'a1 plan',
+      bodyMd: 'body1',
+      status: 'active',
+    });
+    await upsertPlan(db, {
+      id: 'p2' as PlanId,
+      sessionId: taskId,
+      agentId: agentA2,
+      title: 'a2 plan',
+      bodyMd: 'body2',
+      status: 'completed',
+    });
+    const plans = await listPlansForSession(db, taskId);
+    expect(plans).toHaveLength(2);
+  });
+
+  it('list returns most-recent first', async () => {
+    const db = await seedFixture();
+    await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'older',
+      bodyMd: '',
+      status: 'active',
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    await upsertPlan(db, {
+      id: 'p2' as PlanId,
+      sessionId: taskId,
+      agentId: agentA2,
+      title: 'newer',
+      bodyMd: '',
+      status: 'active',
+    });
+    const plans = await listPlansForSession(db, taskId);
+    expect(plans[0]!.title).toBe('newer');
+  });
+
+  it('updatePlanStatus changes the status', async () => {
+    const db = await seedFixture();
+    const plan = await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'x',
+      bodyMd: 'b',
+      status: 'active',
+    });
+    await updatePlanStatus(db, plan.id, 'completed');
+    const refreshed = await listPlansForSession(db, taskId);
+    expect(refreshed[0]!.status).toBe('completed');
+  });
+
+  it('updatePlanBody changes title and body', async () => {
+    const db = await seedFixture();
+    const plan = await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 'old',
+      bodyMd: 'b',
+      status: 'active',
+    });
+    await updatePlanBody(db, plan.id, 'new title', 'new body');
+    const refreshed = await listPlansForSession(db, taskId);
+    expect(refreshed[0]!.title).toBe('new title');
+    expect(refreshed[0]!.bodyMd).toBe('new body');
+  });
+
+  it('deletePlan removes the row', async () => {
+    const db = await seedFixture();
+    const plan = await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 't',
+      bodyMd: 'b',
+      status: 'active',
+    });
+    await deletePlan(db, plan.id);
+    const refreshed = await listPlansForSession(db, taskId);
+    expect(refreshed).toHaveLength(0);
+  });
+
+  it('cascades on task delete', async () => {
+    const db = await seedFixture();
+    await upsertPlan(db, {
+      id: 'p1' as PlanId,
+      sessionId: taskId,
+      agentId: agentA1,
+      title: 't',
+      bodyMd: 'b',
+      status: 'active',
+    });
+    await db.execute(`DELETE FROM tasks WHERE id = ?`, ['t1']);
+    const refreshed = await listPlansForSession(db, taskId);
+    expect(refreshed).toHaveLength(0);
+  });
+});

--- a/packages/db/src/queries/plan.ts
+++ b/packages/db/src/queries/plan.ts
@@ -1,0 +1,102 @@
+import type { IsoDateTime, Plan, PlanId, PlanStatus, SessionId, TaskId } from '@kay-am/types';
+import type { Database } from '../client';
+
+interface PlanRow {
+  id: string;
+  session_id: string;
+  agent_id: string;
+  title: string;
+  body_md: string;
+  status: string;
+  created_at: number;
+  updated_at: number;
+}
+
+function toDomain(row: PlanRow): Plan {
+  return {
+    id: row.id as PlanId,
+    sessionId: row.session_id as TaskId,
+    agentId: row.agent_id as SessionId,
+    title: row.title,
+    bodyMd: row.body_md,
+    status: row.status as PlanStatus,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function listPlansForSession(
+  db: Database,
+  sessionId: TaskId,
+): Promise<ReadonlyArray<Plan>> {
+  const rows = await db.select<PlanRow>(
+    `SELECT id, session_id, agent_id, title, body_md, status, created_at, updated_at
+     FROM session_plans
+     WHERE session_id = ?
+     ORDER BY updated_at DESC`,
+    [sessionId],
+  );
+  return rows.map(toDomain);
+}
+
+export interface UpsertPlanInput {
+  readonly id: PlanId;
+  readonly sessionId: TaskId;
+  readonly agentId: SessionId;
+  readonly title: string;
+  readonly bodyMd: string;
+  readonly status: PlanStatus;
+}
+
+export async function upsertPlan(db: Database, input: UpsertPlanInput): Promise<Plan> {
+  const now = Date.now();
+  await db.execute(
+    `INSERT INTO session_plans (id, session_id, agent_id, title, body_md, status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT (session_id, agent_id) DO UPDATE SET
+       title = excluded.title,
+       body_md = excluded.body_md,
+       status = excluded.status,
+       updated_at = excluded.updated_at`,
+    [input.id, input.sessionId, input.agentId, input.title, input.bodyMd, input.status, now, now],
+  );
+  const rows = await db.select<PlanRow>(
+    `SELECT id, session_id, agent_id, title, body_md, status, created_at, updated_at
+     FROM session_plans
+     WHERE session_id = ? AND agent_id = ?`,
+    [input.sessionId, input.agentId],
+  );
+  const row = rows[0];
+  if (!row) throw new Error(`plan upsert failed: ${input.sessionId} / ${input.agentId}`);
+  return toDomain(row);
+}
+
+export async function updatePlanStatus(
+  db: Database,
+  id: PlanId,
+  status: PlanStatus,
+): Promise<void> {
+  await db.execute(`UPDATE session_plans SET status = ?, updated_at = ? WHERE id = ?`, [
+    status,
+    Date.now(),
+    id,
+  ]);
+}
+
+export async function updatePlanBody(
+  db: Database,
+  id: PlanId,
+  title: string,
+  bodyMd: string,
+): Promise<void> {
+  await db.execute(`UPDATE session_plans SET title = ?, body_md = ?, updated_at = ? WHERE id = ?`, [
+    title,
+    bodyMd,
+    Date.now(),
+    id,
+  ]);
+}
+
+export async function deletePlan(db: Database, id: PlanId): Promise<void> {
+  await db.execute(`DELETE FROM session_plans WHERE id = ?`, [id]);
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -100,6 +100,7 @@ export type {
   DiffCommentSide,
   DiffCommentStatus,
 } from './diff-comment';
+export type { Plan, PlanId, PlanStatus } from './plan';
 export type {
   DiffHunk,
   DiffHunkLine,

--- a/packages/types/src/plan.ts
+++ b/packages/types/src/plan.ts
@@ -1,0 +1,16 @@
+import type { IsoDateTime, SessionId, TaskId } from './ids';
+
+export type PlanId = string & { readonly __brand: 'PlanId' };
+
+export type PlanStatus = 'active' | 'completed' | 'superseded';
+
+export type Plan = Readonly<{
+  id: PlanId;
+  sessionId: TaskId;
+  agentId: SessionId;
+  title: string;
+  bodyMd: string;
+  status: PlanStatus;
+  createdAt: IsoDateTime;
+  updatedAt: IsoDateTime;
+}>;


### PR DESCRIPTION
## Summary
- Plans become a first-class session artifact: planning agents wrap their final plan in `<<plan>>...<</plan>>` markers, the post-turn pipeline captures and upserts a row keyed by (session_id, agent_id).
- Right Context panel grows a Plans section: title + status badge + "by <agent>" caption, click to expand markdown body inline, click body to edit raw source.
- When a new agent is spawned in a session, the kickoff prompt is prefixed with the most recent plan, framed as "Active plan to execute:" or "completed... do NOT re-execute" depending on status.

## Data model
- New table `session_plans` (migration m027, additive `CREATE TABLE IF NOT EXISTS`).
- Columns: `id`, `session_id`, `agent_id`, `title`, `body_md`, `status`, `created_at`, `updated_at`.
- `UNIQUE (session_id, agent_id)` — one plan per (session, agent); re-planning by same agent upserts.
- `FOREIGN KEY session_id → tasks(id) ON DELETE CASCADE`, `agent_id → sessions(id) ON DELETE CASCADE`.
- Status enum: `active` | `completed` | `superseded`.
- `Plan` / `PlanId` / `PlanStatus` exported from `@kay-am/types`.

## Capture
- Marker `<<plan>>...<</plan>>` chosen to fit the existing `<<ctx-*>>` family in `packages/core/src/context/extractors.ts`. `Markdown` already renders generic `<<tag>>` callouts so it won't leak as raw text in chat.
- `extractPlanFromMarker(assistantText)` picks the LAST plan block in a turn (defends against multi-emission drift). Title = first non-empty line, leading `#`s stripped. Body = rest, trimmed.
- Planner system prompt extended in `apps/desktop/src/agent-kind.ts` to instruct emission of one `<<plan>>` block per turn.

## UI
- New `PlansSection` + `PlanRow` in `ContextPanel.tsx`, rendered between `NextActionChips` and the slots `<ul>`. Hidden when no plans (zero visual cost when unused).
- Each row: chevron + title (expand), status badge (toggle active ↔ completed), "by <agent>" caption.
- Expanded: markdown body via `@kay-am/ui` `Markdown`. Click body → textarea edit; blur commits, Esc cancels, Cmd/Ctrl+Enter commits.

## Propagation
- `spawnAgent` calls `buildPlanKickoffSection(taskId)` for the most-recent plan:
  - `active` → "Active plan to execute:" + body
  - `completed` → "The most recent plan in this session was completed and should NOT be re-executed. Provided for context only:" + body
  - `superseded` / none → omitted
- `composeKickoff(planSection, baseKickoff)` joins with the existing `stepPromptPrefix` / `initialPrompt`.

## Migration safety
Additive only. New table + index via `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`. No backfill. `db_wipe` already replays all migrations from m001.

## Out of scope
- Comments thread on plans (re-emit upserts).
- Multi-plan per agent (1:1 by design).
- Plan-to-plan dependency graph.
- Archive/restore UI.
- Auto-detect "looks like a plan" heuristics (marker only).
- "Save as plan" button.
- Per-plan history view.
- Telemetry / settings toggles.

## Test plan
- [ ] `pnpm -F @kay-am/core test` — `extractPlanFromMarker` cases pass.
- [ ] `pnpm -F @kay-am/db test` — `session_plans` queries pass (8 cases).
- [ ] `pnpm -F desktop test` — store tests still green (defensive plan loading in `setCurrentSession`).
- [ ] Manual: spawn planner, ask "plan the migration". Plans row appears with title + active badge.
- [ ] Manual: click row → expand. Click body → edit. Blur → save. Esc → cancel.
- [ ] Manual: toggle to completed. Spawn new agent → kickoff includes "completed... do NOT re-execute".
- [ ] Manual: toggle to active → kickoff includes "Active plan to execute:".
- [ ] Manual: planner emits second `<<plan>>` in later turn → upsert (no second row).
- [ ] Manual: delete task → plans cascade out.
