### PR TITLE
fix(desktop): per-agent input draft so text does not leak across agents

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { create } from 'zustand';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { IsoDateTime, ProviderRunId, Task } from '@kay-am/types';
@@ -8,22 +9,53 @@ import type { IsoDateTime, ProviderRunId, Task } from '@kay-am/types';
 const sendTurnMock = vi.fn(async () => undefined);
 const cancelCurrentTurnMock = vi.fn();
 
-vi.mock('../store', () => ({
-  useAppStore: (selector: (s: unknown) => unknown) =>
-    selector({
-      sendTurn: sendTurnMock,
-      cancelCurrentTurn: cancelCurrentTurnMock,
-      providers: [
-        { id: 'anthropic', connection: 'connected' },
-        { id: 'cursor', connection: 'connected' },
-        { id: 'codex', connection: 'connected' },
-      ],
-      skills: {},
-      providerSpendBreakdown: [],
-      selectedAgentId: {},
-      agentTurnState: {},
-      agentModelOverride: {},
+interface MockStoreState {
+  sendTurn: typeof sendTurnMock;
+  cancelCurrentTurn: typeof cancelCurrentTurnMock;
+  providers: ReadonlyArray<{ id: string; connection: string }>;
+  skills: Record<string, never>;
+  providerSpendBreakdown: ReadonlyArray<never>;
+  selectedAgentId: Record<string, string>;
+  agentTurnState: Record<string, never>;
+  agentModelOverride: Record<string, never>;
+  agentRunHistory: Record<string, never>;
+  agentDraft: Record<string, string>;
+  setAgentDraft: (agentId: string, value: string) => void;
+  clearAgentDraft: (agentId: string) => void;
+}
+
+const mockStore = create<MockStoreState>((set) => ({
+  sendTurn: sendTurnMock,
+  cancelCurrentTurn: cancelCurrentTurnMock,
+  providers: [
+    { id: 'anthropic', connection: 'connected' },
+    { id: 'cursor', connection: 'connected' },
+    { id: 'codex', connection: 'connected' },
+  ],
+  skills: {},
+  providerSpendBreakdown: [],
+  selectedAgentId: { 'session-1': 'agent-1' },
+  agentTurnState: {},
+  agentModelOverride: {},
+  agentRunHistory: {},
+  agentDraft: {},
+  setAgentDraft: (agentId, value) =>
+    set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
+  clearAgentDraft: (agentId) =>
+    set((s) => {
+      if (!(agentId in s.agentDraft)) return s;
+      const next = { ...s.agentDraft };
+      delete next[agentId];
+      return { agentDraft: next };
     }),
+}));
+
+function resetMockStore() {
+  mockStore.setState({ agentDraft: {} });
+}
+
+vi.mock('../store', () => ({
+  useAppStore: mockStore,
   EMPTY_ARRAY: [] as never[],
 }));
 
@@ -78,6 +110,7 @@ function makeSession(overrides: Partial<Task> = {}): Task {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  resetMockStore();
 });
 
 describe('ChatInput — input wiring', () => {

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -84,6 +84,7 @@ vi.mock('@kay-am/core', () => ({
     selectedModel: 'claude-3-5-sonnet-latest',
     reason: 'preference',
   })),
+  assessTurnWeight: () => 'small',
 }));
 
 // Import component AFTER mocks are in place.

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -1,54 +1,56 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { create } from 'zustand';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { IsoDateTime, ProviderRunId, Task } from '@kay-am/types';
 
 // Module mocks — hoisted before imports that transitively pull the mocked modules.
-const sendTurnMock = vi.fn(async () => undefined);
-const cancelCurrentTurnMock = vi.fn();
-
-interface MockStoreState {
-  sendTurn: typeof sendTurnMock;
-  cancelCurrentTurn: typeof cancelCurrentTurnMock;
-  providers: ReadonlyArray<{ id: string; connection: string }>;
-  skills: Record<string, never>;
-  providerSpendBreakdown: ReadonlyArray<never>;
-  selectedAgentId: Record<string, string>;
-  agentTurnState: Record<string, never>;
-  agentModelOverride: Record<string, never>;
-  agentRunHistory: Record<string, never>;
-  agentDraft: Record<string, string>;
-  setAgentDraft: (agentId: string, value: string) => void;
-  clearAgentDraft: (agentId: string) => void;
-}
-
-const mockStore = create<MockStoreState>((set) => ({
-  sendTurn: sendTurnMock,
-  cancelCurrentTurn: cancelCurrentTurnMock,
-  providers: [
-    { id: 'anthropic', connection: 'connected' },
-    { id: 'cursor', connection: 'connected' },
-    { id: 'codex', connection: 'connected' },
-  ],
-  skills: {},
-  providerSpendBreakdown: [],
-  selectedAgentId: { 'session-1': 'agent-1' },
-  agentTurnState: {},
-  agentModelOverride: {},
-  agentRunHistory: {},
-  agentDraft: {},
-  setAgentDraft: (agentId, value) =>
-    set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
-  clearAgentDraft: (agentId) =>
-    set((s) => {
-      if (!(agentId in s.agentDraft)) return s;
-      const next = { ...s.agentDraft };
-      delete next[agentId];
-      return { agentDraft: next };
-    }),
-}));
+// vi.hoisted keeps shared refs alive across the hoisting reorder.
+const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(async () => {
+  const { create } = await import('zustand');
+  const send = vi.fn(async () => undefined);
+  const cancel = vi.fn();
+  interface S {
+    sendTurn: typeof send;
+    cancelCurrentTurn: typeof cancel;
+    providers: ReadonlyArray<{ id: string; connection: string }>;
+    skills: Record<string, never>;
+    providerSpendBreakdown: ReadonlyArray<never>;
+    selectedAgentId: Record<string, string>;
+    agentTurnState: Record<string, never>;
+    agentModelOverride: Record<string, never>;
+    agentRunHistory: Record<string, never>;
+    agentDraft: Record<string, string>;
+    setAgentDraft: (agentId: string, value: string) => void;
+    clearAgentDraft: (agentId: string) => void;
+  }
+  const store = create<S>((set) => ({
+    sendTurn: send,
+    cancelCurrentTurn: cancel,
+    providers: [
+      { id: 'anthropic', connection: 'connected' },
+      { id: 'cursor', connection: 'connected' },
+      { id: 'codex', connection: 'connected' },
+    ],
+    skills: {},
+    providerSpendBreakdown: [],
+    selectedAgentId: { 'session-1': 'agent-1' },
+    agentTurnState: {},
+    agentModelOverride: {},
+    agentRunHistory: {},
+    agentDraft: {},
+    setAgentDraft: (agentId, value) =>
+      set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
+    clearAgentDraft: (agentId) =>
+      set((s) => {
+        if (!(agentId in s.agentDraft)) return s;
+        const next = { ...s.agentDraft };
+        delete next[agentId];
+        return { agentDraft: next };
+      }),
+  }));
+  return { sendTurnMock: send, cancelCurrentTurnMock: cancel, mockStore: store };
+});
 
 function resetMockStore() {
   mockStore.setState({ agentDraft: {} });

--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -134,7 +134,22 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   );
 
   const { showToast } = useToast();
-  const [value, setValue] = useState('');
+
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
+  const value = useAppStore((s) =>
+    selectedAgentId ? (s.agentDraft[selectedAgentId] ?? '') : '',
+  );
+  const setAgentDraft = useAppStore((s) => s.setAgentDraft);
+  const clearAgentDraft = useAppStore((s) => s.clearAgentDraft);
+  const setValue = useCallback(
+    (next: string) => {
+      if (!selectedAgentId) return;
+      if (next.length === 0) clearAgentDraft(selectedAgentId);
+      else setAgentDraft(selectedAgentId, next);
+    },
+    [selectedAgentId, setAgentDraft, clearAgentDraft],
+  );
+
   const [error, setError] = useState<string | null>(null);
   interface FailedTurn {
     readonly content: string;
@@ -151,8 +166,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const selectedAgentId = useAppStore((s) => s.selectedAgentId[session.id] ?? null);
 
   const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
   const isSlashMode = slashQuery !== null;
@@ -205,11 +218,14 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setShowPopover(SLASH_MODE_RE.test(next));
   };
 
-  const onSkillSelect = useCallback((name: string) => {
-    setValue(`/${name} `);
-    setShowPopover(false);
-    wrapperRef.current?.querySelector('textarea')?.focus();
-  }, []);
+  const onSkillSelect = useCallback(
+    (name: string) => {
+      setValue(`/${name} `);
+      setShowPopover(false);
+      wrapperRef.current?.querySelector('textarea')?.focus();
+    },
+    [setValue],
+  );
 
   const setEffort = (level: EffortLevel) => {
     setEffortState(level);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -314,6 +314,9 @@ export interface AppState {
   readonly volatilePermissionAllows: ReadonlySet<string>;
   readonly agentModelOverride: Readonly<Record<SessionId, string>>;
   readonly agentKindOverride: Readonly<Record<SessionId, AgentKind>>;
+  // Per-agent input draft. Ephemeral, in-memory only (not persisted). Lets the
+  // user keep an unsent composition when switching agents/sessions.
+  readonly agentDraft: Readonly<Record<SessionId, string>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
   readonly notifications: ReadonlyArray<Notification>;
   readonly sessionPlans: Readonly<Record<TaskId, ReadonlyArray<Plan>>>;
@@ -457,6 +460,8 @@ export interface AppActions {
   ): Promise<SessionId>;
   renameAgent(taskId: TaskId, agentId: SessionId, name: string): Promise<void>;
   setAgentKind(agentId: SessionId, kind: AgentKind): void;
+  setAgentDraft(agentId: SessionId, value: string): void;
+  clearAgentDraft(agentId: SessionId): void;
   deleteAgent(taskId: TaskId, agentId: SessionId): Promise<void>;
   wipeLocalDatabase(): Promise<void>;
   dismissSystemAlert(id: string): void;
@@ -576,6 +581,7 @@ const initialState: AppState = {
   volatilePermissionAllows: new Set<string>(),
   agentModelOverride: {},
   agentKindOverride: {},
+  agentDraft: {},
   diffComments: {},
   notifications: [],
   sessionPlans: {},
@@ -3162,6 +3168,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
         agentKindOverride: { ...s.agentKindOverride, [agentId]: kind },
         agentModelOverride: nextModelOverride,
       };
+    });
+  },
+
+  setAgentDraft: (agentId, value) => {
+    set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } }));
+  },
+
+  clearAgentDraft: (agentId) => {
+    set((s) => {
+      if (!(agentId in s.agentDraft)) return s;
+      const next = { ...s.agentDraft };
+      delete next[agentId];
+      return { agentDraft: next };
     });
   },
 


