### PR TITLE
feat(desktop): polish bundle — model selector sync, retry, markdown context, copy path

### DIFF
--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -4,6 +4,7 @@ import {
   ChevronLeft,
   ChevronRight,
   ChevronsRight,
+  Copy,
   ExternalLink,
   Loader2,
   MessageSquarePlus,
@@ -14,6 +15,7 @@ import {
   X,
 } from 'lucide-react';
 import { Dialog, ScrollArea, Textarea, cn } from '@kay-am/ui';
+import { useToast } from './Toast';
 import { parseUnifiedDiff } from '@kay-am/core';
 import type {
   DiffComment,
@@ -667,7 +669,23 @@ function TreeNodeView({
   commentCounts: Map<string, number>;
 }) {
   const [expanded, setExpanded] = useState(true);
+  const [pathCopied, setPathCopied] = useState(false);
+  const { showToast } = useToast();
   const indent = depth * 10;
+
+  const copyPath = (path: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(path).then(
+      () => {
+        setPathCopied(true);
+        showToast('success', 'path copied');
+        window.setTimeout(() => setPathCopied(false), 1500);
+      },
+      () => {
+        showToast('error', 'failed to copy path');
+      },
+    );
+  };
 
   if (node.kind === 'file') {
     const { file, index } = node;
@@ -712,6 +730,15 @@ function TreeNodeView({
             {file.deletions > 0 ? <span className="text-danger">−{file.deletions}</span> : null}
           </span>
         </button>
+        <button
+          type="button"
+          onClick={(e) => copyPath(file.path, e)}
+          title="copy path"
+          aria-label="copy file path"
+          className="shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+        >
+          {pathCopied ? <Check size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
+        </button>
         {onStartFileComment ? (
           <button
             type="button"
@@ -721,7 +748,7 @@ function TreeNodeView({
             }}
             title="add file-level note"
             aria-label="add file-level note"
-            className="mr-1 shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+            className="shrink-0 rounded-sm p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
           >
             <MessageSquarePlus size={10} aria-hidden />
           </button>

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -136,6 +136,11 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const { showToast } = useToast();
   const [value, setValue] = useState('');
   const [error, setError] = useState<string | null>(null);
+  interface FailedTurn {
+    readonly content: string;
+    readonly override: TurnProviderOverride | undefined;
+  }
+  const [lastFailedTurn, setLastFailedTurn] = useState<FailedTurn | null>(null);
   const [selectedProvider, setSelectedProviderState] = useState<ProviderId | null>(() =>
     readProvider(session.id),
   );
@@ -256,8 +261,10 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             }
           },
         });
+        setLastFailedTurn(null);
       } catch (err) {
         setError(formatError(err));
+        setLastFailedTurn({ content, override });
       }
     },
     [sendTurn, session.id, showToast],
@@ -285,6 +292,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     const content = value.trim();
     if (!content || providerDisconnected) return;
     setError(null);
+    setLastFailedTurn(null);
 
     if (allowOverride && !isRunning && rightSizeSuggested !== null && rightSizePending === null) {
       setRightSizePending(content);
@@ -302,6 +310,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setRightSizePending(null);
     setRightSizeDismissed(true);
     setValue('');
+    if (suggested !== null) setSelectedModel(suggested);
     await sendWith(content, suggested);
   };
 
@@ -490,9 +499,21 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           )}
         </div>
         {error ? (
-          <p role="alert" className="text-xs text-danger">
-            {error}
-          </p>
+          <div role="alert" className="flex items-center gap-2">
+            <p className="flex-1 text-xs text-danger">{error}</p>
+            {lastFailedTurn !== null ? (
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  void dispatchTurn(lastFailedTurn.content, lastFailedTurn.override);
+                }}
+                className="shrink-0 rounded border border-danger/30 bg-danger/5 px-2 py-0.5 text-xs font-medium text-danger hover:bg-danger/15"
+              >
+                retry
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Fix 1 — model selector sync**: `onUseSuggested` in `ChatInput` now calls `setSelectedModel(suggested)` so the `ModelPicker` chip immediately reflects the lighter model after accepting the right-size suggestion
- **Fix 2 — retry on failed send**: tracks the last failed turn payload (`content` + `override`) in `lastFailedTurn` state; when the error banner is shown, an inline "retry" button re-dispatches the exact same payload without requiring the user to retype
- **Fix 3a — markdown in context panel**: already rendered via `Markdown` component for `open_questions`, `decisions`, `last_output_summary` slots (confirmed in `ContextPanel.tsx` — no change needed)
- **Fix 3b — copy path in diff rail**: each file row in `DiffViewerDialog`'s file rail now has a copy-path icon button (visible on hover); clicking copies `file.path` to clipboard and shows a toast via the existing `ToastProvider`

## Test plan

- [ ] Right-size suggestion: type a short message in a session on a heavy model, accept the lighter model suggestion → `ModelPicker` chip should show the lighter model immediately
- [ ] Failed send: simulate a send failure (disconnect provider mid-send) → error banner appears with a "retry" button → clicking retry re-sends without re-typing
- [ ] Diff rail copy path: open any session with file diffs, open the files modal → hover a file row → copy icon appears → click copies path → toast shows "path copied"
- [ ] No regressions on existing transcript/context panel rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)