### PR TITLE
feat(desktop): auto-name agent on first command + relocate next actions to left sidebar

### DIFF
--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -53,7 +53,6 @@ import { formatError } from '../errors';
 import { tauriGhRunner } from '../github';
 import { DiffViewerDialog } from './DiffViewerDialog';
 import { GithubCard } from './GithubCard';
-import { NextActionChips } from './NextActionChips';
 import { worktreeDiff } from '../worktree';
 
 interface ContextPanelProps {
@@ -228,7 +227,6 @@ export function ContextPanel({
               })}
             </ul>
 
-            <NextActionChips taskId={session.id} workflowBound={session.workflowId !== undefined} />
           </div>
         </ScrollArea>
 

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -77,6 +77,7 @@ import {
   resolveAgentKind,
 } from '../agent-kind';
 import { AgentKindMenu } from './AgentKindMenu';
+import { NextActionChips } from './NextActionChips';
 import { spawnFromNextAction, spawnKindForAction } from '../spawn-from-next-action';
 import { openUrl } from '../editor';
 import { formatError } from '../errors';
@@ -1481,6 +1482,11 @@ function AgentsSection({ task }: AgentsSectionProps) {
           />
         </div>
       ) : null}
+      <NextActionChips
+        taskId={task.id}
+        workflowBound={task.workflowId !== undefined}
+        className="mt-2 px-2"
+      />
       <div className="pl-2">
         <SpawnAgentControl taskId={task.id} workflow={workflow} onSpawn={onSpawn} />
       </div>

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -881,7 +881,7 @@ async function generateAutoTitle(
     if (!session) return;
     const providerId = session.providerPreference.defaultProvider;
     const systemPrompt =
-      'You generate a short title for an AI coding session. Return ONLY the title, 3-5 words, no quotes, no trailing punctuation, no explanation. The title should be a concise micro-summary of what the agent is doing (e.g. "refactor auth module", "debug startup crash"). It will be used as both the session title and the agent name.';
+      'You generate a short title for an AI coding session. Return ONLY the title, 2-4 words, all lowercase, no quotes, no trailing punctuation, no explanation. The title should be a concise micro-summary of what the agent is doing (e.g. "refactor auth module", "debug startup crash", "fix login bug"). It will be used as both the session title and the agent display name.';
     const userMessage = [
       'User request (excerpt):',
       turnInput.slice(0, 600),
@@ -909,7 +909,8 @@ async function generateAutoTitle(
     title = title
       .replace(/^["']|["']$/g, '')
       .replace(/[.!?]+$/, '')
-      .trim();
+      .trim()
+      .toLowerCase();
     if (!title) return;
     const titleNow = new Date().toISOString() as IsoDateTime;
     if (!session.titleUserEdited) {


### PR DESCRIPTION
## Summary

Two small UX bumps in the agent surface:

- **Auto-name agent on first command**: tightened the existing auto-title prompt to produce 2-4 lowercase words so the generated string fits the sidebar agent name (e.g. "fix login bug" instead of "Fix Login Bug Eventually"). Naming continues to be driven by the existing summarizer, no extra LLM call.
- **Next Actions chips relocated**: moved `NextActionChips` from the right `ContextPanel` to the left `WorkspacesSidebar` under the agents list of each session. Spawning a next action effectively spawns an agent, so the affordance belongs next to the agents list semantically.

## Test plan

- [ ] Spawn a new agent → first user turn → sidebar name updates to a short, lowercase 2-4 word title
- [ ] Subsequent turns do NOT rename the agent
- [ ] Verify next-action chips appear under the agents section in the left sidebar for each session
- [ ] Verify chips no longer render in the right context panel
- [ ] Click a next-action chip → spawns the right agent kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)