### PR TITLE
fix(repo): resolve lefthook binaries via main checkout for worktrees

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,9 +3,9 @@ pre-commit:
   commands:
     format:
       glob: '*.{ts,tsx,js,jsx,json,md,yml,yaml}'
-      run: pnpm prettier --write {staged_files} && git add {staged_files}
+      run: pnpm --dir "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" exec prettier --write {staged_files} && git add {staged_files}
 
 commit-msg:
   commands:
     commitlint:
-      run: pnpm commitlint --edit {1}
+      run: pnpm --dir "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" exec commitlint --edit {1}


### PR DESCRIPTION
## Summary

- Replace `pnpm prettier` / `pnpm commitlint` in `lefthook.yml` with `pnpm --dir "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" exec <bin>`.
- `git rev-parse --path-format=absolute --git-common-dir` returns the main `.git` dir even from a worktree; `dirname` gives the main checkout root.
- `pnpm --dir <main> exec <bin>` resolves binaries from main's `node_modules/.bin` regardless of cwd.

## Why

Worktrees spawned by Claude sub-agents had no `node_modules`. Lefthook commands like `pnpm prettier` failed because pnpm walked up from the worktree and never reached main's `node_modules`. Workaround was a fragile symlink dance (`ln -s ../../node_modules`) that:

- Required the parent session to step in (sub-agents lack `ln` permission).
- Confused workspace package resolution (`apps/desktop/node_modules/@kay-am/types` relative-links resolved to main's packages, not the worktree's, breaking typecheck).
- Got accidentally clobbered by `pnpm install` in worktrees.

This change removes the need for any symlink — commit hooks just work in any worktree.

## Test plan

- [x] Commit in a fresh worktree with no `node_modules` — hooks run and pass
- [x] Pre-commit `prettier` and `commit-msg` `commitlint` both invoked correctly
- [ ] Verify in main checkout too (CI / next normal commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)