### PR TITLE
fix(core): align summarizer invoke name with rust command

### DIFF
--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -139,7 +139,7 @@ export class Summarizer {
   async summarize(input: SummarizeInput): Promise<SummarizerResult> {
     const userMessage = buildUserPrompt(input);
 
-    const result = await this.invokeFn<SummarizeCommandResult>('summarize_task', {
+    const result = await this.invokeFn<SummarizeCommandResult>('summarize_session', {
       args: {
         providerId: this.providerId,
         model: this.model,


### PR DESCRIPTION
## Summary
- The task→session rename (7eb8172) updated the Rust Tauri command to `summarize_session` but missed the TS client
- Every summarizer invocation failed with "command summarize_task not found"
- One-line fix in `packages/core/src/summarizer/client.ts`

## Test plan
- [x] Grep confirms no remaining `summarize_task` references
- [x] Cross-checked all TS invoke names against Rust `generate_handler![]` — all aligned
- [ ] Launch desktop app, trigger summarizer (send a turn), verify no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)