### PR TITLE
fix(desktop): cluster E — vertical alignment across panels

### DIFF
--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -1188,7 +1188,7 @@ function LatestPlanCard({ plan, index }: LatestPlanCardProps) {
 
   return (
     <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle px-2.5 py-2">
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <button
           type="button"
           onClick={() => setExpanded((v) => !v)}

--- a/apps/desktop/src/features/plans/components/PlansModal/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlansModal/index.tsx
@@ -173,7 +173,7 @@ export function PlansModal({ sessionId, open, onClose, initialPlanId }: PlansMod
                       </span>
                       <span
                         className={cn(
-                          'shrink-0 rounded-full px-1.5 py-0.5 text-[9px] uppercase tracking-wide',
+                          'shrink-0 rounded-full px-1.5 py-0.5 text-[9px] uppercase leading-none tracking-wide',
                           PLAN_STATUS_STYLE[plan.status],
                         )}
                       >

--- a/apps/desktop/src/features/session/components/AgentKindMenu/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentKindMenu/index.tsx
@@ -44,7 +44,7 @@ export function AgentKindMenu({ kind, agentLabel, onPick }: AgentKindMenuProps) 
         }}
         onDoubleClick={(e) => e.stopPropagation()}
         className={cn(
-          'inline-flex w-[3.25rem] items-center justify-center rounded py-0.5 text-[9px] font-semibold uppercase leading-none tracking-wide transition-opacity hover:opacity-80',
+          'inline-flex w-[3.25rem] items-center justify-center rounded py-0.5 text-[9px] font-semibold uppercase leading-tight tracking-wide transition-opacity hover:opacity-80',
           palette.bg,
           palette.fg,
         )}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1006,7 +1006,7 @@ const SessionRow = memo(function SessionRow({
               {renameError ? <span className="text-2xs text-danger">{renameError}</span> : null}
             </div>
           ) : (
-            <span className="line-clamp-1 min-w-0 flex-1 truncate">{session.goal}</span>
+            <span className="min-w-0 flex-1 truncate">{session.goal}</span>
           )}
           <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
             <PrStatusIcon sessionId={session.id as SessionId} />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1995,7 +1995,7 @@ function AgentRow({
         ) : (
           <span
             className={cn(
-              'line-clamp-1 flex-1 text-left text-2xs font-medium',
+              'truncate flex-1 text-left text-2xs font-medium',
               isSelected ? 'text-foreground' : 'text-muted-foreground',
             )}
           >


### PR DESCRIPTION
## Summary

- **Agents panel**: chip label + name text + dot/timestamp now vertically centered (fixed `leading-none` baseline discrepancy + `line-clamp-1` display override)
- **Sessions panel**: dot, status icon, and goal text aligned (removed redundant `line-clamp-1` that broke flex centering)
- **Plan list**: status badge centers with plan title in ContextPanel card; normalized badge height in PlansModal

## Commits

1. `fix(desktop): vertical alignment in agents panel rows`
2. `fix(desktop): vertical alignment in sessions panel rows`
3. `fix(desktop): vertical alignment in plan list items`

## Test plan

- [ ] Agents panel: verify chip, name, dot, timestamp sit on same center line
- [ ] Sessions panel: verify unread dot, status icon, session name are centered
- [ ] Plan list (PlansModal): all status badges (active/consumed/superseded) at same height
- [ ] Plan card (ContextPanel): status badge centered with plan title

🤖 Generated with [Claude Code](https://claude.com/claude-code)