### PR TITLE
feat(desktop): user-selectable session status with persistence

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -104,6 +104,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: '2026-01-01T00:00:00.000Z' as Session['createdAt'],
     updatedAt: '2026-01-01T00:00:00.000Z' as Session['updatedAt'],
     ...overrides,

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -105,7 +105,7 @@ function makeSession() {
     workflowId: TEMPLATE_ID,
     autoRun: false,
     titleUserEdited: false,
-    userStatus: 'wip',
+    userStatus: 'wip' as const,
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -105,6 +105,7 @@ function makeSession() {
     workflowId: TEMPLATE_ID,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/__tests__/sidebar.test.ts
+++ b/apps/desktop/src/__tests__/sidebar.test.ts
@@ -21,6 +21,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: DT,
     updatedAt: DT,
     ...overrides,

--- a/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
+++ b/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
@@ -134,6 +134,7 @@ function buildSession() {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: AT,
     updatedAt: AT,
   };

--- a/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
+++ b/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
@@ -134,7 +134,7 @@ function buildSession() {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
-    userStatus: 'wip',
+    userStatus: 'wip' as const,
     createdAt: AT,
     updatedAt: AT,
   };

--- a/apps/desktop/src/components/SessionStatusMenu.tsx
+++ b/apps/desktop/src/components/SessionStatusMenu.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+import { cn } from '@kay-am/ui';
+import type { SessionUserStatus } from '@kay-am/types';
+import { SESSION_STATUS_ORDER, SESSION_STATUS_PALETTE } from '../session-status';
+
+interface SessionStatusMenuProps {
+  readonly status: SessionUserStatus;
+  readonly sessionLabel: string;
+  readonly onPick: (next: SessionUserStatus) => void;
+}
+
+export function SessionStatusMenu({ status, sessionLabel, onPick }: SessionStatusMenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('mousedown', onDocClick);
+    window.addEventListener('keydown', onKey);
+    return () => {
+      window.removeEventListener('mousedown', onDocClick);
+      window.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const entry = SESSION_STATUS_PALETTE[status];
+  const Icon = entry.icon;
+
+  return (
+    <div ref={ref} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        onDoubleClick={(e) => e.stopPropagation()}
+        className={cn(
+          'inline-flex h-4 w-4 items-center justify-center rounded transition-colors hover:bg-muted',
+          entry.className,
+        )}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`change session status (current: ${entry.label})`}
+        title={`${sessionLabel} — ${entry.label} (click to change)`}
+      >
+        <Icon size={12} aria-hidden />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute left-0 top-full z-50 mt-1 flex min-w-[10rem] flex-col rounded-md border border-border bg-subtle p-1 text-foreground shadow-md"
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          {SESSION_STATUS_ORDER.map((option) => {
+            const optEntry = SESSION_STATUS_PALETTE[option];
+            const OptIcon = optEntry.icon;
+            const selected = option === status;
+            return (
+              <button
+                key={option}
+                role="menuitem"
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  if (!selected) onPick(option);
+                }}
+                className={cn(
+                  'flex items-center gap-2 rounded px-2 py-1 text-left text-xs transition-colors',
+                  selected ? 'bg-muted font-medium' : 'hover:bg-muted/60',
+                )}
+              >
+                <span
+                  className={cn(
+                    'inline-flex h-4 w-4 items-center justify-center',
+                    optEntry.className,
+                  )}
+                >
+                  <OptIcon size={12} aria-hidden />
+                </span>
+                <span className="text-foreground">{optEntry.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/WorkspacesSidebar.tsx
+++ b/apps/desktop/src/components/WorkspacesSidebar.tsx
@@ -88,6 +88,7 @@ import {
   resolveAgentKind,
 } from '../agent-kind';
 import { AgentKindMenu } from './AgentKindMenu';
+import { SessionStatusMenu } from './SessionStatusMenu';
 import { NextActionChips } from './NextActionChips';
 import { spawnFromNextAction, spawnKindForAction } from '../spawn-from-next-action';
 import { openUrl } from '../editor';
@@ -861,6 +862,7 @@ const SessionRow = memo(function SessionRow({
   const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
   const setSessionAutoRun = useAppStore((s) => s.setSessionAutoRun);
+  const setSessionUserStatus = useAppStore((s) => s.setSessionUserStatus);
   const renameTask = useAppStore((s) => s.renameTask);
   const deleteTask = useAppStore((s) => s.deleteTask);
   const budgetLoaded = useRef(false);
@@ -964,7 +966,7 @@ const SessionRow = memo(function SessionRow({
           isActive ? 'bg-muted' : 'hover:bg-muted/60',
         )}
       >
-        <div className="flex min-w-0 w-full items-center gap-2 text-sm">
+        <div className="flex min-w-0 w-full items-center gap-2 text-xs">
           <span
             aria-hidden
             title={showUnreadDot ? 'unread agent response' : undefined}
@@ -980,6 +982,11 @@ const SessionRow = memo(function SessionRow({
               )}
             />
           </span>
+          <SessionStatusMenu
+            status={session.userStatus}
+            sessionLabel={session.goal}
+            onPick={(next) => void setSessionUserStatus(session.id as SessionId, next)}
+          />
           {renaming ? (
             <div
               className="flex min-w-0 flex-1 flex-col gap-0.5"

--- a/apps/desktop/src/session-status.ts
+++ b/apps/desktop/src/session-status.ts
@@ -1,0 +1,45 @@
+import { Ban, CheckCheck, Construction, Hourglass, type LucideIcon } from 'lucide-react';
+import type { SessionUserStatus } from '@kay-am/types';
+
+export const SESSION_STATUS_ORDER: ReadonlyArray<SessionUserStatus> = [
+  'wip',
+  'waiting',
+  'blocked',
+  'done',
+];
+
+export const SESSION_STATUS_DEFAULT: SessionUserStatus = 'wip';
+
+interface SessionStatusEntry {
+  readonly label: string;
+  readonly description: string;
+  readonly icon: LucideIcon;
+  readonly className: string;
+}
+
+export const SESSION_STATUS_PALETTE: Record<SessionUserStatus, SessionStatusEntry> = {
+  wip: {
+    label: 'in progress',
+    description: 'work in progress',
+    icon: Construction,
+    className: 'text-warning',
+  },
+  waiting: {
+    label: 'waiting',
+    description: 'waiting on something',
+    icon: Hourglass,
+    className: 'text-muted-foreground',
+  },
+  blocked: {
+    label: 'blocked',
+    description: 'blocked',
+    icon: Ban,
+    className: 'text-danger',
+  },
+  done: {
+    label: 'done',
+    description: 'work completed',
+    icon: CheckCheck,
+    className: 'text-success',
+  },
+};

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -157,6 +157,7 @@ function buildSession(): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -154,6 +154,7 @@ function buildSession(stateKind: 'idle' | 'running' = 'idle'): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -147,6 +147,7 @@ function buildSession(): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -171,6 +171,7 @@ function buildSession(): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     workflowId: TEMPLATE_ID,
     createdAt: now,
     updatedAt: now,

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -155,6 +155,7 @@ function buildSession(): Session {
     permissionMode: 'bypassPermissions',
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: now,
     updatedAt: now,
   };

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -169,6 +169,7 @@ function buildSession(): Session {
     permissionMode: 'bypassPermissions' as const,
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -54,6 +54,7 @@ import {
   updateSessionPermissionMode,
   updateSessionAutoRun,
   updateSessionTitleUserEdited,
+  updateSessionUserStatus,
   updateSessionState,
   upsertContextSlot,
   insertDiffComment,
@@ -102,6 +103,7 @@ import type {
   StepId,
   Session,
   SessionId,
+  SessionUserStatus,
   SessionBudget,
   SessionProviderPreference,
   Workflow,
@@ -427,6 +429,7 @@ export interface AppActions {
     args: { branch: string; createNew: boolean },
   ): Promise<void>;
   setSessionAutoRun(sessionId: SessionId, autoRun: boolean): Promise<void>;
+  setSessionUserStatus(sessionId: SessionId, status: SessionUserStatus): Promise<void>;
   maybeAutoAdvanceWorkflow(sessionId: SessionId): Promise<void>;
   loadTranscript(agentId: AgentId, sessionId: SessionId): Promise<void>;
   appendTurnEvent(agentId: AgentId, sessionId: SessionId, event: TurnEvent): void;
@@ -1644,6 +1647,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       ...(workflowId !== undefined ? { workflowId } : {}),
       autoRun: autoRun === true && workflowId !== undefined,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now,
       updatedAt: now,
     };
@@ -3979,6 +3983,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
       ),
     }));
     if (autoRun) void get().maybeAutoAdvanceWorkflow(sessionId);
+  },
+
+  setSessionUserStatus: async (sessionId, status) => {
+    const now = new Date().toISOString() as IsoDateTime;
+    await updateSessionUserStatus(tauriDatabase, sessionId, status, now);
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === sessionId ? { ...s, userStatus: status, updatedAt: now } : s,
+      ),
+    }));
   },
 
   maybeAutoAdvanceWorkflow: async (sessionId) => {

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -126,6 +126,7 @@ function buildIdleSession(id: SessionId, wsId: WorkspaceId): Session {
     permissionMode: 'bypassPermissions',
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };
@@ -142,6 +143,7 @@ function buildRunningSession(id: SessionId, wsId: WorkspaceId, runId: ProviderRu
     permissionMode: 'bypassPermissions',
     autoRun: false,
     titleUserEdited: false,
+    userStatus: 'wip',
     createdAt: NOW,
     updatedAt: NOW,
   };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,6 +17,7 @@ export {
   updateSessionPermissionMode,
   updateSessionAutoRun,
   updateSessionTitleUserEdited,
+  updateSessionUserStatus,
   getSessionById,
   listSessionsForWorkspace,
   renameSession,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -29,6 +29,7 @@ import { m028DiffCommentConsumed } from './m028-diff-comment-consumed';
 import { m029AgentUnread } from './m029-agent-unread';
 import { m030PlanConsumptions } from './m030-plan-consumptions';
 import { m031RenameSoftDeletePersist } from './m031-rename-soft-delete-persist';
+import { m032SessionUserStatus } from './m032-session-user-status';
 
 export interface Migration {
   readonly version: number;
@@ -67,4 +68,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 29, sql: m029AgentUnread },
   { version: 30, sql: m030PlanConsumptions },
   { version: 31, sql: m031RenameSoftDeletePersist },
+  { version: 32, sql: m032SessionUserStatus },
 ];

--- a/packages/db/src/migrations/m032-session-user-status.ts
+++ b/packages/db/src/migrations/m032-session-user-status.ts
@@ -1,0 +1,3 @@
+export const m032SessionUserStatus = /* sql */ `
+ALTER TABLE sessions ADD COLUMN user_status TEXT NOT NULL DEFAULT 'wip';
+`;

--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -96,6 +96,7 @@ describe('migrate', () => {
       permissionMode: 'bypassPermissions',
       autoRun: false,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now(),
       updatedAt: now(),
     };
@@ -130,6 +131,7 @@ describe('migrate', () => {
       permissionMode: 'bypassPermissions',
       autoRun: false,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now(),
       updatedAt: now(),
     };
@@ -163,6 +165,7 @@ describe('migrate', () => {
       permissionMode: 'bypassPermissions',
       autoRun: false,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now(),
       updatedAt: now(),
     };
@@ -263,6 +266,7 @@ describe('migrate', () => {
       permissionMode: 'bypassPermissions',
       autoRun: false,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now(),
       updatedAt: now(),
     };
@@ -320,6 +324,7 @@ describe('migrate', () => {
       permissionMode: 'bypassPermissions',
       autoRun: false,
       titleUserEdited: false,
+      userStatus: 'wip',
       createdAt: now(),
       updatedAt: now(),
     };

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -5,6 +5,7 @@ import type {
   Session,
   SessionId,
   SessionProviderPreference,
+  SessionUserStatus,
   TurnState,
   WorkflowId,
   WorkspaceId,
@@ -30,8 +31,21 @@ interface SessionRow {
   effort: string | null;
   model_override: string | null;
   provider_override: string | null;
+  user_status: string;
   created_at: number;
   updated_at: number;
+}
+
+const VALID_USER_STATUSES: ReadonlySet<SessionUserStatus> = new Set([
+  'wip',
+  'waiting',
+  'blocked',
+  'done',
+]);
+
+function toUserStatus(raw: string): SessionUserStatus {
+  if ((VALID_USER_STATUSES as ReadonlySet<string>).has(raw)) return raw as SessionUserStatus;
+  return 'wip';
 }
 
 function toState(kind: TurnState['kind'], payload: string): TurnState {
@@ -89,6 +103,7 @@ function toDomain(row: SessionRow, contextSlots: Session['contextSlots']): Sessi
     }),
     ...(row.model_override && { modelOverride: row.model_override }),
     ...(row.provider_override && { providerOverride: row.provider_override }),
+    userStatus: toUserStatus(row.user_status),
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
   };
@@ -138,8 +153,8 @@ export async function insertSession(db: Database, session: Session): Promise<voi
   const { kind, payload } = splitState(session.state);
   await db.execute(
     `INSERT INTO sessions
-      (id, workspace_id, goal, state_kind, state_payload, provider_default, provider_allow_override, permission_mode, workflow_id, current_step_ordinal, auto_run, title_user_edited, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      (id, workspace_id, goal, state_kind, state_payload, provider_default, provider_allow_override, permission_mode, workflow_id, current_step_ordinal, auto_run, title_user_edited, user_status, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       session.id,
       session.workspaceId,
@@ -153,6 +168,7 @@ export async function insertSession(db: Database, session: Session): Promise<voi
       session.currentStepOrdinal ?? null,
       session.autoRun ? 1 : 0,
       session.titleUserEdited ? 1 : 0,
+      session.userStatus,
       Date.parse(session.createdAt),
       Date.parse(session.updatedAt),
     ],
@@ -167,6 +183,19 @@ export async function updateSessionAutoRun(
 ): Promise<void> {
   await db.execute('UPDATE sessions SET auto_run = ?, updated_at = ? WHERE id = ?', [
     autoRun ? 1 : 0,
+    Date.parse(updatedAt),
+    id,
+  ]);
+}
+
+export async function updateSessionUserStatus(
+  db: Database,
+  id: SessionId,
+  status: SessionUserStatus,
+  updatedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute('UPDATE sessions SET user_status = ?, updated_at = ? WHERE id = ?', [
+    status,
     Date.parse(updatedAt),
     id,
   ]);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ContextSlotAuthor,
   ContextSlotHistoryEntry,
   Session,
+  SessionUserStatus,
   TurnState,
   Workspace,
 } from './workspace';

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -34,6 +34,8 @@ export type TurnState =
   | { kind: 'error'; message: string; failedAt: IsoDateTime }
   | { kind: 'ended'; endedAt: IsoDateTime };
 
+export type SessionUserStatus = 'wip' | 'waiting' | 'blocked' | 'done';
+
 export type Session = Readonly<{
   id: SessionId;
   workspaceId: WorkspaceId;
@@ -46,6 +48,7 @@ export type Session = Readonly<{
   currentStepOrdinal?: number;
   autoRun: boolean;
   titleUserEdited: boolean;
+  userStatus: SessionUserStatus;
   archivedAt?: IsoDateTime;
   deletedAt?: IsoDateTime;
   verbosity?: 'brief' | 'normal' | 'verbose';


### PR DESCRIPTION
## Summary

- adds wip/waiting/blocked/done status icon between dot indicator and session title in sidebar
- status persists per-session in `sessions.user_status` (migration `m032`), default `wip`
- picker UI mirrors `AgentKindMenu`: click chip → list of options with colored icons

## Icons

- wip → `Construction` (warning/orange)
- waiting → `Hourglass` (muted)
- blocked → `Ban` (danger/red)
- done → `CheckCheck` (success/green)

## Changes

- `packages/types`: add `SessionUserStatus` + field on `Session`
- `packages/db`: new migration `m032`, `updateSessionUserStatus` query, exports
- `apps/desktop`: `session-status.ts` palette, `SessionStatusMenu` component, store action `setSessionUserStatus`, sidebar wiring with `text-xs` title
- 12 test fixtures bumped with `userStatus: 'wip'`

## Test plan

- [ ] `pnpm tauri dev` boots clean, sessions show wip icon by default
- [ ] clicking the icon opens picker, selecting a status updates icon
- [ ] reload → status persists across restart
- [ ] new sessions default to `wip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)