### PR TITLE
perf(desktop): optimize session switch performance

### DIFF
--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -175,3 +175,98 @@ fn value_to_json(value: ValueRef<'_>) -> serde_json::Value {
         ValueRef::Blob(bytes) => serde_json::Value::String(format!("blob:{}", bytes.len())),
     }
 }
+
+fn query_rows(
+    conn: &Connection,
+    sql: &str,
+    params: &[&dyn rusqlite::ToSql],
+) -> Result<Vec<Map<String, serde_json::Value>>, rusqlite::Error> {
+    let mut stmt = conn.prepare(sql)?;
+    let column_names: Vec<String> = stmt.column_names().into_iter().map(String::from).collect();
+    let mut rows = stmt.query(params)?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        let mut record = Map::new();
+        for (idx, name) in column_names.iter().enumerate() {
+            record.insert(name.clone(), value_to_json(row.get_ref(idx)?));
+        }
+        out.push(record);
+    }
+    Ok(out)
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionHydration {
+    agents: Vec<Map<String, serde_json::Value>>,
+    agent_run_ids: Vec<Map<String, serde_json::Value>>,
+    telemetry: Vec<Map<String, serde_json::Value>>,
+    telemetry_summary: Map<String, serde_json::Value>,
+    slots: Vec<Map<String, serde_json::Value>>,
+}
+
+#[tauri::command]
+pub fn session_hydrate(
+    state: State<'_, Db>,
+    session_id: String,
+) -> Result<SessionHydration, DbError> {
+    let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
+    let sid: &dyn rusqlite::ToSql = &session_id;
+
+    let agents = query_rows(
+        &conn,
+        "SELECT id, session_id AS \"sessionId\", step_id AS \"stepId\", ordinal, name, status,
+                provider_run_id AS \"providerRunId\", output_summary AS \"outputSummary\",
+                started_at AS \"startedAt\", completed_at AS \"completedAt\",
+                provider_session_id AS \"providerSessionId\",
+                last_finished_at AS \"lastFinishedAt\", last_viewed_at AS \"lastViewedAt\"
+         FROM agents WHERE session_id = ?1 ORDER BY ordinal ASC",
+        &[sid],
+    )?;
+
+    let agent_run_ids = query_rows(
+        &conn,
+        "SELECT agent_id, GROUP_CONCAT(DISTINCT run_id) AS run_ids
+         FROM (
+           SELECT agent_id, json_extract(payload, '$.runId') AS run_id
+           FROM turn_events
+           WHERE session_id = ?1
+             AND json_extract(payload, '$.runId') IS NOT NULL
+             AND json_extract(payload, '$.runId') != 'history'
+         )
+         GROUP BY agent_id",
+        &[sid],
+    )?;
+
+    let telemetry = query_rows(
+        &conn,
+        "SELECT * FROM telemetry_records WHERE session_id = ?1 ORDER BY recorded_at ASC",
+        &[sid],
+    )?;
+
+    let telemetry_summary = {
+        let rows = query_rows(
+            &conn,
+            "SELECT COALESCE(SUM(input_tokens), 0) AS input,
+                    COALESCE(SUM(output_tokens), 0) AS output,
+                    COALESCE(SUM(estimated_cost_usd), 0) AS cost,
+                    COUNT(*) AS count
+             FROM telemetry_records WHERE session_id = ?1",
+            &[sid],
+        )?;
+        rows.into_iter().next().unwrap_or_default()
+    };
+
+    let slots = query_rows(
+        &conn,
+        "SELECT * FROM context_slots WHERE session_id = ?1 ORDER BY key",
+        &[sid],
+    )?;
+
+    Ok(SessionHydration {
+        agents,
+        agent_run_ids,
+        telemetry,
+        telemetry_summary,
+        slots,
+    })
+}

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -199,7 +199,6 @@ fn query_rows(
 pub struct SessionHydration {
     agents: Vec<Map<String, serde_json::Value>>,
     agent_run_ids: Vec<Map<String, serde_json::Value>>,
-    telemetry: Vec<Map<String, serde_json::Value>>,
     telemetry_summary: Map<String, serde_json::Value>,
     slots: Vec<Map<String, serde_json::Value>>,
 }
@@ -237,12 +236,6 @@ pub fn session_hydrate(
         &[sid],
     )?;
 
-    let telemetry = query_rows(
-        &conn,
-        "SELECT * FROM telemetry_records WHERE session_id = ?1 ORDER BY recorded_at ASC",
-        &[sid],
-    )?;
-
     let telemetry_summary = {
         let rows = query_rows(
             &conn,
@@ -265,7 +258,6 @@ pub fn session_hydrate(
     Ok(SessionHydration {
         agents,
         agent_run_ids,
-        telemetry,
         telemetry_summary,
         slots,
     })

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
       db::db_execute,
       db::db_select,
       db::db_wipe,
+      db::session_hydrate,
       worktree::worktree_create,
       worktree::worktree_remove,
       worktree::worktree_list,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
-import { AppShell } from '@kay-am/ui';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { AppShell, Skeleton } from '@kay-am/ui';
 import type { SessionId } from '@kay-am/types';
 import { CommandPalette } from './features/session/components/CommandPalette';
 import { BootSplash } from './app/components/BootSplash';
@@ -152,12 +152,7 @@ export function App() {
     return merged.length > KEEP_ALIVE_CAP ? merged.slice(merged.length - KEEP_ALIVE_CAP) : merged;
   }, [keepAliveIds, currentSession?.id]);
 
-  // Defer the heavy panel mount so sidebar selection + AppShell swap paint
-  // urgently while React schedules the fresh ChatView/ContextPanel at low
-  // priority. Active id is deferred too so the previous panel stays visible
-  // (and `isActive`) during the lag — otherwise we'd flash a blank frame.
-  const deferredRenderedIds = useDeferredValue(renderedSessionIds);
-  const deferredActiveId = useDeferredValue(currentSession?.id ?? null);
+  const activeSessionId = currentSession?.id ?? null;
 
   if (!hydrated) {
     return <BootSplash phase={bootPhase} error={error} onRetry={() => void hydrate()} />;
@@ -179,11 +174,11 @@ export function App() {
             // the others). React skips unmount/mount on switches between
             // recent sessions — no flash, scroll position preserved.
             <div className="relative h-full w-full">
-              {deferredRenderedIds.map((id) => (
+              {renderedSessionIds.map((id) => (
                 <KeepAliveChatPanel
                   key={id}
                   sessionId={id}
-                  isActive={id === deferredActiveId}
+                  isActive={id === activeSessionId}
                   onRequestEnd={onRequestEnd}
                 />
               ))}
@@ -200,11 +195,11 @@ export function App() {
             // (loadDiffComments, refreshSessionPr*) on isActive so hidden
             // panels don't fire background work.
             <div className="relative h-full w-full">
-              {deferredRenderedIds.map((id) => (
+              {renderedSessionIds.map((id) => (
                 <KeepAliveContextPanel
                   key={id}
                   sessionId={id}
-                  isActive={id === deferredActiveId}
+                  isActive={id === activeSessionId}
                   collapsed={contextCollapsed}
                   onCollapse={onToggleContext}
                   onExpand={onToggleContext}
@@ -249,6 +244,69 @@ export function App() {
   );
 }
 
+// Defers a heavy mount to the next browser idle frame. Returns `true` only
+// once the browser has yielded a slot — the synchronous click + initial paint
+// run with `false`, so a skeleton can fill the panel area immediately. After
+// the idle callback fires, the real component mounts on a subsequent render
+// without blocking input or scroll. Sessions already in the LRU keep-alive
+// window stay `mounted: true` because their KeepAlive component instance
+// persists across switches.
+function useIdleMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    if (typeof requestIdleCallback === 'function') {
+      const handle = requestIdleCallback(() => setMounted(true), { timeout: 200 });
+      return () => cancelIdleCallback(handle);
+    }
+    const t = window.setTimeout(() => setMounted(true), 0);
+    return () => window.clearTimeout(t);
+  }, []);
+  return mounted;
+}
+
+function ChatViewSkeleton() {
+  return (
+    <div role="status" aria-label="loading session" className="flex h-full flex-col">
+      <div className="sticky top-0 z-10 bg-background px-10 py-2.5">
+        <div className="mx-auto flex w-full max-w-[880px] items-center gap-3">
+          <div className="min-w-0 flex-1">
+            <Skeleton className="h-3.5 w-1/3" />
+            <div className="mt-2 flex gap-3">
+              <Skeleton className="h-2.5 w-20" />
+              <Skeleton className="h-2.5 w-16" />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="flex-1 px-10 py-6">
+        <div className="mx-auto flex w-full max-w-[880px] flex-col gap-6">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex flex-col gap-2">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-3 w-full" />
+              <Skeleton className="h-3 w-5/6" />
+              <Skeleton className="h-3 w-3/4" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContextPanelSkeleton() {
+  return (
+    <div role="status" aria-label="loading context" className="flex h-full flex-col p-3">
+      <Skeleton className="h-4 w-1/2" />
+      <div className="mt-3 flex flex-col gap-2">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-4/5" />
+        <Skeleton className="h-3 w-3/5" />
+      </div>
+    </div>
+  );
+}
+
 interface KeepAliveChatPanelProps {
   readonly sessionId: SessionId;
   readonly isActive: boolean;
@@ -257,10 +315,15 @@ interface KeepAliveChatPanelProps {
 
 function KeepAliveChatPanel({ sessionId, isActive, onRequestEnd }: KeepAliveChatPanelProps) {
   const session = useSessionById(sessionId);
+  const mounted = useIdleMounted();
   if (!session) return null;
   return (
     <div hidden={!isActive} className="absolute inset-0">
-      <ChatView session={session} isActive={isActive} onRequestEnd={onRequestEnd} />
+      {mounted ? (
+        <ChatView session={session} isActive={isActive} onRequestEnd={onRequestEnd} />
+      ) : (
+        <ChatViewSkeleton />
+      )}
     </div>
   );
 }
@@ -281,16 +344,21 @@ function KeepAliveContextPanel({
   onExpand,
 }: KeepAliveContextPanelProps) {
   const session = useSessionById(sessionId);
+  const mounted = useIdleMounted();
   if (!session) return null;
   return (
     <div hidden={!isActive} className="absolute inset-0">
-      <ContextPanel
-        session={session}
-        isActive={isActive}
-        collapsed={collapsed}
-        onCollapse={onCollapse}
-        onExpand={onExpand}
-      />
+      {mounted ? (
+        <ContextPanel
+          session={session}
+          isActive={isActive}
+          collapsed={collapsed}
+          onCollapse={onCollapse}
+          onExpand={onExpand}
+        />
+      ) : (
+        <ContextPanelSkeleton />
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AppShell, Skeleton } from '@kay-am/ui';
+import { markForSession as ssMarkFor } from './shared/utils/session-switch-trace';
 import type { SessionId } from '@kay-am/types';
 import { CommandPalette } from './features/session/components/CommandPalette';
 import { BootSplash } from './app/components/BootSplash';
@@ -316,6 +317,12 @@ interface KeepAliveChatPanelProps {
 function KeepAliveChatPanel({ sessionId, isActive, onRequestEnd }: KeepAliveChatPanelProps) {
   const session = useSessionById(sessionId);
   const mounted = useIdleMounted();
+  useEffect(() => {
+    if (isActive && !mounted) ssMarkFor(sessionId, 'chat skeleton mounted (active)');
+  }, [isActive, mounted, sessionId]);
+  useEffect(() => {
+    if (isActive && mounted) ssMarkFor(sessionId, 'real ChatView mounted (active)');
+  }, [isActive, mounted, sessionId]);
   if (!session) return null;
   return (
     <div hidden={!isActive} className="absolute inset-0">
@@ -345,6 +352,12 @@ function KeepAliveContextPanel({
 }: KeepAliveContextPanelProps) {
   const session = useSessionById(sessionId);
   const mounted = useIdleMounted();
+  useEffect(() => {
+    if (isActive && !mounted) ssMarkFor(sessionId, 'context skeleton mounted (active)');
+  }, [isActive, mounted, sessionId]);
+  useEffect(() => {
+    if (isActive && mounted) ssMarkFor(sessionId, 'real ContextPanel mounted (active)');
+  }, [isActive, mounted, sessionId]);
   if (!session) return null;
   return (
     <div hidden={!isActive} className="absolute inset-0">

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -202,14 +202,15 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     void selectAgent(session.id, selectedAgentId);
   }, [isActive, selectedAgentId, transcriptCached, selectAgent, session.id]);
   const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
-  const authResults = useAppStore((s) => s.authResults);
+  const provider = session.providerPreference.defaultProvider;
+  const providerAuthState = useAppStore((s) => s.authResults?.[provider]?.state ?? null);
+  const providerIdentity = useAppStore((s) => s.authResults?.[provider]?.identity ?? null);
   const refreshProviders = useAppStore((s) => s.refreshProviders);
-  const settings = useAppStore((s) => s.settings);
+  const parallelAgentsEnabled = useAppStore(
+    (s) => s.settings['experimental.enable_parallel_agents'] === 'true',
+  );
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
 
-  const provider = session.providerPreference.defaultProvider;
-  const providerAuthState = authResults?.[provider]?.state ?? null;
-  const providerIdentity = authResults?.[provider]?.identity ?? null;
   const isProviderDisconnected = providerAuthState === 'disconnected';
 
   const agentState = useAppStore((s) => {
@@ -221,11 +222,9 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   const isThinking =
     agentKind === 'running' && (lastItem?.kind ?? 'user_text') !== 'assistant_text';
 
-  const flagOn = settings['experimental.enable_parallel_agents'] === 'true';
-
   const parallelRunIds = useMemo<ReadonlyArray<ProviderRunId>>(
-    () => (flagOn ? detectParallelRunIds(events) : []),
-    [events, flagOn],
+    () => (parallelAgentsEnabled ? detectParallelRunIds(events) : []),
+    [events, parallelAgentsEnabled],
   );
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
@@ -240,7 +239,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     });
   }, [parallelRunIds, phaseRuns]);
 
-  const isSplitView = flagOn && parallelRunIds.length > 1;
+  const isSplitView = parallelAgentsEnabled && parallelRunIds.length > 1;
 
   const onSelectRun = (runId: ProviderRunId) => {
     document

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { ArrowDown } from 'lucide-react';
 import type { AgentId, ProviderRunId, Session } from '@kay-am/types';
 import { cn, Skeleton } from '@kay-am/ui';
@@ -17,7 +26,11 @@ import {
   type MergeConflict,
   type MergeResolution,
 } from '../../../../features/permissions/components/MergeDialog';
-import { DiffViewerDialog } from '../../../../features/permissions/components/DiffViewerDialog';
+const DiffViewerDialog = lazy(() =>
+  import('../../../../features/permissions/components/DiffViewerDialog').then((m) => ({
+    default: m.DiffViewerDialog,
+  })),
+);
 import { worktreeDiff } from '../../../../features/worktree/worktree';
 
 interface ChatViewProps {
@@ -350,15 +363,17 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
             providerDisconnected={isProviderDisconnected}
           />
         )}
-        <DiffViewerDialog
-          open={diffJumpFile !== null}
-          onClose={() => setDiffJumpFile(null)}
-          sessionId={session.id}
-          title="worktree diff"
-          loader={diffLoader}
-          workingDir={worktreePath ?? undefined}
-          jumpToFile={diffJumpFile ?? undefined}
-        />
+        <Suspense fallback={null}>
+          <DiffViewerDialog
+            open={diffJumpFile !== null}
+            onClose={() => setDiffJumpFile(null)}
+            sessionId={session.id}
+            title="worktree diff"
+            loader={diffLoader}
+            workingDir={worktreePath ?? undefined}
+            jumpToFile={diffJumpFile ?? undefined}
+          />
+        </Suspense>
       </div>
     );
   }

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -12,11 +12,8 @@ import { ArrowDown } from 'lucide-react';
 import type { AgentId, ProviderRunId, Session } from '@kay-am/types';
 import { cn, Skeleton } from '@kay-am/ui';
 import { EMPTY_ARRAY, useAppStore, useSessionLoading, useTranscript } from '../../../../store';
-import {
-  detectParallelRunIds,
-  filterEventsByRunId,
-  reduceTranscript,
-} from '../../utils/transcript-items';
+import { detectParallelRunIds, filterEventsByRunId } from '../../utils/transcript-items';
+import { useReduceTranscript } from '../../utils/use-reduce-transcript';
 import { TranscriptCard } from '../TranscriptCards';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { ChatHeader } from '../ChatHeader';
@@ -82,7 +79,7 @@ function ParallelColumn({
   onOpenDiff,
 }: ColumnProps) {
   const columnEvents = useMemo(() => filterEventsByRunId(events, runId), [events, runId]);
-  const items = useMemo(() => reduceTranscript(columnEvents), [columnEvents]);
+  const items = useReduceTranscript(columnEvents);
   const { scrollerRef, pinned, setPinned, onScroll } = useScrollPin([items]);
 
   return (
@@ -195,7 +192,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     (s) => s.selectedAgentId[session.id] ?? null,
   ) as AgentId | null;
   const events = useTranscript(selectedAgentId);
-  const items = useMemo(() => reduceTranscript(events), [events]);
+  const items = useReduceTranscript(events);
   // Defer the heavy transcript list so React 18 can paint header / input /
   // empty shell first on session switch and treat the card list as low-priority.
   // Pairs with React.memo on TranscriptCard — together they make session swaps

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -4,11 +4,13 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
 import { ArrowDown } from 'lucide-react';
+import { markForSession as ssMarkFor } from '../../../../shared/utils/session-switch-trace';
 import type { AgentId, ProviderRunId, Session } from '@kay-am/types';
 import { cn, Skeleton } from '@kay-am/ui';
 import { EMPTY_ARRAY, useAppStore, useSessionLoading, useTranscript } from '../../../../store';
@@ -188,10 +190,20 @@ function ThinkingIndicator() {
 }
 
 export function ChatView({ session, isActive = true }: ChatViewProps) {
+  useLayoutEffect(() => {
+    if (isActive) ssMarkFor(session.id, 'ChatView render+commit');
+  }, [isActive, session.id]);
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[session.id] ?? null,
   ) as AgentId | null;
   const events = useTranscript(selectedAgentId);
+  useLayoutEffect(() => {
+    if (isActive)
+      ssMarkFor(
+        session.id,
+        `transcript events=${events.length} agentId=${selectedAgentId?.slice(0, 8) ?? 'null'}`,
+      );
+  }, [isActive, events.length, selectedAgentId, session.id]);
   const items = useReduceTranscript(events);
   // Defer the heavy transcript list so React 18 can paint header / input /
   // empty shell first on session switch and treat the card list as low-priority.

--- a/apps/desktop/src/features/chat/utils/load-turn-events.ts
+++ b/apps/desktop/src/features/chat/utils/load-turn-events.ts
@@ -1,0 +1,89 @@
+// Loads turn-event rows from SQLite and parses them in a Web Worker so the
+// JSON.parse storm never blocks the main thread. Falls back to inline parse
+// when Worker construction fails (test envs, exotic browsers).
+
+import { invoke } from '@tauri-apps/api/core';
+import type { AgentId, TurnEvent } from '@kay-am/types';
+import type { ParseRequest, ParseResponse } from './parse-turn-events.worker';
+
+interface TurnEventRow {
+  id: string;
+  session_id: string;
+  agent_id: string;
+  payload: string;
+  created_at: number;
+}
+
+let worker: Worker | null = null;
+let workerFailed = false;
+
+function getWorker(): Worker | null {
+  if (workerFailed) return null;
+  if (worker) return worker;
+  try {
+    worker = new Worker(new URL('./parse-turn-events.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    return worker;
+  } catch {
+    workerFailed = true;
+    return null;
+  }
+}
+
+let nextId = 0;
+
+function parseInline(rows: ReadonlyArray<TurnEventRow>): ReadonlyArray<TurnEvent> {
+  const out: TurnEvent[] = [];
+  for (const row of rows) {
+    try {
+      out.push(JSON.parse(row.payload) as TurnEvent);
+    } catch {
+      // skip
+    }
+  }
+  return out;
+}
+
+function parseInWorker(rows: ReadonlyArray<TurnEventRow>): Promise<ReadonlyArray<TurnEvent>> {
+  const w = getWorker();
+  if (!w) return Promise.resolve(parseInline(rows));
+  return new Promise((resolve) => {
+    const id = ++nextId;
+    const handler = (e: MessageEvent<ParseResponse>) => {
+      if (e.data.id !== id) return;
+      w.removeEventListener('message', handler);
+      resolve(e.data.events);
+    };
+    w.addEventListener('message', handler);
+    w.postMessage({ id, rows } satisfies ParseRequest);
+  });
+}
+
+export async function loadTurnEventsForAgent(
+  agentId: AgentId,
+  opts?: { readonly limit?: number },
+): Promise<ReadonlyArray<TurnEvent>> {
+  const sql =
+    opts?.limit !== undefined
+      ? 'SELECT * FROM turn_events WHERE agent_id = ? ORDER BY created_at DESC, rowid DESC LIMIT ?'
+      : 'SELECT * FROM turn_events WHERE agent_id = ? ORDER BY created_at ASC, rowid ASC';
+  const params = opts?.limit !== undefined ? [agentId, opts.limit] : [agentId];
+  const rows = await invoke<ReadonlyArray<TurnEventRow>>('db_select', { sql, params });
+  // Small slices (< 30 events) parse faster inline — worker overhead would
+  // dominate. Above that, the worker keeps the main thread responsive: traces
+  // showed ~52 events parsing in ~860ms on the main thread, easily a 1s
+  // freeze for the user. Worker overhead is roughly 15-20ms regardless.
+  if (rows.length < 30) {
+    const events = parseInline(rows);
+    if (opts?.limit !== undefined) {
+      return events.slice().reverse();
+    }
+    return events;
+  }
+  const events = await parseInWorker(rows);
+  if (opts?.limit !== undefined) {
+    return events.slice().reverse();
+  }
+  return events;
+}

--- a/apps/desktop/src/features/chat/utils/parse-turn-events.worker.ts
+++ b/apps/desktop/src/features/chat/utils/parse-turn-events.worker.ts
@@ -1,0 +1,50 @@
+/// <reference lib="webworker" />
+
+// Worker for parsing turn-event payloads off the main thread. Phase-2
+// transcript backfill returns up to a few hundred rows whose `payload`
+// field is a JSON string — parsing them in serial was eating 800ms+ on
+// the main thread, freezing scroll/clicks for a full second after the
+// session-switch skeleton rendered.
+//
+// Protocol: { id, rows: [{ payload, ... }] } → { id, events: TurnEvent[] }
+// Invalid payloads are silently dropped (matches packages/db rowToEvent).
+
+import type { TurnEvent } from '@kay-am/types';
+
+interface TurnEventRow {
+  readonly id: string;
+  readonly session_id: string;
+  readonly agent_id: string;
+  readonly payload: string;
+  readonly created_at: number;
+}
+
+export interface ParseRequest {
+  id: number;
+  rows: ReadonlyArray<TurnEventRow>;
+}
+
+export interface ParseResponse {
+  id: number;
+  events: ReadonlyArray<TurnEvent>;
+}
+
+function rowToEvent(row: TurnEventRow): TurnEvent | null {
+  try {
+    return JSON.parse(row.payload) as TurnEvent;
+  } catch {
+    return null;
+  }
+}
+
+declare const self: DedicatedWorkerGlobalScope;
+
+self.onmessage = (e: MessageEvent<ParseRequest>) => {
+  const { id, rows } = e.data;
+  const events: TurnEvent[] = [];
+  for (const row of rows) {
+    const evt = rowToEvent(row);
+    if (evt !== null) events.push(evt);
+  }
+  self.postMessage({ id, events } satisfies ParseResponse);
+};

--- a/apps/desktop/src/features/chat/utils/transcript-items.worker.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.worker.ts
@@ -1,0 +1,22 @@
+/// <reference lib="webworker" />
+
+import type { TurnEvent } from '@kay-am/types';
+import { reduceTranscript, type TranscriptItem } from './transcript-items';
+
+export interface WorkerRequest {
+  id: number;
+  events: ReadonlyArray<TurnEvent>;
+}
+
+export interface WorkerResponse {
+  id: number;
+  items: ReadonlyArray<TranscriptItem>;
+}
+
+declare const self: DedicatedWorkerGlobalScope;
+
+self.onmessage = (e: MessageEvent<WorkerRequest>) => {
+  const { id, events } = e.data;
+  const items = reduceTranscript(events);
+  self.postMessage({ id, items } satisfies WorkerResponse);
+};

--- a/apps/desktop/src/features/chat/utils/use-reduce-transcript.ts
+++ b/apps/desktop/src/features/chat/utils/use-reduce-transcript.ts
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { TurnEvent } from '@kay-am/types';
+import { reduceTranscript, type TranscriptItem } from './transcript-items';
+import type { WorkerResponse } from './transcript-items.worker';
+
+const EMPTY: ReadonlyArray<TranscriptItem> = [];
+const INLINE_THRESHOLD = 100;
+
+let worker: Worker | null = null;
+let workerFailed = false;
+
+function getWorker(): Worker | null {
+  if (workerFailed) return null;
+  if (worker) return worker;
+  try {
+    worker = new Worker(new URL('./transcript-items.worker.ts', import.meta.url), {
+      type: 'module',
+    });
+    return worker;
+  } catch {
+    workerFailed = true;
+    return null;
+  }
+}
+
+let nextId = 0;
+
+/**
+ * Offloads `reduceTranscript` to a Web Worker when the event array is large
+ * enough to justify the serialization overhead. Falls back to synchronous
+ * inline computation for small arrays or when Worker is unavailable.
+ *
+ * Returns previous result while worker processes — no flash/skeleton.
+ */
+export function useReduceTranscript(
+  events: ReadonlyArray<TurnEvent>,
+): ReadonlyArray<TranscriptItem> {
+  const useWorker = events.length >= INLINE_THRESHOLD && !workerFailed;
+  const [workerItems, setWorkerItems] = useState<ReadonlyArray<TranscriptItem> | null>(null);
+  const latestIdRef = useRef(-1);
+  const prevRef = useRef<ReadonlyArray<TranscriptItem>>(EMPTY);
+
+  // Synchronous fallback — always computed so hook call order is stable.
+  // When worker path is active this value is unused but computation is skipped
+  // because useMemo short-circuits on the same `events` reference.
+  const inlineResult = useMemo(
+    () => (useWorker ? null : reduceTranscript(events)),
+    [events, useWorker],
+  );
+
+  useEffect(() => {
+    if (!useWorker) return;
+
+    const w = getWorker();
+    if (!w) return;
+
+    const id = ++nextId;
+    latestIdRef.current = id;
+
+    const handler = (e: MessageEvent<WorkerResponse>) => {
+      if (e.data.id === latestIdRef.current) {
+        setWorkerItems(e.data.items);
+      }
+    };
+
+    w.addEventListener('message', handler);
+    w.postMessage({ id, events });
+
+    return () => {
+      w.removeEventListener('message', handler);
+    };
+  }, [events, useWorker]);
+
+  // Inline path (small array or no worker)
+  if (inlineResult !== null) {
+    prevRef.current = inlineResult;
+    return inlineResult;
+  }
+
+  // Worker path — return latest result, or previous while computing
+  if (workerItems !== null) {
+    prevRef.current = workerItems;
+    return workerItems;
+  }
+
+  return prevRef.current;
+}

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -49,6 +49,7 @@ import {
 } from '../../../../store';
 import { openUrl } from '../../../../shared/lib/editor';
 import { formatError } from '../../../../shared/lib/errors';
+import { scheduleIdle } from '../../../../shared/utils/idle';
 import { tauriGhRunner } from '../../../../features/github/github';
 const DiffViewerDialog = lazy(() =>
   import('../../../../features/permissions/components/DiffViewerDialog').then((m) => ({
@@ -467,10 +468,15 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     if (!isActive) return;
     if (!branch || githubStatus?.mode === 'absent') return;
     if (ghState?.fetchedAt != null) return;
-    const t0 = performance.now();
-    void refreshSessionPr(session.id).finally(() => {
-      if (import.meta.env.DEV)
-        console.log(`[perf] ctx:refreshSessionPr ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
+    // Defer until the browser is idle. `gh` CLI returns JSON the main thread
+    // has to JSON.parse — large PR comment payloads blocked scrolling and
+    // sidebar clicks for seconds even after the panel skeleton rendered.
+    return scheduleIdle(() => {
+      const t0 = performance.now();
+      void refreshSessionPr(session.id).finally(() => {
+        if (import.meta.env.DEV)
+          console.log(`[perf] ctx:refreshSessionPr ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
+      });
     });
   }, [isActive, branch, githubStatus?.mode, session.id, ghState?.fetchedAt, refreshSessionPr]);
 
@@ -483,10 +489,14 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     // network call (~3s) re-fired on every session switch, leaving a pending
     // PR-card spinner visible for the entire wait.
     if (prDetailFetchedAt !== null) return;
-    const t0 = performance.now();
-    void refreshSessionPrDetail(session.id).finally(() => {
-      if (import.meta.env.DEV)
-        console.log(`[perf] ctx:refreshSessionPrDetail ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
+    // Same idle-defer as the list fetch above — the detail call uses
+    // `gh api --paginate` and parses megabytes of issue comments synchronously.
+    return scheduleIdle(() => {
+      const t0 = performance.now();
+      void refreshSessionPrDetail(session.id).finally(() => {
+        if (import.meta.env.DEV)
+          console.log(`[perf] ctx:refreshSessionPrDetail ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
+      });
     });
   }, [isActive, prNumber, prDetailFetchedAt, session.id, refreshSessionPrDetail]);
 

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -107,8 +107,15 @@ export function ContextPanel({
 
   const workingDir = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
 
-  const slotsByKey = new Map<string, ContextSlot>(
-    slots.map((s) => [s.key, s.key === 'files_touched' ? normalizeFilesSlot(s, workingDir) : s]),
+  const slotsByKey = useMemo(
+    () =>
+      new Map<string, ContextSlot>(
+        slots.map((s) => [
+          s.key,
+          s.key === 'files_touched' ? normalizeFilesSlot(s, workingDir) : s,
+        ]),
+      ),
+    [slots, workingDir],
   );
 
   const visibleSlotKeys = useMemo(

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useMemo } from 'react';
+import { lazy, Suspense, useEffect, useState, useCallback, useMemo } from 'react';
 import {
   PanelRightClose,
   PanelRightOpen,
@@ -50,7 +50,11 @@ import {
 import { openUrl } from '../../../../shared/lib/editor';
 import { formatError } from '../../../../shared/lib/errors';
 import { tauriGhRunner } from '../../../../features/github/github';
-import { DiffViewerDialog } from '../../../../features/permissions/components/DiffViewerDialog';
+const DiffViewerDialog = lazy(() =>
+  import('../../../../features/permissions/components/DiffViewerDialog').then((m) => ({
+    default: m.DiffViewerDialog,
+  })),
+);
 import { GithubCard } from '../../../../features/github/components/Card';
 import { worktreeStatus } from '../../../../features/worktree/worktree';
 import type { WorktreeStatus } from '@kay-am/types';
@@ -320,15 +324,17 @@ export function ContextPanel({
         </div>
       </div>
 
-      <DiffViewerDialog
-        open={filesDiffOpen}
-        onClose={() => setFilesDiffOpen(false)}
-        sessionId={session.id}
-        title={`${filesTouchedCount} file${filesTouchedCount === 1 ? '' : 's'} touched`}
-        workingDir={workingDir ?? undefined}
-        worktreePath={workingDir ?? undefined}
-        jumpToFirstCommented={filesDiffJumpToNotes}
-      />
+      <Suspense fallback={null}>
+        <DiffViewerDialog
+          open={filesDiffOpen}
+          onClose={() => setFilesDiffOpen(false)}
+          sessionId={session.id}
+          title={`${filesTouchedCount} file${filesTouchedCount === 1 ? '' : 's'} touched`}
+          workingDir={workingDir ?? undefined}
+          worktreePath={workingDir ?? undefined}
+          jumpToFirstCommented={filesDiffJumpToNotes}
+        />
+      </Suspense>
     </>
   );
 }
@@ -700,15 +706,17 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
       </div>
 
       {repoSlug && pr ? (
-        <DiffViewerDialog
-          open={diffOpen}
-          onClose={() => setDiffOpen(false)}
-          sessionId={session.id}
-          repoSlug={repoSlug}
-          prNumber={pr.number}
-          cwd={workspace?.rootPath}
-          workingDir={workspace?.rootPath}
-        />
+        <Suspense fallback={null}>
+          <DiffViewerDialog
+            open={diffOpen}
+            onClose={() => setDiffOpen(false)}
+            sessionId={session.id}
+            repoSlug={repoSlug}
+            prNumber={pr.number}
+            cwd={workspace?.rootPath}
+            workingDir={workspace?.rootPath}
+          />
+        </Suspense>
       ) : null}
     </section>
   );

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useState, useCallback, useMemo } from 'react';
+import { lazy, Suspense, useEffect, useLayoutEffect, useState, useCallback, useMemo } from 'react';
+import { markForSession as ssMarkFor } from '../../../../shared/utils/session-switch-trace';
 import {
   PanelRightClose,
   PanelRightOpen,
@@ -87,6 +88,9 @@ export function ContextPanel({
   onExpand,
   isActive = true,
 }: ContextPanelProps) {
+  useLayoutEffect(() => {
+    if (isActive) ssMarkFor(session.id, `ContextPanel render+commit (collapsed=${collapsed})`);
+  }, [isActive, session.id, collapsed]);
   const slots = useSessionSlots(session.id);
   const summarizer = useSummarizerStatus(session.id);
   const loading = useSessionLoading(session.id);
@@ -146,9 +150,13 @@ export function ContextPanel({
       return;
     }
     let cancelled = false;
+    ssMarkFor(session.id, 'worktreeStatus fetch start');
     worktreeStatus(workingDir)
       .then((s) => {
-        if (!cancelled) setGitStatus(s);
+        if (!cancelled) {
+          ssMarkFor(session.id, 'worktreeStatus fetch done');
+          setGitStatus(s);
+        }
       })
       .catch(() => {
         if (!cancelled) setGitStatus(null);
@@ -156,7 +164,7 @@ export function ContextPanel({
     return () => {
       cancelled = true;
     };
-  }, [workingDir, filesTouched.count, summarizer.lastUpdate]);
+  }, [workingDir, filesTouched.count, summarizer.lastUpdate, session.id]);
 
   const filesTouchedCount = gitStatus?.changed ?? filesTouched.count;
   const filesTooltip = useMemo(() => {
@@ -186,8 +194,10 @@ export function ContextPanel({
 
   useEffect(() => {
     if (!isActive) return;
+    ssMarkFor(session.id, 'loadDiffComments dispatched');
     const t0 = performance.now();
     void loadDiffComments(session.id).finally(() => {
+      ssMarkFor(session.id, 'loadDiffComments done');
       if (import.meta.env.DEV)
         console.log(`[perf] ctx:diffComments ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
     });
@@ -471,9 +481,12 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     // Defer until the browser is idle. `gh` CLI returns JSON the main thread
     // has to JSON.parse — large PR comment payloads blocked scrolling and
     // sidebar clicks for seconds even after the panel skeleton rendered.
+    ssMarkFor(session.id, 'refreshSessionPr scheduled (idle)');
     return scheduleIdle(() => {
+      ssMarkFor(session.id, 'refreshSessionPr fetch start (idle fired)');
       const t0 = performance.now();
       void refreshSessionPr(session.id).finally(() => {
+        ssMarkFor(session.id, 'refreshSessionPr fetch+parse done');
         if (import.meta.env.DEV)
           console.log(`[perf] ctx:refreshSessionPr ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
       });
@@ -491,9 +504,12 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     if (prDetailFetchedAt !== null) return;
     // Same idle-defer as the list fetch above — the detail call uses
     // `gh api --paginate` and parses megabytes of issue comments synchronously.
+    ssMarkFor(session.id, 'refreshSessionPrDetail scheduled (idle)');
     return scheduleIdle(() => {
+      ssMarkFor(session.id, 'refreshSessionPrDetail fetch start (idle fired)');
       const t0 = performance.now();
       void refreshSessionPrDetail(session.id).finally(() => {
+        ssMarkFor(session.id, 'refreshSessionPrDetail fetch+parse done');
         if (import.meta.env.DEV)
           console.log(`[perf] ctx:refreshSessionPrDetail ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
       });

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -150,19 +150,26 @@ export function ContextPanel({
       return;
     }
     let cancelled = false;
-    ssMarkFor(session.id, 'worktreeStatus fetch start');
-    worktreeStatus(workingDir)
-      .then((s) => {
-        if (!cancelled) {
-          ssMarkFor(session.id, 'worktreeStatus fetch done');
-          setGitStatus(s);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setGitStatus(null);
-      });
+    // Defer to idle — `git status` shell call was eating ~800ms on the main
+    // thread right after the panel mounted. Idle-defer keeps interactions
+    // responsive; status appears when the browser has a free frame.
+    const cancelIdle = scheduleIdle(() => {
+      if (cancelled) return;
+      ssMarkFor(session.id, 'worktreeStatus fetch start');
+      worktreeStatus(workingDir)
+        .then((s) => {
+          if (!cancelled) {
+            ssMarkFor(session.id, 'worktreeStatus fetch done');
+            setGitStatus(s);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setGitStatus(null);
+        });
+    });
     return () => {
       cancelled = true;
+      cancelIdle();
     };
   }, [workingDir, filesTouched.count, summarizer.lastUpdate, session.id]);
 

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -183,8 +183,8 @@ export function ContextPanel({
     if (!isActive) return;
     const t0 = performance.now();
     void loadDiffComments(session.id).finally(() => {
-      // eslint-disable-next-line no-console
-      console.log(`[perf] ctx:diffComments ${(performance.now() - t0).toFixed(0)}ms`);
+      if (import.meta.env.DEV)
+        console.log(`[perf] ctx:diffComments ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
     });
   }, [isActive, session.id, loadDiffComments]);
 
@@ -463,8 +463,8 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     if (ghState?.fetchedAt != null) return;
     const t0 = performance.now();
     void refreshSessionPr(session.id).finally(() => {
-      // eslint-disable-next-line no-console
-      console.log(`[perf] ctx:refreshSessionPr ${(performance.now() - t0).toFixed(0)}ms`);
+      if (import.meta.env.DEV)
+        console.log(`[perf] ctx:refreshSessionPr ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
     });
   }, [isActive, branch, githubStatus?.mode, session.id, ghState?.fetchedAt, refreshSessionPr]);
 
@@ -479,8 +479,8 @@ function GitHubSection({ session, isActive = true }: { session: Session; isActiv
     if (prDetailFetchedAt !== null) return;
     const t0 = performance.now();
     void refreshSessionPrDetail(session.id).finally(() => {
-      // eslint-disable-next-line no-console
-      console.log(`[perf] ctx:refreshSessionPrDetail ${(performance.now() - t0).toFixed(0)}ms`);
+      if (import.meta.env.DEV)
+        console.log(`[perf] ctx:refreshSessionPrDetail ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
     });
   }, [isActive, prNumber, prDetailFetchedAt, session.id, refreshSessionPrDetail]);
 

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -292,52 +292,56 @@ export function ContextPanel({
           {filesTouchedCount === 0 && (loading.transcript || loading.agents) ? (
             <FilesTouchedSkeleton />
           ) : (
-            <button
-              type="button"
-              onClick={() => {
-                setFilesDiffJumpToNotes(false);
-                setFilesDiffOpen(true);
-              }}
-              disabled={!workingDir}
+            <div
               className={cn(
-                'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+                'flex w-full items-center gap-1 rounded-md border text-xs transition-colors',
                 !workingDir
-                  ? 'cursor-not-allowed text-muted-foreground/50'
+                  ? 'cursor-not-allowed border-border-soft text-muted-foreground/50'
                   : filesTouchedCount === 0
-                    ? 'border border-border-soft text-muted-foreground hover:bg-muted/30 hover:text-foreground'
-                    : 'border border-info/20 bg-info/5 text-info hover:bg-info/10',
+                    ? 'border-border-soft text-muted-foreground'
+                    : 'border-info/20 bg-info/5 text-info',
               )}
-              title={filesTooltip}
             >
-              <span className="inline-flex min-w-0 items-center gap-1.5">
-                <FileEdit size={11} aria-hidden />
-                <span className="truncate">
-                  {filesTouchedCount} file{filesTouchedCount === 1 ? '' : 's'} touched
+              <button
+                type="button"
+                onClick={() => {
+                  setFilesDiffJumpToNotes(false);
+                  setFilesDiffOpen(true);
+                }}
+                disabled={!workingDir}
+                className={cn(
+                  'flex min-w-0 flex-1 items-center justify-between gap-2 rounded-md px-2 py-1.5 transition-colors',
+                  workingDir &&
+                    (filesTouchedCount === 0
+                      ? 'hover:bg-muted/30 hover:text-foreground'
+                      : 'hover:bg-info/10'),
+                )}
+                title={filesTooltip}
+              >
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <FileEdit size={11} aria-hidden />
+                  <span className="truncate">
+                    {filesTouchedCount} file{filesTouchedCount === 1 ? '' : 's'} touched
+                  </span>
                 </span>
-                {openNotesCount > 0 ? (
-                  <>
-                    <span aria-hidden className="opacity-40">
-                      ·
-                    </span>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setFilesDiffJumpToNotes(true);
-                        setFilesDiffOpen(true);
-                      }}
-                      className="shrink-0 rounded-sm px-1 text-warning hover:bg-warning/10"
-                      title={`jump to ${openNotesCount} open note${openNotesCount === 1 ? '' : 's'}`}
-                    >
-                      {openNotesCount} note{openNotesCount === 1 ? '' : 's'}
-                    </button>
-                  </>
-                ) : null}
-              </span>
-              <span aria-hidden className="opacity-60">
-                ↗
-              </span>
-            </button>
+                <span aria-hidden className="opacity-60">
+                  ↗
+                </span>
+              </button>
+              {openNotesCount > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setFilesDiffJumpToNotes(true);
+                    setFilesDiffOpen(true);
+                  }}
+                  className="mr-1 shrink-0 rounded-sm px-1.5 py-1 text-warning transition-colors hover:bg-warning/10"
+                  title={`jump to ${openNotesCount} open note${openNotesCount === 1 ? '' : 's'}`}
+                >
+                  {openNotesCount} note{openNotesCount === 1 ? '' : 's'}
+                </button>
+              ) : null}
+            </div>
           )}
         </div>
       </div>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -331,6 +331,8 @@ export function DiffViewerDialog({
     }
     return m;
   }, [comments]);
+  const openCommentsByFileRef = useRef(openCommentsByFile);
+  openCommentsByFileRef.current = openCommentsByFile;
 
   useEffect(() => {
     if (open) setViewState(DEFAULT_VIEW);
@@ -379,8 +381,8 @@ export function DiffViewerDialog({
         if (jumpToFile) {
           const idx = parsed.findIndex((f) => f.path === jumpToFile || jumpToFile.endsWith(f.path));
           setSelectedIdx(idx >= 0 ? idx : 0);
-        } else if (jumpToFirstCommented && openCommentsByFile.size > 0) {
-          const idx = parsed.findIndex((f) => openCommentsByFile.has(f.path));
+        } else if (jumpToFirstCommented && openCommentsByFileRef.current.size > 0) {
+          const idx = parsed.findIndex((f) => openCommentsByFileRef.current.has(f.path));
           setSelectedIdx(idx >= 0 ? idx : 0);
         } else {
           setSelectedIdx(0);
@@ -406,7 +408,6 @@ export function DiffViewerDialog({
     cwd,
     jumpToFirstCommented,
     jumpToFile,
-    openCommentsByFile,
   ]);
 
   useEffect(() => {

--- a/apps/desktop/src/features/phases/phases.ts
+++ b/apps/desktop/src/features/phases/phases.ts
@@ -77,7 +77,7 @@ function rowToTemplate(row: RawPhaseTemplateRow): Workflow {
   };
 }
 
-function rowToPhaseRun(row: RawPhaseRunRow): Agent {
+export function rowToPhaseRun(row: RawPhaseRunRow): Agent {
   return {
     id: row.id as AgentId,
     sessionId: row.sessionId as SessionId,

--- a/apps/desktop/src/features/providers/components/PricingDialog/index.tsx
+++ b/apps/desktop/src/features/providers/components/PricingDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Dialog, cn } from '@kay-am/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import type { ProviderSpendEntry } from '../../../../store';
@@ -80,6 +80,16 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
     (s) => s.providerSpendBreakdown ?? (EMPTY_ARRAY as ReadonlyArray<ProviderSpendEntry>),
   );
 
+  // Telemetry records are deferred to idle on session switch. If the user
+  // opens the dialog before the idle frame fires (or before records exist),
+  // trigger an explicit fetch so the breakdown isn't blank.
+  useEffect(() => {
+    if (!open || !currentSessionId || sessionTelemetry.length > 0) return;
+    void useAppStore.getState().loadSessionTelemetry(currentSessionId);
+  }, [open, currentSessionId, sessionTelemetry.length]);
+
+  const isLoading = open && currentSessionId !== null && sessionTelemetry.length === 0;
+
   const [sortKey, setSortKey] = useState<SortKey>(() => {
     const stored = localStorage.getItem(SORT_KEY_STORAGE);
     return stored === 'expensive' ? 'expensive' : 'recent';
@@ -159,7 +169,18 @@ export function PricingDialog({ open, onClose }: PricingDialogProps) {
           </section>
         ) : null}
 
-        {modelBreakdown.length > 0 ? (
+        {isLoading ? (
+          <section>
+            <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              by model
+            </h3>
+            <div className="space-y-1.5 rounded-md border border-border-soft p-3">
+              <div className="h-3 w-2/3 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-1/2 animate-pulse rounded bg-muted" />
+              <div className="h-3 w-3/5 animate-pulse rounded bg-muted" />
+            </div>
+          </section>
+        ) : modelBreakdown.length > 0 ? (
           <section>
             <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               by model

--- a/apps/desktop/src/features/session/archived-storage.ts
+++ b/apps/desktop/src/features/session/archived-storage.ts
@@ -1,0 +1,30 @@
+// Client-side archived-session marker. Lives in localStorage (not DB) so the
+// per-device archived view doesn't sync across machines. Shared by the
+// sidebar hook and the store warmup (which skips data loads for archived).
+import { STORAGE_KEYS } from '../../shared/lib/storage-keys';
+
+const ARCHIVED_KEY = STORAGE_KEYS.archivedTasks;
+
+export function readArchivedSet(): Record<string, true> {
+  try {
+    const raw = localStorage.getItem(ARCHIVED_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') {
+      const out: Record<string, true> = {};
+      for (const k of Object.keys(parsed as Record<string, unknown>)) out[k] = true;
+      return out;
+    }
+  } catch {
+    // ignore parse failure — treat as empty set
+  }
+  return {};
+}
+
+export function writeArchivedSet(map: Record<string, true>): void {
+  try {
+    localStorage.setItem(ARCHIVED_KEY, JSON.stringify(map));
+  } catch {
+    // ignore quota/access failure
+  }
+}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -124,7 +124,7 @@ import {
 import { openUrl } from '../../../../shared/lib/editor';
 import { formatError } from '../../../../shared/lib/errors';
 import { useThemeStore } from '../../../../shared/lib/theme';
-import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
+import { readArchivedSet, writeArchivedSet } from '../../../session/archived-storage';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 
 interface WorkspacesSidebarProps {
@@ -619,12 +619,11 @@ function SessionList({
           {archivedOpen && (
             <ul className="flex flex-col gap-0.5 opacity-70">
               {sortedArchived.map((session) => (
-                <SessionRow
+                <ArchivedSessionRow
                   key={session.id}
                   session={session}
                   isActive={session.id === currentSessionId}
                   onClick={rowHandlers.click.get(session.id)!}
-                  archived
                   onArchive={rowHandlers.arch.get(session.id)!}
                   onUnarchive={rowHandlers.unarch.get(session.id)!}
                 />
@@ -709,32 +708,6 @@ function sortSessions(list: ReadonlyArray<Session>, sort: SessionSort): Readonly
   if (sort === 'alpha') copy.sort((a, b) => a.goal.localeCompare(b.goal));
   else copy.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
   return copy;
-}
-
-const ARCHIVED_KEY = STORAGE_KEYS.archivedTasks;
-
-function readArchivedSet(): Record<string, true> {
-  try {
-    const raw = localStorage.getItem(ARCHIVED_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === 'object') {
-      const out: Record<string, true> = {};
-      for (const k of Object.keys(parsed as Record<string, unknown>)) out[k] = true;
-      return out;
-    }
-  } catch {
-    // ignore
-  }
-  return {};
-}
-
-function writeArchivedSet(map: Record<string, true>): void {
-  try {
-    localStorage.setItem(ARCHIVED_KEY, JSON.stringify(map));
-  } catch {
-    // ignore
-  }
 }
 
 function useArchivedSessions(): [
@@ -1186,6 +1159,68 @@ const SessionRow = memo(function SessionRow({
           open={settingsOpen}
           onClose={() => setSettingsOpen(false)}
           archived={archived}
+          onArchive={onArchive}
+          onUnarchive={onUnarchive}
+        />
+      </Suspense>
+    </li>
+  );
+});
+
+interface ArchivedSessionRowProps {
+  session: Session;
+  isActive: boolean;
+  onClick: () => void;
+  onArchive: () => void;
+  onUnarchive: () => void;
+}
+
+// Minimal row for archived sessions: title + settings icon. No subscriptions
+// to git, agents, cost, or auto-run — those slices aren't even loaded for
+// archived sessions (see setCurrentWorkspace warmup). Full hydration kicks
+// in on click via setCurrentSession.
+const ArchivedSessionRow = memo(function ArchivedSessionRow({
+  session,
+  isActive,
+  onClick,
+  onArchive,
+  onUnarchive,
+}: ArchivedSessionRowProps) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  return (
+    <li
+      className={cn(
+        'group flex items-center gap-1 rounded px-2 py-1.5 text-xs transition-colors',
+        isActive ? 'bg-muted' : 'hover:bg-muted/60',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className="min-w-0 flex-1 truncate text-left"
+        title={session.goal}
+      >
+        {session.goal}
+      </button>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setSettingsOpen(true);
+        }}
+        className="shrink-0 rounded p-0.5 text-muted-foreground/40 transition-colors hover:bg-muted hover:text-foreground group-hover:text-muted-foreground"
+        title="session settings"
+        aria-label={`settings for ${session.goal}`}
+      >
+        <Settings2 size={12} aria-hidden />
+      </button>
+      <Suspense fallback={null}>
+        <SessionSettingsDialog
+          sessionId={session.id as SessionId}
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          archived
           onArchive={onArchive}
           onUnarchive={onUnarchive}
         />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -5,10 +5,12 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
+import { markForSession as ssMarkFor } from '../../../../shared/utils/session-switch-trace';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -1495,6 +1497,9 @@ interface AgentsSectionProps {
 }
 
 function AgentsSection({ task }: AgentsSectionProps) {
+  useLayoutEffect(() => {
+    ssMarkFor(task.id, 'sidebar AgentsSection render+commit');
+  }, [task.id]);
   const isTaskActive = useAppStore((s) => s.currentSessionId === task.id);
   const plansForTask = useSessionPlans(task.id);
   const latestPlan = plansForTask[plansForTask.length - 1];

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -146,7 +146,9 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   // skip re-render on every parent paint.
   const onSelectSession = useCallback(
     (id: SessionId) => {
-      void setCurrentSession(id);
+      startTransition(() => {
+        void setCurrentSession(id);
+      });
     },
     [setCurrentSession],
   );
@@ -263,7 +265,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                 key={ws.id}
                 workspace={ws}
                 isActive={ws.id === currentWorkspace?.id}
-                onClick={() => void setCurrentWorkspace(ws.id)}
+                onClick={() => startTransition(() => void setCurrentWorkspace(ws.id))}
               />
             ))}
             <li>
@@ -2150,7 +2152,7 @@ interface AgentRowProps {
   readonly onDelete: () => void;
 }
 
-function AgentRow({
+const AgentRow = memo(function AgentRow({
   run,
   kind,
   telemetry,
@@ -2325,7 +2327,7 @@ function AgentRow({
       </div>
     </li>
   );
-}
+});
 
 function findContextWindow(model: string): number | null {
   for (const cap of Object.values(PROVIDER_CAPABILITIES)) {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -150,7 +150,6 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
     },
     [setCurrentSession],
   );
-  const sessionBranches = useAppStore((s) => s.sessionBranches);
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
 
   const sidebarStateFilter = useAppStore((s) => s.sidebarStateFilter);
@@ -164,12 +163,13 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
   useEffect(() => {
     if (warmedRef.current || sessions.length === 0) return;
     warmedRef.current = true;
+    const branches = useAppStore.getState().sessionBranches;
     for (const s of sessions) {
-      if (sessionBranches[s.id]) {
+      if (branches[s.id]) {
         void refreshSessionPr(s.id as SessionId);
       }
     }
-  }, [sessions, sessionBranches, refreshSessionPr]);
+  }, [sessions, refreshSessionPr]);
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -179,14 +179,18 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
     [workspaces],
   );
 
-  const filteredSessions = sessions.filter((s) => {
-    const matchesState =
-      sidebarStateFilter.length === 0 || sidebarStateFilter.includes(s.state.kind);
-    const matchesProvider =
-      sidebarProviderFilter.length === 0 ||
-      sidebarProviderFilter.includes(s.providerPreference.defaultProvider);
-    return matchesState && matchesProvider;
-  });
+  const filteredSessions = useMemo(
+    () =>
+      sessions.filter((s) => {
+        const matchesState =
+          sidebarStateFilter.length === 0 || sidebarStateFilter.includes(s.state.kind);
+        const matchesProvider =
+          sidebarProviderFilter.length === 0 ||
+          sidebarProviderFilter.includes(s.providerPreference.defaultProvider);
+        return matchesState && matchesProvider;
+      }),
+    [sessions, sidebarStateFilter, sidebarProviderFilter],
+  );
 
   const theme = useThemeStore((s) => s.theme);
   const toggleTheme = useThemeStore((s) => s.toggleTheme);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,4 +1,14 @@
-import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  lazy,
+  memo,
+  startTransition,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -37,9 +47,17 @@ import {
   Zap,
   ZapOff,
 } from 'lucide-react';
-import { WorkspaceSettingsDialog } from '../WorkspaceSettingsDialog';
-import { SessionSettingsDialog } from '../../../session/components/SessionSettingsDialog';
-import { GuideDialog } from '../../../settings/components/GuideDialog';
+const WorkspaceSettingsDialog = lazy(() =>
+  import('../WorkspaceSettingsDialog').then((m) => ({ default: m.WorkspaceSettingsDialog })),
+);
+const SessionSettingsDialog = lazy(() =>
+  import('../../../session/components/SessionSettingsDialog').then((m) => ({
+    default: m.SessionSettingsDialog,
+  })),
+);
+const GuideDialog = lazy(() =>
+  import('../../../settings/components/GuideDialog').then((m) => ({ default: m.GuideDialog })),
+);
 import { ProvidersChip } from '../../../../features/providers/components/ProvidersChip';
 import { NotificationCenter } from '../../../../features/notifications/components/NotificationCenter';
 import { TelemetryPill } from '../../../../features/providers/components/TelemetryPill';
@@ -73,7 +91,11 @@ import {
   useWorkspaceHasUnread,
   useWorkspaces,
 } from '../../../../store';
-import { NewSessionDialog } from '../../../session/components/NewSessionDialog';
+const NewSessionDialog = lazy(() =>
+  import('../../../session/components/NewSessionDialog').then((m) => ({
+    default: m.NewSessionDialog,
+  })),
+);
 import { StatusBadge } from '../../../session/components/StatusBadge';
 import { pickNextWorkflowStep } from '../../../../features/workflow/components/WorkflowNextStepCta';
 import { CostBadge } from '../../../../features/providers/components/CostBadge';
@@ -333,14 +355,18 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       </div>
 
       <AddWorkspaceDialog open={addWorkspaceOpen} onClose={() => setAddWorkspaceOpen(false)} />
-      <GuideDialog open={guideOpen} onClose={() => setGuideOpen(false)} />
+      <Suspense fallback={null}>
+        <GuideDialog open={guideOpen} onClose={() => setGuideOpen(false)} />
+      </Suspense>
       {currentWorkspace ? (
-        <NewSessionDialog
-          open={newSessionOpen}
-          onClose={() => setNewSessionOpen(false)}
-          workspaceId={currentWorkspace.id}
-          onOpenSettings={onOpenSettings}
-        />
+        <Suspense fallback={null}>
+          <NewSessionDialog
+            open={newSessionOpen}
+            onClose={() => setNewSessionOpen(false)}
+            workspaceId={currentWorkspace.id}
+            onOpenSettings={onOpenSettings}
+          />
+        </Suspense>
       ) : null}
     </div>
   );
@@ -426,12 +452,14 @@ function WorkspaceRow({ workspace, isActive, onClick }: WorkspaceRowProps) {
           <Settings2 size={12} aria-hidden />
         </button>
       </div>
-      <WorkspaceSettingsDialog
-        workspaceId={workspace.id}
-        workspaceName={workspace.name}
-        open={wsSettingsOpen}
-        onClose={() => setWsSettingsOpen(false)}
-      />
+      <Suspense fallback={null}>
+        <WorkspaceSettingsDialog
+          workspaceId={workspace.id}
+          workspaceName={workspace.name}
+          open={wsSettingsOpen}
+          onClose={() => setWsSettingsOpen(false)}
+        />
+      </Suspense>
     </li>
   );
 }
@@ -1152,14 +1180,16 @@ const SessionRow = memo(function SessionRow({
           onCancel={() => setConfirmDelete(false)}
         />
       )}
-      <SessionSettingsDialog
-        sessionId={session.id as SessionId}
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        archived={archived}
-        onArchive={onArchive}
-        onUnarchive={onUnarchive}
-      />
+      <Suspense fallback={null}>
+        <SessionSettingsDialog
+          sessionId={session.id as SessionId}
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          archived={archived}
+          onArchive={onArchive}
+          onUnarchive={onUnarchive}
+        />
+      </Suspense>
     </li>
   );
 });

--- a/apps/desktop/src/shared/lib/db.ts
+++ b/apps/desktop/src/shared/lib/db.ts
@@ -1,5 +1,24 @@
 import { invoke } from '@tauri-apps/api/core';
-import { migrate as runMigrations, type Database, type MigrateResult } from '@kay-am/db';
+import {
+  migrate as runMigrations,
+  type Database,
+  type MigrateResult,
+  type TelemetrySummary,
+} from '@kay-am/db';
+import type {
+  Agent,
+  AgentId,
+  AgentStatus,
+  ContextSlot,
+  IsoDateTime,
+  ProviderName,
+  ProviderRunId,
+  SessionId,
+  StepId,
+  TelemetryKind,
+  TelemetryRecord,
+  TelemetryRecordId,
+} from '@kay-am/types';
 
 export const tauriDatabase: Database = {
   async exec(sql) {
@@ -26,4 +45,89 @@ export async function runDbMigrations(): Promise<MigrateResult> {
 export async function wipeDb(): Promise<MigrateResult> {
   await invoke('db_wipe');
   return runMigrations(tauriDatabase);
+}
+
+export interface SessionHydration {
+  agents: ReadonlyArray<Record<string, unknown>>;
+  agent_run_ids: ReadonlyArray<{ agent_id: string; run_ids: string | null }>;
+  telemetry: ReadonlyArray<Record<string, unknown>>;
+  telemetry_summary: { input: number; output: number; cost: number; count: number };
+  slots: ReadonlyArray<Record<string, unknown>>;
+}
+
+async function sessionHydrateRaw(sessionId: string): Promise<SessionHydration> {
+  return invoke<SessionHydration>('session_hydrate', { sessionId });
+}
+
+export interface ParsedSessionHydration {
+  agents: ReadonlyArray<Agent>;
+  agentRunIds: Map<AgentId, ReadonlyArray<ProviderRunId>>;
+  telemetry: ReadonlyArray<TelemetryRecord>;
+  telemetrySummary: TelemetrySummary;
+  slots: ReadonlyArray<ContextSlot>;
+}
+
+function parseAgent(r: Record<string, unknown>): Agent {
+  return {
+    id: r.id as AgentId,
+    sessionId: r.sessionId as SessionId,
+    ...(r.stepId != null && { stepId: r.stepId as StepId }),
+    ordinal: r.ordinal as number,
+    name: r.name as string,
+    status: r.status as AgentStatus,
+    ...(r.providerRunId != null && { runId: r.providerRunId as ProviderRunId }),
+    ...(r.outputSummary != null && { outputSummary: r.outputSummary as string }),
+    ...(r.startedAt != null && { startedAt: r.startedAt as IsoDateTime }),
+    ...(r.completedAt != null && { completedAt: r.completedAt as IsoDateTime }),
+    ...(r.providerSessionId != null && { providerSessionId: r.providerSessionId as string }),
+    ...(r.lastFinishedAt != null && { lastFinishedAt: r.lastFinishedAt as IsoDateTime }),
+    ...(r.lastViewedAt != null && { lastViewedAt: r.lastViewedAt as IsoDateTime }),
+  };
+}
+
+function parseTelemetry(r: Record<string, unknown>): TelemetryRecord {
+  return {
+    id: r.id as TelemetryRecordId,
+    runId: r.run_id as ProviderRunId,
+    sessionId: r.session_id as SessionId,
+    kind: r.kind as TelemetryKind,
+    provider: r.provider as ProviderName,
+    model: r.model as string,
+    inputTokens: r.input_tokens as number,
+    outputTokens: r.output_tokens as number,
+    estimatedCostUsd: r.estimated_cost_usd as number,
+    recordedAt: new Date(r.recorded_at as number).toISOString() as IsoDateTime,
+  };
+}
+
+function parseSlot(r: Record<string, unknown>): ContextSlot {
+  return {
+    key: r.key as string,
+    value: r.value as string,
+    enabled: r.enabled === 1,
+  };
+}
+
+export async function sessionHydrate(sessionId: string): Promise<ParsedSessionHydration> {
+  const raw = await sessionHydrateRaw(sessionId);
+
+  const agentRunIds = new Map<AgentId, ReadonlyArray<ProviderRunId>>();
+  for (const row of raw.agent_run_ids) {
+    const agentId = row.agent_id as AgentId;
+    const ids = row.run_ids ? (row.run_ids.split(',') as ProviderRunId[]) : [];
+    agentRunIds.set(agentId, ids);
+  }
+
+  return {
+    agents: raw.agents.map(parseAgent),
+    agentRunIds,
+    telemetry: raw.telemetry.map(parseTelemetry),
+    telemetrySummary: {
+      inputTokens: raw.telemetry_summary.input ?? 0,
+      outputTokens: raw.telemetry_summary.output ?? 0,
+      estimatedCostUsd: raw.telemetry_summary.cost ?? 0,
+      recordCount: raw.telemetry_summary.count ?? 0,
+    },
+    slots: raw.slots.map(parseSlot),
+  };
 }

--- a/apps/desktop/src/shared/lib/db.ts
+++ b/apps/desktop/src/shared/lib/db.ts
@@ -11,13 +11,9 @@ import type {
   AgentStatus,
   ContextSlot,
   IsoDateTime,
-  ProviderName,
   ProviderRunId,
   SessionId,
   StepId,
-  TelemetryKind,
-  TelemetryRecord,
-  TelemetryRecordId,
 } from '@kay-am/types';
 
 export const tauriDatabase: Database = {
@@ -50,7 +46,6 @@ export async function wipeDb(): Promise<MigrateResult> {
 export interface SessionHydration {
   agents: ReadonlyArray<Record<string, unknown>>;
   agent_run_ids: ReadonlyArray<{ agent_id: string; run_ids: string | null }>;
-  telemetry: ReadonlyArray<Record<string, unknown>>;
   telemetry_summary: { input: number; output: number; cost: number; count: number };
   slots: ReadonlyArray<Record<string, unknown>>;
 }
@@ -62,7 +57,6 @@ async function sessionHydrateRaw(sessionId: string): Promise<SessionHydration> {
 export interface ParsedSessionHydration {
   agents: ReadonlyArray<Agent>;
   agentRunIds: Map<AgentId, ReadonlyArray<ProviderRunId>>;
-  telemetry: ReadonlyArray<TelemetryRecord>;
   telemetrySummary: TelemetrySummary;
   slots: ReadonlyArray<ContextSlot>;
 }
@@ -82,21 +76,6 @@ function parseAgent(r: Record<string, unknown>): Agent {
     ...(r.providerSessionId != null && { providerSessionId: r.providerSessionId as string }),
     ...(r.lastFinishedAt != null && { lastFinishedAt: r.lastFinishedAt as IsoDateTime }),
     ...(r.lastViewedAt != null && { lastViewedAt: r.lastViewedAt as IsoDateTime }),
-  };
-}
-
-function parseTelemetry(r: Record<string, unknown>): TelemetryRecord {
-  return {
-    id: r.id as TelemetryRecordId,
-    runId: r.run_id as ProviderRunId,
-    sessionId: r.session_id as SessionId,
-    kind: r.kind as TelemetryKind,
-    provider: r.provider as ProviderName,
-    model: r.model as string,
-    inputTokens: r.input_tokens as number,
-    outputTokens: r.output_tokens as number,
-    estimatedCostUsd: r.estimated_cost_usd as number,
-    recordedAt: new Date(r.recorded_at as number).toISOString() as IsoDateTime,
   };
 }
 
@@ -121,7 +100,6 @@ export async function sessionHydrate(sessionId: string): Promise<ParsedSessionHy
   return {
     agents: raw.agents.map(parseAgent),
     agentRunIds,
-    telemetry: raw.telemetry.map(parseTelemetry),
     telemetrySummary: {
       inputTokens: raw.telemetry_summary.input ?? 0,
       outputTokens: raw.telemetry_summary.output ?? 0,

--- a/apps/desktop/src/shared/utils/idle.ts
+++ b/apps/desktop/src/shared/utils/idle.ts
@@ -1,0 +1,14 @@
+// Schedules `fn` to run when the browser is idle. Returns a cancel function.
+// Falls back to setTimeout(0) on platforms without requestIdleCallback.
+//
+// `timeout` ensures the work eventually runs even on a perpetually busy main
+// thread — default 1s is enough for "after sidebar/skeleton paint" without
+// users perceiving the deferred work as missing.
+export function scheduleIdle(fn: () => void, timeout = 1000): () => void {
+  if (typeof requestIdleCallback === 'function') {
+    const handle = requestIdleCallback(() => fn(), { timeout });
+    return () => cancelIdleCallback(handle);
+  }
+  const id = window.setTimeout(fn, 0);
+  return () => window.clearTimeout(id);
+}

--- a/apps/desktop/src/shared/utils/session-switch-trace.ts
+++ b/apps/desktop/src/shared/utils/session-switch-trace.ts
@@ -1,0 +1,38 @@
+// Session-switch perf trace. Records elapsed time from the click to every
+// downstream milestone (state update, panel mount, idle fetches). Gated
+// behind import.meta.env.DEV — zero runtime cost in production.
+//
+// Usage: search browser console for "[ss]" to see the full timeline.
+
+let t0 = 0;
+let currentId: string | null = null;
+let seq = 0;
+
+const isDev = (): boolean => import.meta.env.DEV;
+
+function pad(n: number): string {
+  return n.toFixed(0).padStart(4, ' ');
+}
+
+export function startTrace(sessionId: string): void {
+  if (!isDev()) return;
+  t0 = performance.now();
+  currentId = sessionId;
+  seq += 1;
+  // eslint-disable-next-line no-console
+  console.log(`[ss#${seq}] +${pad(0)}ms ── click sessionId=${sessionId.slice(0, 8)} ──`);
+}
+
+export function mark(label: string): void {
+  if (!isDev() || currentId === null) return;
+  const delta = performance.now() - t0;
+  // eslint-disable-next-line no-console
+  console.log(`[ss#${seq}] +${pad(delta)}ms ${label}`);
+}
+
+// Log only when the mark belongs to the most recent switch. Useful for
+// component effects that may still fire for previous sessions.
+export function markForSession(sessionId: string, label: string): void {
+  if (!isDev() || sessionId !== currentId) return;
+  mark(label);
+}

--- a/apps/desktop/src/shared/utils/session-switch-trace.ts
+++ b/apps/desktop/src/shared/utils/session-switch-trace.ts
@@ -21,6 +21,7 @@ export function startTrace(sessionId: string): void {
   seq += 1;
   // eslint-disable-next-line no-console
   console.log(`[ss#${seq}] +${pad(0)}ms ── click sessionId=${sessionId.slice(0, 8)} ──`);
+  startWatchdog();
 }
 
 export function mark(label: string): void {
@@ -35,4 +36,47 @@ export function mark(label: string): void {
 export function markForSession(sessionId: string, label: string): void {
   if (!isDev() || sessionId !== currentId) return;
   mark(label);
+}
+
+// Watchdog: stamps the main thread every 50ms for a short window after the
+// click. Long gaps between consecutive watchdog stamps mean the main thread
+// was BLOCKED for that long. Use this to distinguish "wall-clock waiting on
+// async work" from "main thread frozen". Stops after WATCHDOG_DURATION_MS.
+const WATCHDOG_INTERVAL_MS = 50;
+const WATCHDOG_DURATION_MS = 3000;
+
+let watchdogTimer: number | null = null;
+let lastTick = 0;
+
+function tickWatchdog(): void {
+  if (!isDev()) return;
+  const now = performance.now();
+  const elapsed = now - t0;
+  if (elapsed > WATCHDOG_DURATION_MS) {
+    stopWatchdog();
+    return;
+  }
+  const gap = lastTick > 0 ? now - lastTick : 0;
+  lastTick = now;
+  // Only log when the gap is suspicious — busy main thread couldn't fire
+  // the interval on time. Threshold = 2× interval (under normal browser
+  // load, intervals can drift to ~60-70ms; >100ms is real blocking).
+  if (gap > WATCHDOG_INTERVAL_MS * 2) {
+    // eslint-disable-next-line no-console
+    console.log(`[ss#${seq}] +${pad(elapsed)}ms ⚠️  main thread blocked ${gap.toFixed(0)}ms`);
+  }
+}
+
+function startWatchdog(): void {
+  if (!isDev()) return;
+  stopWatchdog();
+  lastTick = performance.now();
+  watchdogTimer = window.setInterval(tickWatchdog, WATCHDOG_INTERVAL_MS);
+}
+
+function stopWatchdog(): void {
+  if (watchdogTimer !== null) {
+    window.clearInterval(watchdogTimer);
+    watchdogTimer = null;
+  }
 }

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import type {
   Agent,
   ContextSlot,
@@ -116,8 +116,9 @@ const EMPTY_FILES_TOUCHED: FilesTouched = { paths: [], count: 0 };
  * transcript events. Slot-based 'files_touched' lags until the summarizer
  * runs — this gives a live count regardless of summarizer state.
  *
- * Selectors return raw slices so Zustand's Object.is check is stable; the
- * derived list is memoized in React.
+ * Subscribes to per-session slices (phaseRuns, worktrees) and the full transcripts
+ * map, but stabilises the output via ref comparison so the component only re-renders
+ * when the actual file list changes — not on every streaming event.
  */
 export const useFilesTouched = (sessionId: SessionId | null): FilesTouched => {
   const phaseRuns = useAppStore((s) =>
@@ -127,6 +128,7 @@ export const useFilesTouched = (sessionId: SessionId | null): FilesTouched => {
   const workingDir = useAppStore((s) =>
     sessionId ? ((s.sessionWorktrees[sessionId] ?? [])[0] ?? null) : null,
   );
+  const prev = useRef<FilesTouched>(EMPTY_FILES_TOUCHED);
   return useMemo(() => {
     if (!phaseRuns || phaseRuns.length === 0) return EMPTY_FILES_TOUCHED;
     const seen = new Set<string>();
@@ -142,7 +144,15 @@ export const useFilesTouched = (sessionId: SessionId | null): FilesTouched => {
       }
     }
     if (ordered.length === 0) return EMPTY_FILES_TOUCHED;
-    return { paths: ordered, count: ordered.length };
+    const next: FilesTouched = { paths: ordered, count: ordered.length };
+    if (
+      prev.current.count === next.count &&
+      prev.current.paths.every((p, i) => p === next.paths[i])
+    ) {
+      return prev.current;
+    }
+    prev.current = next;
+    return next;
   }, [phaseRuns, transcripts, workingDir]);
 };
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -207,6 +207,11 @@ import {
 import { detectDrift } from '../features/session/drift-detection';
 import { readArchivedSet } from '../features/session/archived-storage';
 import {
+  mark as ssMark,
+  markForSession as ssMarkFor,
+  startTrace as ssStart,
+} from '../shared/utils/session-switch-trace';
+import {
   addPlanConsumption as invokeAddPlanConsumption,
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
   listPlansForSession as invokeListPlansForSession,
@@ -1331,6 +1336,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // the action so callers can pass the action ref directly (stable ref
     // helps memoized rows skip re-renders on session-switch clicks).
     if (get().currentSessionId === id) return;
+    if (id) ssStart(id);
     // Immediately swap the visible session so the UI doesn't freeze while
     // heavy per-session data loads. Each block (agents/transcript/telemetry/
     // slots/plans/summary) loads independently and flips its own loading flag
@@ -1393,6 +1399,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
     };
     if (import.meta.env.DEV)
       console.log(`[perf] session:switchSync ${(performance.now() - tSwitch).toFixed(0)}ms`); // eslint-disable-line no-console
+    ssMark(
+      `store.setCurrentSession sync done (cached: agents=${!!cached?.agents} slots=${!!cached?.slots} telemetry=${!!cached?.telemetry} plans=${!!cached?.plans})`,
+    );
 
     const markDone = (key: keyof SessionLoadingFlags): void => {
       set((state) => {
@@ -1411,9 +1420,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
       // Telemetry records are NOT in the batch — deferred via requestIdleCallback
       // below so first paint shows agents + summary + slots immediately.
       const endHydrate = perf('hydrate');
+      ssMarkFor(id, 'batch sessionHydrate dispatched');
       void sessionHydrate(id)
         .then((hydration) => {
           if (get().currentSessionId !== id) return;
+          ssMarkFor(id, 'batch sessionHydrate resolved');
 
           // Summary (always set — was reset to null above)
           set((state) =>
@@ -1522,9 +1533,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
       idleTelemetryLoads.set(id, controller);
 
       const endIdleTelemetry = perf('idleTelemetry');
+      ssMarkFor(id, 'idle telemetry scheduled');
       scheduleIdle(() => {
         if (controller.signal.aborted) return;
         if (get().currentSessionId !== id) return;
+        ssMarkFor(id, 'idle telemetry fetch start');
         void listTelemetryForSession(tauriDatabase, id)
           .then((records) => {
             if (controller.signal.aborted) return;
@@ -1542,6 +1555,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
           .catch(() => {})
           .finally(() => {
             endIdleTelemetry();
+            ssMarkFor(id, 'idle telemetry done');
             markDone('telemetry');
             if (idleTelemetryLoads.get(id) === controller) {
               idleTelemetryLoads.delete(id);
@@ -1553,6 +1567,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // Plans: separate IPC (lives in planner.rs, different Rust module)
     if (!cached?.plans) {
       const endPlans = perf('plans');
+      ssMarkFor(id, 'plans dispatched');
       void (async (): Promise<ReadonlyArray<PlanWithCount>> => {
         try {
           return await invokeListPlansForSession(id);
@@ -1568,6 +1583,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         .catch(() => {})
         .finally(() => {
           endPlans();
+          ssMarkFor(id, 'plans done');
           markDone('plans');
         });
     }
@@ -1576,9 +1592,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // so on first click we have to fetch the worktree info ourselves. Active
     // sessions already have it cached from setCurrentWorkspace.
     if (get().sessionWorktrees[id] === undefined) {
+      ssMarkFor(id, 'lazy worktree fetch dispatched');
       void listWorktreesForSession(tauriDatabase, id)
         .then((rows) => {
           if (get().currentSessionId !== id) return;
+          ssMarkFor(id, `lazy worktree fetch resolved (${rows.length} rows)`);
           if (rows.length === 0) return;
           const paths = rows.map((r) => r.worktreePath);
           const primaryRow = rows[0];

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -652,6 +652,12 @@ export const summarizerQueues = new Map<SessionId, SummarizerTaskQueue>();
 // switch (cancel stale work) and on workspace switch (clear all).
 const idleTelemetryLoads = new Map<SessionId, AbortController>();
 
+// In-flight selectAgent calls keyed by agentId. React StrictMode mounts every
+// effect twice in dev, which previously fired two parallel transcript fetches
+// per session switch — duplicate DB load + duplicate JSON.parse storm. The
+// shared Promise dedupes them; both callers `await` the same fetch.
+const inFlightSelectAgent = new Map<AgentId, Promise<void>>();
+
 // Merges a freshly-fetched telemetry snapshot with the in-memory slice,
 // preserving any records inserted while the idle load was in flight
 // (e.g. usage events from an active turn). Dedupes by stable record id and
@@ -3267,119 +3273,140 @@ export const useAppStore = create<AppStore>((set, get) => ({
   },
 
   selectAgent: async (sessionId, agentId) => {
-    // Stamp `lastViewedAt` on both the previously-selected agent (capturing
-    // "user was looking at it until now") and the newly-selected agent. The
-    // unread selector additionally treats the currently-selected agent as
-    // viewed, so no visible flicker while you're actually on the row.
-    const stampedAt = new Date().toISOString() as IsoDateTime;
-    const prevAgentId = get().selectedAgentId[sessionId] ?? null;
-    const stampAgents = new Set<AgentId>([agentId]);
-    if (prevAgentId && prevAgentId !== agentId) stampAgents.add(prevAgentId);
+    // Dedupe parallel calls — StrictMode (dev) fires effects twice, which
+    // doubled the transcript fetch + JSON.parse cost on every session switch.
+    const inFlight = inFlightSelectAgent.get(agentId);
+    if (inFlight) return inFlight;
+    const run = (async () => {
+      // Stamp `lastViewedAt` on both the previously-selected agent (capturing
+      // "user was looking at it until now") and the newly-selected agent. The
+      // unread selector additionally treats the currently-selected agent as
+      // viewed, so no visible flicker while you're actually on the row.
+      const stampedAt = new Date().toISOString() as IsoDateTime;
+      const prevAgentId = get().selectedAgentId[sessionId] ?? null;
+      const stampAgents = new Set<AgentId>([agentId]);
+      if (prevAgentId && prevAgentId !== agentId) stampAgents.add(prevAgentId);
 
-    for (const id of stampAgents) {
-      void invokeSessionMarkViewed(id, stampedAt).catch(() => undefined);
-    }
+      for (const id of stampAgents) {
+        void invokeSessionMarkViewed(id, stampedAt).catch(() => undefined);
+      }
 
-    const stampRuns = (runs: ReadonlyArray<Agent>): ReadonlyArray<Agent> =>
-      runs.map((s) => (stampAgents.has(s.id) ? { ...s, lastViewedAt: stampedAt } : s));
+      const stampRuns = (runs: ReadonlyArray<Agent>): ReadonlyArray<Agent> =>
+        runs.map((s) => (stampAgents.has(s.id) ? { ...s, lastViewedAt: stampedAt } : s));
 
-    const cached = get().transcripts[agentId];
-    if (cached) {
-      if (import.meta.env.DEV) console.log(`[perf] selectAgent:${agentId} cached`); // eslint-disable-line no-console
+      const cached = get().transcripts[agentId];
+      if (cached) {
+        if (import.meta.env.DEV) console.log(`[perf] selectAgent:${agentId} cached`); // eslint-disable-line no-console
+        set((state) => {
+          const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
+          return {
+            selectedAgentId: { ...state.selectedAgentId, [sessionId]: agentId },
+            sessionLoading: {
+              ...state.sessionLoading,
+              [sessionId]: { ...current, transcript: false },
+            },
+            sessionPhaseRuns: {
+              ...state.sessionPhaseRuns,
+              [sessionId]: stampRuns(state.sessionPhaseRuns[sessionId] ?? []),
+            },
+          };
+        });
+        void get().refreshUnreadWorkspaces();
+        return;
+      }
       set((state) => {
         const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
         return {
           selectedAgentId: { ...state.selectedAgentId, [sessionId]: agentId },
           sessionLoading: {
             ...state.sessionLoading,
-            [sessionId]: { ...current, transcript: false },
-          },
-          sessionPhaseRuns: {
-            ...state.sessionPhaseRuns,
-            [sessionId]: stampRuns(state.sessionPhaseRuns[sessionId] ?? []),
+            [sessionId]: { ...current, transcript: true },
           },
         };
       });
-      void get().refreshUnreadWorkspaces();
-      return;
-    }
-    set((state) => {
-      const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
-      return {
-        selectedAgentId: { ...state.selectedAgentId, [sessionId]: agentId },
-        sessionLoading: {
-          ...state.sessionLoading,
-          [sessionId]: { ...current, transcript: true },
-        },
-      };
-    });
-    // Two-phase load: phase 1 fetches the recent slice fast (~50-150ms),
-    // unblocks the chat skeleton, then phase 2 fills in older history in the
-    // background. Sessions with <= INITIAL_LIMIT events get only phase 1.
-    const INITIAL_LIMIT = 50;
-    const tInitial = performance.now();
-    try {
-      const [messages, events] = await Promise.all([
-        listMessagesForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
-        listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
-      ]);
-      if (import.meta.env.DEV)
-        console.log(
-          `[perf] selectAgent:initial ${(performance.now() - tInitial).toFixed(0)}ms (${events.length} events)`,
-        ); // eslint-disable-line no-console
-      set((state) => {
-        const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
-        return {
-          transcripts: { ...state.transcripts, [agentId]: events },
-          messages: { ...state.messages, [sessionId]: messages },
-          sessionLoading: {
-            ...state.sessionLoading,
-            [sessionId]: { ...current, transcript: false },
-          },
-          sessionPhaseRuns: {
-            ...state.sessionPhaseRuns,
-            [sessionId]: stampRuns(state.sessionPhaseRuns[sessionId] ?? []),
-          },
-        };
-      });
-      void get().refreshUnreadWorkspaces();
-      // Phase 2: only when the recent slice was at the limit (more older
-      // history likely exists). Fired non-awaited so the click flow returns.
-      if (events.length === INITIAL_LIMIT) {
-        const tFull = performance.now();
-        void Promise.all([
-          listMessagesForAgent(tauriDatabase, agentId),
-          listTurnEventsForAgent(tauriDatabase, agentId),
-        ])
-          .then(([fullMessages, fullEvents]) => {
-            if (import.meta.env.DEV)
-              console.log(
-                `[perf] selectAgent:full ${(performance.now() - tFull).toFixed(0)}ms (${fullEvents.length} events)`,
-              ); // eslint-disable-line no-console
-            // Replace only if the agent is still selected and the in-store
-            // slice hasn't grown past the full snapshot via streaming.
-            set((state) => {
-              const current = state.transcripts[agentId];
-              if (current && current.length > fullEvents.length) return {};
-              return {
-                transcripts: { ...state.transcripts, [agentId]: fullEvents },
-                messages: { ...state.messages, [sessionId]: fullMessages },
-              };
-            });
-          })
-          .catch(() => {});
+      // Two-phase load: phase 1 fetches the recent slice fast (~50-150ms),
+      // unblocks the chat skeleton, then phase 2 fills in older history in the
+      // background. Sessions with <= INITIAL_LIMIT events get only phase 1.
+      const INITIAL_LIMIT = 50;
+      const tInitial = performance.now();
+      try {
+        const [messages, events] = await Promise.all([
+          listMessagesForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
+          listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
+        ]);
+        if (import.meta.env.DEV)
+          console.log(
+            `[perf] selectAgent:initial ${(performance.now() - tInitial).toFixed(0)}ms (${events.length} events)`,
+          ); // eslint-disable-line no-console
+        set((state) => {
+          const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
+          return {
+            transcripts: { ...state.transcripts, [agentId]: events },
+            messages: { ...state.messages, [sessionId]: messages },
+            sessionLoading: {
+              ...state.sessionLoading,
+              [sessionId]: { ...current, transcript: false },
+            },
+            sessionPhaseRuns: {
+              ...state.sessionPhaseRuns,
+              [sessionId]: stampRuns(state.sessionPhaseRuns[sessionId] ?? []),
+            },
+          };
+        });
+        void get().refreshUnreadWorkspaces();
+        // Phase 2: only when the recent slice was at the limit (more older
+        // history likely exists). Deferred to a browser-idle frame — the parse
+        // is JSON.parse-per-row and was eating 800-1300ms on the main thread
+        // right after the panel skeleton rendered. Idle-deferring keeps clicks
+        // and scrolls responsive while the backfill catches up.
+        if (events.length === INITIAL_LIMIT) {
+          scheduleIdle(() => {
+            if (get().selectedAgentId[sessionId] !== agentId) return;
+            const tFull = performance.now();
+            void Promise.all([
+              listMessagesForAgent(tauriDatabase, agentId),
+              listTurnEventsForAgent(tauriDatabase, agentId),
+            ])
+              .then(([fullMessages, fullEvents]) => {
+                if (import.meta.env.DEV)
+                  console.log(
+                    `[perf] selectAgent:full ${(performance.now() - tFull).toFixed(0)}ms (${fullEvents.length} events)`,
+                  ); // eslint-disable-line no-console
+                // Replace only if the agent is still selected and the in-store
+                // slice hasn't grown past the full snapshot via streaming.
+                set((state) => {
+                  if (state.selectedAgentId[sessionId] !== agentId) return {};
+                  const current = state.transcripts[agentId];
+                  if (current && current.length > fullEvents.length) return {};
+                  return {
+                    transcripts: { ...state.transcripts, [agentId]: fullEvents },
+                    messages: { ...state.messages, [sessionId]: fullMessages },
+                  };
+                });
+              })
+              .catch(() => {});
+          });
+        }
+      } catch (err) {
+        set((state) => {
+          const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
+          return {
+            sessionLoading: {
+              ...state.sessionLoading,
+              [sessionId]: { ...current, transcript: false },
+            },
+          };
+        });
+        throw err;
       }
-    } catch (err) {
-      set((state) => {
-        const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
-        return {
-          sessionLoading: {
-            ...state.sessionLoading,
-            [sessionId]: { ...current, transcript: false },
-          },
-        };
-      });
-      throw err;
+    })();
+    inFlightSelectAgent.set(agentId, run);
+    try {
+      await run;
+    } finally {
+      if (inFlightSelectAgent.get(agentId) === run) {
+        inFlightSelectAgent.delete(agentId);
+      }
     }
   },
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -205,6 +205,7 @@ import {
   type AgentKind,
 } from '../features/session/agent-kind';
 import { detectDrift } from '../features/session/drift-detection';
+import { readArchivedSet } from '../features/session/archived-storage';
 import {
   addPlanConsumption as invokeAddPlanConsumption,
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
@@ -1279,21 +1280,26 @@ export const useAppStore = create<AppStore>((set, get) => ({
           return { ...s, state: idleState, updatedAt: recoveryNow };
         }),
       );
+      // Archived sessions get a minimal render (title + settings icon) and load
+      // their full state only on click. Skip the per-session warmup for them —
+      // saves N IPC calls × 2 queries on workspaces with many archives.
+      const archivedSet = readArchivedSet();
+      const activeForWarmup = sessions.filter((s) => !archivedSet[s.id]);
       const [worktreeRows, phaseRunsPerTask] = await Promise.all([
-        Promise.all(sessions.map((s) => listWorktreesForSession(tauriDatabase, s.id))),
-        // Eager-load agents (phase runs) for every session in this workspace. The
+        Promise.all(activeForWarmup.map((s) => listWorktreesForSession(tauriDatabase, s.id))),
+        // Eager-load agents (phase runs) for every NON-ARCHIVED session. The
         // unread indicators on workspace- and session-rows derive from each
         // agent's `lastFinishedAt` vs `lastViewedAt` columns, and those are
         // only inspected once we have the agent rows in memory. Without this
         // prefetch, the sidebar would only know about agents for sessions the
         // user has explicitly opened — yellow dots vanish on workspace switch.
-        Promise.all(sessions.map((s) => invokePhaseRunList(s.id))),
+        Promise.all(activeForWarmup.map((s) => invokePhaseRunList(s.id))),
       ]);
       const sessionWorktrees: Record<string, ReadonlyArray<string>> = {};
       const sessionBranches: Record<string, string> = {};
       const sessionPhaseRuns: Record<string, ReadonlyArray<Agent>> = {};
-      for (let i = 0; i < sessions.length; i++) {
-        const s = sessions[i]!;
+      for (let i = 0; i < activeForWarmup.length; i++) {
+        const s = activeForWarmup[i]!;
         const rows = worktreeRows[i]!;
         if (rows.length > 0) {
           sessionWorktrees[s.id] = rows.map((r) => r.worktreePath);
@@ -1564,6 +1570,26 @@ export const useAppStore = create<AppStore>((set, get) => ({
           endPlans();
           markDone('plans');
         });
+    }
+
+    // Worktree/branch lazy-load: archived sessions skip the workspace warmup,
+    // so on first click we have to fetch the worktree info ourselves. Active
+    // sessions already have it cached from setCurrentWorkspace.
+    if (get().sessionWorktrees[id] === undefined) {
+      void listWorktreesForSession(tauriDatabase, id)
+        .then((rows) => {
+          if (get().currentSessionId !== id) return;
+          if (rows.length === 0) return;
+          const paths = rows.map((r) => r.worktreePath);
+          const primaryRow = rows[0];
+          set((state) => ({
+            sessionWorktrees: { ...state.sessionWorktrees, [id]: paths },
+            sessionBranches: primaryRow
+              ? { ...state.sessionBranches, [id]: primaryRow.branch }
+              : state.sessionBranches,
+          }));
+        })
+        .catch(() => {});
     }
   },
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -1360,12 +1360,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const perf = (op: string) => {
       const t0 = performance.now();
       return () => {
-        // eslint-disable-next-line no-console
-        console.log(`[perf] session:${op} ${(performance.now() - t0).toFixed(0)}ms`);
+        if (import.meta.env.DEV)
+          console.log(`[perf] session:${op} ${(performance.now() - t0).toFixed(0)}ms`); // eslint-disable-line no-console
       };
     };
-    // eslint-disable-next-line no-console
-    console.log(`[perf] session:switchSync ${(performance.now() - tSwitch).toFixed(0)}ms`);
+    if (import.meta.env.DEV)
+      console.log(`[perf] session:switchSync ${(performance.now() - tSwitch).toFixed(0)}ms`); // eslint-disable-line no-console
 
     const markDone = (key: keyof SessionLoadingFlags): void => {
       set((state) => {
@@ -3206,8 +3206,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     const cached = get().transcripts[agentId];
     if (cached) {
-      // eslint-disable-next-line no-console
-      console.log(`[perf] selectAgent:${agentId} cached`);
+      if (import.meta.env.DEV) console.log(`[perf] selectAgent:${agentId} cached`); // eslint-disable-line no-console
       set((state) => {
         const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
         return {
@@ -3245,10 +3244,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
         listMessagesForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
         listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
       ]);
-      // eslint-disable-next-line no-console
-      console.log(
-        `[perf] selectAgent:initial ${(performance.now() - tInitial).toFixed(0)}ms (${events.length} events)`,
-      );
+      if (import.meta.env.DEV)
+        console.log(
+          `[perf] selectAgent:initial ${(performance.now() - tInitial).toFixed(0)}ms (${events.length} events)`,
+        ); // eslint-disable-line no-console
       set((state) => {
         const current = state.sessionLoading[sessionId] ?? EMPTY_LOADING;
         return {
@@ -3274,10 +3273,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
           listTurnEventsForAgent(tauriDatabase, agentId),
         ])
           .then(([fullMessages, fullEvents]) => {
-            // eslint-disable-next-line no-console
-            console.log(
-              `[perf] selectAgent:full ${(performance.now() - tFull).toFixed(0)}ms (${fullEvents.length} events)`,
-            );
+            if (import.meta.env.DEV)
+              console.log(
+                `[perf] selectAgent:full ${(performance.now() - tFull).toFixed(0)}ms (${fullEvents.length} events)`,
+              ); // eslint-disable-line no-console
             // Replace only if the agent is still selected and the in-store
             // slice hasn't grown past the full snapshot via streaming.
             set((state) => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -126,7 +126,7 @@ import {
   computeCursorCostUsd,
   extractPlanFromMarker,
 } from '@kay-am/core';
-import { runDbMigrations, tauriDatabase, wipeDb } from '../shared/lib/db';
+import { runDbMigrations, sessionHydrate, tauriDatabase, wipeDb } from '../shared/lib/db';
 import {
   buildProviderList,
   checkProviderAuth,
@@ -1377,51 +1377,123 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     };
 
-    // Summary
-    const endSummary = perf('summary');
-    void summarizeSessionTelemetry(tauriDatabase, id)
-      .then((summary) => {
-        set((state) => (state.currentSessionId === id ? { sessionSummary: summary } : {}));
-      })
-      .catch(() => {})
-      .finally(() => {
-        endSummary();
-        markDone('summary');
-      });
+    const needsBatch = !cached?.agents || !cached?.telemetry || !cached?.slots;
 
-    // Telemetry
-    if (!cached?.telemetry) {
-      const endTelemetry = perf('telemetry');
-      void listTelemetryForSession(tauriDatabase, id)
-        .then((telemetry) => {
-          set((state) => ({
-            sessionTelemetry: { ...state.sessionTelemetry, [id]: telemetry },
-          }));
-        })
-        .catch(() => {})
-        .finally(() => {
-          endTelemetry();
+    if (needsBatch) {
+      // Single IPC call replaces 4+ separate queries through the DB mutex.
+      const endHydrate = perf('hydrate');
+      void sessionHydrate(id)
+        .then((hydration) => {
+          if (get().currentSessionId !== id) return;
+
+          // Summary (always set — was reset to null above)
+          set((state) =>
+            state.currentSessionId === id ? { sessionSummary: hydration.telemetrySummary } : {},
+          );
+          markDone('summary');
+
+          // Telemetry
+          if (!cached?.telemetry) {
+            set((state) => ({
+              sessionTelemetry: { ...state.sessionTelemetry, [id]: hydration.telemetry },
+            }));
+          }
           markDone('telemetry');
-        });
-    }
 
-    // Context slots
-    if (!cached?.slots) {
-      const endSlots = perf('slots');
-      void listContextSlotsForSession(tauriDatabase, id)
-        .then((slots) => {
-          set((state) => ({
-            sessionSlots: { ...state.sessionSlots, [id]: slots },
-          }));
+          // Context slots
+          if (!cached?.slots) {
+            set((state) => ({
+              sessionSlots: { ...state.sessionSlots, [id]: hydration.slots },
+            }));
+          }
+          markDone('slots');
+
+          // Agents + run ID seeding
+          if (!cached?.agents) {
+            const agents = hydration.agents;
+            const agentRunIds = hydration.agentRunIds;
+            const previouslySelected = get().selectedAgentId[id] ?? null;
+            const sortedAgents = [...agents].sort((a, b) => a.ordinal - b.ordinal);
+            const fallbackAgent = sortedAgents[sortedAgents.length - 1] ?? null;
+            const selectedAgent =
+              (previouslySelected && agents.find((a) => a.id === previouslySelected)) ||
+              fallbackAgent;
+
+            const seededHistory: Record<string, ReadonlyArray<ProviderRunId>> = {};
+            const seededTurnState: Record<string, TurnState> = {};
+            const session = get().sessions.find((s) => s.id === id);
+            const sessionState =
+              session?.state ??
+              ({ kind: 'idle', lastActivityAt: new Date().toISOString() } as TurnState);
+            for (const agent of agents) {
+              const historical = agentRunIds.get(agent.id) ?? [];
+              const merged: ProviderRunId[] = [...historical];
+              if (agent.runId && !merged.includes(agent.runId)) merged.push(agent.runId);
+              if (merged.length > 0) {
+                seededHistory[agent.id] = merged;
+              }
+              if (agent.status === 'running' && agent.runId) {
+                seededTurnState[agent.id] = {
+                  kind: 'running',
+                  runId: agent.runId,
+                  startedAt: agent.startedAt ?? (new Date().toISOString() as IsoDateTime),
+                };
+              } else if (agent.status === 'failed') {
+                seededTurnState[agent.id] = {
+                  kind: 'error',
+                  message: 'agent failed',
+                  failedAt: agent.completedAt ?? (new Date().toISOString() as IsoDateTime),
+                };
+              } else {
+                seededTurnState[agent.id] =
+                  sessionState.kind === 'ended'
+                    ? sessionState
+                    : { kind: 'idle', lastActivityAt: new Date().toISOString() as IsoDateTime };
+              }
+            }
+
+            set((state) => ({
+              sessionPhaseRuns: { ...state.sessionPhaseRuns, [id]: agents },
+              selectedAgentId: {
+                ...state.selectedAgentId,
+                [id]: selectedAgent?.id ?? null,
+              },
+              agentRunHistory: { ...state.agentRunHistory, ...seededHistory },
+              agentTurnState: { ...state.agentTurnState, ...seededTurnState },
+            }));
+            markDone('agents');
+
+            if (!selectedAgent) {
+              set((state) => ({
+                messages: { ...state.messages, [id]: [] as ReadonlyArray<Message> },
+              }));
+              markDone('transcript');
+            }
+          }
+        })
+        .catch(() => {
+          markDone('summary');
+          markDone('telemetry');
+          markDone('slots');
+          markDone('agents');
+          markDone('transcript');
+        })
+        .finally(() => endHydrate());
+    } else {
+      // Hot revisit — all slices cached. Only summary needs refresh.
+      const endSummary = perf('summary');
+      void summarizeSessionTelemetry(tauriDatabase, id)
+        .then((summary) => {
+          set((state) => (state.currentSessionId === id ? { sessionSummary: summary } : {}));
         })
         .catch(() => {})
         .finally(() => {
-          endSlots();
-          markDone('slots');
+          endSummary();
+          markDone('summary');
         });
     }
 
-    // Plans
+    // Plans: separate IPC (lives in planner.rs, different Rust module)
     if (!cached?.plans) {
       const endPlans = perf('plans');
       void (async (): Promise<ReadonlyArray<PlanWithCount>> => {
@@ -1441,98 +1513,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
           endPlans();
           markDone('plans');
         });
-    }
-
-    // Agents only: transcript is loaded lazily by ChatView when an agent is
-    // selected (via selectAgent). Keeps session switch fast — no per-agent
-    // history fetch blocks the UI.
-    if (cached?.agents) {
-      // Cached: phase runs + selected agent are already in store. transcript
-      // flag still gets cleared by ChatView's selectAgent effect (cached or
-      // fresh). Nothing else to do.
-    } else {
-      const endAgents = perf('agents+runIds');
-      const endPhaseRunList = perf('agents:phaseRunList');
-      const endRunIds = perf('agents:runIds');
-      void Promise.all([
-        invokePhaseRunList(id).finally(() => endPhaseRunList()),
-        listAgentRunIdsForSession(tauriDatabase, id).finally(() => endRunIds()),
-      ])
-        .then(([agents, agentRunIds]) => {
-          const previouslySelected = get().selectedAgentId[id] ?? null;
-          const sortedAgents = [...agents].sort((a, b) => a.ordinal - b.ordinal);
-          // Fresh entry defaults to the most recently created agent (highest
-          // ordinal). Chronologically the latest is the one the user is most
-          // likely returning to. Previous selection still wins on revisit.
-          const fallbackAgent = sortedAgents[sortedAgents.length - 1] ?? null;
-          const selectedAgent =
-            (previouslySelected && agents.find((a) => a.id === previouslySelected)) ||
-            fallbackAgent;
-
-          // Seed agentRunHistory with EVERY provider run an agent ever spawned,
-          // not just its latest. Recovered from turn_events (single source of
-          // truth post restart) so aggregate token/cost counters in the sidebar
-          // reflect the full agent lifetime — birth to death — instead of the
-          // last turn.
-          const seededHistory: Record<string, ReadonlyArray<ProviderRunId>> = {};
-          const seededTurnState: Record<string, TurnState> = {};
-          const session = get().sessions.find((s) => s.id === id);
-          const sessionState =
-            session?.state ??
-            ({ kind: 'idle', lastActivityAt: new Date().toISOString() } as TurnState);
-          for (const agent of agents) {
-            const historical = agentRunIds.get(agent.id) ?? [];
-            const merged: ProviderRunId[] = [...historical];
-            if (agent.runId && !merged.includes(agent.runId)) merged.push(agent.runId);
-            if (merged.length > 0) {
-              seededHistory[agent.id] = merged;
-            }
-            if (agent.status === 'running' && agent.runId) {
-              seededTurnState[agent.id] = {
-                kind: 'running',
-                runId: agent.runId,
-                startedAt: agent.startedAt ?? (new Date().toISOString() as IsoDateTime),
-              };
-            } else if (agent.status === 'failed') {
-              seededTurnState[agent.id] = {
-                kind: 'error',
-                message: 'agent failed',
-                failedAt: agent.completedAt ?? (new Date().toISOString() as IsoDateTime),
-              };
-            } else {
-              seededTurnState[agent.id] =
-                sessionState.kind === 'ended'
-                  ? sessionState
-                  : { kind: 'idle', lastActivityAt: new Date().toISOString() as IsoDateTime };
-            }
-          }
-
-          set((state) => ({
-            sessionPhaseRuns: { ...state.sessionPhaseRuns, [id]: agents },
-            selectedAgentId: {
-              ...state.selectedAgentId,
-              [id]: selectedAgent?.id ?? null,
-            },
-            agentRunHistory: { ...state.agentRunHistory, ...seededHistory },
-            agentTurnState: { ...state.agentTurnState, ...seededTurnState },
-          }));
-          markDone('agents');
-
-          // No selected agent → no chat to render → drop transcript flag now.
-          // With a selected agent, ChatView's effect calls selectAgent which
-          // owns the flag lifecycle from there.
-          if (!selectedAgent) {
-            set((state) => ({
-              messages: { ...state.messages, [id]: [] as ReadonlyArray<Message> },
-            }));
-            markDone('transcript');
-          }
-        })
-        .catch(() => {
-          markDone('agents');
-          markDone('transcript');
-        })
-        .finally(() => endAgents());
     }
   },
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -642,6 +642,25 @@ interface SummarizerTaskQueue {
 
 export const summarizerQueues = new Map<SessionId, SummarizerTaskQueue>();
 
+// Tracks in-flight idle-frame telemetry loads per session. Aborted on session
+// switch (cancel stale work) and on workspace switch (clear all).
+const idleTelemetryLoads = new Map<SessionId, AbortController>();
+
+// Merges a freshly-fetched telemetry snapshot with the in-memory slice,
+// preserving any records inserted while the idle load was in flight
+// (e.g. usage events from an active turn). Dedupes by stable record id and
+// orders by recordedAt ASC.
+function mergeTelemetry(
+  existing: ReadonlyArray<TelemetryRecord>,
+  fetched: ReadonlyArray<TelemetryRecord>,
+): ReadonlyArray<TelemetryRecord> {
+  if (existing.length === 0) return fetched;
+  const byId = new Map<string, TelemetryRecord>();
+  for (const r of fetched) byId.set(r.id, r);
+  for (const r of existing) if (!byId.has(r.id)) byId.set(r.id, r);
+  return [...byId.values()].sort((a, b) => Date.parse(a.recordedAt) - Date.parse(b.recordedAt));
+}
+
 // Run IDs cancelled by the user via cancelCurrentTurn. The stream-end
 // finalization in sendTurn checks this set and skips marking the agent as
 // `completed` — a cancelled turn must NOT count as a workflow step
@@ -1199,6 +1218,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // Option A: wipe all per-session maps unconditionally. Simpler than filtering by
     // workspaceId (Option B) and correct because setCurrentSession reloads from DB
     // on demand — the cache is cheap to rebuild, stale cross-workspace data is not.
+    for (const ctl of idleTelemetryLoads.values()) ctl.abort();
+    idleTelemetryLoads.clear();
     set({
       currentWorkspaceId: id,
       currentSessionId: null,
@@ -1377,10 +1398,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
     };
 
-    const needsBatch = !cached?.agents || !cached?.telemetry || !cached?.slots;
+    const needsBatch = !cached?.agents || !cached?.slots;
 
     if (needsBatch) {
-      // Single IPC call replaces 4+ separate queries through the DB mutex.
+      // Single IPC call replaces 3+ separate queries through the DB mutex.
+      // Telemetry records are NOT in the batch — deferred via requestIdleCallback
+      // below so first paint shows agents + summary + slots immediately.
       const endHydrate = perf('hydrate');
       void sessionHydrate(id)
         .then((hydration) => {
@@ -1391,14 +1414,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
             state.currentSessionId === id ? { sessionSummary: hydration.telemetrySummary } : {},
           );
           markDone('summary');
-
-          // Telemetry
-          if (!cached?.telemetry) {
-            set((state) => ({
-              sessionTelemetry: { ...state.sessionTelemetry, [id]: hydration.telemetry },
-            }));
-          }
-          markDone('telemetry');
 
           // Context slots
           if (!cached?.slots) {
@@ -1473,7 +1488,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
         })
         .catch(() => {
           markDone('summary');
-          markDone('telemetry');
           markDone('slots');
           markDone('agents');
           markDone('transcript');
@@ -1491,6 +1505,43 @@ export const useAppStore = create<AppStore>((set, get) => ({
           endSummary();
           markDone('summary');
         });
+    }
+
+    // Telemetry records: deferred to idle frame. UI shows session total
+    // (from summary in batch) immediately; per-agent costs and PricingDialog
+    // breakdown populate when the idle callback fires.
+    if (!cached?.telemetry) {
+      idleTelemetryLoads.get(id)?.abort();
+      const controller = new AbortController();
+      idleTelemetryLoads.set(id, controller);
+
+      const endIdleTelemetry = perf('idleTelemetry');
+      scheduleIdle(() => {
+        if (controller.signal.aborted) return;
+        if (get().currentSessionId !== id) return;
+        void listTelemetryForSession(tauriDatabase, id)
+          .then((records) => {
+            if (controller.signal.aborted) return;
+            if (get().currentSessionId !== id) return;
+            set((state) => {
+              const existing = state.sessionTelemetry[id] ?? [];
+              return {
+                sessionTelemetry: {
+                  ...state.sessionTelemetry,
+                  [id]: mergeTelemetry(existing, records),
+                },
+              };
+            });
+          })
+          .catch(() => {})
+          .finally(() => {
+            endIdleTelemetry();
+            markDone('telemetry');
+            if (idleTelemetryLoads.get(id) === controller) {
+              idleTelemetryLoads.delete(id);
+            }
+          });
+      });
     }
 
     // Plans: separate IPC (lives in planner.rs, different Rust module)
@@ -3049,6 +3100,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // Optimistic UI update
     const prevWorkspaces = state.workspaces;
     const wasCurrentWorkspace = state.currentWorkspaceId === id;
+    if (wasCurrentWorkspace) {
+      for (const ctl of idleTelemetryLoads.values()) ctl.abort();
+      idleTelemetryLoads.clear();
+    }
     set((s) => ({
       workspaces: s.workspaces.filter((w) => w.id !== id),
       ...(wasCurrentWorkspace

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -33,7 +33,6 @@ import {
   listContextSlotHistory,
   listMessagesForAgent,
   listMessagesForSession,
-  listTurnEventsForAgent,
   listTurnEventsForSession,
   listAgentRunIdsForSession,
   listSessionsForWorkspace,
@@ -206,6 +205,7 @@ import {
 } from '../features/session/agent-kind';
 import { detectDrift } from '../features/session/drift-detection';
 import { readArchivedSet } from '../features/session/archived-storage';
+import { loadTurnEventsForAgent } from '../features/chat/utils/load-turn-events';
 import {
   mark as ssMark,
   markForSession as ssMarkFor,
@@ -1906,7 +1906,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   loadTranscript: async (agentId, sessionId) => {
     const [messages, events] = await Promise.all([
       listMessagesForAgent(tauriDatabase, agentId),
-      listTurnEventsForAgent(tauriDatabase, agentId),
+      loadTurnEventsForAgent(agentId),
     ]);
     set((state) => ({
       messages: { ...state.messages, [sessionId]: messages },
@@ -3332,7 +3332,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       try {
         const [messages, events] = await Promise.all([
           listMessagesForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
-          listTurnEventsForAgent(tauriDatabase, agentId, { limit: INITIAL_LIMIT }),
+          loadTurnEventsForAgent(agentId, { limit: INITIAL_LIMIT }),
         ]);
         if (import.meta.env.DEV)
           console.log(
@@ -3365,7 +3365,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             const tFull = performance.now();
             void Promise.all([
               listMessagesForAgent(tauriDatabase, agentId),
-              listTurnEventsForAgent(tauriDatabase, agentId),
+              loadTurnEventsForAgent(agentId),
             ])
               .then(([fullMessages, fullEvents]) => {
                 if (import.meta.env.DEV)

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { Activity, CheckCheck, FileEdit, HelpCircle, Target, type LucideIcon } from 'lucide-react';
 import { cn } from '../cn';
 
@@ -618,7 +618,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
 }
 
 export function Markdown({ text, className }: MarkdownProps) {
-  const blocks = parseBlocks(text);
+  const blocks = useMemo(() => parseBlocks(text), [text]);
   return (
     <div className={cn('space-y-2 text-base text-foreground/85', className)}>
       {blocks.map(renderBlock)}


### PR DESCRIPTION
## Summary

Session switching froze the UI for seconds with 3-4+ sessions. Root causes: cascading Zustand re-renders, missing memoization, synchronous main-thread work, zero code-splitting, 6 serialized IPC calls through a single DB mutex, eager loading of telemetry records, eager loading of archived sessions, **and the heavy synchronous mount of ChatView (517 lines) + ContextPanel (1233 lines) blocking the main thread on every fresh session switch**.

### Commit breakdown

1. **Narrow Zustand subscriptions** (`a320411`)
2. **Add missing memoization** (`2bb7054`)
3. **startTransition + AgentRow memo** (`a201324`)
4. **Gate perf console.log behind DEV** (`4d03dd5`)
5. **Lazy-load heavy dialogs** (`b53f9db`) — ~4k lines of dialog code
6. **Web Worker for reduceTranscript** (`dd71244`)
7. **Batch session hydration** (`6401e38`) — single Tauri command, SQL GROUP_CONCAT
8. **Defer telemetry records to idle** (`f477e14`) — abortable, race-safe merge
9. **Minimal archived session rendering** (`3c14808`) — skip warmup, title+settings only
10. **Skeleton + idle mount for chat/context** (`db07d82`) — Suspense-style mount

### #10 — the actual fix for "feels frozen for seconds"

`useDeferredValue` kept the previous panel visible during the deferred render. React still had to mount the new heavy tree in one synchronous chunk during the low-priority render — main thread blocked, user saw stale content.

New flow:
- Click session → `KeepAliveChatPanel` for new id mounts **instantly** with a `<ChatViewSkeleton />`
- `useIdleMounted` hook waits for `requestIdleCallback` (200ms timeout fallback)
- When the browser is genuinely idle → real `<ChatView>` mounts
- LRU sessions skip the skeleton entirely (component instance persists)

The click is **always acknowledged with visible UI change**. Heavy mount happens when the browser yields.

## Test plan

- [ ] Switch between 4+ sessions rapidly — skeleton flashes briefly, no freeze
- [ ] LRU revisits (last 5) — instant, no skeleton
- [ ] DEV console: `session:hydrate` then `session:idleTelemetry` later
- [ ] Sidebar with many agents: names + status immediately, costs during idle
- [ ] Open PricingDialog mid-idle: skeleton then data
- [ ] Archive a session: row shrinks to title + settings icon
- [ ] Click archived session: opens normally, lazy-loads worktree
- [ ] `cargo check` + `pnpm tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)