### PR TITLE
fix(desktop): plan panel tree rendering + files touched default view

### DIFF
--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -333,6 +333,10 @@ export function DiffViewerDialog({
   }, [comments]);
 
   useEffect(() => {
+    if (open) setViewState(DEFAULT_VIEW);
+  }, [open]);
+
+  useEffect(() => {
     if (!open || !worktreePath) return;
     let cancelled = false;
     Promise.all([listBranchCommits(worktreePath), worktreeStatus(worktreePath)])

--- a/apps/desktop/src/features/plans/components/PlansModal/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlansModal/index.tsx
@@ -376,7 +376,7 @@ export function PlansModal({ sessionId, open, onClose, initialPlanId }: PlansMod
                   )}
                 </div>
               </div>
-              <div className="flex min-h-0 flex-1 overflow-y-auto rounded-md border border-border-soft p-2">
+              <div className="min-h-0 flex-1 overflow-y-auto rounded-md border border-border-soft p-2">
                 {mode === 'edit' ? (
                   <Textarea
                     autoFocus

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -600,19 +600,27 @@ function renderBlock(block: Block, idx: number): ReactNode {
         </div>
       );
     }
-    case 'paragraph':
+    case 'paragraph': {
+      const isTree = /[├└│┌┐┘┤┬┼]/.test(block.content);
       return (
-        <p key={key} className="whitespace-pre-wrap leading-relaxed">
+        <p
+          key={key}
+          className={cn(
+            'whitespace-pre-wrap leading-relaxed',
+            isTree && 'overflow-x-auto font-mono',
+          )}
+        >
           {renderInline(block.content, key)}
         </p>
       );
+    }
   }
 }
 
 export function Markdown({ text, className }: MarkdownProps) {
   const blocks = parseBlocks(text);
   return (
-    <div className={cn('flex flex-col gap-2 text-base text-foreground/85', className)}>
+    <div className={cn('space-y-2 text-base text-foreground/85', className)}>
       {blocks.map(renderBlock)}
     </div>
   );


### PR DESCRIPTION
## Summary

- **D1**: paragraphs with box-drawing chars (├, └, │) now render with `font-mono` + `overflow-x-auto` so directory trees in plans align correctly even without a code fence.
- **D2**: "files touched" dialog always opens on working tree view instead of restoring the last-persisted view from localStorage.

## Test plan

- [ ] Open a plan with a directory tree as plain text (no code fence) → monospace, aligned
- [ ] Open a plan with a directory tree inside a code fence → still renders as `pre` (unchanged)
- [ ] Open files touched → defaults to working tree
- [ ] Switch to commit/branch view, close, reopen → resets to working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)