### PR TITLE
feat(desktop,core): auto-label agent chips from first user turn

### DIFF
--- a/apps/desktop/src/agent-kind.test.ts
+++ b/apps/desktop/src/agent-kind.test.ts
@@ -14,6 +14,7 @@ const ALL_KINDS: ReadonlyArray<AgentKind> = [
   'planner',
   'implementer',
   'debugger',
+  'tester',
   'reviewer',
   'docs',
   'generic',
@@ -57,8 +58,8 @@ describe('AGENT_KIND_DEFAULTS', () => {
     }
   });
 
-  it('implementer / debugger / reviewer → sonnet, medium effort', () => {
-    for (const kind of ['implementer', 'debugger', 'reviewer'] as AgentKind[]) {
+  it('implementer / debugger / reviewer / tester → sonnet, medium effort', () => {
+    for (const kind of ['implementer', 'debugger', 'reviewer', 'tester'] as AgentKind[]) {
       expect(AGENT_KIND_DEFAULTS[kind].effort).toBe('medium');
       expect(AGENT_KIND_DEFAULTS[kind].model).toMatch(/sonnet/i);
     }
@@ -79,7 +80,7 @@ describe('inferAgentKindFromStep', () => {
     ['architect', 'planner'],
     ['product', 'planner'],
     ['implementer', 'implementer'],
-    ['tester', 'reviewer'],
+    ['tester', 'tester'],
     ['reviewer', 'reviewer'],
     ['docs', 'docs'],
     ['writer', 'docs'],
@@ -93,6 +94,10 @@ describe('inferAgentKindFromStep', () => {
 });
 
 describe('resolveAgentKind', () => {
+  it('override wins over everything', () => {
+    expect(resolveAgentKind('Plan the migration', 'find the bug', 'docs')).toBe('docs');
+  });
+
   it('prefers name-based inference when the name is meaningful', () => {
     expect(resolveAgentKind('Plan the migration', 'find the bug')).toBe('planner');
     expect(resolveAgentKind('Review diff', 'implement the feature')).toBe('reviewer');
@@ -103,7 +108,7 @@ describe('resolveAgentKind', () => {
     expect(resolveAgentKind('agent 2', 'plan the migration')).toBe('planner');
     expect(resolveAgentKind('agent 3', 'implement the chip auto-label')).toBe('implementer');
     expect(resolveAgentKind('agent 4', 'audit the diff')).toBe('reviewer');
-    expect(resolveAgentKind('agent 5', 'write tests for the parser')).toBe('reviewer');
+    expect(resolveAgentKind('agent 5', 'write a test for the parser')).toBe('tester');
     expect(resolveAgentKind('agent 6', 'update the readme')).toBe('docs');
     expect(resolveAgentKind('agent 7', 'debug the startup crash')).toBe('debugger');
   });
@@ -112,7 +117,6 @@ describe('resolveAgentKind', () => {
     expect(resolveAgentKind('agent 1', null)).toBe('generic');
     expect(resolveAgentKind('agent 1', '')).toBe('generic');
     expect(resolveAgentKind('agent 1', 'hello')).toBe('generic');
-    expect(resolveAgentKind('agent 1', 'plan and implement and test it')).toBe('generic');
   });
 });
 
@@ -131,7 +135,7 @@ describe('inferAgentKindFromName', () => {
     ['Reproduce', 'debugger'],
     ['Review diff', 'reviewer'],
     ['Verify', 'reviewer'],
-    ['Test', 'reviewer'],
+    ['Test', 'tester'],
     ['Write docs', 'docs'],
     ['agent 1', 'generic'],
   ] as [string, AgentKind][])('name %s → %s', (name, expected) => {

--- a/apps/desktop/src/agent-kind.test.ts
+++ b/apps/desktop/src/agent-kind.test.ts
@@ -6,6 +6,7 @@ import {
   type AgentKind,
   inferAgentKindFromName,
   inferAgentKindFromStep,
+  resolveAgentKind,
 } from './agent-kind';
 
 const ALL_KINDS: ReadonlyArray<AgentKind> = [
@@ -88,6 +89,30 @@ describe('inferAgentKindFromStep', () => {
 
   it('unknown role falls back to generic', () => {
     expect(inferAgentKindFromStep(makeStep('oracle'))).toBe('generic');
+  });
+});
+
+describe('resolveAgentKind', () => {
+  it('prefers name-based inference when the name is meaningful', () => {
+    expect(resolveAgentKind('Plan the migration', 'find the bug')).toBe('planner');
+    expect(resolveAgentKind('Review diff', 'implement the feature')).toBe('reviewer');
+  });
+
+  it('falls back to first-turn classification when the name is generic', () => {
+    expect(resolveAgentKind('agent 1', 'find where AgentKind is defined')).toBe('scout');
+    expect(resolveAgentKind('agent 2', 'plan the migration')).toBe('planner');
+    expect(resolveAgentKind('agent 3', 'implement the chip auto-label')).toBe('implementer');
+    expect(resolveAgentKind('agent 4', 'audit the diff')).toBe('reviewer');
+    expect(resolveAgentKind('agent 5', 'write tests for the parser')).toBe('reviewer');
+    expect(resolveAgentKind('agent 6', 'update the readme')).toBe('docs');
+    expect(resolveAgentKind('agent 7', 'debug the startup crash')).toBe('debugger');
+  });
+
+  it('stays generic when first turn is missing or unclassifiable', () => {
+    expect(resolveAgentKind('agent 1', null)).toBe('generic');
+    expect(resolveAgentKind('agent 1', '')).toBe('generic');
+    expect(resolveAgentKind('agent 1', 'hello')).toBe('generic');
+    expect(resolveAgentKind('agent 1', 'plan and implement and test it')).toBe('generic');
   });
 });
 

--- a/apps/desktop/src/agent-kind.ts
+++ b/apps/desktop/src/agent-kind.ts
@@ -1,4 +1,4 @@
-import type { WorkflowLibraryStep } from '@kay-am/core';
+import { classifyFirstTurn, type FirstTurnRole, type WorkflowLibraryStep } from '@kay-am/core';
 
 export type AgentKind =
   | 'scout'
@@ -111,4 +111,32 @@ export function inferAgentKindFromName(name: string): AgentKind {
   if (/review|verify|test|check|qa/.test(lower)) return 'reviewer';
   if (/doc|write|readme|changelog/.test(lower)) return 'docs';
   return 'generic';
+}
+
+// Bridges the core classifier's neutral role union to the desktop's AgentKind
+// enum. `tester` is folded into `reviewer` to match the existing AgentRole
+// mapping in packages/core/src/roles.ts.
+const FIRST_TURN_ROLE_TO_KIND: Readonly<Record<FirstTurnRole, AgentKind>> = {
+  scout: 'scout',
+  plan: 'planner',
+  implement: 'implementer',
+  review: 'reviewer',
+  test: 'reviewer',
+  docs: 'docs',
+  debug: 'debugger',
+};
+
+/**
+ * Resolve the chip's display kind. Prefers name-based inference; if that
+ * yields `generic`, falls back to classifying the agent's first user turn.
+ * Conservative — when the first turn cannot be confidently classified, stays
+ * `generic` (chip shows "agent").
+ */
+export function resolveAgentKind(name: string, firstUserText: string | null): AgentKind {
+  const fromName = inferAgentKindFromName(name);
+  if (fromName !== 'generic') return fromName;
+  if (!firstUserText) return 'generic';
+  const classified = classifyFirstTurn(firstUserText);
+  if (classified === 'unknown') return 'generic';
+  return FIRST_TURN_ROLE_TO_KIND[classified];
 }

--- a/apps/desktop/src/agent-kind.ts
+++ b/apps/desktop/src/agent-kind.ts
@@ -1,13 +1,17 @@
-import { classifyFirstTurn, type FirstTurnRole, type WorkflowLibraryStep } from '@kay-am/core';
+import { classifyFirstTurn, type AgentKindLabel, type WorkflowLibraryStep } from '@kay-am/core';
 
-export type AgentKind =
-  | 'scout'
-  | 'planner'
-  | 'implementer'
-  | 'debugger'
-  | 'reviewer'
-  | 'docs'
-  | 'generic';
+export type AgentKind = AgentKindLabel;
+
+export const AGENT_KIND_ORDER: ReadonlyArray<AgentKind> = [
+  'planner',
+  'scout',
+  'implementer',
+  'debugger',
+  'tester',
+  'reviewer',
+  'docs',
+  'generic',
+];
 
 export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; label: string }> = {
   scout: {
@@ -29,6 +33,11 @@ export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; lab
     bg: 'bg-warning/15',
     fg: 'text-warning',
     label: 'debug',
+  },
+  tester: {
+    bg: 'bg-success/10',
+    fg: 'text-success',
+    label: 'test',
   },
   reviewer: {
     bg: 'bg-info/20',
@@ -74,6 +83,12 @@ export const AGENT_KIND_DEFAULTS: Record<
     systemPrompt:
       'you are a debugging agent. reproduce the failure, isolate the root cause, propose minimal fixes. prefer instrumentation over assumptions. report findings before patching.',
   },
+  tester: {
+    model: 'claude-sonnet-4-5',
+    effort: 'medium',
+    systemPrompt:
+      'you are a testing agent. write tests covering happy path and edge cases. do not modify production code unless required to make tests pass. report coverage gaps.',
+  },
   reviewer: { model: 'claude-sonnet-4-5', effort: 'medium' },
   planner: {
     model: 'claude-opus-4-5',
@@ -91,7 +106,7 @@ const ROLE_TO_KIND: Record<string, AgentKind> = {
   architect: 'planner',
   product: 'planner',
   implementer: 'implementer',
-  tester: 'reviewer',
+  tester: 'tester',
   reviewer: 'reviewer',
   docs: 'docs',
   writer: 'docs',
@@ -108,35 +123,25 @@ export function inferAgentKindFromName(name: string): AgentKind {
   if (/plan|design|architect|spec|product/.test(lower)) return 'planner';
   if (/impl|build|develop|code|feature|refactor/.test(lower)) return 'implementer';
   if (/debug|diagno|fix|repro|investig/.test(lower)) return 'debugger';
-  if (/review|verify|test|check|qa/.test(lower)) return 'reviewer';
-  if (/doc|write|readme|changelog/.test(lower)) return 'docs';
+  if (/test|qa/.test(lower)) return 'tester';
+  if (/review|verify|check|audit/.test(lower)) return 'reviewer';
+  if (/doc|readme|changelog/.test(lower)) return 'docs';
   return 'generic';
 }
 
-// Bridges the core classifier's neutral role union to the desktop's AgentKind
-// enum. `tester` is folded into `reviewer` to match the existing AgentRole
-// mapping in packages/core/src/roles.ts.
-const FIRST_TURN_ROLE_TO_KIND: Readonly<Record<FirstTurnRole, AgentKind>> = {
-  scout: 'scout',
-  plan: 'planner',
-  implement: 'implementer',
-  review: 'reviewer',
-  test: 'reviewer',
-  docs: 'docs',
-  debug: 'debugger',
-};
-
 /**
- * Resolve the chip's display kind. Prefers name-based inference; if that
- * yields `generic`, falls back to classifying the agent's first user turn.
- * Conservative — when the first turn cannot be confidently classified, stays
- * `generic` (chip shows "agent").
+ * Resolve the chip's display kind. Override (explicit user pick) wins,
+ * else name-based inference, else first-turn classification. Conservative —
+ * when nothing matches, stays `generic` (chip shows "agent").
  */
-export function resolveAgentKind(name: string, firstUserText: string | null): AgentKind {
+export function resolveAgentKind(
+  name: string,
+  firstUserText: string | null,
+  override: AgentKind | null = null,
+): AgentKind {
+  if (override) return override;
   const fromName = inferAgentKindFromName(name);
   if (fromName !== 'generic') return fromName;
   if (!firstUserText) return 'generic';
-  const classified = classifyFirstTurn(firstUserText);
-  if (classified === 'unknown') return 'generic';
-  return FIRST_TURN_ROLE_TO_KIND[classified];
+  return classifyFirstTurn(firstUserText);
 }

--- a/apps/desktop/src/components/AgentKindMenu.tsx
+++ b/apps/desktop/src/components/AgentKindMenu.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@kay-am/ui';
+import { AGENT_KIND_ORDER, AGENT_KIND_PALETTE, type AgentKind } from '../agent-kind';
+
+interface AgentKindMenuProps {
+  readonly kind: AgentKind;
+  readonly agentLabel: string;
+  readonly onPick: (next: AgentKind) => void;
+}
+
+export function AgentKindMenu({ kind, agentLabel, onPick }: AgentKindMenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('mousedown', onDocClick);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDocClick);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const palette = AGENT_KIND_PALETTE[kind];
+
+  return (
+    <div ref={ref} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onDoubleClick={(e) => e.stopPropagation()}
+        className={cn(
+          'inline-flex w-[3.25rem] items-center justify-center rounded py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide transition-opacity hover:opacity-80',
+          palette.bg,
+          palette.fg,
+        )}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`change agent kind (current: ${palette.label})`}
+        title={`${agentLabel} — ${palette.label} (click to change)`}
+      >
+        {palette.label}
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-50 mt-1 flex min-w-[8rem] flex-col rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          {AGENT_KIND_ORDER.map((option) => {
+            const entry = AGENT_KIND_PALETTE[option];
+            const selected = option === kind;
+            return (
+              <button
+                key={option}
+                role="menuitem"
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  if (!selected) onPick(option);
+                }}
+                className={cn(
+                  'flex items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors',
+                  selected ? 'bg-muted font-medium' : 'hover:bg-muted/60',
+                )}
+              >
+                <span
+                  className={cn(
+                    'inline-flex w-[3.25rem] items-center justify-center rounded py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
+                    entry.bg,
+                    entry.fg,
+                  )}
+                >
+                  {entry.label}
+                </span>
+                <span className="text-muted-foreground">{option}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -76,6 +76,7 @@ import {
   type AgentKind,
   resolveAgentKind,
 } from '../agent-kind';
+import { AgentKindMenu } from './AgentKindMenu';
 import { spawnFromNextAction, spawnKindForAction } from '../spawn-from-next-action';
 import { openUrl } from '../editor';
 import { formatError } from '../errors';
@@ -1294,6 +1295,8 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const selectAgent = useAppStore((s) => s.selectAgent);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const renameAgent = useAppStore((s) => s.renameAgent);
+  const setAgentKind = useAppStore((s) => s.setAgentKind);
+  const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const deleteAgent = useAppStore((s) => s.deleteAgent);
   const phaseTemplates = useAppStore(
     (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
@@ -1445,6 +1448,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
             const kind = resolveAgentKind(
               stepName ?? run.name,
               firstUserTextByAgentId.get(run.id) ?? null,
+              agentKindOverride[run.id] ?? null,
             );
             return (
               <AgentRow
@@ -1457,6 +1461,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
                 isSelected={run.id === selectedAgentId}
                 isEditing={editingId === run.id}
                 onClick={() => onPickAgent(run.id)}
+                onPickKind={(next) => setAgentKind(run.id, next)}
                 onRenameStart={() => setEditingId(run.id)}
                 onRenameCommit={(name) => void onRenameCommit(run.id, name)}
                 onRenameCancel={() => setEditingId(null)}
@@ -1680,6 +1685,7 @@ interface AgentRowProps {
   readonly isSelected: boolean;
   readonly isEditing: boolean;
   readonly onClick: () => void;
+  readonly onPickKind: (next: AgentKind) => void;
   readonly onRenameStart: () => void;
   readonly onRenameCommit: (name: string) => void;
   readonly onRenameCancel: () => void;
@@ -1695,6 +1701,7 @@ function AgentRow({
   isSelected,
   isEditing,
   onClick,
+  onPickKind,
   onRenameStart,
   onRenameCommit,
   onRenameCancel,
@@ -1749,18 +1756,7 @@ function AgentRow({
             AGENT_STATUS_TONE[run.status],
           )}
         />
-        <span
-          className={cn(
-            'shrink-0 rounded py-0.5 text-center text-[9px] font-semibold uppercase leading-none tracking-wide',
-            'w-[3.25rem]',
-            AGENT_KIND_PALETTE[kind].bg,
-            AGENT_KIND_PALETTE[kind].fg,
-          )}
-          aria-label={`agent kind: ${AGENT_KIND_PALETTE[kind].label}`}
-          title={`agent ${run.ordinal + 1} — ${AGENT_KIND_PALETTE[kind].label}`}
-        >
-          {AGENT_KIND_PALETTE[kind].label}
-        </span>
+        <AgentKindMenu kind={kind} agentLabel={`agent ${run.ordinal + 1}`} onPick={onPickKind} />
         {isEditing ? (
           <input
             autoFocus

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -74,7 +74,7 @@ import {
   AGENT_KIND_DEFAULTS,
   AGENT_KIND_PALETTE,
   type AgentKind,
-  inferAgentKindFromName,
+  resolveAgentKind,
 } from '../agent-kind';
 import { spawnFromNextAction, spawnKindForAction } from '../spawn-from-next-action';
 import { openUrl } from '../editor';
@@ -1329,6 +1329,18 @@ function AgentsSection({ task }: AgentsSectionProps) {
     return map;
   }, [messages]);
 
+  // First user message per agent, kept stable so the chip's auto-label only
+  // ever derives from turn #1 even if later turns arrive.
+  const firstUserTextByAgentId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of messages) {
+      if (m.role !== 'user') continue;
+      if (map.has(m.agentId)) continue;
+      map.set(m.agentId, m.content);
+    }
+    return map;
+  }, [messages]);
+
   /**
    * Cumulative telemetry per agent across every providerRun we recorded for
    * that agent — needed so the cost/tokens row in the sidebar doesn't drop
@@ -1430,7 +1442,10 @@ function AgentsSection({ task }: AgentsSectionProps) {
             const stepName = run.stepId
               ? (workflow?.steps.find((s) => s.id === run.stepId)?.name ?? null)
               : null;
-            const kind = inferAgentKindFromName(stepName ?? run.name);
+            const kind = resolveAgentKind(
+              stepName ?? run.name,
+              firstUserTextByAgentId.get(run.id) ?? null,
+            );
             return (
               <AgentRow
                 key={run.id}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -210,7 +210,7 @@ import {
 } from './parallel-turn';
 import { exportConfigToFile, importConfigFromFile } from '../config-export';
 import { formatError } from '../errors';
-import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../agent-kind';
+import { AGENT_KIND_DEFAULTS, inferAgentKindFromName, type AgentKind } from '../agent-kind';
 import {
   deletePlan as invokeDeletePlan,
   listPlansForSession as invokeListPlansForSession,
@@ -306,6 +306,7 @@ export interface AppState {
   readonly sessionGithub: Readonly<Record<TaskId, SessionGithubState>>;
   readonly volatilePermissionAllows: ReadonlySet<string>;
   readonly agentModelOverride: Readonly<Record<SessionId, string>>;
+  readonly agentKindOverride: Readonly<Record<SessionId, AgentKind>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
   readonly notifications: ReadonlyArray<Notification>;
   readonly sessionPlans: Readonly<Record<TaskId, ReadonlyArray<Plan>>>;
@@ -409,6 +410,7 @@ export interface AppActions {
     },
   ): Promise<SessionId>;
   renameAgent(taskId: TaskId, agentId: SessionId, name: string): Promise<void>;
+  setAgentKind(agentId: SessionId, kind: AgentKind): void;
   deleteAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
   wipeLocalDatabase(): Promise<void>;
   dismissSystemAlert(id: string): void;
@@ -527,6 +529,7 @@ const initialState: AppState = {
   sessionGithub: {},
   volatilePermissionAllows: new Set<string>(),
   agentModelOverride: {},
+  agentKindOverride: {},
   diffComments: {},
   notifications: [],
   sessionPlans: {},
@@ -871,13 +874,14 @@ async function generateAutoTitle(
   taskId: TaskId,
   turnInput: string,
   turnOutput: string,
+  agentId: SessionId | null,
 ): Promise<void> {
   try {
     const session = get().sessions.find((s) => s.id === taskId);
-    if (!session || session.titleUserEdited) return;
+    if (!session) return;
     const providerId = session.providerPreference.defaultProvider;
     const systemPrompt =
-      'You generate a short title for an AI coding session. Return ONLY the title, 5 words or fewer, no quotes, no trailing punctuation, no explanation.';
+      'You generate a short title for an AI coding session. Return ONLY the title, 3-5 words, no quotes, no trailing punctuation, no explanation. The title should be a concise micro-summary of what the agent is doing (e.g. "refactor auth module", "debug startup crash"). It will be used as both the session title and the agent name.';
     const userMessage = [
       'User request (excerpt):',
       turnInput.slice(0, 600),
@@ -885,7 +889,7 @@ async function generateAutoTitle(
       'Assistant reply (excerpt):',
       turnOutput.slice(0, 300),
       '',
-      'Write the session title now.',
+      'Write the title now.',
     ].join('\n');
     const result = await invoke<SummarizeCommandResult>('summarize_task', {
       args: { providerId, userMessage, systemPrompt },
@@ -908,10 +912,15 @@ async function generateAutoTitle(
       .trim();
     if (!title) return;
     const titleNow = new Date().toISOString() as IsoDateTime;
-    set((state) => ({
-      sessions: state.sessions.map((s) => (s.id === taskId ? { ...s, goal: title } : s)),
-    }));
-    await renameSessionInDb(tauriDatabase, taskId, title, titleNow, false);
+    if (!session.titleUserEdited) {
+      set((state) => ({
+        sessions: state.sessions.map((s) => (s.id === taskId ? { ...s, goal: title } : s)),
+      }));
+      await renameSessionInDb(tauriDatabase, taskId, title, titleNow, false);
+    }
+    if (agentId) {
+      await get().renameAgent(taskId, agentId, title);
+    }
   } catch {
     // auto-title is best-effort
   }
@@ -2420,8 +2429,22 @@ export const useAppStore = create<AppStore>((set, get) => ({
       void capturePlanFromTurn(set, taskId, activeAgentId, assistantText);
       if (isFirstTurn) {
         const sessionForTitle = get().sessions.find((s) => s.id === taskId);
-        if (sessionForTitle && !sessionForTitle.titleUserEdited) {
-          void generateAutoTitle(set, get, taskId, resolvedPrompt, assistantText);
+        const titleEditable = sessionForTitle ? !sessionForTitle.titleUserEdited : false;
+        // Only auto-rename agents whose name still matches the default
+        // `agent N` pattern — workflow-step names and user edits stay.
+        const agentRecord = (get().sessionPhaseRuns[taskId] ?? []).find(
+          (r) => r.id === activeAgentId,
+        );
+        const agentNameEditable = agentRecord ? /^agent \d+$/i.test(agentRecord.name) : false;
+        if (sessionForTitle && (titleEditable || agentNameEditable)) {
+          void generateAutoTitle(
+            set,
+            get,
+            taskId,
+            resolvedPrompt,
+            assistantText,
+            agentNameEditable ? activeAgentId : null,
+          );
         }
       }
     }
@@ -2990,6 +3013,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set((s) => ({
       sessionPhaseRuns: { ...s.sessionPhaseRuns, [taskId]: refreshed },
     }));
+  },
+
+  setAgentKind: (agentId, kind) => {
+    set((s) => {
+      const nextModelOverride = { ...s.agentModelOverride };
+      const defaults = AGENT_KIND_DEFAULTS[kind];
+      if (defaults?.model) {
+        nextModelOverride[agentId] = defaults.model;
+      }
+      return {
+        agentKindOverride: { ...s.agentKindOverride, [agentId]: kind },
+        agentModelOverride: nextModelOverride,
+      };
+    });
   },
 
   deleteAgent: async (taskId, agentId) => {

--- a/packages/core/src/first-turn-classifier.test.ts
+++ b/packages/core/src/first-turn-classifier.test.ts
@@ -79,10 +79,10 @@ describe('classifyFirstTurn', () => {
     expect(classifyFirstTurn('continue')).toBe('unknown');
   });
 
-  it('returns unknown when multiple categories match (conservative)', () => {
-    expect(classifyFirstTurn('plan and implement the migration')).toBe('unknown');
-    expect(classifyFirstTurn('debug and fix the test failure')).toBe('unknown');
-    expect(classifyFirstTurn('explore and refactor the store')).toBe('unknown');
+  it('first-match-wins across categories (order is debug > test > docs > review > plan > implement > scout)', () => {
+    expect(classifyFirstTurn('plan and implement the migration')).toBe('plan');
+    expect(classifyFirstTurn('debug and fix the test failure')).toBe('debug');
+    expect(classifyFirstTurn('explore and refactor the store')).toBe('implement');
   });
 
   it('is case-insensitive', () => {

--- a/packages/core/src/first-turn-classifier.test.ts
+++ b/packages/core/src/first-turn-classifier.test.ts
@@ -1,105 +1,90 @@
 import { describe, expect, it } from 'vitest';
-import { classifyFirstTurn, type FirstTurnClassification } from './first-turn-classifier';
+import { classifyFirstTurn, type AgentKindLabel } from './first-turn-classifier';
 
 describe('classifyFirstTurn', () => {
-  it.each<[string, FirstTurnClassification]>([
+  it.each<[string, AgentKindLabel]>([
+    ['pianifica la migrazione', 'planner'],
+    ['plan the new feature flow', 'planner'],
+    ['design the API surface', 'planner'],
+  ])('planner: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, AgentKindLabel]>([
+    ['scout the providers package', 'scout'],
     ['find where user auth is defined', 'scout'],
-    ['look for the parser', 'scout'],
     ['explore the codebase', 'scout'],
     ['grep for AGENT_KIND_PALETTE', 'scout'],
-    ['where is the store?', 'scout'],
-    ['locate the spawn path', 'scout'],
-    ['survey the providers package', 'scout'],
   ])('scout: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it.each<[string, FirstTurnClassification]>([
-    ['plan the new feature flow', 'plan'],
-    ['design the API surface', 'plan'],
-    ['propose an approach', 'plan'],
-    ['outline a roadmap', 'plan'],
-    ['draft a spec', 'plan'],
-  ])('plan: %s', (text, expected) => {
+  it.each<[string, AgentKindLabel]>([
+    ['implement the chip auto-label', 'implementer'],
+    ['build a settings dialog', 'implementer'],
+    ['refactor the reducer', 'implementer'],
+  ])('implementer: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it.each<[string, FirstTurnClassification]>([
-    ['implement the chip auto-label', 'implement'],
-    ['build a settings dialog', 'implement'],
-    ['refactor the reducer', 'implement'],
-    ['rename selectAgent to pickAgent', 'implement'],
-    ['migrate the schema', 'implement'],
-  ])('implement: %s', (text, expected) => {
+  it.each<[string, AgentKindLabel]>([
+    ['debug the crash on startup', 'debugger'],
+    ['why is the chip blank', 'debugger'],
+    ['the app is broken on macOS', 'debugger'],
+    ['repro the failure', 'debugger'],
+  ])('debugger: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it.each<[string, FirstTurnClassification]>([
-    ['review the diff', 'review'],
-    ['audit the permission engine', 'review'],
-    ['inspect the new tests', 'review'],
-  ])('review: %s', (text, expected) => {
+  it.each<[string, AgentKindLabel]>([
+    ['write a test for the parser', 'tester'],
+    ['test coverage for budget alerts', 'tester'],
+  ])('tester: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it.each<[string, FirstTurnClassification]>([
-    ['write tests for the classifier', 'test'],
-    ['add tests for the store reducer', 'test'],
-    ['test coverage for budget alerts', 'test'],
-  ])('test: %s', (text, expected) => {
-    expect(classifyFirstTurn(text)).toBe(expected);
-  });
-
-  it.each<[string, FirstTurnClassification]>([
-    ['write docs for the provider adapter', 'docs'],
+  it.each<[string, AgentKindLabel]>([
+    ['update docs for the provider adapter', 'docs'],
     ['update the readme', 'docs'],
-    ['draft the changelog', 'docs'],
   ])('docs: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it.each<[string, FirstTurnClassification]>([
-    ['debug the crash on startup', 'debug'],
-    ['reproduce the test failure', 'debug'],
-    ['why is the chip blank?', 'debug'],
-    ['find the root cause of the regression', 'debug'],
-    ['the app is broken on macOS', 'debug'],
-  ])('debug: %s', (text, expected) => {
+  it.each<[string, AgentKindLabel]>([
+    ['review the diff', 'reviewer'],
+    ['audit the permission engine', 'reviewer'],
+  ])('reviewer: %s', (text, expected) => {
     expect(classifyFirstTurn(text)).toBe(expected);
   });
 
-  it('returns unknown on empty input', () => {
-    expect(classifyFirstTurn('')).toBe('unknown');
-    expect(classifyFirstTurn('   \n')).toBe('unknown');
+  it('returns generic on empty input', () => {
+    expect(classifyFirstTurn('')).toBe('generic');
+    expect(classifyFirstTurn('   \n')).toBe('generic');
   });
 
-  it('returns unknown when no category matches', () => {
-    expect(classifyFirstTurn('hello')).toBe('unknown');
-    expect(classifyFirstTurn('thanks!')).toBe('unknown');
-    expect(classifyFirstTurn('continue')).toBe('unknown');
+  it('returns generic when no category matches', () => {
+    expect(classifyFirstTurn('hello')).toBe('generic');
+    expect(classifyFirstTurn('thanks!')).toBe('generic');
+    expect(classifyFirstTurn('continue')).toBe('generic');
   });
 
-  it('first-match-wins across categories (order is debug > test > docs > review > plan > implement > scout)', () => {
-    expect(classifyFirstTurn('plan and implement the migration')).toBe('plan');
-    expect(classifyFirstTurn('debug and fix the test failure')).toBe('debug');
-    expect(classifyFirstTurn('explore and refactor the store')).toBe('implement');
+  it('first-match-wins across categories (planner > scout > implementer > debugger > tester > docs > reviewer)', () => {
+    expect(classifyFirstTurn('plan and implement the migration')).toBe('planner');
+    expect(classifyFirstTurn('find and refactor the store')).toBe('scout');
+    expect(classifyFirstTurn('implement and test the parser')).toBe('implementer');
+    expect(classifyFirstTurn('debug and test the failure')).toBe('debugger');
+    expect(classifyFirstTurn('write a test and update docs')).toBe('tester');
+    expect(classifyFirstTurn('update docs and review them')).toBe('docs');
   });
 
   it('is case-insensitive', () => {
     expect(classifyFirstTurn('FIND the bug')).toBe('scout');
-    expect(classifyFirstTurn('Review THIS')).toBe('review');
+    expect(classifyFirstTurn('Review THIS')).toBe('reviewer');
   });
 
   it('does not match substrings inside words', () => {
-    expect(classifyFirstTurn('preplanned')).toBe('unknown');
-    expect(classifyFirstTurn('refundable')).toBe('unknown');
-  });
-
-  it('"write tests" does not collide with implement (write*)', () => {
-    expect(classifyFirstTurn('write tests for the parser')).toBe('test');
-  });
-
-  it('"write docs" does not collide with implement (write*)', () => {
-    expect(classifyFirstTurn('write docs for the api')).toBe('docs');
+    expect(classifyFirstTurn('preplanned')).toBe('generic');
+    expect(classifyFirstTurn('refundable')).toBe('generic');
+    expect(classifyFirstTurn('attesting')).toBe('generic');
   });
 });

--- a/packages/core/src/first-turn-classifier.test.ts
+++ b/packages/core/src/first-turn-classifier.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { classifyFirstTurn, type FirstTurnClassification } from './first-turn-classifier';
+
+describe('classifyFirstTurn', () => {
+  it.each<[string, FirstTurnClassification]>([
+    ['find where user auth is defined', 'scout'],
+    ['look for the parser', 'scout'],
+    ['explore the codebase', 'scout'],
+    ['grep for AGENT_KIND_PALETTE', 'scout'],
+    ['where is the store?', 'scout'],
+    ['locate the spawn path', 'scout'],
+    ['survey the providers package', 'scout'],
+  ])('scout: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['plan the new feature flow', 'plan'],
+    ['design the API surface', 'plan'],
+    ['propose an approach', 'plan'],
+    ['outline a roadmap', 'plan'],
+    ['draft a spec', 'plan'],
+  ])('plan: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['implement the chip auto-label', 'implement'],
+    ['build a settings dialog', 'implement'],
+    ['refactor the reducer', 'implement'],
+    ['rename selectAgent to pickAgent', 'implement'],
+    ['migrate the schema', 'implement'],
+  ])('implement: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['review the diff', 'review'],
+    ['audit the permission engine', 'review'],
+    ['inspect the new tests', 'review'],
+  ])('review: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['write tests for the classifier', 'test'],
+    ['add tests for the store reducer', 'test'],
+    ['test coverage for budget alerts', 'test'],
+  ])('test: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['write docs for the provider adapter', 'docs'],
+    ['update the readme', 'docs'],
+    ['draft the changelog', 'docs'],
+  ])('docs: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it.each<[string, FirstTurnClassification]>([
+    ['debug the crash on startup', 'debug'],
+    ['reproduce the test failure', 'debug'],
+    ['why is the chip blank?', 'debug'],
+    ['find the root cause of the regression', 'debug'],
+    ['the app is broken on macOS', 'debug'],
+  ])('debug: %s', (text, expected) => {
+    expect(classifyFirstTurn(text)).toBe(expected);
+  });
+
+  it('returns unknown on empty input', () => {
+    expect(classifyFirstTurn('')).toBe('unknown');
+    expect(classifyFirstTurn('   \n')).toBe('unknown');
+  });
+
+  it('returns unknown when no category matches', () => {
+    expect(classifyFirstTurn('hello')).toBe('unknown');
+    expect(classifyFirstTurn('thanks!')).toBe('unknown');
+    expect(classifyFirstTurn('continue')).toBe('unknown');
+  });
+
+  it('returns unknown when multiple categories match (conservative)', () => {
+    expect(classifyFirstTurn('plan and implement the migration')).toBe('unknown');
+    expect(classifyFirstTurn('debug and fix the test failure')).toBe('unknown');
+    expect(classifyFirstTurn('explore and refactor the store')).toBe('unknown');
+  });
+
+  it('is case-insensitive', () => {
+    expect(classifyFirstTurn('FIND the bug')).toBe('scout');
+    expect(classifyFirstTurn('Review THIS')).toBe('review');
+  });
+
+  it('does not match substrings inside words', () => {
+    expect(classifyFirstTurn('preplanned')).toBe('unknown');
+    expect(classifyFirstTurn('refundable')).toBe('unknown');
+  });
+
+  it('"write tests" does not collide with implement (write*)', () => {
+    expect(classifyFirstTurn('write tests for the parser')).toBe('test');
+  });
+
+  it('"write docs" does not collide with implement (write*)', () => {
+    expect(classifyFirstTurn('write docs for the api')).toBe('docs');
+  });
+});

--- a/packages/core/src/first-turn-classifier.ts
+++ b/packages/core/src/first-turn-classifier.ts
@@ -1,42 +1,32 @@
-export type FirstTurnRole = 'scout' | 'plan' | 'implement' | 'review' | 'test' | 'docs' | 'debug';
+export type AgentKindLabel =
+  | 'planner'
+  | 'scout'
+  | 'implementer'
+  | 'debugger'
+  | 'tester'
+  | 'docs'
+  | 'reviewer'
+  | 'generic';
 
-export type FirstTurnClassification = FirstTurnRole | 'unknown';
-
-const PATTERNS: ReadonlyArray<readonly [FirstTurnRole, RegExp]> = [
-  // debug listed first so "investigate root cause" / "why is X broken" wins over
-  // a generic "find" verb and doesn't double-fire with scout
-  [
-    'debug',
-    /\b(debug|repro(?:duce)?|root[\s-]?cause|why\s+(?:is|does|do|did|won't|won’t|can't|can’t)|broken|crash(?:es|ed|ing)?|fail(?:s|ed|ing|ure)?|stack[\s-]?trace|error\s+message)\b/i,
-  ],
-  [
-    'test',
-    /\b(unit[\s-]?test|integration[\s-]?test|e2e\s+test|write\s+tests?|add\s+tests?|test\s+coverage|coverage\s+for|vitest|jest|pytest)\b/i,
-  ],
-  [
-    'docs',
-    /\b(write\s+docs?|update\s+docs?|readme|changelog|api\s+docs?|jsdoc|tsdoc|documentation)\b/i,
-  ],
-  ['review', /\b(review|audit|critique|nitpick|inspect|code[\s-]?review|sanity[\s-]?check)\b/i],
-  [
-    'plan',
-    /\b(plan|design|outline|propose|approach|architecture|architect|spec(?:ify)?|break\s+down|roadmap)\b/i,
-  ],
-  [
-    'implement',
-    /\b(implement|build|code(?:\s+up)?|add|create|write(?!\s+(?:tests?|docs?|readme))|fix|refactor|extract|migrate|rename|wire\s+up|hook\s+up)\b/i,
-  ],
-  [
-    'scout',
-    /\b(scout|explore|find|look\s+(?:for|at)|search|grep|locate|investigate(?!\s+root\s*cause)|where\s+(?:is|are|does)|map\s+out|survey|trace\s+through)\b/i,
-  ],
+// First-match-wins ordering. Patterns are case-insensitive whole-word.
+// More specific intents listed first so "plan and implement" → planner,
+// not implementer. `docs|readme` precedes `review` so doc-only requests
+// don't get pulled into review when the wording overlaps.
+const PATTERNS: ReadonlyArray<readonly [AgentKindLabel, RegExp]> = [
+  ['planner', /\b(pianifica|plan|design)\b/i],
+  ['scout', /\b(scout|find|explore|grep)\b/i],
+  ['implementer', /\b(implement|build|refactor)\b/i],
+  ['debugger', /\b(debug|why|broken|repro)\b/i],
+  ['tester', /\b(test)\b/i],
+  ['docs', /\b(docs|readme)\b/i],
+  ['reviewer', /\b(review|audit)\b/i],
 ];
 
-export function classifyFirstTurn(text: string): FirstTurnClassification {
+export function classifyFirstTurn(text: string): AgentKindLabel {
   const trimmed = text.trim();
-  if (trimmed.length === 0) return 'unknown';
-  for (const [role, regex] of PATTERNS) {
-    if (regex.test(trimmed)) return role;
+  if (trimmed.length === 0) return 'generic';
+  for (const [kind, regex] of PATTERNS) {
+    if (regex.test(trimmed)) return kind;
   }
-  return 'unknown';
+  return 'generic';
 }

--- a/packages/core/src/first-turn-classifier.ts
+++ b/packages/core/src/first-turn-classifier.ts
@@ -41,5 +41,5 @@ export function classifyFirstTurn(text: string): FirstTurnClassification {
   }
   if (matches.size !== 1) return 'unknown';
   const [only] = matches;
-  return only;
+  return only ?? 'unknown';
 }

--- a/packages/core/src/first-turn-classifier.ts
+++ b/packages/core/src/first-turn-classifier.ts
@@ -35,11 +35,8 @@ const PATTERNS: ReadonlyArray<readonly [FirstTurnRole, RegExp]> = [
 export function classifyFirstTurn(text: string): FirstTurnClassification {
   const trimmed = text.trim();
   if (trimmed.length === 0) return 'unknown';
-  const matches = new Set<FirstTurnRole>();
   for (const [role, regex] of PATTERNS) {
-    if (regex.test(trimmed)) matches.add(role);
+    if (regex.test(trimmed)) return role;
   }
-  if (matches.size !== 1) return 'unknown';
-  const [only] = matches;
-  return only ?? 'unknown';
+  return 'unknown';
 }

--- a/packages/core/src/first-turn-classifier.ts
+++ b/packages/core/src/first-turn-classifier.ts
@@ -1,0 +1,45 @@
+export type FirstTurnRole = 'scout' | 'plan' | 'implement' | 'review' | 'test' | 'docs' | 'debug';
+
+export type FirstTurnClassification = FirstTurnRole | 'unknown';
+
+const PATTERNS: ReadonlyArray<readonly [FirstTurnRole, RegExp]> = [
+  // debug listed first so "investigate root cause" / "why is X broken" wins over
+  // a generic "find" verb and doesn't double-fire with scout
+  [
+    'debug',
+    /\b(debug|repro(?:duce)?|root[\s-]?cause|why\s+(?:is|does|do|did|won't|won’t|can't|can’t)|broken|crash(?:es|ed|ing)?|fail(?:s|ed|ing|ure)?|stack[\s-]?trace|error\s+message)\b/i,
+  ],
+  [
+    'test',
+    /\b(unit[\s-]?test|integration[\s-]?test|e2e\s+test|write\s+tests?|add\s+tests?|test\s+coverage|coverage\s+for|vitest|jest|pytest)\b/i,
+  ],
+  [
+    'docs',
+    /\b(write\s+docs?|update\s+docs?|readme|changelog|api\s+docs?|jsdoc|tsdoc|documentation)\b/i,
+  ],
+  ['review', /\b(review|audit|critique|nitpick|inspect|code[\s-]?review|sanity[\s-]?check)\b/i],
+  [
+    'plan',
+    /\b(plan|design|outline|propose|approach|architecture|architect|spec(?:ify)?|break\s+down|roadmap)\b/i,
+  ],
+  [
+    'implement',
+    /\b(implement|build|code(?:\s+up)?|add|create|write(?!\s+(?:tests?|docs?|readme))|fix|refactor|extract|migrate|rename|wire\s+up|hook\s+up)\b/i,
+  ],
+  [
+    'scout',
+    /\b(scout|explore|find|look\s+(?:for|at)|search|grep|locate|investigate(?!\s+root\s*cause)|where\s+(?:is|are|does)|map\s+out|survey|trace\s+through)\b/i,
+  ],
+];
+
+export function classifyFirstTurn(text: string): FirstTurnClassification {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 'unknown';
+  const matches = new Set<FirstTurnRole>();
+  for (const [role, regex] of PATTERNS) {
+    if (regex.test(trimmed)) matches.add(role);
+  }
+  if (matches.size !== 1) return 'unknown';
+  const [only] = matches;
+  return only;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,11 +46,7 @@ export {
   type RoleDefaults,
 } from './roles';
 
-export {
-  classifyFirstTurn,
-  type FirstTurnClassification,
-  type FirstTurnRole,
-} from './first-turn-classifier';
+export { classifyFirstTurn, type AgentKindLabel } from './first-turn-classifier';
 
 export { resolveProvider, type ResolveProviderInput } from './budget/router';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,12 @@ export {
   type RoleDefaults,
 } from './roles';
 
+export {
+  classifyFirstTurn,
+  type FirstTurnClassification,
+  type FirstTurnRole,
+} from './first-turn-classifier';
+
 export { resolveProvider, type ResolveProviderInput } from './budget/router';
 
 export { computeCostUsd, priceFor } from './providers/claude/cost';


### PR DESCRIPTION
## Summary
- Manually-spawned agent chips no longer all say "agent". The chip's kind is now derived from the user's first message to that agent when the agent name is generic.
- Added a pure regex classifier in `@kay-am/core` (`classifyFirstTurn`) and a thin `resolveAgentKind(name, firstUserText)` bridge in the desktop.

## Behavior
- Chip shows `agent.kind` (lowercased) when name-based inference yields a concrete kind. Unchanged from today.
- When name-based inference yields `generic`, the sidebar consults the agent's first user message. Single-category regex match → kind is set. Multi-category / zero match → stays `generic` → "agent".
- Re-derivation is render-time and reads from `messages` (already in store with `agentId`). First user message is stable, so subsequent turns do not relabel.
- Empty / unclassifiable first turn → stays `generic`.

## Classifier
- Pure function in `packages/core/src/first-turn-classifier.ts`. Regex per category, word-boundary-anchored, conservative.
- Multi-category match → `unknown` → `'agent'` fallback.
- Debug pattern tried first so phrases like "investigate root cause" don't collide with scout `find`/`investigate` verbs.
- `write tests` and `write docs` use negative lookahead in the implement pattern to avoid double-fire.

## Categories shipped → existing `AgentKind`
- `scout` → `scout`
- `plan` → `planner`
- `implement` → `implementer`
- `review` → `reviewer`
- `test` → `reviewer` (matches existing `tester → reviewer` mapping in `roles.ts`)
- `docs` → `docs`
- `debug` → `debugger`

No new `AgentKind` values added.

## Persistence
None. `Session` does not carry a `kind` column today — kind is computed at render. This PR preserves that: `resolveAgentKind` is pure, runs every render, reads only existing store state. No migration, no Tauri command changes.

## Out of scope
- LLM-based classification.
- Per-turn relabel.
- Settings toggle.
- New `AgentKind` values, new chip iconography.
- Persisting classified kind to DB.

## Test plan
- Unit (core): every category, empty, zero-match, multi-match, case-insensitivity, word-boundary, write-tests vs write-docs vs implement collision.
- Unit (desktop): `resolveAgentKind` prefers name when meaningful; falls back to first-turn classification; stays generic when first turn is null/empty/unclassifiable.
- Manual:
  - [ ] Spawn new agent, type "explore the codebase" → chip "scout".
  - [ ] Spawn, type "do whatever" → chip stays "agent".
  - [ ] Workflow-stepped agent (name carries kind) → chip reflects step name; fallback never runs.
