### PR TITLE
fix(desktop): cluster A — agent data, state & metrics (A1–A6)

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatHeader/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatHeader/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../../store';
 import { OpenInEditorButton } from '../../../../app/components/OpenInEditorButton';
 import { ParallelProgressPill } from '../ParallelProgressPill';
+import { shortModel, formatCost } from '../../../session/agent-row-format';
 
 interface ChatHeaderProps {
   session: Session;
@@ -78,9 +79,6 @@ export function ChatHeader({
             >
               <MessagesSquare size={12} aria-hidden />
               {transcriptLoading ? (
-                // Micro-skeleton so the header swaps instantly on session
-                // click while transcript fetch is still in flight; otherwise
-                // a stale "0 turns" briefly shows before the real count.
                 <span
                   aria-label="loading turn count"
                   className="inline-block h-2.5 w-8 animate-pulse rounded bg-muted"
@@ -95,7 +93,7 @@ export function ChatHeader({
                 </>
               )}
             </span>
-            {session.workflowId ? <PhaseProgressPill sessionId={session.id} /> : null}
+            <AgentInfoPill sessionId={session.id} />
           </div>
         </div>
 
@@ -115,44 +113,32 @@ const STATUS_DOT: Record<AgentStatus, string> = {
   skipped: 'bg-muted-foreground/20',
 };
 
-function PhaseProgressPill({ sessionId }: { sessionId: SessionId }) {
-  const runs = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+function AgentInfoPill({ sessionId }: { sessionId: SessionId }) {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId[sessionId] ?? null);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const agentRunHistory = useAppStore((s) => s.agentRunHistory);
+  const telemetry = useAppStore((s) => s.sessionTelemetry[sessionId] ?? EMPTY_ARRAY);
 
-  if (runs.length === 0) return null;
+  if (!selectedAgentId) return null;
 
-  const sorted = runs.slice().sort((a, b) => a.ordinal - b.ordinal);
-  const selectedIdx = selectedAgentId ? sorted.findIndex((r) => r.id === selectedAgentId) : -1;
-  const activeIdx = sorted.findIndex((r) => r.status === 'running');
-  const lastCompletedIdx = sorted.reduce(
-    (acc: number, r: Agent, i: number) => (r.status === 'completed' ? i : acc),
-    -1,
-  );
-  // Selected agent takes priority — pill reflects the agent the user is
-  // looking at, not workflow-wide running state. Falls back to running, then
-  // last completed when no agent is selected (e.g. fresh task).
-  const displayIdx = (() => {
-    if (selectedIdx >= 0) return selectedIdx;
-    if (activeIdx >= 0) return activeIdx;
-    return lastCompletedIdx;
-  })();
-  const current = displayIdx >= 0 ? sorted[displayIdx] : sorted[0];
+  const agent = phaseRuns.find((r) => r.id === selectedAgentId) as Agent | undefined;
+  const runIds = new Set(agentRunHistory[selectedAgentId] ?? (agent?.runId ? [agent.runId] : []));
 
-  if (!current) return null;
+  const agentRecords = telemetry.filter((r) => r.kind === 'turn' && runIds.has(r.runId));
+  const totalCost = agentRecords.reduce((sum, r) => sum + r.estimatedCostUsd, 0);
+  const latestModel = agentRecords[agentRecords.length - 1]?.model ?? null;
+
+  if (!latestModel && totalCost === 0) return null;
+
+  const status = agent?.status ?? 'pending';
 
   return (
     <div className="inline-flex items-center gap-1.5 rounded-full border border-border-soft bg-subtle px-2 py-0.5 text-2xs text-muted-foreground">
-      <span className="font-mono">
-        {displayIdx + 1}/{sorted.length} · {current.name}
-      </span>
-      <span className="flex items-center gap-0.5">
-        {sorted.map((r) => (
-          <span
-            key={r.id}
-            className={cn('inline-block h-1.5 w-1.5 rounded-full', STATUS_DOT[r.status])}
-          />
-        ))}
-      </span>
+      <span className={cn('inline-block h-1.5 w-1.5 rounded-full flex-none', STATUS_DOT[status])} />
+      {latestModel ? <span className="font-mono">{shortModel(latestModel)}</span> : null}
+      {totalCost > 0 ? (
+        <span className="font-mono text-muted-foreground/70">{formatCost(totalCost)}</span>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -207,6 +207,13 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   const settings = useAppStore((s) => s.settings);
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
 
+  const prevAgentRef = useRef(selectedAgentId);
+  useEffect(() => {
+    if (prevAgentRef.current === selectedAgentId) return;
+    prevAgentRef.current = selectedAgentId;
+    setPinned(true);
+  }, [selectedAgentId, setPinned]);
+
   const provider = session.providerPreference.defaultProvider;
   const providerAuthState = authResults?.[provider]?.state ?? null;
   const providerIdentity = authResults?.[provider]?.identity ?? null;

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1523,29 +1523,29 @@ function AgentsSection({ task }: AgentsSectionProps) {
       string,
       { inputTokens: number; outputTokens: number; estimatedCostUsd: number; turns: number }
     >();
-    const telemetryByRun = new Map<string, TelemetryRecord>();
+    // Build runId → agentId index. Prefer agentRunHistory (full lifetime) but
+    // fall back to agent.runId so agents whose turn events haven't been seeded
+    // yet (e.g. first session load, race between telemetry and runIds fetch) still
+    // count their latest run. Sum ALL turn records — multiple records per run
+    // (provider retries, cursor) are each counted, not just the latest.
+    const runIdToAgentId = new Map<string, string>();
+    for (const run of phaseRuns) {
+      map.set(run.id, { inputTokens: 0, outputTokens: 0, estimatedCostUsd: 0, turns: 0 });
+      const runIds = agentRunHistory[run.id] ?? (run.runId ? [run.runId] : []);
+      for (const rid of runIds) runIdToAgentId.set(rid, run.id);
+    }
     for (const rec of telemetry) {
       if (rec.kind !== 'turn') continue;
-      const existing = telemetryByRun.get(rec.runId);
-      if (!existing || existing.recordedAt < rec.recordedAt) {
-        telemetryByRun.set(rec.runId, rec);
-      }
-    }
-    for (const run of phaseRuns) {
-      const runIds = agentRunHistory[run.id] ?? (run.runId ? [run.runId] : []);
-      let inputTokens = 0;
-      let outputTokens = 0;
-      let estimatedCostUsd = 0;
-      let turns = 0;
-      for (const rid of runIds) {
-        const rec = telemetryByRun.get(rid);
-        if (!rec) continue;
-        inputTokens += rec.inputTokens;
-        outputTokens += rec.outputTokens;
-        estimatedCostUsd += rec.estimatedCostUsd;
-        turns += 1;
-      }
-      map.set(run.id, { inputTokens, outputTokens, estimatedCostUsd, turns });
+      const agentId = runIdToAgentId.get(rec.runId);
+      if (!agentId) continue;
+      const agg = map.get(agentId);
+      if (!agg) continue;
+      map.set(agentId, {
+        inputTokens: agg.inputTokens + rec.inputTokens,
+        outputTokens: agg.outputTokens + rec.outputTokens,
+        estimatedCostUsd: agg.estimatedCostUsd + rec.estimatedCostUsd,
+        turns: agg.turns + 1,
+      });
     }
     return map;
   }, [telemetry, phaseRuns, agentRunHistory]);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1470,10 +1470,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
         .then(([agents, agentRunIds]) => {
           const previouslySelected = get().selectedAgentId[id] ?? null;
           const sortedAgents = [...agents].sort((a, b) => a.ordinal - b.ordinal);
-          // Fresh entry defaults to the most recently created agent (highest
-          // ordinal). Chronologically the latest is the one the user is most
-          // likely returning to. Previous selection still wins on revisit.
-          const fallbackAgent = sortedAgents[sortedAgents.length - 1] ?? null;
+          // Fallback priority: running agent > last-ordinal agent. Previous
+          // selection wins on revisit. Without the running preference the
+          // highlight would always land on the highest-ordinal row (visually
+          // always the third item when a session has exactly 3 agents).
+          const runningAgent = sortedAgents.find((a) => a.status === 'running') ?? null;
+          const fallbackAgent = runningAgent ?? sortedAgents[sortedAgents.length - 1] ?? null;
           const selectedAgent =
             (previouslySelected && agents.find((a) => a.id === previouslySelected)) ||
             fallbackAgent;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -990,7 +990,8 @@ async function generateAutoTitle(
       await renameSessionInDb(tauriDatabase, sessionId, title, titleNow, false);
     }
     if (agentId) {
-      if (!get().agentKindOverride[agentId]) {
+      const lockedKind = get().agentKindOverride[agentId];
+      if (!lockedKind) {
         const runs = get().sessionPhaseRuns[sessionId] ?? [];
         const row = runs.find((r) => r.id === agentId);
         const currentKind = inferAgentKindFromName(row?.name ?? '');
@@ -999,6 +1000,15 @@ async function generateAutoTitle(
         }));
       }
       await get().renameAgent(sessionId, agentId, title);
+      // Only upgrade the chip when the agent was still generic — respect
+      // overrides set by workflow steps or user selection (#581).
+      const effectiveKind = lockedKind ?? 'generic';
+      if (effectiveKind === 'generic') {
+        const titleKind = inferAgentKindFromName(title);
+        if (titleKind !== 'generic') {
+          get().setAgentKind(agentId, titleKind);
+        }
+      }
     }
   } catch {
     // auto-title is best-effort

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -31,7 +31,6 @@ import {
   listContextSlotsForSession,
   insertContextSlotHistory,
   listContextSlotHistory,
-  listMessagesForAgent,
   listMessagesForSession,
   listTurnEventsForAgent,
   listTurnEventsForSession,
@@ -1414,6 +1413,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
         });
     }
 
+    // Session messages — keyed by sessionId, contains ALL agents' messages so
+    // sidebar turn counts and first-user-text (kind chip inference) reflect
+    // every agent, not only the currently selected one.
+    void listMessagesForSession(tauriDatabase, id)
+      .then((msgs) => {
+        set((state) => ({ messages: { ...state.messages, [id]: msgs } }));
+      })
+      .catch(() => {});
+
     // Context slots
     if (!cached?.slots) {
       const endSlots = perf('slots');
@@ -1533,9 +1541,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
           // With a selected agent, ChatView's effect calls selectAgent which
           // owns the flag lifecycle from there.
           if (!selectedAgent) {
-            set((state) => ({
-              messages: { ...state.messages, [id]: [] as ReadonlyArray<Message> },
-            }));
             markDone('transcript');
           }
         })
@@ -1833,13 +1838,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
-  loadTranscript: async (agentId, sessionId) => {
-    const [messages, events] = await Promise.all([
-      listMessagesForAgent(tauriDatabase, agentId),
-      listTurnEventsForAgent(tauriDatabase, agentId),
-    ]);
+  loadTranscript: async (agentId, _sessionId) => {
+    const events = await listTurnEventsForAgent(tauriDatabase, agentId);
     set((state) => ({
-      messages: { ...state.messages, [sessionId]: messages },
       transcripts: { ...state.transcripts, [agentId]: events },
     }));
   },
@@ -2166,6 +2167,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
         ...(resolvedOverride !== undefined ? { providerOverride: resolvedOverride } : {}),
       };
       await insertMessage(tauriDatabase, userMessage);
+      set((state) => ({
+        messages: {
+          ...state.messages,
+          [sessionId]: [...(state.messages[sessionId] ?? []), userMessage],
+        },
+      }));
       get().appendTurnEvent(activeAgentId, sessionId, {
         kind: 'user_text',
         runId,
@@ -2327,6 +2334,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
         createdAt: now(),
       };
       await insertMessage(tauriDatabase, userMessage);
+      set((state) => ({
+        messages: {
+          ...state.messages,
+          [sessionId]: [...(state.messages[sessionId] ?? []), userMessage],
+        },
+      }));
 
       const groupSessionRunId = crypto.randomUUID() as ProviderRunId;
       get().appendTurnEvent(activeAgentId, sessionId, {
@@ -3252,10 +3265,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const INITIAL_LIMIT = 50;
     const tInitial = performance.now();
     try {
-      const [messages, events] = await Promise.all([
-        listMessagesForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
-        listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
-      ]);
+      const events = await listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT });
       // eslint-disable-next-line no-console
       console.log(
         `[perf] selectAgent:initial ${(performance.now() - tInitial).toFixed(0)}ms (${events.length} events)`,
@@ -3264,7 +3274,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
         const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
         return {
           transcripts: { ...state.transcripts, [agentId]: events },
-          messages: { ...state.messages, [sessionId]: messages },
           sessionLoading: {
             ...state.sessionLoading,
             [sessionId]: { ...current, transcript: false },
@@ -3280,11 +3289,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // history likely exists). Fired non-awaited so the click flow returns.
       if (events.length === INITIAL_LIMIT) {
         const tFull = performance.now();
-        void Promise.all([
-          listMessagesForAgent(tauriDatabase, agentId),
-          listTurnEventsForAgent(tauriDatabase, agentId),
-        ])
-          .then(([fullMessages, fullEvents]) => {
+        void listTurnEventsForAgent(tauriDatabase, agentId)
+          .then((fullEvents) => {
             // eslint-disable-next-line no-console
             console.log(
               `[perf] selectAgent:full ${(performance.now() - tFull).toFixed(0)}ms (${fullEvents.length} events)`,
@@ -3296,7 +3302,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
               if (current && current.length > fullEvents.length) return {};
               return {
                 transcripts: { ...state.transcripts, [agentId]: fullEvents },
-                messages: { ...state.messages, [sessionId]: fullMessages },
               };
             });
           })
@@ -3351,7 +3356,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
       sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed },
       selectedAgentId: { ...s.selectedAgentId, [sessionId]: inserted.id },
       transcripts: { ...s.transcripts, [inserted.id]: [] },
-      messages: { ...s.messages, [sessionId]: [] },
       agentTurnState: {
         ...s.agentTurnState,
         [inserted.id]: { kind: 'idle', lastActivityAt: new Date().toISOString() as IsoDateTime },


### PR DESCRIPTION
## Summary

Six interconnected fixes and features in the agent sidebar, chat view, and header — shipped as three logical commits.

**Commit 1 · A1 + A2 — metrics aggregation + active-agent highlight**
- A1: Agent telemetry (tokens/cost) showed 0 for agents 4+ due to two compounding bugs: a latest-record-wins strategy per `runId` dropped earlier records, and a missing `agentRunHistory` fallback silently skipped agents whose run-ID seeding raced with telemetry load. Fixed with a direct runId→agentId index that sums *all* `turn`-kind records per agent.
- A2: Active-agent yellow highlight was always placed on the third sidebar row. `setCurrentSession` was falling back to `sortedAgents[last]` instead of the actually-running agent. Fixed to prefer `status === 'running'` before falling back to last.

**Commit 2 · A3 + A4 — per-agent message isolation + scroll-to-bottom**
- A3: Sidebar turn counts and kind-chip inference only reflected the currently selected agent because `messages[sessionId]` was written by `selectAgent` (per-agent load). Fixed: load all session messages once via `listMessagesForSession` at session switch; remove the per-agent overwrites from `selectAgent`, `loadTranscript`, and `spawnAgent`; append new user messages in `sendTurn` to keep counts live between switches.
- A4: Chat scroll position carried over across agent switches — switching to agent B after scrolling up in agent A landed at the top. Fixed by resetting the `pinned` flag to `true` on `selectedAgentId` change.

**Commit 3 · A5 + A6 — header info pill + auto-title chip**
- A5: `PhaseProgressPill` (N-of-M counter) duplicated the sidebar agent list. Replaced with `AgentInfoPill` showing the selected agent's model, cumulative cost, and status indicator — high-value per-agent metrics that weren't visible anywhere else. Rendered for all sessions (not workflow-only); hidden until the agent has telemetry data.
- A6: After `generateAutoTitle` renames the agent, explicitly call `setAgentKind` with the inferred kind so the sidebar chip updates immediately without waiting for `firstUserTextByAgentId` to propagate on the next session load.

## Test plan

- [ ] Session with 5+ workflow agents → all rows show non-zero tokens/cost after agents complete
- [ ] Switch sessions repeatedly → highlighted agent matches the running one, not always the third
- [ ] Switch agents → transcript shows correct content, scroll jumps to bottom each time
- [ ] Header: no N-of-M pill; shows model + cost dot for the selected agent after first turn
- [ ] New agent → first command auto-titles it and immediately updates the sidebar chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)