### PR TITLE
feat(desktop,core): plan consumption history with modal management

### DIFF
--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -22,7 +22,7 @@ import {
   HelpCircle,
   Activity,
   ClipboardList,
-  Play,
+  List,
   type LucideIcon,
 } from 'lucide-react';
 import { ScrollArea, Textarea, Dialog, Button, Markdown, cn } from '@kay-am/ui';
@@ -30,14 +30,14 @@ import { SLOT_KEYS, SLOT_LABELS, type SlotKey, detectRepoSlug } from '@kay-am/co
 import type {
   ContextSlot,
   ContextSlotHistoryEntry,
-  Plan,
   PlanStatus,
-  Session,
+  PlanWithCount,
   Task,
   TaskId,
   TelemetryRecord,
   PullRequestStateKind,
 } from '@kay-am/types';
+import { PlansModal } from './PlansModal';
 import {
   EMPTY_ARRAY,
   useAppStore,
@@ -232,7 +232,6 @@ export function ContextPanel({
                 })}
               </ul>
             )}
-
           </div>
         </ScrollArea>
 
@@ -943,17 +942,15 @@ function SummarizerBadge({
 }
 
 const PLAN_STATUS_STYLE: Record<PlanStatus, string> = {
-  active: 'bg-success/10 text-success',
-  completed: 'bg-muted text-muted-foreground',
-  superseded: 'bg-warning/10 text-warning',
+  active: 'bg-warning/10 text-warning',
+  consumed: 'bg-info/10 text-info',
+  superseded: 'bg-muted text-muted-foreground',
 };
 
 function PlansSection({ taskId }: { taskId: TaskId }) {
   const plans = useSessionPlans(taskId);
   const loadSessionPlans = useAppStore((s) => s.loadSessionPlans);
-  const agents = useAppStore(
-    (s) => s.sessionPhaseRuns[taskId] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
-  );
+  const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
     void loadSessionPlans(taskId);
@@ -961,72 +958,50 @@ function PlansSection({ taskId }: { taskId: TaskId }) {
 
   if (plans.length === 0) return null;
 
+  const latest = plans[plans.length - 1];
+  if (!latest) return null;
+  const latestIndex = plans.length;
+
   return (
     <section className="flex flex-col gap-2">
-      <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-        <ClipboardList size={11} aria-hidden className="text-primary" />
-        plans
-      </span>
-      <ul className="flex flex-col gap-1.5">
-        {plans.map((plan) => (
-          <PlanRow
-            key={plan.id}
-            taskId={taskId}
-            plan={plan}
-            agentName={agents.find((a) => a.id === plan.agentId)?.name ?? 'unknown agent'}
-          />
-        ))}
-      </ul>
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          <ClipboardList size={11} aria-hidden className="text-primary" />
+          plans
+        </span>
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          title={`view all plans (${plans.length})`}
+          aria-label={`view all plans (${plans.length})`}
+          className={cn(ICON_BTN, 'inline-flex items-center gap-1 text-2xs')}
+        >
+          <span>{plans.length}</span>
+          <List size={11} aria-hidden />
+        </button>
+      </div>
+      <LatestPlanCard plan={latest} index={latestIndex} />
+      <PlansModal
+        taskId={taskId}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        initialPlanId={latest.id}
+      />
     </section>
   );
 }
 
-interface PlanRowProps {
-  readonly taskId: TaskId;
-  readonly plan: Plan;
-  readonly agentName: string;
+interface LatestPlanCardProps {
+  readonly plan: PlanWithCount;
+  readonly index: number;
 }
 
-function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
+function LatestPlanCard({ plan, index }: LatestPlanCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(planToSource(plan));
-  const [spawning, setSpawning] = useState(false);
-  const setPlanStatus = useAppStore((s) => s.setPlanStatus);
-  const updatePlanBody = useAppStore((s) => s.updatePlanBody);
-  const spawnAgent = useAppStore((s) => s.spawnAgent);
-
-  useEffect(() => {
-    if (!editing) setDraft(planToSource(plan));
-  }, [plan, editing]);
-
-  const toggleStatus = () => {
-    const next: PlanStatus = plan.status === 'active' ? 'completed' : 'active';
-    void setPlanStatus(taskId, plan.id, next);
-  };
-
-  const commit = () => {
-    setEditing(false);
-    const next = parsePlanSource(draft);
-    if (next.title.length === 0) return;
-    if (next.title === plan.title && next.bodyMd === plan.bodyMd) return;
-    void updatePlanBody(taskId, plan.id, next.title, next.bodyMd);
-  };
-
-  const runPlan = async () => {
-    if (spawning) return;
-    setSpawning(true);
-    try {
-      await spawnAgent(taskId, { initialPrompt: plan.bodyMd });
-    } finally {
-      setSpawning(false);
-    }
-  };
-
   const Chevron = expanded ? ChevronDown : ChevronRight;
 
   return (
-    <li className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
+    <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
       <div className="flex items-start justify-between gap-2">
         <button
           type="button"
@@ -1035,95 +1010,21 @@ function PlanRow({ taskId, plan, agentName }: PlanRowProps) {
           title={expanded ? 'collapse plan' : 'expand plan'}
         >
           <Chevron size={11} aria-hidden className="shrink-0 text-muted-foreground" />
+          <span className="shrink-0 text-2xs uppercase tracking-wide text-muted-foreground">
+            plan {index}
+          </span>
           <span className="truncate text-xs font-medium text-foreground">{plan.title}</span>
         </button>
-        <button
-          type="button"
-          onClick={toggleStatus}
-          title={`mark as ${plan.status === 'active' ? 'completed' : 'active'}`}
+        <span
           className={cn(
             'shrink-0 rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
             PLAN_STATUS_STYLE[plan.status],
           )}
         >
           {plan.status}
-        </button>
+        </span>
       </div>
-      <span className="text-2xs text-muted-foreground">by {agentName}</span>
-      {plan.status === 'active' ? (
-        <button
-          type="button"
-          onClick={() => void runPlan()}
-          disabled={spawning}
-          className={cn(
-            'inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-1 text-xs text-primary transition-colors hover:bg-primary/10',
-            spawning && 'cursor-not-allowed opacity-60',
-          )}
-          title="avvia nuovo agent che esegue questo piano"
-        >
-          {spawning ? (
-            <Loader2 size={11} aria-hidden className="animate-spin" />
-          ) : (
-            <Play size={11} aria-hidden />
-          )}
-          Avvia nuovo agent che esegue questo piano
-        </button>
-      ) : null}
-      {expanded ? (
-        editing ? (
-          <Textarea
-            autoFocus
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commit}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setDraft(planToSource(plan));
-                setEditing(false);
-              }
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                commit();
-              }
-            }}
-            className="font-mono text-xs"
-            autoGrow
-            maxRows={24}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            title="edit plan source"
-            className="rounded-md border border-transparent px-1 py-1 text-left hover:border-border-soft hover:bg-muted/40"
-          >
-            <Markdown text={plan.bodyMd} className="text-xs" />
-          </button>
-        )
-      ) : null}
-    </li>
+      {expanded ? <Markdown text={plan.bodyMd} className="text-xs" /> : null}
+    </div>
   );
