### PR TITLE
feat(desktop): track diff comments consumed by reviewer agent

### DIFF
--- a/apps/desktop/src/components/DiffViewerDialog.tsx
+++ b/apps/desktop/src/components/DiffViewerDialog.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import {
+  ArrowUpRight,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -10,6 +11,7 @@ import {
   MessageSquarePlus,
   PanelLeftClose,
   PanelLeftOpen,
+  RotateCcw,
   Sparkles,
   Trash2,
   X,
@@ -23,6 +25,7 @@ import type {
   DiffHunkLine,
   FileDiff,
   FileDiffStatus,
+  SessionId,
   TaskId,
 } from '@kay-am/types';
 import { ghPrDiff } from '../github';
@@ -205,7 +208,18 @@ export function DiffViewerDialog({
   const loadDiffComments = useAppStore((s) => s.loadDiffComments);
   const addDiffComment = useAppStore((s) => s.addDiffComment);
   const resolveDiffComment = useAppStore((s) => s.resolveDiffComment);
+  const consumeDiffComments = useAppStore((s) => s.consumeDiffComments);
+  const reopenDiffComment = useAppStore((s) => s.reopenDiffComment);
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const phaseRuns = useAppStore((s) =>
+    taskId ? (s.sessionPhaseRuns[taskId] ?? null) : null,
+  );
+  const agentNameById = useMemo(() => {
+    const m = new Map<SessionId, string>();
+    if (phaseRuns) for (const r of phaseRuns) m.set(r.id, r.name);
+    return m;
+  }, [phaseRuns]);
 
   const openCommentsByFile = useMemo(() => {
     const m = new Map<string, number>();
@@ -321,16 +335,28 @@ export function DiffViewerDialog({
       const defaults = AGENT_KIND_DEFAULTS.reviewer;
       const fileCount = new Set(openComments.map((c) => c.filePath)).size;
       const name = `review notes (${fileCount}F/${openComments.length}N)`;
-      await spawnAgent(taskId, {
+      const idsToConsume = openComments.map((c) => c.id);
+      const agentId = await spawnAgent(taskId, {
         name,
         model: defaults.model,
         effort: defaults.effort,
       });
+      try {
+        await consumeDiffComments(taskId, idsToConsume, agentId);
+      } catch (err) {
+        console.error('failed to mark comments consumed', err);
+      }
       void sendTurn({ taskId, content: prompt });
       onClose();
     } finally {
       setSpawning(false);
     }
+  };
+
+  const handleViewAgent = async (agentId: SessionId) => {
+    if (!taskId) return;
+    await selectAgent(taskId, agentId);
+    onClose();
   };
 
   const handleOpenInEditor = async () => {
@@ -436,7 +462,10 @@ export function DiffViewerDialog({
                     onCancelFileLevelComment={() => setFileLevelComposerOpen(false)}
                     onSubmitFileLevelComment={(body) => void handleAddFileLevelComment(body)}
                     onResolve={(id) => taskId && void resolveDiffComment(taskId, id)}
+                    onReopen={(id) => taskId && void reopenDiffComment(taskId, id)}
                     onDelete={(id) => taskId && void deleteDiffComment(taskId, id)}
+                    onViewAgent={(id) => void handleViewAgent(id)}
+                    getAgentName={(id) => agentNameById.get(id)}
                   />
                 ) : null}
               </div>
@@ -794,48 +823,95 @@ function TreeNodeView({
 function CommentItem({
   comment,
   onResolve,
+  onReopen,
   onDelete,
+  onViewAgent,
+  getAgentName,
 }: {
   comment: DiffComment;
   onResolve: (id: string) => void;
+  onReopen: (id: string) => void;
   onDelete: (id: string) => void;
+  onViewAgent: (agentId: SessionId) => void;
+  getAgentName: (agentId: SessionId) => string | undefined;
 }) {
+  const agentName = comment.consumedByAgentId
+    ? getAgentName(comment.consumedByAgentId)
+    : undefined;
+  const containerClass =
+    comment.status === 'resolved'
+      ? 'border-success/40 bg-success/5 opacity-60'
+      : comment.status === 'consumed'
+        ? 'border-info/40 bg-info/5'
+        : 'border-warning bg-warning/5';
   return (
     <div
       className={cn(
-        'group flex items-start gap-2 rounded-md border-l-2 border-warning bg-warning/5 px-3 py-1.5',
-        comment.status === 'resolved' && 'border-success/40 bg-success/5 opacity-60',
+        'group flex flex-col gap-1 rounded-md border-l-2 px-3 py-1.5',
+        containerClass,
       )}
     >
-      <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">
-        {comment.status === 'resolved' ? (
-          <span className="line-through">{comment.body}</span>
-        ) : (
-          comment.body
-        )}
-      </p>
-      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        {comment.status === 'open' ? (
+      <div className="flex items-start gap-2">
+        <p className="min-w-0 flex-1 whitespace-pre-wrap break-words text-xs leading-relaxed text-foreground">
+          {comment.status === 'resolved' ? (
+            <span className="line-through">{comment.body}</span>
+          ) : (
+            comment.body
+          )}
+        </p>
+        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+          {comment.status === 'open' ? (
+            <button
+              type="button"
+              onClick={() => onResolve(comment.id)}
+              title="mark resolved"
+              aria-label="resolve"
+              className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-success"
+            >
+              <Check size={11} />
+            </button>
+          ) : null}
+          {comment.status === 'consumed' ? (
+            <button
+              type="button"
+              onClick={() => onReopen(comment.id)}
+              title="reopen note"
+              aria-label="reopen"
+              className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-warning"
+            >
+              <RotateCcw size={11} />
+            </button>
+          ) : null}
           <button
             type="button"
-            onClick={() => onResolve(comment.id)}
-            title="mark resolved"
-            aria-label="resolve"
-            className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-success"
+            onClick={() => onDelete(comment.id)}
+            title="delete"
+            aria-label="delete"
+            className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-danger"
           >
-            <Check size={11} />
+            <Trash2 size={11} />
           </button>
-        ) : null}
-        <button
-          type="button"
-          onClick={() => onDelete(comment.id)}
-          title="delete"
-          aria-label="delete"
-          className="rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-danger"
-        >
-          <Trash2 size={11} />
-        </button>
+        </div>
       </div>
+      {comment.status === 'consumed' ? (
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          {agentName && comment.consumedByAgentId ? (
+            <>
+              <span>consumed by</span>
+              <button
+                type="button"
+                onClick={() => onViewAgent(comment.consumedByAgentId as SessionId)}
+                className="inline-flex items-center gap-0.5 rounded-sm px-1 py-0.5 text-info hover:bg-info/10 hover:text-info"
+              >
+                <span className="font-medium">{agentName}</span>
+                <ArrowUpRight size={9} aria-hidden />
+              </button>
+            </>
+          ) : (
+            <span className="italic">consumed by removed agent</span>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -865,7 +941,10 @@ interface FileDiffPaneProps {
   onCancelFileLevelComment: () => void;
   onSubmitFileLevelComment: (body: string) => void;
   onResolve: (id: string) => void;
+  onReopen: (id: string) => void;
   onDelete: (id: string) => void;
+  onViewAgent: (agentId: SessionId) => void;
+  getAgentName: (agentId: SessionId) => string | undefined;
 }
 
 function FileDiffPane({
@@ -882,7 +961,10 @@ function FileDiffPane({
   onCancelFileLevelComment,
   onSubmitFileLevelComment,
   onResolve,
+  onReopen,
   onDelete,
+  onViewAgent,
+  getAgentName,
 }: FileDiffPaneProps) {
   const commentsByAnchor = useMemo(() => {
     const m = new Map<string, DiffComment[]>();
@@ -918,7 +1000,15 @@ function FileDiffPane({
               ) : null}
             </div>
             {fileLevelComments.map((c) => (
-              <CommentItem key={c.id} comment={c} onResolve={onResolve} onDelete={onDelete} />
+              <CommentItem
+                key={c.id}
+                comment={c}
+                onResolve={onResolve}
+                onReopen={onReopen}
+                onDelete={onDelete}
+                onViewAgent={onViewAgent}
+                getAgentName={getAgentName}
+              />
             ))}
             {fileLevelComposerOpen ? (
               <InlineComposer
@@ -1019,7 +1109,10 @@ function FileDiffPane({
                                     key={c.id}
                                     comment={c}
                                     onResolve={onResolve}
+                                    onReopen={onReopen}
                                     onDelete={onDelete}
+                                    onViewAgent={onViewAgent}
+                                    getAgentName={getAgentName}
                                   />
                                 ))}
                               </div>

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -59,6 +59,8 @@ import {
   insertDiffComment,
   listDiffCommentsForTask,
   resolveDiffComment as dbResolveDiffComment,
+  consumeDiffComments as dbConsumeDiffComments,
+  reopenDiffComment as dbReopenDiffComment,
   deleteDiffComment as dbDeleteDiffComment,
   insertNotification,
   listNotifications,
@@ -512,6 +514,12 @@ export interface AppActions {
     anchor?: import('@kay-am/types').DiffCommentAnchor,
   ): Promise<void>;
   resolveDiffComment(taskId: TaskId, commentId: string): Promise<void>;
+  consumeDiffComments(
+    taskId: TaskId,
+    commentIds: ReadonlyArray<string>,
+    agentId: SessionId,
+  ): Promise<void>;
+  reopenDiffComment(taskId: TaskId, commentId: string): Promise<void>;
   deleteDiffComment(taskId: TaskId, commentId: string): Promise<void>;
   loadNotifications(): Promise<void>;
   emitNotification(
@@ -2701,6 +2709,23 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   resolveDiffComment: async (taskId, commentId) => {
     await dbResolveDiffComment(tauriDatabase, commentId);
+    const comments = await listDiffCommentsForTask(tauriDatabase, taskId);
+    set((state) => ({
+      diffComments: { ...state.diffComments, [taskId]: comments },
+    }));
+  },
+
+  consumeDiffComments: async (taskId, commentIds, agentId) => {
+    if (commentIds.length === 0) return;
+    await dbConsumeDiffComments(tauriDatabase, commentIds, agentId);
+    const comments = await listDiffCommentsForTask(tauriDatabase, taskId);
+    set((state) => ({
+      diffComments: { ...state.diffComments, [taskId]: comments },
+    }));
+  },
+
+  reopenDiffComment: async (taskId, commentId) => {
+    await dbReopenDiffComment(tauriDatabase, commentId);
     const comments = await listDiffCommentsForTask(tauriDatabase, taskId);
     set((state) => ({
       diffComments: { ...state.diffComments, [taskId]: comments },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -108,6 +108,8 @@ export {
   insertDiffComment,
   listDiffCommentsForTask,
   resolveDiffComment,
+  consumeDiffComments,
+  reopenDiffComment,
   deleteDiffComment,
 } from './queries/diff-comment';
 export {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -25,6 +25,7 @@ import { m024SessionProviderSessionId } from './m024-session-provider-session-id
 import { m025TaskTitleUserEdited } from './m025-task-title-user-edited';
 import { m026Notifications } from './m026-notifications';
 import { m027SessionPlans } from './m027-session-plans';
+import { m028DiffCommentConsumed } from './m028-diff-comment-consumed';
 
 export interface Migration {
   readonly version: number;
@@ -59,4 +60,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 25, sql: m025TaskTitleUserEdited },
   { version: 26, sql: m026Notifications },
   { version: 27, sql: m027SessionPlans },
+  { version: 28, sql: m028DiffCommentConsumed },
 ];

--- a/packages/db/src/migrations/m028-diff-comment-consumed.ts
+++ b/packages/db/src/migrations/m028-diff-comment-consumed.ts
@@ -1,0 +1,33 @@
+export const m028DiffCommentConsumed = /* sql */ `
+CREATE TABLE diff_comments_new (
+  id TEXT PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  body TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('open', 'resolved', 'consumed')) DEFAULT 'open',
+  created_at INTEGER NOT NULL,
+  resolved_at INTEGER,
+  consumed_at INTEGER,
+  consumed_by_agent_id TEXT,
+  line_number INTEGER,
+  line_side TEXT CHECK (line_side IN ('old', 'new')),
+  FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (consumed_by_agent_id) REFERENCES sessions(id) ON DELETE SET NULL
+);
+
+INSERT INTO diff_comments_new (
+  id, task_id, file_path, body, status, created_at, resolved_at, line_number, line_side
+)
+SELECT
+  id, task_id, file_path, body, status, created_at, resolved_at, line_number, line_side
+FROM diff_comments;
+
+DROP TABLE diff_comments;
+ALTER TABLE diff_comments_new RENAME TO diff_comments;
+
+CREATE INDEX idx_diff_comments_task_status ON diff_comments(task_id, status);
+CREATE INDEX idx_diff_comments_task_file ON diff_comments(task_id, file_path);
+CREATE INDEX idx_diff_comments_task_file_line
+  ON diff_comments(task_id, file_path, line_side, line_number);
+CREATE INDEX idx_diff_comments_consumed_by ON diff_comments(consumed_by_agent_id);
+`;

--- a/packages/db/src/queries/diff-comment.ts
+++ b/packages/db/src/queries/diff-comment.ts
@@ -4,6 +4,7 @@ import type {
   DiffCommentSide,
   DiffCommentStatus,
   IsoDateTime,
+  SessionId,
   TaskId,
 } from '@kay-am/types';
 import type { Database } from '../client';
@@ -16,6 +17,8 @@ interface DiffCommentRow {
   status: string;
   created_at: number;
   resolved_at: number | null;
+  consumed_at: number | null;
+  consumed_by_agent_id: string | null;
   line_number: number | null;
   line_side: string | null;
 }
@@ -36,9 +39,18 @@ function toDomain(row: DiffCommentRow): DiffComment {
       row.resolved_at !== null
         ? (new Date(row.resolved_at).toISOString() as IsoDateTime)
         : undefined,
+    consumedAt:
+      row.consumed_at !== null
+        ? (new Date(row.consumed_at).toISOString() as IsoDateTime)
+        : undefined,
+    consumedByAgentId:
+      row.consumed_by_agent_id !== null ? (row.consumed_by_agent_id as SessionId) : undefined,
     anchor,
   };
 }
+
+const SELECT_COLUMNS = `id, task_id, file_path, body, status, created_at, resolved_at,
+    consumed_at, consumed_by_agent_id, line_number, line_side`;
 
 export async function insertDiffComment(
   db: Database,
@@ -60,7 +72,7 @@ export async function listDiffCommentsForTask(
   taskId: TaskId,
 ): Promise<ReadonlyArray<DiffComment>> {
   const rows = await db.select<DiffCommentRow>(
-    `SELECT id, task_id, file_path, body, status, created_at, resolved_at, line_number, line_side
+    `SELECT ${SELECT_COLUMNS}
      FROM diff_comments
      WHERE task_id = ?
      ORDER BY created_at ASC`,
@@ -74,6 +86,30 @@ export async function resolveDiffComment(db: Database, id: string): Promise<void
     Date.now(),
     id,
   ]);
+}
+
+export async function consumeDiffComments(
+  db: Database,
+  ids: ReadonlyArray<string>,
+  agentId: SessionId,
+): Promise<void> {
+  if (ids.length === 0) return;
+  const placeholders = ids.map(() => '?').join(', ');
+  await db.execute(
+    `UPDATE diff_comments
+     SET status = 'consumed', consumed_at = ?, consumed_by_agent_id = ?
+     WHERE status = 'open' AND id IN (${placeholders})`,
+    [Date.now(), agentId, ...ids],
+  );
+}
+
+export async function reopenDiffComment(db: Database, id: string): Promise<void> {
+  await db.execute(
+    `UPDATE diff_comments
+     SET status = 'open', consumed_at = NULL, consumed_by_agent_id = NULL
+     WHERE id = ?`,
+    [id],
+  );
 }
 
 export async function deleteDiffComment(db: Database, id: string): Promise<void> {

--- a/packages/types/src/diff-comment.ts
+++ b/packages/types/src/diff-comment.ts
@@ -1,6 +1,6 @@
-import type { IsoDateTime, TaskId } from './ids';
+import type { IsoDateTime, SessionId, TaskId } from './ids';
 
-export type DiffCommentStatus = 'open' | 'resolved';
+export type DiffCommentStatus = 'open' | 'resolved' | 'consumed';
 
 export type DiffCommentSide = 'old' | 'new';
 
@@ -17,5 +17,7 @@ export type DiffComment = Readonly<{
   status: DiffCommentStatus;
   createdAt: IsoDateTime;
   resolvedAt?: IsoDateTime;
+  consumedAt?: IsoDateTime;
+  consumedByAgentId?: SessionId;
   anchor?: DiffCommentAnchor;
 }>;


### PR DESCRIPTION
## Summary
- When **Propose fixes** spawns a reviewer agent from the diff modal, comments now move from `open` to a new `consumed` status — they leave the open-notes counter / warning state but remain visible inline on the file.
- Each consumed comment shows a `consumed by <agent-name>` link that jumps to the agent's transcript, and a hover **Reopen** button that pulls it back to `open` if the agent ran off the rails.
- Manual checkmark-resolve stays a distinct state (green strikethrough) so you can tell at a glance which notes you signed off vs. which an agent picked up.

## Implementation notes
- `DiffComment` gains `status: 'consumed'` + `consumedAt` + `consumedByAgentId` (FK on `sessions(id) ON DELETE SET NULL`, so deleting the agent gracefully degrades to "consumed by removed agent" with reopen still functional).
- Migration `m028` rebuilds `diff_comments` with the new CHECK and FK.
- Two new store actions: `consumeDiffComments(taskId, ids, agentId)` (called optimistically right after `spawnAgent` returns the new id, guarded by `WHERE status='open'` so duplicate clicks are no-ops) and `reopenDiffComment(taskId, id)`.
- `CommentItem` rendered in three branches: open (yellow + check), consumed (neutral info + link + reopen), resolved (green strikethrough).

## Test plan
- [ ] Open a task with a dirty working tree → DiffViewerDialog.
- [ ] Add 2 anchored notes + 1 file-level note. Footer reads "3 open notes".
- [ ] Click **Propose fixes**: dialog closes, reviewer agent appears with the formatted notes as its kickoff.
- [ ] Reopen dialog: all 3 notes still rendered, in neutral (non-yellow) style. Each shows `consumed by review notes (XF/YN)` linking to the agent. Footer + rail badges gone.
- [ ] Click the agent link → main view switches to that agent transcript.
- [ ] Hover a consumed note → click **Reopen** → it returns to yellow and the footer counter ticks back up. Re-clicking **Propose fixes** spawns a new run with only the reopened note.
- [ ] Resolve a different open note via the green check → renders strikethrough/green, visually distinct from consumed.
- [ ] Delete the spawned reviewer agent → its consumed notes show `consumed by removed agent` (link disabled), reopen still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)