### PR TITLE
chore(desktop): enlarge default window to 1440x900

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -13,8 +13,11 @@
     "windows": [
       {
         "title": "kAY.am",
-        "width": 800,
-        "height": 600,
+        "width": 1440,
+        "height": 900,
+        "minWidth": 1024,
+        "minHeight": 700,
+        "center": true,
         "resizable": true,
         "fullscreen": false
       }


### PR DESCRIPTION
## Summary
- default window 800x600 → 1440x900, centered
- min 1024x700 to prevent over-shrinking

## Test plan
- [ ] launch app → opens at 1440x900, centered
- [ ] resize down → stops at 1024x700
- [ ] resize up + fullscreen still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)