-}
-
-function planToSource(plan: Plan): string {
-  const head = plan.title.startsWith('#') ? plan.title : `# ${plan.title}`;
-  return plan.bodyMd.length > 0 ? `${head}\n\n${plan.bodyMd}` : head;
-}
-
-function parsePlanSource(raw: string): { title: string; bodyMd: string } {
-  const lines = raw.split('\n');
-  let firstIdx = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if ((lines[i] ?? '').trim().length > 0) {
-      firstIdx = i;
-      break;
-    }
-  }
-  if (firstIdx === -1) return { title: '', bodyMd: '' };
-  const titleLine = (lines[firstIdx] ?? '').trim();
-  const title = titleLine.replace(/^#+\s*/, '').trim();
-  const restLines = lines.slice(firstIdx + 1);
-  const bodyMd = restLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
-  return { title, bodyMd };
 }

--- a/apps/desktop/src/components/PlansModal.tsx
+++ b/apps/desktop/src/components/PlansModal.tsx
@@ -1,0 +1,432 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  Loader2,
+  Pencil,
+  Play,
+  Sparkles,
+  Trash2,
+} from 'lucide-react';
+import { Dialog, Markdown, Textarea, cn } from '@kay-am/ui';
+import type { PlanId, PlanStatus, PlanWithCount, Session, TaskId } from '@kay-am/types';
+import { EMPTY_ARRAY, useAppStore, useSessionPlans } from '../store';
+
+const PLAN_STATUS_STYLE: Record<PlanStatus, string> = {
+  active: 'bg-warning/10 text-warning',
+  consumed: 'bg-info/10 text-info',
+  superseded: 'bg-muted text-muted-foreground',
+};
+
+interface PlansModalProps {
+  readonly taskId: TaskId;
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly initialPlanId?: PlanId;
+}
+
+export function PlansModal({ taskId, open, onClose, initialPlanId }: PlansModalProps) {
+  const plans = useSessionPlans(taskId);
+  const agents = useAppStore(
+    (s) => s.sessionPhaseRuns[taskId] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
+  );
+  const planConsumptions = useAppStore((s) => s.planConsumptions);
+  const loadConsumptionsForPlan = useAppStore((s) => s.loadConsumptionsForPlan);
+  const updatePlanBody = useAppStore((s) => s.updatePlanBody);
+  const deletePlan = useAppStore((s) => s.deletePlan);
+  const runPlan = useAppStore((s) => s.runPlan);
+  const abandonPlan = useAppStore((s) => s.abandonPlan);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+
+  const [selectedId, setSelectedId] = useState<PlanId | null>(initialPlanId ?? null);
+  const [mode, setMode] = useState<'preview' | 'edit'>('preview');
+  const [draft, setDraft] = useState('');
+  const [spawning, setSpawning] = useState(false);
+  const [retriggerArmed, setRetriggerArmed] = useState(false);
+  const retriggerTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    setRetriggerArmed(false);
+    if (retriggerTimerRef.current !== null) {
+      window.clearTimeout(retriggerTimerRef.current);
+      retriggerTimerRef.current = null;
+    }
+  }, [selectedId, open]);
+
+  useEffect(() => {
+    return () => {
+      if (retriggerTimerRef.current !== null) window.clearTimeout(retriggerTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (open && initialPlanId) setSelectedId(initialPlanId);
+  }, [open, initialPlanId]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectedId === null && plans.length > 0) {
+      const fallback = plans[plans.length - 1];
+      if (fallback) setSelectedId(fallback.id);
+    }
+  }, [open, selectedId, plans]);
+
+  useEffect(() => {
+    if (open && selectedId) void loadConsumptionsForPlan(selectedId);
+  }, [open, selectedId, loadConsumptionsForPlan]);
+
+  const selected: PlanWithCount | null = plans.find((p) => p.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (selected && mode === 'preview') setDraft(planToSource(selected));
+  }, [selected, mode]);
+
+  const commitEdit = useCallback(() => {
+    if (!selected) return;
+    const next = parsePlanSource(draft);
+    if (next.title.length === 0) return;
+    if (next.title === selected.title && next.bodyMd === selected.bodyMd) return;
+    void updatePlanBody(taskId, selected.id, next.title, next.bodyMd);
+  }, [selected, draft, taskId, updatePlanBody]);
+
+  const handleClose = useCallback(() => {
+    if (mode === 'edit') commitEdit();
+    setMode('preview');
+    onClose();
+  }, [mode, commitEdit, onClose]);
+
+  const handleSelectPlan = (id: PlanId) => {
+    if (mode === 'edit') commitEdit();
+    setMode('preview');
+    setSelectedId(id);
+  };
+
+  const handleTrigger = async () => {
+    if (!selected || spawning) return;
+    if (selected.status === 'consumed' && !retriggerArmed) {
+      setRetriggerArmed(true);
+      if (retriggerTimerRef.current !== null) window.clearTimeout(retriggerTimerRef.current);
+      retriggerTimerRef.current = window.setTimeout(() => {
+        setRetriggerArmed(false);
+        retriggerTimerRef.current = null;
+      }, 4000);
+      return;
+    }
+    if (retriggerTimerRef.current !== null) {
+      window.clearTimeout(retriggerTimerRef.current);
+      retriggerTimerRef.current = null;
+    }
+    setRetriggerArmed(false);
+    setSpawning(true);
+    try {
+      await runPlan(taskId, selected.id);
+      handleClose();
+    } finally {
+      setSpawning(false);
+    }
+  };
+
+  const handleDelete = (plan: PlanWithCount) => {
+    if (!window.confirm(`delete plan "${plan.title}"? this cannot be undone.`)) return;
+    const remaining = plans.filter((p) => p.id !== plan.id);
+    void deletePlan(taskId, plan.id);
+    if (selectedId === plan.id) {
+      setSelectedId(remaining[remaining.length - 1]?.id ?? null);
+    }
+  };
+
+  const consumptions = selected ? (planConsumptions[selected.id] ?? []) : [];
+  const creatorAgent = selected ? agents.find((a) => a.id === selected.agentId) : null;
+  const creatorDeleted = selected ? !creatorAgent : false;
+  const selectedAgentName = selected ? (creatorAgent?.name ?? 'unknown agent') : '';
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title="Plans"
+      size="xl"
+      fixedHeightClass="h-[92vh] max-w-[1400px]"
+      className="w-[92vw] max-w-[1400px]"
+    >
+      <div className="flex h-full min-h-0 gap-3">
+        <ul className="w-72 shrink-0 overflow-y-auto border-r border-border pr-3">
+          {plans.length === 0 ? (
+            <li className="py-2 text-xs text-muted-foreground">no plans yet</li>
+          ) : (
+            plans.map((plan, idx) => {
+              const isSel = plan.id === selectedId;
+              return (
+                <li key={plan.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectPlan(plan.id)}
+                    className={cn(
+                      'flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-1.5 text-left',
+                      isSel ? 'bg-muted' : 'hover:bg-muted/40',
+                    )}
+                  >
+                    <div className="flex w-full items-center gap-1.5">
+                      <span className="shrink-0 text-2xs uppercase tracking-wide text-muted-foreground">
+                        plan {idx + 1}
+                      </span>
+                      <span
+                        className={cn(
+                          'shrink-0 rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wide',
+                          PLAN_STATUS_STYLE[plan.status],
+                        )}
+                      >
+                        {plan.status}
+                      </span>
+                    </div>
+                    <span className="line-clamp-2 text-xs text-foreground">{plan.title}</span>
+                    <span className="text-[10px] text-muted-foreground">
+                      {fmtTimestamp(plan.createdAt)}
+                    </span>
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          {selected ? (
+            <>
+              <div className="flex items-start gap-3">
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-2xs text-muted-foreground">
+                  <div className="flex items-center gap-1.5">
+                    <Sparkles size={11} aria-hidden className="shrink-0 text-warning" />
+                    <span>created by</span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (creatorDeleted) {
+                          window.alert(
+                            `agent "${selectedAgentName}" has been deleted and can no longer be opened.`,
+                          );
+                          return;
+                        }
+                        void selectAgent(taskId, selected.agentId);
+                        handleClose();
+                      }}
+                      className={cn(
+                        'truncate font-medium underline-offset-2',
+                        creatorDeleted
+                          ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
+                          : 'text-foreground hover:underline',
+                      )}
+                      title={
+                        creatorDeleted ? 'agent deleted — click for details' : 'open creator agent'
+                      }
+                    >
+                      {selectedAgentName}
+                    </button>
+                    {creatorDeleted ? (
+                      <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                        deleted
+                      </span>
+                    ) : null}
+                    <span aria-hidden>·</span>
+                    <span className="shrink-0">{fmtTimestamp(selected.createdAt)}</span>
+                  </div>
+                  {consumptions.map((c) => {
+                    const ag = agents.find((a) => a.id === c.agentId);
+                    const isDeleted = !ag;
+                    const displayName = ag?.name ?? c.agentName ?? c.agentId.substring(0, 8);
+                    return (
+                      <div key={c.id} className="flex items-center gap-1.5">
+                        <CheckCircle2 size={11} aria-hidden className="shrink-0 text-info" />
+                        <span>consumed by</span>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (isDeleted) {
+                              window.alert(
+                                `agent "${displayName}" has been deleted and can no longer be opened.`,
+                              );
+                              return;
+                            }
+                            void selectAgent(taskId, c.agentId);
+                            handleClose();
+                          }}
+                          className={cn(
+                            'truncate font-medium underline-offset-2',
+                            isDeleted
+                              ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
+                              : 'text-foreground hover:underline',
+                          )}
+                          title={isDeleted ? 'agent deleted — click for details' : 'open agent'}
+                        >
+                          {displayName}
+                        </button>
+                        {isDeleted ? (
+                          <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                            deleted
+                          </span>
+                        ) : null}
+                        <span aria-hidden>·</span>
+                        <span className="shrink-0">{fmtTimestamp(c.consumedAt)}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => void handleTrigger()}
+                    disabled={spawning}
+                    className={cn(
+                      'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium shadow-sm transition',
+                      retriggerArmed
+                        ? 'animate-pulse bg-danger text-danger-foreground hover:bg-danger/90'
+                        : 'bg-primary text-primary-foreground hover:bg-primary/90',
+                      spawning && 'cursor-not-allowed opacity-60',
+                    )}
+                    title={
+                      retriggerArmed
+                        ? 'click again to confirm retrigger'
+                        : selected.status === 'consumed'
+                          ? 'plan already consumed — click to retrigger (asks for confirmation)'
+                          : 'spawn new agent to execute this plan'
+                    }
+                  >
+                    {spawning ? (
+                      <Loader2 size={12} aria-hidden className="animate-spin" />
+                    ) : retriggerArmed ? (
+                      <AlertTriangle size={12} aria-hidden />
+                    ) : (
+                      <Play size={12} aria-hidden className="fill-current" />
+                    )}
+                    {retriggerArmed
+                      ? 'already consumed — click again to confirm'
+                      : selected.status === 'consumed'
+                        ? 'retrigger plan'
+                        : 'trigger plan'}
+                  </button>
+                  {selected.status === 'active' ? (
+                    <button
+                      type="button"
+                      onClick={() => void abandonPlan(taskId, selected.id)}
+                      className="rounded-md border border-border-soft px-2 py-1 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                    >
+                      abandon
+                    </button>
+                  ) : null}
+                  <div className="mx-0.5 h-5 w-px bg-border-soft" aria-hidden />
+                  <div
+                    role="tablist"
+                    aria-label="content mode"
+                    className="inline-flex items-center rounded-md border border-border-soft p-0.5"
+                  >
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={mode === 'preview'}
+                      onClick={() => {
+                        if (mode === 'edit') commitEdit();
+                        setMode('preview');
+                      }}
+                      className={cn(
+                        'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
+                        mode === 'preview'
+                          ? 'bg-muted text-foreground'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                      title="preview rendered markdown"
+                    >
+                      <Eye size={11} aria-hidden />
+                      preview
+                    </button>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={mode === 'edit'}
+                      onClick={() => setMode('edit')}
+                      className={cn(
+                        'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
+                        mode === 'edit'
+                          ? 'bg-muted text-foreground'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                      title="edit markdown source"
+                    >
+                      <Pencil size={11} aria-hidden />
+                      edit
+                    </button>
+                  </div>
+                  {selected.status === 'consumed' ? (
+                    <span
+                      className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
+                      title="consumed plans cannot be deleted"
+                      aria-label="consumed plans cannot be deleted"
+                    >
+                      <Trash2 size={13} aria-hidden />
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(selected)}
+                      title="delete plan"
+                      aria-label="delete plan"
+                      className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
+                    >
+                      <Trash2 size={13} aria-hidden />
+                    </button>
+                  )}
+                </div>
+              </div>
+              <div className="flex min-h-0 flex-1 overflow-y-auto rounded-md border border-border-soft p-2">
+                {mode === 'edit' ? (
+                  <Textarea
+                    autoFocus
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    className="h-full w-full resize-none border-0 bg-transparent p-0 font-mono text-xs shadow-none focus-visible:shadow-none focus-visible:ring-0"
+                  />
+                ) : (
+                  <Markdown text={selected.bodyMd} className="text-xs" />
+                )}
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-xs text-muted-foreground">
+              no plan selected
+            </div>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function fmtTimestamp(ts: string | number): string {
+  return new Date(ts).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function planToSource(plan: { title: string; bodyMd: string }): string {
+  const head = plan.title.startsWith('#') ? plan.title : `# ${plan.title}`;
+  return plan.bodyMd.length > 0 ? `${head}\n\n${plan.bodyMd}` : head;
+}
+
+function parsePlanSource(raw: string): { title: string; bodyMd: string } {
+  const lines = raw.split('\n');
+  let firstIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if ((lines[i] ?? '').trim().length > 0) {
+      firstIdx = i;
+      break;
+    }
+  }
+  if (firstIdx === -1) return { title: '', bodyMd: '' };
+  const titleLine = (lines[firstIdx] ?? '').trim();
+  const title = titleLine.replace(/^#+\s*/, '').trim();
+  const restLines = lines.slice(firstIdx + 1);
+  const bodyMd = restLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
+  return { title, bodyMd };
+}

--- a/apps/desktop/src/components/WorkflowNextStepCta.tsx
+++ b/apps/desktop/src/components/WorkflowNextStepCta.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ArrowRight } from 'lucide-react';
+import { ArrowRight, ClipboardList } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import type { Session, Step, Workflow } from '@kay-am/types';
 import type { VerbosityLevel } from '../verbosity';
@@ -14,6 +14,7 @@ export interface WorkflowNextStepCtaProps {
     verbosity: VerbosityLevel | undefined,
   ) => void | Promise<void>;
   readonly hasOpenQuestions?: boolean;
+  readonly consumesActivePlan?: boolean;
   readonly className?: string;
 }
 
@@ -47,6 +48,7 @@ export function WorkflowNextStepCta({
   runs,
   onAdvance,
   hasOpenQuestions = false,
+  consumesActivePlan = false,
   className,
 }: WorkflowNextStepCtaProps) {
   const [busy, setBusy] = useState(false);
@@ -98,6 +100,15 @@ export function WorkflowNextStepCta({
           >
             {palette.label}
           </span>
+          {consumesActivePlan ? (
+            <span
+              className="inline-flex items-center gap-0.5 rounded bg-primary/15 px-1 py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-primary"
+              title="advancing will consume the active plan"
+            >
+              <ClipboardList size={9} aria-hidden />
+              <span>consume plan</span>
+            </span>
+          ) : null}
         </span>
         <span className="flex items-center gap-1.5">
           <span className="text-[10px] font-normal opacity-60">

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -7,6 +7,7 @@ import {
   Bot,
   ChevronDown,
   ChevronRight,
+  ClipboardList,
   FolderOpen,
   FolderPlus,
   Gauge,
@@ -19,6 +20,7 @@ import {
   Loader2,
   MessagesSquare,
   Moon,
+  Play,
   Plus,
   Settings,
   Settings2,
@@ -59,6 +61,7 @@ import {
   useCurrentWorkspace,
   useSessionNextActions,
   useSessionLoading,
+  useSessionPlans,
   useSessionSlots,
   useSessions,
   useTaskHasUnread,
@@ -1359,6 +1362,9 @@ interface AgentsSectionProps {
 
 function AgentsSection({ task }: AgentsSectionProps) {
   const isTaskActive = useAppStore((s) => s.currentSessionId === task.id);
+  const plansForTask = useSessionPlans(task.id);
+  const latestPlan = plansForTask[plansForTask.length - 1];
+  const hasActivePlan = !!latestPlan && latestPlan.status === 'active';
   const phaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<Session>),
   );
@@ -1567,9 +1573,11 @@ function AgentsSection({ task }: AgentsSectionProps) {
             runs={sorted}
             onAdvance={(step, model) => onSpawn(step.id, model)}
             hasOpenQuestions={hasOpenQuestions}
+            consumesActivePlan={hasActivePlan}
           />
         </div>
       ) : null}
+      {workflow && hasActivePlan ? null : <ActivePlanCta taskId={task.id} />}
       <NextActionChips
         taskId={task.id}
         workflowBound={task.workflowId !== undefined}
@@ -1727,6 +1735,64 @@ function SpawnAgentControl({ taskId, workflow, onSpawn }: SpawnAgentControlProps
           </div>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function ActivePlanCta({ taskId }: { taskId: TaskId }) {
+  const plans = useSessionPlans(taskId);
+  const runPlan = useAppStore((s) => s.runPlan);
+  const abandonPlan = useAppStore((s) => s.abandonPlan);
+  const [spawning, setSpawning] = useState(false);
+  const latest = plans[plans.length - 1];
+  if (!latest || latest.status !== 'active') return null;
+
+  const handleTrigger = async () => {
+    if (spawning) return;
+    setSpawning(true);
+    try {
+      await runPlan(taskId, latest.id);
+    } finally {
+      setSpawning(false);
+    }
+  };
+
+  return (
+    <div className="mt-2 flex flex-col gap-1 pl-2">
+      <div className="flex items-center gap-1.5 text-2xs uppercase tracking-wide text-muted-foreground">
+        <ClipboardList size={11} aria-hidden className="text-primary" />
+        active plan
+      </div>
+      <span className="truncate text-xs text-foreground" title={latest.title}>
+        {latest.title}
+      </span>
+      <div className="flex gap-1.5">
+        <button
+          type="button"
+          onClick={() => void handleTrigger()}
+          disabled={spawning}
+          className={cn(
+            'inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-1 text-xs text-primary transition-colors hover:bg-primary/10',
+            spawning && 'cursor-not-allowed opacity-60',
+          )}
+          title="spawn new agent to execute this plan"
+        >
+          {spawning ? (
+            <Loader2 size={11} aria-hidden className="animate-spin" />
+          ) : (
+            <Play size={11} aria-hidden />
+          )}
+          trigger plan
+        </button>
+        <button
+          type="button"
+          onClick={() => void abandonPlan(taskId, latest.id)}
+          className="rounded-md border border-border-soft px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          title="mark plan as superseded; next plan emitted starts a new logical plan"
+        >
+          abandon
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/plans.ts
+++ b/apps/desktop/src/plans.ts
@@ -1,6 +1,17 @@
-import type { Plan, PlanId, PlanStatus, SessionId, TaskId } from '@kay-am/types';
+import type {
+  Plan,
+  PlanConsumption,
+  PlanConsumptionId,
+  PlanId,
+  PlanStatus,
+  PlanWithCount,
+  SessionId,
+  TaskId,
+} from '@kay-am/types';
 import {
+  addPlanConsumption as dbAddPlanConsumption,
   deletePlan as dbDeletePlan,
+  listConsumptionsForPlan as dbListConsumptionsForPlan,
   listPlansForSession as dbListPlansForSession,
   updatePlanBody as dbUpdatePlanBody,
   updatePlanStatus as dbUpdatePlanStatus,
@@ -8,7 +19,9 @@ import {
 } from '@kay-am/db';
 import { tauriDatabase } from './db';
 
-export async function listPlansForSession(sessionId: TaskId): Promise<ReadonlyArray<Plan>> {
+export async function listPlansForSession(
+  sessionId: TaskId,
+): Promise<ReadonlyArray<PlanWithCount>> {
   return dbListPlansForSession(tauriDatabase, sessionId);
 }
 
@@ -17,7 +30,6 @@ export interface UpsertPlanArgs {
   readonly agentId: SessionId;
   readonly title: string;
   readonly bodyMd: string;
-  readonly status?: PlanStatus;
 }
 
 export async function upsertPlan(args: UpsertPlanArgs): Promise<Plan> {
@@ -28,7 +40,6 @@ export async function upsertPlan(args: UpsertPlanArgs): Promise<Plan> {
     agentId: args.agentId,
     title: args.title,
     bodyMd: args.bodyMd,
-    status: args.status ?? 'active',
   });
 }
 
@@ -42,4 +53,18 @@ export async function setPlanBody(id: PlanId, title: string, bodyMd: string): Pr
 
 export async function deletePlan(id: PlanId): Promise<void> {
   await dbDeletePlan(tauriDatabase, id);
+}
+
+export async function addPlanConsumption(
+  planId: PlanId,
+  agentId: SessionId,
+): Promise<PlanConsumption> {
+  const id = crypto.randomUUID() as PlanConsumptionId;
+  return dbAddPlanConsumption(tauriDatabase, { id, planId, agentId });
+}
+
+export async function listConsumptionsForPlan(
+  planId: PlanId,
+): Promise<ReadonlyArray<PlanConsumption>> {
+  return dbListConsumptionsForPlan(tauriDatabase, planId);
 }

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -3,7 +3,7 @@ import type {
   ContextSlot,
   ContextSlotHistoryEntry,
   DiffComment,
-  Plan,
+  PlanWithCount,
   Session,
   Task,
   TaskId,
@@ -82,14 +82,14 @@ const EMPTY_COMMENTS: ReadonlyArray<DiffComment> = [];
 export const useDiffComments = (taskId: TaskId | null): ReadonlyArray<DiffComment> =>
   useAppStore((s) => (taskId ? (s.diffComments[taskId] ?? EMPTY_COMMENTS) : EMPTY_COMMENTS));
 
-const EMPTY_PLANS: ReadonlyArray<Plan> = [];
+const EMPTY_PLANS: ReadonlyArray<PlanWithCount> = [];
 
-export const useSessionPlans = (taskId: TaskId | null): ReadonlyArray<Plan> =>
+export const useSessionPlans = (taskId: TaskId | null): ReadonlyArray<PlanWithCount> =>
   useAppStore((s) => (taskId ? (s.sessionPlans[taskId] ?? EMPTY_PLANS) : EMPTY_PLANS));
 
-export const useMostRecentPlan = (taskId: TaskId | null): Plan | null => {
+export const useMostRecentPlan = (taskId: TaskId | null): PlanWithCount | null => {
   const plans = useSessionPlans(taskId);
-  return plans[0] ?? null;
+  return plans[plans.length - 1] ?? null;
 };
 
 interface FilesTouched {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -89,9 +89,10 @@ import type {
   PermissionRequest,
   PermissionRequestId,
   PermissionRule,
-  Plan,
+  PlanConsumption,
   PlanId,
   PlanStatus,
+  PlanWithCount,
   Step,
   StepId,
   Session,
@@ -223,7 +224,9 @@ import { exportConfigToFile, importConfigFromFile } from '../config-export';
 import { formatError } from '../errors';
 import { AGENT_KIND_DEFAULTS, inferAgentKindFromName, type AgentKind } from '../agent-kind';
 import {
+  addPlanConsumption as invokeAddPlanConsumption,
   deletePlan as invokeDeletePlan,
+  listConsumptionsForPlan as invokeListConsumptionsForPlan,
   listPlansForSession as invokeListPlansForSession,
   setPlanBody as invokeSetPlanBody,
   setPlanStatus as invokeSetPlanStatus,
@@ -327,7 +330,8 @@ export interface AppState {
   readonly agentDraft: Readonly<Record<SessionId, string>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
   readonly notifications: ReadonlyArray<Notification>;
-  readonly sessionPlans: Readonly<Record<TaskId, ReadonlyArray<Plan>>>;
+  readonly sessionPlans: Readonly<Record<TaskId, ReadonlyArray<PlanWithCount>>>;
+  readonly planConsumptions: Readonly<Record<PlanId, ReadonlyArray<PlanConsumption>>>;
   /**
    * Per-session loading flags. Each block (agents, transcript, telemetry,
    * slots, plans, summary) starts true on session switch and is flipped off
@@ -461,6 +465,7 @@ export interface AppActions {
       model?: string;
       effort?: string;
       initialPrompt?: string;
+      triggeredPlanId?: PlanId;
     },
   ): Promise<SessionId>;
   renameAgent(taskId: TaskId, agentId: SessionId, name: string): Promise<void>;
@@ -539,6 +544,9 @@ export interface AppActions {
   setPlanStatus(taskId: TaskId, planId: PlanId, status: PlanStatus): Promise<void>;
   updatePlanBody(taskId: TaskId, planId: PlanId, title: string, bodyMd: string): Promise<void>;
   deletePlan(taskId: TaskId, planId: PlanId): Promise<void>;
+  abandonPlan(taskId: TaskId, planId: PlanId): Promise<void>;
+  loadConsumptionsForPlan(planId: PlanId): Promise<void>;
+  runPlan(taskId: TaskId, planId: PlanId): Promise<void>;
 }
 
 type AppStore = AppState & AppActions;
@@ -598,6 +606,7 @@ const initialState: AppState = {
   diffComments: {},
   notifications: [],
   sessionPlans: {},
+  planConsumptions: {},
   sessionLoading: {},
 };
 
@@ -876,22 +885,19 @@ async function runSummarizer(
   }
 }
 
-async function buildPlanKickoffSection(taskId: TaskId): Promise<string> {
+async function buildPlanKickoffSection(
+  taskId: TaskId,
+): Promise<{ section: string; plan: PlanWithCount | null }> {
   try {
     const plans = await invokeListPlansForSession(taskId);
-    const plan = plans[0];
-    if (!plan) return '';
-    if (plan.status === 'completed') {
-      return [
-        'The most recent plan in this session was completed and should NOT be re-executed. Provided for context only:',
-        '',
-        plan.bodyMd,
-      ].join('\n');
-    }
-    if (plan.status === 'superseded') return '';
-    return ['Active plan to execute:', '', plan.bodyMd].join('\n');
+    const latest = plans[plans.length - 1] ?? null;
+    if (!latest || latest.status !== 'active') return { section: '', plan: latest };
+    return {
+      section: ['Active plan to execute:', '', latest.bodyMd].join('\n'),
+      plan: latest,
+    };
   } catch {
-    return '';
+    return { section: '', plan: null };
   }
 }
 
@@ -915,7 +921,6 @@ async function capturePlanFromTurn(
       agentId,
       title: extracted.title,
       bodyMd: extracted.bodyMd,
-      status: 'active',
     });
     const refreshed = await invokeListPlansForSession(taskId);
     set((state) => ({
@@ -1340,7 +1345,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       .finally(() => markDone('slots'));
 
     // Plans
-    void (async (): Promise<ReadonlyArray<Plan>> => {
+    void (async (): Promise<ReadonlyArray<PlanWithCount>> => {
       try {
         return await invokeListPlansForSession(id);
       } catch {
@@ -2820,6 +2825,25 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
+  abandonPlan: async (taskId, planId) => {
+    await invokeSetPlanStatus(planId, 'superseded');
+    const refreshed = await invokeListPlansForSession(taskId);
+    set((state) => ({
+      sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+    }));
+  },
+
+  loadConsumptionsForPlan: async (planId) => {
+    const items = await invokeListConsumptionsForPlan(planId);
+    set((state) => ({
+      planConsumptions: { ...state.planConsumptions, [planId]: items },
+    }));
+  },
+
+  runPlan: async (taskId, planId) => {
+    await get().spawnAgent(taskId, { triggeredPlanId: planId });
+  },
+
   toggleSessionSlot: async (taskId, key, enabled) => {
     const existing = get().sessionSlots[taskId] ?? [];
     const prev = existing.find((s) => s.key === key);
@@ -3214,11 +3238,31 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }),
     }));
     const baseKickoff = stepPromptPrefix.length > 0 ? stepPromptPrefix : (args.initialPrompt ?? '');
-    const planSection = await buildPlanKickoffSection(taskId);
+    const { section: latestSection, plan: latestPlan } = await buildPlanKickoffSection(taskId);
+    const explicitTrigger = args.triggeredPlanId !== undefined;
+    const explicitPlan = explicitTrigger
+      ? (get().sessionPlans[taskId]?.find((p) => p.id === args.triggeredPlanId) ?? null)
+      : null;
+    const planSection = explicitPlan
+      ? ['Active plan to execute:', '', explicitPlan.bodyMd].join('\n')
+      : latestSection;
     const kickoff = composeKickoff(planSection, baseKickoff);
     if (kickoff.length > 0) {
       void get().sendTurn({ taskId, content: kickoff });
     }
+
+    const workflowAutoConsume = args.stepId !== undefined && latestPlan?.status === 'active';
+    const planToConsume = explicitPlan ?? (workflowAutoConsume ? latestPlan : null);
+    if (planToConsume) {
+      await invokeAddPlanConsumption(planToConsume.id, inserted.id);
+      const refreshed = await invokeListPlansForSession(taskId);
+      const consumptions = await invokeListConsumptionsForPlan(planToConsume.id);
+      set((state) => ({
+        sessionPlans: { ...state.sessionPlans, [taskId]: refreshed },
+        planConsumptions: { ...state.planConsumptions, [planToConsume.id]: consumptions },
+      }));
+    }
+
     return inserted.id;
   },
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -127,5 +127,8 @@ export {
   updatePlanStatus,
   updatePlanBody,
   deletePlan,
+  addPlanConsumption,
+  listConsumptionsForPlan,
   type UpsertPlanInput,
+  type AddPlanConsumptionInput,
 } from './queries/plan';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -27,6 +27,7 @@ import { m026Notifications } from './m026-notifications';
 import { m027SessionPlans } from './m027-session-plans';
 import { m028DiffCommentConsumed } from './m028-diff-comment-consumed';
 import { m029AgentUnread } from './m029-agent-unread';
+import { m030PlanConsumptions } from './m030-plan-consumptions';
 
 export interface Migration {
   readonly version: number;
@@ -63,4 +64,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 27, sql: m027SessionPlans },
   { version: 28, sql: m028DiffCommentConsumed },
   { version: 29, sql: m029AgentUnread },
+  { version: 30, sql: m030PlanConsumptions },
 ];

--- a/packages/db/src/migrations/m030-plan-consumptions.ts
+++ b/packages/db/src/migrations/m030-plan-consumptions.ts
@@ -1,0 +1,53 @@
+export const m030PlanConsumptions = /* sql */ `
+CREATE TABLE IF NOT EXISTS session_plans (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body_md TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('active', 'completed', 'superseded')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (session_id, agent_id),
+  FOREIGN KEY (session_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+DROP TABLE IF EXISTS session_plans_new;
+
+CREATE TABLE session_plans_new (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body_md TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('active', 'consumed', 'superseded')),
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES tasks(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO session_plans_new (id, session_id, agent_id, title, body_md, status, created_at, updated_at)
+  SELECT id, session_id, agent_id, title, body_md,
+         CASE WHEN status = 'completed' THEN 'consumed' ELSE status END,
+         created_at, updated_at
+  FROM session_plans;
+
+DROP TABLE session_plans;
+ALTER TABLE session_plans_new RENAME TO session_plans;
+
+CREATE INDEX IF NOT EXISTS idx_session_plans_session ON session_plans(session_id, created_at ASC);
+
+CREATE TABLE IF NOT EXISTS plan_consumptions (
+  id TEXT PRIMARY KEY,
+  plan_id TEXT NOT NULL,
+  agent_id TEXT NOT NULL,
+  consumed_at INTEGER NOT NULL,
+  FOREIGN KEY (plan_id) REFERENCES session_plans(id) ON DELETE CASCADE,
+  FOREIGN KEY (agent_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_plan_consumptions_plan ON plan_consumptions(plan_id, consumed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_plan_consumptions_agent ON plan_consumptions(agent_id);
+`;

--- a/packages/db/src/queries/plan.test.ts
+++ b/packages/db/src/queries/plan.test.ts
@@ -46,7 +46,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'first plan',
       bodyMd: 'body',
-      status: 'active',
     });
     const plans = await listPlansForSession(db, taskId);
     expect(plans).toHaveLength(1);
@@ -64,7 +63,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'v1',
       bodyMd: 'b1',
-      status: 'active',
     });
     await upsertPlan(db, {
       id: 'p2' as PlanId,
@@ -72,7 +70,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'v2',
       bodyMd: 'b2',
-      status: 'active',
     });
     const plans = await listPlansForSession(db, taskId);
     expect(plans).toHaveLength(1);
@@ -80,7 +77,7 @@ describe('session_plans queries', () => {
     expect(plans[0]!.bodyMd).toBe('b2');
   });
 
-  it('different agents create separate rows (session has many plans, one per agent)', async () => {
+  it('upsert from a different agent overwrites the single active plan slot', async () => {
     const db = await seedFixture();
     await upsertPlan(db, {
       id: 'p1' as PlanId,
@@ -88,7 +85,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'a1 plan',
       bodyMd: 'body1',
-      status: 'active',
     });
     await upsertPlan(db, {
       id: 'p2' as PlanId,
@@ -96,22 +92,23 @@ describe('session_plans queries', () => {
       agentId: agentA2,
       title: 'a2 plan',
       bodyMd: 'body2',
-      status: 'completed',
     });
     const plans = await listPlansForSession(db, taskId);
-    expect(plans).toHaveLength(2);
+    expect(plans).toHaveLength(1);
+    expect(plans[0]!.title).toBe('a2 plan');
+    expect(plans[0]!.status).toBe('active');
   });
 
-  it('list returns most-recent first', async () => {
+  it('after consume a new plan starts a fresh row; list is creation-order (oldest first)', async () => {
     const db = await seedFixture();
-    await upsertPlan(db, {
+    const older = await upsertPlan(db, {
       id: 'p1' as PlanId,
       sessionId: taskId,
       agentId: agentA1,
       title: 'older',
       bodyMd: '',
-      status: 'active',
     });
+    await updatePlanStatus(db, older.id, 'consumed');
     await new Promise((r) => setTimeout(r, 5));
     await upsertPlan(db, {
       id: 'p2' as PlanId,
@@ -119,10 +116,11 @@ describe('session_plans queries', () => {
       agentId: agentA2,
       title: 'newer',
       bodyMd: '',
-      status: 'active',
     });
     const plans = await listPlansForSession(db, taskId);
-    expect(plans[0]!.title).toBe('newer');
+    expect(plans).toHaveLength(2);
+    expect(plans[0]!.title).toBe('older');
+    expect(plans[plans.length - 1]!.title).toBe('newer');
   });
 
   it('updatePlanStatus changes the status', async () => {
@@ -133,11 +131,10 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'x',
       bodyMd: 'b',
-      status: 'active',
     });
-    await updatePlanStatus(db, plan.id, 'completed');
+    await updatePlanStatus(db, plan.id, 'consumed');
     const refreshed = await listPlansForSession(db, taskId);
-    expect(refreshed[0]!.status).toBe('completed');
+    expect(refreshed[0]!.status).toBe('consumed');
   });
 
   it('updatePlanBody changes title and body', async () => {
@@ -148,7 +145,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 'old',
       bodyMd: 'b',
-      status: 'active',
     });
     await updatePlanBody(db, plan.id, 'new title', 'new body');
     const refreshed = await listPlansForSession(db, taskId);
@@ -164,7 +160,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 't',
       bodyMd: 'b',
-      status: 'active',
     });
     await deletePlan(db, plan.id);
     const refreshed = await listPlansForSession(db, taskId);
@@ -179,7 +174,6 @@ describe('session_plans queries', () => {
       agentId: agentA1,
       title: 't',
       bodyMd: 'b',
-      status: 'active',
     });
     await db.execute(`DELETE FROM tasks WHERE id = ?`, ['t1']);
     const refreshed = await listPlansForSession(db, taskId);

--- a/packages/db/src/queries/plan.ts
+++ b/packages/db/src/queries/plan.ts
@@ -1,4 +1,14 @@
-import type { IsoDateTime, Plan, PlanId, PlanStatus, SessionId, TaskId } from '@kay-am/types';
+import type {
+  IsoDateTime,
+  Plan,
+  PlanConsumption,
+  PlanConsumptionId,
+  PlanId,
+  PlanStatus,
+  PlanWithCount,
+  SessionId,
+  TaskId,
+} from '@kay-am/types';
 import type { Database } from '../client';
 
 interface PlanRow {
@@ -10,6 +20,10 @@ interface PlanRow {
   status: string;
   created_at: number;
   updated_at: number;
+}
+
+interface PlanWithCountRow extends PlanRow {
+  consumption_count: number;
 }
 
 function toDomain(row: PlanRow): Plan {
@@ -25,18 +39,26 @@ function toDomain(row: PlanRow): Plan {
   };
 }
 
+function toDomainWithCount(row: PlanWithCountRow): PlanWithCount {
+  return { ...toDomain(row), consumptionCount: row.consumption_count };
+}
+
 export async function listPlansForSession(
   db: Database,
   sessionId: TaskId,
-): Promise<ReadonlyArray<Plan>> {
-  const rows = await db.select<PlanRow>(
-    `SELECT id, session_id, agent_id, title, body_md, status, created_at, updated_at
-     FROM session_plans
-     WHERE session_id = ?
-     ORDER BY updated_at DESC`,
+): Promise<ReadonlyArray<PlanWithCount>> {
+  const rows = await db.select<PlanWithCountRow>(
+    `SELECT p.id, p.session_id, p.agent_id, p.title, p.body_md, p.status,
+            p.created_at, p.updated_at,
+            COUNT(c.id) AS consumption_count
+     FROM session_plans p
+     LEFT JOIN plan_consumptions c ON c.plan_id = p.id
+     WHERE p.session_id = ?
+     GROUP BY p.id
+     ORDER BY p.created_at ASC`,
     [sessionId],
   );
-  return rows.map(toDomain);
+  return rows.map(toDomainWithCount);
 }
 
 export interface UpsertPlanInput {
@@ -45,29 +67,43 @@ export interface UpsertPlanInput {
   readonly agentId: SessionId;
   readonly title: string;
   readonly bodyMd: string;
-  readonly status: PlanStatus;
 }
 
 export async function upsertPlan(db: Database, input: UpsertPlanInput): Promise<Plan> {
   const now = Date.now();
+  const existing = await db.select<{ id: string }>(
+    `SELECT id FROM session_plans
+     WHERE session_id = ? AND status = 'active'
+     ORDER BY created_at DESC LIMIT 1`,
+    [input.sessionId],
+  );
+  const activeId = existing[0]?.id;
+  if (activeId) {
+    await db.execute(
+      `UPDATE session_plans SET title = ?, body_md = ?, updated_at = ? WHERE id = ?`,
+      [input.title, input.bodyMd, now, activeId],
+    );
+    const rows = await db.select<PlanRow>(
+      `SELECT id, session_id, agent_id, title, body_md, status, created_at, updated_at
+       FROM session_plans WHERE id = ?`,
+      [activeId],
+    );
+    const row = rows[0];
+    if (!row) throw new Error(`plan update failed: ${activeId}`);
+    return toDomain(row);
+  }
   await db.execute(
     `INSERT INTO session_plans (id, session_id, agent_id, title, body_md, status, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT (session_id, agent_id) DO UPDATE SET
-       title = excluded.title,
-       body_md = excluded.body_md,
-       status = excluded.status,
-       updated_at = excluded.updated_at`,
-    [input.id, input.sessionId, input.agentId, input.title, input.bodyMd, input.status, now, now],
+     VALUES (?, ?, ?, ?, ?, 'active', ?, ?)`,
+    [input.id, input.sessionId, input.agentId, input.title, input.bodyMd, now, now],
   );
   const rows = await db.select<PlanRow>(
     `SELECT id, session_id, agent_id, title, body_md, status, created_at, updated_at
-     FROM session_plans
-     WHERE session_id = ? AND agent_id = ?`,
-    [input.sessionId, input.agentId],
+     FROM session_plans WHERE id = ?`,
+    [input.id],
   );
   const row = rows[0];
-  if (!row) throw new Error(`plan upsert failed: ${input.sessionId} / ${input.agentId}`);
+  if (!row) throw new Error(`plan insert failed: ${input.id}`);
   return toDomain(row);
 }
 
@@ -99,4 +135,68 @@ export async function updatePlanBody(
 
 export async function deletePlan(db: Database, id: PlanId): Promise<void> {
   await db.execute(`DELETE FROM session_plans WHERE id = ?`, [id]);
+}
+
+interface PlanConsumptionRow {
+  id: string;
+  plan_id: string;
+  agent_id: string;
+  agent_name: string | null;
+  consumed_at: number;
+}
+
+function toConsumption(row: PlanConsumptionRow): PlanConsumption {
+  return {
+    id: row.id as PlanConsumptionId,
+    planId: row.plan_id as PlanId,
+    agentId: row.agent_id as SessionId,
+    agentName: row.agent_name,
+    consumedAt: new Date(row.consumed_at).toISOString() as IsoDateTime,
+  };
+}
+
+export interface AddPlanConsumptionInput {
+  readonly id: PlanConsumptionId;
+  readonly planId: PlanId;
+  readonly agentId: SessionId;
+}
+
+export async function addPlanConsumption(
+  db: Database,
+  input: AddPlanConsumptionInput,
+): Promise<PlanConsumption> {
+  const now = Date.now();
+  await db.execute(
+    `INSERT INTO plan_consumptions (id, plan_id, agent_id, consumed_at) VALUES (?, ?, ?, ?)`,
+    [input.id, input.planId, input.agentId, now],
+  );
+  await db.execute(`UPDATE session_plans SET status = 'consumed', updated_at = ? WHERE id = ?`, [
+    now,
+    input.planId,
+  ]);
+  const rows = await db.select<{ name: string | null }>(`SELECT name FROM sessions WHERE id = ?`, [
+    input.agentId,
+  ]);
+  return {
+    id: input.id,
+    planId: input.planId,
+    agentId: input.agentId,
+    agentName: rows[0]?.name ?? null,
+    consumedAt: new Date(now).toISOString() as IsoDateTime,
+  };
+}
+
+export async function listConsumptionsForPlan(
+  db: Database,
+  planId: PlanId,
+): Promise<ReadonlyArray<PlanConsumption>> {
+  const rows = await db.select<PlanConsumptionRow>(
+    `SELECT c.id, c.plan_id, c.agent_id, c.consumed_at, s.name AS agent_name
+     FROM plan_consumptions c
+     LEFT JOIN sessions s ON s.id = c.agent_id
+     WHERE c.plan_id = ?
+     ORDER BY c.consumed_at DESC`,
+    [planId],
+  );
+  return rows.map(toConsumption);
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -100,7 +100,14 @@ export type {
   DiffCommentSide,
   DiffCommentStatus,
 } from './diff-comment';
-export type { Plan, PlanId, PlanStatus } from './plan';
+export type {
+  Plan,
+  PlanConsumption,
+  PlanConsumptionId,
+  PlanId,
+  PlanStatus,
+  PlanWithCount,
+} from './plan';
 export type {
   DiffHunk,
   DiffHunkLine,

--- a/packages/types/src/plan.ts
+++ b/packages/types/src/plan.ts
@@ -2,7 +2,7 @@ import type { IsoDateTime, SessionId, TaskId } from './ids';
 
 export type PlanId = string & { readonly __brand: 'PlanId' };
 
-export type PlanStatus = 'active' | 'completed' | 'superseded';
+export type PlanStatus = 'active' | 'consumed' | 'superseded';
 
 export type Plan = Readonly<{
   id: PlanId;
@@ -13,4 +13,16 @@ export type Plan = Readonly<{
   status: PlanStatus;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
+}>;
+
+export type PlanWithCount = Plan & Readonly<{ consumptionCount: number }>;
+
+export type PlanConsumptionId = string & { readonly __brand: 'PlanConsumptionId' };
+
+export type PlanConsumption = Readonly<{
+  id: PlanConsumptionId;
+  planId: PlanId;
+  agentId: SessionId;
+  agentName: string | null;
+  consumedAt: IsoDateTime;
 }>;


### PR DESCRIPTION
## Summary
- New `m030` migration: `plan_consumptions` join table; `session_plans` status `completed` → `consumed`.
- `spawnAgent` auto-consumes the active plan on workflow advance (`stepId` set) or explicit `triggeredPlanId`. `runPlan` is now a thin wrapper around `spawnAgent`.
- `listConsumptionsForPlan` LEFT JOINs `sessions` so deleted agents survive in the history; `addPlanConsumption` snapshots `agentName`.
- Right `ContextPanel` is info-only: latest plan card (chevron + status) + icon link to modal. All management lives in the new modal.
- New `PlansModal`: GitHub-style preview/edit segment control (auto-save on switch/close), inline event timeline (`created by` / `consumed by`), inline two-click retrigger confirm, deleted-agent fallback (strikethrough + click alert).
- Left sidebar: `ActivePlanCta` (`trigger plan` + `abandon`) hidden when in workflow mode; `WorkflowNextStepCta` shows a `📋 consume plan` pill when an active plan exists, since advancing already consumes it.

## Out of scope
- Soft delete of agents (`deleteAgent` is still hard `DELETE FROM sessions`). The consumption query is already future-proofed (LEFT JOIN, no `deleted_at` filter), so once soft delete lands the history will keep resolving names.

## Test plan
- [ ] open a workflow session, emit a plan from the planner agent. Plan appears in right-pane card + modal, status `active`. Sidebar shows `📋 consume plan` pill inside the workflow next-step CTA, no separate trigger button.
- [ ] click the workflow next-step CTA. The new agent receives `Active plan to execute:\n\n<bodyMd>` as kickoff. `plan_consumptions` row is inserted, plan moves to `consumed`.
- [ ] in a non-workflow task with an active plan, the sidebar `ActivePlanCta` is visible. `trigger plan` spawns a fresh agent with the plan injected once (no duplicate). After spawn, status → `consumed` and the CTA hides.
- [ ] modal: switch preview ↔ edit. Edit auto-saves on switch / on modal close / on plan switch.
- [ ] modal: retrigger on a consumed plan → first click arms the danger label + pulse; second click within 4s executes and closes the modal.
- [ ] modal: deleted creator/consumer agent renders strikethrough with `deleted` chip; click shows an alert and does not navigate.
- [ ] `pnpm typecheck` + `pnpm test` green (3 packages typecheck, 22 db tests, 324 desktop tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)