### PR TITLE
feat(desktop): github panel refactor — emotional, actionable, agent-aware

### DIFF
--- a/apps/desktop/src/__tests__/spawn-from-comment.test.ts
+++ b/apps/desktop/src/__tests__/spawn-from-comment.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import type { PrComment, PullRequestState } from '@kay-am/types';
+import {
+  buildCommentAgentArgs,
+  buildCommentAgentTitle,
+  buildReviewChangesAgentArgs,
+  inferAgentKindFromComment,
+} from '../spawn-from-comment';
+
+const PR: PullRequestState = {
+  number: 9108,
+  title: 'fix: foo',
+  url: 'https://github.com/o/r/pull/9108',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'kay/foo',
+  isDraft: false,
+  reviewDecision: 'changes_requested',
+  body: '',
+  updatedAt: '2026-05-15T00:00:00Z',
+};
+
+function makeComment(over: Partial<PrComment> = {}): PrComment {
+  return {
+    id: 'review-1',
+    author: 'alice',
+    authorAvatarUrl: null,
+    body: 'this should use a helper',
+    createdAt: '2026-05-15T10:00:00Z',
+    url: 'https://github.com/o/r/pull/9108#discussion_r1',
+    source: 'review',
+    path: 'src/foo.ts',
+    line: 42,
+    resolved: false,
+    ...over,
+  };
+}
+
+describe('spawn-from-comment', () => {
+  it('titles review comments with short file + line', () => {
+    expect(buildCommentAgentTitle(makeComment())).toBe('fix: alice on foo.ts:42');
+  });
+
+  it('strips [bot] suffix from authors in titles', () => {
+    expect(buildCommentAgentTitle(makeComment({ author: 'cursor[bot]' }))).toBe(
+      'fix: cursor on foo.ts:42',
+    );
+  });
+
+  it('falls back to generic title for issue comments', () => {
+    expect(
+      buildCommentAgentTitle(
+        makeComment({ source: 'issue', path: undefined, line: undefined, id: 'issue-1' }),
+      ),
+    ).toBe('fix: alice comment');
+  });
+
+  it('infers implementer for review with path', () => {
+    expect(inferAgentKindFromComment(makeComment())).toBe('implementer');
+  });
+
+  it('infers debugger for issue comments containing bug keywords', () => {
+    expect(
+      inferAgentKindFromComment(
+        makeComment({
+          source: 'issue',
+          path: undefined,
+          line: undefined,
+          body: 'this crashes when X',
+        }),
+      ),
+    ).toBe('debugger');
+  });
+
+  it('builds args with sonnet implementer for review comments', () => {
+    const args = buildCommentAgentArgs(makeComment(), PR);
+    expect(args.name).toBe('fix: alice on foo.ts:42');
+    expect(args.effort).toBe('medium');
+    expect(args.initialPrompt).toContain('src/foo.ts:42');
+    expect(args.initialPrompt).toContain('this should use a helper');
+    expect(args.initialPrompt).toContain('#9108');
+  });
+
+  it('aggregates open comments for fix-all', () => {
+    const args = buildReviewChangesAgentArgs(PR, [
+      makeComment({ id: 'r1', author: 'bob', body: 'rename foo' }),
+      makeComment({ id: 'r2', author: 'eve', path: 'a/b.ts', line: 7, body: 'extract' }),
+    ]);
+    expect(args.name).toContain('#9108');
+    expect(args.initialPrompt).toContain('bob');
+    expect(args.initialPrompt).toContain('eve');
+    expect(args.initialPrompt).toContain('a/b.ts:7');
+  });
+});

