### PR TITLE
feat(desktop): unread agent indicator across sidebar hierarchy

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -103,6 +103,8 @@ pub fn run() {
       workflows::session_insert,
       workflows::session_update_status,
       workflows::session_set_provider_session_id,
+      workflows::session_mark_viewed,
+      workflows::workspaces_with_unread,
       parallel_groups::parallel_group_create,
       parallel_groups::parallel_group_list,
       parallel_groups::parallel_group_get,

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -79,6 +79,10 @@ pub struct SessionRow {
     pub completed_at: Option<String>,
     #[serde(rename = "providerSessionId")]
     pub provider_session_id: Option<String>,
+    #[serde(rename = "lastFinishedAt")]
+    pub last_finished_at: Option<String>,
+    #[serde(rename = "lastViewedAt")]
+    pub last_viewed_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -427,7 +431,7 @@ pub fn session_list_for_task(
     let mut stmt = conn.prepare(
         "SELECT id, task_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id
+                provider_session_id, last_finished_at, last_viewed_at
          FROM sessions
          WHERE task_id = ?1
          ORDER BY ordinal ASC",
@@ -445,6 +449,8 @@ pub fn session_list_for_task(
             started_at: row.get(8)?,
             completed_at: row.get(9)?,
             provider_session_id: row.get(10)?,
+            last_finished_at: row.get(11)?,
+            last_viewed_at: row.get(12)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -489,6 +495,8 @@ pub fn session_insert(
         started_at: input.started_at,
         completed_at: input.completed_at,
         provider_session_id: None,
+        last_finished_at: None,
+        last_viewed_at: None,
     })
 }
 
@@ -499,13 +507,20 @@ pub fn session_update_status(
 ) -> Result<SessionRow, PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
 
+    // When status transitions to a terminal state, also stamp `last_finished_at`
+    // so the sidebar can show an unread indicator until the user views the
+    // agent (which stamps `last_viewed_at` via `session_mark_viewed`).
+    let is_terminal = matches!(input.status.as_str(), "completed" | "failed" | "skipped");
     conn.execute(
         "UPDATE sessions SET
            status         = ?2,
            provider_run_id = COALESCE(?3, provider_run_id),
            output_summary  = COALESCE(?4, output_summary),
            started_at      = COALESCE(?5, started_at),
-           completed_at    = COALESCE(?6, completed_at)
+           completed_at    = COALESCE(?6, completed_at),
+           last_finished_at = CASE WHEN ?7 = 1
+             THEN COALESCE(?6, last_finished_at, CURRENT_TIMESTAMP)
+             ELSE last_finished_at END
          WHERE id = ?1",
         rusqlite::params![
             input.id,
@@ -514,6 +529,7 @@ pub fn session_update_status(
             input.output_summary,
             input.started_at,
             input.completed_at,
+            is_terminal as i32,
         ],
     )?;
 
@@ -521,7 +537,7 @@ pub fn session_update_status(
     let mut stmt = conn.prepare(
         "SELECT id, task_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id
+                provider_session_id, last_finished_at, last_viewed_at
          FROM sessions
          WHERE id = ?1
          LIMIT 1",
@@ -539,6 +555,8 @@ pub fn session_update_status(
             started_at: row.get(8)?,
             completed_at: row.get(9)?,
             provider_session_id: row.get(10)?,
+            last_finished_at: row.get(11)?,
+            last_viewed_at: row.get(12)?,
         })
     })?;
     match rows.next() {
@@ -565,6 +583,43 @@ pub fn session_set_provider_session_id(
         return Err(PhaseError::RunNotFound(id));
     }
     Ok(())
+}
+
+// Stamps `last_viewed_at` when the user selects/views an agent in the sidebar.
+// Compared against `last_finished_at` to derive the unread indicator.
+#[tauri::command]
+pub fn session_mark_viewed(
+    state: State<'_, Db>,
+    id: String,
+    at: String,
+) -> Result<(), PhaseError> {
+    let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
+    let affected = conn.execute(
+        "UPDATE sessions SET last_viewed_at = ?2 WHERE id = ?1",
+        rusqlite::params![id, at],
+    )?;
+    if affected == 0 {
+        return Err(PhaseError::RunNotFound(id));
+    }
+    Ok(())
+}
+
+// Returns the set of workspace ids that contain at least one agent whose
+// terminal turn hasn't been viewed yet. The sidebar uses this to pulse the
+// workspace dot even for workspaces the user isn't currently on (their tasks
+// are not loaded in memory there).
+#[tauri::command]
+pub fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, PhaseError> {
+    let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT t.workspace_id
+         FROM sessions s
+         JOIN tasks t ON s.task_id = t.id
+         WHERE s.last_finished_at IS NOT NULL
+           AND (s.last_viewed_at IS NULL OR s.last_finished_at > s.last_viewed_at)",
+    )?;
+    let rows = stmt.query_map([], |row| row.get::<_, String>(0))?;
+    rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -53,6 +53,7 @@ import type {
 } from '@kay-am/types';
 import {
   EMPTY_ARRAY,
+  agentHasUnread,
   useAppStore,
   useCurrentSession,
   useCurrentWorkspace,
@@ -60,6 +61,8 @@ import {
   useSessionLoading,
   useSessionSlots,
   useSessions,
+  useTaskHasUnread,
+  useWorkspaceHasUnread,
   useWorkspaces,
 } from '../store';
 import { NewSessionDialog } from './NewSessionDialog';
@@ -344,6 +347,8 @@ interface WorkspaceRowProps {
 
 function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
   const [wsSettingsOpen, setWsSettingsOpen] = useState(false);
+  const workspaceHasUnread = useWorkspaceHasUnread(workspace.id);
+  const showUnreadDot = workspaceHasUnread && !isActive;
 
   return (
     <li className="group">
@@ -359,12 +364,20 @@ function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
           className="flex min-w-0 flex-1 items-center gap-2 px-2 py-1.5 text-left text-sm"
         >
           <span
-            className={cn(
-              'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-              isActive ? 'bg-primary' : 'bg-muted-foreground/30',
-            )}
             aria-hidden
-          />
+            title={showUnreadDot ? 'unread agent response in this workspace' : undefined}
+            className="relative inline-flex h-1.5 w-1.5 shrink-0"
+          >
+            {showUnreadDot && (
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warning opacity-60" />
+            )}
+            <span
+              className={cn(
+                'relative inline-block h-1.5 w-1.5 rounded-full',
+                showUnreadDot ? 'bg-warning' : isActive ? 'bg-primary' : 'bg-muted-foreground/30',
+              )}
+            />
+          </span>
           <FolderOpen
             size={13}
             aria-hidden
@@ -729,8 +742,7 @@ function PrStatusIcon({ taskId }: PrStatusIconProps) {
   const github = useAppStore((s) => s.sessionGithub[taskId]);
   const branch = useAppStore((s) => s.sessionBranches[taskId]);
 
-  const isLoading =
-    !github || github.loading || (github.fetchedAt === null && !github.error);
+  const isLoading = !github || github.loading || (github.fetchedAt === null && !github.error);
 
   if (isLoading) {
     return (
@@ -892,6 +904,9 @@ function SessionRow({
     setConfirmDelete(false);
   };
 
+  const taskHasUnread = useTaskHasUnread(session.id as TaskId);
+  const showUnreadDot = taskHasUnread && !isActive;
+
   return (
     <li>
       <div
@@ -909,12 +924,20 @@ function SessionRow({
       >
         <div className="flex min-w-0 w-full items-center gap-2 text-sm">
           <span
-            className={cn(
-              'inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-              isActive ? 'bg-primary' : 'bg-muted-foreground/30',
-            )}
             aria-hidden
-          />
+            title={showUnreadDot ? 'unread agent response' : undefined}
+            className="relative inline-flex h-1.5 w-1.5 shrink-0"
+          >
+            {showUnreadDot && (
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warning opacity-60" />
+            )}
+            <span
+              className={cn(
+                'relative inline-block h-1.5 w-1.5 rounded-full',
+                showUnreadDot ? 'bg-warning' : isActive ? 'bg-primary' : 'bg-muted-foreground/30',
+              )}
+            />
+          </span>
           {renaming ? (
             <div
               className="flex min-w-0 flex-1 flex-col gap-0.5"
@@ -1335,6 +1358,7 @@ interface AgentsSectionProps {
 }
 
 function AgentsSection({ task }: AgentsSectionProps) {
+  const isTaskActive = useAppStore((s) => s.currentSessionId === task.id);
   const phaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
   );
@@ -1523,6 +1547,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
                 aggregate={aggregatesByAgentId.get(run.id) ?? null}
                 turns={turnsByAgentId.get(run.id) ?? 0}
                 isSelected={run.id === selectedAgentId}
+                isTaskActive={isTaskActive}
                 isEditing={editingId === run.id}
                 onClick={() => onPickAgent(run.id)}
                 onPickKind={(next) => setAgentKind(run.id, next)}
@@ -1752,6 +1777,7 @@ interface AgentRowProps {
   readonly aggregate: AgentAggregate | null;
   readonly turns: number;
   readonly isSelected: boolean;
+  readonly isTaskActive: boolean;
   readonly isEditing: boolean;
   readonly onClick: () => void;
   readonly onPickKind: (next: AgentKind) => void;
@@ -1768,6 +1794,7 @@ function AgentRow({
   aggregate,
   turns,
   isSelected,
+  isTaskActive,
   isEditing,
   onClick,
   onPickKind,
@@ -1815,6 +1842,7 @@ function AgentRow({
         'group rounded-md transition-colors',
         isEditing ? '' : 'cursor-pointer',
         isSelected ? 'bg-muted' : 'hover:bg-muted/60',
+        agentHasUnread(run, isSelected && isTaskActive) && 'ring-1 ring-inset ring-warning/70',
       )}
     >
       <div className="flex items-center gap-2 px-2 py-1.5" title={titleParts.join('\n')}>

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -220,7 +220,7 @@ export async function invokeSessionMarkViewed(id: SessionId, at: IsoDateTime): P
 
 export async function invokeWorkspacesWithUnread(): Promise<ReadonlyArray<WorkspaceId>> {
   const ids = await invoke<string[]>('workspaces_with_unread');
-  return ids as ReadonlyArray<WorkspaceId>;
+  return ids as ReadonlyArray<string> as ReadonlyArray<WorkspaceId>;
 }
 
 // Parallel phase group commands (#207).

--- a/apps/desktop/src/phases.ts
+++ b/apps/desktop/src/phases.ts
@@ -49,6 +49,8 @@ interface RawPhaseRunRow {
   readonly startedAt: string | null;
   readonly completedAt: string | null;
   readonly providerSessionId: string | null;
+  readonly lastFinishedAt: string | null;
+  readonly lastViewedAt: string | null;
 }
 
 function rowToDefinition(row: RawPhaseDefinitionRow): Step {
@@ -88,6 +90,8 @@ function rowToPhaseRun(row: RawPhaseRunRow): Session {
     ...(row.startedAt != null && { startedAt: row.startedAt as IsoDateTime }),
     ...(row.completedAt != null && { completedAt: row.completedAt as IsoDateTime }),
     ...(row.providerSessionId != null && { providerSessionId: row.providerSessionId }),
+    ...(row.lastFinishedAt != null && { lastFinishedAt: row.lastFinishedAt as IsoDateTime }),
+    ...(row.lastViewedAt != null && { lastViewedAt: row.lastViewedAt as IsoDateTime }),
   };
 }
 
@@ -208,6 +212,15 @@ export async function invokeSessionSetProviderSessionId(
     id,
     providerSessionId,
   });
+}
+
+export async function invokeSessionMarkViewed(id: SessionId, at: IsoDateTime): Promise<void> {
+  await invoke<void>('session_mark_viewed', { id, at });
+}
+
+export async function invokeWorkspacesWithUnread(): Promise<ReadonlyArray<WorkspaceId>> {
+  const ids = await invoke<string[]>('workspaces_with_unread');
+  return ids as ReadonlyArray<WorkspaceId>;
 }
 
 // Parallel phase group commands (#207).

--- a/apps/desktop/src/store/index.ts
+++ b/apps/desktop/src/store/index.ts
@@ -1,6 +1,7 @@
 export { useAppStore, type BootPhase, type ProviderSpendEntry } from './store';
 
 export {
+  agentHasUnread,
   useCurrentSession,
   useCurrentWorkspace,
   useDiffComments,
@@ -13,6 +14,8 @@ export {
   useSlotHistory,
   useSessions,
   useSummarizerStatus,
+  useTaskHasUnread,
+  useWorkspaceHasUnread,
   useWorkspaces,
 } from './selectors';
 export { useTranscript } from './transcript';

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -4,8 +4,10 @@ import type {
   ContextSlotHistoryEntry,
   DiffComment,
   Plan,
+  Session,
   Task,
   TaskId,
+  WorkspaceId,
 } from '@kay-am/types';
 import type { Workspace } from '@kay-am/types';
 import type { NextAction } from '@kay-am/core';
@@ -129,3 +131,40 @@ export const useFilesTouched = (taskId: TaskId | null): FilesTouched => {
     return { paths: ordered, count: ordered.length };
   }, [phaseRuns, transcripts, workingDir]);
 };
+
+/**
+ * Unread = agent finished a terminal turn after the user last viewed it.
+ * `isCurrentlyViewed` must be true ONLY when the user is actively looking at
+ * this agent right now (i.e. agent is selected in its task AND its task is the
+ * active task). Being merely "selected" in a non-active task does not count —
+ * the user is elsewhere.
+ */
+export const agentHasUnread = (agent: Session, isCurrentlyViewed: boolean): boolean => {
+  if (isCurrentlyViewed) return false;
+  if (!agent.lastFinishedAt) return false;
+  if (!agent.lastViewedAt) return true;
+  return agent.lastFinishedAt > agent.lastViewedAt;
+};
+
+/**
+ * Returns true if any child agent of the task has an unread terminal response.
+ * Excludes the agent the user is currently viewing (selected + task active).
+ */
+export const useTaskHasUnread = (taskId: TaskId | null): boolean => {
+  const phaseRuns = useAppStore((s) => (taskId ? (s.sessionPhaseRuns[taskId] ?? null) : null));
+  const selectedAgentId = useAppStore((s) => (taskId ? (s.selectedAgentId[taskId] ?? null) : null));
+  const isCurrentTask = useAppStore((s) => taskId !== null && s.currentSessionId === taskId);
+  return useMemo(() => {
+    if (!phaseRuns) return false;
+    return phaseRuns.some((r) => agentHasUnread(r, isCurrentTask && r.id === selectedAgentId));
+  }, [phaseRuns, selectedAgentId, isCurrentTask]);
+};
+
+/**
+ * Workspace bubbles up: true if any of its tasks contain an unread agent.
+ * Backed by `unreadWorkspaceIds`, a DB-aggregated set so the dot can pulse
+ * even on workspaces whose tasks aren't loaded in memory (the user is
+ * currently on a different workspace).
+ */
+export const useWorkspaceHasUnread = (workspaceId: WorkspaceId | null): boolean =>
+  useAppStore((s) => (workspaceId ? s.unreadWorkspaceIds.has(workspaceId) : false));

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -210,6 +210,8 @@ import {
   invokePhaseRunInsert,
   invokePhaseRunUpdateStatus,
   invokeSessionSetProviderSessionId,
+  invokeSessionMarkViewed,
+  invokeWorkspacesWithUnread,
   type PhaseTemplateUpsertArgs,
 } from '../phases';
 import {
@@ -309,6 +311,10 @@ export interface AppState {
   readonly sessionOverrides: Readonly<Record<TaskId, OverrideSettings>>;
   readonly sidebarWorkspaceSearch: string;
   readonly sidebarSessionSearch: string;
+  // Workspaces with at least one agent whose terminal turn hasn't been viewed.
+  // Refreshed from a DB aggregate so the workspace dot can pulse even for
+  // workspaces whose tasks aren't currently loaded in memory.
+  readonly unreadWorkspaceIds: ReadonlySet<WorkspaceId>;
   readonly sidebarStateFilter: ReadonlyArray<TurnState['kind']>;
   readonly sidebarProviderFilter: ReadonlyArray<ProviderId>;
   readonly githubStatus: GhTokenStatus | null;
@@ -410,10 +416,7 @@ export interface AppActions {
     workflowId?: WorkflowId;
     autoRun?: boolean;
   }): Promise<{ session: Task; worktree: CreatedWorktree }>;
-  changeSessionBranch(
-    taskId: TaskId,
-    args: { branch: string; createNew: boolean },
-  ): Promise<void>;
+  changeSessionBranch(taskId: TaskId, args: { branch: string; createNew: boolean }): Promise<void>;
   setSessionAutoRun(taskId: TaskId, autoRun: boolean): Promise<void>;
   maybeAutoAdvanceWorkflow(taskId: TaskId): Promise<void>;
   loadTranscript(agentId: SessionId, taskId: TaskId): Promise<void>;
@@ -486,6 +489,7 @@ export interface AppActions {
   deleteTask(taskId: TaskId): Promise<void>;
   setSidebarWorkspaceSearch(query: string): void;
   setSidebarSessionSearch(query: string): void;
+  refreshUnreadWorkspaces(): Promise<void>;
   setSidebarStateFilter(states: ReadonlyArray<TurnState['kind']>): void;
   setSidebarProviderFilter(providers: ReadonlyArray<ProviderId>): void;
   exportConfig(): Promise<string | null>;
@@ -582,6 +586,7 @@ const initialState: AppState = {
   sessionOverrides: {},
   sidebarWorkspaceSearch: '',
   sidebarSessionSearch: '',
+  unreadWorkspaceIds: new Set<WorkspaceId>(),
   sidebarStateFilter: [],
   sidebarProviderFilter: [],
   githubStatus: null,
@@ -1240,11 +1245,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
           return { ...s, state: idleState, updatedAt: recoveryNow };
         }),
       );
-      const worktreeRows = await Promise.all(
-        sessions.map((s) => listWorktreesForTask(tauriDatabase, s.id)),
-      );
+      const [worktreeRows, phaseRunsPerTask] = await Promise.all([
+        Promise.all(sessions.map((s) => listWorktreesForTask(tauriDatabase, s.id))),
+        // Eager-load agents (phase runs) for every task in this workspace. The
+        // unread indicators on workspace- and session-rows derive from each
+        // agent's `lastFinishedAt` vs `lastViewedAt` columns, and those are
+        // only inspected once we have the agent rows in memory. Without this
+        // prefetch, the sidebar would only know about agents for tasks the
+        // user has explicitly opened — yellow dots vanish on workspace switch.
+        Promise.all(sessions.map((s) => invokePhaseRunList(s.id))),
+      ]);
       const sessionWorktrees: Record<string, ReadonlyArray<string>> = {};
       const sessionBranches: Record<string, string> = {};
+      const sessionPhaseRuns: Record<string, ReadonlyArray<Session>> = {};
       for (let i = 0; i < sessions.length; i++) {
         const s = sessions[i]!;
         const rows = worktreeRows[i]!;
@@ -1253,11 +1266,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
           const primaryRow = rows[0];
           if (primaryRow) sessionBranches[s.id] = primaryRow.branch;
         }
+        sessionPhaseRuns[s.id] = phaseRunsPerTask[i]!;
       }
       set((state) => ({
         sessions,
         sessionWorktrees,
         sessionBranches,
+        sessionPhaseRuns,
         workspaceSummary,
         providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
         skills: { ...state.skills, [id]: skills },
@@ -1268,6 +1283,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
     await dbSetSetting(tauriDatabase, SETTING_LAST_WORKSPACE_ID, id ?? '');
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, '');
+    void get().refreshUnreadWorkspaces();
   },
 
   setCurrentSession: async (id) => {
@@ -1643,9 +1659,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const primary = worktrees[0];
     if (!primary) throw new Error(`no worktree found for session ${taskId}`);
     const task = get().sessions.find((s) => s.id === taskId);
-    const workspace = task
-      ? get().workspaces.find((w) => w.id === task.workspaceId)
-      : null;
+    const workspace = task ? get().workspaces.find((w) => w.id === task.workspaceId) : null;
     if (!workspace) throw new Error('workspace not found for session');
     await changeWorktreeBranch({
       repoPath: workspace.rootPath,
@@ -2499,6 +2513,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             ),
           }),
         }));
+        void get().refreshUnreadWorkspaces();
         void get().maybeAutoAdvanceWorkflow(taskId);
       }
 
@@ -2559,6 +2574,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         set((state) => ({
           sessionPhaseRuns: { ...state.sessionPhaseRuns, [taskId]: refreshedRuns },
         }));
+        void get().refreshUnreadWorkspaces();
       }
     }
 
@@ -3109,11 +3125,32 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   selectAgent: async (taskId, agentId) => {
+    // Stamp `lastViewedAt` on both the previously-selected agent (capturing
+    // "user was looking at it until now") and the newly-selected agent. The
+    // unread selector additionally treats the currently-selected agent as
+    // viewed, so no visible flicker while you're actually on the row.
+    const stampedAt = new Date().toISOString() as IsoDateTime;
+    const prevAgentId = get().selectedAgentId[taskId] ?? null;
+    const stampAgents = new Set<SessionId>([agentId]);
+    if (prevAgentId && prevAgentId !== agentId) stampAgents.add(prevAgentId);
+
+    for (const id of stampAgents) {
+      void invokeSessionMarkViewed(id, stampedAt).catch(() => undefined);
+    }
+
+    const stampRuns = (runs: ReadonlyArray<Session>): ReadonlyArray<Session> =>
+      runs.map((s) => (stampAgents.has(s.id) ? { ...s, lastViewedAt: stampedAt } : s));
+
     const cached = get().transcripts[agentId];
     if (cached) {
       set((state) => ({
         selectedAgentId: { ...state.selectedAgentId, [taskId]: agentId },
+        sessionPhaseRuns: {
+          ...state.sessionPhaseRuns,
+          [taskId]: stampRuns(state.sessionPhaseRuns[taskId] ?? []),
+        },
       }));
+      void get().refreshUnreadWorkspaces();
       return;
     }
     const [messages, events] = await Promise.all([
@@ -3124,7 +3161,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       selectedAgentId: { ...state.selectedAgentId, [taskId]: agentId },
       transcripts: { ...state.transcripts, [agentId]: events },
       messages: { ...state.messages, [taskId]: messages },
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [taskId]: stampRuns(state.sessionPhaseRuns[taskId] ?? []),
+      },
     }));
+    void get().refreshUnreadWorkspaces();
   },
 
   spawnAgent: async (taskId, args) => {
@@ -3415,6 +3457,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   setSidebarWorkspaceSearch: (query) => set({ sidebarWorkspaceSearch: query }),
   setSidebarSessionSearch: (query) => set({ sidebarSessionSearch: query }),
+  refreshUnreadWorkspaces: async () => {
+    try {
+      const ids = await invokeWorkspacesWithUnread();
+      set({ unreadWorkspaceIds: new Set(ids) });
+    } catch {
+      // Best-effort: stale unread indicators are recoverable from the next
+      // selectAgent / status update.
+    }
+  },
   setSidebarStateFilter: (states) => set({ sidebarStateFilter: states }),
   setSidebarProviderFilter: (providers) => set({ sidebarProviderFilter: providers }),
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,9 +3,13 @@ pre-commit:
   commands:
     format:
       glob: '*.{ts,tsx,js,jsx,json,md,yml,yaml}'
-      run: pnpm --dir "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" exec prettier --write {staged_files} && git add {staged_files}
+      # Resolve the binary from main's node_modules (worktrees don't always
+      # `pnpm install`) but invoke it directly so the process inherits the
+      # current cwd — otherwise files that exist only in a worktree (e.g.
+      # newly added) wouldn't be found by prettier.
+      run: '"$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/node_modules/.bin/prettier" --write {staged_files} && git add {staged_files}'
 
 commit-msg:
   commands:
     commitlint:
-      run: pnpm --dir "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" exec commitlint --edit {1}
+      run: '"$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")/node_modules/.bin/commitlint" --edit {1}'

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -26,6 +26,7 @@ import { m025TaskTitleUserEdited } from './m025-task-title-user-edited';
 import { m026Notifications } from './m026-notifications';
 import { m027SessionPlans } from './m027-session-plans';
 import { m028DiffCommentConsumed } from './m028-diff-comment-consumed';
+import { m029AgentUnread } from './m029-agent-unread';
 
 export interface Migration {
   readonly version: number;
@@ -61,4 +62,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 26, sql: m026Notifications },
   { version: 27, sql: m027SessionPlans },
   { version: 28, sql: m028DiffCommentConsumed },
+  { version: 29, sql: m029AgentUnread },
 ];

--- a/packages/db/src/migrations/m029-agent-unread.ts
+++ b/packages/db/src/migrations/m029-agent-unread.ts
@@ -1,0 +1,4 @@
+export const m029AgentUnread = /* sql */ `
+ALTER TABLE sessions ADD COLUMN last_finished_at TEXT;
+ALTER TABLE sessions ADD COLUMN last_viewed_at TEXT;
+`;

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -20,6 +20,8 @@ interface SessionRow {
   output_summary: string | null;
   started_at: string | null;
   completed_at: string | null;
+  last_finished_at: string | null;
+  last_viewed_at: string | null;
 }
 
 function toSession(row: SessionRow): Session {
@@ -34,6 +36,8 @@ function toSession(row: SessionRow): Session {
     ...(row.output_summary && { outputSummary: row.output_summary }),
     ...(row.started_at && { startedAt: row.started_at as IsoDateTime }),
     ...(row.completed_at && { completedAt: row.completed_at as IsoDateTime }),
+    ...(row.last_finished_at && { lastFinishedAt: row.last_finished_at as IsoDateTime }),
+    ...(row.last_viewed_at && { lastViewedAt: row.last_viewed_at as IsoDateTime }),
   };
 }
 

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -67,6 +67,12 @@ export type Session = Readonly<{
   // (currently only claude). Threaded back via `--resume` on subsequent turns
   // so the provider keeps full prior-turn context across one-shot invocations.
   providerSessionId?: string;
+  // Timestamp of the last terminal transition (completed/failed/skipped). Used
+  // with `lastViewedAt` to derive an "unread response" indicator in the sidebar.
+  lastFinishedAt?: IsoDateTime;
+  // Timestamp of when the user last selected this agent in the sidebar. Unread
+  // = `lastFinishedAt > lastViewedAt`.
+  lastViewedAt?: IsoDateTime;
 }>;
 
 export type StepTransition = Readonly<{


### PR DESCRIPTION
## Summary

Adds a yellow pulse / inset ring that surfaces unread agent responses through the whole sidebar hierarchy (agent row → session row → workspace row). Backed by two new columns on `sessions` (`last_finished_at`, `last_viewed_at`) so the state survives restarts.

- Agent row gets a yellow inset ring when its last terminal turn hasn't been viewed.
- Session row reuses the existing status dot — it turns warning + pulses when any child agent is unread and the task isn't currently active.
- Workspace row likewise reuses its status dot, driven by a DB-aggregated `workspaces_with_unread` query so it pulses even for workspaces whose tasks aren't loaded in memory.

## Implementation

- `m029-agent-unread` migration adds `last_finished_at` and `last_viewed_at` to `sessions`.
- `session_update_status` (Rust) auto-stamps `last_finished_at` whenever status moves to a terminal state (`completed` / `failed` / `skipped`).
- New `session_mark_viewed` command + `workspaces_with_unread` aggregate query.
- `selectAgent` stamps `last_viewed_at` on both the previously-selected and the newly-selected agent.
- Eager-load phase runs for every task on workspace switch so session-level pulses survive cross-workspace navigation.
- `lefthook.yml`: invoke main's prettier / commitlint binary directly so the hook works for files that exist only inside a worktree.

## Test plan

- [ ] launch on a workspace with multiple sessions; finish a turn on one and verify the agent row + session row + workspace row indicators behave correctly while you switch around
- [ ] restart the app and confirm unread state is restored from DB
- [ ] click the unread agent → ring + pulse clear; switch workspace and back → state is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)