### PR TITLE
feat(desktop,core): next-actions trio scout/plan/implement

### DIFF
--- a/apps/desktop/src/components/NextActionChips.tsx
+++ b/apps/desktop/src/components/NextActionChips.tsx
@@ -4,7 +4,7 @@ import { cn } from '@kay-am/ui';
 import type { NextAction } from '@kay-am/core';
 import type { TaskId } from '@kay-am/types';
 import { formatError } from '../errors';
-import { useAppStore, useSessionNextActions, useSessionSlots } from '../store';
+import { useAppStore, useSessionNextActions } from '../store';
 import { AGENT_KIND_DEFAULTS, AGENT_KIND_PALETTE } from '../agent-kind';
 import { spawnKindForAction } from '../spawn-from-next-action';
 
@@ -14,56 +14,33 @@ export interface NextActionChipsProps {
   readonly className?: string;
 }
 
-function isSpawnAction(action: NextAction): boolean {
-  return spawnKindForAction(action) !== null;
-}
-
 export function NextActionChips({ taskId, workflowBound, className }: NextActionChipsProps) {
   const actions = useSessionNextActions(taskId);
-  const slots = useSessionSlots(taskId);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
-  const createPrForSession = useAppStore((s) => s.createPrForSession);
   const clearSessionNextActions = useAppStore((s) => s.clearSessionNextActions);
   const [busyId, setBusyId] = useState<NextAction['id'] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [pendingAction, setPendingAction] = useState<NextAction | null>(null);
-
-  const hasOpenQuestions =
-    (slots.find((s) => s.key === 'open_questions')?.value?.trim().length ?? 0) > 0;
 
   if (workflowBound || actions.length === 0) return null;
 
   const executeAction = async (action: NextAction) => {
     setBusyId(action.id);
     setError(null);
-    setPendingAction(null);
     try {
       const kind = spawnKindForAction(action);
-      if (kind) {
-        const defaults = AGENT_KIND_DEFAULTS[kind];
-        await spawnAgent(taskId, {
-          name: action.label,
-          model: defaults.model,
-          effort: defaults.effort,
-        });
-      } else if (action.id === 'open_pr') {
-        await createPrForSession(taskId);
-      }
+      const defaults = AGENT_KIND_DEFAULTS[kind];
+      await spawnAgent(taskId, {
+        name: action.label,
+        model: defaults.model,
+        effort: defaults.effort,
+        initialPrompt: action.prompt,
+      });
       clearSessionNextActions(taskId);
     } catch (err) {
       setError(formatError(err));
     } finally {
       setBusyId(null);
     }
-  };
-
-  const onClick = async (action: NextAction) => {
-    if (busyId) return;
-    if (hasOpenQuestions && isSpawnAction(action)) {
-      setPendingAction(action);
-      return;
-    }
-    await executeAction(action);
   };
 
   return (
@@ -75,40 +52,17 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
       <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
         next
       </span>
-      <div className="flex flex-wrap gap-1.5">
+      <div className="flex flex-col gap-1.5">
         {actions.map((action) => (
-          <Chip
+          <Cta
             key={action.id}
             action={action}
             busy={busyId === action.id}
             disabled={busyId !== null && busyId !== action.id}
-            onClick={() => void onClick(action)}
+            onClick={() => void executeAction(action)}
           />
         ))}
       </div>
-      {pendingAction ? (
-        <div className="rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
-          <p className="mb-2 font-medium text-foreground">
-            open questions need resolution before spawning an agent.
-          </p>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setPendingAction(null)}
-              className="rounded bg-warning px-2 py-0.5 text-[10px] font-semibold text-warning-foreground hover:opacity-90"
-            >
-              resolve first
-            </button>
-            <button
-              type="button"
-              onClick={() => void executeAction(pendingAction)}
-              className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
-            >
-              force spawn
-            </button>
-          </div>
-        </div>
-      ) : null}
       {error ? (
         <p className="rounded border border-danger/30 bg-danger/10 px-2 py-1 text-[10px] text-danger">
           {error}
@@ -118,7 +72,7 @@ export function NextActionChips({ taskId, workflowBound, className }: NextAction
   );
 }
 
-function Chip({
+function Cta({
   action,
   busy,
   disabled,
@@ -130,9 +84,9 @@ function Chip({
   onClick: () => void;
 }) {
   const kind = spawnKindForAction(action);
-  const palette = kind ? AGENT_KIND_PALETTE[kind] : null;
-  const defaults = kind ? AGENT_KIND_DEFAULTS[kind] : null;
-  const title = defaults ? `model: ${defaults.model} · effort: ${defaults.effort}` : action.label;
+  const palette = AGENT_KIND_PALETTE[kind];
+  const defaults = AGENT_KIND_DEFAULTS[kind];
+  const title = `${action.prompt} · model: ${defaults.model} · effort: ${defaults.effort}`;
 
   return (
     <button
@@ -143,11 +97,10 @@ function Chip({
       title={title}
       aria-label={action.label}
       className={cn(
-        'group inline-flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-60',
+        'group inline-flex w-full items-center justify-between gap-2 rounded-md border border-primary/40 bg-primary/5 px-2.5 py-1.5 text-left text-xs font-medium text-primary shadow-sm transition-colors hover:border-primary hover:bg-primary/15 disabled:cursor-not-allowed disabled:opacity-60',
       )}
     >
-      <span>{action.label}</span>
-      {palette ? (
+      <span className="flex items-center gap-2">
         <span
           className={cn(
             'rounded px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
@@ -158,11 +111,12 @@ function Chip({
         >
           {palette.label}
         </span>
-      ) : null}
+        <span>{action.label}</span>
+      </span>
       <ArrowRight
-        size={11}
+        size={12}
         aria-hidden
-        className="transition-transform group-hover:translate-x-0.5"
+        className="shrink-0 transition-transform group-hover:translate-x-0.5"
       />
     </button>
   );

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1619,24 +1619,24 @@ function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps
 
 function SuggestionMenuItem({ action, onSelect }: { action: NextAction; onSelect: () => void }) {
   const kind = spawnKindForAction(action);
-  const palette = kind ? AGENT_KIND_PALETTE[kind] : null;
-  const defaults = kind ? AGENT_KIND_DEFAULTS[kind] : null;
+  const palette = AGENT_KIND_PALETTE[kind];
+  const defaults = AGENT_KIND_DEFAULTS[kind];
   return (
     <button
       type="button"
       role="menuitem"
       onClick={onSelect}
-      title={defaults ? `${defaults.model} · ${defaults.effort} effort` : action.label}
+      title={`${defaults.model} · ${defaults.effort} effort`}
       className={cn(
         'flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left transition-colors',
-        palette ? `${palette.bg} ${palette.fg} hover:opacity-90` : 'hover:bg-muted',
+        `${palette.bg} ${palette.fg} hover:opacity-90`,
       )}
     >
       <span className="flex items-center gap-1.5">
         <ArrowRight size={11} aria-hidden />
         <span className="font-medium">{action.label}</span>
       </span>
-      {defaults ? <span className="text-2xs opacity-70">{shortModel(defaults.model)}</span> : null}
+      <span className="text-2xs opacity-70">{shortModel(defaults.model)}</span>
     </button>
   );
 }

--- a/apps/desktop/src/spawn-from-next-action.ts
+++ b/apps/desktop/src/spawn-from-next-action.ts
@@ -1,4 +1,4 @@
-import type { NextAction } from '@kay-am/core';
+import type { NextAction, NextActionKind } from '@kay-am/core';
 import type { TaskId } from '@kay-am/types';
 import { AGENT_KIND_DEFAULTS, type AgentKind } from './agent-kind';
 
@@ -12,48 +12,14 @@ export type SpawnAgentFn = (
   },
 ) => Promise<unknown>;
 
-export function spawnKindForAction(action: NextAction): AgentKind | null {
-  switch (action.id) {
-    case 'spawn_scout':
-      return 'scout';
-    case 'spawn_planner':
-      return 'planner';
-    case 'spawn_implementer':
-      return 'implementer';
-    case 'spawn_debugger':
-      return 'debugger';
-    case 'spawn_reviewer':
-      return 'reviewer';
-    case 'spawn_tester':
-      return 'reviewer';
-    case 'spawn_docs':
-      return 'docs';
-    default:
-      return null;
-  }
-}
+const NEXT_KIND_TO_AGENT_KIND: Record<NextActionKind, AgentKind> = {
+  scout: 'scout',
+  plan: 'planner',
+  implement: 'implementer',
+};
 
-function kickoffPromptFor(action: NextAction): string {
-  switch (action.id) {
-    case 'spawn_scout':
-      return 'explore the current scope and surface what is still unclear before planning.';
-    case 'spawn_planner':
-      return 'plan the next steps based on the current context.';
-    case 'spawn_implementer':
-      return 'implement based on the latest plan.';
-    case 'spawn_debugger': {
-      const topic = action.payload?.topic?.trim();
-      return topic ? `debug ${topic}.` : 'debug the current failure.';
-    }
-    case 'spawn_reviewer':
-      return 'review the latest changes for correctness, style, and edge cases.';
-    case 'spawn_tester':
-      return 'write tests covering the latest changes. include unit and edge cases.';
-    case 'spawn_docs':
-      return 'document the latest changes. update relevant readme or guides.';
-    default:
-      return '';
-  }
+export function spawnKindForAction(action: NextAction): AgentKind {
+  return NEXT_KIND_TO_AGENT_KIND[action.kind];
 }
 
 export async function spawnFromNextAction(
@@ -62,14 +28,12 @@ export async function spawnFromNextAction(
   spawnAgent: SpawnAgentFn,
 ): Promise<boolean> {
   const kind = spawnKindForAction(action);
-  if (!kind) return false;
   const defaults = AGENT_KIND_DEFAULTS[kind];
-  const initialPrompt = kickoffPromptFor(action);
   await spawnAgent(taskId, {
     name: action.label,
     model: defaults.model,
     effort: defaults.effort,
-    ...(initialPrompt ? { initialPrompt } : {}),
+    initialPrompt: action.prompt,
   });
   return true;
 }

--- a/apps/desktop/src/store/store.next-actions.test.ts
+++ b/apps/desktop/src/store/store.next-actions.test.ts
@@ -127,9 +127,16 @@ vi.mock('@tauri-apps/api/core', () => ({
 const TASK_ID = 'task-next-actions' as TaskId;
 
 const ACTIONS_PLAN: ReadonlyArray<NextAction> = [
-  { id: 'spawn_planner', label: 'start plan', kind: 'planner' },
+  { id: 'next-plan', kind: 'plan', label: 'Pianifica', prompt: 'produci un piano per X' },
 ];
-const ACTIONS_PR: ReadonlyArray<NextAction> = [{ id: 'open_pr', label: 'open pr' }];
+const ACTIONS_PR: ReadonlyArray<NextAction> = [
+  {
+    id: 'next-implement',
+    kind: 'implement',
+    label: 'Implementa',
+    prompt: 'vai diretto e implementa X',
+  },
+];
 
 describe('sessionNextActions store slice', () => {
   afterEach(() => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   type ContextSlotDeltaUpsert,
   type InferNextActionsInput,
   type NextAction,
+  type NextActionKind,
   type NextActionsPrState,
   type SummarizeInput,
   type SummarizerDeps,

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -15,5 +15,6 @@ export {
   inferNextActions,
   type InferNextActionsInput,
   type NextAction,
+  type NextActionKind,
   type NextActionsPrState,
 } from './next-actions';

--- a/packages/core/src/summarizer/next-actions.test.ts
+++ b/packages/core/src/summarizer/next-actions.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ContextSlot } from '@kay-am/types';
 import type { ContextSlotDelta, SummarizeInput } from './client';
-import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
-
-const LOCKED_GOAL = 'add caching layer to the auth module';
+import { inferNextActions } from './next-actions';
 
 function buildInput(
   turnOutput: string,
@@ -16,191 +14,122 @@ function delta(upserts: Array<{ key: string; value: string }> = []): ContextSlot
   return { upserts: upserts as ContextSlotDelta['upserts'] };
 }
 
-function slots(map: Record<string, string>, opts: { withGoal?: boolean } = {}): ContextSlot[] {
-  const out: ContextSlot[] = [];
-  if (opts.withGoal !== false && map.goal === undefined) {
-    out.push({ key: 'goal', value: LOCKED_GOAL, enabled: true });
-  }
-  for (const [key, value] of Object.entries(map)) {
-    out.push({ key, value, enabled: true });
-  }
-  return out;
-}
-
-function findById<T extends NextAction['id']>(
-  actions: ReadonlyArray<NextAction>,
-  id: T,
-): Extract<NextAction, { id: T }> | undefined {
-  return actions.find((a) => a.id === id) as Extract<NextAction, { id: T }> | undefined;
+function slots(map: Record<string, string>): ContextSlot[] {
+  return Object.entries(map).map(([key, value]) => ({ key, value, enabled: true }));
 }
 
 describe('inferNextActions — trigger gating', () => {
-  it('returns [] when open_questions slot has content (still refining)', () => {
-    const actions = inferNextActions({
-      input: buildInput('here is a draft plan'),
-      delta: delta(),
-      slotsAfter: slots({ open_questions: 'which db driver?' }),
-    });
-    expect(actions).toEqual([]);
-  });
-
-  it('returns [] when goal is empty (still framing)', () => {
-    const actions = inferNextActions({
-      input: buildInput('drafted a plan'),
-      delta: delta(),
-      slotsAfter: slots({ goal: '' }, { withGoal: false }),
-    });
-    expect(actions).toEqual([]);
-  });
-
-  it('returns [] when goal is very short (still framing)', () => {
-    const actions = inferNextActions({
-      input: buildInput('drafted a plan'),
-      delta: delta(),
-      slotsAfter: slots({ goal: 'fix it' }, { withGoal: false }),
-    });
-    expect(actions).toEqual([]);
-  });
-
-  it('surfaces actions once goal is locked and no open questions remain', () => {
-    const actions = inferNextActions({
-      input: buildInput('drafted a plan for the new caching layer'),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    expect(actions.length).toBeGreaterThan(0);
-  });
-});
-
-describe('inferNextActions — option set after each phase', () => {
-  it('after scout turn → plan + refine scope', () => {
-    const actions = inferNextActions({
-      input: buildInput('explored the auth module and mapped its dependencies'),
-      delta: delta([{ key: 'last_output_summary', value: 'investigated auth code paths' }]),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'spawn_planner')).toBeDefined();
-    expect(findById(actions, 'spawn_scout')).toBeDefined();
-  });
-
-  it('after plan turn → implement + refine plan', () => {
-    const actions = inferNextActions({
-      input: buildInput('drafted a plan for the new caching layer'),
-      delta: delta([{ key: 'last_output_summary', value: 'planned caching design' }]),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'spawn_implementer')).toBeDefined();
-    expect(findById(actions, 'spawn_planner')).toBeDefined();
-  });
-
-  it('after implementation turn → review + tests + open pr', () => {
-    const actions = inferNextActions({
-      input: buildInput('implemented the new endpoint'),
-      delta: delta([{ key: 'last_output_summary', value: 'wrote handler' }]),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'spawn_reviewer')).toBeDefined();
-    expect(findById(actions, 'spawn_tester')).toBeDefined();
-    expect(findById(actions, 'open_pr')).toBeDefined();
-  });
-
-  it('after implementation that already mentions tests → review + open pr (no extra test chip)', () => {
-    const actions = inferNextActions({
-      input: buildInput('implemented endpoint and added unit tests'),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'spawn_reviewer')).toBeDefined();
-    expect(findById(actions, 'spawn_tester')).toBeUndefined();
-    expect(findById(actions, 'open_pr')).toBeDefined();
-  });
-
-  it('after implementation when PR already exists → suggests neither open_pr nor a new impl chip', () => {
-    const actions = inferNextActions({
-      input: buildInput('implemented and opened pr #42'),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'open_pr')).toBeUndefined();
-  });
-});
-
-describe('inferNextActions — bug + pr-state branches', () => {
-  it('suggests debug + tests when bug mentioned', () => {
-    const actions = inferNextActions({
-      input: buildInput('found a bug in auth/session.ts where tokens leak across requests'),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    const debug = findById(actions, 'spawn_debugger');
-    expect(debug).toBeDefined();
-    expect(debug?.payload?.topic).toMatch(/auth\/session\.ts/);
-    expect(findById(actions, 'spawn_tester')).toBeDefined();
-  });
-
-  it('returns merge_pr only when PR open + checks green', () => {
-    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: true };
-    const actions = inferNextActions({
-      input: buildInput('ci passed'),
-      delta: delta(),
-      slotsAfter: slots({}),
-      prState,
-    });
-    expect(actions).toEqual([{ id: 'merge_pr', label: 'merge pr' }]);
-  });
-
-  it('returns debug + tests when PR open + checks failing', () => {
-    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: false };
-    const actions = inferNextActions({
-      input: buildInput('ci red'),
-      delta: delta(),
-      slotsAfter: slots({}),
-      prState,
-    });
-    expect(findById(actions, 'spawn_debugger')).toBeDefined();
-    expect(findById(actions, 'spawn_tester')).toBeDefined();
-  });
-
-  it('pr-state branches override the refinement gate', () => {
-    const prState: NextActionsPrState = { hasOpenPr: true, checksGreen: true };
-    const actions = inferNextActions({
-      input: buildInput('ci passed'),
-      delta: delta(),
-      slotsAfter: slots({ open_questions: 'still unclear' }),
-      prState,
-    });
-    expect(actions).toEqual([{ id: 'merge_pr', label: 'merge pr' }]);
-  });
-});
-
-describe('inferNextActions — invariants', () => {
-  it('caps at 3 actions', () => {
-    const actions = inferNextActions({
-      input: buildInput(
-        'scouted the code, drafted a plan, implemented the change, found a regression',
-      ),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    expect(actions.length).toBeLessThanOrEqual(3);
-  });
-
-  it('returns a generic plan + refine fallback when goal locked and nothing else fires', () => {
-    const actions = inferNextActions({
-      input: buildInput('hello world'),
-      delta: delta(),
-      slotsAfter: slots({}),
-    });
-    expect(findById(actions, 'spawn_planner')).toBeDefined();
-    expect(findById(actions, 'spawn_scout')).toBeDefined();
-  });
-
-  it('reads delta upsert values to detect impl phase', () => {
+  it('returns [] when no turn output and no slots populated', () => {
     const actions = inferNextActions({
       input: buildInput(''),
-      delta: delta([{ key: 'last_output_summary', value: 'finished implementation of feature X' }]),
-      slotsAfter: slots({}),
+      delta: delta(),
+      slotsAfter: [],
     });
-    expect(findById(actions, 'open_pr')).toBeDefined();
+    expect(actions).toEqual([]);
+  });
+
+  it('emits the trio after the first turn (turnOutput present)', () => {
+    const actions = inferNextActions({
+      input: buildInput('drafted a plan for the caching layer'),
+      delta: delta(),
+      slotsAfter: [],
+    });
+    expect(actions.map((a) => a.kind)).toEqual(['scout', 'plan', 'implement']);
+  });
+
+  it('emits the trio when open_questions has content', () => {
+    const actions = inferNextActions({
+      input: buildInput(''),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: 'which db driver? which cache layer?' }),
+    });
+    expect(actions).toHaveLength(3);
+    expect(actions.map((a) => a.kind)).toEqual(['scout', 'plan', 'implement']);
+  });
+
+  it('emits the trio when last_output_summary describes a decision branch', () => {
+    const actions = inferNextActions({
+      input: buildInput(''),
+      delta: delta(),
+      slotsAfter: slots({ last_output_summary: 'decide between redis and memcached' }),
+    });
+    expect(actions).toHaveLength(3);
+  });
+});
+
+describe('inferNextActions — trio shape', () => {
+  it('emits exactly 3 actions with stable ids', () => {
+    const actions = inferNextActions({
+      input: buildInput('explored the auth module'),
+      delta: delta(),
+      slotsAfter: [],
+    });
+    expect(actions.map((a) => a.id)).toEqual(['next-scout', 'next-plan', 'next-implement']);
+  });
+
+  it('uses Italian labels for the trio', () => {
+    const actions = inferNextActions({
+      input: buildInput('something'),
+      delta: delta(),
+      slotsAfter: [],
+    });
+    expect(actions.map((a) => a.label)).toEqual(['Esplora codice', 'Pianifica', 'Implementa']);
+  });
+
+  it('embeds open_questions topics into prompts (comma-joined for scout)', () => {
+    const actions = inferNextActions({
+      input: buildInput(''),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: 'auth flow, session storage, token TTL' }),
+    });
+    const scout = actions.find((a) => a.kind === 'scout');
+    expect(scout?.prompt).toContain('auth flow');
+    expect(scout?.prompt).toContain('session storage');
+    expect(scout?.prompt).toContain('token TTL');
+  });
+
+  it('falls back to last_output_summary nouns when open_questions empty', () => {
+    const actions = inferNextActions({
+      input: buildInput(''),
+      delta: delta(),
+      slotsAfter: slots({ last_output_summary: 'caching layer authentication module' }),
+    });
+    const scout = actions.find((a) => a.kind === 'scout');
+    expect(scout?.prompt).toMatch(/caching/);
+  });
+
+  it('plan and implement prompts use the first topic only', () => {
+    const actions = inferNextActions({
+      input: buildInput(''),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: 'topicA, topicB, topicC' }),
+    });
+    const plan = actions.find((a) => a.kind === 'plan');
+    const impl = actions.find((a) => a.kind === 'implement');
+    expect(plan?.prompt).toContain('topicA');
+    expect(plan?.prompt).not.toContain('topicB');
+    expect(impl?.prompt).toContain('topicA');
+    expect(impl?.prompt).not.toContain('topicB');
+  });
+
+  it('uses a fallback subject when no topics can be derived', () => {
+    const actions = inferNextActions({
+      input: buildInput('   '),
+      delta: delta(),
+      slotsAfter: slots({ open_questions: '   ' }),
+    });
+    expect(actions).toEqual([]);
+  });
+});
+
+describe('inferNextActions — pr-state ignored', () => {
+  it('pr-state does not change the trio output', () => {
+    const actions = inferNextActions({
+      input: buildInput('ci passed'),
+      delta: delta(),
+      slotsAfter: [],
+      prState: { hasOpenPr: true, checksGreen: true },
+    });
+    expect(actions.map((a) => a.kind)).toEqual(['scout', 'plan', 'implement']);
   });
 });

--- a/packages/core/src/summarizer/next-actions.ts
+++ b/packages/core/src/summarizer/next-actions.ts
@@ -1,21 +1,14 @@
 import type { ContextSlot } from '@kay-am/types';
 import type { ContextSlotDelta, SummarizeInput } from './client';
 
-export type NextAction =
-  | { readonly id: 'spawn_scout'; readonly label: string; readonly kind: 'scout' }
-  | { readonly id: 'spawn_planner'; readonly label: string; readonly kind: 'planner' }
-  | { readonly id: 'spawn_implementer'; readonly label: string; readonly kind: 'implementer' }
-  | {
-      readonly id: 'spawn_debugger';
-      readonly label: string;
-      readonly kind: 'debugger';
-      readonly payload?: { readonly topic?: string };
-    }
-  | { readonly id: 'spawn_reviewer'; readonly label: string; readonly kind: 'reviewer' }
-  | { readonly id: 'spawn_tester'; readonly label: string; readonly kind: 'reviewer' }
-  | { readonly id: 'spawn_docs'; readonly label: string; readonly kind: 'docs' }
-  | { readonly id: 'open_pr'; readonly label: string }
-  | { readonly id: 'merge_pr'; readonly label: string };
+export type NextActionKind = 'scout' | 'plan' | 'implement';
+
+export interface NextAction {
+  readonly id: string;
+  readonly kind: NextActionKind;
+  readonly label: string;
+  readonly prompt: string;
+}
 
 export interface InferNextActionsInput {
   readonly input: SummarizeInput;
@@ -24,112 +17,80 @@ export interface InferNextActionsInput {
   readonly prState?: NextActionsPrState | null;
 }
 
+// Kept on the public surface so existing client wiring (cli.ts, client.ts)
+// keeps compiling without a sweep. PR-state no longer changes the trio output.
 export interface NextActionsPrState {
   readonly hasOpenPr: boolean;
   readonly checksGreen: boolean;
 }
 
-const SCOUT_PATTERN =
-  /\b(scout(?:ed|ing)?|explor(?:e|ed|ing|ation)|investigat(?:e|ed|ing|ion)|survey(?:ed|ing)?|map(?:ped|ping)?|analy[sz](?:e|ed|ing|is))\b/i;
-const PLAN_PATTERN =
-  /\b(plan(?:ned|ning)?|design(?:ed|ing)?|architect(?:ed|ing|ure)?|spec(?:ed|ified|ification)?|propos(?:e|ed|al))\b/i;
-const IMPL_PATTERN =
-  /\b(implement(?:ed|ing|ation)?|built|build|coded|wrote|added|introduced|landed|refactor(?:ed|ing)?|finished\s+impl)\b/i;
-const PR_PATTERN = /\b(pull\s+request|\bpr\b|opened\s+pr|created\s+pr)\b/i;
-const BUG_PATTERN =
-  /\b(bug|error|failing|failure|regression|broken|crash(?:ed|ing)?|exception|stack\s*trace)\b/i;
-const TEST_PATTERN = /\b(test(?:ed|ing|s)?|spec(?:s)?|unit\s+test|coverage)\b/i;
-const DOCS_PATTERN = /\b(doc(?:s|ument|umented|umentation)?|readme|changelog|guide|reference)\b/i;
+const MAX_TOPICS = 3;
+const STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'are',
+  'as',
+  'at',
+  'be',
+  'by',
+  'for',
+  'from',
+  'has',
+  'have',
+  'in',
+  'into',
+  'is',
+  'it',
+  'of',
+  'on',
+  'or',
+  'that',
+  'the',
+  'this',
+  'to',
+  'was',
+  'were',
+  'will',
+  'with',
+]);
 
-const GOAL_MIN_CHARS = 12;
-const MAX_ACTIONS = 3;
-
-// Trigger gating uses slot state instead of regex: card should appear only at
-// natural hand-off boundaries. If goal is still ambiguous or open questions are
-// pending, the user is mid-refinement — let them keep talking, do not surface
-// "spawn a new agent" chips.
+// Trigger: a turn has produced output, or the assistant left open questions, or
+// last_output_summary captured a decision branch worth acting on. Otherwise the
+// user is still framing — surface nothing.
 export function inferNextActions(input: InferNextActionsInput): ReadonlyArray<NextAction> {
-  const summary = collectSummaryText(input);
   const slots = mapSlots(input.slotsAfter);
-  const goal = slots.goal ?? '';
-  const openQuestions = slots.open_questions ?? '';
-  const decisions = slots.decisions ?? '';
-  const lastOutput = slots.last_output_summary ?? '';
+  const openQuestions = (slots.open_questions ?? '').trim();
+  const lastOutput = (slots.last_output_summary ?? '').trim();
+  const turnOutput = input.input.turnOutput.trim();
 
-  const prOpen = input.prState?.hasOpenPr === true;
-  const prGreen = prOpen && input.prState?.checksGreen === true;
-  const prFailing = prOpen && input.prState?.checksGreen === false;
+  const triggered = turnOutput.length > 0 || openQuestions.length > 0 || lastOutput.length > 0;
+  if (!triggered) return [];
 
-  // PR-state branches are unconditional: they override the refinement gate
-  // because they describe a concrete next step the user can act on regardless
-  // of slot freshness.
-  if (prGreen) {
-    return [{ id: 'merge_pr', label: 'merge pr' }];
-  }
-  if (prFailing) {
-    return capActions([
-      bugAction(summary) ?? { id: 'spawn_debugger', label: 'start debug', kind: 'debugger' },
-      { id: 'spawn_tester', label: 'write tests', kind: 'reviewer' },
-    ]);
-  }
+  const topics = pickTopics(openQuestions, lastOutput, turnOutput);
+  const subject = topics.length > 0 ? topics.join(', ') : 'lo scope corrente';
+  const focus = topics[0] ?? 'lo scope corrente';
 
-  const refining = openQuestions.trim().length > 0 || goal.trim().length < GOAL_MIN_CHARS;
-  if (refining) {
-    return [];
-  }
-
-  if (BUG_PATTERN.test(summary)) {
-    const debug = bugAction(summary) ?? {
-      id: 'spawn_debugger',
-      label: 'start debug',
-      kind: 'debugger',
-    };
-    return capActions([debug, { id: 'spawn_tester', label: 'write tests', kind: 'reviewer' }]);
-  }
-
-  const mentionsImpl = IMPL_PATTERN.test(summary) || IMPL_PATTERN.test(lastOutput);
-  const mentionsPlan = PLAN_PATTERN.test(summary) || PLAN_PATTERN.test(decisions);
-  const mentionsScout = SCOUT_PATTERN.test(summary);
-  const mentionsPr = PR_PATTERN.test(summary) || prOpen;
-  const mentionsTests = TEST_PATTERN.test(summary);
-  const mentionsDocs = DOCS_PATTERN.test(summary);
-
-  if (mentionsImpl && !mentionsPr) {
-    const post: NextAction[] = [
-      { id: 'spawn_reviewer', label: 'review changes', kind: 'reviewer' },
-    ];
-    if (!mentionsTests) {
-      post.push({ id: 'spawn_tester', label: 'write tests', kind: 'reviewer' });
-    }
-    post.push({ id: 'open_pr', label: 'open pr' });
-    return capActions(post);
-  }
-
-  if (mentionsPlan && !mentionsImpl) {
-    return capActions([
-      { id: 'spawn_implementer', label: 'start implementation', kind: 'implementer' },
-      { id: 'spawn_planner', label: 'refine plan', kind: 'planner' },
-    ]);
-  }
-
-  if (mentionsScout && !mentionsPlan && !mentionsImpl) {
-    return capActions([
-      { id: 'spawn_planner', label: 'start plan', kind: 'planner' },
-      { id: 'spawn_scout', label: 'keep exploring', kind: 'scout' },
-    ]);
-  }
-
-  if (mentionsDocs && mentionsImpl) {
-    return capActions([{ id: 'spawn_docs', label: 'write docs', kind: 'docs' }]);
-  }
-
-  // Goal locked, no obvious phase hint — offer the safest forward step: plan.
-  // Pair with refine so the user can deepen scope instead if the goal is
-  // locked but still shallow.
-  return capActions([
-    { id: 'spawn_planner', label: 'start plan', kind: 'planner' },
-    { id: 'spawn_scout', label: 'refine scope', kind: 'scout' },
-  ]);
+  return [
+    {
+      id: 'next-scout',
+      kind: 'scout',
+      label: 'Esplora codice',
+      prompt: `esplora il codice per capire dove vivono ${subject}`,
+    },
+    {
+      id: 'next-plan',
+      kind: 'plan',
+      label: 'Pianifica',
+      prompt: `produci un piano per ${focus} prima di toccare codice`,
+    },
+    {
+      id: 'next-implement',
+      kind: 'implement',
+      label: 'Implementa',
+      prompt: `vai diretto e implementa ${focus}`,
+    },
+  ];
 }
 
 function mapSlots(slots: ReadonlyArray<ContextSlot>): Record<string, string> {
@@ -141,50 +102,42 @@ function mapSlots(slots: ReadonlyArray<ContextSlot>): Record<string, string> {
   return out;
 }
 
-function collectSummaryText(input: InferNextActionsInput): string {
-  const parts: string[] = [input.input.turnOutput];
-  for (const upsert of input.delta.upserts) {
-    parts.push(upsert.value);
+function pickTopics(
+  openQuestions: string,
+  lastOutput: string,
+  turnOutput: string,
+): ReadonlyArray<string> {
+  if (openQuestions.length > 0) {
+    const items = splitList(openQuestions).slice(0, MAX_TOPICS);
+    if (items.length > 0) return items;
   }
-  for (const slot of input.slotsAfter) {
-    if (slot.enabled && slot.value) parts.push(slot.value);
-  }
-  return parts.join('\n');
+  const fromOutput = extractNouns(lastOutput.length > 0 ? lastOutput : turnOutput);
+  return fromOutput.slice(0, MAX_TOPICS);
 }
 
-function bugAction(text: string): NextAction | null {
-  const topic = extractBugTopic(text);
-  if (!topic) return null;
-  return {
-    id: 'spawn_debugger',
-    label: `start debug on ${topic}`,
-    kind: 'debugger',
-    payload: { topic },
-  };
+function splitList(text: string): ReadonlyArray<string> {
+  return text
+    .split(/[\n,;?]+/)
+    .map((s) =>
+      s
+        .trim()
+        .replace(/^[-*•\d.)\s]+/, '')
+        .trim(),
+    )
+    .filter((s) => s.length > 0);
 }
 
-function extractBugTopic(text: string): string | undefined {
-  const quoted = /\b(?:bug|error|regression|failure)[^"'`]*["'`]([^"'`]{2,60})["'`]/i.exec(text);
-  if (quoted?.[1]) return quoted[1].trim();
-  const inline =
-    /\b(?:bug|error|failing|failure|regression)\s+(?:in|with|on|when|at)\s+([\w./-]+(?:\s+[\w./-]+){0,4})/i.exec(
-      text,
-    );
-  if (inline?.[1]) return inline[1].trim();
-  return undefined;
-}
-
-function capActions(actions: ReadonlyArray<NextAction>): ReadonlyArray<NextAction> {
-  return dedupeById(actions).slice(0, MAX_ACTIONS);
-}
-
-function dedupeById(actions: ReadonlyArray<NextAction>): NextAction[] {
-  const seen = new Set<NextAction['id']>();
-  const out: NextAction[] = [];
-  for (const a of actions) {
-    if (seen.has(a.id)) continue;
-    seen.add(a.id);
-    out.push(a);
+function extractNouns(text: string): ReadonlyArray<string> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of text.split(/[^\p{L}\p{N}_/.-]+/u)) {
+    const token = raw.trim();
+    if (token.length < 3) continue;
+    const lower = token.toLowerCase();
+    if (STOPWORDS.has(lower)) continue;
+    if (seen.has(lower)) continue;
+    seen.add(lower);
+    out.push(token);
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- Replace phase-aware next-actions rule engine with fixed trio: **scout**, **plan**, **implement**.
- Trigger when turn output OR open_questions OR last_output_summary has content.
- Topics derived from open_questions (comma-split, first 3) or last_output_summary nouns.
- Chips wired to spawn agent with mapped kind (`scout→scout`, `plan→planner`, `implement→implementer`) and initial prompt.

## Why

Rule engine kept suggesting "run tests" / "debug" when user usually wants to plan or scout first. Replacing with a deterministic 3-option choice instead of guessing intent.

## Test plan

- [x] `pnpm --filter @kay-am/core test` — 544 pass
- [x] `pnpm --filter @kay-am/desktop typecheck`
- [x] `pnpm --filter @kay-am/desktop test` — 320 pass
- [ ] Click each trio chip in app; verify agent spawns with expected kind + prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)