### PR TITLE
fix(desktop): use defined theme tokens for agent kind menu dropdown

### DIFF
--- a/apps/desktop/src/components/AgentKindMenu.tsx
+++ b/apps/desktop/src/components/AgentKindMenu.tsx
@@ -54,7 +54,7 @@ export function AgentKindMenu({ kind, agentLabel, onPick }: AgentKindMenuProps) 
       {open ? (
         <div
           role="menu"
-          className="absolute left-0 top-full z-50 mt-1 flex min-w-[8rem] flex-col rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md"
+          className="absolute left-0 top-full z-50 mt-1 flex min-w-[8rem] flex-col rounded-md border border-border bg-subtle p-1 text-foreground shadow-md"
           onClick={(e) => e.stopPropagation()}
           onDoubleClick={(e) => e.stopPropagation()}
         >


### PR DESCRIPTION
## Summary

- `bg-popover` and `text-popover-foreground` reference `--color-popover` which is not defined in `@theme {}` — Tailwind 4 resolves it to nothing, leaving the dropdown with no background
- replaced with `bg-subtle` + `text-foreground`, both defined in the custom theme

## Test plan

- [ ] open desktop app, click any agent kind chip in sidebar
- [ ] dropdown shows solid dark background with readable text
- [ ] verify in light theme (`data-theme="light"`) — `bg-subtle` has a light-mode override

🤖 Generated with [Claude Code](https://claude.com/claude-code)