### PR DESCRIPTION
## Summary
- Move ChatInput's text from local `useState` to a store-backed `agentDraft: Record<SessionId, string>`, same pattern as `agentModelOverride`.
- ChatInput reads/writes the draft keyed by `selectedAgentId`, so typing in agent-1 no longer carries over when you switch to agent-2. Drafts are memorized per agent — switching away and back restores them.
- Sending clears only the sending agent's draft. No DB persistence (ephemeral, in-memory).

## Why
Repro: type in agent-1's input, spawn agent-2, switch to it → agent-2's input was pre-filled with agent-1's text. Root cause: `ChatInput` was mounted with `key={session.id}` ([ChatView.tsx:317](apps/desktop/src/components/chat/ChatView.tsx#L317), [ChatView.tsx:448](apps/desktop/src/components/chat/ChatView.tsx#L448)) so the component instance survived agent switches and its local `value` state leaked across agents. The existing `useEffect` on `selectedAgentId` change reset provider/model but never cleared the text.

Transcript per-agent isolation was already correct (verified) — only the input draft leaked.

## Test plan
- [ ] Open a session with 2+ agents. Type "hello from one" in agent-1, do NOT send.
- [ ] Switch to agent-2 → input is empty.
- [ ] Type "hello from two" in agent-2, do NOT send. Switch back to agent-1 → input shows "hello from one".
- [ ] Send from agent-1 → its draft clears; agent-2 still has "hello from two".
- [ ] Start a turn on agent-1, switch UI to agent-2 mid-stream, type text → agent-1's transcript keeps populating; agent-2's draft is independent.
- [ ] Switch across sessions: draft on S1/agent-1 preserved after visiting S2 and returning.

## Out of scope
Other local-state fields in ChatInput that also persist across agent switches via the `session.id` key (`lastFailedTurn`, `queued`, `rightSizePending`, `rightSizeDismissed`, `error`). Same class of bug — defer until reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)