### PR TITLE
feat(desktop): rework new-session + session-settings modals

### DIFF
--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1596,6 +1596,7 @@ function AgentKindSelect({
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
 
   useEffect(() => {
     if (!open) return;
@@ -1606,6 +1607,16 @@ function AgentKindSelect({
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    // ~280px tall popup; flip up when below is tight.
+    setDirection(spaceBelow < 300 && spaceAbove > spaceBelow ? 'up' : 'down');
   }, [open]);
 
   const meta = AGENT_KIND_META[value];
@@ -1638,7 +1649,12 @@ function AgentKindSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 max-h-[280px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div
+          className={cn(
+            'absolute left-0 z-50 max-h-[280px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg',
+            direction === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
+          )}
+        >
           {[...AGENT_KIND_ORDER]
             .filter((k) => k !== 'init')
             .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1611,10 +1611,22 @@ function AgentKindSelect({
 
   useEffect(() => {
     if (!open) return;
-    const rect = containerRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
+    const el = containerRef.current;
+    const rect = el?.getBoundingClientRect();
+    if (!el || !rect) return;
+    // Walk up to the nearest clipping ancestor — the Dialog's
+    // overflow-hidden wrapper would clip the popover otherwise.
+    let clipper: HTMLElement | null = el.parentElement;
+    while (clipper) {
+      const overflowY = getComputedStyle(clipper).overflowY;
+      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'hidden') break;
+      clipper = clipper.parentElement;
+    }
+    const clipperRect = clipper?.getBoundingClientRect();
+    const bottomBound = clipperRect ? clipperRect.bottom : window.innerHeight;
+    const topBound = clipperRect ? clipperRect.top : 0;
+    const spaceBelow = bottomBound - rect.bottom;
+    const spaceAbove = rect.top - topBound;
     // ~280px tall popup; flip up when below is tight.
     setDirection(spaceBelow < 300 && spaceAbove > spaceBelow ? 'up' : 'down');
   }, [open]);

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
@@ -52,6 +52,7 @@ import { PlannerWidget } from '../../../../features/plans/components/PlannerWidg
 import { useToast } from '../../../../app/components/Toast';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
+import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 
 interface NewSessionDialogProps {
   open: boolean;
@@ -1580,159 +1581,6 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <p className="text-2xs text-muted-foreground/70">
         each agent runs in its own chat thread. you decide which one gets the next turn.
       </p>
-    </div>
-  );
-}
-
-function BranchCombobox({
-  branches,
-  value,
-  onChange,
-  disabled,
-  loading,
-}: {
-  branches: ReadonlyArray<LocalBranchInfo>;
-  value: string;
-  onChange: (v: string) => void;
-  disabled: boolean;
-  loading: boolean;
-}) {
-  const [query, setQuery] = useState('');
-  const [open, setOpen] = useState(false);
-  const [highlightIdx, setHighlightIdx] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
-
-  const filtered = useMemo(
-    () => branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase())),
-    [branches, query],
-  );
-
-  const select = useCallback(
-    (name: string) => {
-      onChange(name);
-      setQuery(name);
-      setOpen(false);
-    },
-    [onChange],
-  );
-
-  useEffect(() => {
-    if (value && !query) setQuery(value);
-  }, [value, query]);
-
-  useEffect(() => {
-    setHighlightIdx(0);
-  }, [query]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || !listRef.current) return;
-    const el = listRef.current.children[highlightIdx] as HTMLElement | undefined;
-    el?.scrollIntoView({ block: 'nearest' });
-  }, [highlightIdx, open]);
-
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
-      setOpen(true);
-      e.preventDefault();
-      return;
-    }
-    if (!open) return;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setHighlightIdx((i) => Math.min(i + 1, filtered.length - 1));
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setHighlightIdx((i) => Math.max(i - 1, 0));
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (filtered[highlightIdx]) select(filtered[highlightIdx].name);
-        break;
-      case 'Escape':
-        e.preventDefault();
-        setOpen(false);
-        break;
-    }
-  };
-
-  const placeholder = loading
-    ? 'Loading…'
-    : branches.length === 0
-      ? 'No local branches'
-      : 'Search branch…';
-
-  return (
-    <div ref={containerRef} className="relative w-full">
-      <input
-        ref={inputRef}
-        type="text"
-        value={query}
-        placeholder={placeholder}
-        disabled={disabled || branches.length === 0}
-        aria-label="Existing branch"
-        role="combobox"
-        aria-expanded={open}
-        aria-autocomplete="list"
-        autoComplete="off"
-        className="h-8 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setOpen(true);
-          if (!e.target.value) onChange('');
-        }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={onKeyDown}
-      />
-      {open && filtered.length > 0 ? (
-        <ul
-          ref={listRef}
-          role="listbox"
-          className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg"
-        >
-          {filtered.map((b, i) => (
-            <li
-              key={b.name}
-              role="option"
-              aria-selected={highlightIdx === i}
-              onMouseEnter={() => setHighlightIdx(i)}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                select(b.name);
-              }}
-              className={cn(
-                'flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-sm font-mono',
-                highlightIdx === i ? 'bg-primary/10 text-foreground' : 'text-muted-foreground',
-              )}
-            >
-              <span className="min-w-0 truncate">{b.name}</span>
-              {b.inUse ? <span className="shrink-0 text-2xs text-warning">in use</span> : null}
-              {b.hasUncommitted ? (
-                <span className="shrink-0 text-2xs text-warning">dirty</span>
-              ) : null}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-      {open && !loading && filtered.length === 0 && query ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-full rounded-md border border-border bg-subtle px-2 py-2 text-xs text-muted-foreground shadow-lg">
-          No matching branches
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,17 +1,19 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
+  Bot,
   Check,
   ChevronDown,
   DollarSign,
+  GitBranch,
   Layers,
   Loader2,
   Sparkles,
   Terminal,
-  Wand2,
   Target,
+  Wand2,
   Zap,
   X,
 } from 'lucide-react';
@@ -23,7 +25,7 @@ import type {
   SessionProviderPreference,
   WorkspaceId,
 } from '@kay-am/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@kay-am/core';
+import { getDefaultTurnModel } from '@kay-am/core';
 import { shortModel } from '../../../../features/session/agent-row-format';
 import {
   AGENT_KIND_META,
@@ -47,12 +49,6 @@ import { STORAGE_PREFIXES } from '../../../../shared/lib/storage-keys';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { PlannerWidget } from '../../../../features/plans/components/PlannerWidget';
-import { fetchGithubIssue, parseGithubIssueUrl } from '../../../../features/github/github';
-
-interface IssueData {
-  readonly title: string;
-  readonly body: string;
-}
 import { useToast } from '../../../../app/components/Toast';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
@@ -81,29 +77,40 @@ function formatError(err: unknown): string {
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
-type WorkflowMode = 'one-off' | 'preset' | 'custom';
+type WorkflowMode = 'single' | 'preset' | 'custom';
 
-const WORKFLOW_MODES: ReadonlyArray<{
-  id: WorkflowMode;
-  label: string;
-  hint: string;
-  beta?: boolean;
-}> = [
+interface WorkflowModeMeta {
+  readonly id: WorkflowMode;
+  readonly label: string;
+  readonly tagline: string;
+  readonly description: string;
+  readonly icon: typeof Bot;
+  readonly beta?: boolean;
+}
+
+const WORKFLOW_MODES: ReadonlyArray<WorkflowModeMeta> = [
   {
-    id: 'one-off',
-    label: 'One-off',
-    hint: 'Single chat session. Spawn agents manually as needed.',
+    id: 'single',
+    label: 'Single agent',
+    tagline: 'Solo chat session',
+    description:
+      'One agent, one conversation. Spawn more agents from the sidebar as the work unfolds.',
+    icon: Bot,
   },
   {
     id: 'preset',
-    label: 'Preset',
-    hint: 'Pick a saved workflow blueprint. Each step spawns its own agent.',
+    label: 'Workflow preset',
+    tagline: 'Run a saved blueprint',
+    description: 'Pick a preset workflow. Each step spawns its own agent in order.',
+    icon: Layers,
     beta: true,
   },
   {
     id: 'custom',
-    label: 'Custom',
-    hint: 'Design a fresh workflow with the planner, then run it.',
+    label: 'Custom plan',
+    tagline: 'Designed for this goal',
+    description: 'Let the planner draft a workflow tailored to your goal, then run it.',
+    icon: Sparkles,
     beta: true,
   },
 ];
@@ -153,6 +160,27 @@ function getDefaultBinary(providerId: ProviderId): string {
   }
 }
 
+const SLUG_MAX_LEN = 48;
+
+function slugifyLive(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, SLUG_MAX_LEN)
+    .replace(/-+$/, '');
+}
+
+function sanitizePrefix(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '')
+    .replace(/^-+/, '')
+    .slice(0, 16);
+}
+
 function isValidBranchSlug(slug: string): boolean {
   const s = slug.trim();
   if (!s) return false;
@@ -193,32 +221,6 @@ async function generateBranchSlug(goal: string, providerId: ProviderId): Promise
     .join('-');
 }
 
-async function generateGoalFromIssue(issue: IssueData, providerId: ProviderId): Promise<string> {
-  const systemPrompt =
-    'You are a goal extractor for AI coding sessions. Given a task or issue, write a concise goal in 2-4 sentences, imperative form (e.g. "Refactor the auth middleware to..."). Output ONLY the goal text, nothing else.';
-  const userMessage = `Title: ${issue.title}\n\nDescription:\n${issue.body}`.slice(0, 4000);
-  const result = await invoke<SummarizeTaskResult>('summarize_session', {
-    args: {
-      providerId,
-      model: getCheapModel(providerId),
-      binary: getDefaultBinary(providerId),
-      userMessage,
-      systemPrompt,
-    },
-  });
-  if ((result.exitCode ?? 0) !== 0) {
-    throw new Error(`goal generation failed: ${result.stderr}`);
-  }
-  const raw = result.stdout.trim();
-  try {
-    const parsed = JSON.parse(raw) as { result?: string };
-    if (typeof parsed.result === 'string') return parsed.result.trim();
-  } catch {
-    // not json, use raw
-  }
-  return raw;
-}
-
 export function NewSessionDialog({
   open,
   onClose,
@@ -236,11 +238,12 @@ export function NewSessionDialog({
   const workspaceInitScript = useAppStore((s) => s.workspaceInitScripts?.[workspaceId] ?? null);
 
   const [goal, setGoal] = useState('');
-  const [issueUrl, setIssueUrl] = useState('');
-  const [issueFetching, setIssueFetching] = useState(false);
-  const [issueError, setIssueError] = useState<string | null>(null);
 
   const [branchSlug, setBranchSlug] = useState('');
+  // Tracks whether the user has manually edited the slug. While false, the
+  // slug stays linked to the goal (live slugify). Once true, edits no longer
+  // overwrite their manual value.
+  const [slugTouched, setSlugTouched] = useState(false);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [slugGenerating, setSlugGenerating] = useState(false);
   const [branchMode, setBranchMode] = useState<'new' | 'existing'>('new');
@@ -250,7 +253,7 @@ export function NewSessionDialog({
   const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
 
   const [softCapRaw, setSoftCapRaw] = useState('');
-  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('one-off');
+  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('single');
   const [presetTemplateId, setPresetTemplateId] = useState<WorkflowId | ''>('');
   const [customTemplateId, setCustomTemplateId] = useState<WorkflowId | ''>('');
   const selectedPhaseTemplateId =
@@ -317,10 +320,8 @@ export function NewSessionDialog({
   useEffect(() => {
     if (!open) return;
     setGoal('');
-    setIssueUrl('');
-    setIssueFetching(false);
-    setIssueError(null);
     setBranchSlug('');
+    setSlugTouched(false);
     setSlugGenerating(false);
     setBranchMode('new');
     setExistingBranch('');
@@ -329,7 +330,7 @@ export function NewSessionDialog({
     setCustomTemplateId('');
     setHasCustomPlan(false);
     setFirstAgentKind('generic');
-    setWorkflowMode('one-off');
+    setWorkflowMode('single');
     setAutoRun(false);
     setEffort('medium');
     setVerbosity('normal');
@@ -359,6 +360,12 @@ export function NewSessionDialog({
     if (open && workspaceInitScript) setInitContent(workspaceInitScript);
   }, [open, workspaceInitScript]);
 
+  // Live slug derivation from goal while the user hasn't manually edited it.
+  useEffect(() => {
+    if (slugTouched) return;
+    setBranchSlug(slugifyLive(goal));
+  }, [goal, slugTouched]);
+
   const handleGenerateSlug = () => {
     const trimmed = goal.trim();
     if (!trimmed || slugGenerating) return;
@@ -366,6 +373,7 @@ export function NewSessionDialog({
     generateBranchSlug(trimmed, selectedProvider)
       .then((slug) => {
         setBranchSlug(slug);
+        setSlugTouched(true);
       })
       .catch(() => {
         // silent — user can type manually
@@ -375,41 +383,17 @@ export function NewSessionDialog({
       });
   };
 
-  const handleIssueUrl = async (value: string) => {
-    setIssueUrl(value);
-    setIssueError(null);
-
-    const githubParsed = parseGithubIssueUrl(value);
-    if (!githubParsed) return;
-
-    setIssueFetching(true);
-    try {
-      const gh = await fetchGithubIssue(githubParsed.repoSlug, githubParsed.number);
-      const goal = await generateGoalFromIssue(
-        { title: gh.title, body: gh.body },
-        selectedProvider,
-      );
-      setGoal(goal);
-    } catch (err) {
-      setIssueError(formatError(err));
-    } finally {
-      setIssueFetching(false);
-    }
-  };
-
   const reset = () => {
     setGoal('');
-    setIssueUrl('');
-    setIssueFetching(false);
-    setIssueError(null);
     setBranchSlug('');
+    setSlugTouched(false);
     setSlugGenerating(false);
     setSoftCapRaw('');
     setPresetTemplateId('');
     setCustomTemplateId('');
     setHasCustomPlan(false);
     setFirstAgentKind('generic');
-    setWorkflowMode('one-off');
+    setWorkflowMode('single');
     setAutoRun(false);
     setEffort('medium');
     setVerbosity('normal');
@@ -476,7 +460,7 @@ export function NewSessionDialog({
   const goalReady = goal.trim().length > 0 && branchReady;
   const budgetReady = softCapRaw.trim().length > 0;
   const workflowReady =
-    workflowMode === 'one-off' ||
+    workflowMode === 'single' ||
     selectedPhaseTemplateId !== '' ||
     (workflowMode === 'custom' && hasCustomPlan);
   const providerReady = connectedProviderIds.has(selectedProvider);
@@ -547,7 +531,9 @@ export function NewSessionDialog({
       title="New session"
       description="Creates a worktree on a fresh branch from the workspace root."
       size="xl"
-      fixedHeightClass="h-[640px]"
+      className="w-[68rem] max-w-[95vw]"
+      fixedHeightClass="h-[680px]"
+      bodyClassName="px-0 py-0 gap-0"
       footer={
         <div className="flex w-full items-center gap-2">
           <div className="flex-1">
@@ -584,8 +570,9 @@ export function NewSessionDialog({
         </div>
       }
     >
-      <div className="flex h-full min-h-0 gap-0">
-        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
+      <div className="flex h-full min-h-0">
+        {/* Fixed ladder — never scrolls */}
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
           {sections.map((s) => (
             <button
               key={s.id}
@@ -593,10 +580,10 @@ export function NewSessionDialog({
               onClick={() => setActiveSection(s.id as SectionId)}
               title={s.required && !s.ready ? `${s.label.toLowerCase()} is required` : undefined}
               className={cn(
-                'relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+                'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
                 activeSection === s.id
-                  ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  ? 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+                  : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
               )}
             >
               {s.icon}
@@ -614,395 +601,908 @@ export function NewSessionDialog({
           ))}
         </nav>
 
-        <div className="min-w-0 flex-1 overflow-y-auto pl-4 pr-2">
-          <div className={activeSection === 'goal' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <Field
-                label="Issue link"
-                labelSuffix={<BetaChip />}
-                hint="Paste a GitHub, GitLab, Jira, or Linear issue URL. The goal will be generated automatically."
-              >
-                <div className="relative">
-                  <Input
-                    value={issueUrl}
-                    onChange={(e) => void handleIssueUrl(e.target.value)}
-                    placeholder="github.com/…/issues/42 · linear.app/…/TEAM-1 · jira · gitlab"
-                    disabled={issueFetching || busy}
-                  />
-                  {issueFetching ? (
-                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
-                      <Loader2
-                        size={13}
-                        className="animate-spin text-muted-foreground"
-                        aria-label="fetching issue"
-                      />
-                    </span>
-                  ) : null}
-                </div>
-                {issueError ? <p className="text-xs text-danger">{issueError}</p> : null}
-              </Field>
-              <Field label="Goal" hint="What this session should accomplish.">
-                {issueFetching ? (
-                  <div className="flex flex-col gap-2 rounded-md border border-border-soft bg-subtle px-3 py-3">
-                    <div className="h-3 w-3/4 animate-pulse rounded bg-muted-foreground/20" />
-                    <div className="h-3 w-full animate-pulse rounded bg-muted-foreground/20" />
-                    <div className="h-3 w-5/6 animate-pulse rounded bg-muted-foreground/20" />
-                  </div>
-                ) : (
-                  <Textarea
-                    value={goal}
-                    placeholder="Refactor auth domain"
-                    onChange={(e) => setGoal(e.target.value)}
-                    autoGrow
-                    minRows={4}
-                    maxRows={16}
-                    autoFocus
-                    disabled={busy}
-                  />
-                )}
-              </Field>
-              <Field label="Branch" hint="Worktree branch for this session.">
-                <div className="flex flex-col gap-2">
-                  <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
-                  {branchMode === 'new' ? (
-                    <div className="flex items-center gap-1.5">
-                      <span className="shrink-0 text-xs text-muted-foreground font-mono">
-                        {branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/
-                      </span>
-                      {slugGenerating ? (
-                        <span className="flex h-8 flex-1 animate-pulse items-center rounded border border-border bg-subtle px-2">
-                          <span className="h-2 w-full rounded bg-muted-foreground/20" />
-                        </span>
-                      ) : (
-                        <Input
-                          value={branchSlug}
-                          onChange={(e) => setBranchSlug(e.target.value)}
-                          placeholder="branch-slug"
-                          className="h-8 flex-1 font-mono text-sm"
-                          disabled={busy}
-                          aria-label="Branch slug"
-                        />
-                      )}
-                      <button
-                        type="button"
-                        onClick={handleGenerateSlug}
-                        disabled={!goal.trim() || slugGenerating || busy}
-                        title="Generate from goal"
-                        aria-label="Generate branch name"
-                        className={cn(
-                          'shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors',
-                          goal.trim() && !slugGenerating && !busy
-                            ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                            : 'cursor-not-allowed text-muted-foreground/30',
-                        )}
-                      >
-                        <Wand2 size={13} aria-hidden />
-                      </button>
-                    </div>
-                  ) : (
-                    <BranchCombobox
-                      branches={existingBranches}
-                      value={existingBranch}
-                      onChange={setExistingBranch}
-                      disabled={busy || branchesLoading}
-                      loading={branchesLoading}
-                    />
-                  )}
-                </div>
-              </Field>
-            </div>
-          </div>
+        {/* Only this column scrolls */}
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {activeSection === 'goal' ? (
+            <GoalSection
+              goal={goal}
+              setGoal={setGoal}
+              branchSlug={branchSlug}
+              setBranchSlug={(v) => {
+                setBranchSlug(v);
+                setSlugTouched(true);
+              }}
+              slugGenerating={slugGenerating}
+              branchPrefix={branchPrefix}
+              setBranchPrefix={setBranchPrefix}
+              branchMode={branchMode}
+              setBranchMode={setBranchMode}
+              existingBranches={existingBranches}
+              existingBranch={existingBranch}
+              setExistingBranch={setExistingBranch}
+              branchesLoading={branchesLoading}
+              busy={busy}
+              onGenerateSlug={handleGenerateSlug}
+            />
+          ) : null}
 
-          <div className={activeSection === 'budget' ? '' : 'hidden'}>
-            <Field
-              label="Soft cap (USD)"
-              hint="Optional spend limit. Session gets flagged when exceeded."
-            >
-              <Input
-                value={softCapRaw}
-                onChange={(e) => setSoftCapRaw(e.target.value)}
-                placeholder="5.00"
-                type="number"
-                min="0"
-                step="0.01"
-                disabled={busy}
-              />
-            </Field>
-          </div>
+          {activeSection === 'workflow' ? (
+            <WorkflowSection
+              workflowMode={workflowMode}
+              onModeChange={onWorkflowModeChange}
+              phaseTemplates={phaseTemplates}
+              selectedPhaseTemplateId={selectedPhaseTemplateId}
+              setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
+              customTemplateId={customTemplateId}
+              setCustomTemplateId={setCustomTemplateId}
+              workspaceId={workspaceId}
+              selectedProvider={selectedProvider}
+              selectedModel={selectedModel}
+              setSelectedModel={setSelectedModel}
+              firstAgentKind={firstAgentKind}
+              setFirstAgentKind={setFirstAgentKind}
+              effort={effort}
+              setEffort={setEffort}
+              verbosity={verbosity}
+              setVerbosity={setVerbosity}
+              autoRun={autoRun}
+              setAutoRun={setAutoRun}
+              goal={goal}
+              busy={busy}
+              providerReady={providerReady}
+              onPlanChange={setHasCustomPlan}
+            />
+          ) : null}
 
-          <div className={activeSection === 'init' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs">
-                <input
-                  type="checkbox"
-                  checked={initEnabled}
-                  onChange={(e) => setInitEnabled(e.target.checked)}
-                  className="mt-0.5 accent-primary"
-                />
-                <span className="flex flex-col gap-0.5">
-                  <span className="font-medium text-foreground">Run init script</span>
-                  <span className="text-muted-foreground">
-                    Execute workspace setup before agents start.
-                  </span>
-                </span>
-              </label>
-              <Field
-                label="Script"
-                hint="Edit for this session only. Changes won't save to workspace."
-              >
-                <Textarea
-                  value={initContent}
-                  onChange={(e) => setInitContent(e.target.value)}
-                  className="min-h-[200px] resize-y font-mono text-xs"
-                  disabled={!initEnabled || busy}
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  rows={10}
-                />
-              </Field>
-            </div>
-          </div>
+          {activeSection === 'provider' ? (
+            <ProviderSection
+              connectedProviderIds={connectedProviderIds}
+              selectedProvider={selectedProvider}
+              onRequestChange={requestProviderChange}
+              pendingProviderSwitch={pendingProviderSwitch}
+              onCancelSwitch={() => setPendingProviderSwitch(null)}
+              onConfirmSwitch={confirmProviderSwitch}
+              onClose={onClose}
+              onOpenSettings={onOpenSettings}
+            />
+          ) : null}
 
-          <div className={activeSection === 'workflow' ? '' : 'hidden'}>
-            <Field label="Workflow" hint={workflowModeHint(workflowMode)}>
-              <WorkflowModeSegmented mode={workflowMode} onChange={onWorkflowModeChange} />
+          {activeSection === 'init' ? (
+            <InitSection
+              initEnabled={initEnabled}
+              setInitEnabled={setInitEnabled}
+              initContent={initContent}
+              setInitContent={setInitContent}
+              busy={busy}
+            />
+          ) : null}
 
-              <div className={workflowMode === 'one-off' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                <Field
-                  label="Agent role"
-                  hint="Role for the first agent. Spawn more from the sidebar."
-                >
-                  <AgentKindSelect
-                    value={firstAgentKind}
-                    onChange={setFirstAgentKind}
-                    disabled={busy}
-                  />
-                </Field>
-                <div className="grid grid-cols-3 gap-3">
-                  <InlineField label="Model">
-                    <ModelSelect
-                      provider={selectedProvider}
-                      value={selectedModel}
-                      onChange={setSelectedModel}
-                      disabled={busy || !providerReady}
-                    />
-                  </InlineField>
-                  <InlineField label="Effort">
-                    <EffortSelect
-                      model={selectedModel}
-                      value={effort}
-                      onChange={setEffort}
-                      disabled={busy}
-                    />
-                  </InlineField>
-                  <InlineField label="Verbosity">
-                    <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
-                  </InlineField>
-                </div>
-              </div>
-
-              <div className={workflowMode === 'preset' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                {phaseTemplates.length === 0 ? (
-                  <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-soft bg-subtle px-4 py-6 text-center">
-                    <Layers size={20} className="text-muted-foreground/30" aria-hidden />
-                    <p className="text-xs font-medium text-muted-foreground">No workflow presets</p>
-                    <p className="max-w-[14rem] text-2xs leading-relaxed text-muted-foreground/60">
-                      Switch to{' '}
-                      <button
-                        type="button"
-                        onClick={() => onWorkflowModeChange('custom')}
-                        className="font-medium text-primary underline-offset-2 hover:underline"
-                      >
-                        Custom
-                      </button>{' '}
-                      to design your first workflow.
-                    </p>
-                  </div>
-                ) : (
-                  <PresetSelect
-                    templates={phaseTemplates}
-                    value={selectedPhaseTemplateId}
-                    onChange={setSelectedPhaseTemplateId}
-                    disabled={busy}
-                  />
-                )}
-                {selectedPhaseTemplateId !== '' ? (
-                  <WorkflowPreview
-                    template={phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null}
-                  />
-                ) : null}
-              </div>
-
-              <div className={workflowMode === 'custom' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                {customTemplateId !== '' ? (
-                  (() => {
-                    const customTemplate =
-                      phaseTemplates.find((t) => t.id === customTemplateId) ?? null;
-                    return (
-                      <div className="flex flex-col gap-3">
-                        <div className="flex items-center gap-1.5 text-xs">
-                          <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
-                            <Check size={10} className="text-success" />
-                          </span>
-                          <span className="font-medium text-foreground">
-                            Workflow ready
-                            {customTemplate
-                              ? ` · ${customTemplate.steps.length} step${customTemplate.steps.length === 1 ? '' : 's'}`
-                              : ''}
-                          </span>
-                        </div>
-                        <WorkflowPreview template={customTemplate} />
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() => setCustomTemplateId('')}
-                            className="flex items-center gap-1 rounded-md border border-border-soft px-2.5 py-1 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-                          >
-                            <Sparkles size={10} aria-hidden /> Re-design
-                          </button>
-                        </div>
-                      </div>
-                    );
-                  })()
-                ) : (
-                  <PlannerWidget
-                    workspaceId={workspaceId}
-                    providerId={selectedProvider}
-                    initialTheme={goal}
-                    onWorkflowReady={(workflowId) => {
-                      setCustomTemplateId(workflowId);
-                    }}
-                    onPlanChange={setHasCustomPlan}
-                  />
-                )}
-              </div>
-
-              {workflowMode !== 'one-off' && selectedPhaseTemplateId !== '' ? (
-                <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs">
-                  <input
-                    type="checkbox"
-                    checked={autoRun}
-                    onChange={(e) => setAutoRun(e.target.checked)}
-                    className="mt-0.5 accent-primary"
-                  />
-                  <span className="flex flex-col gap-0.5">
-                    <span className="flex items-center gap-1.5 font-medium text-foreground">
-                      Run autonomously
-                      <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                        beta
-                      </span>
-                    </span>
-                    <span className="text-muted-foreground">
-                      Auto-spawn each step on completion. Pauses on error or budget exceed.
-                    </span>
-                  </span>
-                </label>
-              ) : null}
-            </Field>
-          </div>
-
-          <div className={activeSection === 'provider' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <Field label="Provider">
-                <div className="flex gap-2">
-                  {PROVIDER_ORDER.map((id) => {
-                    const connected = connectedProviderIds.has(id);
-                    const selected = selectedProvider === id;
-                    return (
-                      <button
-                        key={id}
-                        type="button"
-                        disabled={!connected}
-                        onClick={() => requestProviderChange(id)}
-                        className={cn(
-                          'flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors',
-                          selected && connected
-                            ? 'border-primary bg-primary/5 font-medium text-foreground'
-                            : connected
-                              ? 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50'
-                              : 'cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40',
-                        )}
-                      >
-                        <span className="flex items-center gap-1.5">
-                          {connected ? (
-                            <span
-                              className={cn(
-                                'size-1.5 rounded-full',
-                                selected ? 'bg-success' : 'bg-muted-foreground/40',
-                              )}
-                            />
-                          ) : (
-                            <X size={10} className="text-danger/60" aria-hidden />
-                          )}
-                          {PROVIDER_LABEL_LOWER[id]}
-                          {id !== 'anthropic' ? (
-                            <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                              beta
-                            </span>
-                          ) : null}
-                        </span>
-                        {!connected ? (
-                          <span
-                            role="button"
-                            tabIndex={0}
-                            className="text-2xs text-primary/70 underline"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onClose();
-                              window.dispatchEvent(
-                                new CustomEvent('kayam:open-settings', {
-                                  detail: { section: 'providers' },
-                                }),
-                              );
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.stopPropagation();
-                                onClose();
-                                window.dispatchEvent(
-                                  new CustomEvent('kayam:open-settings', {
-                                    detail: { section: 'providers' },
-                                  }),
-                                );
-                              }
-                            }}
-                          >
-                            Connect
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </Field>
-              {pendingProviderSwitch ? (
-                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5">
-                  <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden />
-                  <div className="flex flex-1 flex-col gap-1.5">
-                    <p className="text-xs font-medium text-foreground">
-                      Switching provider will discard your custom workflow.
-                    </p>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setPendingProviderSwitch(null)}
-                      >
-                        Cancel
-                      </Button>
-                      <Button size="sm" onClick={confirmProviderSwitch}>
-                        Switch provider
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </div>
+          {activeSection === 'budget' ? (
+            <BudgetSection softCapRaw={softCapRaw} setSoftCapRaw={setSoftCapRaw} busy={busy} />
+          ) : null}
         </div>
       </div>
     </Dialog>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Goal + branch                                                */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface GoalSectionProps {
+  readonly goal: string;
+  readonly setGoal: (v: string) => void;
+  readonly branchSlug: string;
+  readonly setBranchSlug: (v: string) => void;
+  readonly slugGenerating: boolean;
+  readonly branchPrefix: string;
+  readonly setBranchPrefix: (v: string) => void;
+  readonly branchMode: 'new' | 'existing';
+  readonly setBranchMode: (m: 'new' | 'existing') => void;
+  readonly existingBranches: ReadonlyArray<LocalBranchInfo>;
+  readonly existingBranch: string;
+  readonly setExistingBranch: (v: string) => void;
+  readonly branchesLoading: boolean;
+  readonly busy: boolean;
+  readonly onGenerateSlug: () => void;
+}
+
+function GoalSection({
+  goal,
+  setGoal,
+  branchSlug,
+  setBranchSlug,
+  slugGenerating,
+  branchPrefix,
+  setBranchPrefix,
+  branchMode,
+  setBranchMode,
+  existingBranches,
+  existingBranch,
+  setExistingBranch,
+  branchesLoading,
+  busy,
+  onGenerateSlug,
+}: GoalSectionProps) {
+  // Live-derived slug used when goal is set. Visible-only branch preview
+  // string so the user sees the final shape.
+  const fullBranch = `${branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/${branchSlug || 'branch-slug'}`;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Target size={14} aria-hidden className="text-primary" />}
+        title="What needs to get done?"
+        subtitle="Describe the task in plain English. We'll create a worktree and route it to an agent."
+      />
+
+      <div className="flex flex-col gap-2">
+        <Textarea
+          value={goal}
+          placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
+          onChange={(e) => setGoal(e.target.value)}
+          autoGrow
+          minRows={4}
+          maxRows={14}
+          autoFocus
+          disabled={busy}
+          className="text-sm leading-relaxed"
+        />
+        <p className="text-2xs leading-relaxed text-muted-foreground/70">
+          Tip: a clear, imperative sentence yields a better branch name and helps agents stay
+          focused.
+        </p>
+      </div>
+
+      {/* Branch — compact, prefix + slug live preview */}
+      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <GitBranch size={13} aria-hidden className="text-muted-foreground" />
+            <span className="text-xs font-semibold text-foreground">Branch</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setBranchMode(branchMode === 'new' ? 'existing' : 'new')}
+            className="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+          >
+            {branchMode === 'new' ? 'use existing branch instead' : 'create new branch instead'}
+          </button>
+        </div>
+
+        {branchMode === 'new' ? (
+          <>
+            <div className="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary">
+              <input
+                type="text"
+                value={branchPrefix}
+                onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
+                disabled={busy}
+                placeholder={DEFAULT_BRANCH_PREFIX}
+                aria-label="Branch prefix"
+                title="Branch prefix (editable). Saved per workspace."
+                className="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
+              />
+              <span className="flex select-none items-center text-muted-foreground/50">/</span>
+              {slugGenerating ? (
+                <span className="flex flex-1 animate-pulse items-center px-1.5">
+                  <span className="h-2 w-1/2 rounded bg-muted-foreground/20" />
+                </span>
+              ) : (
+                <input
+                  type="text"
+                  value={branchSlug}
+                  onChange={(e) => setBranchSlug(slugifyLive(e.target.value))}
+                  placeholder="branch-slug"
+                  disabled={busy}
+                  aria-label="Branch slug"
+                  className="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                />
+              )}
+              <button
+                type="button"
+                onClick={onGenerateSlug}
+                disabled={!goal.trim() || slugGenerating || busy}
+                title="Generate a better name from your goal"
+                aria-label="Generate branch name"
+                className={cn(
+                  'flex shrink-0 items-center justify-center rounded px-2 transition-colors',
+                  goal.trim() && !slugGenerating && !busy
+                    ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    : 'cursor-not-allowed text-muted-foreground/30',
+                )}
+              >
+                <Wand2 size={13} aria-hidden />
+              </button>
+            </div>
+            <p className="flex items-center gap-1.5 text-2xs text-muted-foreground/70">
+              <span>Preview:</span>
+              <span className="font-mono text-muted-foreground">{fullBranch}</span>
+            </p>
+          </>
+        ) : (
+          <BranchCombobox
+            branches={existingBranches}
+            value={existingBranch}
+            onChange={setExistingBranch}
+            disabled={busy || branchesLoading}
+            loading={branchesLoading}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Workflow                                                     */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface WorkflowSectionProps {
+  readonly workflowMode: WorkflowMode;
+  readonly onModeChange: (m: WorkflowMode) => void;
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly selectedPhaseTemplateId: WorkflowId | '';
+  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
+  readonly customTemplateId: WorkflowId | '';
+  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
+  readonly workspaceId: WorkspaceId;
+  readonly selectedProvider: ProviderId;
+  readonly selectedModel: string;
+  readonly setSelectedModel: (m: string) => void;
+  readonly firstAgentKind: AgentKind;
+  readonly setFirstAgentKind: (k: AgentKind) => void;
+  readonly effort: EffortLevel;
+  readonly setEffort: (e: EffortLevel) => void;
+  readonly verbosity: VerbosityLevel;
+  readonly setVerbosity: (v: VerbosityLevel) => void;
+  readonly autoRun: boolean;
+  readonly setAutoRun: (v: boolean) => void;
+  readonly goal: string;
+  readonly busy: boolean;
+  readonly providerReady: boolean;
+  readonly onPlanChange: (v: boolean) => void;
+}
+
+function WorkflowSection(props: WorkflowSectionProps) {
+  const {
+    workflowMode,
+    onModeChange,
+    phaseTemplates,
+    selectedPhaseTemplateId,
+    setSelectedPhaseTemplateId,
+    customTemplateId,
+    setCustomTemplateId,
+    workspaceId,
+    selectedProvider,
+    selectedModel,
+    setSelectedModel,
+    firstAgentKind,
+    setFirstAgentKind,
+    effort,
+    setEffort,
+    verbosity,
+    setVerbosity,
+    autoRun,
+    setAutoRun,
+    goal,
+    busy,
+    providerReady,
+    onPlanChange,
+  } = props;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SectionHeader
+        icon={<Layers size={14} aria-hidden className="text-primary" />}
+        title="How should the session run?"
+        subtitle="Pick a shape. You can always evolve it once the session is live."
+      />
+
+      {/* 3-card grid */}
+      <div className="grid grid-cols-3 gap-3">
+        {WORKFLOW_MODES.map((m) => {
+          const Icon = m.icon;
+          const active = workflowMode === m.id;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => onModeChange(m.id)}
+              aria-pressed={active}
+              className={cn(
+                'group relative flex flex-col items-start gap-2 rounded-lg border p-3.5 text-left transition-all',
+                active
+                  ? 'border-primary bg-primary/5 shadow-sm ring-1 ring-primary/20'
+                  : 'border-border-soft bg-background hover:-translate-y-0.5 hover:border-border hover:bg-subtle/40 hover:shadow-sm',
+              )}
+            >
+              <div className="flex w-full items-center justify-between">
+                <span
+                  className={cn(
+                    'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+                    active
+                      ? 'bg-primary/15 text-primary'
+                      : 'bg-muted/60 text-muted-foreground group-hover:bg-muted',
+                  )}
+                >
+                  <Icon size={15} aria-hidden />
+                </span>
+                <div className="flex items-center gap-1">
+                  {m.beta ? (
+                    <span className="rounded bg-warning/20 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-warning">
+                      beta
+                    </span>
+                  ) : null}
+                  {active ? (
+                    <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                      <Check size={10} aria-hidden />
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span
+                  className={cn(
+                    'text-sm font-semibold leading-tight',
+                    active ? 'text-foreground' : 'text-foreground/90',
+                  )}
+                >
+                  {m.label}
+                </span>
+                <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+                  {m.tagline}
+                </span>
+              </div>
+              <p className="text-2xs leading-relaxed text-muted-foreground">{m.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Mode-specific body */}
+      <div className="rounded-lg border border-border-soft bg-subtle/30 p-4">
+        {workflowMode === 'single' ? (
+          <SingleAgentPanel
+            firstAgentKind={firstAgentKind}
+            setFirstAgentKind={setFirstAgentKind}
+            selectedProvider={selectedProvider}
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
+            effort={effort}
+            setEffort={setEffort}
+            verbosity={verbosity}
+            setVerbosity={setVerbosity}
+            providerReady={providerReady}
+            busy={busy}
+          />
+        ) : null}
+
+        {workflowMode === 'preset' ? (
+          <PresetPanel
+            phaseTemplates={phaseTemplates}
+            selectedPhaseTemplateId={selectedPhaseTemplateId}
+            setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
+            onSwitchToCustom={() => onModeChange('custom')}
+            busy={busy}
+          />
+        ) : null}
+
+        {workflowMode === 'custom' ? (
+          <CustomPanel
+            phaseTemplates={phaseTemplates}
+            customTemplateId={customTemplateId}
+            setCustomTemplateId={setCustomTemplateId}
+            workspaceId={workspaceId}
+            selectedProvider={selectedProvider}
+            goal={goal}
+            onPlanChange={onPlanChange}
+          />
+        ) : null}
+      </div>
+
+      {workflowMode !== 'single' && selectedPhaseTemplateId !== '' ? (
+        <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+          <input
+            type="checkbox"
+            checked={autoRun}
+            onChange={(e) => setAutoRun(e.target.checked)}
+            className="mt-0.5 accent-primary"
+          />
+          <span className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-1.5 font-medium text-foreground">
+              Run autonomously
+              <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+                beta
+              </span>
+            </span>
+            <span className="text-muted-foreground">
+              Auto-spawn each step on completion. Pauses on error or budget exceed.
+            </span>
+          </span>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+interface SingleAgentPanelProps {
+  readonly firstAgentKind: AgentKind;
+  readonly setFirstAgentKind: (k: AgentKind) => void;
+  readonly selectedProvider: ProviderId;
+  readonly selectedModel: string;
+  readonly setSelectedModel: (m: string) => void;
+  readonly effort: EffortLevel;
+  readonly setEffort: (e: EffortLevel) => void;
+  readonly verbosity: VerbosityLevel;
+  readonly setVerbosity: (v: VerbosityLevel) => void;
+  readonly providerReady: boolean;
+  readonly busy: boolean;
+}
+
+function SingleAgentPanel({
+  firstAgentKind,
+  setFirstAgentKind,
+  selectedProvider,
+  selectedModel,
+  setSelectedModel,
+  effort,
+  setEffort,
+  verbosity,
+  setVerbosity,
+  providerReady,
+  busy,
+}: SingleAgentPanelProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Configure the first agent"
+        subtitle="One conversation, ready to talk. You can spawn more agents from the sidebar anytime."
+      />
+      <Field label="Agent role" hint="Sets the system prompt and default tools.">
+        <AgentKindSelect value={firstAgentKind} onChange={setFirstAgentKind} disabled={busy} />
+      </Field>
+      <div className="grid grid-cols-3 gap-3">
+        <InlineField label="Model">
+          <ModelSelect
+            provider={selectedProvider}
+            value={selectedModel}
+            onChange={setSelectedModel}
+            disabled={busy || !providerReady}
+          />
+        </InlineField>
+        <InlineField label="Effort">
+          <EffortSelect model={selectedModel} value={effort} onChange={setEffort} disabled={busy} />
+        </InlineField>
+        <InlineField label="Verbosity">
+          <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
+        </InlineField>
+      </div>
+    </div>
+  );
+}
+
+interface PresetPanelProps {
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly selectedPhaseTemplateId: WorkflowId | '';
+  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
+  readonly onSwitchToCustom: () => void;
+  readonly busy: boolean;
+}
+
+function PresetPanel({
+  phaseTemplates,
+  selectedPhaseTemplateId,
+  setSelectedPhaseTemplateId,
+  onSwitchToCustom,
+  busy,
+}: PresetPanelProps) {
+  if (phaseTemplates.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+        <Layers size={28} className="text-muted-foreground/30" aria-hidden />
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-foreground">No workflow presets yet</p>
+          <p className="max-w-xs text-2xs leading-relaxed text-muted-foreground">
+            Workspaces ship with a small library. If yours is empty, design one with the planner.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onSwitchToCustom}
+          className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+        >
+          <Sparkles size={11} aria-hidden /> Switch to custom plan
+        </button>
+      </div>
+    );
+  }
+  const selected = phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null;
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Pick a blueprint"
+        subtitle={`${phaseTemplates.length} preset${phaseTemplates.length === 1 ? '' : 's'} available in this workspace. Each preset runs its steps in order.`}
+      />
+      <div className="flex flex-col gap-2">
+        {phaseTemplates.map((t) => {
+          const active = selectedPhaseTemplateId === t.id;
+          const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
+          return (
+            <button
+              key={t.id}
+              type="button"
+              disabled={busy}
+              onClick={() => setSelectedPhaseTemplateId(active ? '' : t.id)}
+              className={cn(
+                'flex flex-col gap-2 rounded-md border px-3 py-2.5 text-left transition-colors',
+                active
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border-soft bg-background hover:border-border hover:bg-subtle/40',
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded-full',
+                    active
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground/40',
+                  )}
+                >
+                  {active ? <Check size={10} aria-hidden /> : null}
+                </span>
+                <span className="flex-1 truncate text-xs font-semibold text-foreground">
+                  {t.name}
+                </span>
+                <span className="shrink-0 text-2xs text-muted-foreground">
+                  {sorted.length} step{sorted.length === 1 ? '' : 's'}
+                </span>
+              </div>
+              {t.description ? (
+                <p className="pl-6 text-2xs leading-relaxed text-muted-foreground">
+                  {t.description}
+                </p>
+              ) : null}
+              {sorted.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1 pl-6">
+                  {sorted.map((step, i) => {
+                    const kind = inferAgentKindFromName(step.name);
+                    const pal = AGENT_KIND_PALETTE[kind];
+                    return (
+                      <span key={step.id} className="flex items-center gap-1">
+                        {i > 0 ? (
+                          <span className="text-2xs text-muted-foreground/40">→</span>
+                        ) : null}
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-full bg-background px-1.5 py-0.5 text-2xs',
+                            pal.fg,
+                          )}
+                        >
+                          <span className={cn('size-1.5 rounded-full', pal.bg)} />
+                          {step.name}
+                        </span>
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {selected ? <WorkflowPreview template={selected} /> : null}
+    </div>
+  );
+}
+
+interface CustomPanelProps {
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly customTemplateId: WorkflowId | '';
+  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
+  readonly workspaceId: WorkspaceId;
+  readonly selectedProvider: ProviderId;
+  readonly goal: string;
+  readonly onPlanChange: (v: boolean) => void;
+}
+
+function CustomPanel({
+  phaseTemplates,
+  customTemplateId,
+  setCustomTemplateId,
+  workspaceId,
+  selectedProvider,
+  goal,
+  onPlanChange,
+}: CustomPanelProps) {
+  if (customTemplateId !== '') {
+    const customTemplate = phaseTemplates.find((t) => t.id === customTemplateId) ?? null;
+    return (
+      <div className="flex flex-col gap-4">
+        <PanelHeader
+          title="Custom plan ready"
+          subtitle={
+            customTemplate
+              ? `Planner produced a workflow with ${customTemplate.steps.length} step${customTemplate.steps.length === 1 ? '' : 's'}. Review below.`
+              : 'Planner produced a workflow. Review below.'
+          }
+        />
+        <WorkflowPreview template={customTemplate} />
+        <div>
+          <button
+            type="button"
+            onClick={() => setCustomTemplateId('')}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+          >
+            <Sparkles size={11} aria-hidden /> Re-plan
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Design a plan from your goal"
+        subtitle="The planner drafts a sequence of agents tailored to what you typed. Tune it before locking it in."
+      />
+      <PlannerWidget
+        workspaceId={workspaceId}
+        providerId={selectedProvider}
+        initialTheme={goal}
+        onWorkflowReady={(workflowId) => setCustomTemplateId(workflowId)}
+        onPlanChange={onPlanChange}
+      />
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Provider                                                     */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface ProviderSectionProps {
+  readonly connectedProviderIds: ReadonlySet<ProviderId>;
+  readonly selectedProvider: ProviderId;
+  readonly onRequestChange: (id: ProviderId) => void;
+  readonly pendingProviderSwitch: ProviderId | null;
+  readonly onCancelSwitch: () => void;
+  readonly onConfirmSwitch: () => void;
+  readonly onClose: () => void;
+  readonly onOpenSettings: () => void;
+}
+
+function ProviderSection({
+  connectedProviderIds,
+  selectedProvider,
+  onRequestChange,
+  pendingProviderSwitch,
+  onCancelSwitch,
+  onConfirmSwitch,
+  onClose,
+}: ProviderSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<Zap size={14} aria-hidden className="text-primary" />}
+        title="Which provider should drive this session?"
+        subtitle="Affects model availability and routing. You can override per-turn later."
+      />
+      <div className="grid grid-cols-3 gap-2">
+        {PROVIDER_ORDER.map((id) => {
+          const connected = connectedProviderIds.has(id);
+          const selected = selectedProvider === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              disabled={!connected}
+              onClick={() => onRequestChange(id)}
+              className={cn(
+                'flex flex-col items-center gap-1.5 rounded-md border px-3 py-3 text-sm transition-colors',
+                selected && connected
+                  ? 'border-primary bg-primary/5 font-medium text-foreground'
+                  : connected
+                    ? 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50'
+                    : 'cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40',
+              )}
+            >
+              <span className="flex items-center gap-1.5">
+                {connected ? (
+                  <span
+                    className={cn(
+                      'size-1.5 rounded-full',
+                      selected ? 'bg-success' : 'bg-muted-foreground/40',
+                    )}
+                  />
+                ) : (
+                  <X size={10} className="text-danger/60" aria-hidden />
+                )}
+                {PROVIDER_LABEL_LOWER[id]}
+                {id !== 'anthropic' ? (
+                  <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+                    beta
+                  </span>
+                ) : null}
+              </span>
+              {!connected ? (
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="text-2xs text-primary/70 underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose();
+                    window.dispatchEvent(
+                      new CustomEvent('kayam:open-settings', {
+                        detail: { section: 'providers' },
+                      }),
+                    );
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.stopPropagation();
+                      onClose();
+                      window.dispatchEvent(
+                        new CustomEvent('kayam:open-settings', {
+                          detail: { section: 'providers' },
+                        }),
+                      );
+                    }
+                  }}
+                >
+                  Connect
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {pendingProviderSwitch ? (
+        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden />
+          <div className="flex flex-1 flex-col gap-1.5">
+            <p className="text-xs font-medium text-foreground">
+              Switching provider will discard your custom workflow.
+            </p>
+            <div className="flex gap-2">
+              <Button size="sm" variant="ghost" onClick={onCancelSwitch}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={onConfirmSwitch}>
+                Switch provider
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Init                                                         */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface InitSectionProps {
+  readonly initEnabled: boolean;
+  readonly setInitEnabled: (v: boolean) => void;
+  readonly initContent: string;
+  readonly setInitContent: (v: string) => void;
+  readonly busy: boolean;
+}
+
+function InitSection({
+  initEnabled,
+  setInitEnabled,
+  initContent,
+  setInitContent,
+  busy,
+}: InitSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<Terminal size={14} aria-hidden className="text-primary" />}
+        title="Init script"
+        subtitle="Workspace setup that runs before agents start. Edit for this session only."
+      />
+      <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+        <input
+          type="checkbox"
+          checked={initEnabled}
+          onChange={(e) => setInitEnabled(e.target.checked)}
+          className="mt-0.5 accent-primary"
+        />
+        <span className="flex flex-col gap-0.5">
+          <span className="font-medium text-foreground">Run init script</span>
+          <span className="text-muted-foreground">
+            Execute workspace setup before agents start.
+          </span>
+        </span>
+      </label>
+      <Field label="Script" hint="Edit for this session only. Changes won't save to workspace.">
+        <Textarea
+          value={initContent}
+          onChange={(e) => setInitContent(e.target.value)}
+          className="min-h-[220px] resize-y font-mono text-xs"
+          disabled={!initEnabled || busy}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          rows={10}
+        />
+      </Field>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Budget                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface BudgetSectionProps {
+  readonly softCapRaw: string;
+  readonly setSoftCapRaw: (v: string) => void;
+  readonly busy: boolean;
+}
+
+function BudgetSection({ softCapRaw, setSoftCapRaw, busy }: BudgetSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<DollarSign size={14} aria-hidden className="text-primary" />}
+        title="Soft cap"
+        subtitle="Optional spend limit. Session gets flagged once exceeded — agents keep running."
+      />
+      <Field label="Soft cap (USD)" hint="Leave blank to skip.">
+        <Input
+          value={softCapRaw}
+          onChange={(e) => setSoftCapRaw(e.target.value)}
+          placeholder="5.00"
+          type="number"
+          min="0"
+          step="0.01"
+          disabled={busy}
+        />
+      </Field>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
+          {icon}
+        </span>
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      </div>
+      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
+  );
+}
+
+function PanelHeader({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs font-semibold text-foreground">{title}</span>
+      <p className="text-2xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }
 
@@ -1029,26 +1529,18 @@ function Field({
   );
 }
 
-function BetaChip() {
-  return (
-    <span className="rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning">
-      beta
-    </span>
-  );
-}
-
 function WorkflowPreview({ template }: { template: Workflow | null }) {
   if (!template) return null;
   if (template.steps.length === 0) {
     return (
-      <p className="mt-2 rounded-md bg-subtle px-3 py-2 text-xs text-muted-foreground">
+      <p className="rounded-md bg-subtle px-3 py-2 text-xs text-muted-foreground">
         This workflow has no steps yet. Add some via the planner above.
       </p>
     );
   }
   const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
   return (
-    <div className="mt-2 flex flex-col gap-1.5 rounded-md bg-subtle p-3">
+    <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-background p-3">
       <div className="flex items-baseline justify-between">
         <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
           will spawn {template.steps.length} agent
@@ -1061,12 +1553,12 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <ol className="flex flex-col gap-1">
         {sortedSteps.map((step, i) => {
           const model = step.modelOverride ? shortModel(step.modelOverride) : null;
-          const effort = step.effort ?? null;
-          const verbosity = step.verbosity ?? null;
+          const eff = step.effort ?? null;
+          const verb = step.verbosity ?? null;
           return (
             <li
               key={step.id}
-              className="flex items-center gap-2 rounded-md bg-background px-2 py-1 text-xs"
+              className="flex items-center gap-2 rounded-md bg-subtle px-2 py-1 text-xs"
             >
               <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
               <span
@@ -1076,9 +1568,9 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
                 )}
               />
               <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
-              {model || effort || verbosity ? (
-                <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-                  {[model, effort, verbosity ? `v:${verbosity}` : null].filter(Boolean).join(' · ')}
+              {model || eff || verb ? (
+                <span className="shrink-0 rounded-full bg-background px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
+                  {[model, eff, verb ? `v:${verb}` : null].filter(Boolean).join(' · ')}
                 </span>
               ) : null}
             </li>
@@ -1088,97 +1580,6 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <p className="text-2xs text-muted-foreground/70">
         each agent runs in its own chat thread. you decide which one gets the next turn.
       </p>
-    </div>
-  );
-}
-
-function WorkflowModeSegmented({
-  mode,
-  onChange,
-}: {
-  mode: WorkflowMode;
-  onChange: (next: WorkflowMode) => void;
-}) {
-  return (
-    <div
-      role="tablist"
-      aria-label="workflow mode"
-      className="inline-flex rounded-md border border-border bg-subtle p-0.5"
-    >
-      {WORKFLOW_MODES.map((m) => {
-        const active = mode === m.id;
-        return (
-          <button
-            key={m.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => onChange(m.id)}
-            className={cn(
-              'flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors',
-              active
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            {m.label}
-            {m.beta ? (
-              <span className="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning">
-                beta
-              </span>
-            ) : null}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function workflowModeHint(mode: WorkflowMode): string {
-  return WORKFLOW_MODES.find((m) => m.id === mode)?.hint ?? '';
-}
-
-function BranchModeToggle({
-  mode,
-  onChange,
-  disabled,
-}: {
-  mode: 'new' | 'existing';
-  onChange: (next: 'new' | 'existing') => void;
-  disabled: boolean;
-}) {
-  const modes: ReadonlyArray<{ id: 'new' | 'existing'; label: string }> = [
-    { id: 'new', label: 'New' },
-    { id: 'existing', label: 'Existing' },
-  ];
-  return (
-    <div
-      role="tablist"
-      aria-label="branch source"
-      className="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
-    >
-      {modes.map((m) => {
-        const active = mode === m.id;
-        return (
-          <button
-            key={m.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            disabled={disabled}
-            onClick={() => onChange(m.id)}
-            className={cn(
-              'rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
-              active
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-              disabled && 'cursor-not-allowed opacity-50',
-            )}
-          >
-            {m.label}
-          </button>
-        );
-      })}
     </div>
   );
 }
@@ -1203,7 +1604,10 @@ function BranchCombobox({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
-  const filtered = branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase()));
+  const filtered = useMemo(
+    () => branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase())),
+    [branches, query],
+  );
 
   const select = useCallback(
     (name: string) => {
@@ -1285,7 +1689,7 @@ function BranchCombobox({
         aria-expanded={open}
         aria-autocomplete="list"
         autoComplete="off"
-        className="h-7 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+        className="h-8 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
         onChange={(e) => {
           setQuery(e.target.value);
           setOpen(true);
@@ -1369,7 +1773,7 @@ function AgentKindSelect({
           'flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors',
           open
             ? 'border-primary bg-primary/5'
-            : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+            : 'border-border-soft bg-background hover:border-border hover:bg-muted/50',
           disabled && 'cursor-not-allowed opacity-50',
         )}
       >
@@ -1425,129 +1829,6 @@ function AgentKindSelect({
                 </button>
               );
             })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function PresetSelect({
-  templates,
-  value,
-  onChange,
-  disabled,
-}: {
-  templates: ReadonlyArray<Workflow>;
-  value: WorkflowId | '';
-  onChange: (id: WorkflowId | '') => void;
-  disabled: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  const selected = templates.find((t) => t.id === value) ?? null;
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setOpen(!open)}
-        className={cn(
-          'flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors',
-          open
-            ? 'border-primary bg-primary/5'
-            : value
-              ? 'border-primary/50 bg-primary/5'
-              : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
-      >
-        {selected ? (
-          <>
-            <span className="flex-1 truncate font-medium text-foreground">{selected.name}</span>
-            <span className="shrink-0 text-2xs text-muted-foreground">
-              {selected.steps.length} step{selected.steps.length === 1 ? '' : 's'}
-            </span>
-          </>
-        ) : (
-          <span className="flex-1 text-muted-foreground/60">Select a workflow preset</span>
-        )}
-        <ChevronDown
-          size={12}
-          className={cn(
-            'shrink-0 text-muted-foreground transition-transform',
-            open && 'rotate-180',
-          )}
-          aria-hidden
-        />
-      </button>
-      {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 max-h-[240px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg">
-          {templates.map((t) => {
-            const active = value === t.id;
-            const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
-            return (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => {
-                  onChange(active ? '' : t.id);
-                  setOpen(false);
-                }}
-                className={cn(
-                  'flex w-full flex-col gap-0.5 px-2.5 py-2 text-left transition-colors',
-                  active ? 'bg-primary/10' : 'hover:bg-muted/50',
-                )}
-              >
-                <div className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      'flex-1 truncate text-xs font-medium',
-                      active ? 'text-foreground' : 'text-foreground/80',
-                    )}
-                  >
-                    {t.name}
-                  </span>
-                  <span className="shrink-0 text-2xs text-muted-foreground">
-                    {t.steps.length} step{t.steps.length === 1 ? '' : 's'}
-                  </span>
-                  {active ? (
-                    <Check size={11} className="shrink-0 text-primary" aria-hidden />
-                  ) : null}
-                </div>
-                {sorted.length > 0 ? (
-                  <div className="flex items-center gap-1">
-                    {sorted.map((step, i) => {
-                      const kind = inferAgentKindFromName(step.name);
-                      const pal = AGENT_KIND_PALETTE[kind];
-                      return (
-                        <span key={step.id} className="flex items-center gap-0.5">
-                          {i > 0 ? (
-                            <span className="text-2xs text-muted-foreground/30">→</span>
-                          ) : null}
-                          <span className={cn('max-w-[5rem] truncate text-2xs', pal.fg)}>
-                            {step.name}
-                          </span>
-                        </span>
-                      );
-                    })}
-                  </div>
-                ) : null}
-              </button>
-            );
-          })}
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/features/session/components/OpenInEditorIconButton/index.tsx
+++ b/apps/desktop/src/features/session/components/OpenInEditorIconButton/index.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, FolderOpen } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import { openInEditor } from '../../../../shared/lib/editor';
+import { formatError } from '../../../../shared/lib/errors';
+import {
+  DEFAULT_EDITOR_BINARY,
+  SETTING_DEFAULT_EDITOR,
+  SETTING_EDITOR_BINARY,
+} from '../../../../features/settings/settings';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+
+interface OpenInEditorIconButtonProps {
+  readonly worktreePath: string | null;
+}
+
+/**
+ * Compact icon-only "open this session's worktree in an external editor"
+ * affordance. Intended for header chrome (e.g. the session detail panel)
+ * where space is tight and a labelled button would clash. Click behaviour:
+ * - 0 editors detected → disabled
+ * - 1 editor → opens directly
+ * - 2+ editors → opens a small popover. Last picked editor is remembered.
+ */
+export function OpenInEditorIconButton({ worktreePath }: OpenInEditorIconButtonProps) {
+  const detectedEditors = useAppStore((s) => s.detectedEditors);
+  const globalEditorBinary = useAppStore(
+    (s) => s.settings[SETTING_EDITOR_BINARY] ?? DEFAULT_EDITOR_BINARY,
+  );
+  const savedDefault = useAppStore((s) => s.settings[SETTING_DEFAULT_EDITOR] ?? null);
+  const saveSetting = useAppStore((s) => s.saveSetting);
+  const { showToast } = useToast();
+
+  const resolvedDefault = savedDefault ?? globalEditorBinary;
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const launch = async (binary: string) => {
+    if (!worktreePath) return;
+    setOpen(false);
+    try {
+      await openInEditor(worktreePath, binary);
+      if (binary !== resolvedDefault) {
+        await saveSetting(SETTING_DEFAULT_EDITOR, binary);
+      }
+    } catch (err) {
+      showToast('error', `couldn't open editor: ${formatError(err)}`);
+    }
+  };
+
+  const disabled = !worktreePath || detectedEditors.length === 0;
+  const hasMultiple = detectedEditors.length > 1;
+
+  const onClick = () => {
+    if (disabled) return;
+    if (hasMultiple) {
+      setOpen((v) => !v);
+    } else {
+      void launch(detectedEditors[0]!.binary);
+    }
+  };
+
+  const title = disabled
+    ? detectedEditors.length === 0
+      ? 'no editor detected'
+      : 'no worktree available'
+    : hasMultiple
+      ? 'open worktree in editor'
+      : `open in ${detectedEditors[0]!.label}`;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        title={title}
+        aria-label={title}
+        aria-haspopup={hasMultiple ? 'menu' : undefined}
+        aria-expanded={hasMultiple ? open : undefined}
+        className={cn(
+          'shrink-0 rounded p-1 motion-safe:transition-colors',
+          disabled
+            ? 'cursor-not-allowed text-muted-foreground/30'
+            : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
+          open && 'bg-foreground/10 text-foreground',
+        )}
+      >
+        <FolderOpen size={13} aria-hidden />
+      </button>
+      {open && hasMultiple ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-30 mt-1 min-w-[160px] rounded-md border border-border bg-subtle py-1 text-xs shadow-lg"
+        >
+          {detectedEditors.map((ed) => {
+            const active = ed.binary === resolvedDefault;
+            return (
+              <button
+                key={ed.binary}
+                type="button"
+                role="menuitem"
+                onClick={() => void launch(ed.binary)}
+                className={cn(
+                  'flex w-full items-center gap-2 px-2.5 py-1.5 text-left motion-safe:transition-colors',
+                  active
+                    ? 'bg-primary/10 text-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <FolderOpen
+                  size={11}
+                  aria-hidden
+                  className={active ? 'text-primary' : 'text-muted-foreground/60'}
+                />
+                <span className="flex-1 truncate">{ed.label}</span>
+                {active ? <Check size={11} className="text-primary" aria-hidden /> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -21,6 +21,7 @@ import { useAppStore } from '../../../../store';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
+import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 import { useToast } from '../../../../app/components/Toast';
 import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
 
@@ -516,29 +517,14 @@ function GeneralSection(props: GeneralSectionProps) {
               </div>
 
               {branchMode === 'existing' ? (
-                <select
+                <BranchCombobox
+                  branches={branches}
                   value={branchTarget}
-                  onChange={(e) => setBranchTarget(e.target.value)}
-                  disabled={busy || branchesLoading}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">
-                    {branchesLoading
-                      ? 'Loading…'
-                      : branches.length === 0
-                        ? 'No local branches'
-                        : 'Select branch…'}
-                  </option>
-                  {branches
-                    .filter((b) => b.name !== branch)
-                    .map((b) => (
-                      <option key={b.name} value={b.name}>
-                        {b.name}
-                        {b.inUse ? ' · in use' : ''}
-                        {b.hasUncommitted ? ' · dirty' : ''}
-                      </option>
-                    ))}
-                </select>
+                  onChange={setBranchTarget}
+                  disabled={busy}
+                  loading={branchesLoading}
+                  excludeNames={branch ? [branch] : undefined}
+                />
               ) : (
                 <Input
                   value={branchTarget}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -221,7 +221,6 @@ export function SessionSettingsDialog({
       description={session.goal}
       size="xl"
       className="w-[64rem] max-w-[95vw]"
-      fixedHeightClass="h-[600px]"
       bodyClassName="px-0 py-0 gap-0"
       fullScreenOnSmall
       footer={
@@ -555,15 +554,7 @@ function GeneralSection(props: GeneralSectionProps) {
                 </div>
               ) : null}
 
-              <div className="flex items-center justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setBranchEditOpen(false)}
-                  disabled={busy}
-                >
-                  Cancel
-                </Button>
+              <div className="flex items-center justify-end">
                 <Button
                   size="sm"
                   onClick={onChangeBranch}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
   Archive,
   ArchiveRestore,
-  Bot,
+  Check,
+  ChevronDown,
+  ChevronUp,
   DollarSign,
   GitBranch,
   Loader2,
+  Settings2,
+  Terminal,
   Trash2,
+  Zap,
 } from 'lucide-react';
 import type { SessionId } from '@kay-am/types';
 import { formatError } from '../../../../shared/lib/errors';
@@ -17,6 +22,7 @@ import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/fea
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
 import { useToast } from '../../../../app/components/Toast';
+import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
 
 interface SessionSettingsDialogProps {
   sessionId: SessionId;
@@ -30,23 +36,11 @@ interface SessionSettingsDialogProps {
 type Section = 'general' | 'budget' | 'danger';
 
 interface NavItem {
-  id: Section;
-  label: string;
-  icon: React.ReactNode;
+  readonly id: Section;
+  readonly label: string;
+  readonly icon: ReactNode;
+  readonly tone?: 'danger';
 }
-
-const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'general', label: 'General', icon: <Bot size={14} aria-hidden /> },
-  ...(SESSION_FEATURES.budget
-    ? [{ id: 'budget' as const, label: 'Budget', icon: <DollarSign size={14} aria-hidden /> }]
-    : []),
-];
-
-const DANGER_NAV: NavItem = {
-  id: 'danger',
-  label: 'Delete',
-  icon: <Trash2 size={14} aria-hidden />,
-};
 
 export function SessionSettingsDialog({
   sessionId,
@@ -123,16 +117,25 @@ export function SessionSettingsDialog({
   const isActiveSession = sessionSummary !== null;
   const spent = isActiveSession ? (sessionSummary?.estimatedCostUsd ?? 0) : 0;
 
+  const navItems: ReadonlyArray<NavItem> = [
+    { id: 'general', label: 'General', icon: <Settings2 size={13} aria-hidden /> },
+    ...(SESSION_FEATURES.budget
+      ? ([{ id: 'budget', label: 'Budget', icon: <DollarSign size={13} aria-hidden /> }] as const)
+      : []),
+    { id: 'danger', label: 'Danger zone', icon: <Trash2 size={13} aria-hidden />, tone: 'danger' },
+  ];
+
   const onSaveGoal = async () => {
     const trimmed = goalDraft.trim();
     if (!trimmed) {
-      setError('goal cannot be empty');
+      setError('Name cannot be empty.');
       return;
     }
     setBusy(true);
     setError(null);
     try {
       await renameTask(sessionId, trimmed);
+      showToast('success', 'session renamed');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -143,13 +146,14 @@ export function SessionSettingsDialog({
   const onSaveCap = async () => {
     const parsed = parseCap(capDraft);
     if (parsed === null) {
-      setError('cap must be a positive number');
+      setError('Cap must be a positive number.');
       return;
     }
     setBusy(true);
     setError(null);
     try {
       await setSessionBudget(sessionId, parsed);
+      showToast('success', 'budget updated');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -159,8 +163,6 @@ export function SessionSettingsDialog({
 
   const targetTrimmed = branchTarget.trim();
   const targetInfo = branches.find((b) => b.name === targetTrimmed) ?? null;
-  // Friction sources: branch already owned by another session, branch in use
-  // in another worktree, branch has uncommitted work in its current worktree.
   const targetOwnedByOtherSession = Object.entries(sessionBranches).some(
     ([otherSessionId, b]) => otherSessionId !== sessionId && b === targetTrimmed,
   );
@@ -171,7 +173,7 @@ export function SessionSettingsDialog({
 
   const onChangeBranch = async () => {
     if (!targetTrimmed) {
-      setError('branch is required');
+      setError('Pick a branch.');
       return;
     }
     if (targetTrimmed === branch) {
@@ -210,399 +212,698 @@ export function SessionSettingsDialog({
     }
   };
 
-  const renderContent = () => {
-    switch (active) {
-      case 'general':
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold tracking-wide text-muted-foreground">Session</div>
-            <Field
-              label="name"
-              hint="display name for the session in the sidebar. to update the actual goal text the agent reads, use the context panel on the right."
-            >
-              <div className="flex gap-2">
-                <Input
-                  value={goalDraft}
-                  onChange={(e) => setGoalDraft(e.target.value)}
-                  placeholder="refactor auth domain"
-                  className="flex-1"
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Session settings"
+      description={session.goal}
+      size="xl"
+      className="w-[64rem] max-w-[95vw]"
+      fixedHeightClass="h-[600px]"
+      bodyClassName="px-0 py-0 gap-0"
+      fullScreenOnSmall
+      footer={
+        <div className="flex w-full items-center gap-2">
+          <div className="flex-1">
+            {error ? <span className="text-xs text-danger">{error}</span> : null}
+          </div>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex h-full min-h-0">
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
+          {navItems
+            .filter((i) => i.tone !== 'danger')
+            .map((item) => (
+              <NavButton
+                key={item.id}
+                item={item}
+                active={active === item.id}
+                onClick={() => setActive(item.id)}
+              />
+            ))}
+          <div className="mt-auto">
+            {navItems
+              .filter((i) => i.tone === 'danger')
+              .map((item) => (
+                <NavButton
+                  key={item.id}
+                  item={item}
+                  active={active === item.id}
+                  onClick={() => setActive(item.id)}
                 />
-                <Button
-                  variant="secondary"
-                  onClick={() => void onSaveGoal()}
-                  disabled={busy || goalDraft.trim() === session.goal.trim()}
-                >
-                  Save
-                </Button>
-              </div>
-            </Field>
-            <Field
-              label="branch"
-              hint="switch this session to a different branch. existing checkouts with uncommitted work require confirmation."
-            >
-              <div className="flex items-center gap-2">
-                <div className="inline-flex items-center gap-2 rounded-md bg-subtle px-2.5 py-2 text-xs text-muted-foreground ring-1 ring-border-soft">
-                  <GitBranch size={12} aria-hidden />
-                  <code className="font-mono text-foreground">{branch ?? 'unknown'}</code>
-                </div>
-                <Button
-                  variant="secondary"
-                  onClick={() => setBranchEditOpen(true)}
-                  disabled={busy || !workspace}
-                >
-                  Change branch
-                </Button>
-              </div>
-            </Field>
-            <Field label="provider" hint="set at creation time.">
-              <span className="inline-flex w-fit items-center gap-2 rounded-md bg-subtle px-2.5 py-1.5 text-xs text-muted-foreground ring-1 ring-border-soft">
-                {session.providerPreference.defaultProvider}
-              </span>
-            </Field>
-            {WORKSPACE_FEATURES.initScript && hasInitScript ? (
-              <Field
-                label="init script"
-                hint="when enabled, a setup agent runs the workspace init script before the first agent fires."
-              >
-                <label className="flex items-center gap-2 text-xs text-foreground">
-                  <input
-                    type="checkbox"
-                    checked={!session.skipInit}
-                    onChange={(e) => void updateSessionSkipInit(sessionId, !e.target.checked)}
-                    className="accent-primary"
-                  />
-                  run workspace init script
-                </label>
-              </Field>
-            ) : null}
+              ))}
           </div>
-        );
+        </nav>
 
-      case 'budget':
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
-              Soft cap
-            </div>
-            <Field
-              label="cap (usd)"
-              hint="warning fires at 80%, error at 100%. session keeps running unless you stop it."
-            >
-              <div className="flex gap-2">
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={capDraft}
-                  onChange={(e) => setCapDraft(e.target.value)}
-                  placeholder="2.50"
-                  className="flex-1"
-                />
-                <Button variant="secondary" onClick={() => void onSaveCap()} disabled={busy}>
-                  Save
-                </Button>
-              </div>
-            </Field>
-            {budget?.softCapUsd != null ? (
-              <div className="rounded-md bg-subtle p-3 text-xs text-muted-foreground ring-1 ring-border-soft">
-                <div className="flex items-center justify-between">
-                  <span>spent this session</span>
-                  <span className="font-mono text-foreground">
-                    ${spent.toFixed(2)} / ${budget.softCapUsd.toFixed(2)}
-                  </span>
-                </div>
-              </div>
-            ) : null}
-          </div>
-        );
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {active === 'general' ? (
+            <GeneralSection
+              session={session}
+              goalDraft={goalDraft}
+              setGoalDraft={setGoalDraft}
+              onSaveGoal={onSaveGoal}
+              branch={branch}
+              workspaceReady={!!workspace}
+              busy={busy}
+              hasInitScript={hasInitScript}
+              skipInit={session.skipInit ?? false}
+              onToggleInit={(enabled) => void updateSessionSkipInit(sessionId, !enabled)}
+              branchEditOpen={branchEditOpen}
+              setBranchEditOpen={setBranchEditOpen}
+              branchMode={branchMode}
+              setBranchMode={(m) => {
+                setBranchMode(m);
+                setBranchTarget('');
+                setConfirmReuse(false);
+              }}
+              branchTarget={branchTarget}
+              setBranchTarget={(v) => {
+                setBranchTarget(v);
+                setConfirmReuse(false);
+              }}
+              branches={branches}
+              branchesLoading={branchesLoading}
+              targetNeedsConfirm={targetNeedsConfirm}
+              targetOwnedByOtherSession={targetOwnedByOtherSession}
+              targetInUseElsewhere={targetInUseElsewhere}
+              targetDirty={targetDirty}
+              confirmReuse={confirmReuse}
+              onChangeBranch={onChangeBranch}
+            />
+          ) : null}
 
-      case 'danger':
-        return (
-          <div className="flex flex-col gap-5">
-            <div>
-              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                permanent actions on this session.
-              </p>
-            </div>
+          {active === 'budget' ? (
+            <BudgetSection
+              capDraft={capDraft}
+              setCapDraft={setCapDraft}
+              onSaveCap={onSaveCap}
+              busy={busy}
+              softCapUsd={budget?.softCapUsd ?? null}
+              spent={spent}
+            />
+          ) : null}
 
-            {/* Archive row */}
-            <div className="flex items-start justify-between gap-4 rounded-md border border-border-soft p-3">
-              <div className="flex-1">
-                <div className="text-xs font-semibold text-foreground">
-                  {archived ? 'unarchive' : 'archive'}
-                </div>
-                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                  {archived
-                    ? 'restore this session to the active list.'
-                    : 'hide from the active list, keep history. reversible.'}
-                </p>
-              </div>
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  archived ? onUnarchive() : onArchive();
-                  onClose();
-                }}
-                disabled={busy}
-              >
-                {archived ? (
-                  <>
-                    <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
-                    Unarchive
-                  </>
-                ) : (
-                  <>
-                    <Archive size={13} aria-hidden className="mr-1.5" />
-                    Archive
-                  </>
-                )}
-              </Button>
-            </div>
+          {active === 'danger' ? (
+            <DangerSection
+              archived={archived}
+              onArchive={onArchive}
+              onUnarchive={onUnarchive}
+              onClose={onClose}
+              confirmDelete={confirmDelete}
+              setConfirmDelete={setConfirmDelete}
+              onDelete={() => void onDelete()}
+              busy={busy}
+            />
+          ) : null}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
 
-            {/* Delete row */}
-            <div
-              className={cn(
-                'flex flex-col gap-3 rounded-md border p-3 transition-colors',
-                confirmDelete ? 'border-danger/40 bg-danger/5' : 'border-border-soft',
-              )}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1">
-                  <div className="text-xs font-semibold text-foreground">delete session</div>
-                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                    removes worktree, transcripts, audit logs, and the branch. cannot be undone.
-                  </p>
-                </div>
-                {!confirmDelete ? (
-                  <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
-                    <Trash2 size={13} aria-hidden className="mr-1.5" />
-                    Delete
-                  </Button>
-                ) : null}
-              </div>
+/* ──────────────────────────────────────────────────────────────────── */
+/* Nav button                                                            */
+/* ──────────────────────────────────────────────────────────────────── */
 
-              {confirmDelete ? (
-                <>
-                  <div className="flex items-center gap-2 text-xs text-warning">
-                    <Archive size={13} aria-hidden />
-                    <span>consider archiving instead. keeps history and is reversible.</span>
-                  </div>
-                  <div className="flex items-center justify-end gap-2">
-                    <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
-                      Cancel
-                    </Button>
-                    {!archived ? (
-                      <Button
-                        variant="warning"
-                        onClick={() => {
-                          onArchive();
-                          setConfirmDelete(false);
-                          onClose();
-                        }}
-                        disabled={busy}
-                      >
-                        <Archive size={13} aria-hidden className="mr-1.5" />
-                        Archive instead
-                      </Button>
-                    ) : null}
-                    <Button variant="danger" onClick={() => void onDelete()} disabled={busy}>
-                      {busy ? 'Deleting…' : 'Confirm delete'}
-                    </Button>
-                  </div>
-                </>
-              ) : null}
-            </div>
-          </div>
-        );
-    }
-  };
+function NavButton({
+  item,
+  active,
+  onClick,
+}: {
+  item: NavItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const danger = item.tone === 'danger';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+        active
+          ? danger
+            ? 'bg-danger/10 font-medium text-danger before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-danger'
+            : 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+          : danger
+            ? 'text-danger/70 hover:bg-danger/5 hover:text-danger'
+            : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
+      )}
+    >
+      {item.icon}
+      <span className="flex-1">{item.label}</span>
+    </button>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: General                                                      */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface GeneralSectionProps {
+  readonly session: { goal: string; providerPreference: { defaultProvider: string } };
+  readonly goalDraft: string;
+  readonly setGoalDraft: (v: string) => void;
+  readonly onSaveGoal: () => void;
+  readonly branch: string | null;
+  readonly workspaceReady: boolean;
+  readonly busy: boolean;
+  readonly hasInitScript: boolean;
+  readonly skipInit: boolean;
+  readonly onToggleInit: (enabled: boolean) => void;
+  readonly branchEditOpen: boolean;
+  readonly setBranchEditOpen: (v: boolean) => void;
+  readonly branchMode: 'existing' | 'new';
+  readonly setBranchMode: (m: 'existing' | 'new') => void;
+  readonly branchTarget: string;
+  readonly setBranchTarget: (v: string) => void;
+  readonly branches: ReadonlyArray<LocalBranchInfo>;
+  readonly branchesLoading: boolean;
+  readonly targetNeedsConfirm: boolean;
+  readonly targetOwnedByOtherSession: boolean;
+  readonly targetInUseElsewhere: boolean;
+  readonly targetDirty: boolean;
+  readonly confirmReuse: boolean;
+  readonly onChangeBranch: () => void;
+}
+
+function GeneralSection(props: GeneralSectionProps) {
+  const {
+    session,
+    goalDraft,
+    setGoalDraft,
+    onSaveGoal,
+    branch,
+    workspaceReady,
+    busy,
+    hasInitScript,
+    skipInit,
+    onToggleInit,
+    branchEditOpen,
+    setBranchEditOpen,
+    branchMode,
+    setBranchMode,
+    branchTarget,
+    setBranchTarget,
+    branches,
+    branchesLoading,
+    targetNeedsConfirm,
+    targetOwnedByOtherSession,
+    targetInUseElsewhere,
+    targetDirty,
+    confirmReuse,
+    onChangeBranch,
+  } = props;
+
+  const providerLabel =
+    PROVIDER_LABEL_LOWER[
+      session.providerPreference.defaultProvider as keyof typeof PROVIDER_LABEL_LOWER
+    ] ?? session.providerPreference.defaultProvider;
 
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        title={session.goal}
-        description="rename, edit budget, or delete this session."
-        size="xl"
-        fixedHeightClass="h-[520px]"
-        fullScreenOnSmall
-        footer={
-          <>
-            {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-            <Button variant="ghost" onClick={onClose}>
-              Close
-            </Button>
-          </>
-        }
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Settings2 size={14} aria-hidden className="text-primary" />}
+        title="General"
+        subtitle="Identity and infrastructure for this session. The goal text the agent actually reads lives in the right-hand context panel."
+      />
+
+      {/* Name */}
+      <Field
+        label="Name"
+        hint="Display name in the sidebar. Renaming doesn't change what the agent sees."
       >
-        <div className="flex h-full min-h-0 gap-0">
-          <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setActive(item.id)}
-                className={`relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === item.id
-                    ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-                }`}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-              </button>
-            ))}
-            <div className="mt-auto pt-3">
-              <button
-                type="button"
-                onClick={() => setActive('danger')}
-                className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === 'danger'
-                    ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
-                    : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
-                }`}
-              >
-                {DANGER_NAV.icon}
-                <span>{DANGER_NAV.label}</span>
-              </button>
-            </div>
-          </nav>
-          <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
-        </div>
-      </Dialog>
-      <Dialog
-        open={branchEditOpen}
-        onClose={() => setBranchEditOpen(false)}
-        title="Change session branch"
-        description="point this session's worktree at a different branch."
-        size="md"
-        footer={
-          <>
-            {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-            <Button variant="ghost" onClick={() => setBranchEditOpen(false)} disabled={busy}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void onChangeBranch()}
-              disabled={busy || branchesLoading || targetTrimmed.length === 0}
-              variant={targetNeedsConfirm && confirmReuse ? 'warning' : 'primary'}
-            >
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
-                  Switching…
-                </>
-              ) : targetNeedsConfirm && confirmReuse ? (
-                'Confirm switch'
-              ) : (
-                'Switch branch'
-              )}
-            </Button>
-          </>
-        }
-      >
-        <div className="flex flex-col gap-4">
-          <div
-            role="tablist"
-            aria-label="branch source"
-            className="inline-flex rounded-md border border-border bg-subtle p-0.5"
+        <div className="flex gap-2">
+          <Input
+            value={goalDraft}
+            onChange={(e) => setGoalDraft(e.target.value)}
+            placeholder="e.g. refactor auth domain"
+            disabled={busy}
+            className="flex-1"
+          />
+          <Button
+            variant="secondary"
+            onClick={onSaveGoal}
+            disabled={busy || goalDraft.trim() === session.goal.trim() || goalDraft.trim() === ''}
           >
-            {(['existing', 'new'] as const).map((m) => {
-              const active = branchMode === m;
-              return (
-                <button
-                  key={m}
-                  type="button"
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => {
-                    setBranchMode(m);
-                    setBranchTarget('');
-                    setConfirmReuse(false);
-                  }}
-                  disabled={busy}
-                  className={cn(
-                    'rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors',
-                    active
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  {m === 'existing' ? 'existing branch' : 'new branch'}
-                </button>
-              );
-            })}
+            Save
+          </Button>
+        </div>
+      </Field>
+
+      {/* Branch — inline change */}
+      <Field
+        label="Branch"
+        hint="Switch this session to a different branch. Existing checkouts with uncommitted work require confirmation."
+      >
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-3">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex flex-1 items-center gap-1.5 truncate rounded-md border border-border-soft bg-background px-2.5 py-1.5 font-mono text-xs text-foreground">
+              <GitBranch size={11} aria-hidden className="shrink-0 text-muted-foreground" />
+              <span className="truncate">{branch ?? 'unknown'}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setBranchEditOpen(!branchEditOpen)}
+              disabled={busy || !workspaceReady}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-border hover:bg-muted/50',
+                (busy || !workspaceReady) && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              {branchEditOpen ? (
+                <ChevronUp size={12} aria-hidden />
+              ) : (
+                <ChevronDown size={12} aria-hidden />
+              )}
+              {branchEditOpen ? 'Cancel' : 'Change…'}
+            </button>
           </div>
 
-          {branchMode === 'existing' ? (
-            <Field label="branch" hint="pick from local branches in this workspace.">
-              <select
-                value={branchTarget}
-                onChange={(e) => {
-                  setBranchTarget(e.target.value);
-                  setConfirmReuse(false);
-                }}
-                disabled={busy || branchesLoading}
-                className="rounded-md border border-border bg-background px-3 py-2 text-sm motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+          {branchEditOpen ? (
+            <div className="flex flex-col gap-3 border-t border-border-soft pt-3">
+              <div
+                role="tablist"
+                aria-label="branch source"
+                className="inline-flex w-fit rounded-md border border-border bg-background p-0.5"
               >
-                <option value="">
-                  {branchesLoading
-                    ? 'loading…'
-                    : branches.length === 0
-                      ? 'no local branches'
-                      : 'select branch…'}
-                </option>
-                {branches
-                  .filter((b) => b.name !== branch)
-                  .map((b) => (
-                    <option key={b.name} value={b.name}>
-                      {b.name}
-                      {b.inUse ? ' · in use' : ''}
-                      {b.hasUncommitted ? ' · dirty' : ''}
-                    </option>
-                  ))}
-              </select>
-            </Field>
-          ) : (
-            <Field
-              label="new branch name"
-              hint="creates and switches to a new branch from current HEAD."
-            >
-              <Input
-                value={branchTarget}
-                onChange={(e) => {
-                  setBranchTarget(e.target.value);
-                  setConfirmReuse(false);
-                }}
-                placeholder="feat/something"
-                disabled={busy}
-              />
-            </Field>
-          )}
+                {(['existing', 'new'] as const).map((m) => {
+                  const active = branchMode === m;
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setBranchMode(m)}
+                      disabled={busy}
+                      className={cn(
+                        'rounded px-2.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
+                        active
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {m === 'existing' ? 'pick existing' : 'create new'}
+                    </button>
+                  );
+                })}
+              </div>
 
-          {targetNeedsConfirm ? (
-            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs text-warning">
-              <AlertTriangle size={13} aria-hidden className="mt-0.5 shrink-0" />
-              <div className="flex flex-col gap-1">
-                <span className="font-semibold">heads up</span>
-                <ul className="list-disc pl-4">
-                  {targetOwnedByOtherSession ? (
-                    <li>this branch is already attached to another kay-am session.</li>
-                  ) : null}
-                  {targetInUseElsewhere ? (
-                    <li>this branch is checked out in another git worktree.</li>
-                  ) : null}
-                  {targetDirty ? <li>that worktree has uncommitted changes.</li> : null}
-                </ul>
-                <span className="text-2xs text-warning/80">click again to confirm.</span>
+              {branchMode === 'existing' ? (
+                <select
+                  value={branchTarget}
+                  onChange={(e) => setBranchTarget(e.target.value)}
+                  disabled={busy || branchesLoading}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  <option value="">
+                    {branchesLoading
+                      ? 'Loading…'
+                      : branches.length === 0
+                        ? 'No local branches'
+                        : 'Select branch…'}
+                  </option>
+                  {branches
+                    .filter((b) => b.name !== branch)
+                    .map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                        {b.inUse ? ' · in use' : ''}
+                        {b.hasUncommitted ? ' · dirty' : ''}
+                      </option>
+                    ))}
+                </select>
+              ) : (
+                <Input
+                  value={branchTarget}
+                  onChange={(e) => setBranchTarget(e.target.value)}
+                  placeholder="feat/something"
+                  disabled={busy}
+                  className="font-mono"
+                />
+              )}
+
+              {targetNeedsConfirm ? (
+                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs">
+                  <AlertTriangle size={13} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                  <div className="flex flex-col gap-1">
+                    <span className="font-semibold text-foreground">Heads up</span>
+                    <ul className="list-disc pl-4 text-muted-foreground">
+                      {targetOwnedByOtherSession ? (
+                        <li>Already attached to another kay.am session.</li>
+                      ) : null}
+                      {targetInUseElsewhere ? <li>Checked out in another git worktree.</li> : null}
+                      {targetDirty ? <li>That worktree has uncommitted changes.</li> : null}
+                    </ul>
+                    <span className="text-2xs text-warning/80">
+                      Click {confirmReuse ? '"Confirm switch"' : '"Switch branch"'} again to
+                      confirm.
+                    </span>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setBranchEditOpen(false)}
+                  disabled={busy}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={onChangeBranch}
+                  disabled={busy || branchesLoading || branchTarget.trim().length === 0}
+                  variant={targetNeedsConfirm && confirmReuse ? 'warning' : 'primary'}
+                >
+                  {busy ? (
+                    <>
+                      <Loader2 size={12} className="mr-1.5 animate-spin" aria-hidden />
+                      Switching…
+                    </>
+                  ) : targetNeedsConfirm && confirmReuse ? (
+                    'Confirm switch'
+                  ) : (
+                    'Switch branch'
+                  )}
+                </Button>
               </div>
             </div>
           ) : null}
         </div>
-      </Dialog>
-    </>
+      </Field>
+
+      {/* Provider — read-only */}
+      <Field
+        label="Provider"
+        hint="Set at creation time. Per-turn overrides happen in the chat composer."
+      >
+        <span className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs">
+          <Zap size={11} aria-hidden className="text-muted-foreground" />
+          <span className="font-medium text-foreground">{providerLabel}</span>
+        </span>
+      </Field>
+
+      {/* Init script — only when workspace has one */}
+      {WORKSPACE_FEATURES.initScript && hasInitScript ? (
+        <Field
+          label="Init script"
+          hint="When enabled, a setup agent runs the workspace init script before the first agent fires."
+        >
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+            <input
+              type="checkbox"
+              checked={!skipInit}
+              onChange={(e) => onToggleInit(e.target.checked)}
+              className="mt-0.5 accent-primary"
+            />
+            <span className="flex flex-col gap-0.5">
+              <span className="flex items-center gap-1.5 font-medium text-foreground">
+                <Terminal size={11} aria-hidden className="text-muted-foreground" />
+                Run workspace init script
+              </span>
+              <span className="text-muted-foreground">
+                Useful for installing deps, hydrating env files, etc.
+              </span>
+            </span>
+          </label>
+        </Field>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Budget                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface BudgetSectionProps {
+  readonly capDraft: string;
+  readonly setCapDraft: (v: string) => void;
+  readonly onSaveCap: () => void;
+  readonly busy: boolean;
+  readonly softCapUsd: number | null;
+  readonly spent: number;
+}
+
+function BudgetSection({
+  capDraft,
+  setCapDraft,
+  onSaveCap,
+  busy,
+  softCapUsd,
+  spent,
+}: BudgetSectionProps) {
+  const pct = softCapUsd && softCapUsd > 0 ? Math.min(1, spent / softCapUsd) : 0;
+  const barTone =
+    pct >= 1 ? 'bg-danger' : pct >= 0.8 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<DollarSign size={14} aria-hidden className="text-primary" />}
+        title="Budget"
+        subtitle="Optional spend ceiling. Warning at 80%, error at 100%. The session keeps running unless you stop it."
+      />
+      <Field label="Soft cap (USD)" hint="Leave blank to skip. Increments allowed in cents.">
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            value={capDraft}
+            onChange={(e) => setCapDraft(e.target.value)}
+            placeholder="2.50"
+            className="flex-1"
+            disabled={busy}
+          />
+          <Button variant="secondary" onClick={onSaveCap} disabled={busy}>
+            Save
+          </Button>
+        </div>
+      </Field>
+      {softCapUsd != null && softCapUsd > 0 ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/50 p-4">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Spent this session</span>
+            <span className="font-mono text-foreground">
+              ${spent.toFixed(2)} / ${softCapUsd.toFixed(2)}
+            </span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted/60">
+            <div
+              className={cn('h-full rounded-full transition-all', barTone)}
+              style={{ width: `${pct * 100}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-2xs text-muted-foreground/70">
+            <span>{Math.round(pct * 100)}% used</span>
+            {pct >= 0.8 ? (
+              <span className={pct >= 1 ? 'text-danger' : 'text-warning'}>
+                {pct >= 1 ? 'cap exceeded' : 'approaching cap'}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Danger zone                                                  */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface DangerSectionProps {
+  readonly archived: boolean;
+  readonly onArchive: () => void;
+  readonly onUnarchive: () => void;
+  readonly onClose: () => void;
+  readonly confirmDelete: boolean;
+  readonly setConfirmDelete: (v: boolean) => void;
+  readonly onDelete: () => void;
+  readonly busy: boolean;
+}
+
+function DangerSection({
+  archived,
+  onArchive,
+  onUnarchive,
+  onClose,
+  confirmDelete,
+  setConfirmDelete,
+  onDelete,
+  busy,
+}: DangerSectionProps) {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<AlertTriangle size={14} aria-hidden className="text-danger" />}
+        title="Danger zone"
+        subtitle="Archive to step away gracefully. Delete only if you're sure — it nukes the worktree, transcripts, and the branch."
+        tone="danger"
+      />
+
+      {/* Archive row */}
+      <div className="flex items-start justify-between gap-4 rounded-lg border border-border-soft bg-background p-4">
+        <div className="flex-1">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+            {archived ? (
+              <ArchiveRestore size={12} aria-hidden className="text-muted-foreground" />
+            ) : (
+              <Archive size={12} aria-hidden className="text-muted-foreground" />
+            )}
+            {archived ? 'Unarchive session' : 'Archive session'}
+          </div>
+          <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+            {archived
+              ? 'Restore this session to the active list. Worktree stays untouched.'
+              : 'Hide from the active list, keep history and worktree intact. Reversible.'}
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            if (archived) onUnarchive();
+            else onArchive();
+            onClose();
+          }}
+          disabled={busy}
+        >
+          {archived ? (
+            <>
+              <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
+              Unarchive
+            </>
+          ) : (
+            <>
+              <Archive size={13} aria-hidden className="mr-1.5" />
+              Archive
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Delete row */}
+      <div
+        className={cn(
+          'flex flex-col gap-3 rounded-lg border p-4 transition-colors',
+          confirmDelete ? 'border-danger/50 bg-danger/5' : 'border-border-soft bg-background',
+        )}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+              <Trash2 size={12} aria-hidden className="text-danger" />
+              Delete session
+            </div>
+            <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+              Removes worktree, transcripts, audit logs, and the branch. Cannot be undone.
+            </p>
+          </div>
+          {!confirmDelete ? (
+            <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
+              <Trash2 size={13} aria-hidden className="mr-1.5" />
+              Delete
+            </Button>
+          ) : null}
+        </div>
+
+        {confirmDelete ? (
+          <>
+            <div className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-2xs text-warning">
+              <Archive size={12} aria-hidden className="mt-px shrink-0" />
+              <span>Consider archiving instead — keeps history and is reversible.</span>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmDelete(false)}
+                disabled={busy}
+              >
+                Cancel
+              </Button>
+              {!archived ? (
+                <Button
+                  variant="warning"
+                  size="sm"
+                  onClick={() => {
+                    onArchive();
+                    setConfirmDelete(false);
+                    onClose();
+                  }}
+                  disabled={busy}
+                >
+                  <Archive size={12} aria-hidden className="mr-1.5" />
+                  Archive instead
+                </Button>
+              ) : null}
+              <Button variant="danger" size="sm" onClick={onDelete} disabled={busy}>
+                {busy ? (
+                  <>
+                    <Loader2 size={12} className="mr-1.5 animate-spin" aria-hidden />
+                    Deleting…
+                  </>
+                ) : (
+                  <>
+                    <Check size={12} aria-hidden className="mr-1.5" />
+                    Confirm delete
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  tone,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  tone?: 'danger';
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'flex h-7 w-7 items-center justify-center rounded-md',
+            tone === 'danger' ? 'bg-danger/10' : 'bg-primary/10',
+          )}
+        >
+          {icon}
+        </span>
+        <h3
+          className={cn(
+            'text-base font-semibold',
+            tone === 'danger' ? 'text-danger' : 'text-foreground',
+          )}
+        >
+          {title}
+        </h3>
+      </div>
+      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }
 
@@ -618,8 +919,8 @@ function Field({
   return (
     <div className="flex flex-col gap-1.5">
       <span className="text-xs font-semibold text-foreground">{label}</span>
+      {hint ? <p className="text-2xs leading-relaxed text-muted-foreground">{hint}</p> : null}
       {children}
-      {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/session/components/config-selects.tsx
+++ b/apps/desktop/src/features/session/components/config-selects.tsx
@@ -54,6 +54,32 @@ function useClickOutside(ref: React.RefObject<HTMLElement | null>, onClose: () =
   }, [ref, onClose]);
 }
 
+/**
+ * Picks the opening direction based on the trigger's viewport position
+ * when the dropdown is about to open. Avoids the bottom-of-scroll-container
+ * trap where `top-full` would push the popover into a scroll region.
+ */
+function useDropdownDirection(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+): 'up' | 'down' {
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
+  useEffect(() => {
+    if (!open) return;
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    setDirection(spaceBelow < 200 && spaceAbove > spaceBelow ? 'up' : 'down');
+  }, [open, triggerRef]);
+  return direction;
+}
+
+const POPUP_BASE =
+  'absolute left-0 z-50 w-full rounded-md border border-border bg-subtle py-0.5 shadow-lg';
+const POPUP_DOWN = 'top-full mt-1';
+const POPUP_UP = 'bottom-full mb-1';
+
 export function ModelSelect({
   provider,
   value,
@@ -68,6 +94,7 @@ export function ModelSelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   const models = [...PROVIDER_CAPABILITIES[provider].models].reverse();
   const tier = modelCostTier(value);
@@ -100,7 +127,9 @@ export function ModelSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[10rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div
+          className={cn(POPUP_BASE, 'min-w-[10rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}
+        >
           {models.map((m) => {
             const active = value === m.id;
             const t = modelCostTier(m.id);
@@ -149,6 +178,7 @@ export function EffortSelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   if (!levels) {
     return (
@@ -184,7 +214,7 @@ export function EffortSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[8rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div className={cn(POPUP_BASE, 'min-w-[8rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}>
           {levels.map((level) => {
             const active = value === level;
             return (
@@ -229,6 +259,7 @@ export function VerbositySelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   return (
     <div ref={containerRef} className="relative">
@@ -258,7 +289,7 @@ export function VerbositySelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[7rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div className={cn(POPUP_BASE, 'min-w-[7rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}>
           {VERBOSITY_LEVELS.map((level) => {
             const active = value === level;
             return (

--- a/apps/desktop/src/features/session/components/config-selects.tsx
+++ b/apps/desktop/src/features/session/components/config-selects.tsx
@@ -55,23 +55,48 @@ function useClickOutside(ref: React.RefObject<HTMLElement | null>, onClose: () =
 }
 
 /**
- * Picks the opening direction based on the trigger's viewport position
- * when the dropdown is about to open. Avoids the bottom-of-scroll-container
- * trap where `top-full` would push the popover into a scroll region.
+ * Walks up the DOM until it finds an ancestor that clips overflow
+ * (auto/scroll/hidden on Y). That's the box our popover would actually
+ * be cut off by — measuring against `window` is misleading when the
+ * trigger sits inside a Dialog with `overflow: hidden`.
+ */
+function findClippingAncestor(el: HTMLElement | null): HTMLElement | null {
+  let current = el?.parentElement ?? null;
+  while (current) {
+    const style = getComputedStyle(current);
+    const overflowY = style.overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'hidden') {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Picks the opening direction based on the trigger's position relative
+ * to its nearest clipping ancestor. Avoids the bottom-of-scroll-container
+ * trap where `top-full` would push the popover into a hidden region.
  */
 function useDropdownDirection(
   triggerRef: React.RefObject<HTMLElement | null>,
   open: boolean,
+  expectedHeight = 200,
 ): 'up' | 'down' {
   const [direction, setDirection] = useState<'up' | 'down'>('down');
   useEffect(() => {
     if (!open) return;
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
-    setDirection(spaceBelow < 200 && spaceAbove > spaceBelow ? 'up' : 'down');
-  }, [open, triggerRef]);
+    const el = triggerRef.current;
+    const rect = el?.getBoundingClientRect();
+    if (!el || !rect) return;
+    const clipper = findClippingAncestor(el);
+    const clipperRect = clipper?.getBoundingClientRect();
+    const bottomBound = clipperRect ? clipperRect.bottom : window.innerHeight;
+    const topBound = clipperRect ? clipperRect.top : 0;
+    const spaceBelow = bottomBound - rect.bottom;
+    const spaceAbove = rect.top - topBound;
+    setDirection(spaceBelow < expectedHeight && spaceAbove > spaceBelow ? 'up' : 'down');
+  }, [open, triggerRef, expectedHeight]);
   return direction;
 }
 

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -34,6 +34,7 @@ import {
   useSummarizerStatus,
 } from '../../../../store';
 import { SessionStatusMenu } from '../../../session/components/SessionStatusMenu';
+import { OpenInEditorIconButton } from '../../../session/components/OpenInEditorIconButton';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { DiffViewerDialog } from '../../../permissions/components/DiffViewerDialog';
@@ -58,6 +59,7 @@ export function SessionDetailPanel({
   onNewSession,
 }: SessionDetailPanelProps) {
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId]);
+  const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id as SessionId]?.[0] ?? null);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
   const setSessionUserStatus = useAppStore((s) => s.setSessionUserStatus);
   const renameTask = useAppStore((s) => s.renameTask);
@@ -141,6 +143,7 @@ export function SessionDetailPanel({
             <span>New</span>
           </button>
         ) : null}
+        <OpenInEditorIconButton worktreePath={worktreePath} />
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -12,6 +12,7 @@ import {
   GitPullRequestDraft,
   Loader2,
   MessageSquare,
+  Plus,
   RefreshCw,
   Settings2,
   XCircle,
@@ -42,12 +43,19 @@ interface SessionDetailPanelProps {
   session: Session;
   onOpenSessionSettings: () => void;
   onOpenGithubDetails?: () => void;
+  /**
+   * When provided, renders a "+ New session" affordance in the header. The
+   * sidebar passes this only when the activity bar is collapsed (1 session
+   * total) — so the user always has a discoverable way to add another.
+   */
+  onNewSession?: () => void;
 }
 
 export function SessionDetailPanel({
   session,
   onOpenSessionSettings,
   onOpenGithubDetails,
+  onNewSession,
 }: SessionDetailPanelProps) {
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId]);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
@@ -121,6 +129,18 @@ export function SessionDetailPanel({
             </span>
           )}
         </div>
+        {onNewSession ? (
+          <button
+            type="button"
+            onClick={onNewSession}
+            className="shrink-0 inline-flex items-center gap-1 rounded-md border border-border-soft bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+            title="new session"
+            aria-label="new session"
+          >
+            <Plus size={11} aria-hidden />
+            <span>New</span>
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -185,6 +185,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                       <ScrollArea className="min-h-0 flex-1">
                         <AgentsSection task={currentSession} />
                       </ScrollArea>
+                      <NextSuggestionsPlaceholder />
                       <SessionFilesTouchedFooter session={currentSession} />
                     </>
                   ) : (
@@ -273,6 +274,17 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
         onClose={() => setGithubDetailsOpen(false)}
         sessionId={(currentSession?.id as SessionId) ?? null}
       />
+    </div>
+  );
+}
+
+function NextSuggestionsPlaceholder() {
+  return (
+    <div
+      className="shrink-0 border-t border-border-soft px-3 py-1.5 text-2xs italic text-muted-foreground/60"
+      title="next-action suggestions are coming back in a future update"
+    >
+      Next suggestions will be re-added soon.
     </div>
   );
 }
@@ -952,12 +964,6 @@ function AgentsSection({ task }: AgentsSectionProps) {
         <ul className="flex flex-col gap-1 pl-2">{sorted.map(renderAdHocRow)}</ul>
       )}
       {hasActivePlan ? null : <ActivePlanCta sessionId={task.id} />}
-      <div className="mt-2 px-2">
-        <div className="rounded border border-dashed border-border-soft px-3 py-2">
-          <p className="text-2xs font-medium text-muted-foreground">Next</p>
-          <p className="text-2xs text-muted-foreground/60">temporarily disabled</p>
-        </div>
-      </div>
       <div className="pl-2">
         <SpawnAgentControl sessionId={task.id} />
       </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -145,15 +145,20 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       <div className="flex min-h-0 flex-1">
         {currentWorkspace ? (
           (() => {
-            const hasAnySession = activeSessions.length > 0 || archivedSessions.length > 0;
+            const totalSessions = activeSessions.length + archivedSessions.length;
+            const hasAnySession = totalSessions > 0;
+            // The activity bar only makes sense as a switcher. With a single
+            // session the user never switches — collapse it and expose the
+            // "new session" action inside the detail panel header instead.
+            const showActivityBar = totalSessions > 1;
             return (
               <>
                 <div
                   className={cn(
                     'overflow-hidden transition-[width] duration-300 ease-out',
-                    hasAnySession ? 'w-28' : 'w-0',
+                    showActivityBar ? 'w-28' : 'w-0',
                   )}
-                  aria-hidden={!hasAnySession}
+                  aria-hidden={!showActivityBar}
                 >
                   <SessionActivityBar
                     sessions={activeSessions}
@@ -166,7 +171,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                 <div
                   className={cn(
                     'mr-1.5 mt-1.5 mb-1.5 flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-background transition-[margin-left] duration-300 ease-out dark:bg-muted',
-                    hasAnySession ? 'ml-0' : 'ml-1.5',
+                    showActivityBar ? 'ml-0' : 'ml-1.5',
                   )}
                 >
                   {currentSession ? (
@@ -175,6 +180,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                         session={currentSession}
                         onOpenSessionSettings={() => setSessionSettingsOpen(true)}
                         onOpenGithubDetails={() => setGithubDetailsOpen(true)}
+                        onNewSession={showActivityBar ? undefined : () => setNewSessionOpen(true)}
                       />
                       <ScrollArea className="min-h-0 flex-1">
                         <AgentsSection task={currentSession} />

--- a/apps/desktop/src/features/worktree/BranchCombobox.tsx
+++ b/apps/desktop/src/features/worktree/BranchCombobox.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@kay-am/ui';
+import { ChevronDown } from 'lucide-react';
+import type { LocalBranchInfo } from './worktree';
+
+interface BranchComboboxProps {
+  readonly branches: ReadonlyArray<LocalBranchInfo>;
+  readonly value: string;
+  readonly onChange: (v: string) => void;
+  readonly disabled: boolean;
+  readonly loading: boolean;
+  /**
+   * Branches to hide from the list (e.g. the current session branch when
+   * we don't want the user picking it again). Filtering happens before
+   * the substring search.
+   */
+  readonly excludeNames?: ReadonlyArray<string>;
+  /**
+   * Vertical anchor for the popup. `'auto'` (default) opens below; `'up'`
+   * opens above. Used by callers where the input sits near the bottom of
+   * a scroll container.
+   */
+  readonly openDirection?: 'down' | 'up';
+}
+
+export function BranchCombobox({
+  branches,
+  value,
+  onChange,
+  disabled,
+  loading,
+  excludeNames,
+  openDirection = 'down',
+}: BranchComboboxProps) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlightIdx, setHighlightIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const excludeSet = useMemo(() => new Set(excludeNames ?? []), [excludeNames]);
+
+  const filtered = useMemo(
+    () =>
+      branches.filter(
+        (b) => !excludeSet.has(b.name) && b.name.toLowerCase().includes(query.toLowerCase()),
+      ),
+    [branches, excludeSet, query],
+  );
+
+  const select = useCallback(
+    (name: string) => {
+      onChange(name);
+      setQuery(name);
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (value && !query) setQuery(value);
+  }, [value, query]);
+
+  useEffect(() => {
+    setHighlightIdx(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const el = listRef.current.children[highlightIdx] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [highlightIdx, open]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      setOpen(true);
+      e.preventDefault();
+      return;
+    }
+    if (!open) return;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightIdx((i) => Math.min(i + 1, filtered.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightIdx((i) => Math.max(i - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filtered[highlightIdx]) select(filtered[highlightIdx].name);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        break;
+    }
+  };
+
+  const placeholder = loading
+    ? 'Loading…'
+    : branches.length === 0
+      ? 'No local branches'
+      : 'Search branch…';
+
+  const popupClass = cn(
+    'absolute left-0 z-50 w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg',
+    openDirection === 'up' ? 'bottom-full mb-1 max-h-48' : 'top-full mt-1 max-h-56',
+  );
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div
+        className={cn(
+          'flex h-9 w-full items-center gap-1 rounded-md border border-border bg-background px-1 motion-safe:transition-colors focus-within:border-primary hover:border-border-strong',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          placeholder={placeholder}
+          disabled={disabled || branches.length === 0}
+          aria-label="Branch"
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          autoComplete="off"
+          className="flex-1 truncate bg-transparent px-2 text-sm font-mono text-foreground outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed"
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+            if (!e.target.value) onChange('');
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => {
+            if (disabled || branches.length === 0) return;
+            setOpen((v) => !v);
+            inputRef.current?.focus();
+          }}
+          aria-label={open ? 'Close branch list' : 'Open branch list'}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ChevronDown
+            size={13}
+            aria-hidden
+            className={cn('transition-transform', open && 'rotate-180')}
+          />
+        </button>
+      </div>
+      {open && filtered.length > 0 ? (
+        <ul ref={listRef} role="listbox" className={popupClass}>
+          {filtered.map((b, i) => (
+            <li
+              key={b.name}
+              role="option"
+              aria-selected={highlightIdx === i}
+              onMouseEnter={() => setHighlightIdx(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(b.name);
+              }}
+              className={cn(
+                'flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-sm font-mono',
+                highlightIdx === i ? 'bg-primary/10 text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              <span className="min-w-0 truncate">{b.name}</span>
+              {b.inUse ? <span className="shrink-0 text-2xs text-warning">in use</span> : null}
+              {b.hasUncommitted ? (
+                <span className="shrink-0 text-2xs text-warning">dirty</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {open && !loading && filtered.length === 0 && query ? (
+        <div className={cn(popupClass, 'px-2 py-2 text-xs text-muted-foreground')}>
+          No matching branches
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New-session modal: drop issue-link beta, rewrite goal copy, merge branch prefix/slug into one input with live slugify, replace workflow segmented control with three descriptive cards, widen to 68rem, freeze ladder so only content scrolls
- Session-settings modal: same visual language (section headers + fixed ladder), inline branch-change UI (kills the secondary dialog), Danger zone promoted out of the orphan footer, soft-cap progress bar
- Shared BranchCombobox under features/worktree replaces the native select used in session settings
- Workspaces sidebar: collapse the activity bar when only one session exists; expose a "+ New" affordance in the session detail header so the user can still spawn another one
- Move the "Next / temporarily disabled" card out of the scroll body into a sticky one-liner pinned above the files-touched footer
- Restore open-in-editor as a folder icon between the session title and the settings cog (icon-only, popover for multi-editor)
- Workflow selects (model/effort/verbosity/agent-role) now flip upward when the trigger sits near the bottom of the modal's clipping ancestor (Dialog's overflow-hidden box), not the viewport

## Test plan
- [ ] New session: write a goal → branch slug fills live, spaces → dashes, prefix editable separately
- [ ] New session: pick each of the 3 workflow cards → panel below switches correctly
- [ ] New session: open Model / Effort / Verbosity / Agent role near the bottom → popovers flip upward
- [ ] Session settings: expand Change branch → search-as-you-type combobox, no native dropdown
- [ ] Session settings: dialog grows with content, no inner scrollbar
- [ ] Workspace with 1 session: activity bar hidden, "+ New" pill in detail header
- [ ] Workspace with 2+ sessions: activity bar visible, no "+ New" pill in detail header
- [ ] Folder icon next to session settings: 0 editors → disabled, 1 → opens directly, 2+ → popover with list
- [ ] Sidebar shows "Next suggestions will be re-added soon." pinned just above files-touched footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)