### PR TITLE
feat(desktop,core): suggest lighter model on light first turn

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -16,7 +16,7 @@ import type {
   TaskId,
   TurnProviderOverride,
 } from '@kay-am/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@kay-am/core';
+import { PROVIDER_CAPABILITIES, assessTurnWeight, getDefaultTurnModel } from '@kay-am/core';
 import { useShallow } from 'zustand/react/shallow';
 import { EMPTY_ARRAY, useAppStore } from '../../store';
 import { formatError } from '../../errors';
@@ -24,10 +24,11 @@ import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
 import { type VerbosityLevel, readVerbosity, writeVerbosity } from '../../verbosity';
-import { EFFORT_LEVELS, type EffortLevel } from './chat-constants';
+import { EFFORT_LEVELS, type EffortLevel, suggestLighterModel } from './chat-constants';
 import { ProviderUsagePill } from './ProviderUsagePill';
 import { ModelPicker } from './ModelPicker';
 import { PermissionModePicker } from './PermissionModePicker';
+import { RightSizeCard } from './RightSizeCard';
 import { STORAGE_PREFIXES } from '../../storage-keys';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
@@ -157,6 +158,9 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const agentModelOverride = useAppStore((s) =>
     selectedAgentId ? (s.agentModelOverride[selectedAgentId] ?? null) : null,
   );
+  const isFirstTurnForAgent = useAppStore((s) =>
+    selectedAgentId ? (s.agentRunHistory[selectedAgentId]?.length ?? 0) === 0 : false,
+  );
   const isRunning = RUNNING_KINDS.has(selectedAgentState?.kind ?? session.state.kind);
   const wasRunning = useRef(isRunning);
   interface QueuedTurn {
@@ -164,6 +168,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     readonly override: TurnProviderOverride | undefined;
   }
   const [queued, setQueued] = useState<QueuedTurn | null>(null);
+  const [rightSizePending, setRightSizePending] = useState<string | null>(null);
+  const [rightSizeDismissed, setRightSizeDismissed] = useState(false);
   const canSend = !providerDisconnected && value.trim().length > 0;
   const allowOverride = session.providerPreference.allowTurnOverride;
   const defaultProvider = session.providerPreference.defaultProvider;
@@ -257,17 +263,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     [sendTurn, session.id, showToast],
   );
 
-  const onSend = async () => {
-    const content = value.trim();
-    if (!content || providerDisconnected) return;
-    setError(null);
-    setValue('');
-
+  const sendWith = async (content: string, modelOverrideId: string | null) => {
+    const useModel = modelOverrideId ?? (modelChanged ? effectiveModel : null);
     const override: TurnProviderOverride | undefined =
-      allowOverride && (providerChanged || modelChanged)
+      allowOverride && (providerChanged || useModel !== null)
         ? {
             providerId: effectiveProvider,
-            ...(modelChanged ? { model: effectiveModel } : {}),
+            ...(useModel !== null ? { model: useModel } : {}),
           }
         : undefined;
 
@@ -277,6 +279,44 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     }
 
     await dispatchTurn(content, override);
+  };
+
+  const onSend = async () => {
+    const content = value.trim();
+    if (!content || providerDisconnected) return;
+    setError(null);
+
+    if (allowOverride && !isRunning && rightSizeSuggested !== null && rightSizePending === null) {
+      setRightSizePending(content);
+      return;
+    }
+
+    setValue('');
+    await sendWith(content, null);
+  };
+
+  const onUseSuggested = async () => {
+    const content = rightSizePending;
+    if (content === null) return;
+    const suggested = rightSizeSuggested;
+    setRightSizePending(null);
+    setRightSizeDismissed(true);
+    setValue('');
+    await sendWith(content, suggested);
+  };
+
+  const onKeepCurrent = async () => {
+    const content = rightSizePending;
+    if (content === null) return;
+    setRightSizePending(null);
+    setRightSizeDismissed(true);
+    setValue('');
+    await sendWith(content, null);
+  };
+
+  const onChangeModel = () => {
+    setRightSizePending(null);
+    setRightSizeDismissed(true);
   };
 
   useEffect(() => {
@@ -295,6 +335,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     lastAgentIdRef.current = selectedAgentId;
     setSelectedProvider(null);
     setSelectedModel(null);
+    setRightSizePending(null);
+    setRightSizeDismissed(false);
   }, [selectedAgentId]);
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -323,6 +365,19 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     if (effectiveModel) ids.add(effectiveModel);
     return Array.from(ids);
   }, [providerModels, effectiveModel]);
