### PR TITLE
fix(desktop): persist model/provider/effort/verbosity per agent

### DIFF
--- a/apps/desktop/src/components/chat/ChatInput.tsx
+++ b/apps/desktop/src/components/chat/ChatInput.tsx
@@ -12,6 +12,7 @@ import type {
   BudgetAlert,
   BudgetAlertKind,
   ProviderId,
+  SessionId,
   Task,
   TaskId,
   TurnProviderOverride,
@@ -23,7 +24,13 @@ import { formatError } from '../../errors';
 import { RoutingIndicator } from './RoutingIndicator';
 import { useToast, type ToastKind } from '../Toast';
 import { SlashCommandPopover } from './SlashCommandPopover';
-import { type VerbosityLevel, readVerbosity, writeVerbosity } from '../../verbosity';
+import {
+  type VerbosityLevel,
+  readVerbosity,
+  writeVerbosity,
+  readAgentVerbosity,
+  writeAgentVerbosity,
+} from '../../verbosity';
 import { EFFORT_LEVELS, type EffortLevel, suggestLighterModel } from './chat-constants';
 import { ProviderUsagePill } from './ProviderUsagePill';
 import { ModelPicker } from './ModelPicker';
@@ -38,6 +45,9 @@ const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
 const EFFORT_STORAGE_PREFIX = STORAGE_PREFIXES.effort;
 const MODEL_STORAGE_PREFIX = STORAGE_PREFIXES.model;
 const PROVIDER_STORAGE_PREFIX = STORAGE_PREFIXES.provider;
+const AGENT_EFFORT_PREFIX = STORAGE_PREFIXES.agentEffort;
+const AGENT_MODEL_PREFIX = STORAGE_PREFIXES.agentModel;
+const AGENT_PROVIDER_PREFIX = STORAGE_PREFIXES.agentProvider;
 
 function readEffort(taskId: TaskId): EffortLevel {
   try {
@@ -94,6 +104,67 @@ function writeProvider(taskId: TaskId, provider: ProviderId | null): void {
       localStorage.removeItem(`${PROVIDER_STORAGE_PREFIX}${taskId}`);
     } else {
       localStorage.setItem(`${PROVIDER_STORAGE_PREFIX}${taskId}`, provider);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function readAgentEffort(agentId: SessionId): EffortLevel | null {
+  try {
+    const raw = localStorage.getItem(`${AGENT_EFFORT_PREFIX}${agentId}`);
+    if (raw && EFFORT_LEVELS.includes(raw as EffortLevel)) return raw as EffortLevel;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function writeAgentEffort(agentId: SessionId, level: EffortLevel): void {
+  try {
+    localStorage.setItem(`${AGENT_EFFORT_PREFIX}${agentId}`, level);
+  } catch {
+    // ignore
+  }
+}
+
+function readAgentModel(agentId: SessionId): string | null {
+  try {
+    return localStorage.getItem(`${AGENT_MODEL_PREFIX}${agentId}`);
+  } catch {
+    return null;
+  }
+}
+
+function writeAgentModel(agentId: SessionId, model: string | null): void {
+  try {
+    if (model === null) {
+      localStorage.removeItem(`${AGENT_MODEL_PREFIX}${agentId}`);
+    } else {
+      localStorage.setItem(`${AGENT_MODEL_PREFIX}${agentId}`, model);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+function readAgentProvider(agentId: SessionId): ProviderId | null {
+  try {
+    const raw = localStorage.getItem(`${AGENT_PROVIDER_PREFIX}${agentId}`);
+    const valid: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+    if (raw && valid.includes(raw as ProviderId)) return raw as ProviderId;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function writeAgentProvider(agentId: SessionId, provider: ProviderId | null): void {
+  try {
+    if (provider === null) {
+      localStorage.removeItem(`${AGENT_PROVIDER_PREFIX}${agentId}`);
+    } else {
+      localStorage.setItem(`${AGENT_PROVIDER_PREFIX}${agentId}`, provider);
     }
   } catch {
     // ignore
@@ -168,6 +239,15 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   );
   const isRunning = RUNNING_KINDS.has(selectedAgentState?.kind ?? session.state.kind);
   const wasRunning = useRef(isRunning);
+
+  const currentProviderRef = useRef(selectedProvider);
+  currentProviderRef.current = selectedProvider;
+  const currentModelRef = useRef(selectedModel);
+  currentModelRef.current = selectedModel;
+  const currentEffortRef = useRef(effort);
+  currentEffortRef.current = effort;
+  const currentVerbosityRef = useRef(verbosity);
+  currentVerbosityRef.current = verbosity;
   interface QueuedTurn {
     readonly content: string;
     readonly override: TurnProviderOverride | undefined;
@@ -214,21 +294,25 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const setEffort = (level: EffortLevel) => {
     setEffortState(level);
     writeEffort(session.id, level);
+    if (selectedAgentId) writeAgentEffort(selectedAgentId, level);
   };
 
   const setVerbosity = (level: VerbosityLevel) => {
     setVerbosityState(level);
     writeVerbosity(session.id, level);
+    if (selectedAgentId) writeAgentVerbosity(selectedAgentId, level);
   };
 
   const setSelectedProvider = (id: ProviderId | null) => {
     setSelectedProviderState(id);
     writeProvider(session.id, id);
+    if (selectedAgentId) writeAgentProvider(selectedAgentId, id);
   };
 
   const setSelectedModel = (id: string | null) => {
     setSelectedModelState(id);
     writeModel(session.id, id);
+    if (selectedAgentId) writeAgentModel(selectedAgentId, id);
   };
 
   const onSelectProvider = (id: ProviderId) => {
@@ -341,9 +425,26 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const lastAgentIdRef = useRef(selectedAgentId);
   useEffect(() => {
     if (lastAgentIdRef.current === selectedAgentId) return;
+    const outgoingAgentId = lastAgentIdRef.current;
     lastAgentIdRef.current = selectedAgentId;
-    setSelectedProvider(null);
-    setSelectedModel(null);
+
+    if (outgoingAgentId !== null) {
+      writeAgentProvider(outgoingAgentId, currentProviderRef.current);
+      writeAgentModel(outgoingAgentId, currentModelRef.current);
+      writeAgentEffort(outgoingAgentId, currentEffortRef.current);
+      writeAgentVerbosity(outgoingAgentId, currentVerbosityRef.current);
+    }
+
+    const restoredProvider = selectedAgentId !== null ? readAgentProvider(selectedAgentId) : null;
+    const restoredModel = selectedAgentId !== null ? readAgentModel(selectedAgentId) : null;
+    const restoredEffort = selectedAgentId !== null ? readAgentEffort(selectedAgentId) : null;
+    const restoredVerbosity = selectedAgentId !== null ? readAgentVerbosity(selectedAgentId) : null;
+
+    setSelectedProviderState(restoredProvider);
+    setSelectedModelState(restoredModel);
+    if (restoredEffort !== null) setEffortState(restoredEffort);
+    if (restoredVerbosity !== null) setVerbosityState(restoredVerbosity);
+
     setRightSizePending(null);
     setRightSizeDismissed(false);
   }, [selectedAgentId]);

--- a/apps/desktop/src/storage-keys.ts
+++ b/apps/desktop/src/storage-keys.ts
@@ -13,6 +13,10 @@ export const STORAGE_PREFIXES = {
   model: `${PREFIX}model:`,
   provider: `${PREFIX}provider:`,
   contextPanelOpen: `${PREFIX}context-panel-open:`,
+  agentVerbosity: `${PREFIX}agent-verbosity:`,
+  agentEffort: `${PREFIX}agent-effort:`,
+  agentModel: `${PREFIX}agent-model:`,
+  agentProvider: `${PREFIX}agent-provider:`,
 } as const;
 
 const LEGACY_KEY_MAP: Record<string, string> = {

--- a/apps/desktop/src/verbosity.ts
+++ b/apps/desktop/src/verbosity.ts
@@ -1,4 +1,4 @@
-import type { TaskId } from '@kay-am/types';
+import type { SessionId, TaskId } from '@kay-am/types';
 import { STORAGE_PREFIXES } from './storage-keys';
 
 export const VERBOSITY_LEVELS = ['brief', 'normal', 'verbose'] as const;
@@ -34,6 +34,28 @@ export function readVerbosity(taskId: TaskId): VerbosityLevel {
 export function writeVerbosity(taskId: TaskId, level: VerbosityLevel): void {
   try {
     localStorage.setItem(`${STORAGE_PREFIX}${taskId}`, level);
+  } catch {
+    // ignore
+  }
+}
+
+const AGENT_STORAGE_PREFIX = STORAGE_PREFIXES.agentVerbosity;
+
+export function readAgentVerbosity(agentId: SessionId): VerbosityLevel | null {
+  try {
+    const raw = localStorage.getItem(`${AGENT_STORAGE_PREFIX}${agentId}`);
+    if (!raw) return null;
+    if ((VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) return raw as VerbosityLevel;
+    if (raw in LEGACY_MAP) return LEGACY_MAP[raw]!;
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+export function writeAgentVerbosity(agentId: SessionId, level: VerbosityLevel): void {
+  try {
+    localStorage.setItem(`${AGENT_STORAGE_PREFIX}${agentId}`, level);
   } catch {
     // ignore
   }


### PR DESCRIPTION
## Summary

- On agent switch, `selectedProvider` and `selectedModel` were reset to `null` → fell back to session defaults (cloud/ops/4.7/high/normal)
- `effort` and `verbosity` were session-level, not per-agent
- Fix: each agent now saves/restores its own provider, model, effort, verbosity in localStorage

## How

- New storage prefixes: `agent-provider:`, `agent-model:`, `agent-effort:`, `agent-verbosity:` keyed by `SessionId`
- `setEffort`, `setVerbosity`, `setSelectedProvider`, `setSelectedModel` write to both session-level and per-agent storage
- Agent-switch effect: saves outgoing agent config, restores incoming agent config (if any — new agents get current values unchanged)
- Value refs (`currentProviderRef` etc.) capture state safely inside the effect

## Test plan

- [ ] Set Cursor + Haiku in agent A → switch to agent B → agent B shows its own config (or default if new)
- [ ] Return to agent A → Cursor + Haiku restored
- [ ] Change effort/verbosity in agent A → switch → return → values restored
- [ ] New agent → no saved config → values unchanged from previous agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)