### PR TITLE
fix(desktop): prevent auto-title from overwriting agent kind

### DIFF
--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -99,6 +99,11 @@ describe('resolveAgentKind', () => {
     expect(resolveAgentKind('Plan the migration', 'find the bug', 'docs')).toBe('docs');
   });
 
+  it('override wins even when name contains role-triggering keywords', () => {
+    expect(resolveAgentKind('fix login bug', null, 'generic')).toBe('generic');
+    expect(resolveAgentKind('refactor auth module', null, 'scout')).toBe('scout');
+  });
+
   it('prefers name-based inference when the name is meaningful', () => {
     expect(resolveAgentKind('Plan the migration', 'find the bug')).toBe('planner');
     expect(resolveAgentKind('Review diff', 'implement the feature')).toBe('reviewer');

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1460,12 +1460,15 @@ function AgentsSection({ task }: AgentsSectionProps) {
 
   const sorted = useMemo(() => [...phaseRuns].sort((a, b) => a.ordinal - b.ordinal), [phaseRuns]);
   const initAgent = useMemo(
-    () => sorted.find((r) => inferAgentKindFromName(r.name) === 'init') ?? null,
-    [sorted],
+    () =>
+      sorted.find((r) => (agentKindOverride[r.id] ?? inferAgentKindFromName(r.name)) === 'init') ??
+      null,
+    [sorted, agentKindOverride],
   );
   const nonInitSorted = useMemo(
-    () => sorted.filter((r) => inferAgentKindFromName(r.name) !== 'init'),
-    [sorted],
+    () =>
+      sorted.filter((r) => (agentKindOverride[r.id] ?? inferAgentKindFromName(r.name)) !== 'init'),
+    [sorted, agentKindOverride],
   );
   const workflowAgents = useMemo(
     () => nonInitSorted.filter((r) => r.stepId != null),
@@ -1638,6 +1641,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
           <div className="flex flex-col gap-1 pl-2">
             <WorkflowStepRow
               run={initAgent}
+              kind={agentKindOverride[initAgent.id] ?? 'init'}
               resolvedModel={
                 agentModelOverride[initAgent.id] ??
                 initAgent.modelOverride ??
@@ -1676,13 +1680,14 @@ function AgentsSection({ task }: AgentsSectionProps) {
           <div className="flex flex-col gap-1 pl-2">
             {workflowAgents.map((run) => {
               const isActionable = run.stepId === actionableStepId && run.status === 'pending';
-              const kind = inferAgentKindFromName(run.name);
+              const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
               const resolvedModel =
                 agentModelOverride[run.id] ?? run.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model;
               return (
                 <WorkflowStepRow
                   key={run.id}
                   run={run}
+                  kind={kind}
                   resolvedModel={resolvedModel}
                   isActionable={isActionable}
                   isBlocked={isActionable && actionBlocked}
@@ -1896,6 +1901,7 @@ const AGENT_STATUS_TONE: Record<AgentStatus, string> = {
 
 interface WorkflowStepRowProps {
   readonly run: Agent;
+  readonly kind: AgentKind;
   readonly resolvedModel: string;
   readonly isActionable: boolean;
   readonly isBlocked: boolean;
@@ -1914,6 +1920,7 @@ interface WorkflowStepRowProps {
 
 function WorkflowStepRow({
   run,
+  kind,
   resolvedModel,
   isActionable,
   isBlocked,
@@ -1929,7 +1936,6 @@ function WorkflowStepRow({
   onRenameCommit,
   onRenameCancel,
 }: WorkflowStepRowProps) {
-  const kind = inferAgentKindFromName(run.name);
   const isPendingFuture = run.status === 'pending' && !isActionable;
   const modelLabel = resolvedModel.split('-').slice(1, 3).join('-');
   const isStartable = isActionable && !isBlocked;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -990,6 +990,14 @@ async function generateAutoTitle(
       await renameSessionInDb(tauriDatabase, sessionId, title, titleNow, false);
     }
     if (agentId) {
+      if (!get().agentKindOverride[agentId]) {
+        const runs = get().sessionPhaseRuns[sessionId] ?? [];
+        const row = runs.find((r) => r.id === agentId);
+        const currentKind = inferAgentKindFromName(row?.name ?? '');
+        set((s) => ({
+          agentKindOverride: { ...s.agentKindOverride, [agentId]: currentKind },
+        }));
+      }
       await get().renameAgent(sessionId, agentId, title);
     }
   } catch {


### PR DESCRIPTION
## Summary

- `generateAutoTitle` was renaming the agent with the auto-generated session title, causing `inferAgentKindFromName` to re-derive the role from title keywords (e.g. "fix login bug" → `debugger`)
- Lock the current kind into `agentKindOverride` before the rename so the role stays fixed once assigned
- Fix sidebar callsites that used raw `inferAgentKindFromName(run.name)` without checking the override first

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm vitest run` — existing + new test passes
- [ ] Manual: create ad-hoc session → send turn → auto-title generates but agent chip stays `generic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)