+
+  const rightSizeSuggested = useMemo<string | null>(() => {
+    if (!isFirstTurnForAgent || rightSizeDismissed) return null;
+    const weight = assessTurnWeight(value);
+    if (weight !== 'light') return null;
+    return suggestLighterModel(effectiveModel, modelCandidates);
+  }, [isFirstTurnForAgent, rightSizeDismissed, value, effectiveModel, modelCandidates]);
+
+  useEffect(() => {
+    if (rightSizePending !== null && rightSizeSuggested === null) {
+      setRightSizePending(null);
+    }
+  }, [rightSizePending, rightSizeSuggested]);
 
   return (
     <div className="px-10 py-3">
@@ -375,6 +430,15 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             />
           </div>
         </div>
+        {rightSizePending !== null && rightSizeSuggested !== null ? (
+          <RightSizeCard
+            currentModel={effectiveModel}
+            suggestedModel={rightSizeSuggested}
+            onUseSuggested={() => void onUseSuggested()}
+            onKeepCurrent={() => void onKeepCurrent()}
+            onChangeModel={onChangeModel}
+          />
+        ) : null}
         <div className="relative" ref={wrapperRef}>
           {showPopover && isSlashMode ? (
             <SlashCommandPopover

--- a/apps/desktop/src/components/chat/RightSizeCard.tsx
+++ b/apps/desktop/src/components/chat/RightSizeCard.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useRef } from 'react';
+import { cn } from '@kay-am/ui';
+import { modelLabel, modelTier, TIER_TEXT } from './chat-constants';
+
+export interface RightSizeCardProps {
+  readonly currentModel: string;
+  readonly suggestedModel: string;
+  readonly onUseSuggested: () => void;
+  readonly onKeepCurrent: () => void;
+  readonly onChangeModel: () => void;
+}
+
+export function RightSizeCard({
+  currentModel,
+  suggestedModel,
+  onUseSuggested,
+  onKeepCurrent,
+  onChangeModel,
+}: RightSizeCardProps) {
+  const suggestBtnRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    suggestBtnRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      className="rounded border border-info/40 bg-info/10 px-2.5 py-2 text-[11px]"
+      data-testid="right-size-card"
+      aria-label="model right-sizing suggestion"
+    >
+      <p className="mb-2 text-foreground">
+        This looks light. Run with{' '}
+        <span className={cn('font-semibold', TIER_TEXT[modelTier(suggestedModel)])}>
+          {modelLabel(suggestedModel)}
+        </span>{' '}
+        instead of{' '}
+        <span className={cn('font-semibold', TIER_TEXT[modelTier(currentModel)])}>
+          {modelLabel(currentModel)}
+        </span>
+        ?
+      </p>
+      <div className="flex gap-2">
+        <button
+          ref={suggestBtnRef}
+          type="button"
+          onClick={onUseSuggested}
+          className="rounded bg-info px-2 py-0.5 text-[10px] font-semibold text-info-foreground hover:opacity-90"
+          data-testid="right-size-use-suggested"
+        >
+          Use {modelLabel(suggestedModel)}
+        </button>
+        <button
+          type="button"
+          onClick={onKeepCurrent}
+          className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
+          data-testid="right-size-keep-current"
+        >
+          Keep {modelLabel(currentModel)}
+        </button>
+        <button
+          type="button"
+          onClick={onChangeModel}
+          className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
+          data-testid="right-size-change-model"
+        >
+          Change model…
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/components/chat/chat-constants.ts
+++ b/apps/desktop/src/components/chat/chat-constants.ts
@@ -194,6 +194,31 @@ export function modelWeight(model: string): number {
   return MODEL_COST[model]?.weight ?? 10;
 }
 
+// Heuristic floor used by the first-turn right-sizing card.
+// Never suggest Haiku — user explicitly disallows it for this workspace.
+const SUGGESTION_FLOOR_PATTERN = /haiku|small|mini|nano|cursor-small/i;
+
+// Weight delta below which a suggestion is not worth surfacing (avoid nagging
+// for marginal savings like Sonnet 4.6 → 4.5).
+const MIN_WEIGHT_GAP = 20;
+
+export function suggestLighterModel(
+  current: string,
+  candidates: ReadonlyArray<string>,
+): string | null {
+  const currentWeight = modelWeight(current);
+  let best: { id: string; weight: number } | null = null;
+  for (const id of candidates) {
+    if (id === current) continue;
+    if (SUGGESTION_FLOOR_PATTERN.test(id)) continue;
+    const w = modelWeight(id);
+    if (w >= currentWeight) continue;
+    if (currentWeight - w < MIN_WEIGHT_GAP) continue;
+    if (!best || w > best.weight) best = { id, weight: w };
+  }
+  return best?.id ?? null;
+}
+
 export const FAMILY_SECTION_LABEL: Record<ModelFamily, string> = {
   claude: 'Claude',
   gpt: 'GPT',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,8 @@ export {
   getDefaultTurnModel,
 } from './providers/capabilities';
 
+export { assessTurnWeight, type TurnWeight } from './providers/turn-weight';
+
 // CursorAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from @kay-am/core/src/providers/cursor/adapter when needed in Node context.
 export { CURSOR_CHEAP_MODEL, computeCursorCostUsd } from './providers/cursor/cost';

--- a/packages/core/src/providers/turn-weight.test.ts
+++ b/packages/core/src/providers/turn-weight.test.ts
@@ -40,7 +40,7 @@ describe('assessTurnWeight', () => {
 
   it('returns unknown for ambiguous prompts', () => {
     const ambiguous =
-      'i was looking at the parser yesterday and noticed some odd behavior, not sure where to start but i think it might be worth digging in further to understand the flow better, can you take a look';
+      'i was poking around the parser module yesterday afternoon and noticed some slightly odd behavior, not entirely sure where to start digging but i think it might be worth investigating the flow a bit further to understand what is going on, can you take a look at this when you have a moment';
     expect(assessTurnWeight(ambiguous)).toBe('unknown');
   });
 

--- a/packages/core/src/providers/turn-weight.test.ts
+++ b/packages/core/src/providers/turn-weight.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { assessTurnWeight } from './turn-weight';
+
+describe('assessTurnWeight', () => {
+  it('flags greetings as light', () => {
+    expect(assessTurnWeight('hi')).toBe('light');
+    expect(assessTurnWeight('hello')).toBe('light');
+    expect(assessTurnWeight('thanks!')).toBe('light');
+    expect(assessTurnWeight('ping')).toBe('light');
+  });
+
+  it('flags short single questions as light', () => {
+    expect(assessTurnWeight('what does this function do?')).toBe('light');
+    expect(assessTurnWeight('how do I rename this var?')).toBe('light');
+  });
+
+  it('flags trivial verbs as light', () => {
+    expect(assessTurnWeight('rename foo to bar')).toBe('light');
+    expect(assessTurnWeight('bump version to 2.0')).toBe('light');
+    expect(assessTurnWeight('revert the last commit')).toBe('light');
+  });
+
+  it('flags long prompts as heavy', () => {
+    expect(assessTurnWeight('x'.repeat(1600))).toBe('heavy');
+  });
+
+  it('flags code fences as heavy', () => {
+    expect(assessTurnWeight('fix this:\n```ts\nconst x = 1;\n```')).toBe('heavy');
+  });
+
+  it('flags multi-step language as heavy', () => {
+    expect(assessTurnWeight('first do X then do Y then do Z')).toBe('heavy');
+    expect(assessTurnWeight('refactor auth across the whole codebase')).toBe('heavy');
+  });
+
+  it('flags architectural verbs as heavy', () => {
+    expect(assessTurnWeight('design the new caching layer')).toBe('heavy');
+    expect(assessTurnWeight('rewrite the parser')).toBe('heavy');
+  });
+
+  it('returns unknown for ambiguous prompts', () => {
+    const ambiguous =
+      'i was looking at the parser yesterday and noticed some odd behavior, not sure where to start but i think it might be worth digging in further to understand the flow better, can you take a look';
+    expect(assessTurnWeight(ambiguous)).toBe('unknown');
+  });
+
+  it('returns unknown for empty input', () => {
+    expect(assessTurnWeight('')).toBe('unknown');
+    expect(assessTurnWeight('   ')).toBe('unknown');
+  });
+
+  it('treats multi-line bullet lists as not light', () => {
+    const bullets = '- foo\n- bar\n- baz';
+    expect(assessTurnWeight(bullets)).not.toBe('light');
+  });
+});

--- a/packages/core/src/providers/turn-weight.ts
+++ b/packages/core/src/providers/turn-weight.ts
@@ -1,0 +1,101 @@
+export type TurnWeight = 'light' | 'heavy' | 'unknown';
+
+const GREETINGS = new Set([
+  'hi',
+  'hello',
+  'hey',
+  'yo',
+  'ping',
+  'test',
+  'thanks',
+  'thx',
+  'ok',
+  'okay',
+  'sup',
+]);
+
+const TRIVIAL_VERB_PATTERNS: ReadonlyArray<RegExp> = [
+  /^\s*rename\b/i,
+  /^\s*format\b/i,
+  /^\s*lint\b/i,
+  /^\s*revert\b/i,
+  /^\s*bump\s+version\b/i,
+  /^\s*delete\s+file\b/i,
+  /^\s*add\s+console\.log\b/i,
+  /^\s*what\s+does\s+\S+\s+do\b/i,
+];
+
+const QUESTION_OPENERS = /^(what|where|when|which|why|who|how\s+(do|does|is|are|can|should))\b/i;
+
+const ARCHITECTURAL_VERBS =
+  /\b(design|architect|propose\s+architecture|migrate\s+database|redesign|rewrite)\b/i;
+
+const MULTI_STEP =
+  /\bfirst\b.+\bthen\b.+\bthen\b|\bimplement\b.+\band\s+also\b|\brefactor\b.+\bacross\b/i;
+
+// Hard wrap of length-related heuristic constants so heavy/light bands are explicit.
+const SHORT_LEN = 200;
+const QUESTION_LEN = 400;
+const HEAVY_LEN = 1500;
+
+function isGreeting(text: string): boolean {
+  const compact = text
+    .trim()
+    .toLowerCase()
+    .replace(/[!?.…]+$/g, '');
+  if (!compact) return false;
+  if (GREETINGS.has(compact)) return true;
+  for (const g of GREETINGS) {
+    if (compact === g || compact === `${g} there`) return true;
+  }
+  return false;
+}
+
+function hasCodeFence(text: string): boolean {
+  return /```/.test(text);
+}
+
+function hasMultiLineStructure(text: string): boolean {
+  if (/^\s*[-*]\s/m.test(text)) return true;
+  if (/^\s*\d+\.\s/m.test(text)) return true;
+  return text.split('\n').filter((l) => l.trim().length > 0).length > 1;
+}
+
+function countDistinctAsks(text: string): number {
+  // Conjunctions linking two imperative verbs ("rename X and delete Y") count as
+  // multi-ask. We approximate by counting `and` joiners between verb-like tokens.
+  const matches = text.match(
+    /\b(and|then|also)\s+(implement|add|remove|delete|create|build|design|refactor|migrate|fix|update|rename|move)\b/gi,
+  );
+  return matches?.length ?? 0;
+}
+
+export function assessTurnWeight(firstTurnText: string): TurnWeight {
+  const text = firstTurnText ?? '';
+  const trimmed = text.trim();
+  if (!trimmed) return 'unknown';
+
+  if (trimmed.length > HEAVY_LEN) return 'heavy';
+  if (hasCodeFence(trimmed)) return 'heavy';
+  if (MULTI_STEP.test(trimmed)) return 'heavy';
+  if (ARCHITECTURAL_VERBS.test(trimmed)) return 'heavy';
+  if (countDistinctAsks(trimmed) >= 1 && trimmed.length > SHORT_LEN) return 'heavy';
+
+  if (isGreeting(trimmed)) return 'light';
+
+  for (const re of TRIVIAL_VERB_PATTERNS) {
+    if (re.test(trimmed)) return 'light';
+  }
+
+  if (trimmed.length < SHORT_LEN && !hasMultiLineStructure(trimmed)) return 'light';
+
+  if (
+    QUESTION_OPENERS.test(trimmed) &&
+    trimmed.length < QUESTION_LEN &&
+    !hasMultiLineStructure(trimmed)
+  ) {
+    return 'light';
+  }
+
+  return 'unknown';
+}


### PR DESCRIPTION
## Summary
- Add an opt-in friction card on the first turn of a freshly spawned agent that suggests a lighter model when the prompt looks trivially light (greeting, short Q, rename, etc.) and the routed model is meaningfully heavier (e.g. Opus 4.7 → Sonnet 4.6).
- Pure heuristic, no LLM call. Per-turn override only; no persistence, no setting, no per-agent preference change.

## Behavior
- First turn only (detected via `agentRunHistory[selectedAgentId].length === 0`).
- Heuristic returns `light` / `heavy` / `unknown`.
- Card shows iff first turn AND classification is `light` AND there is a strictly lighter, non-Haiku candidate within the current provider's catalog AND the weight gap is meaningful.
- Buttons: **Use suggested** (default focus, Enter accepts) / **Keep current** / **Change model…**
- Editing the prompt while the card is visible re-classifies live; the card disappears if the new text classifies as `heavy` or `unknown`.
- Dismissing via Keep / Change model… suppresses the card for the rest of that first turn.

## Heuristic
Light if ANY:
- Greeting / smoke token (`hi`, `hello`, `ping`, `test`, `thanks`, `ok`, …).
- Plain text < 200 chars and no multi-line / bullet structure.
- Short single question (< 400 chars) opened by `what / where / when / which / why / who / how (do|does|is|are|can|should)`.
- Trivial verb head: `rename`, `format`, `lint`, `revert`, `bump version`, `delete file`, `add console.log`, `what does X do`.

Heavy if ANY:
- Length > 1500 chars.
- Contains a code fence ` ``` `.
- Multi-step language (`first … then … then …`, `refactor … across …`, `implement … and also …`).
- Architectural verbs (`design`, `architect`, `propose architecture`, `migrate database`, `redesign`, `rewrite`).
- Multiple distinct asks (`and / then / also` joining imperative verbs) on a > 200-char prompt.

Otherwise: `unknown` → no card.

## Model tiering
Reuses the existing `MODEL_COST` weight table in `apps/desktop/src/components/chat/chat-constants.ts` (Opus 4.7=75, Opus 4.6=60, Codex latest=20, Sonnet 4.6=15, Sonnet 4.5=14, …). A new `suggestLighterModel(current, candidates)` returns the heaviest candidate strictly lighter than `current` whose id does NOT match `/haiku|small|mini|nano|cursor-small/i` and whose weight is at least 20 below the current. Suggestions stay within the active provider — no cross-provider routing.

## Hard constraint
- Never suggests Haiku (or `small` / `mini` / `nano`). Floor is Sonnet for Anthropic, the equivalent mid-tier within other providers.

## Persistence
None. The model swap is for this one send only. The agent's default routing, the session preference, and the per-agent model override are all untouched.

## Files touched
- `packages/core/src/providers/turn-weight.ts` (new) — pure heuristic.
- `packages/core/src/providers/turn-weight.test.ts` (new) — unit tests.
- `packages/core/src/index.ts` — re-export.
- `apps/desktop/src/components/chat/chat-constants.ts` — `suggestLighterModel` helper.
- `apps/desktop/src/components/chat/RightSizeCard.tsx` (new) — inline card.
- `apps/desktop/src/components/chat/ChatInput.tsx` — first-turn detection, deferred send, card wiring.

## Out of scope
- LLM-based classification.
- Per-turn cost / token display in the card.
- Per-agent dismissal memory across turns ("don't show this again").
- A settings toggle for auto-suggest.
- Cross-provider routing changes.

## Test plan
- Unit: `pnpm -F @kay-am/core test -- turn-weight` — greetings/short Qs → `light`; >1500 chars / code fences / multi-step / architectural → `heavy`; ambiguous medium-length → `unknown`.
- Manual: spawn new agent with Opus 4.7, type "hi" → card appears, default button "Use Sonnet 4.6". Press Enter → routes Sonnet 4.6 for this turn.
- Manual: spawn with Opus 4.7, paste a 2000-char architectural prompt → no card.
- Manual: spawn with Sonnet 4.6 → no card regardless.
- Manual: spawn with Opus 4.7, type "hi", then expand to architectural → card dismisses live.
- Manual: spawn with Opus 4.7, type "hi", click "Change model…" → card dismisses, model picker chip available.
- Manual: spawn with Opus 4.7, send "hi", then on second turn card does NOT appear.
