### PR TITLE
fix(desktop): open in cursor loads correct folder

### DIFF
--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -68,30 +68,18 @@ impl serde::Serialize for EditorError {
 pub fn open_in_editor(path: String, editor: Option<String>) -> Result<(), EditorError> {
     let binary = editor.unwrap_or_else(|| DEFAULT_EDITOR.to_string());
 
-    // On macOS, cursor's CLI shim opens paths inside the current window which can
-    // resolve to a single file rather than the workspace folder. Use `open -a Cursor`
-    // when targeting a directory so the folder loads as a workspace.
-    #[cfg(target_os = "macos")]
-    {
-        if binary == "cursor" && std::path::Path::new(&path).is_dir() {
-            return match Command::new("open")
-                .args(["-a", "Cursor", "-n", &path])
-                .spawn()
-            {
-                Ok(_) => Ok(()),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                    Err(EditorError::NotFound(binary))
-                }
-                Err(source) => Err(EditorError::Spawn { binary, source }),
-            };
-        }
-    }
+    // Resolve to absolute canonical path so editors load it as a workspace folder
+    // rather than treating it as a relative-to-cwd file. Falls back to the input
+    // string when canonicalize fails (e.g. path does not exist yet).
+    let abs_path = std::fs::canonicalize(&path)
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.clone());
 
     let mut cmd = crate::path_env::command(&binary);
     if binary == "cursor" || binary == "code" {
         cmd.arg("--new-window");
     }
-    cmd.arg(&path);
+    cmd.arg(&abs_path);
 
     match cmd.spawn() {
         Ok(_) => Ok(()),

--- a/apps/desktop/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop/src/components/chat/ChatHeader.tsx
@@ -78,7 +78,7 @@ export function ChatHeader({
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
-          <OpenInEditorButton worktreePath={worktreePath} />
+          <OpenInEditorButton worktreePath={worktreePath ?? workspace?.rootPath ?? null} />
         </div>
       </div>
     </div>

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -3,12 +3,13 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
 const host = process.env.TAURI_DEV_HOST;
+const port = process.env.VITE_PORT ? Number(process.env.VITE_PORT) : 1420;
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   clearScreen: false,
   server: {
-    port: 1420,
+    port,
     strictPort: true,
     host: host ?? false,
   },


### PR DESCRIPTION
## Summary

- **cursor fix**: replace macOS `open -a Cursor -n <path>` workaround with `cursor --new-window <abs_path>`. The old workaround launched the app but didn't load the target directory as a workspace (empty window / wrong file). Canonicalize path before passing.
- **main-checkout fallback**: `OpenInEditorButton` now falls back to `workspace.rootPath` when `worktreePath` is null, so the button works on sessions running against main, not only worktree-backed ones.
- **dev-server port override**: `vite.config.ts` honors `VITE_PORT` env (defaults to 1420). Enables running a second `pnpm tauri:dev` from a worktree alongside main:
  ```
  VITE_PORT=1421 pnpm tauri:dev --config '{"build":{"devUrl":"http://localhost:1421"}}'
  ```

## Test plan
- [x] manual: open in cursor from worktree session → loads worktree folder as workspace
- [x] manual: open in cursor from main-checkout session → loads workspace.rootPath
- [x] manual: parallel `pnpm tauri:dev` on 1420 (main) + 1421 (worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)