### PR TITLE
feat(desktop): pulse halo on running agent indicator

### DIFF
--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -1685,7 +1685,7 @@ function SuggestionMenuItem({ action, onSelect }: { action: NextAction; onSelect
 
 const AGENT_STATUS_TONE: Record<SessionStatus, string> = {
   pending: 'bg-muted-foreground/40',
-  running: 'bg-info animate-pulse',
+  running: 'bg-info',
   completed: 'bg-success',
   failed: 'bg-danger',
   skipped: 'bg-muted-foreground/20',
@@ -1771,13 +1771,17 @@ function AgentRow({
       )}
     >
       <div className="flex items-center gap-2 px-2 py-1.5" title={titleParts.join('\n')}>
-        <span
-          aria-hidden
-          className={cn(
-            'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-            AGENT_STATUS_TONE[run.status],
+        <span aria-hidden className="relative inline-flex h-1.5 w-1.5 shrink-0">
+          {run.status === 'running' && (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-info opacity-60" />
           )}
-        />
+          <span
+            className={cn(
+              'relative inline-block h-1.5 w-1.5 rounded-full',
+              AGENT_STATUS_TONE[run.status],
+            )}
+          />
+        </span>
         <AgentKindMenu kind={kind} agentLabel={`agent ${run.ordinal + 1}`} onPick={onPickKind} />
         {isEditing ? (
           <input


### PR DESCRIPTION
## Summary
- adds an `animate-ping` halo around the agent status dot only while the agent is in `running` state
- removes the previous `animate-pulse` on the solid dot (replaced by the halo) — no more double animation
- zero layout shift: halo is absolutely positioned over a `1.5×1.5` wrapper

## Why
"a volte" si beccava `illegal transition: cannot apply send in state running` senza capire al volo quale agent fosse mid-turn. il pallino esistente era troppo discreto. ora l'occhio individua immediatamente la riga "viva" senza rumore visivo.

race condition non toccata (out of scope).

## Test plan
- [ ] avvia un turn → la riga dell'agent mostra pallino blu con halo che pulsa
- [ ] al `done` → halo sparisce, pallino diventa verde fisso
- [ ] altri stati (`pending` / `failed` / `skipped`) invariati, nessun halo
- [ ] dark mode: halo leggibile
- [ ] nessun shift di layout durante il pulse

🤖 Generated with [Claude Code](https://claude.com/claude-code)