### PR TITLE
fix(desktop): record plan consumption in activate-workflow-agent

### DIFF
--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -3720,10 +3720,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
       },
     }));
 
-    const { section: planSection } = await buildPlanKickoffSection(sessionId);
+    const { section: planSection, plan: latestPlan } = await buildPlanKickoffSection(sessionId);
     const kickoff = composeKickoff(planSection, promptPrefix);
     if (kickoff.length > 0) {
       void get().sendTurn({ sessionId, content: kickoff });
+    }
+
+    if (latestPlan && latestPlan.status === 'active') {
+      await invokeAddPlanConsumption(latestPlan.id, agentId);
+      const refreshedPlans = await invokeListPlansForSession(sessionId);
+      const consumptions = await invokeListConsumptionsForPlan(latestPlan.id);
+      set((state) => ({
+        sessionPlans: { ...state.sessionPlans, [sessionId]: refreshedPlans },
+        planConsumptions: { ...state.planConsumptions, [latestPlan.id]: consumptions },
+      }));
     }
   },
 


### PR DESCRIPTION
## Summary

- `activateWorkflowAgent` sent active plan text to agents via `sendTurn` but never called `invokeAddPlanConsumption` → plan stayed "active" in DB/UI after implementation started
- Added plan consumption logic (same pattern as `spawnAgent` lines 3371-3378) with guards for null/already-consumed plans

## Test plan

- [ ] Workflow session: planner creates plan → auto-advance to implementer → plan status transitions to "consumed"
- [ ] Sidebar CTA: click to activate pending implementer → plan consumed
- [ ] Edge: no active plan → agent activates normally without error
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)