### PR TITLE
feat(desktop): two-tier commit gate for resolve button

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -81,6 +81,8 @@ describe('spawn-from-comment', () => {
     expect(args.initialPrompt).toContain('src/foo.ts:42');
     expect(args.initialPrompt).toContain('this should use a helper');
     expect(args.initialPrompt).toContain('#9108');
+    expect(args.initialPrompt).toContain('EASY');
+    expect(args.initialPrompt).toContain('NON-TRIVIAL');
   });
 
   it('aggregates open comments for fix-all', () => {
@@ -92,5 +94,7 @@ describe('spawn-from-comment', () => {
     expect(args.initialPrompt).toContain('bob');
     expect(args.initialPrompt).toContain('eve');
     expect(args.initialPrompt).toContain('a/b.ts:7');
+    expect(args.initialPrompt).toContain('EASY');
+    expect(args.initialPrompt).toContain('NON-TRIVIAL');
   });
 });

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -35,7 +35,20 @@ export function buildCommentAgentPrompt(c: PrComment, pr: PullRequestState): str
   lines.push(`Comment URL: ${c.url}`);
   lines.push('');
   lines.push(
-    'Your task: address this comment with the smallest reasonable change. Read the file, apply the change, run lint/tests, commit and push. Do not over-scope.',
+    'Your task: address this comment with the smallest reasonable change. Read the file, apply the change, run lint/tests. Do not over-scope.',
+  );
+  lines.push('');
+  lines.push('Before committing, classify your change:');
+  lines.push(
+    'EASY (auto-commit+push): rename, typo, formatting, import fix, small one-liner, adjusting a literal/constant.',
+  );
+  lines.push(
+    'NON-TRIVIAL (stop and ask): structural rework, new/deleted files, multi-file refactor, architecture change, anything you are uncertain about.',
+  );
+  lines.push('');
+  lines.push('If EASY: commit and push immediately.');
+  lines.push(
+    'If NON-TRIVIAL: stop. Show a short summary of what you changed and why, then ask "Can I commit?" and wait for confirmation before committing.',
   );
   return lines.join('\n');
 }
@@ -88,7 +101,20 @@ export function buildReviewChangesAgentArgs(
     lines.push('');
   }
   lines.push(
-    'Your task: address every comment with the smallest reasonable change. Read the files, apply the changes, run lint/tests, commit and push. Do not over-scope.',
+    'Your task: address every comment with the smallest reasonable change. Read the files, apply the changes, run lint/tests. Do not over-scope.',
+  );
+  lines.push('');
+  lines.push('Before committing, classify the overall change:');
+  lines.push(
+    'EASY (auto-commit+push): all fixes are renames, typos, formatting, import fixes, small one-liners, adjusting literals/constants.',
+  );
+  lines.push(
+    'NON-TRIVIAL (stop and ask): any fix involves structural rework, new/deleted files, multi-file refactor, architecture change, or anything you are uncertain about.',
+  );
+  lines.push('');
+  lines.push('If EASY: commit and push immediately.');
+  lines.push(
+    'If NON-TRIVIAL: stop. Show a short summary of what you changed and why, then ask "Can I commit?" and wait for confirmation before committing.',
   );
   return {
     name: truncate(`resolve: address review changes on #${pr.number}`, TITLE_MAX),


### PR DESCRIPTION
## Summary
- Resolve agent now self-classifies its change **before committing**: easy fixes (rename, typo, import, one-liner, constant) auto-commit+push; non-trivial changes (structural rework, new/deleted files, multi-file refactor, architecture change) pause and ask user for confirmation.
- Same gate applied to both single-comment and batch "resolve all" flows.
- Added regression test assertions for the gate keywords.

## Test plan
- [x] `pnpm test` — 374 tests pass
- [ ] Manual: trigger resolve on trivial comment → agent auto-commits
- [ ] Manual: trigger resolve on comment requiring rework → agent stops and asks

🤖 Generated with [Claude Code](https://claude.com/claude-code)