--- a/apps/desktop/src/__tests__/spawn-from-comment.test.ts
+++ b/apps/desktop/src/__tests__/spawn-from-comment.test.ts
@@ -9,7 +9,7 @@ import {
 
 const PR: PullRequestState = {
   number: 9108,
-  title: 'fix: foo',
+  title: 'resolve: foo',
   url: 'https://github.com/o/r/pull/9108',
   state: 'open',
   mergeable: true,
@@ -40,12 +40,12 @@ function makeComment(over: Partial<PrComment> = {}): PrComment {
 
 describe('spawn-from-comment', () => {
   it('titles review comments with short file + line', () => {
-    expect(buildCommentAgentTitle(makeComment())).toBe('fix: alice on foo.ts:42');
+    expect(buildCommentAgentTitle(makeComment())).toBe('resolve: alice on foo.ts:42');
   });
 
   it('strips [bot] suffix from authors in titles', () => {
     expect(buildCommentAgentTitle(makeComment({ author: 'cursor[bot]' }))).toBe(
-      'fix: cursor on foo.ts:42',
+      'resolve: cursor on foo.ts:42',
     );
   });
 
@@ -54,7 +54,7 @@ describe('spawn-from-comment', () => {
       buildCommentAgentTitle(
         makeComment({ source: 'issue', path: undefined, line: undefined, id: 'issue-1' }),
       ),
-    ).toBe('fix: alice comment');
+    ).toBe('resolve: alice comment');
   });
 
   it('infers implementer for review with path', () => {
@@ -76,7 +76,7 @@ describe('spawn-from-comment', () => {
 
   it('builds args with sonnet implementer for review comments', () => {
     const args = buildCommentAgentArgs(makeComment(), PR);
-    expect(args.name).toBe('fix: alice on foo.ts:42');
+    expect(args.name).toBe('resolve: alice on foo.ts:42');
     expect(args.effort).toBe('medium');
     expect(args.initialPrompt).toContain('src/foo.ts:42');
     expect(args.initialPrompt).toContain('this should use a helper');

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -29,6 +29,7 @@ import type {
   ContextSlotHistoryEntry,
   PlanStatus,
   PlanWithCount,
+  PrComment,
   Session,
   SessionId,
   TelemetryRecord,
@@ -53,6 +54,7 @@ import { DiffViewerDialog } from './DiffViewerDialog';
 import { GithubCard } from './GithubCard';
 import { worktreeStatus } from '../worktree';
 import type { WorktreeStatus } from '@kay-am/types';
+import { buildCommentAgentArgs, buildReviewChangesAgentArgs } from '../spawn-from-comment';
 
 interface ContextPanelProps {
   session: Session;
@@ -430,6 +432,7 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const refreshSessionPrDetail = useAppStore((s) => s.refreshSessionPrDetail);
   const createPrForSession = useAppStore((s) => s.createPrForSession);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
 
   const [repoSlug, setRepoSlug] = useState<string | null>(null);
   const [diffOpen, setDiffOpen] = useState(false);
@@ -666,6 +669,18 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
               branchLastActivity={session.updatedAt}
               onOpenUrl={openInBrowser}
               onRefresh={() => void refreshSessionPrDetail(session.id, { force: true })}
+              onSpawnFromComment={(c: PrComment) => {
+                const args = buildCommentAgentArgs(c, pr);
+                void spawnAgent(session.id, args);
+              }}
+              onSpawnFromReviewChanges={() => {
+                const open = (ghState?.detail?.comments ?? []).filter(
+                  (c) => c.source !== 'review' || c.resolved === false,
+                );
+                if (open.length === 0) return;
+                const args = buildReviewChangesAgentArgs(pr, open);
+                void spawnAgent(session.id, args);
+              }}
             />
           </div>
         ) : null}

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -9,11 +9,8 @@ import {
   GitPullRequestDraft,
   GitMerge,
   RefreshCw,
-  ExternalLink,
   Plus,
   Loader2,
-  Copy,
-  X,
   ChevronRight,
   ChevronDown,
   FileEdit,
@@ -332,18 +329,19 @@ const PR_STATE_LABEL: Record<PullRequestStateKind, string> = {
   closed: 'closed',
 };
 
-const PR_STATE_STYLE: Record<PullRequestStateKind, string> = {
-  draft: 'bg-muted text-muted-foreground',
-  open: 'bg-success/10 text-success',
-  approved: 'bg-success/20 text-success',
-  merged: 'bg-accent/10 text-accent',
-  closed: 'bg-danger/10 text-danger',
+const PR_STATE_ICON_CLASS: Record<PullRequestStateKind, string> = {
+  draft: 'text-muted-foreground',
+  open: 'text-success',
+  approved: 'text-success',
+  merged: 'text-accent',
+  closed: 'text-danger',
 };
 
-function PrStateIcon({ state }: { state: PullRequestStateKind }) {
-  if (state === 'draft') return <GitPullRequestDraft size={11} aria-hidden />;
-  if (state === 'merged') return <GitMerge size={11} aria-hidden />;
-  return <GitPullRequest size={11} aria-hidden />;
+function PrStateIcon({ state, size = 12 }: { state: PullRequestStateKind; size?: number }) {
+  const cls = PR_STATE_ICON_CLASS[state];
+  if (state === 'draft') return <GitPullRequestDraft size={size} aria-hidden className={cls} />;
+  if (state === 'merged') return <GitMerge size={size} aria-hidden className={cls} />;
+  return <GitPullRequest size={size} aria-hidden className={cls} />;
 }
 
 function openInBrowser(url: string) {
@@ -519,72 +517,88 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
       </div>
 
       <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
-        <div className="flex items-center justify-between gap-1.5">
-          <span className="truncate font-mono text-xs text-foreground" title={branch}>
-            {branch}
-          </span>
-          <button
-            type="button"
-            onClick={copyBranch}
-            title="copy branch name"
-            aria-label="copy branch name"
-            className={cn('shrink-0', ICON_BTN)}
-          >
-            {copied ? <X size={10} aria-hidden /> : <Copy size={10} aria-hidden />}
-          </button>
-        </div>
-
         {isFirstLoad ? (
           <PrSkeleton />
         ) : pr ? (
-          <div className="flex items-start gap-1.5">
+          <div
+            className="flex items-center gap-1.5"
+            title={`#${pr.number} ${pr.title} — ${PR_STATE_LABEL[pr.state]}`}
+          >
+            <PrStateIcon state={pr.state} />
             <button
               type="button"
               onClick={() => openInBrowser(pr.url)}
-              className="flex min-w-0 flex-1 items-center gap-1 text-left text-xs text-foreground hover:underline"
-              title={pr.title}
+              className="shrink-0 font-mono text-xs text-foreground hover:underline focus:underline focus:outline-none"
+              title={`open #${pr.number} on github — ${pr.title}`}
+              aria-label={`open pull request #${pr.number} on github`}
             >
-              <PrStateIcon state={pr.state} />
-              <span className="truncate">
-                #{pr.number} {pr.title}
-              </span>
+              #{pr.number}
             </button>
-            <div className="flex shrink-0 items-center gap-1">
-              <span
-                className={cn(
-                  'rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide',
-                  PR_STATE_STYLE[pr.state],
-                )}
+            <button
+              type="button"
+              onClick={copyBranch}
+              className={cn(
+                'min-w-0 flex-1 truncate text-left font-mono text-xs transition-colors focus:outline-none',
+                copied
+                  ? 'text-success'
+                  : 'text-muted-foreground hover:text-foreground focus:text-foreground',
+              )}
+              title={copied ? 'copied!' : `copy branch: ${branch}`}
+              aria-label={`copy branch name ${branch}`}
+            >
+              {branch}
+            </button>
+            {repoSlug ? (
+              <button
+                type="button"
+                onClick={() => setDiffOpen(true)}
+                title="view diff"
+                aria-label="view pr diff"
+                className={cn('shrink-0', ICON_BTN)}
               >
-                {PR_STATE_LABEL[pr.state]}
-              </span>
-              {repoSlug ? (
-                <button
-                  type="button"
-                  onClick={() => setDiffOpen(true)}
-                  title="view diff"
-                  aria-label="view pr diff"
-                  className={ICON_BTN}
-                >
-                  <ExternalLink size={10} aria-hidden />
-                </button>
-              ) : null}
-            </div>
+                <FileEdit size={11} aria-hidden />
+              </button>
+            ) : null}
           </div>
         ) : loading ? (
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Loader2 size={10} className="animate-spin" aria-hidden />
-            checking…
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Loader2 size={11} className="shrink-0 animate-spin" aria-hidden />
+            <button
+              type="button"
+              onClick={copyBranch}
+              className={cn(
+                'min-w-0 flex-1 truncate text-left font-mono focus:outline-none',
+                copied ? 'text-success' : 'hover:text-foreground',
+              )}
+              title={copied ? 'copied!' : `copy branch: ${branch}`}
+              aria-label={`copy branch name ${branch}`}
+            >
+              {branch}
+            </button>
           </div>
         ) : (
-          <div className="flex items-center justify-between gap-1.5">
-            <span className="text-xs italic text-muted-foreground">no pr yet</span>
+          <div className="flex items-center gap-1.5">
+            <GitBranch size={11} aria-hidden className="shrink-0 text-muted-foreground" />
+            <button
+              type="button"
+              onClick={copyBranch}
+              className={cn(
+                'min-w-0 flex-1 truncate text-left font-mono text-xs transition-colors focus:outline-none',
+                copied
+                  ? 'text-success'
+                  : 'text-foreground hover:text-muted-foreground focus:text-muted-foreground',
+              )}
+              title={copied ? 'copied!' : `copy branch: ${branch}`}
+              aria-label={`copy branch name ${branch}`}
+            >
+              {branch}
+            </button>
             <Button
               size="sm"
               variant="ghost"
               onClick={() => void handleCreatePr()}
               disabled={loading}
-              className="h-5 gap-0.5 px-1.5 text-[10px]"
+              className="h-5 shrink-0 gap-0.5 px-1.5 text-[10px]"
             >
               <Plus size={10} aria-hidden />
               Open PR

--- a/apps/desktop/src/components/ContextPanel.tsx
+++ b/apps/desktop/src/components/ContextPanel.tsx
@@ -416,10 +416,10 @@ function FilesTouchedSkeleton() {
 
 function PrSkeleton() {
   return (
-    <div className="flex items-center gap-1.5" aria-hidden>
-      <div className="h-2.5 w-2.5 animate-pulse rounded-sm bg-muted" />
-      <div className="h-2.5 flex-1 animate-pulse rounded bg-muted" />
-      <div className="h-4 w-10 animate-pulse rounded-full bg-muted" />
+    <div className="flex items-center gap-1.5" role="status" aria-label="loading pr">
+      <div className="h-3 w-3 animate-pulse rounded-sm bg-muted [animation-delay:0ms]" />
+      <div className="h-3 w-10 animate-pulse rounded bg-muted [animation-delay:80ms]" />
+      <div className="h-3 flex-1 animate-pulse rounded bg-muted [animation-delay:160ms]" />
     </div>
   );
 }
@@ -519,7 +519,10 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
         </button>
       </div>
 
-      <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
+      <div
+        className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2"
+        aria-live="polite"
+      >
         {isFirstLoad ? (
           <PrSkeleton />
         ) : pr ? (

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -124,7 +124,10 @@ export function GithubCard({
         </div>
       </div>
 
-      <div className="max-h-44 overflow-y-auto rounded-md border border-border-soft bg-subtle px-2.5 py-2">
+      <div
+        className="max-h-44 overflow-y-auto rounded-md border border-border-soft bg-subtle px-2.5 py-2 transition-opacity duration-150"
+        key={active}
+      >
         {detailError ? (
           <ErrorRow message={detailError} onRetry={onRefresh} />
         ) : detailLoading && !detail ? (
@@ -194,10 +197,10 @@ function ErrorRow({ message, onRetry }: { message: string; onRetry: () => void }
 
 function DetailSkeleton() {
   return (
-    <div className="flex flex-col gap-1.5" aria-hidden>
-      <div className="h-2.5 w-3/4 animate-pulse rounded bg-muted" />
-      <div className="h-2.5 w-1/2 animate-pulse rounded bg-muted" />
-      <div className="h-2.5 w-2/3 animate-pulse rounded bg-muted" />
+    <div className="flex flex-col gap-1.5" role="status" aria-label="loading pr data">
+      <div className="h-2.5 w-3/4 animate-pulse rounded bg-muted [animation-delay:0ms]" />
+      <div className="h-2.5 w-1/2 animate-pulse rounded bg-muted [animation-delay:120ms]" />
+      <div className="h-2.5 w-2/3 animate-pulse rounded bg-muted [animation-delay:240ms]" />
     </div>
   );
 }

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -11,6 +11,7 @@ import {
   MessageSquare,
   MinusCircle,
   RefreshCw,
+  Sparkles,
   XCircle,
 } from 'lucide-react';
 import { cn } from '@kay-am/ui';
@@ -46,6 +47,8 @@ interface GithubCardProps {
   readonly branchLastActivity: string | null;
   readonly onOpenUrl: (url: string) => void;
   readonly onRefresh: () => void;
+  readonly onSpawnFromComment?: (comment: PrComment) => void;
+  readonly onSpawnFromReviewChanges?: () => void;
 }
 
 export function GithubCard({
@@ -57,6 +60,8 @@ export function GithubCard({
   branchLastActivity,
   onOpenUrl,
   onRefresh,
+  onSpawnFromComment,
+  onSpawnFromReviewChanges,
 }: GithubCardProps) {
   const smartDefault = useMemo(
     () => pickSmartTab(pr, detail, branchLastActivity),
@@ -127,13 +132,19 @@ export function GithubCard({
         ) : active === 'ci' ? (
           <CiPane checks={detail?.checks ?? []} pr={pr} onOpenUrl={onOpenUrl} />
         ) : active === 'comments' ? (
-          <CommentsPane comments={detail?.comments ?? []} pr={pr} onOpenUrl={onOpenUrl} />
+          <CommentsPane
+            comments={detail?.comments ?? []}
+            pr={pr}
+            onOpenUrl={onOpenUrl}
+            onSpawnFromComment={onSpawnFromComment}
+          />
         ) : (
           <ReviewPane
             reviews={detail?.reviews ?? []}
             requests={detail?.reviewRequests ?? []}
             pr={pr}
             onOpenUrl={onOpenUrl}
+            onSpawnFromReviewChanges={onSpawnFromReviewChanges}
           />
         )}
       </div>
@@ -276,10 +287,12 @@ function CommentsPane({
   comments,
   pr,
   onOpenUrl,
+  onSpawnFromComment,
 }: {
   comments: ReadonlyArray<PrComment>;
   pr: PullRequestState;
   onOpenUrl: (url: string) => void;
+  onSpawnFromComment?: (c: PrComment) => void;
 }) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
   const [showAll, setShowAll] = useState(false);
@@ -325,6 +338,7 @@ function CommentsPane({
             expanded={expanded.has(t.head.id)}
             onToggle={() => toggle(t.head.id)}
             onOpenUrl={onOpenUrl}
+            onSpawn={onSpawnFromComment ? () => onSpawnFromComment(t.head) : undefined}
           />
         </li>
       ))}
@@ -348,11 +362,13 @@ function CommentThreadRow({
   expanded,
   onToggle,
   onOpenUrl,
+  onSpawn,
 }: {
   thread: CommentThread;
   expanded: boolean;
   onToggle: () => void;
   onOpenUrl: (url: string) => void;
+  onSpawn?: () => void;
 }) {
   const { head, replies } = thread;
   const isReview = head.source === 'review';
@@ -389,15 +405,28 @@ function CommentThreadRow({
               · +{replies.length} repl{replies.length === 1 ? 'y' : 'ies'}
             </span>
           ) : null}
-          <button
-            type="button"
-            onClick={() => onOpenUrl(head.url)}
-            title="open comment in browser"
-            aria-label="open comment in browser"
-            className={cn(TAB_ICON_BTN, 'ml-auto')}
-          >
-            <ExternalLink size={9} aria-hidden />
-          </button>
+          <div className="ml-auto flex items-center gap-0.5">
+            {onSpawn && status !== 'resolved' ? (
+              <button
+                type="button"
+                onClick={onSpawn}
+                title="spawn agent to address this comment"
+                aria-label="spawn agent to address this comment"
+                className={cn(TAB_ICON_BTN, 'hover:text-accent')}
+              >
+                <Sparkles size={10} aria-hidden />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => onOpenUrl(head.url)}
+              title="open comment in browser"
+              aria-label="open comment in browser"
+              className={TAB_ICON_BTN}
+            >
+              <ExternalLink size={9} aria-hidden />
+            </button>
+          </div>
         </div>
         {head.path ? (
           <button
@@ -448,11 +477,13 @@ function ReviewPane({
   requests,
   pr,
   onOpenUrl,
+  onSpawnFromReviewChanges,
 }: {
   reviews: ReadonlyArray<PrReview>;
   requests: ReadonlyArray<PrReviewRequest>;
   pr: PullRequestState;
   onOpenUrl: (url: string) => void;
+  onSpawnFromReviewChanges?: () => void;
 }) {
   const summary = summarizeReview(pr, reviews, requests);
   return (
@@ -479,6 +510,17 @@ function ReviewPane({
             </span>
           ))}
         </div>
+      ) : null}
+      {pr.reviewDecision === 'changes_requested' && onSpawnFromReviewChanges ? (
+        <button
+          type="button"
+          onClick={onSpawnFromReviewChanges}
+          className="inline-flex w-fit items-center gap-1 rounded border border-accent/30 bg-accent/5 px-2 py-0.5 text-[10px] font-medium text-accent hover:bg-accent/10"
+          title="spawn agent to address all requested changes"
+        >
+          <Sparkles size={10} aria-hidden />
+          fix all requested changes
+        </button>
       ) : null}
       {reviews.length === 0 && requests.length === 0 ? (
         <button

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -164,9 +164,11 @@ function AnimatedTabBody({ activeKey, children }: { activeKey: string; children:
   useLayoutEffect(() => {
     const el = innerRef.current;
     if (!el) return;
-    setHeight(el.getBoundingClientRect().height);
+    setHeight(el.offsetHeight);
     const ro = new ResizeObserver((entries) => {
-      const h = entries[0]?.contentRect.height;
+      const entry = entries[0];
+      if (!entry) return;
+      const h = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
       if (h != null) setHeight(h);
     });
     ro.observe(el);
@@ -178,7 +180,7 @@ function AnimatedTabBody({ activeKey, children }: { activeKey: string; children:
       className="overflow-hidden rounded-md border border-border-soft bg-subtle transition-[height] duration-200 ease-out motion-reduce:transition-none"
       style={height != null ? { height } : undefined}
     >
-      <div ref={innerRef} key={activeKey} className="max-h-44 overflow-y-auto px-2.5 py-2">
+      <div ref={innerRef} key={activeKey} className="min-h-16 max-h-48 overflow-y-auto px-2.5 py-2">
         {children}
       </div>
     </div>

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   AlertCircle,
   Check,
@@ -129,10 +129,7 @@ export function GithubCard({
         </div>
       </div>
 
-      <div
-        className="max-h-44 overflow-y-auto rounded-md border border-border-soft bg-subtle px-2.5 py-2 transition-opacity duration-150"
-        key={active}
-      >
+      <AnimatedTabBody activeKey={active}>
         {detailError ? (
           <ErrorRow message={detailError} onRetry={onRefresh} />
         ) : detailLoading && !detail ? (
@@ -155,6 +152,34 @@ export function GithubCard({
             onSpawnFromReviewChanges={onSpawnFromReviewChanges}
           />
         )}
+      </AnimatedTabBody>
+    </div>
+  );
+}
+
+function AnimatedTabBody({ activeKey, children }: { activeKey: string; children: ReactNode }) {
+  const innerRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = innerRef.current;
+    if (!el) return;
+    setHeight(el.getBoundingClientRect().height);
+    const ro = new ResizeObserver((entries) => {
+      const h = entries[0]?.contentRect.height;
+      if (h != null) setHeight(h);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [activeKey]);
+
+  return (
+    <div
+      className="overflow-hidden rounded-md border border-border-soft bg-subtle transition-[height] duration-200 ease-out motion-reduce:transition-none"
+      style={height != null ? { height } : undefined}
+    >
+      <div ref={innerRef} key={activeKey} className="max-h-44 overflow-y-auto px-2.5 py-2">
+        {children}
       </div>
     </div>
   );

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -80,6 +80,8 @@ export function GithubCard({
     setActive(k);
   };
 
+  const tabStatus = useMemo(() => computeTabStatus(pr, detail), [pr, detail]);
+
   return (
     <div className="flex flex-col gap-1.5">
       <div className="flex items-center gap-1">
@@ -90,6 +92,7 @@ export function GithubCard({
         >
           {TAB_KEYS.map((k) => {
             const isActive = k === active;
+            const status = tabStatus[k];
             return (
               <button
                 key={k}
@@ -97,14 +100,16 @@ export function GithubCard({
                 role="tab"
                 aria-selected={isActive}
                 onClick={() => selectTab(k)}
+                title={status?.label}
                 className={cn(
-                  'px-2 py-0.5 text-2xs transition-colors first:rounded-l last:rounded-r',
+                  'inline-flex items-center gap-1 px-2 py-0.5 text-2xs transition-colors first:rounded-l last:rounded-r',
                   isActive
                     ? 'bg-background font-semibold text-foreground shadow-sm'
                     : 'text-muted-foreground/70 hover:text-foreground',
                 )}
               >
-                {TAB_LABEL[k]}
+                <span>{TAB_LABEL[k]}</span>
+                {status ? <TabBadge status={status} dim={!isActive} /> : null}
               </button>
             );
           })}
@@ -153,6 +158,151 @@ export function GithubCard({
       </div>
     </div>
   );
+}
+
+interface TabStatus {
+  readonly tone: 'success' | 'warning' | 'danger' | 'info' | 'muted';
+  readonly icon: ReactNode;
+  readonly count?: number;
+  readonly label: string;
+}
+
+const TONE_PILL: Record<TabStatus['tone'], string> = {
+  success: 'bg-success/10 text-success',
+  danger: 'bg-danger/15 text-danger',
+  warning: 'bg-warning/15 text-warning',
+  info: 'bg-info/10 text-info',
+  muted: 'bg-muted text-muted-foreground',
+};
+
+function TabBadge({ status, dim }: { status: TabStatus; dim: boolean }) {
+  const hasCount = status.count != null && status.count > 0;
+  return (
+    <span
+      aria-label={status.label}
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded-full px-1 leading-none transition-opacity',
+        TONE_PILL[status.tone],
+        dim && 'opacity-80',
+      )}
+    >
+      {status.icon}
+      {hasCount ? (
+        <span className="text-[9px] font-semibold tabular-nums">{status.count}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function computeTabStatus(
+  pr: PullRequestState,
+  detail: PrDetail | null,
+): Record<GithubTabKey, TabStatus | null> {
+  return {
+    ci: computeCiStatus(pr, detail?.checks ?? []),
+    comments: computeCommentsStatus(detail?.comments ?? []),
+    review: computeReviewStatus(pr, detail?.reviews ?? [], detail?.reviewRequests ?? []),
+  };
+}
+
+function computeCiStatus(
+  pr: PullRequestState,
+  checks: ReadonlyArray<PrCheckRun>,
+): TabStatus | null {
+  if (checks.length === 0) {
+    if (pr.checks === 'failure')
+      return { tone: 'danger', icon: <XCircle size={9} aria-hidden />, label: 'ci failing' };
+    if (pr.checks === 'pending')
+      return {
+        tone: 'warning',
+        icon: <Clock size={9} aria-hidden className="motion-safe:animate-pulse" />,
+        label: 'ci running',
+      };
+    if (pr.checks === 'success')
+      return { tone: 'success', icon: <Check size={9} aria-hidden />, label: 'ci passing' };
+    return null;
+  }
+  const fail = checks.filter(
+    (c) =>
+      c.conclusion === 'failure' ||
+      c.conclusion === 'cancelled' ||
+      c.conclusion === 'timed_out' ||
+      c.conclusion === 'action_required',
+  ).length;
+  const pending = checks.filter((c) => c.conclusion === 'pending').length;
+  if (fail > 0)
+    return {
+      tone: 'danger',
+      icon: <XCircle size={9} aria-hidden />,
+      count: fail,
+      label: `${fail} failing check${fail === 1 ? '' : 's'}`,
+    };
+  if (pending > 0)
+    return {
+      tone: 'warning',
+      icon: <Clock size={9} aria-hidden className="motion-safe:animate-pulse" />,
+      count: pending,
+      label: `${pending} check${pending === 1 ? '' : 's'} running`,
+    };
+  return { tone: 'success', icon: <Check size={9} aria-hidden />, label: 'all checks passing' };
+}
+
+function computeCommentsStatus(comments: ReadonlyArray<PrComment>): TabStatus | null {
+  const heads = comments.filter((c) => c.source === 'review' && !c.inReplyToId);
+  if (heads.length === 0) return null;
+  const open = heads.filter((c) => c.resolved === false).length;
+  if (open > 0)
+    return {
+      tone: 'warning',
+      icon: <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-warning" />,
+      count: open,
+      label: `${open} unresolved comment${open === 1 ? '' : 's'}`,
+    };
+  return {
+    tone: 'success',
+    icon: <CheckCheck size={9} aria-hidden />,
+    label: 'all comments resolved',
+  };
+}
+
+function computeReviewStatus(
+  pr: PullRequestState,
+  reviews: ReadonlyArray<PrReview>,
+  requests: ReadonlyArray<PrReviewRequest>,
+): TabStatus | null {
+  const latest = latestTerminalReviewsByAuthor(reviews);
+  const changes = latest.filter((r) => r.state === 'changes_requested');
+  if (changes.length > 0)
+    return {
+      tone: 'danger',
+      icon: <AlertCircle size={9} aria-hidden />,
+      count: changes.length,
+      label: `changes requested by ${changes.map((r) => r.author).join(', ')}`,
+    };
+  const approvals = latest.filter((r) => r.state === 'approved');
+  if (pr.reviewDecision === 'approved' || approvals.length > 0)
+    return {
+      tone: 'success',
+      icon: <CheckCheck size={9} aria-hidden />,
+      label:
+        approvals.length > 0
+          ? `approved by ${approvals.map((r) => r.author).join(', ')}`
+          : 'approved',
+    };
+  if (requests.length > 0)
+    return {
+      tone: 'info',
+      icon: <CircleDashed size={9} aria-hidden />,
+      count: requests.length,
+      label: `awaiting ${requests.length} reviewer${requests.length === 1 ? '' : 's'}`,
+    };
+  if (reviews.some((r) => r.state === 'commented'))
+    return {
+      tone: 'muted',
+      icon: <MessageSquare size={9} aria-hidden />,
+      label: 'reviewer commented',
+    };
+  return null;
 }
 
 function StaleCaption({ fetchedAt }: { fetchedAt: string | null }) {

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -486,6 +486,7 @@ function ReviewPane({
   onSpawnFromReviewChanges?: () => void;
 }) {
   const summary = summarizeReview(pr, reviews, requests);
+  const perReviewer = useMemo(() => latestTerminalReviewsByAuthor(reviews), [reviews]);
   return (
     <div className="flex flex-col gap-1.5">
       <div
@@ -497,20 +498,6 @@ function ReviewPane({
         {summary.icon}
         <span>{summary.label}</span>
       </div>
-      {requests.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-1">
-          <span className="text-[10px] text-muted-foreground">requested:</span>
-          {requests.map((r) => (
-            <span
-              key={`${r.kind}-${r.login}`}
-              className="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-1.5 py-0.5 text-[10px] text-foreground"
-            >
-              <Avatar url={r.avatarUrl} alt={r.login} />
-              <span className="truncate">{r.login}</span>
-            </span>
-          ))}
-        </div>
-      ) : null}
       {pr.reviewDecision === 'changes_requested' && onSpawnFromReviewChanges ? (
         <button
           type="button"
@@ -521,6 +508,45 @@ function ReviewPane({
           <Sparkles size={10} aria-hidden />
           fix all requested changes
         </button>
+      ) : null}
+      {perReviewer.length > 0 ? (
+        <ul className="flex flex-col gap-0.5">
+          {perReviewer.map((r) => (
+            <li
+              key={r.author}
+              className="flex items-center gap-1.5 rounded px-1 py-0.5 text-[10px] text-foreground hover:bg-background"
+            >
+              <ReviewStateIcon state={r.state} />
+              <Avatar url={r.authorAvatarUrl} alt={r.author} />
+              <span className="truncate font-medium">{r.author}</span>
+              {isBot(r.author) ? (
+                <span className="rounded bg-info/10 px-1 text-[8px] uppercase tracking-wide text-info">
+                  bot
+                </span>
+              ) : null}
+              <span className="ml-auto shrink-0 text-[9px] text-muted-foreground/70">
+                {r.submittedAt
+                  ? formatRelative(Date.now() - new Date(r.submittedAt).getTime())
+                  : ''}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {requests.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1">
+          <span className="text-[10px] text-muted-foreground">awaiting:</span>
+          {requests.map((r) => (
+            <span
+              key={`${r.kind}-${r.login}`}
+              className="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-1.5 py-0.5 text-[10px] text-foreground"
+            >
+              <CircleDashed size={9} aria-hidden className="text-info" />
+              <Avatar url={r.avatarUrl} alt={r.login} />
+              <span className="truncate">{r.login}</span>
+            </span>
+          ))}
+        </div>
       ) : null}
       {reviews.length === 0 && requests.length === 0 ? (
         <button
@@ -534,6 +560,26 @@ function ReviewPane({
       ) : null}
     </div>
   );
+}
+
+function ReviewStateIcon({ state }: { state: PrReviewState }) {
+  const props = { size: 10, 'aria-hidden': true } as const;
+  if (state === 'approved') return <CheckCheck {...props} className="text-success" />;
+  if (state === 'changes_requested') return <AlertCircle {...props} className="text-danger" />;
+  if (state === 'commented') return <MessageSquare {...props} className="text-muted-foreground" />;
+  if (state === 'dismissed') return <MinusCircle {...props} className="text-muted-foreground" />;
+  return <CircleDashed {...props} className="text-muted-foreground" />;
+}
+
+function latestTerminalReviewsByAuthor(reviews: ReadonlyArray<PrReview>): ReadonlyArray<PrReview> {
+  const map = new Map<string, PrReview>();
+  for (const r of [...reviews].sort((a, b) =>
+    (a.submittedAt ?? '').localeCompare(b.submittedAt ?? ''),
+  )) {
+    if (r.state === 'commented' || r.state === 'pending' || r.state === 'dismissed') continue;
+    map.set(r.author, r);
+  }
+  return [...map.values()];
 }
 
 function EmptyRow({

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -232,6 +232,46 @@ function CiPane({
   );
 }
 
+interface CommentThread {
+  readonly head: PrComment;
+  readonly replies: ReadonlyArray<PrComment>;
+}
+
+function groupThreads(comments: ReadonlyArray<PrComment>): ReadonlyArray<CommentThread> {
+  const byId = new Map<string, PrComment>();
+  for (const c of comments) byId.set(c.id, c);
+  const heads: Array<PrComment> = [];
+  const repliesByHead = new Map<string, Array<PrComment>>();
+  for (const c of comments) {
+    if (c.source === 'review' && c.inReplyToId && byId.has(c.inReplyToId)) {
+      const arr = repliesByHead.get(c.inReplyToId) ?? [];
+      arr.push(c);
+      repliesByHead.set(c.inReplyToId, arr);
+    } else {
+      heads.push(c);
+    }
+  }
+  return heads.map((head) => ({
+    head,
+    replies: (repliesByHead.get(head.id) ?? []).sort((a, b) =>
+      a.createdAt.localeCompare(b.createdAt),
+    ),
+  }));
+}
+
+function threadPriority(t: CommentThread): number {
+  // open review > issue > resolved review. Smaller = higher priority.
+  if (t.head.source === 'review' && t.head.resolved === false) return 0;
+  if (t.head.source === 'issue') return 1;
+  return 2;
+}
+
+function isBot(author: string): boolean {
+  return author.endsWith('[bot]') || author.endsWith('-bot');
+}
+
+const COMMENT_DISPLAY_LIMIT = 5;
+
 function CommentsPane({
   comments,
   pr,
@@ -242,7 +282,18 @@ function CommentsPane({
   onOpenUrl: (url: string) => void;
 }) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
-  if (comments.length === 0) {
+  const [showAll, setShowAll] = useState(false);
+
+  const threads = useMemo(() => {
+    const all = groupThreads(comments);
+    return [...all].sort((a, b) => {
+      const p = threadPriority(a) - threadPriority(b);
+      if (p !== 0) return p;
+      return b.head.createdAt.localeCompare(a.head.createdAt);
+    });
+  }, [comments]);
+
+  if (threads.length === 0) {
     return (
       <EmptyRow
         text="No comments yet"
@@ -252,7 +303,10 @@ function CommentsPane({
       />
     );
   }
-  const latest = [...comments].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, 3);
+
+  const visible = showAll ? threads : threads.slice(0, COMMENT_DISPLAY_LIMIT);
+  const hidden = threads.length - visible.length;
+
   const toggle = (id: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -261,41 +315,131 @@ function CommentsPane({
       return next;
     });
   };
+
   return (
     <ul className="flex flex-col gap-1.5">
-      {latest.map((c) => (
-        <li key={c.id} className="flex gap-1.5">
-          <Avatar url={c.authorAvatarUrl} alt={c.author} />
-          <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-              <span className="truncate font-medium text-foreground">{c.author}</span>
-              <span className="opacity-60">·</span>
-              <span>{formatRelative(Date.now() - new Date(c.createdAt).getTime())}</span>
-              <button
-                type="button"
-                onClick={() => onOpenUrl(c.url)}
-                title="open comment in browser"
-                aria-label="open comment in browser"
-                className={cn(TAB_ICON_BTN, 'ml-auto')}
-              >
-                <ExternalLink size={9} aria-hidden />
-              </button>
-            </div>
-            <button
-              type="button"
-              onClick={() => toggle(c.id)}
-              className={cn(
-                'text-left text-[11px] text-foreground/90 hover:text-foreground',
-                expanded.has(c.id) ? 'whitespace-pre-wrap break-words' : 'line-clamp-2',
-              )}
-              title={expanded.has(c.id) ? 'collapse' : 'expand'}
-            >
-              {c.body.trim() || '(empty)'}
-            </button>
-          </div>
+      {visible.map((t) => (
+        <li key={t.head.id}>
+          <CommentThreadRow
+            thread={t}
+            expanded={expanded.has(t.head.id)}
+            onToggle={() => toggle(t.head.id)}
+            onOpenUrl={onOpenUrl}
+          />
         </li>
       ))}
+      {hidden > 0 ? (
+        <li>
+          <button
+            type="button"
+            onClick={() => setShowAll(true)}
+            className="text-[10px] text-muted-foreground hover:text-foreground"
+          >
+            +{hidden} more
+          </button>
+        </li>
+      ) : null}
     </ul>
+  );
+}
+
+function CommentThreadRow({
+  thread,
+  expanded,
+  onToggle,
+  onOpenUrl,
+}: {
+  thread: CommentThread;
+  expanded: boolean;
+  onToggle: () => void;
+  onOpenUrl: (url: string) => void;
+}) {
+  const { head, replies } = thread;
+  const isReview = head.source === 'review';
+  const status: 'open' | 'resolved' | 'issue' = !isReview
+    ? 'issue'
+    : head.resolved
+      ? 'resolved'
+      : 'open';
+  const statusTone =
+    status === 'open' ? 'bg-warning' : status === 'resolved' ? 'bg-success' : 'bg-muted-foreground';
+  const statusLabel = status === 'open' ? 'open' : status === 'resolved' ? 'resolved' : 'comment';
+  const bot = isBot(head.author);
+
+  return (
+    <div className="flex gap-1.5">
+      <span
+        aria-hidden
+        className={cn('mt-1 h-1.5 w-1.5 shrink-0 rounded-full', statusTone)}
+        title={statusLabel}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+          <Avatar url={head.authorAvatarUrl} alt={head.author} />
+          <span className="truncate font-medium text-foreground">{head.author}</span>
+          {bot ? (
+            <span className="rounded bg-info/10 px-1 text-[8px] uppercase tracking-wide text-info">
+              bot
+            </span>
+          ) : null}
+          <span className="opacity-50">·</span>
+          <span>{formatRelative(Date.now() - new Date(head.createdAt).getTime())}</span>
+          {replies.length > 0 ? (
+            <span className="opacity-50">
+              · +{replies.length} repl{replies.length === 1 ? 'y' : 'ies'}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => onOpenUrl(head.url)}
+            title="open comment in browser"
+            aria-label="open comment in browser"
+            className={cn(TAB_ICON_BTN, 'ml-auto')}
+          >
+            <ExternalLink size={9} aria-hidden />
+          </button>
+        </div>
+        {head.path ? (
+          <button
+            type="button"
+            onClick={() => onOpenUrl(head.url)}
+            title={`${head.path}${head.line ? ':' + head.line : ''}`}
+            className="self-start truncate rounded bg-background/60 px-1 py-px font-mono text-[9px] text-muted-foreground hover:text-foreground"
+          >
+            {head.path}
+            {head.line ? `:${head.line}` : ''}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onToggle}
+          className={cn(
+            'text-left text-[11px] text-foreground/90 hover:text-foreground',
+            expanded ? 'whitespace-pre-wrap break-words' : 'line-clamp-2',
+          )}
+          title={expanded ? 'collapse' : 'expand'}
+        >
+          {head.body.trim() || '(empty)'}
+        </button>
+        {expanded && replies.length > 0 ? (
+          <ul className="ml-2 mt-1 flex flex-col gap-1 border-l border-border-soft pl-2">
+            {replies.map((r) => (
+              <li key={r.id} className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <Avatar url={r.authorAvatarUrl} alt={r.author} />
+                  <span className="truncate font-medium text-foreground">{r.author}</span>
+                  <span className="opacity-50">·</span>
+                  <span>{formatRelative(Date.now() - new Date(r.createdAt).getTime())}</span>
+                </div>
+                <p className="whitespace-pre-wrap break-words text-[11px] text-foreground/90">
+                  {r.body.trim() || '(empty)'}
+                </p>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -299,17 +299,27 @@ function CommentsPane({
 }) {
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
   const [showAll, setShowAll] = useState(false);
+  const [showResolved, setShowResolved] = useState(false);
+
+  const allThreads = useMemo(() => groupThreads(comments), [comments]);
+
+  const resolvedCount = useMemo(
+    () => allThreads.filter((t) => t.head.source === 'review' && t.head.resolved === true).length,
+    [allThreads],
+  );
 
   const threads = useMemo(() => {
-    const all = groupThreads(comments);
-    return [...all].sort((a, b) => {
+    const filtered = showResolved
+      ? allThreads
+      : allThreads.filter((t) => t.head.source !== 'review' || t.head.resolved !== true);
+    return [...filtered].sort((a, b) => {
       const p = threadPriority(a) - threadPriority(b);
       if (p !== 0) return p;
       return b.head.createdAt.localeCompare(a.head.createdAt);
     });
-  }, [comments]);
+  }, [allThreads, showResolved]);
 
-  if (threads.length === 0) {
+  if (allThreads.length === 0) {
     return (
       <EmptyRow
         text="No comments yet"
@@ -317,6 +327,23 @@ function CommentsPane({
         actionLabel="view on github"
         onOpenUrl={onOpenUrl}
       />
+    );
+  }
+
+  if (threads.length === 0) {
+    return (
+      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+        <span>All comments resolved 🎉</span>
+        {resolvedCount > 0 ? (
+          <button
+            type="button"
+            onClick={() => setShowResolved(true)}
+            className="text-[10px] underline-offset-2 hover:text-foreground hover:underline"
+          >
+            show {resolvedCount}
+          </button>
+        ) : null}
+      </div>
     );
   }
 
@@ -353,6 +380,17 @@ function CommentsPane({
             className="text-[10px] text-muted-foreground hover:text-foreground"
           >
             +{hidden} more
+          </button>
+        </li>
+      ) : null}
+      {resolvedCount > 0 ? (
+        <li>
+          <button
+            type="button"
+            onClick={() => setShowResolved((v) => !v)}
+            className="text-[10px] text-muted-foreground/70 hover:text-foreground"
+          >
+            {showResolved ? `hide ${resolvedCount} resolved` : `show ${resolvedCount} resolved`}
           </button>
         </li>
       ) : null}
@@ -408,16 +446,17 @@ function CommentThreadRow({
               · +{replies.length} repl{replies.length === 1 ? 'y' : 'ies'}
             </span>
           ) : null}
-          <div className="ml-auto flex items-center gap-0.5">
+          <div className="ml-auto flex items-center gap-1">
             {onSpawn && status !== 'resolved' ? (
               <button
                 type="button"
                 onClick={onSpawn}
-                title="spawn agent to address this comment"
-                aria-label="spawn agent to address this comment"
-                className={cn(TAB_ICON_BTN, 'hover:text-accent')}
+                title="spawn agent to resolve this comment"
+                aria-label="spawn agent to resolve this comment"
+                className="inline-flex items-center gap-0.5 rounded border border-accent/30 bg-accent/5 px-1.5 py-px text-[10px] font-medium text-accent transition-colors hover:bg-accent/15"
               >
-                <Sparkles size={10} aria-hidden />
+                <Sparkles size={9} aria-hidden />
+                resolve
               </button>
             ) : null}
             <button
@@ -506,10 +545,10 @@ function ReviewPane({
           type="button"
           onClick={onSpawnFromReviewChanges}
           className="inline-flex w-fit items-center gap-1 rounded border border-accent/30 bg-accent/5 px-2 py-0.5 text-[10px] font-medium text-accent hover:bg-accent/10"
-          title="spawn agent to address all requested changes"
+          title="spawn agent to resolve all requested changes"
         >
           <Sparkles size={10} aria-hidden />
-          fix all requested changes
+          resolve all requested changes
         </button>
       ) : null}
       {perReviewer.length > 0 ? (

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -303,46 +303,67 @@ function CommentsPane({
 
   const allThreads = useMemo(() => groupThreads(comments), [comments]);
 
-  const resolvedCount = useMemo(
-    () => allThreads.filter((t) => t.head.source === 'review' && t.head.resolved === true).length,
+  // Only review threads are resolvable / actionable. General issue-comments
+  // (no path, no resolved state) are filtered out — they live "view on github".
+  const reviewThreads = useMemo(
+    () => allThreads.filter((t) => t.head.source === 'review'),
     [allThreads],
+  );
+  const generalCount = allThreads.length - reviewThreads.length;
+  const resolvedCount = useMemo(
+    () => reviewThreads.filter((t) => t.head.resolved === true).length,
+    [reviewThreads],
   );
 
   const threads = useMemo(() => {
     const filtered = showResolved
-      ? allThreads
-      : allThreads.filter((t) => t.head.source !== 'review' || t.head.resolved !== true);
+      ? reviewThreads
+      : reviewThreads.filter((t) => t.head.resolved !== true);
     return [...filtered].sort((a, b) => {
       const p = threadPriority(a) - threadPriority(b);
       if (p !== 0) return p;
       return b.head.createdAt.localeCompare(a.head.createdAt);
     });
-  }, [allThreads, showResolved]);
+  }, [reviewThreads, showResolved]);
 
-  if (allThreads.length === 0) {
+  const generalFooter =
+    generalCount > 0 ? (
+      <button
+        type="button"
+        onClick={() => onOpenUrl(pr.url)}
+        className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground/70 hover:text-foreground"
+        title="open general comments on github"
+      >
+        {generalCount} general comment{generalCount === 1 ? '' : 's'}
+        <ExternalLink size={9} aria-hidden />
+      </button>
+    ) : null;
+
+  if (reviewThreads.length === 0) {
     return (
-      <EmptyRow
-        text="No comments yet"
-        actionUrl={pr.url}
-        actionLabel="view on github"
-        onOpenUrl={onOpenUrl}
-      />
+      <div className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+        <span>No review comments yet</span>
+        {generalFooter}
+      </div>
     );
   }
 
   if (threads.length === 0) {
     return (
-      <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
-        <span>All comments resolved 🎉</span>
-        {resolvedCount > 0 ? (
-          <button
-            type="button"
-            onClick={() => setShowResolved(true)}
-            className="text-[10px] underline-offset-2 hover:text-foreground hover:underline"
-          >
-            show {resolvedCount}
-          </button>
-        ) : null}
+      <div className="flex flex-col gap-1 text-[11px] text-muted-foreground">
+        <div className="flex items-center gap-1.5">
+          <span>All review comments resolved 🎉</span>
+          {resolvedCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => setShowResolved(true)}
+              className="text-[10px] underline-offset-2 hover:text-foreground hover:underline"
+            >
+              show {resolvedCount}
+            </button>
+          ) : null}
+        </div>
+        {generalFooter}
       </div>
     );
   }
@@ -394,6 +415,7 @@ function CommentsPane({
           </button>
         </li>
       ) : null}
+      {generalFooter ? <li>{generalFooter}</li> : null}
     </ul>
   );
 }

--- a/apps/desktop/src/components/GithubCard.tsx
+++ b/apps/desktop/src/components/GithubCard.tsx
@@ -440,8 +440,6 @@ function CommentThreadRow({
     : head.resolved
       ? 'resolved'
       : 'open';
-  const statusTone =
-    status === 'open' ? 'bg-warning' : status === 'resolved' ? 'bg-success' : 'bg-muted-foreground';
   const statusLabel = status === 'open' ? 'open' : status === 'resolved' ? 'resolved' : 'comment';
   const bot = isBot(head.author);
 
@@ -449,9 +447,17 @@ function CommentThreadRow({
     <div className="flex gap-1.5">
       <span
         aria-hidden
-        className={cn('mt-1 h-1.5 w-1.5 shrink-0 rounded-full', statusTone)}
         title={statusLabel}
-      />
+        className="mt-0.5 inline-flex h-3 w-3 shrink-0 items-center justify-center"
+      >
+        {status === 'resolved' ? (
+          <CheckCheck size={11} className="text-success" aria-hidden />
+        ) : status === 'open' ? (
+          <span className="h-1.5 w-1.5 rounded-full bg-warning" />
+        ) : (
+          <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+        )}
+      </span>
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex items-center gap-1 text-[10px] text-muted-foreground">
           <Avatar url={head.authorAvatarUrl} alt={head.author} />

--- a/apps/desktop/src/spawn-from-comment.ts
+++ b/apps/desktop/src/spawn-from-comment.ts
@@ -1,0 +1,103 @@
+import type { PrComment, PullRequestState } from '@kay-am/types';
+import type { AgentKind } from './agent-kind';
+import { AGENT_KIND_DEFAULTS } from './agent-kind';
+
+const TITLE_MAX = 60;
+
+function shortPath(path: string): string {
+  const segments = path.split('/');
+  const last = segments.at(-1) ?? path;
+  return last;
+}
+
+export function buildCommentAgentTitle(c: PrComment): string {
+  const who = c.author.replace(/\[bot\]$/, '');
+  if (c.source === 'review' && c.path) {
+    const loc = c.line ? `${shortPath(c.path)}:${c.line}` : shortPath(c.path);
+    return truncate(`fix: ${who} on ${loc}`, TITLE_MAX);
+  }
+  return truncate(`fix: ${who} comment`, TITLE_MAX);
+}
+
+export function buildCommentAgentPrompt(c: PrComment, pr: PullRequestState): string {
+  const lines: Array<string> = [];
+  lines.push(`Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`);
+  if (c.source === 'review' && c.path) {
+    lines.push(`${c.author} left a review comment on \`${c.path}${c.line ? `:${c.line}` : ''}\`:`);
+  } else {
+    lines.push(`${c.author} left this comment on the PR:`);
+  }
+  lines.push('');
+  for (const ln of (c.body.trim() || '(empty body)').split('\n')) {
+    lines.push(`> ${ln}`);
+  }
+  lines.push('');
+  lines.push(`Comment URL: ${c.url}`);
+  lines.push('');
+  lines.push(
+    'Your task: address this comment with the smallest reasonable change. Read the file, apply the change, run lint/tests, commit and push. Do not over-scope.',
+  );
+  return lines.join('\n');
+}
+
+export function inferAgentKindFromComment(c: PrComment): AgentKind {
+  // review comment with a path → implementer touches the file directly.
+  if (c.source === 'review' && c.path) return 'implementer';
+  // heuristic for issue comments: bug/error/fail keywords → debugger.
+  const lower = c.body.toLowerCase();
+  if (/\b(bug|crash|fails?|broken|regression|exception|error)\b/.test(lower)) return 'debugger';
+  return 'implementer';
+}
+
+export interface CommentAgentArgs {
+  readonly name: string;
+  readonly model: string;
+  readonly effort: 'low' | 'medium' | 'high';
+  readonly initialPrompt: string;
+}
+
+export function buildCommentAgentArgs(c: PrComment, pr: PullRequestState): CommentAgentArgs {
+  const kind = inferAgentKindFromComment(c);
+  const defaults = AGENT_KIND_DEFAULTS[kind];
+  return {
+    name: buildCommentAgentTitle(c),
+    model: defaults.model,
+    effort: defaults.effort,
+    initialPrompt: buildCommentAgentPrompt(c, pr),
+  };
+}
+
+export function buildReviewChangesAgentArgs(
+  pr: PullRequestState,
+  openComments: ReadonlyArray<PrComment>,
+): CommentAgentArgs {
+  const defaults = AGENT_KIND_DEFAULTS.implementer;
+  const lines: Array<string> = [];
+  lines.push(`Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`);
+  lines.push('Reviewers have requested changes. Address every open comment below.');
+  lines.push('');
+  for (const c of openComments) {
+    const loc =
+      c.source === 'review' && c.path ? ` on \`${c.path}${c.line ? `:${c.line}` : ''}\`` : '';
+    lines.push(`### ${c.author}${loc}`);
+    for (const ln of (c.body.trim() || '(empty body)').split('\n')) {
+      lines.push(`> ${ln}`);
+    }
+    lines.push(`(${c.url})`);
+    lines.push('');
+  }
+  lines.push(
+    'Your task: address every comment with the smallest reasonable change. Read the files, apply the changes, run lint/tests, commit and push. Do not over-scope.',
+  );
+  return {
+    name: truncate(`fix: address review changes on #${pr.number}`, TITLE_MAX),
+    model: defaults.model,
+    effort: defaults.effort,
+    initialPrompt: lines.join('\n'),
+  };
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max - 1)}…`;
+}

--- a/apps/desktop/src/spawn-from-comment.ts
+++ b/apps/desktop/src/spawn-from-comment.ts
@@ -14,9 +14,9 @@ export function buildCommentAgentTitle(c: PrComment): string {
   const who = c.author.replace(/\[bot\]$/, '');
   if (c.source === 'review' && c.path) {
     const loc = c.line ? `${shortPath(c.path)}:${c.line}` : shortPath(c.path);
-    return truncate(`fix: ${who} on ${loc}`, TITLE_MAX);
+    return truncate(`resolve: ${who} on ${loc}`, TITLE_MAX);
   }
-  return truncate(`fix: ${who} comment`, TITLE_MAX);
+  return truncate(`resolve: ${who} comment`, TITLE_MAX);
 }
 
 export function buildCommentAgentPrompt(c: PrComment, pr: PullRequestState): string {
@@ -90,7 +90,7 @@ export function buildReviewChangesAgentArgs(
     'Your task: address every comment with the smallest reasonable change. Read the files, apply the changes, run lint/tests, commit and push. Do not over-scope.',
   );
   return {
-    name: truncate(`fix: address review changes on #${pr.number}`, TITLE_MAX),
+    name: truncate(`resolve: address review changes on #${pr.number}`, TITLE_MAX),
     model: defaults.model,
     effort: defaults.effort,
     initialPrompt: lines.join('\n'),

--- a/apps/desktop/src/spawn-from-comment.ts
+++ b/apps/desktop/src/spawn-from-comment.ts
@@ -45,7 +45,8 @@ export function inferAgentKindFromComment(c: PrComment): AgentKind {
   if (c.source === 'review' && c.path) return 'implementer';
   // heuristic for issue comments: bug/error/fail keywords → debugger.
   const lower = c.body.toLowerCase();
-  if (/\b(bug|crash|fails?|broken|regression|exception|error)\b/.test(lower)) return 'debugger';
+  if (/\b(bugs?|crash(?:es)?|fails?|broken|regressions?|exceptions?|errors?)\b/.test(lower))
+    return 'debugger';
   return 'implementer';
 }
 

--- a/packages/core/src/github/__tests__/details.test.ts
+++ b/packages/core/src/github/__tests__/details.test.ts
@@ -153,7 +153,7 @@ describe('fetchPrDetail', () => {
     const detail = await fetchPrDetail(runner, 'org/repo', 1);
     expect(detail.comments).toHaveLength(2);
     expect(detail.comments.every((c) => c.resolved === true)).toBe(true);
-    expect(detail.comments[1]!.inReplyToId).toBe('PRRC_A');
+    expect(detail.comments[1]!.inReplyToId).toBe('review-1');
   });
 
   it('maps review states + review requests', async () => {

--- a/packages/core/src/github/__tests__/details.test.ts
+++ b/packages/core/src/github/__tests__/details.test.ts
@@ -22,11 +22,19 @@ function jsonOk(data: unknown): GhResult {
   return { stdout: JSON.stringify(data), stderr: '', exitCode: 0 };
 }
 
+const matchIssueComments = (a: ReadonlyArray<string>) =>
+  a.some((s) => s.includes('issues/1/comments'));
+const matchReviewThreads = (a: ReadonlyArray<string>) => a[0] === 'api' && a[1] === 'graphql';
+
+const emptyReviewThreads = jsonOk({
+  data: { repository: { pullRequest: { reviewThreads: { nodes: [] } } } },
+});
+
 describe('fetchPrDetail', () => {
   it('merges issue + review comments sorted by createdAt', async () => {
     const runner = makeMultiRunner([
       {
-        match: (a) => a.some((s) => s.includes('issues/1/comments')),
+        match: matchIssueComments,
         result: jsonOk([
           {
             id: 100,
@@ -38,16 +46,39 @@ describe('fetchPrDetail', () => {
         ]),
       },
       {
-        match: (a) => a.some((s) => s.includes('pulls/1/comments')),
-        result: jsonOk([
-          {
-            id: 200,
-            user: { login: 'bob', avatar_url: null },
-            body: 'review note',
-            created_at: '2026-01-02T10:00:00Z',
-            html_url: 'https://github.com/org/repo/pull/1#discussion_r200',
+        match: matchReviewThreads,
+        result: jsonOk({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'PRT_1',
+                      isResolved: false,
+                      isOutdated: false,
+                      path: 'src/foo.ts',
+                      line: 42,
+                      comments: {
+                        nodes: [
+                          {
+                            id: 'PRRC_1',
+                            databaseId: 200,
+                            author: { login: 'bob', avatarUrl: null },
+                            body: 'review note',
+                            createdAt: '2026-01-02T10:00:00Z',
+                            url: 'https://github.com/org/repo/pull/1#discussion_r200',
+                            replyTo: null,
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
           },
-        ]),
+        }),
       },
       {
         match: (a) => a[0] === 'pr' && a[1] === 'view',
@@ -62,12 +93,73 @@ describe('fetchPrDetail', () => {
     expect(detail.comments.map((c) => c.author)).toEqual(['alice', 'bob']);
     expect(detail.comments[0]!.source).toBe('issue');
     expect(detail.comments[1]!.source).toBe('review');
+    expect(detail.comments[1]!.path).toBe('src/foo.ts');
+    expect(detail.comments[1]!.line).toBe(42);
+    expect(detail.comments[1]!.resolved).toBe(false);
+  });
+
+  it('propagates resolved status and reply threading from review threads', async () => {
+    const runner = makeMultiRunner([
+      { match: matchIssueComments, result: jsonOk([]) },
+      {
+        match: matchReviewThreads,
+        result: jsonOk({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'PRT_X',
+                      isResolved: true,
+                      isOutdated: false,
+                      path: 'pkg/a.ts',
+                      line: 10,
+                      comments: {
+                        nodes: [
+                          {
+                            id: 'PRRC_A',
+                            databaseId: 1,
+                            author: { login: 'alice', avatarUrl: null },
+                            body: 'parent',
+                            createdAt: '2026-01-01T10:00:00Z',
+                            url: 'https://x/1',
+                            replyTo: null,
+                          },
+                          {
+                            id: 'PRRC_B',
+                            databaseId: 2,
+                            author: { login: 'bob', avatarUrl: null },
+                            body: 'reply',
+                            createdAt: '2026-01-01T11:00:00Z',
+                            url: 'https://x/2',
+                            replyTo: { id: 'PRRC_A' },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      },
+      {
+        match: (a) => a[0] === 'pr' && a[1] === 'view',
+        result: jsonOk({ reviews: [], reviewRequests: [], statusCheckRollup: [] }),
+      },
+    ]);
+    const detail = await fetchPrDetail(runner, 'org/repo', 1);
+    expect(detail.comments).toHaveLength(2);
+    expect(detail.comments.every((c) => c.resolved === true)).toBe(true);
+    expect(detail.comments[1]!.inReplyToId).toBe('PRRC_A');
   });
 
   it('maps review states + review requests', async () => {
     const runner = makeMultiRunner([
-      { match: (a) => a.some((s) => s.includes('issues/1/comments')), result: jsonOk([]) },
-      { match: (a) => a.some((s) => s.includes('pulls/1/comments')), result: jsonOk([]) },
+      { match: matchIssueComments, result: jsonOk([]) },
+      { match: matchReviewThreads, result: emptyReviewThreads },
       {
         match: (a) => a[0] === 'pr' && a[1] === 'view',
         result: jsonOk({
@@ -96,8 +188,8 @@ describe('fetchPrDetail', () => {
 
   it('derives check conclusions including pending and failure', async () => {
     const runner = makeMultiRunner([
-      { match: (a) => a.some((s) => s.includes('issues/1/comments')), result: jsonOk([]) },
-      { match: (a) => a.some((s) => s.includes('pulls/1/comments')), result: jsonOk([]) },
+      { match: matchIssueComments, result: jsonOk([]) },
+      { match: matchReviewThreads, result: emptyReviewThreads },
       {
         match: (a) => a[0] === 'pr' && a[1] === 'view',
         result: jsonOk({

--- a/packages/core/src/github/details.ts
+++ b/packages/core/src/github/details.ts
@@ -18,12 +18,33 @@ interface RawIssueComment {
   html_url: string;
 }
 
-interface RawReviewComment {
-  id: number;
-  user: { login: string; avatar_url: string | null } | null;
+interface RawReviewThreadComment {
+  id: string;
+  databaseId: number;
+  author: { login: string; avatarUrl: string | null } | null;
   body: string | null;
-  created_at: string;
-  html_url: string;
+  createdAt: string;
+  url: string;
+  replyTo: { id: string } | null;
+}
+
+interface RawReviewThreadNode {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  path: string | null;
+  line: number | null;
+  comments: { nodes: ReadonlyArray<RawReviewThreadComment> } | null;
+}
+
+interface RawReviewThreadsResponse {
+  data?: {
+    repository?: {
+      pullRequest?: {
+        reviewThreads?: { nodes?: ReadonlyArray<RawReviewThreadNode> } | null;
+      } | null;
+    } | null;
+  };
 }
 
 interface RawReview {
@@ -134,27 +155,79 @@ async function fetchIssueComments(
   }
 }
 
-async function fetchReviewComments(
+const REVIEW_THREADS_QUERY = `query($owner:String!,$name:String!,$pr:Int!){
+  repository(owner:$owner,name:$name){
+    pullRequest(number:$pr){
+      reviewThreads(first:50){
+        nodes{
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first:50){
+            nodes{
+              id
+              databaseId
+              author{login avatarUrl}
+              body
+              createdAt
+              url
+              replyTo{id}
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+async function fetchReviewThreads(
   runner: GhRunner,
   repo: string,
   prNumber: number,
   opts: { cwd?: string } = {},
 ): Promise<ReadonlyArray<PrComment>> {
+  const [owner, name] = repo.split('/');
+  if (!owner || !name) return [];
   try {
-    const raw = await runJson<ReadonlyArray<RawReviewComment>>(
+    const raw = await runJson<RawReviewThreadsResponse>(
       runner,
-      ['api', `repos/${repo}/pulls/${prNumber}/comments`, '--paginate'],
+      [
+        'api',
+        'graphql',
+        '-f',
+        `query=${REVIEW_THREADS_QUERY}`,
+        '-F',
+        `owner=${owner}`,
+        '-F',
+        `name=${name}`,
+        '-F',
+        `pr=${prNumber}`,
+      ],
       opts,
     );
-    return raw.map((c) => ({
-      id: `review-${c.id}`,
-      author: c.user?.login ?? 'unknown',
-      authorAvatarUrl: c.user?.avatar_url ?? null,
-      body: c.body ?? '',
-      createdAt: c.created_at,
-      url: c.html_url,
-      source: 'review' as const,
-    }));
+    const threads = raw.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    const out: Array<PrComment> = [];
+    for (const t of threads) {
+      const nodes = t.comments?.nodes ?? [];
+      for (const c of nodes) {
+        out.push({
+          id: `review-${c.databaseId}`,
+          author: c.author?.login ?? 'unknown',
+          authorAvatarUrl: c.author?.avatarUrl ?? null,
+          body: c.body ?? '',
+          createdAt: c.createdAt,
+          url: c.url,
+          source: 'review',
+          path: t.path ?? undefined,
+          line: t.line ?? undefined,
+          resolved: t.isResolved,
+          inReplyToId: c.replyTo?.id ?? undefined,
+        });
+      }
+    }
+    return out;
   } catch (err) {
     if (err instanceof GhCliError) return [];
     throw err;
@@ -195,7 +268,7 @@ export async function fetchPrDetail(
 ): Promise<PrDetail> {
   const [issueComments, reviewComments, prView] = await Promise.all([
     fetchIssueComments(runner, repo, prNumber, opts),
-    fetchReviewComments(runner, repo, prNumber, opts),
+    fetchReviewThreads(runner, repo, prNumber, opts),
     fetchPrViewDetail(runner, repo, prNumber, opts),
   ]);
 

--- a/packages/core/src/github/details.ts
+++ b/packages/core/src/github/details.ts
@@ -209,6 +209,14 @@ async function fetchReviewThreads(
     );
     const threads = raw.data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
     const out: Array<PrComment> = [];
+    // First pass: map graphql node ids → PrComment id form so inReplyToId can be
+    // resolved against the same id space the UI uses.
+    const nodeIdToCommentId = new Map<string, string>();
+    for (const t of threads) {
+      for (const c of t.comments?.nodes ?? []) {
+        nodeIdToCommentId.set(c.id, `review-${c.databaseId}`);
+      }
+    }
     for (const t of threads) {
       const nodes = t.comments?.nodes ?? [];
       for (const c of nodes) {
@@ -223,7 +231,9 @@ async function fetchReviewThreads(
           path: t.path ?? undefined,
           line: t.line ?? undefined,
           resolved: t.isResolved,
-          inReplyToId: c.replyTo?.id ?? undefined,
+          inReplyToId: c.replyTo?.id
+            ? (nodeIdToCommentId.get(c.replyTo.id) ?? undefined)
+            : undefined,
         });
       }
     }

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -101,6 +101,14 @@ export interface PrComment {
   createdAt: string;
   url: string;
   source: 'issue' | 'review';
+  // Review-comment metadata (only present when source === 'review').
+  path?: string;
+  line?: number;
+  // Whether the review thread containing this comment is resolved.
+  // Always undefined for issue comments.
+  resolved?: boolean;
+  // GraphQL node id of the parent comment, if this is a reply.
+  inReplyToId?: string;
 }
 
 export type PrReviewState =


### PR DESCRIPTION
## Summary

Refactor of the GitHub side panel in `ContextPanel`. Each phase ships as a separate commit on this PR for easy review/rollback.

## Plan

1. **PR-first compact header** — single line, colored PR icon, `#num` link, branch as copy target, drop MERGED chip.
2. **Types + adapter** — extend `PrComment` with `path`/`line`/`resolved`/`kind`; backend gh adapter populates them.
3. **CommentsPane redesign** — status dot (open/resolved), path anchor, expand, bot detection.
4. **Spawn agent from comment** — hover CTA that opens a pre-titled implementer agent with comment context as the kickoff prompt.
5. **ReviewPane richer** — per-reviewer state, "fix all requested changes" CTA when changes_requested.
6. **Micro UX** — focus rings, transitions, empty states, a11y polish.

## Test plan

- [ ] Header renders correctly for draft / open / approved / merged / closed states (icon color check)
- [ ] `#num` opens PR in browser
- [ ] Click on branch copies it to clipboard (feedback visible)
- [ ] No regression in "no pr yet" state with `Open PR` button
- [ ] Linked issues row still works
- [ ] Comments show resolved vs open distinction (phase 3)
- [ ] Spawn-from-comment creates a pre-titled agent (phase 4)
- [ ] Reviewer states display correctly (phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)