### PR TITLE
fix(core): cluster B — summarizer B1 fixes

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -8,6 +8,8 @@ import {
   buildStepPrompt,
   currentStep,
   findReusableAgent,
+  getCheapModel,
+  getDefaultBinary,
   parseSlashCommand,
   resolveConflicts,
   resolveSettings,
@@ -934,8 +936,10 @@ async function generateAutoTitle(
       '',
       'Write the title now.',
     ].join('\n');
+    const model = getCheapModel(providerId);
+    const binary = getDefaultBinary(providerId);
     const result = await invoke<SummarizeCommandResult>('summarize_session', {
-      args: { providerId, userMessage, systemPrompt },
+      args: { providerId, model, binary, userMessage, systemPrompt },
     });
     if ((result.exitCode ?? 0) !== 0) return;
     let title = '';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,8 @@ export {
 // SummarizerCli (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/summarizer/cli in Node/test contexts.
 export {
+  getCheapModel,
+  getDefaultBinary,
   Summarizer,
   SummarizerParseError,
   SummarizerSpawnError,

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -121,7 +121,8 @@ Schema:
 { "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
 
 Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
-If nothing should change, return { "upserts": [] }.`;
+If nothing should change, return { "upserts": [] }.
+NEVER write 'none', 'null', 'nothing', 'no changes', or any prose. The response MUST start with '{' and end with '}'.`;
 
 export class Summarizer {
   private readonly providerId: ProviderId;
@@ -139,22 +140,32 @@ export class Summarizer {
   async summarize(input: SummarizeInput): Promise<SummarizerResult> {
     const userMessage = buildUserPrompt(input);
 
-    const result = await this.invokeFn<SummarizeCommandResult>('summarize_session', {
-      args: {
-        providerId: this.providerId,
-        model: this.model,
-        binary: this.binary,
-        userMessage,
-        systemPrompt: SYSTEM_PROMPT,
-      },
-    });
+    const invokeOnce = async () => {
+      const result = await this.invokeFn<SummarizeCommandResult>('summarize_session', {
+        args: {
+          providerId: this.providerId,
+          model: this.model,
+          binary: this.binary,
+          userMessage,
+          systemPrompt: SYSTEM_PROMPT,
+        },
+      });
+      if ((result.exitCode ?? 0) !== 0) {
+        throw new SummarizerSpawnError(result.exitCode, result.stderr);
+      }
+      return extractTextAndUsage(this.providerId, result.stdout, this.model);
+    };
 
-    if ((result.exitCode ?? 0) !== 0) {
-      throw new SummarizerSpawnError(result.exitCode, result.stderr);
+    let { text, usage } = await invokeOnce();
+    let delta: ContextSlotDelta;
+    try {
+      delta = parseDelta(text);
+    } catch (err) {
+      if (!(err instanceof SummarizerParseError)) throw err;
+      ({ text, usage } = await invokeOnce());
+      delta = parseDelta(text);
     }
 
-    const { text, usage } = extractTextAndUsage(this.providerId, result.stdout, this.model);
-    const delta = parseDelta(text);
     const slotsAfter = applyDelta(input.prevSlots, delta);
     const nextActions = inferNextActions({
       input,
@@ -254,16 +265,35 @@ function buildUserPrompt(input: SummarizeInput): string {
   ].join('\n');
 }
 
+function extractJsonObject(text: string): string | null {
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  return text.slice(start, end + 1);
+}
+
 function parseDelta(raw: string): ContextSlotDelta {
   const stripped = stripCodeFences(raw);
   let parsed: unknown;
   try {
     parsed = JSON.parse(stripped);
-  } catch (err) {
-    throw new SummarizerParseError(
-      `summarizer response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
-      raw,
-    );
+  } catch (firstErr) {
+    const extracted = extractJsonObject(stripped);
+    if (extracted !== null) {
+      try {
+        parsed = JSON.parse(extracted);
+      } catch (err) {
+        throw new SummarizerParseError(
+          `summarizer response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+          raw,
+        );
+      }
+    } else {
+      throw new SummarizerParseError(
+        `summarizer response was not valid JSON: ${firstErr instanceof Error ? firstErr.message : String(firstErr)}`,
+        raw,
+      );
+    }
   }
 
   if (typeof parsed !== 'object' || parsed === null || !('upserts' in parsed)) {

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -4,12 +4,12 @@ import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
 
-function getCheapModel(providerId: ProviderId): string {
+export function getCheapModel(providerId: ProviderId): string {
   const caps = PROVIDER_CAPABILITIES[providerId];
   return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
 }
 
-function getDefaultBinary(providerId: ProviderId): string {
+export function getDefaultBinary(providerId: ProviderId): string {
   switch (providerId) {
     case 'anthropic':
       return 'claude';

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -1,6 +1,8 @@
 // SummarizerCli (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/summarizer/cli in Node/test contexts.
 export {
+  getCheapModel,
+  getDefaultBinary,
   Summarizer,
   SummarizerParseError,
   SummarizerSpawnError,


### PR DESCRIPTION
## Summary

- **B1a** `generateAutoTitle` invoked `summarize_session` without `model` and `binary` — both required by Rust `SummarizeArgs`. Rust serde failed silently (caught by the outer try/catch). Now exports `getCheapModel`/`getDefaultBinary` from `@kay-am/core` and uses them in the invoke payload.
- **B1b** Model occasionally returns prose instead of JSON, causing `SummarizerParseError: JSON Parse error: Unexpected identifier "n"`. Three-layer fix: stronger prompt, `extractJsonObject` fallback, one retry on parse failure.

## Commits

1. `fix(core): provide required model+binary args in auto-title invoke`
2. `fix(core): harden summarizer against non-json model responses`

## Files changed

- `packages/core/src/summarizer/client.ts` — export helpers, stronger prompt, `extractJsonObject`, `parseDelta` fallback, `summarize()` retry
- `packages/core/src/summarizer/index.ts` — re-export new helpers
- `packages/core/src/index.ts` — re-export new helpers
- `apps/desktop/src/store/store.ts` — import + use helpers in `generateAutoTitle`

## Test plan

- [ ] Send a session turn → context slots update without console errors
- [ ] Check that auto-title generates correctly after first turn
- [ ] Simulate non-JSON model response → confirm retry fires and recovers or logs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)