### PR TITLE
feat(core): summarizer preserves context and emits compact markdown

### DIFF
--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -58,19 +58,42 @@ export class SummarizerParseError extends Error {
   }
 }
 
-const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session.
+const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session. The summary is the handoff payload — a fresh agent must be able to read these slots alone and continue the work without seeing any prior turns.
 
 There are exactly five slots, each with a stable key:
 ${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
 
-You will receive the previous slot values plus the most recent user turn and assistant turn.
-Decide which slots, if any, should change. Keep values terse: a sentence or short bullet list per slot.
+INPUT
+You receive the previous slot values plus the most recent user turn and assistant turn.
 
-You MUST respond with a single JSON object and nothing else. No prose, no markdown, no code fences.
-The schema is:
-{ "upserts": [ { "key": "<one of the five keys>", "value": "<new slot value>" } ] }
+CONTEXT PRESERVATION (critical)
+Previous slot content is canonical memory. There is no "append" operation — every upsert REPLACES the slot — so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
+Never silently drop facts that are still valid. Per slot:
+- goal: refine over time as intent clarifies; do not erase prior framing if still valid.
+- decisions: append new decisions to the existing list. Never remove accepted ones.
+- open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
+- files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
+- last_output_summary: REPLACE, not merge — it summarizes only the latest assistant turn.
 
-Only include slots that should change. Omit slots that stay the same. Never invent new keys.
+FORMATTING (critical — values render as markdown in the UI)
+Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
+Rules:
+- Prefer short bullet lists ("- " prefix). One fact per bullet, under ~100 chars; split long bullets in two.
+- Insert a blank line between logically distinct groups of bullets.
+- Use two-space indent + "- " for sub-bullets when nesting context.
+- Use \`backticks\` for identifiers, paths, commands. Use **bold** sparingly for keys/file names that aid scanning.
+- Do NOT use markdown headings (#) — the slot label is already the heading.
+- Do NOT wrap the value in code fences unless quoting actual code.
+- Exclude raw tool output and chat-style narration.
+- The "goal" slot stays as one tight sentence or two — no bullets needed unless multiple sub-goals exist.
+
+OUTPUT
+You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.
+The value field is a JSON string; encode newlines inside it as the escape sequence \\n so the rendered markdown breaks across lines.
+Schema:
+{ "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
+
+Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
 If nothing should change, return { "upserts": [] }.`;
 
 function getCheapModel(providerId: ProviderId): string {

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -90,18 +90,37 @@ const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding 
 There are exactly five slots, each with a stable key:
 ${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
 
-You will receive the previous slot values plus the most recent user turn and assistant turn.
-Decide which slots, if any, should change. Keep values terse: a sentence or short bullet list per slot. Prefer decisions, constraints, and unresolved items over verbose narration of what happened. Exclude raw tool output.
+INPUT
+You receive the previous slot values plus the most recent user turn and assistant turn.
 
-Goal refinement: the "goal" slot is not write-once. As the conversation clarifies what the user actually wants, sharpen the goal — make it more specific, surface implicit constraints, drop vague phrasing. Update goal whenever the latest turn changed or clarified the target. Don't rewrite when nothing new emerged.
+CONTEXT PRESERVATION (critical)
+Previous slot content is canonical memory. There is no "append" operation — every upsert REPLACES the slot — so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
+Never silently drop facts that are still valid. Per slot:
+- goal: refine over time as intent clarifies — sharpen wording, surface implicit constraints, drop vague phrasing. Do not erase prior framing if still valid.
+- decisions: append new decisions to the existing list. Never remove accepted ones.
+- open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
+- files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
+- last_output_summary: this slot is REPLACE, not merge — it summarizes only the latest assistant turn.
 
-Open questions: when the latest user turn answers a previously-listed open question, drop the resolved item from the open_questions slot value. Add new questions only when the assistant explicitly needs the user before continuing.
+FORMATTING (critical — values render as markdown in the UI)
+Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
+Rules:
+- Prefer short bullet lists ("- " prefix). One fact per bullet, under ~100 chars; split long bullets in two.
+- Insert a blank line between logically distinct groups of bullets so the UI does not render them squashed.
+- Use two-space indent + "- " for sub-bullets when nesting context.
+- Use \`backticks\` for identifiers, paths, commands. Use **bold** sparingly for keys/file names that aid scanning.
+- Do NOT use markdown headings (#) — the slot label is already the heading.
+- Do NOT wrap the value in code fences unless quoting actual code.
+- Exclude raw tool output and chat-style narration.
+- The "goal" slot stays as one tight sentence or two — no bullets needed unless multiple sub-goals exist.
 
-You MUST respond with a single JSON object and nothing else. No prose, no markdown, no code fences.
-The schema is:
-{ "upserts": [ { "key": "<one of the five keys>", "value": "<new slot value>" } ] }
+OUTPUT
+You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.
+The value field is a JSON string; encode newlines inside it as the escape sequence \\n so the rendered markdown breaks across lines.
+Schema:
+{ "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
 
-Only include slots that should change. Omit slots that stay the same. Never invent new keys.
+Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
 If nothing should change, return { "upserts": [] }.`;
 
 export class Summarizer {


### PR DESCRIPTION
## Summary
- Rewrites the summarizer `SYSTEM_PROMPT` (in both [client.ts](packages/core/src/summarizer/client.ts) and [cli.ts](packages/core/src/summarizer/cli.ts)) so each upsert must emit the **full merged slot value** — no more silent drops of still-valid context across turns.
- Forces every value to render as **compact, structured markdown** (short `-` bullets, blank-line groups, sub-bullets, backticks for paths/ids) so the right-panel slots stop looking like one squashed line of prose.
- Per-slot merge rules made explicit: `decisions` append-only, `open_questions` drop on resolution, `files_touched` unique-append, `last_output_summary` replace, `goal` refine.

## Test plan
- [ ] Run a session, watch a slot like `decisions` accumulate across turns instead of being overwritten.
- [ ] Confirm `last_output_summary` / `decisions` / `open_questions` render as multi-line markdown in the context panel ([ContextPanel.tsx:627](apps/desktop/src/components/ContextPanel.tsx:627)).
- [ ] Existing tests still pass: `pnpm --filter @kay-am/core test` (schema and `parseDelta` are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)