### PR TITLE
feat(desktop): auto-refresh githubcard when agent creates a pr

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -2563,6 +2563,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
     if (!lastError && assistantText.length > 0) {
       enqueueSummarizer(set, get, taskId, resolvedPrompt, assistantText);
       void capturePlanFromTurn(set, taskId, activeAgentId, assistantText);
+      if (
+        !get().sessionGithub[taskId]?.pr &&
+        /github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/.test(assistantText)
+      ) {
+        void get()
+          .refreshSessionPr(taskId, { force: true })
+          .then(() => void get().refreshSessionPrDetail(taskId, { force: true }));
+      }
       if (isFirstTurn) {
         const sessionForTitle = get().sessions.find((s) => s.id === taskId);
         const titleEditable = sessionForTitle ? !sessionForTitle.titleUserEdited : false;


### PR DESCRIPTION
## Summary

- scans `assistantText` after each successful turn for a GitHub PR URL pattern (`github.com/.../pull/N`)
- if match found and no PR is currently tracked for the session → fires `refreshSessionPr(force: true)` chained with `refreshSessionPrDetail(force: true)`
- guard `!sessionGithub[taskId]?.pr` prevents spurious refreshes when a PR is already known

## Test plan

- [ ] run a session where the agent executes `gh pr create`
- [ ] confirm GithubCard appears in the right panel with CI/Comments/Review tabs without manual refresh
- [ ] confirm no spurious refresh when agent narrates an existing PR URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)