### PR TITLE
feat(desktop): redesign session, workspace, and guide modals

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
   open=""
 >
   <div
-    class="flex min-h-0 flex-col h-[640px] w-[56rem]"
+    class="flex min-h-0 flex-col h-[680px] w-[68rem] max-w-[95vw]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
@@ -43,16 +43,16 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm px-0 py-0 gap-0"
     >
       <div
-        class="flex h-full min-h-0 gap-0"
+        class="flex h-full min-h-0"
       >
         <nav
-          class="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2"
+          class="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5"
         >
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary"
             title="goal is required"
             type="button"
           >
@@ -115,7 +115,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
             </svg>
           </button>
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
             title="provider is required"
             type="button"
           >
@@ -166,7 +166,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
             </svg>
           </button>
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
             type="button"
           >
             <svg
@@ -217,720 +217,207 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           </button>
         </nav>
         <div
-          class="min-w-0 flex-1 overflow-y-auto pl-4 pr-2"
+          class="min-w-0 flex-1 overflow-y-auto px-8 py-6"
         >
           <div
-            class=""
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Issue link
-                  <span
-                    class="rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Paste a GitHub, GitLab, Jira, or Linear issue URL. The goal will be generated automatically.
-                </p>
-                <div
-                  class="relative"
-                >
-                  <input
-                    class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-                    placeholder="github.com/…/issues/42 · linear.app/…/TEAM-1 · jira · gitlab"
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Goal
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  What this session should accomplish.
-                </p>
-                <textarea
-                  class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-                  placeholder="Refactor auth domain"
-                  style="overflow-y: hidden;"
-                />
-              </div>
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Branch
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Worktree branch for this session.
-                </p>
-                <div
-                  class="flex flex-col gap-2"
-                >
-                  <div
-                    aria-label="branch source"
-                    class="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
-                    role="tablist"
-                  >
-                    <button
-                      aria-selected="true"
-                      class="rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors bg-background text-foreground shadow-sm"
-                      role="tab"
-                      type="button"
-                    >
-                      New
-                    </button>
-                    <button
-                      aria-selected="false"
-                      class="rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                      role="tab"
-                      type="button"
-                    >
-                      Existing
-                    </button>
-                  </div>
-                  <div
-                    class="flex items-center gap-1.5"
-                  >
-                    <span
-                      class="shrink-0 text-xs text-muted-foreground font-mono"
-                    >
-                      kay
-                      /
-                    </span>
-                    <input
-                      aria-label="Branch slug"
-                      class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
-                      placeholder="branch-slug"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Generate branch name"
-                      class="shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors cursor-not-allowed text-muted-foreground/30"
-                      disabled=""
-                      title="Generate from goal"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-wand-sparkles"
-                        fill="none"
-                        height="13"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="13"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"
-                        />
-                        <path
-                          d="m14 7 3 3"
-                        />
-                        <path
-                          d="M5 6v4"
-                        />
-                        <path
-                          d="M19 14v4"
-                        />
-                        <path
-                          d="M10 2v2"
-                        />
-                        <path
-                          d="M7 8H3"
-                        />
-                        <path
-                          d="M21 16h-4"
-                        />
-                        <path
-                          d="M11 3H9"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
+            class="flex flex-col gap-7"
           >
             <div
               class="flex flex-col gap-1.5"
             >
-              <span
-                class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-              >
-                Soft cap (USD)
-              </span>
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground"
-              >
-                Optional spend limit. Session gets flagged when exceeded.
-              </p>
-              <input
-                class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-                min="0"
-                placeholder="5.00"
-                step="0.01"
-                type="number"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
-              <label
-                class="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs"
-              >
-                <input
-                  class="mt-0.5 accent-primary"
-                  type="checkbox"
-                />
-                <span
-                  class="flex flex-col gap-0.5"
-                >
-                  <span
-                    class="font-medium text-foreground"
-                  >
-                    Run init script
-                  </span>
-                  <span
-                    class="text-muted-foreground"
-                  >
-                    Execute workspace setup before agents start.
-                  </span>
-                </span>
-              </label>
               <div
-                class="flex flex-col gap-1.5"
+                class="flex items-center gap-2"
               >
                 <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Script
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Edit for this session only. Changes won't save to workspace.
-                </p>
-                <textarea
-                  autocapitalize="off"
-                  autocorrect="off"
-                  class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 transition-[border-color,box-shadow] focus-visible:shadow-md min-h-[200px] resize-y font-mono text-xs"
-                  rows="10"
-                  spellcheck="false"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-1.5"
-            >
-              <span
-                class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-              >
-                Workflow
-              </span>
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground"
-              >
-                Single chat session. Spawn agents manually as needed.
-              </p>
-              <div
-                aria-label="workflow mode"
-                class="inline-flex rounded-md border border-border bg-subtle p-0.5"
-                role="tablist"
-              >
-                <button
-                  aria-selected="true"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors bg-background text-foreground shadow-sm"
-                  role="tab"
-                  type="button"
-                >
-                  One-off
-                </button>
-                <button
-                  aria-selected="false"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                  role="tab"
-                  type="button"
-                >
-                  Preset
-                  <span
-                    class="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </button>
-                <button
-                  aria-selected="false"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                  role="tab"
-                  type="button"
-                >
-                  Custom
-                  <span
-                    class="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </button>
-              </div>
-              <div
-                class="mt-3 flex flex-col gap-3"
-              >
-                <div
-                  class="flex flex-col gap-1.5"
-                >
-                  <span
-                    class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                  >
-                    Agent role
-                  </span>
-                  <p
-                    class="text-2xs leading-relaxed text-muted-foreground"
-                  >
-                    Role for the first agent. Spawn more from the sidebar.
-                  </p>
-                  <div
-                    class="relative"
-                  >
-                    <button
-                      class="flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                      type="button"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="size-2 shrink-0 rounded-full bg-rose-400"
-                      />
-                      <span
-                        class="shrink-0 font-medium text-foreground"
-                      >
-                        Agent
-                      </span>
-                      <span
-                        class="flex-1 truncate text-muted-foreground/70"
-                      >
-                        Can do whatever you want, no restrictions
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                        fill="none"
-                        height="12"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m6 9 6 6 6-6"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="grid grid-cols-3 gap-3"
-                >
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Model
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50 cursor-not-allowed opacity-50"
-                        disabled=""
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-rose-400"
-                        />
-                        <span
-                          class="flex-1 truncate font-mono font-medium text-foreground"
-                        >
-                          opus 4.7
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Effort
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-info"
-                        />
-                        <span
-                          class="flex-1 truncate font-medium text-foreground"
-                        >
-                          Medium
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Verbosity
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-amber-400"
-                        />
-                        <span
-                          class="flex-1 truncate font-medium text-foreground"
-                        >
-                          Normal
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="hidden"
-              >
-                <div
-                  class="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-soft bg-subtle px-4 py-6 text-center"
+                  class="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10"
                 >
                   <svg
                     aria-hidden="true"
-                    class="lucide lucide-layers text-muted-foreground/30"
+                    class="lucide lucide-target text-primary"
                     fill="none"
-                    height="20"
+                    height="14"
                     stroke="currentColor"
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     stroke-width="2"
                     viewBox="0 0 24 24"
-                    width="20"
+                    width="14"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="10"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="6"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="2"
+                    />
+                  </svg>
+                </span>
+                <h3
+                  class="text-base font-semibold text-foreground"
+                >
+                  What needs to get done?
+                </h3>
+              </div>
+              <p
+                class="max-w-2xl text-xs leading-relaxed text-muted-foreground"
+              >
+                Describe the task in plain English. We'll create a worktree and route it to an agent.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-2"
+            >
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md text-sm leading-relaxed"
+                placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
+                style="overflow-y: hidden;"
+              />
+              <p
+                class="text-2xs leading-relaxed text-muted-foreground/70"
+              >
+                Tip: a clear, imperative sentence yields a better branch name and helps agents stay focused.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4"
+            >
+              <div
+                class="flex items-center justify-between gap-2"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-git-branch text-muted-foreground"
+                    fill="none"
+                    height="13"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="13"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+                      d="M15 6a9 9 0 0 0-9 9V3"
                     />
-                    <path
-                      d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+                    <circle
+                      cx="18"
+                      cy="6"
+                      r="3"
                     />
-                    <path
-                      d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+                    <circle
+                      cx="6"
+                      cy="18"
+                      r="3"
                     />
                   </svg>
-                  <p
-                    class="text-xs font-medium text-muted-foreground"
+                  <span
+                    class="text-xs font-semibold text-foreground"
                   >
-                    No workflow presets
-                  </p>
-                  <p
-                    class="max-w-[14rem] text-2xs leading-relaxed text-muted-foreground/60"
-                  >
-                    Switch to
-                     
-                    <button
-                      class="font-medium text-primary underline-offset-2 hover:underline"
-                      type="button"
-                    >
-                      Custom
-                    </button>
-                     
-                    to design your first workflow.
-                  </p>
+                    Branch
+                  </span>
                 </div>
-              </div>
-              <div
-                class="hidden"
-              >
-                <div
-                  class="flex flex-col gap-2"
+                <button
+                  class="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+                  type="button"
                 >
-                  <textarea
-                    class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-                    placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
-                    style="overflow-y: hidden;"
-                  />
-                  <div
-                    class="flex items-center justify-end gap-2"
-                  >
-                    <span
-                      class="mr-auto text-2xs text-muted-foreground/60"
-                    >
-                      cheap-tier · 
-                      anthropic
-                    </span>
-                    <button
-                      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-7 px-2.5 text-xs"
-                      disabled=""
-                      type="button"
-                    >
-                      Generate plan
-                    </button>
-                  </div>
-                </div>
+                  use existing branch instead
+                </button>
               </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
               <div
-                class="flex flex-col gap-1.5"
+                class="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary"
               >
+                <input
+                  aria-label="Branch prefix"
+                  class="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
+                  placeholder="kay"
+                  title="Branch prefix (editable). Saved per workspace."
+                  type="text"
+                  value="kay"
+                />
                 <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
+                  class="flex select-none items-center text-muted-foreground/50"
                 >
-                  Provider
+                  /
                 </span>
-                <div
-                  class="flex gap-2"
+                <input
+                  aria-label="Branch slug"
+                  class="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                  placeholder="branch-slug"
+                  type="text"
+                  value=""
+                />
+                <button
+                  aria-label="Generate branch name"
+                  class="flex shrink-0 items-center justify-center rounded px-2 transition-colors cursor-not-allowed text-muted-foreground/30"
+                  disabled=""
+                  title="Generate a better name from your goal"
+                  type="button"
                 >
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-wand-sparkles"
+                    fill="none"
+                    height="13"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="13"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      claude
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      cursor
-                      <span
-                        class="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning"
-                      >
-                        beta
-                      </span>
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      codex
-                      <span
-                        class="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning"
-                      >
-                        beta
-                      </span>
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                </div>
+                    <path
+                      d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"
+                    />
+                    <path
+                      d="m14 7 3 3"
+                    />
+                    <path
+                      d="M5 6v4"
+                    />
+                    <path
+                      d="M19 14v4"
+                    />
+                    <path
+                      d="M10 2v2"
+                    />
+                    <path
+                      d="M7 8H3"
+                    />
+                    <path
+                      d="M21 16h-4"
+                    />
+                    <path
+                      d="M11 3H9"
+                    />
+                  </svg>
+                </button>
               </div>
+              <p
+                class="flex items-center gap-1.5 text-2xs text-muted-foreground/70"
+              >
+                <span>
+                  Preview:
+                </span>
+                <span
+                  class="font-mono text-muted-foreground"
+                >
+                  kay/branch-slug
+                </span>
+              </p>
             </div>
           </div>
         </div>
@@ -1182,6 +669,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
   >
     <div
       class="shrink-0 px-2 py-1.5"
+      data-tauri-drag-region="false"
     >
       <span
         class="mb-1 flex items-center gap-1.5 px-0.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground"
@@ -1215,10 +703,12 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
       </span>
       <div
         class="flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none]"
+        data-tauri-drag-region="false"
       >
         <button
           aria-label="add workspace"
           class="flex shrink-0 items-center justify-center rounded border border-dashed px-2 py-1.5 transition-colors border-border-soft text-muted-foreground/60 hover:border-border hover:bg-muted/50 hover:text-muted-foreground"
+          data-tauri-drag-region="false"
           title="add workspace"
           type="button"
         >
@@ -1711,7 +1201,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
     class="overflow-hidden rounded-lg border border-border bg-background p-0 text-foreground shadow-xl max-md:m-0 max-md:h-screen max-md:max-h-none max-md:w-screen max-md:max-w-none max-md:rounded-none max-md:border-0 max-md:shadow-none"
   >
     <div
-      class="flex min-h-0 flex-col h-[640px] w-[56rem] max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none"
+      class="flex min-h-0 flex-col h-[720px] max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none w-[64rem] max-w-[95vw]"
     >
       <header
         class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
@@ -1729,7 +1219,7 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             class="text-xs leading-relaxed text-muted-foreground"
             id="_r_1_-desc"
           >
-            how kAY.am, sessions, agents, and CLI providers fit together.
+            How kAY.am, sessions, agents, and CLI providers fit together.
           </p>
         </div>
         <button
@@ -1746,29 +1236,29 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
         </button>
       </header>
       <div
-        class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
+        class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm px-0 py-0 gap-0"
       >
         <div
-          class="flex h-full min-h-0 gap-0"
+          class="flex h-full min-h-0"
         >
           <nav
-            class="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2"
+            class="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5"
           >
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-book-open"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1783,20 +1273,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-git-branch"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1818,20 +1308,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-messages-square"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1846,20 +1336,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-wrench"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1871,20 +1361,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-coins"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1907,20 +1397,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-bot"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1951,20 +1441,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-lightbulb"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -1982,20 +1472,20 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
               </span>
             </button>
             <button
-              class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+              class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
               type="button"
             >
               <svg
                 aria-hidden="true"
                 class="lucide lucide-palette"
                 fill="none"
-                height="14"
+                height="13"
                 stroke="currentColor"
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 stroke-width="2"
                 viewBox="0 0 24 24"
-                width="14"
+                width="13"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
@@ -2032,98 +1522,296 @@ exports[`snapshot — empty states > WorkspacesSidebar: no workspace selected 1`
             </button>
           </nav>
           <div
-            class="min-w-0 flex-1 overflow-y-auto pl-4 pr-1"
+            class="min-w-0 flex-1 overflow-y-auto px-8 py-6"
           >
-            <article
-              class="flex flex-col gap-3 pb-6 text-sm leading-relaxed"
+            <div
+              class="flex flex-col gap-7"
             >
-              <h2
-                class="text-base font-semibold tracking-tight text-foreground"
+              <div
+                class="flex flex-col gap-2"
               >
-                What is kAY.am?
-              </h2>
-              <p
-                class="text-muted-foreground"
-              >
-                kAY.am orchestrates AI coding CLIs (claude, cursor-agent, codex) so you can run multiple agents in parallel against your repo, with audit logs and structured workflows.
-              </p>
-              <p
-                class="text-sm leading-relaxed text-muted-foreground"
-              >
-                kAY.am does 
-                <strong
-                  class="font-semibold text-foreground"
-                >
-                  not
-                </strong>
-                 talk to AI providers directly. It spawns the provider's CLI as a subprocess and streams events. That means: your usage, login, and quotas live in the CLI itself; kAY.am just adds the workspace layer on top.
-              </p>
-              <h3
-                class="mt-2 text-xs font-semibold uppercase tracking-wide text-foreground/85"
-              >
-                Mental model
-              </h3>
-              <ul
-                class="flex flex-col gap-1.5"
-              >
-                <li
-                  class="flex flex-col gap-0.5"
+                <div
+                  class="flex items-center gap-2.5"
                 >
                   <span
-                    class="text-sm font-semibold text-foreground"
+                    class="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10"
                   >
-                    Workspace
+                    <svg
+                      aria-hidden="true"
+                      class="lucide lucide-book-open text-primary"
+                      fill="none"
+                      height="14"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      viewBox="0 0 24 24"
+                      width="14"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M12 7v14"
+                      />
+                      <path
+                        d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"
+                      />
+                    </svg>
                   </span>
-                  <span
-                    class="text-sm leading-relaxed text-muted-foreground"
+                  <h2
+                    class="text-lg font-semibold tracking-tight text-foreground"
                   >
-                    a git repo on disk. you can connect many.
-                  </span>
-                </li>
-                <li
-                  class="flex flex-col gap-0.5"
+                    What is kAY.am?
+                  </h2>
+                </div>
+                <p
+                  class="max-w-3xl text-sm leading-relaxed text-muted-foreground"
                 >
-                  <span
-                    class="text-sm font-semibold text-foreground"
-                  >
-                    Session
-                  </span>
-                  <span
-                    class="text-sm leading-relaxed text-muted-foreground"
-                  >
-                    a chat with one goal, on its own git worktree + branch. like a feature branch with built-in chat.
-                  </span>
-                </li>
-                <li
-                  class="flex flex-col gap-0.5"
+                  kAY.am orchestrates AI coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo — with audit logs and structured workflows.
+                </p>
+              </div>
+              <div
+                class="flex items-start gap-2.5 rounded-lg border px-3.5 py-3 text-sm leading-relaxed text-muted-foreground bg-info/10 border-info/20"
+              >
+                <span
+                  class="mt-0.5 shrink-0 text-info"
                 >
-                  <span
-                    class="text-sm font-semibold text-foreground"
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-sparkles"
+                    fill="none"
+                    height="13"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="13"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    Agent
-                  </span>
-                  <span
-                    class="text-sm leading-relaxed text-muted-foreground"
+                    <path
+                      d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+                    />
+                    <path
+                      d="M20 2v4"
+                    />
+                    <path
+                      d="M22 4h-4"
+                    />
+                    <circle
+                      cx="4"
+                      cy="20"
+                      r="2"
+                    />
+                  </svg>
+                </span>
+                <div>
+                  kAY.am does 
+                  <strong
+                    class="text-foreground"
                   >
-                    one provider/CLI invocation inside a session. a session may have several agents (e.g. one for planning, one for coding).
-                  </span>
-                </li>
-                <li
-                  class="flex flex-col gap-0.5"
+                    not
+                  </strong>
+                   talk to AI providers directly. It spawns the provider's CLI as a subprocess and streams events. Your usage, login, and quotas live in the CLI itself — kAY.am just adds the workspace layer on top.
+                </div>
+              </div>
+              <div>
+                <span
+                  class="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground/70"
                 >
-                  <span
-                    class="text-sm font-semibold text-foreground"
+                  Mental model
+                </span>
+                <div
+                  class="mt-3 grid grid-cols-2 gap-3"
+                >
+                  <button
+                    class="group flex flex-col items-start gap-2 rounded-lg border border-border-soft bg-background p-4 text-left transition-all hover:-translate-y-0.5 hover:border-border hover:shadow-sm"
+                    type="button"
                   >
-                    Turn
-                  </span>
-                  <span
-                    class="text-sm leading-relaxed text-muted-foreground"
+                    <span
+                      class="flex h-8 w-8 items-center justify-center rounded-md bg-primary/10 text-primary"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-folder-git2 lucide-folder-git-2"
+                        fill="none"
+                        height="14"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="14"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M18 19a5 5 0 0 1-5-5v8"
+                        />
+                        <path
+                          d="M9 20H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.67.9H20a2 2 0 0 1 2 2v5"
+                        />
+                        <circle
+                          cx="13"
+                          cy="12"
+                          r="2"
+                        />
+                        <circle
+                          cx="20"
+                          cy="19"
+                          r="2"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="text-sm font-semibold text-foreground"
+                    >
+                      Workspace
+                    </span>
+                    <span
+                      class="text-xs leading-relaxed text-muted-foreground"
+                    >
+                      A git repo on disk. You can connect many.
+                    </span>
+                  </button>
+                  <button
+                    class="group flex flex-col items-start gap-2 rounded-lg border border-border-soft bg-background p-4 text-left transition-all hover:-translate-y-0.5 hover:border-border hover:shadow-sm"
+                    type="button"
                   >
-                    a single user → assistant exchange inside an agent. tools called inside count as the same turn.
-                  </span>
-                </li>
-              </ul>
-            </article>
+                    <span
+                      class="flex h-8 w-8 items-center justify-center rounded-md bg-success/10 text-success"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-git-branch"
+                        fill="none"
+                        height="14"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="14"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M15 6a9 9 0 0 0-9 9V3"
+                        />
+                        <circle
+                          cx="18"
+                          cy="6"
+                          r="3"
+                        />
+                        <circle
+                          cx="6"
+                          cy="18"
+                          r="3"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="text-sm font-semibold text-foreground"
+                    >
+                      Session
+                    </span>
+                    <span
+                      class="text-xs leading-relaxed text-muted-foreground"
+                    >
+                      A chat with one goal, on its own git worktree + branch. Like a feature branch with built-in chat.
+                    </span>
+                  </button>
+                  <button
+                    class="group flex flex-col items-start gap-2 rounded-lg border border-border-soft bg-background p-4 text-left transition-all hover:-translate-y-0.5 hover:border-border hover:shadow-sm"
+                    type="button"
+                  >
+                    <span
+                      class="flex h-8 w-8 items-center justify-center rounded-md bg-warning/10 text-warning"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-bot"
+                        fill="none"
+                        height="14"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="14"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M12 8V4H8"
+                        />
+                        <rect
+                          height="12"
+                          rx="2"
+                          width="16"
+                          x="4"
+                          y="8"
+                        />
+                        <path
+                          d="M2 14h2"
+                        />
+                        <path
+                          d="M20 14h2"
+                        />
+                        <path
+                          d="M15 13v2"
+                        />
+                        <path
+                          d="M9 13v2"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="text-sm font-semibold text-foreground"
+                    >
+                      Agent
+                    </span>
+                    <span
+                      class="text-xs leading-relaxed text-muted-foreground"
+                    >
+                      One provider/CLI invocation inside a session. A session may host several agents (planning, coding, review…).
+                    </span>
+                  </button>
+                  <button
+                    class="group flex flex-col items-start gap-2 rounded-lg border border-border-soft bg-background p-4 text-left transition-all hover:-translate-y-0.5 hover:border-border hover:shadow-sm"
+                    type="button"
+                  >
+                    <span
+                      class="flex h-8 w-8 items-center justify-center rounded-md bg-info/10 text-info"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="lucide lucide-message-square"
+                        fill="none"
+                        height="14"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        viewBox="0 0 24 24"
+                        width="14"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M22 17a2 2 0 0 1-2 2H6.828a2 2 0 0 0-1.414.586l-2.202 2.202A.71.71 0 0 1 2 21.286V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2z"
+                        />
+                      </svg>
+                    </span>
+                    <span
+                      class="text-sm font-semibold text-foreground"
+                    >
+                      Turn
+                    </span>
+                    <span
+                      class="text-xs leading-relaxed text-muted-foreground"
+                    >
+                      A single user → assistant exchange inside an agent. Tools called inside count as the same turn.
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -2683,7 +2371,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
   open=""
 >
   <div
-    class="flex min-h-0 flex-col h-[640px] w-[56rem]"
+    class="flex min-h-0 flex-col h-[680px] w-[68rem] max-w-[95vw]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
@@ -2718,16 +2406,16 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm px-0 py-0 gap-0"
     >
       <div
-        class="flex h-full min-h-0 gap-0"
+        class="flex h-full min-h-0"
       >
         <nav
-          class="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2"
+          class="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5"
         >
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary"
             title="goal is required"
             type="button"
           >
@@ -2790,7 +2478,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
             </svg>
           </button>
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
             title="provider is required"
             type="button"
           >
@@ -2841,7 +2529,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
             </svg>
           </button>
           <button
-            class="relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
             type="button"
           >
             <svg
@@ -2892,720 +2580,207 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           </button>
         </nav>
         <div
-          class="min-w-0 flex-1 overflow-y-auto pl-4 pr-2"
+          class="min-w-0 flex-1 overflow-y-auto px-8 py-6"
         >
           <div
-            class=""
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Issue link
-                  <span
-                    class="rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Paste a GitHub, GitLab, Jira, or Linear issue URL. The goal will be generated automatically.
-                </p>
-                <div
-                  class="relative"
-                >
-                  <input
-                    class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-                    placeholder="github.com/…/issues/42 · linear.app/…/TEAM-1 · jira · gitlab"
-                    type="text"
-                    value=""
-                  />
-                </div>
-              </div>
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Goal
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  What this session should accomplish.
-                </p>
-                <textarea
-                  class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-                  placeholder="Refactor auth domain"
-                  style="overflow-y: hidden;"
-                />
-              </div>
-              <div
-                class="flex flex-col gap-1.5"
-              >
-                <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Branch
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Worktree branch for this session.
-                </p>
-                <div
-                  class="flex flex-col gap-2"
-                >
-                  <div
-                    aria-label="branch source"
-                    class="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
-                    role="tablist"
-                  >
-                    <button
-                      aria-selected="true"
-                      class="rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors bg-background text-foreground shadow-sm"
-                      role="tab"
-                      type="button"
-                    >
-                      New
-                    </button>
-                    <button
-                      aria-selected="false"
-                      class="rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                      role="tab"
-                      type="button"
-                    >
-                      Existing
-                    </button>
-                  </div>
-                  <div
-                    class="flex items-center gap-1.5"
-                  >
-                    <span
-                      class="shrink-0 text-xs text-muted-foreground font-mono"
-                    >
-                      kay
-                      /
-                    </span>
-                    <input
-                      aria-label="Branch slug"
-                      class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
-                      placeholder="branch-slug"
-                      type="text"
-                      value=""
-                    />
-                    <button
-                      aria-label="Generate branch name"
-                      class="shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors cursor-not-allowed text-muted-foreground/30"
-                      disabled=""
-                      title="Generate from goal"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-wand-sparkles"
-                        fill="none"
-                        height="13"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="13"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"
-                        />
-                        <path
-                          d="m14 7 3 3"
-                        />
-                        <path
-                          d="M5 6v4"
-                        />
-                        <path
-                          d="M19 14v4"
-                        />
-                        <path
-                          d="M10 2v2"
-                        />
-                        <path
-                          d="M7 8H3"
-                        />
-                        <path
-                          d="M21 16h-4"
-                        />
-                        <path
-                          d="M11 3H9"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
+            class="flex flex-col gap-7"
           >
             <div
               class="flex flex-col gap-1.5"
             >
-              <span
-                class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-              >
-                Soft cap (USD)
-              </span>
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground"
-              >
-                Optional spend limit. Session gets flagged when exceeded.
-              </p>
-              <input
-                class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50"
-                min="0"
-                placeholder="5.00"
-                step="0.01"
-                type="number"
-                value=""
-              />
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
-              <label
-                class="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs"
-              >
-                <input
-                  class="mt-0.5 accent-primary"
-                  type="checkbox"
-                />
-                <span
-                  class="flex flex-col gap-0.5"
-                >
-                  <span
-                    class="font-medium text-foreground"
-                  >
-                    Run init script
-                  </span>
-                  <span
-                    class="text-muted-foreground"
-                  >
-                    Execute workspace setup before agents start.
-                  </span>
-                </span>
-              </label>
               <div
-                class="flex flex-col gap-1.5"
+                class="flex items-center gap-2"
               >
                 <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                >
-                  Script
-                </span>
-                <p
-                  class="text-2xs leading-relaxed text-muted-foreground"
-                >
-                  Edit for this session only. Changes won't save to workspace.
-                </p>
-                <textarea
-                  autocapitalize="off"
-                  autocorrect="off"
-                  class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 transition-[border-color,box-shadow] focus-visible:shadow-md min-h-[200px] resize-y font-mono text-xs"
-                  rows="10"
-                  spellcheck="false"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-1.5"
-            >
-              <span
-                class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-              >
-                Workflow
-              </span>
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground"
-              >
-                Single chat session. Spawn agents manually as needed.
-              </p>
-              <div
-                aria-label="workflow mode"
-                class="inline-flex rounded-md border border-border bg-subtle p-0.5"
-                role="tablist"
-              >
-                <button
-                  aria-selected="true"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors bg-background text-foreground shadow-sm"
-                  role="tab"
-                  type="button"
-                >
-                  One-off
-                </button>
-                <button
-                  aria-selected="false"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                  role="tab"
-                  type="button"
-                >
-                  Preset
-                  <span
-                    class="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </button>
-                <button
-                  aria-selected="false"
-                  class="flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
-                  role="tab"
-                  type="button"
-                >
-                  Custom
-                  <span
-                    class="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning"
-                  >
-                    beta
-                  </span>
-                </button>
-              </div>
-              <div
-                class="mt-3 flex flex-col gap-3"
-              >
-                <div
-                  class="flex flex-col gap-1.5"
-                >
-                  <span
-                    class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
-                  >
-                    Agent role
-                  </span>
-                  <p
-                    class="text-2xs leading-relaxed text-muted-foreground"
-                  >
-                    Role for the first agent. Spawn more from the sidebar.
-                  </p>
-                  <div
-                    class="relative"
-                  >
-                    <button
-                      class="flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                      type="button"
-                    >
-                      <span
-                        aria-hidden="true"
-                        class="size-2 shrink-0 rounded-full bg-rose-400"
-                      />
-                      <span
-                        class="shrink-0 font-medium text-foreground"
-                      >
-                        Agent
-                      </span>
-                      <span
-                        class="flex-1 truncate text-muted-foreground/70"
-                      >
-                        Can do whatever you want, no restrictions
-                      </span>
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                        fill="none"
-                        height="12"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="12"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m6 9 6 6 6-6"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="grid grid-cols-3 gap-3"
-                >
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Model
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50 cursor-not-allowed opacity-50"
-                        disabled=""
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-rose-400"
-                        />
-                        <span
-                          class="flex-1 truncate font-mono font-medium text-foreground"
-                        >
-                          opus 4.7
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Effort
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-info"
-                        />
-                        <span
-                          class="flex-1 truncate font-medium text-foreground"
-                        >
-                          Medium
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    class="flex flex-col gap-1"
-                  >
-                    <span
-                      class="text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70"
-                    >
-                      Verbosity
-                    </span>
-                    <div
-                      class="relative"
-                    >
-                      <button
-                        class="flex w-full items-center gap-1.5 rounded-md border px-2 py-1.5 text-left text-xs transition-colors border-border-soft bg-subtle hover:border-border hover:bg-muted/50"
-                        type="button"
-                      >
-                        <span
-                          aria-hidden="true"
-                          class="size-1.5 shrink-0 rounded-full bg-amber-400"
-                        />
-                        <span
-                          class="flex-1 truncate font-medium text-foreground"
-                        >
-                          Normal
-                        </span>
-                        <svg
-                          aria-hidden="true"
-                          class="lucide lucide-chevron-down shrink-0 text-muted-foreground transition-transform"
-                          fill="none"
-                          height="11"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          viewBox="0 0 24 24"
-                          width="11"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="m6 9 6 6 6-6"
-                          />
-                        </svg>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="hidden"
-              >
-                <div
-                  class="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-soft bg-subtle px-4 py-6 text-center"
+                  class="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10"
                 >
                   <svg
                     aria-hidden="true"
-                    class="lucide lucide-layers text-muted-foreground/30"
+                    class="lucide lucide-target text-primary"
                     fill="none"
-                    height="20"
+                    height="14"
                     stroke="currentColor"
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     stroke-width="2"
                     viewBox="0 0 24 24"
-                    width="20"
+                    width="14"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="10"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="6"
+                    />
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="2"
+                    />
+                  </svg>
+                </span>
+                <h3
+                  class="text-base font-semibold text-foreground"
+                >
+                  What needs to get done?
+                </h3>
+              </div>
+              <p
+                class="max-w-2xl text-xs leading-relaxed text-muted-foreground"
+              >
+                Describe the task in plain English. We'll create a worktree and route it to an agent.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-2"
+            >
+              <textarea
+                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md text-sm leading-relaxed"
+                placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
+                style="overflow-y: hidden;"
+              />
+              <p
+                class="text-2xs leading-relaxed text-muted-foreground/70"
+              >
+                Tip: a clear, imperative sentence yields a better branch name and helps agents stay focused.
+              </p>
+            </div>
+            <div
+              class="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4"
+            >
+              <div
+                class="flex items-center justify-between gap-2"
+              >
+                <div
+                  class="flex items-center gap-2"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-git-branch text-muted-foreground"
+                    fill="none"
+                    height="13"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="13"
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <path
-                      d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
+                      d="M15 6a9 9 0 0 0-9 9V3"
                     />
-                    <path
-                      d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
+                    <circle
+                      cx="18"
+                      cy="6"
+                      r="3"
                     />
-                    <path
-                      d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
+                    <circle
+                      cx="6"
+                      cy="18"
+                      r="3"
                     />
                   </svg>
-                  <p
-                    class="text-xs font-medium text-muted-foreground"
+                  <span
+                    class="text-xs font-semibold text-foreground"
                   >
-                    No workflow presets
-                  </p>
-                  <p
-                    class="max-w-[14rem] text-2xs leading-relaxed text-muted-foreground/60"
-                  >
-                    Switch to
-                     
-                    <button
-                      class="font-medium text-primary underline-offset-2 hover:underline"
-                      type="button"
-                    >
-                      Custom
-                    </button>
-                     
-                    to design your first workflow.
-                  </p>
+                    Branch
+                  </span>
                 </div>
-              </div>
-              <div
-                class="hidden"
-              >
-                <div
-                  class="flex flex-col gap-2"
+                <button
+                  class="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+                  type="button"
                 >
-                  <textarea
-                    class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
-                    placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
-                    style="overflow-y: hidden;"
-                  />
-                  <div
-                    class="flex items-center justify-end gap-2"
-                  >
-                    <span
-                      class="mr-auto text-2xs text-muted-foreground/60"
-                    >
-                      cheap-tier · 
-                      anthropic
-                    </span>
-                    <button
-                      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-7 px-2.5 text-xs"
-                      disabled=""
-                      type="button"
-                    >
-                      Generate plan
-                    </button>
-                  </div>
-                </div>
+                  use existing branch instead
+                </button>
               </div>
-            </div>
-          </div>
-          <div
-            class="hidden"
-          >
-            <div
-              class="flex flex-col gap-4"
-            >
               <div
-                class="flex flex-col gap-1.5"
+                class="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary"
               >
+                <input
+                  aria-label="Branch prefix"
+                  class="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
+                  placeholder="kay"
+                  title="Branch prefix (editable). Saved per workspace."
+                  type="text"
+                  value="kay"
+                />
                 <span
-                  class="flex items-center gap-1.5 text-xs font-semibold text-foreground"
+                  class="flex select-none items-center text-muted-foreground/50"
                 >
-                  Provider
+                  /
                 </span>
-                <div
-                  class="flex gap-2"
+                <input
+                  aria-label="Branch slug"
+                  class="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                  placeholder="branch-slug"
+                  type="text"
+                  value=""
+                />
+                <button
+                  aria-label="Generate branch name"
+                  class="flex shrink-0 items-center justify-center rounded px-2 transition-colors cursor-not-allowed text-muted-foreground/30"
+                  disabled=""
+                  title="Generate a better name from your goal"
+                  type="button"
                 >
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
+                  <svg
+                    aria-hidden="true"
+                    class="lucide lucide-wand-sparkles"
+                    fill="none"
+                    height="13"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    viewBox="0 0 24 24"
+                    width="13"
+                    xmlns="http://www.w3.org/2000/svg"
                   >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      claude
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      cursor
-                      <span
-                        class="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning"
-                      >
-                        beta
-                      </span>
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                  <button
-                    class="flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40"
-                    disabled=""
-                    type="button"
-                  >
-                    <span
-                      class="flex items-center gap-1.5"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="lucide lucide-x text-danger/60"
-                        fill="none"
-                        height="10"
-                        stroke="currentColor"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        viewBox="0 0 24 24"
-                        width="10"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M18 6 6 18"
-                        />
-                        <path
-                          d="m6 6 12 12"
-                        />
-                      </svg>
-                      codex
-                      <span
-                        class="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning"
-                      >
-                        beta
-                      </span>
-                    </span>
-                    <span
-                      class="text-2xs text-primary/70 underline"
-                      role="button"
-                      tabindex="0"
-                    >
-                      Connect
-                    </span>
-                  </button>
-                </div>
+                    <path
+                      d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"
+                    />
+                    <path
+                      d="m14 7 3 3"
+                    />
+                    <path
+                      d="M5 6v4"
+                    />
+                    <path
+                      d="M19 14v4"
+                    />
+                    <path
+                      d="M10 2v2"
+                    />
+                    <path
+                      d="M7 8H3"
+                    />
+                    <path
+                      d="M21 16h-4"
+                    />
+                    <path
+                      d="M11 3H9"
+                    />
+                  </svg>
+                </button>
               </div>
+              <p
+                class="flex items-center gap-1.5 text-2xs text-muted-foreground/70"
+              >
+                <span>
+                  Preview:
+                </span>
+                <span
+                  class="font-mono text-muted-foreground"
+                >
+                  kay/branch-slug
+                </span>
+              </p>
             </div>
           </div>
         </div>

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1596,6 +1596,7 @@ function AgentKindSelect({
 }) {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
 
   useEffect(() => {
     if (!open) return;
@@ -1606,6 +1607,16 @@ function AgentKindSelect({
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const rect = containerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    // ~280px tall popup; flip up when below is tight.
+    setDirection(spaceBelow < 300 && spaceAbove > spaceBelow ? 'up' : 'down');
   }, [open]);
 
   const meta = AGENT_KIND_META[value];
@@ -1638,7 +1649,12 @@ function AgentKindSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 max-h-[280px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div
+          className={cn(
+            'absolute left-0 z-50 max-h-[280px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg',
+            direction === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
+          )}
+        >
           {[...AGENT_KIND_ORDER]
             .filter((k) => k !== 'init')
             .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1611,10 +1611,22 @@ function AgentKindSelect({
 
   useEffect(() => {
     if (!open) return;
-    const rect = containerRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
+    const el = containerRef.current;
+    const rect = el?.getBoundingClientRect();
+    if (!el || !rect) return;
+    // Walk up to the nearest clipping ancestor — the Dialog's
+    // overflow-hidden wrapper would clip the popover otherwise.
+    let clipper: HTMLElement | null = el.parentElement;
+    while (clipper) {
+      const overflowY = getComputedStyle(clipper).overflowY;
+      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'hidden') break;
+      clipper = clipper.parentElement;
+    }
+    const clipperRect = clipper?.getBoundingClientRect();
+    const bottomBound = clipperRect ? clipperRect.bottom : window.innerHeight;
+    const topBound = clipperRect ? clipperRect.top : 0;
+    const spaceBelow = bottomBound - rect.bottom;
+    const spaceAbove = rect.top - topBound;
     // ~280px tall popup; flip up when below is tight.
     setDirection(spaceBelow < 300 && spaceAbove > spaceBelow ? 'up' : 'down');
   }, [open]);

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
@@ -52,6 +52,7 @@ import { PlannerWidget } from '../../../../features/plans/components/PlannerWidg
 import { useToast } from '../../../../app/components/Toast';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
+import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 
 interface NewSessionDialogProps {
   open: boolean;
@@ -1580,159 +1581,6 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <p className="text-2xs text-muted-foreground/70">
         each agent runs in its own chat thread. you decide which one gets the next turn.
       </p>
-    </div>
-  );
-}
-
-function BranchCombobox({
-  branches,
-  value,
-  onChange,
-  disabled,
-  loading,
-}: {
-  branches: ReadonlyArray<LocalBranchInfo>;
-  value: string;
-  onChange: (v: string) => void;
-  disabled: boolean;
-  loading: boolean;
-}) {
-  const [query, setQuery] = useState('');
-  const [open, setOpen] = useState(false);
-  const [highlightIdx, setHighlightIdx] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
-
-  const filtered = useMemo(
-    () => branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase())),
-    [branches, query],
-  );
-
-  const select = useCallback(
-    (name: string) => {
-      onChange(name);
-      setQuery(name);
-      setOpen(false);
-    },
-    [onChange],
-  );
-
-  useEffect(() => {
-    if (value && !query) setQuery(value);
-  }, [value, query]);
-
-  useEffect(() => {
-    setHighlightIdx(0);
-  }, [query]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open || !listRef.current) return;
-    const el = listRef.current.children[highlightIdx] as HTMLElement | undefined;
-    el?.scrollIntoView({ block: 'nearest' });
-  }, [highlightIdx, open]);
-
-  const onKeyDown = (e: React.KeyboardEvent) => {
-    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
-      setOpen(true);
-      e.preventDefault();
-      return;
-    }
-    if (!open) return;
-    switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        setHighlightIdx((i) => Math.min(i + 1, filtered.length - 1));
-        break;
-      case 'ArrowUp':
-        e.preventDefault();
-        setHighlightIdx((i) => Math.max(i - 1, 0));
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (filtered[highlightIdx]) select(filtered[highlightIdx].name);
-        break;
-      case 'Escape':
-        e.preventDefault();
-        setOpen(false);
-        break;
-    }
-  };
-
-  const placeholder = loading
-    ? 'Loading…'
-    : branches.length === 0
-      ? 'No local branches'
-      : 'Search branch…';
-
-  return (
-    <div ref={containerRef} className="relative w-full">
-      <input
-        ref={inputRef}
-        type="text"
-        value={query}
-        placeholder={placeholder}
-        disabled={disabled || branches.length === 0}
-        aria-label="Existing branch"
-        role="combobox"
-        aria-expanded={open}
-        aria-autocomplete="list"
-        autoComplete="off"
-        className="h-8 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setOpen(true);
-          if (!e.target.value) onChange('');
-        }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={onKeyDown}
-      />
-      {open && filtered.length > 0 ? (
-        <ul
-          ref={listRef}
-          role="listbox"
-          className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg"
-        >
-          {filtered.map((b, i) => (
-            <li
-              key={b.name}
-              role="option"
-              aria-selected={highlightIdx === i}
-              onMouseEnter={() => setHighlightIdx(i)}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                select(b.name);
-              }}
-              className={cn(
-                'flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-sm font-mono',
-                highlightIdx === i ? 'bg-primary/10 text-foreground' : 'text-muted-foreground',
-              )}
-            >
-              <span className="min-w-0 truncate">{b.name}</span>
-              {b.inUse ? <span className="shrink-0 text-2xs text-warning">in use</span> : null}
-              {b.hasUncommitted ? (
-                <span className="shrink-0 text-2xs text-warning">dirty</span>
-              ) : null}
-            </li>
-          ))}
-        </ul>
-      ) : null}
-      {open && !loading && filtered.length === 0 && query ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-full rounded-md border border-border bg-subtle px-2 py-2 text-xs text-muted-foreground shadow-lg">
-          No matching branches
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,17 +1,19 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
+  Bot,
   Check,
   ChevronDown,
   DollarSign,
+  GitBranch,
   Layers,
   Loader2,
   Sparkles,
   Terminal,
-  Wand2,
   Target,
+  Wand2,
   Zap,
   X,
 } from 'lucide-react';
@@ -23,7 +25,7 @@ import type {
   SessionProviderPreference,
   WorkspaceId,
 } from '@kay-am/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@kay-am/core';
+import { getDefaultTurnModel } from '@kay-am/core';
 import { shortModel } from '../../../../features/session/agent-row-format';
 import {
   AGENT_KIND_META,
@@ -47,12 +49,6 @@ import { STORAGE_PREFIXES } from '../../../../shared/lib/storage-keys';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { PlannerWidget } from '../../../../features/plans/components/PlannerWidget';
-import { fetchGithubIssue, parseGithubIssueUrl } from '../../../../features/github/github';
-
-interface IssueData {
-  readonly title: string;
-  readonly body: string;
-}
 import { useToast } from '../../../../app/components/Toast';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
@@ -81,29 +77,40 @@ function formatError(err: unknown): string {
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
 
-type WorkflowMode = 'one-off' | 'preset' | 'custom';
+type WorkflowMode = 'single' | 'preset' | 'custom';
 
-const WORKFLOW_MODES: ReadonlyArray<{
-  id: WorkflowMode;
-  label: string;
-  hint: string;
-  beta?: boolean;
-}> = [
+interface WorkflowModeMeta {
+  readonly id: WorkflowMode;
+  readonly label: string;
+  readonly tagline: string;
+  readonly description: string;
+  readonly icon: typeof Bot;
+  readonly beta?: boolean;
+}
+
+const WORKFLOW_MODES: ReadonlyArray<WorkflowModeMeta> = [
   {
-    id: 'one-off',
-    label: 'One-off',
-    hint: 'Single chat session. Spawn agents manually as needed.',
+    id: 'single',
+    label: 'Single agent',
+    tagline: 'Solo chat session',
+    description:
+      'One agent, one conversation. Spawn more agents from the sidebar as the work unfolds.',
+    icon: Bot,
   },
   {
     id: 'preset',
-    label: 'Preset',
-    hint: 'Pick a saved workflow blueprint. Each step spawns its own agent.',
+    label: 'Workflow preset',
+    tagline: 'Run a saved blueprint',
+    description: 'Pick a preset workflow. Each step spawns its own agent in order.',
+    icon: Layers,
     beta: true,
   },
   {
     id: 'custom',
-    label: 'Custom',
-    hint: 'Design a fresh workflow with the planner, then run it.',
+    label: 'Custom plan',
+    tagline: 'Designed for this goal',
+    description: 'Let the planner draft a workflow tailored to your goal, then run it.',
+    icon: Sparkles,
     beta: true,
   },
 ];
@@ -153,6 +160,27 @@ function getDefaultBinary(providerId: ProviderId): string {
   }
 }
 
+const SLUG_MAX_LEN = 48;
+
+function slugifyLive(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, SLUG_MAX_LEN)
+    .replace(/-+$/, '');
+}
+
+function sanitizePrefix(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '')
+    .replace(/^-+/, '')
+    .slice(0, 16);
+}
+
 function isValidBranchSlug(slug: string): boolean {
   const s = slug.trim();
   if (!s) return false;
@@ -193,32 +221,6 @@ async function generateBranchSlug(goal: string, providerId: ProviderId): Promise
     .join('-');
 }
 
-async function generateGoalFromIssue(issue: IssueData, providerId: ProviderId): Promise<string> {
-  const systemPrompt =
-    'You are a goal extractor for AI coding sessions. Given a task or issue, write a concise goal in 2-4 sentences, imperative form (e.g. "Refactor the auth middleware to..."). Output ONLY the goal text, nothing else.';
-  const userMessage = `Title: ${issue.title}\n\nDescription:\n${issue.body}`.slice(0, 4000);
-  const result = await invoke<SummarizeTaskResult>('summarize_session', {
-    args: {
-      providerId,
-      model: getCheapModel(providerId),
-      binary: getDefaultBinary(providerId),
-      userMessage,
-      systemPrompt,
-    },
-  });
-  if ((result.exitCode ?? 0) !== 0) {
-    throw new Error(`goal generation failed: ${result.stderr}`);
-  }
-  const raw = result.stdout.trim();
-  try {
-    const parsed = JSON.parse(raw) as { result?: string };
-    if (typeof parsed.result === 'string') return parsed.result.trim();
-  } catch {
-    // not json, use raw
-  }
-  return raw;
-}
-
 export function NewSessionDialog({
   open,
   onClose,
@@ -236,11 +238,12 @@ export function NewSessionDialog({
   const workspaceInitScript = useAppStore((s) => s.workspaceInitScripts?.[workspaceId] ?? null);
 
   const [goal, setGoal] = useState('');
-  const [issueUrl, setIssueUrl] = useState('');
-  const [issueFetching, setIssueFetching] = useState(false);
-  const [issueError, setIssueError] = useState<string | null>(null);
 
   const [branchSlug, setBranchSlug] = useState('');
+  // Tracks whether the user has manually edited the slug. While false, the
+  // slug stays linked to the goal (live slugify). Once true, edits no longer
+  // overwrite their manual value.
+  const [slugTouched, setSlugTouched] = useState(false);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [slugGenerating, setSlugGenerating] = useState(false);
   const [branchMode, setBranchMode] = useState<'new' | 'existing'>('new');
@@ -250,7 +253,7 @@ export function NewSessionDialog({
   const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
 
   const [softCapRaw, setSoftCapRaw] = useState('');
-  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('one-off');
+  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('single');
   const [presetTemplateId, setPresetTemplateId] = useState<WorkflowId | ''>('');
   const [customTemplateId, setCustomTemplateId] = useState<WorkflowId | ''>('');
   const selectedPhaseTemplateId =
@@ -317,10 +320,8 @@ export function NewSessionDialog({
   useEffect(() => {
     if (!open) return;
     setGoal('');
-    setIssueUrl('');
-    setIssueFetching(false);
-    setIssueError(null);
     setBranchSlug('');
+    setSlugTouched(false);
     setSlugGenerating(false);
     setBranchMode('new');
     setExistingBranch('');
@@ -329,7 +330,7 @@ export function NewSessionDialog({
     setCustomTemplateId('');
     setHasCustomPlan(false);
     setFirstAgentKind('generic');
-    setWorkflowMode('one-off');
+    setWorkflowMode('single');
     setAutoRun(false);
     setEffort('medium');
     setVerbosity('normal');
@@ -359,6 +360,12 @@ export function NewSessionDialog({
     if (open && workspaceInitScript) setInitContent(workspaceInitScript);
   }, [open, workspaceInitScript]);
 
+  // Live slug derivation from goal while the user hasn't manually edited it.
+  useEffect(() => {
+    if (slugTouched) return;
+    setBranchSlug(slugifyLive(goal));
+  }, [goal, slugTouched]);
+
   const handleGenerateSlug = () => {
     const trimmed = goal.trim();
     if (!trimmed || slugGenerating) return;
@@ -366,6 +373,7 @@ export function NewSessionDialog({
     generateBranchSlug(trimmed, selectedProvider)
       .then((slug) => {
         setBranchSlug(slug);
+        setSlugTouched(true);
       })
       .catch(() => {
         // silent — user can type manually
@@ -375,41 +383,17 @@ export function NewSessionDialog({
       });
   };
 
-  const handleIssueUrl = async (value: string) => {
-    setIssueUrl(value);
-    setIssueError(null);
-
-    const githubParsed = parseGithubIssueUrl(value);
-    if (!githubParsed) return;
-
-    setIssueFetching(true);
-    try {
-      const gh = await fetchGithubIssue(githubParsed.repoSlug, githubParsed.number);
-      const goal = await generateGoalFromIssue(
-        { title: gh.title, body: gh.body },
-        selectedProvider,
-      );
-      setGoal(goal);
-    } catch (err) {
-      setIssueError(formatError(err));
-    } finally {
-      setIssueFetching(false);
-    }
-  };
-
   const reset = () => {
     setGoal('');
-    setIssueUrl('');
-    setIssueFetching(false);
-    setIssueError(null);
     setBranchSlug('');
+    setSlugTouched(false);
     setSlugGenerating(false);
     setSoftCapRaw('');
     setPresetTemplateId('');
     setCustomTemplateId('');
     setHasCustomPlan(false);
     setFirstAgentKind('generic');
-    setWorkflowMode('one-off');
+    setWorkflowMode('single');
     setAutoRun(false);
     setEffort('medium');
     setVerbosity('normal');
@@ -476,7 +460,7 @@ export function NewSessionDialog({
   const goalReady = goal.trim().length > 0 && branchReady;
   const budgetReady = softCapRaw.trim().length > 0;
   const workflowReady =
-    workflowMode === 'one-off' ||
+    workflowMode === 'single' ||
     selectedPhaseTemplateId !== '' ||
     (workflowMode === 'custom' && hasCustomPlan);
   const providerReady = connectedProviderIds.has(selectedProvider);
@@ -547,7 +531,9 @@ export function NewSessionDialog({
       title="New session"
       description="Creates a worktree on a fresh branch from the workspace root."
       size="xl"
-      fixedHeightClass="h-[640px]"
+      className="w-[68rem] max-w-[95vw]"
+      fixedHeightClass="h-[680px]"
+      bodyClassName="px-0 py-0 gap-0"
       footer={
         <div className="flex w-full items-center gap-2">
           <div className="flex-1">
@@ -584,8 +570,9 @@ export function NewSessionDialog({
         </div>
       }
     >
-      <div className="flex h-full min-h-0 gap-0">
-        <nav className="flex w-40 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
+      <div className="flex h-full min-h-0">
+        {/* Fixed ladder — never scrolls */}
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
           {sections.map((s) => (
             <button
               key={s.id}
@@ -593,10 +580,10 @@ export function NewSessionDialog({
               onClick={() => setActiveSection(s.id as SectionId)}
               title={s.required && !s.ready ? `${s.label.toLowerCase()} is required` : undefined}
               className={cn(
-                'relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+                'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
                 activeSection === s.id
-                  ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  ? 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+                  : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
               )}
             >
               {s.icon}
@@ -614,395 +601,908 @@ export function NewSessionDialog({
           ))}
         </nav>
 
-        <div className="min-w-0 flex-1 overflow-y-auto pl-4 pr-2">
-          <div className={activeSection === 'goal' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <Field
-                label="Issue link"
-                labelSuffix={<BetaChip />}
-                hint="Paste a GitHub, GitLab, Jira, or Linear issue URL. The goal will be generated automatically."
-              >
-                <div className="relative">
-                  <Input
-                    value={issueUrl}
-                    onChange={(e) => void handleIssueUrl(e.target.value)}
-                    placeholder="github.com/…/issues/42 · linear.app/…/TEAM-1 · jira · gitlab"
-                    disabled={issueFetching || busy}
-                  />
-                  {issueFetching ? (
-                    <span className="absolute right-2.5 top-1/2 -translate-y-1/2">
-                      <Loader2
-                        size={13}
-                        className="animate-spin text-muted-foreground"
-                        aria-label="fetching issue"
-                      />
-                    </span>
-                  ) : null}
-                </div>
-                {issueError ? <p className="text-xs text-danger">{issueError}</p> : null}
-              </Field>
-              <Field label="Goal" hint="What this session should accomplish.">
-                {issueFetching ? (
-                  <div className="flex flex-col gap-2 rounded-md border border-border-soft bg-subtle px-3 py-3">
-                    <div className="h-3 w-3/4 animate-pulse rounded bg-muted-foreground/20" />
-                    <div className="h-3 w-full animate-pulse rounded bg-muted-foreground/20" />
-                    <div className="h-3 w-5/6 animate-pulse rounded bg-muted-foreground/20" />
-                  </div>
-                ) : (
-                  <Textarea
-                    value={goal}
-                    placeholder="Refactor auth domain"
-                    onChange={(e) => setGoal(e.target.value)}
-                    autoGrow
-                    minRows={4}
-                    maxRows={16}
-                    autoFocus
-                    disabled={busy}
-                  />
-                )}
-              </Field>
-              <Field label="Branch" hint="Worktree branch for this session.">
-                <div className="flex flex-col gap-2">
-                  <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
-                  {branchMode === 'new' ? (
-                    <div className="flex items-center gap-1.5">
-                      <span className="shrink-0 text-xs text-muted-foreground font-mono">
-                        {branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/
-                      </span>
-                      {slugGenerating ? (
-                        <span className="flex h-8 flex-1 animate-pulse items-center rounded border border-border bg-subtle px-2">
-                          <span className="h-2 w-full rounded bg-muted-foreground/20" />
-                        </span>
-                      ) : (
-                        <Input
-                          value={branchSlug}
-                          onChange={(e) => setBranchSlug(e.target.value)}
-                          placeholder="branch-slug"
-                          className="h-8 flex-1 font-mono text-sm"
-                          disabled={busy}
-                          aria-label="Branch slug"
-                        />
-                      )}
-                      <button
-                        type="button"
-                        onClick={handleGenerateSlug}
-                        disabled={!goal.trim() || slugGenerating || busy}
-                        title="Generate from goal"
-                        aria-label="Generate branch name"
-                        className={cn(
-                          'shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors',
-                          goal.trim() && !slugGenerating && !busy
-                            ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                            : 'cursor-not-allowed text-muted-foreground/30',
-                        )}
-                      >
-                        <Wand2 size={13} aria-hidden />
-                      </button>
-                    </div>
-                  ) : (
-                    <BranchCombobox
-                      branches={existingBranches}
-                      value={existingBranch}
-                      onChange={setExistingBranch}
-                      disabled={busy || branchesLoading}
-                      loading={branchesLoading}
-                    />
-                  )}
-                </div>
-              </Field>
-            </div>
-          </div>
+        {/* Only this column scrolls */}
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {activeSection === 'goal' ? (
+            <GoalSection
+              goal={goal}
+              setGoal={setGoal}
+              branchSlug={branchSlug}
+              setBranchSlug={(v) => {
+                setBranchSlug(v);
+                setSlugTouched(true);
+              }}
+              slugGenerating={slugGenerating}
+              branchPrefix={branchPrefix}
+              setBranchPrefix={setBranchPrefix}
+              branchMode={branchMode}
+              setBranchMode={setBranchMode}
+              existingBranches={existingBranches}
+              existingBranch={existingBranch}
+              setExistingBranch={setExistingBranch}
+              branchesLoading={branchesLoading}
+              busy={busy}
+              onGenerateSlug={handleGenerateSlug}
+            />
+          ) : null}
 
-          <div className={activeSection === 'budget' ? '' : 'hidden'}>
-            <Field
-              label="Soft cap (USD)"
-              hint="Optional spend limit. Session gets flagged when exceeded."
-            >
-              <Input
-                value={softCapRaw}
-                onChange={(e) => setSoftCapRaw(e.target.value)}
-                placeholder="5.00"
-                type="number"
-                min="0"
-                step="0.01"
-                disabled={busy}
-              />
-            </Field>
-          </div>
+          {activeSection === 'workflow' ? (
+            <WorkflowSection
+              workflowMode={workflowMode}
+              onModeChange={onWorkflowModeChange}
+              phaseTemplates={phaseTemplates}
+              selectedPhaseTemplateId={selectedPhaseTemplateId}
+              setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
+              customTemplateId={customTemplateId}
+              setCustomTemplateId={setCustomTemplateId}
+              workspaceId={workspaceId}
+              selectedProvider={selectedProvider}
+              selectedModel={selectedModel}
+              setSelectedModel={setSelectedModel}
+              firstAgentKind={firstAgentKind}
+              setFirstAgentKind={setFirstAgentKind}
+              effort={effort}
+              setEffort={setEffort}
+              verbosity={verbosity}
+              setVerbosity={setVerbosity}
+              autoRun={autoRun}
+              setAutoRun={setAutoRun}
+              goal={goal}
+              busy={busy}
+              providerReady={providerReady}
+              onPlanChange={setHasCustomPlan}
+            />
+          ) : null}
 
-          <div className={activeSection === 'init' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs">
-                <input
-                  type="checkbox"
-                  checked={initEnabled}
-                  onChange={(e) => setInitEnabled(e.target.checked)}
-                  className="mt-0.5 accent-primary"
-                />
-                <span className="flex flex-col gap-0.5">
-                  <span className="font-medium text-foreground">Run init script</span>
-                  <span className="text-muted-foreground">
-                    Execute workspace setup before agents start.
-                  </span>
-                </span>
-              </label>
-              <Field
-                label="Script"
-                hint="Edit for this session only. Changes won't save to workspace."
-              >
-                <Textarea
-                  value={initContent}
-                  onChange={(e) => setInitContent(e.target.value)}
-                  className="min-h-[200px] resize-y font-mono text-xs"
-                  disabled={!initEnabled || busy}
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  rows={10}
-                />
-              </Field>
-            </div>
-          </div>
+          {activeSection === 'provider' ? (
+            <ProviderSection
+              connectedProviderIds={connectedProviderIds}
+              selectedProvider={selectedProvider}
+              onRequestChange={requestProviderChange}
+              pendingProviderSwitch={pendingProviderSwitch}
+              onCancelSwitch={() => setPendingProviderSwitch(null)}
+              onConfirmSwitch={confirmProviderSwitch}
+              onClose={onClose}
+              onOpenSettings={onOpenSettings}
+            />
+          ) : null}
 
-          <div className={activeSection === 'workflow' ? '' : 'hidden'}>
-            <Field label="Workflow" hint={workflowModeHint(workflowMode)}>
-              <WorkflowModeSegmented mode={workflowMode} onChange={onWorkflowModeChange} />
+          {activeSection === 'init' ? (
+            <InitSection
+              initEnabled={initEnabled}
+              setInitEnabled={setInitEnabled}
+              initContent={initContent}
+              setInitContent={setInitContent}
+              busy={busy}
+            />
+          ) : null}
 
-              <div className={workflowMode === 'one-off' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                <Field
-                  label="Agent role"
-                  hint="Role for the first agent. Spawn more from the sidebar."
-                >
-                  <AgentKindSelect
-                    value={firstAgentKind}
-                    onChange={setFirstAgentKind}
-                    disabled={busy}
-                  />
-                </Field>
-                <div className="grid grid-cols-3 gap-3">
-                  <InlineField label="Model">
-                    <ModelSelect
-                      provider={selectedProvider}
-                      value={selectedModel}
-                      onChange={setSelectedModel}
-                      disabled={busy || !providerReady}
-                    />
-                  </InlineField>
-                  <InlineField label="Effort">
-                    <EffortSelect
-                      model={selectedModel}
-                      value={effort}
-                      onChange={setEffort}
-                      disabled={busy}
-                    />
-                  </InlineField>
-                  <InlineField label="Verbosity">
-                    <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
-                  </InlineField>
-                </div>
-              </div>
-
-              <div className={workflowMode === 'preset' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                {phaseTemplates.length === 0 ? (
-                  <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-soft bg-subtle px-4 py-6 text-center">
-                    <Layers size={20} className="text-muted-foreground/30" aria-hidden />
-                    <p className="text-xs font-medium text-muted-foreground">No workflow presets</p>
-                    <p className="max-w-[14rem] text-2xs leading-relaxed text-muted-foreground/60">
-                      Switch to{' '}
-                      <button
-                        type="button"
-                        onClick={() => onWorkflowModeChange('custom')}
-                        className="font-medium text-primary underline-offset-2 hover:underline"
-                      >
-                        Custom
-                      </button>{' '}
-                      to design your first workflow.
-                    </p>
-                  </div>
-                ) : (
-                  <PresetSelect
-                    templates={phaseTemplates}
-                    value={selectedPhaseTemplateId}
-                    onChange={setSelectedPhaseTemplateId}
-                    disabled={busy}
-                  />
-                )}
-                {selectedPhaseTemplateId !== '' ? (
-                  <WorkflowPreview
-                    template={phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null}
-                  />
-                ) : null}
-              </div>
-
-              <div className={workflowMode === 'custom' ? 'mt-3 flex flex-col gap-3' : 'hidden'}>
-                {customTemplateId !== '' ? (
-                  (() => {
-                    const customTemplate =
-                      phaseTemplates.find((t) => t.id === customTemplateId) ?? null;
-                    return (
-                      <div className="flex flex-col gap-3">
-                        <div className="flex items-center gap-1.5 text-xs">
-                          <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
-                            <Check size={10} className="text-success" />
-                          </span>
-                          <span className="font-medium text-foreground">
-                            Workflow ready
-                            {customTemplate
-                              ? ` · ${customTemplate.steps.length} step${customTemplate.steps.length === 1 ? '' : 's'}`
-                              : ''}
-                          </span>
-                        </div>
-                        <WorkflowPreview template={customTemplate} />
-                        <div className="flex items-center gap-2">
-                          <button
-                            type="button"
-                            onClick={() => setCustomTemplateId('')}
-                            className="flex items-center gap-1 rounded-md border border-border-soft px-2.5 py-1 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-                          >
-                            <Sparkles size={10} aria-hidden /> Re-design
-                          </button>
-                        </div>
-                      </div>
-                    );
-                  })()
-                ) : (
-                  <PlannerWidget
-                    workspaceId={workspaceId}
-                    providerId={selectedProvider}
-                    initialTheme={goal}
-                    onWorkflowReady={(workflowId) => {
-                      setCustomTemplateId(workflowId);
-                    }}
-                    onPlanChange={setHasCustomPlan}
-                  />
-                )}
-              </div>
-
-              {workflowMode !== 'one-off' && selectedPhaseTemplateId !== '' ? (
-                <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2 text-xs">
-                  <input
-                    type="checkbox"
-                    checked={autoRun}
-                    onChange={(e) => setAutoRun(e.target.checked)}
-                    className="mt-0.5 accent-primary"
-                  />
-                  <span className="flex flex-col gap-0.5">
-                    <span className="flex items-center gap-1.5 font-medium text-foreground">
-                      Run autonomously
-                      <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                        beta
-                      </span>
-                    </span>
-                    <span className="text-muted-foreground">
-                      Auto-spawn each step on completion. Pauses on error or budget exceed.
-                    </span>
-                  </span>
-                </label>
-              ) : null}
-            </Field>
-          </div>
-
-          <div className={activeSection === 'provider' ? '' : 'hidden'}>
-            <div className="flex flex-col gap-4">
-              <Field label="Provider">
-                <div className="flex gap-2">
-                  {PROVIDER_ORDER.map((id) => {
-                    const connected = connectedProviderIds.has(id);
-                    const selected = selectedProvider === id;
-                    return (
-                      <button
-                        key={id}
-                        type="button"
-                        disabled={!connected}
-                        onClick={() => requestProviderChange(id)}
-                        className={cn(
-                          'flex flex-1 flex-col items-center gap-1 rounded-md border px-3 py-2.5 text-sm transition-colors',
-                          selected && connected
-                            ? 'border-primary bg-primary/5 font-medium text-foreground'
-                            : connected
-                              ? 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50'
-                              : 'cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40',
-                        )}
-                      >
-                        <span className="flex items-center gap-1.5">
-                          {connected ? (
-                            <span
-                              className={cn(
-                                'size-1.5 rounded-full',
-                                selected ? 'bg-success' : 'bg-muted-foreground/40',
-                              )}
-                            />
-                          ) : (
-                            <X size={10} className="text-danger/60" aria-hidden />
-                          )}
-                          {PROVIDER_LABEL_LOWER[id]}
-                          {id !== 'anthropic' ? (
-                            <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                              beta
-                            </span>
-                          ) : null}
-                        </span>
-                        {!connected ? (
-                          <span
-                            role="button"
-                            tabIndex={0}
-                            className="text-2xs text-primary/70 underline"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              onClose();
-                              window.dispatchEvent(
-                                new CustomEvent('kayam:open-settings', {
-                                  detail: { section: 'providers' },
-                                }),
-                              );
-                            }}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                e.stopPropagation();
-                                onClose();
-                                window.dispatchEvent(
-                                  new CustomEvent('kayam:open-settings', {
-                                    detail: { section: 'providers' },
-                                  }),
-                                );
-                              }
-                            }}
-                          >
-                            Connect
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              </Field>
-              {pendingProviderSwitch ? (
-                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5">
-                  <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden />
-                  <div className="flex flex-1 flex-col gap-1.5">
-                    <p className="text-xs font-medium text-foreground">
-                      Switching provider will discard your custom workflow.
-                    </p>
-                    <div className="flex gap-2">
-                      <Button
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setPendingProviderSwitch(null)}
-                      >
-                        Cancel
-                      </Button>
-                      <Button size="sm" onClick={confirmProviderSwitch}>
-                        Switch provider
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              ) : null}
-            </div>
-          </div>
+          {activeSection === 'budget' ? (
+            <BudgetSection softCapRaw={softCapRaw} setSoftCapRaw={setSoftCapRaw} busy={busy} />
+          ) : null}
         </div>
       </div>
     </Dialog>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Goal + branch                                                */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface GoalSectionProps {
+  readonly goal: string;
+  readonly setGoal: (v: string) => void;
+  readonly branchSlug: string;
+  readonly setBranchSlug: (v: string) => void;
+  readonly slugGenerating: boolean;
+  readonly branchPrefix: string;
+  readonly setBranchPrefix: (v: string) => void;
+  readonly branchMode: 'new' | 'existing';
+  readonly setBranchMode: (m: 'new' | 'existing') => void;
+  readonly existingBranches: ReadonlyArray<LocalBranchInfo>;
+  readonly existingBranch: string;
+  readonly setExistingBranch: (v: string) => void;
+  readonly branchesLoading: boolean;
+  readonly busy: boolean;
+  readonly onGenerateSlug: () => void;
+}
+
+function GoalSection({
+  goal,
+  setGoal,
+  branchSlug,
+  setBranchSlug,
+  slugGenerating,
+  branchPrefix,
+  setBranchPrefix,
+  branchMode,
+  setBranchMode,
+  existingBranches,
+  existingBranch,
+  setExistingBranch,
+  branchesLoading,
+  busy,
+  onGenerateSlug,
+}: GoalSectionProps) {
+  // Live-derived slug used when goal is set. Visible-only branch preview
+  // string so the user sees the final shape.
+  const fullBranch = `${branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/${branchSlug || 'branch-slug'}`;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Target size={14} aria-hidden className="text-primary" />}
+        title="What needs to get done?"
+        subtitle="Describe the task in plain English. We'll create a worktree and route it to an agent."
+      />
+
+      <div className="flex flex-col gap-2">
+        <Textarea
+          value={goal}
+          placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
+          onChange={(e) => setGoal(e.target.value)}
+          autoGrow
+          minRows={4}
+          maxRows={14}
+          autoFocus
+          disabled={busy}
+          className="text-sm leading-relaxed"
+        />
+        <p className="text-2xs leading-relaxed text-muted-foreground/70">
+          Tip: a clear, imperative sentence yields a better branch name and helps agents stay
+          focused.
+        </p>
+      </div>
+
+      {/* Branch — compact, prefix + slug live preview */}
+      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <GitBranch size={13} aria-hidden className="text-muted-foreground" />
+            <span className="text-xs font-semibold text-foreground">Branch</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => setBranchMode(branchMode === 'new' ? 'existing' : 'new')}
+            className="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+          >
+            {branchMode === 'new' ? 'use existing branch instead' : 'create new branch instead'}
+          </button>
+        </div>
+
+        {branchMode === 'new' ? (
+          <>
+            <div className="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary">
+              <input
+                type="text"
+                value={branchPrefix}
+                onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
+                disabled={busy}
+                placeholder={DEFAULT_BRANCH_PREFIX}
+                aria-label="Branch prefix"
+                title="Branch prefix (editable). Saved per workspace."
+                className="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
+              />
+              <span className="flex select-none items-center text-muted-foreground/50">/</span>
+              {slugGenerating ? (
+                <span className="flex flex-1 animate-pulse items-center px-1.5">
+                  <span className="h-2 w-1/2 rounded bg-muted-foreground/20" />
+                </span>
+              ) : (
+                <input
+                  type="text"
+                  value={branchSlug}
+                  onChange={(e) => setBranchSlug(slugifyLive(e.target.value))}
+                  placeholder="branch-slug"
+                  disabled={busy}
+                  aria-label="Branch slug"
+                  className="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                />
+              )}
+              <button
+                type="button"
+                onClick={onGenerateSlug}
+                disabled={!goal.trim() || slugGenerating || busy}
+                title="Generate a better name from your goal"
+                aria-label="Generate branch name"
+                className={cn(
+                  'flex shrink-0 items-center justify-center rounded px-2 transition-colors',
+                  goal.trim() && !slugGenerating && !busy
+                    ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    : 'cursor-not-allowed text-muted-foreground/30',
+                )}
+              >
+                <Wand2 size={13} aria-hidden />
+              </button>
+            </div>
+            <p className="flex items-center gap-1.5 text-2xs text-muted-foreground/70">
+              <span>Preview:</span>
+              <span className="font-mono text-muted-foreground">{fullBranch}</span>
+            </p>
+          </>
+        ) : (
+          <BranchCombobox
+            branches={existingBranches}
+            value={existingBranch}
+            onChange={setExistingBranch}
+            disabled={busy || branchesLoading}
+            loading={branchesLoading}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Workflow                                                     */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface WorkflowSectionProps {
+  readonly workflowMode: WorkflowMode;
+  readonly onModeChange: (m: WorkflowMode) => void;
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly selectedPhaseTemplateId: WorkflowId | '';
+  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
+  readonly customTemplateId: WorkflowId | '';
+  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
+  readonly workspaceId: WorkspaceId;
+  readonly selectedProvider: ProviderId;
+  readonly selectedModel: string;
+  readonly setSelectedModel: (m: string) => void;
+  readonly firstAgentKind: AgentKind;
+  readonly setFirstAgentKind: (k: AgentKind) => void;
+  readonly effort: EffortLevel;
+  readonly setEffort: (e: EffortLevel) => void;
+  readonly verbosity: VerbosityLevel;
+  readonly setVerbosity: (v: VerbosityLevel) => void;
+  readonly autoRun: boolean;
+  readonly setAutoRun: (v: boolean) => void;
+  readonly goal: string;
+  readonly busy: boolean;
+  readonly providerReady: boolean;
+  readonly onPlanChange: (v: boolean) => void;
+}
+
+function WorkflowSection(props: WorkflowSectionProps) {
+  const {
+    workflowMode,
+    onModeChange,
+    phaseTemplates,
+    selectedPhaseTemplateId,
+    setSelectedPhaseTemplateId,
+    customTemplateId,
+    setCustomTemplateId,
+    workspaceId,
+    selectedProvider,
+    selectedModel,
+    setSelectedModel,
+    firstAgentKind,
+    setFirstAgentKind,
+    effort,
+    setEffort,
+    verbosity,
+    setVerbosity,
+    autoRun,
+    setAutoRun,
+    goal,
+    busy,
+    providerReady,
+    onPlanChange,
+  } = props;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SectionHeader
+        icon={<Layers size={14} aria-hidden className="text-primary" />}
+        title="How should the session run?"
+        subtitle="Pick a shape. You can always evolve it once the session is live."
+      />
+
+      {/* 3-card grid */}
+      <div className="grid grid-cols-3 gap-3">
+        {WORKFLOW_MODES.map((m) => {
+          const Icon = m.icon;
+          const active = workflowMode === m.id;
+          return (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => onModeChange(m.id)}
+              aria-pressed={active}
+              className={cn(
+                'group relative flex flex-col items-start gap-2 rounded-lg border p-3.5 text-left transition-all',
+                active
+                  ? 'border-primary bg-primary/5 shadow-sm ring-1 ring-primary/20'
+                  : 'border-border-soft bg-background hover:-translate-y-0.5 hover:border-border hover:bg-subtle/40 hover:shadow-sm',
+              )}
+            >
+              <div className="flex w-full items-center justify-between">
+                <span
+                  className={cn(
+                    'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+                    active
+                      ? 'bg-primary/15 text-primary'
+                      : 'bg-muted/60 text-muted-foreground group-hover:bg-muted',
+                  )}
+                >
+                  <Icon size={15} aria-hidden />
+                </span>
+                <div className="flex items-center gap-1">
+                  {m.beta ? (
+                    <span className="rounded bg-warning/20 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-warning">
+                      beta
+                    </span>
+                  ) : null}
+                  {active ? (
+                    <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                      <Check size={10} aria-hidden />
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <span
+                  className={cn(
+                    'text-sm font-semibold leading-tight',
+                    active ? 'text-foreground' : 'text-foreground/90',
+                  )}
+                >
+                  {m.label}
+                </span>
+                <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+                  {m.tagline}
+                </span>
+              </div>
+              <p className="text-2xs leading-relaxed text-muted-foreground">{m.description}</p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Mode-specific body */}
+      <div className="rounded-lg border border-border-soft bg-subtle/30 p-4">
+        {workflowMode === 'single' ? (
+          <SingleAgentPanel
+            firstAgentKind={firstAgentKind}
+            setFirstAgentKind={setFirstAgentKind}
+            selectedProvider={selectedProvider}
+            selectedModel={selectedModel}
+            setSelectedModel={setSelectedModel}
+            effort={effort}
+            setEffort={setEffort}
+            verbosity={verbosity}
+            setVerbosity={setVerbosity}
+            providerReady={providerReady}
+            busy={busy}
+          />
+        ) : null}
+
+        {workflowMode === 'preset' ? (
+          <PresetPanel
+            phaseTemplates={phaseTemplates}
+            selectedPhaseTemplateId={selectedPhaseTemplateId}
+            setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
+            onSwitchToCustom={() => onModeChange('custom')}
+            busy={busy}
+          />
+        ) : null}
+
+        {workflowMode === 'custom' ? (
+          <CustomPanel
+            phaseTemplates={phaseTemplates}
+            customTemplateId={customTemplateId}
+            setCustomTemplateId={setCustomTemplateId}
+            workspaceId={workspaceId}
+            selectedProvider={selectedProvider}
+            goal={goal}
+            onPlanChange={onPlanChange}
+          />
+        ) : null}
+      </div>
+
+      {workflowMode !== 'single' && selectedPhaseTemplateId !== '' ? (
+        <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+          <input
+            type="checkbox"
+            checked={autoRun}
+            onChange={(e) => setAutoRun(e.target.checked)}
+            className="mt-0.5 accent-primary"
+          />
+          <span className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-1.5 font-medium text-foreground">
+              Run autonomously
+              <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+                beta
+              </span>
+            </span>
+            <span className="text-muted-foreground">
+              Auto-spawn each step on completion. Pauses on error or budget exceed.
+            </span>
+          </span>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
+interface SingleAgentPanelProps {
+  readonly firstAgentKind: AgentKind;
+  readonly setFirstAgentKind: (k: AgentKind) => void;
+  readonly selectedProvider: ProviderId;
+  readonly selectedModel: string;
+  readonly setSelectedModel: (m: string) => void;
+  readonly effort: EffortLevel;
+  readonly setEffort: (e: EffortLevel) => void;
+  readonly verbosity: VerbosityLevel;
+  readonly setVerbosity: (v: VerbosityLevel) => void;
+  readonly providerReady: boolean;
+  readonly busy: boolean;
+}
+
+function SingleAgentPanel({
+  firstAgentKind,
+  setFirstAgentKind,
+  selectedProvider,
+  selectedModel,
+  setSelectedModel,
+  effort,
+  setEffort,
+  verbosity,
+  setVerbosity,
+  providerReady,
+  busy,
+}: SingleAgentPanelProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Configure the first agent"
+        subtitle="One conversation, ready to talk. You can spawn more agents from the sidebar anytime."
+      />
+      <Field label="Agent role" hint="Sets the system prompt and default tools.">
+        <AgentKindSelect value={firstAgentKind} onChange={setFirstAgentKind} disabled={busy} />
+      </Field>
+      <div className="grid grid-cols-3 gap-3">
+        <InlineField label="Model">
+          <ModelSelect
+            provider={selectedProvider}
+            value={selectedModel}
+            onChange={setSelectedModel}
+            disabled={busy || !providerReady}
+          />
+        </InlineField>
+        <InlineField label="Effort">
+          <EffortSelect model={selectedModel} value={effort} onChange={setEffort} disabled={busy} />
+        </InlineField>
+        <InlineField label="Verbosity">
+          <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
+        </InlineField>
+      </div>
+    </div>
+  );
+}
+
+interface PresetPanelProps {
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly selectedPhaseTemplateId: WorkflowId | '';
+  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
+  readonly onSwitchToCustom: () => void;
+  readonly busy: boolean;
+}
+
+function PresetPanel({
+  phaseTemplates,
+  selectedPhaseTemplateId,
+  setSelectedPhaseTemplateId,
+  onSwitchToCustom,
+  busy,
+}: PresetPanelProps) {
+  if (phaseTemplates.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
+        <Layers size={28} className="text-muted-foreground/30" aria-hidden />
+        <div className="flex flex-col gap-1">
+          <p className="text-sm font-medium text-foreground">No workflow presets yet</p>
+          <p className="max-w-xs text-2xs leading-relaxed text-muted-foreground">
+            Workspaces ship with a small library. If yours is empty, design one with the planner.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onSwitchToCustom}
+          className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+        >
+          <Sparkles size={11} aria-hidden /> Switch to custom plan
+        </button>
+      </div>
+    );
+  }
+  const selected = phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null;
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Pick a blueprint"
+        subtitle={`${phaseTemplates.length} preset${phaseTemplates.length === 1 ? '' : 's'} available in this workspace. Each preset runs its steps in order.`}
+      />
+      <div className="flex flex-col gap-2">
+        {phaseTemplates.map((t) => {
+          const active = selectedPhaseTemplateId === t.id;
+          const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
+          return (
+            <button
+              key={t.id}
+              type="button"
+              disabled={busy}
+              onClick={() => setSelectedPhaseTemplateId(active ? '' : t.id)}
+              className={cn(
+                'flex flex-col gap-2 rounded-md border px-3 py-2.5 text-left transition-colors',
+                active
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border-soft bg-background hover:border-border hover:bg-subtle/40',
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span
+                  className={cn(
+                    'flex size-4 shrink-0 items-center justify-center rounded-full',
+                    active
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground/40',
+                  )}
+                >
+                  {active ? <Check size={10} aria-hidden /> : null}
+                </span>
+                <span className="flex-1 truncate text-xs font-semibold text-foreground">
+                  {t.name}
+                </span>
+                <span className="shrink-0 text-2xs text-muted-foreground">
+                  {sorted.length} step{sorted.length === 1 ? '' : 's'}
+                </span>
+              </div>
+              {t.description ? (
+                <p className="pl-6 text-2xs leading-relaxed text-muted-foreground">
+                  {t.description}
+                </p>
+              ) : null}
+              {sorted.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1 pl-6">
+                  {sorted.map((step, i) => {
+                    const kind = inferAgentKindFromName(step.name);
+                    const pal = AGENT_KIND_PALETTE[kind];
+                    return (
+                      <span key={step.id} className="flex items-center gap-1">
+                        {i > 0 ? (
+                          <span className="text-2xs text-muted-foreground/40">→</span>
+                        ) : null}
+                        <span
+                          className={cn(
+                            'inline-flex items-center gap-1 rounded-full bg-background px-1.5 py-0.5 text-2xs',
+                            pal.fg,
+                          )}
+                        >
+                          <span className={cn('size-1.5 rounded-full', pal.bg)} />
+                          {step.name}
+                        </span>
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {selected ? <WorkflowPreview template={selected} /> : null}
+    </div>
+  );
+}
+
+interface CustomPanelProps {
+  readonly phaseTemplates: ReadonlyArray<Workflow>;
+  readonly customTemplateId: WorkflowId | '';
+  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
+  readonly workspaceId: WorkspaceId;
+  readonly selectedProvider: ProviderId;
+  readonly goal: string;
+  readonly onPlanChange: (v: boolean) => void;
+}
+
+function CustomPanel({
+  phaseTemplates,
+  customTemplateId,
+  setCustomTemplateId,
+  workspaceId,
+  selectedProvider,
+  goal,
+  onPlanChange,
+}: CustomPanelProps) {
+  if (customTemplateId !== '') {
+    const customTemplate = phaseTemplates.find((t) => t.id === customTemplateId) ?? null;
+    return (
+      <div className="flex flex-col gap-4">
+        <PanelHeader
+          title="Custom plan ready"
+          subtitle={
+            customTemplate
+              ? `Planner produced a workflow with ${customTemplate.steps.length} step${customTemplate.steps.length === 1 ? '' : 's'}. Review below.`
+              : 'Planner produced a workflow. Review below.'
+          }
+        />
+        <WorkflowPreview template={customTemplate} />
+        <div>
+          <button
+            type="button"
+            onClick={() => setCustomTemplateId('')}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+          >
+            <Sparkles size={11} aria-hidden /> Re-plan
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-4">
+      <PanelHeader
+        title="Design a plan from your goal"
+        subtitle="The planner drafts a sequence of agents tailored to what you typed. Tune it before locking it in."
+      />
+      <PlannerWidget
+        workspaceId={workspaceId}
+        providerId={selectedProvider}
+        initialTheme={goal}
+        onWorkflowReady={(workflowId) => setCustomTemplateId(workflowId)}
+        onPlanChange={onPlanChange}
+      />
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Provider                                                     */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface ProviderSectionProps {
+  readonly connectedProviderIds: ReadonlySet<ProviderId>;
+  readonly selectedProvider: ProviderId;
+  readonly onRequestChange: (id: ProviderId) => void;
+  readonly pendingProviderSwitch: ProviderId | null;
+  readonly onCancelSwitch: () => void;
+  readonly onConfirmSwitch: () => void;
+  readonly onClose: () => void;
+  readonly onOpenSettings: () => void;
+}
+
+function ProviderSection({
+  connectedProviderIds,
+  selectedProvider,
+  onRequestChange,
+  pendingProviderSwitch,
+  onCancelSwitch,
+  onConfirmSwitch,
+  onClose,
+}: ProviderSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<Zap size={14} aria-hidden className="text-primary" />}
+        title="Which provider should drive this session?"
+        subtitle="Affects model availability and routing. You can override per-turn later."
+      />
+      <div className="grid grid-cols-3 gap-2">
+        {PROVIDER_ORDER.map((id) => {
+          const connected = connectedProviderIds.has(id);
+          const selected = selectedProvider === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              disabled={!connected}
+              onClick={() => onRequestChange(id)}
+              className={cn(
+                'flex flex-col items-center gap-1.5 rounded-md border px-3 py-3 text-sm transition-colors',
+                selected && connected
+                  ? 'border-primary bg-primary/5 font-medium text-foreground'
+                  : connected
+                    ? 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50'
+                    : 'cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40',
+              )}
+            >
+              <span className="flex items-center gap-1.5">
+                {connected ? (
+                  <span
+                    className={cn(
+                      'size-1.5 rounded-full',
+                      selected ? 'bg-success' : 'bg-muted-foreground/40',
+                    )}
+                  />
+                ) : (
+                  <X size={10} className="text-danger/60" aria-hidden />
+                )}
+                {PROVIDER_LABEL_LOWER[id]}
+                {id !== 'anthropic' ? (
+                  <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+                    beta
+                  </span>
+                ) : null}
+              </span>
+              {!connected ? (
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="text-2xs text-primary/70 underline"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onClose();
+                    window.dispatchEvent(
+                      new CustomEvent('kayam:open-settings', {
+                        detail: { section: 'providers' },
+                      }),
+                    );
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.stopPropagation();
+                      onClose();
+                      window.dispatchEvent(
+                        new CustomEvent('kayam:open-settings', {
+                          detail: { section: 'providers' },
+                        }),
+                      );
+                    }
+                  }}
+                >
+                  Connect
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      {pendingProviderSwitch ? (
+        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden />
+          <div className="flex flex-1 flex-col gap-1.5">
+            <p className="text-xs font-medium text-foreground">
+              Switching provider will discard your custom workflow.
+            </p>
+            <div className="flex gap-2">
+              <Button size="sm" variant="ghost" onClick={onCancelSwitch}>
+                Cancel
+              </Button>
+              <Button size="sm" onClick={onConfirmSwitch}>
+                Switch provider
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Init                                                         */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface InitSectionProps {
+  readonly initEnabled: boolean;
+  readonly setInitEnabled: (v: boolean) => void;
+  readonly initContent: string;
+  readonly setInitContent: (v: string) => void;
+  readonly busy: boolean;
+}
+
+function InitSection({
+  initEnabled,
+  setInitEnabled,
+  initContent,
+  setInitContent,
+  busy,
+}: InitSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<Terminal size={14} aria-hidden className="text-primary" />}
+        title="Init script"
+        subtitle="Workspace setup that runs before agents start. Edit for this session only."
+      />
+      <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+        <input
+          type="checkbox"
+          checked={initEnabled}
+          onChange={(e) => setInitEnabled(e.target.checked)}
+          className="mt-0.5 accent-primary"
+        />
+        <span className="flex flex-col gap-0.5">
+          <span className="font-medium text-foreground">Run init script</span>
+          <span className="text-muted-foreground">
+            Execute workspace setup before agents start.
+          </span>
+        </span>
+      </label>
+      <Field label="Script" hint="Edit for this session only. Changes won't save to workspace.">
+        <Textarea
+          value={initContent}
+          onChange={(e) => setInitContent(e.target.value)}
+          className="min-h-[220px] resize-y font-mono text-xs"
+          disabled={!initEnabled || busy}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          rows={10}
+        />
+      </Field>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Budget                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface BudgetSectionProps {
+  readonly softCapRaw: string;
+  readonly setSoftCapRaw: (v: string) => void;
+  readonly busy: boolean;
+}
+
+function BudgetSection({ softCapRaw, setSoftCapRaw, busy }: BudgetSectionProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      <SectionHeader
+        icon={<DollarSign size={14} aria-hidden className="text-primary" />}
+        title="Soft cap"
+        subtitle="Optional spend limit. Session gets flagged once exceeded — agents keep running."
+      />
+      <Field label="Soft cap (USD)" hint="Leave blank to skip.">
+        <Input
+          value={softCapRaw}
+          onChange={(e) => setSoftCapRaw(e.target.value)}
+          placeholder="5.00"
+          type="number"
+          min="0"
+          step="0.01"
+          disabled={busy}
+        />
+      </Field>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
+          {icon}
+        </span>
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      </div>
+      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
+  );
+}
+
+function PanelHeader({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs font-semibold text-foreground">{title}</span>
+      <p className="text-2xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }
 
@@ -1029,26 +1529,18 @@ function Field({
   );
 }
 
-function BetaChip() {
-  return (
-    <span className="rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning">
-      beta
-    </span>
-  );
-}
-
 function WorkflowPreview({ template }: { template: Workflow | null }) {
   if (!template) return null;
   if (template.steps.length === 0) {
     return (
-      <p className="mt-2 rounded-md bg-subtle px-3 py-2 text-xs text-muted-foreground">
+      <p className="rounded-md bg-subtle px-3 py-2 text-xs text-muted-foreground">
         This workflow has no steps yet. Add some via the planner above.
       </p>
     );
   }
   const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
   return (
-    <div className="mt-2 flex flex-col gap-1.5 rounded-md bg-subtle p-3">
+    <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-background p-3">
       <div className="flex items-baseline justify-between">
         <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
           will spawn {template.steps.length} agent
@@ -1061,12 +1553,12 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <ol className="flex flex-col gap-1">
         {sortedSteps.map((step, i) => {
           const model = step.modelOverride ? shortModel(step.modelOverride) : null;
-          const effort = step.effort ?? null;
-          const verbosity = step.verbosity ?? null;
+          const eff = step.effort ?? null;
+          const verb = step.verbosity ?? null;
           return (
             <li
               key={step.id}
-              className="flex items-center gap-2 rounded-md bg-background px-2 py-1 text-xs"
+              className="flex items-center gap-2 rounded-md bg-subtle px-2 py-1 text-xs"
             >
               <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
               <span
@@ -1076,9 +1568,9 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
                 )}
               />
               <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
-              {model || effort || verbosity ? (
-                <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-                  {[model, effort, verbosity ? `v:${verbosity}` : null].filter(Boolean).join(' · ')}
+              {model || eff || verb ? (
+                <span className="shrink-0 rounded-full bg-background px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
+                  {[model, eff, verb ? `v:${verb}` : null].filter(Boolean).join(' · ')}
                 </span>
               ) : null}
             </li>
@@ -1088,97 +1580,6 @@ function WorkflowPreview({ template }: { template: Workflow | null }) {
       <p className="text-2xs text-muted-foreground/70">
         each agent runs in its own chat thread. you decide which one gets the next turn.
       </p>
-    </div>
-  );
-}
-
-function WorkflowModeSegmented({
-  mode,
-  onChange,
-}: {
-  mode: WorkflowMode;
-  onChange: (next: WorkflowMode) => void;
-}) {
-  return (
-    <div
-      role="tablist"
-      aria-label="workflow mode"
-      className="inline-flex rounded-md border border-border bg-subtle p-0.5"
-    >
-      {WORKFLOW_MODES.map((m) => {
-        const active = mode === m.id;
-        return (
-          <button
-            key={m.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            onClick={() => onChange(m.id)}
-            className={cn(
-              'flex items-center gap-1 rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors',
-              active
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-            )}
-          >
-            {m.label}
-            {m.beta ? (
-              <span className="rounded-sm bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning">
-                beta
-              </span>
-            ) : null}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-function workflowModeHint(mode: WorkflowMode): string {
-  return WORKFLOW_MODES.find((m) => m.id === mode)?.hint ?? '';
-}
-
-function BranchModeToggle({
-  mode,
-  onChange,
-  disabled,
-}: {
-  mode: 'new' | 'existing';
-  onChange: (next: 'new' | 'existing') => void;
-  disabled: boolean;
-}) {
-  const modes: ReadonlyArray<{ id: 'new' | 'existing'; label: string }> = [
-    { id: 'new', label: 'New' },
-    { id: 'existing', label: 'Existing' },
-  ];
-  return (
-    <div
-      role="tablist"
-      aria-label="branch source"
-      className="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
-    >
-      {modes.map((m) => {
-        const active = mode === m.id;
-        return (
-          <button
-            key={m.id}
-            type="button"
-            role="tab"
-            aria-selected={active}
-            disabled={disabled}
-            onClick={() => onChange(m.id)}
-            className={cn(
-              'rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
-              active
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground',
-              disabled && 'cursor-not-allowed opacity-50',
-            )}
-          >
-            {m.label}
-          </button>
-        );
-      })}
     </div>
   );
 }
@@ -1203,7 +1604,10 @@ function BranchCombobox({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
 
-  const filtered = branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase()));
+  const filtered = useMemo(
+    () => branches.filter((b) => b.name.toLowerCase().includes(query.toLowerCase())),
+    [branches, query],
+  );
 
   const select = useCallback(
     (name: string) => {
@@ -1285,7 +1689,7 @@ function BranchCombobox({
         aria-expanded={open}
         aria-autocomplete="list"
         autoComplete="off"
-        className="h-7 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+        className="h-8 w-full truncate rounded border border-border bg-background px-2.5 text-sm font-mono motion-safe:transition-colors placeholder:text-muted-foreground/50 hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
         onChange={(e) => {
           setQuery(e.target.value);
           setOpen(true);
@@ -1369,7 +1773,7 @@ function AgentKindSelect({
           'flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors',
           open
             ? 'border-primary bg-primary/5'
-            : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+            : 'border-border-soft bg-background hover:border-border hover:bg-muted/50',
           disabled && 'cursor-not-allowed opacity-50',
         )}
       >
@@ -1425,129 +1829,6 @@ function AgentKindSelect({
                 </button>
               );
             })}
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function PresetSelect({
-  templates,
-  value,
-  onChange,
-  disabled,
-}: {
-  templates: ReadonlyArray<Workflow>;
-  value: WorkflowId | '';
-  onChange: (id: WorkflowId | '') => void;
-  disabled: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  const selected = templates.find((t) => t.id === value) ?? null;
-
-  return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setOpen(!open)}
-        className={cn(
-          'flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors',
-          open
-            ? 'border-primary bg-primary/5'
-            : value
-              ? 'border-primary/50 bg-primary/5'
-              : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
-      >
-        {selected ? (
-          <>
-            <span className="flex-1 truncate font-medium text-foreground">{selected.name}</span>
-            <span className="shrink-0 text-2xs text-muted-foreground">
-              {selected.steps.length} step{selected.steps.length === 1 ? '' : 's'}
-            </span>
-          </>
-        ) : (
-          <span className="flex-1 text-muted-foreground/60">Select a workflow preset</span>
-        )}
-        <ChevronDown
-          size={12}
-          className={cn(
-            'shrink-0 text-muted-foreground transition-transform',
-            open && 'rotate-180',
-          )}
-          aria-hidden
-        />
-      </button>
-      {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 max-h-[240px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg">
-          {templates.map((t) => {
-            const active = value === t.id;
-            const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
-            return (
-              <button
-                key={t.id}
-                type="button"
-                onClick={() => {
-                  onChange(active ? '' : t.id);
-                  setOpen(false);
-                }}
-                className={cn(
-                  'flex w-full flex-col gap-0.5 px-2.5 py-2 text-left transition-colors',
-                  active ? 'bg-primary/10' : 'hover:bg-muted/50',
-                )}
-              >
-                <div className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      'flex-1 truncate text-xs font-medium',
-                      active ? 'text-foreground' : 'text-foreground/80',
-                    )}
-                  >
-                    {t.name}
-                  </span>
-                  <span className="shrink-0 text-2xs text-muted-foreground">
-                    {t.steps.length} step{t.steps.length === 1 ? '' : 's'}
-                  </span>
-                  {active ? (
-                    <Check size={11} className="shrink-0 text-primary" aria-hidden />
-                  ) : null}
-                </div>
-                {sorted.length > 0 ? (
-                  <div className="flex items-center gap-1">
-                    {sorted.map((step, i) => {
-                      const kind = inferAgentKindFromName(step.name);
-                      const pal = AGENT_KIND_PALETTE[kind];
-                      return (
-                        <span key={step.id} className="flex items-center gap-0.5">
-                          {i > 0 ? (
-                            <span className="text-2xs text-muted-foreground/30">→</span>
-                          ) : null}
-                          <span className={cn('max-w-[5rem] truncate text-2xs', pal.fg)}>
-                            {step.name}
-                          </span>
-                        </span>
-                      );
-                    })}
-                  </div>
-                ) : null}
-              </button>
-            );
-          })}
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/features/session/components/OpenInEditorIconButton/index.tsx
+++ b/apps/desktop/src/features/session/components/OpenInEditorIconButton/index.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, FolderOpen } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+import { openInEditor } from '../../../../shared/lib/editor';
+import { formatError } from '../../../../shared/lib/errors';
+import {
+  DEFAULT_EDITOR_BINARY,
+  SETTING_DEFAULT_EDITOR,
+  SETTING_EDITOR_BINARY,
+} from '../../../../features/settings/settings';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+
+interface OpenInEditorIconButtonProps {
+  readonly worktreePath: string | null;
+}
+
+/**
+ * Compact icon-only "open this session's worktree in an external editor"
+ * affordance. Intended for header chrome (e.g. the session detail panel)
+ * where space is tight and a labelled button would clash. Click behaviour:
+ * - 0 editors detected → disabled
+ * - 1 editor → opens directly
+ * - 2+ editors → opens a small popover. Last picked editor is remembered.
+ */
+export function OpenInEditorIconButton({ worktreePath }: OpenInEditorIconButtonProps) {
+  const detectedEditors = useAppStore((s) => s.detectedEditors);
+  const globalEditorBinary = useAppStore(
+    (s) => s.settings[SETTING_EDITOR_BINARY] ?? DEFAULT_EDITOR_BINARY,
+  );
+  const savedDefault = useAppStore((s) => s.settings[SETTING_DEFAULT_EDITOR] ?? null);
+  const saveSetting = useAppStore((s) => s.saveSetting);
+  const { showToast } = useToast();
+
+  const resolvedDefault = savedDefault ?? globalEditorBinary;
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const launch = async (binary: string) => {
+    if (!worktreePath) return;
+    setOpen(false);
+    try {
+      await openInEditor(worktreePath, binary);
+      if (binary !== resolvedDefault) {
+        await saveSetting(SETTING_DEFAULT_EDITOR, binary);
+      }
+    } catch (err) {
+      showToast('error', `couldn't open editor: ${formatError(err)}`);
+    }
+  };
+
+  const disabled = !worktreePath || detectedEditors.length === 0;
+  const hasMultiple = detectedEditors.length > 1;
+
+  const onClick = () => {
+    if (disabled) return;
+    if (hasMultiple) {
+      setOpen((v) => !v);
+    } else {
+      void launch(detectedEditors[0]!.binary);
+    }
+  };
+
+  const title = disabled
+    ? detectedEditors.length === 0
+      ? 'no editor detected'
+      : 'no worktree available'
+    : hasMultiple
+      ? 'open worktree in editor'
+      : `open in ${detectedEditors[0]!.label}`;
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        title={title}
+        aria-label={title}
+        aria-haspopup={hasMultiple ? 'menu' : undefined}
+        aria-expanded={hasMultiple ? open : undefined}
+        className={cn(
+          'shrink-0 rounded p-1 motion-safe:transition-colors',
+          disabled
+            ? 'cursor-not-allowed text-muted-foreground/30'
+            : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
+          open && 'bg-foreground/10 text-foreground',
+        )}
+      >
+        <FolderOpen size={13} aria-hidden />
+      </button>
+      {open && hasMultiple ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-30 mt-1 min-w-[160px] rounded-md border border-border bg-subtle py-1 text-xs shadow-lg"
+        >
+          {detectedEditors.map((ed) => {
+            const active = ed.binary === resolvedDefault;
+            return (
+              <button
+                key={ed.binary}
+                type="button"
+                role="menuitem"
+                onClick={() => void launch(ed.binary)}
+                className={cn(
+                  'flex w-full items-center gap-2 px-2.5 py-1.5 text-left motion-safe:transition-colors',
+                  active
+                    ? 'bg-primary/10 text-foreground'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <FolderOpen
+                  size={11}
+                  aria-hidden
+                  className={active ? 'text-primary' : 'text-muted-foreground/60'}
+                />
+                <span className="flex-1 truncate">{ed.label}</span>
+                {active ? <Check size={11} className="text-primary" aria-hidden /> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -21,6 +21,7 @@ import { useAppStore } from '../../../../store';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
+import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 import { useToast } from '../../../../app/components/Toast';
 import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
 
@@ -516,29 +517,14 @@ function GeneralSection(props: GeneralSectionProps) {
               </div>
 
               {branchMode === 'existing' ? (
-                <select
+                <BranchCombobox
+                  branches={branches}
                   value={branchTarget}
-                  onChange={(e) => setBranchTarget(e.target.value)}
-                  disabled={busy || branchesLoading}
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
-                >
-                  <option value="">
-                    {branchesLoading
-                      ? 'Loading…'
-                      : branches.length === 0
-                        ? 'No local branches'
-                        : 'Select branch…'}
-                  </option>
-                  {branches
-                    .filter((b) => b.name !== branch)
-                    .map((b) => (
-                      <option key={b.name} value={b.name}>
-                        {b.name}
-                        {b.inUse ? ' · in use' : ''}
-                        {b.hasUncommitted ? ' · dirty' : ''}
-                      </option>
-                    ))}
-                </select>
+                  onChange={setBranchTarget}
+                  disabled={busy}
+                  loading={branchesLoading}
+                  excludeNames={branch ? [branch] : undefined}
+                />
               ) : (
                 <Input
                   value={branchTarget}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -221,7 +221,6 @@ export function SessionSettingsDialog({
       description={session.goal}
       size="xl"
       className="w-[64rem] max-w-[95vw]"
-      fixedHeightClass="h-[600px]"
       bodyClassName="px-0 py-0 gap-0"
       fullScreenOnSmall
       footer={
@@ -555,15 +554,7 @@ function GeneralSection(props: GeneralSectionProps) {
                 </div>
               ) : null}
 
-              <div className="flex items-center justify-end gap-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setBranchEditOpen(false)}
-                  disabled={busy}
-                >
-                  Cancel
-                </Button>
+              <div className="flex items-center justify-end">
                 <Button
                   size="sm"
                   onClick={onChangeBranch}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
   Archive,
   ArchiveRestore,
-  Bot,
+  Check,
+  ChevronDown,
+  ChevronUp,
   DollarSign,
   GitBranch,
   Loader2,
+  Settings2,
+  Terminal,
   Trash2,
+  Zap,
 } from 'lucide-react';
 import type { SessionId } from '@kay-am/types';
 import { formatError } from '../../../../shared/lib/errors';
@@ -17,6 +22,7 @@ import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/fea
 import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
 import { useToast } from '../../../../app/components/Toast';
+import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
 
 interface SessionSettingsDialogProps {
   sessionId: SessionId;
@@ -30,23 +36,11 @@ interface SessionSettingsDialogProps {
 type Section = 'general' | 'budget' | 'danger';
 
 interface NavItem {
-  id: Section;
-  label: string;
-  icon: React.ReactNode;
+  readonly id: Section;
+  readonly label: string;
+  readonly icon: ReactNode;
+  readonly tone?: 'danger';
 }
-
-const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'general', label: 'General', icon: <Bot size={14} aria-hidden /> },
-  ...(SESSION_FEATURES.budget
-    ? [{ id: 'budget' as const, label: 'Budget', icon: <DollarSign size={14} aria-hidden /> }]
-    : []),
-];
-
-const DANGER_NAV: NavItem = {
-  id: 'danger',
-  label: 'Delete',
-  icon: <Trash2 size={14} aria-hidden />,
-};
 
 export function SessionSettingsDialog({
   sessionId,
@@ -123,16 +117,25 @@ export function SessionSettingsDialog({
   const isActiveSession = sessionSummary !== null;
   const spent = isActiveSession ? (sessionSummary?.estimatedCostUsd ?? 0) : 0;
 
+  const navItems: ReadonlyArray<NavItem> = [
+    { id: 'general', label: 'General', icon: <Settings2 size={13} aria-hidden /> },
+    ...(SESSION_FEATURES.budget
+      ? ([{ id: 'budget', label: 'Budget', icon: <DollarSign size={13} aria-hidden /> }] as const)
+      : []),
+    { id: 'danger', label: 'Danger zone', icon: <Trash2 size={13} aria-hidden />, tone: 'danger' },
+  ];
+
   const onSaveGoal = async () => {
     const trimmed = goalDraft.trim();
     if (!trimmed) {
-      setError('goal cannot be empty');
+      setError('Name cannot be empty.');
       return;
     }
     setBusy(true);
     setError(null);
     try {
       await renameTask(sessionId, trimmed);
+      showToast('success', 'session renamed');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -143,13 +146,14 @@ export function SessionSettingsDialog({
   const onSaveCap = async () => {
     const parsed = parseCap(capDraft);
     if (parsed === null) {
-      setError('cap must be a positive number');
+      setError('Cap must be a positive number.');
       return;
     }
     setBusy(true);
     setError(null);
     try {
       await setSessionBudget(sessionId, parsed);
+      showToast('success', 'budget updated');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -159,8 +163,6 @@ export function SessionSettingsDialog({
 
   const targetTrimmed = branchTarget.trim();
   const targetInfo = branches.find((b) => b.name === targetTrimmed) ?? null;
-  // Friction sources: branch already owned by another session, branch in use
-  // in another worktree, branch has uncommitted work in its current worktree.
   const targetOwnedByOtherSession = Object.entries(sessionBranches).some(
     ([otherSessionId, b]) => otherSessionId !== sessionId && b === targetTrimmed,
   );
@@ -171,7 +173,7 @@ export function SessionSettingsDialog({
 
   const onChangeBranch = async () => {
     if (!targetTrimmed) {
-      setError('branch is required');
+      setError('Pick a branch.');
       return;
     }
     if (targetTrimmed === branch) {
@@ -210,399 +212,698 @@ export function SessionSettingsDialog({
     }
   };
 
-  const renderContent = () => {
-    switch (active) {
-      case 'general':
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold tracking-wide text-muted-foreground">Session</div>
-            <Field
-              label="name"
-              hint="display name for the session in the sidebar. to update the actual goal text the agent reads, use the context panel on the right."
-            >
-              <div className="flex gap-2">
-                <Input
-                  value={goalDraft}
-                  onChange={(e) => setGoalDraft(e.target.value)}
-                  placeholder="refactor auth domain"
-                  className="flex-1"
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Session settings"
+      description={session.goal}
+      size="xl"
+      className="w-[64rem] max-w-[95vw]"
+      fixedHeightClass="h-[600px]"
+      bodyClassName="px-0 py-0 gap-0"
+      fullScreenOnSmall
+      footer={
+        <div className="flex w-full items-center gap-2">
+          <div className="flex-1">
+            {error ? <span className="text-xs text-danger">{error}</span> : null}
+          </div>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex h-full min-h-0">
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
+          {navItems
+            .filter((i) => i.tone !== 'danger')
+            .map((item) => (
+              <NavButton
+                key={item.id}
+                item={item}
+                active={active === item.id}
+                onClick={() => setActive(item.id)}
+              />
+            ))}
+          <div className="mt-auto">
+            {navItems
+              .filter((i) => i.tone === 'danger')
+              .map((item) => (
+                <NavButton
+                  key={item.id}
+                  item={item}
+                  active={active === item.id}
+                  onClick={() => setActive(item.id)}
                 />
-                <Button
-                  variant="secondary"
-                  onClick={() => void onSaveGoal()}
-                  disabled={busy || goalDraft.trim() === session.goal.trim()}
-                >
-                  Save
-                </Button>
-              </div>
-            </Field>
-            <Field
-              label="branch"
-              hint="switch this session to a different branch. existing checkouts with uncommitted work require confirmation."
-            >
-              <div className="flex items-center gap-2">
-                <div className="inline-flex items-center gap-2 rounded-md bg-subtle px-2.5 py-2 text-xs text-muted-foreground ring-1 ring-border-soft">
-                  <GitBranch size={12} aria-hidden />
-                  <code className="font-mono text-foreground">{branch ?? 'unknown'}</code>
-                </div>
-                <Button
-                  variant="secondary"
-                  onClick={() => setBranchEditOpen(true)}
-                  disabled={busy || !workspace}
-                >
-                  Change branch
-                </Button>
-              </div>
-            </Field>
-            <Field label="provider" hint="set at creation time.">
-              <span className="inline-flex w-fit items-center gap-2 rounded-md bg-subtle px-2.5 py-1.5 text-xs text-muted-foreground ring-1 ring-border-soft">
-                {session.providerPreference.defaultProvider}
-              </span>
-            </Field>
-            {WORKSPACE_FEATURES.initScript && hasInitScript ? (
-              <Field
-                label="init script"
-                hint="when enabled, a setup agent runs the workspace init script before the first agent fires."
-              >
-                <label className="flex items-center gap-2 text-xs text-foreground">
-                  <input
-                    type="checkbox"
-                    checked={!session.skipInit}
-                    onChange={(e) => void updateSessionSkipInit(sessionId, !e.target.checked)}
-                    className="accent-primary"
-                  />
-                  run workspace init script
-                </label>
-              </Field>
-            ) : null}
+              ))}
           </div>
-        );
+        </nav>
 
-      case 'budget':
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
-              Soft cap
-            </div>
-            <Field
-              label="cap (usd)"
-              hint="warning fires at 80%, error at 100%. session keeps running unless you stop it."
-            >
-              <div className="flex gap-2">
-                <Input
-                  type="number"
-                  min="0"
-                  step="0.01"
-                  value={capDraft}
-                  onChange={(e) => setCapDraft(e.target.value)}
-                  placeholder="2.50"
-                  className="flex-1"
-                />
-                <Button variant="secondary" onClick={() => void onSaveCap()} disabled={busy}>
-                  Save
-                </Button>
-              </div>
-            </Field>
-            {budget?.softCapUsd != null ? (
-              <div className="rounded-md bg-subtle p-3 text-xs text-muted-foreground ring-1 ring-border-soft">
-                <div className="flex items-center justify-between">
-                  <span>spent this session</span>
-                  <span className="font-mono text-foreground">
-                    ${spent.toFixed(2)} / ${budget.softCapUsd.toFixed(2)}
-                  </span>
-                </div>
-              </div>
-            ) : null}
-          </div>
-        );
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {active === 'general' ? (
+            <GeneralSection
+              session={session}
+              goalDraft={goalDraft}
+              setGoalDraft={setGoalDraft}
+              onSaveGoal={onSaveGoal}
+              branch={branch}
+              workspaceReady={!!workspace}
+              busy={busy}
+              hasInitScript={hasInitScript}
+              skipInit={session.skipInit ?? false}
+              onToggleInit={(enabled) => void updateSessionSkipInit(sessionId, !enabled)}
+              branchEditOpen={branchEditOpen}
+              setBranchEditOpen={setBranchEditOpen}
+              branchMode={branchMode}
+              setBranchMode={(m) => {
+                setBranchMode(m);
+                setBranchTarget('');
+                setConfirmReuse(false);
+              }}
+              branchTarget={branchTarget}
+              setBranchTarget={(v) => {
+                setBranchTarget(v);
+                setConfirmReuse(false);
+              }}
+              branches={branches}
+              branchesLoading={branchesLoading}
+              targetNeedsConfirm={targetNeedsConfirm}
+              targetOwnedByOtherSession={targetOwnedByOtherSession}
+              targetInUseElsewhere={targetInUseElsewhere}
+              targetDirty={targetDirty}
+              confirmReuse={confirmReuse}
+              onChangeBranch={onChangeBranch}
+            />
+          ) : null}
 
-      case 'danger':
-        return (
-          <div className="flex flex-col gap-5">
-            <div>
-              <div className="text-xs font-semibold tracking-wide text-danger">Danger zone</div>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                permanent actions on this session.
-              </p>
-            </div>
+          {active === 'budget' ? (
+            <BudgetSection
+              capDraft={capDraft}
+              setCapDraft={setCapDraft}
+              onSaveCap={onSaveCap}
+              busy={busy}
+              softCapUsd={budget?.softCapUsd ?? null}
+              spent={spent}
+            />
+          ) : null}
 
-            {/* Archive row */}
-            <div className="flex items-start justify-between gap-4 rounded-md border border-border-soft p-3">
-              <div className="flex-1">
-                <div className="text-xs font-semibold text-foreground">
-                  {archived ? 'unarchive' : 'archive'}
-                </div>
-                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                  {archived
-                    ? 'restore this session to the active list.'
-                    : 'hide from the active list, keep history. reversible.'}
-                </p>
-              </div>
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  archived ? onUnarchive() : onArchive();
-                  onClose();
-                }}
-                disabled={busy}
-              >
-                {archived ? (
-                  <>
-                    <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
-                    Unarchive
-                  </>
-                ) : (
-                  <>
-                    <Archive size={13} aria-hidden className="mr-1.5" />
-                    Archive
-                  </>
-                )}
-              </Button>
-            </div>
+          {active === 'danger' ? (
+            <DangerSection
+              archived={archived}
+              onArchive={onArchive}
+              onUnarchive={onUnarchive}
+              onClose={onClose}
+              confirmDelete={confirmDelete}
+              setConfirmDelete={setConfirmDelete}
+              onDelete={() => void onDelete()}
+              busy={busy}
+            />
+          ) : null}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
 
-            {/* Delete row */}
-            <div
-              className={cn(
-                'flex flex-col gap-3 rounded-md border p-3 transition-colors',
-                confirmDelete ? 'border-danger/40 bg-danger/5' : 'border-border-soft',
-              )}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1">
-                  <div className="text-xs font-semibold text-foreground">delete session</div>
-                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                    removes worktree, transcripts, audit logs, and the branch. cannot be undone.
-                  </p>
-                </div>
-                {!confirmDelete ? (
-                  <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
-                    <Trash2 size={13} aria-hidden className="mr-1.5" />
-                    Delete
-                  </Button>
-                ) : null}
-              </div>
+/* ──────────────────────────────────────────────────────────────────── */
+/* Nav button                                                            */
+/* ──────────────────────────────────────────────────────────────────── */
 
-              {confirmDelete ? (
-                <>
-                  <div className="flex items-center gap-2 text-xs text-warning">
-                    <Archive size={13} aria-hidden />
-                    <span>consider archiving instead. keeps history and is reversible.</span>
-                  </div>
-                  <div className="flex items-center justify-end gap-2">
-                    <Button variant="ghost" onClick={() => setConfirmDelete(false)} disabled={busy}>
-                      Cancel
-                    </Button>
-                    {!archived ? (
-                      <Button
-                        variant="warning"
-                        onClick={() => {
-                          onArchive();
-                          setConfirmDelete(false);
-                          onClose();
-                        }}
-                        disabled={busy}
-                      >
-                        <Archive size={13} aria-hidden className="mr-1.5" />
-                        Archive instead
-                      </Button>
-                    ) : null}
-                    <Button variant="danger" onClick={() => void onDelete()} disabled={busy}>
-                      {busy ? 'Deleting…' : 'Confirm delete'}
-                    </Button>
-                  </div>
-                </>
-              ) : null}
-            </div>
-          </div>
-        );
-    }
-  };
+function NavButton({
+  item,
+  active,
+  onClick,
+}: {
+  item: NavItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const danger = item.tone === 'danger';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+        active
+          ? danger
+            ? 'bg-danger/10 font-medium text-danger before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-danger'
+            : 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+          : danger
+            ? 'text-danger/70 hover:bg-danger/5 hover:text-danger'
+            : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
+      )}
+    >
+      {item.icon}
+      <span className="flex-1">{item.label}</span>
+    </button>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: General                                                      */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface GeneralSectionProps {
+  readonly session: { goal: string; providerPreference: { defaultProvider: string } };
+  readonly goalDraft: string;
+  readonly setGoalDraft: (v: string) => void;
+  readonly onSaveGoal: () => void;
+  readonly branch: string | null;
+  readonly workspaceReady: boolean;
+  readonly busy: boolean;
+  readonly hasInitScript: boolean;
+  readonly skipInit: boolean;
+  readonly onToggleInit: (enabled: boolean) => void;
+  readonly branchEditOpen: boolean;
+  readonly setBranchEditOpen: (v: boolean) => void;
+  readonly branchMode: 'existing' | 'new';
+  readonly setBranchMode: (m: 'existing' | 'new') => void;
+  readonly branchTarget: string;
+  readonly setBranchTarget: (v: string) => void;
+  readonly branches: ReadonlyArray<LocalBranchInfo>;
+  readonly branchesLoading: boolean;
+  readonly targetNeedsConfirm: boolean;
+  readonly targetOwnedByOtherSession: boolean;
+  readonly targetInUseElsewhere: boolean;
+  readonly targetDirty: boolean;
+  readonly confirmReuse: boolean;
+  readonly onChangeBranch: () => void;
+}
+
+function GeneralSection(props: GeneralSectionProps) {
+  const {
+    session,
+    goalDraft,
+    setGoalDraft,
+    onSaveGoal,
+    branch,
+    workspaceReady,
+    busy,
+    hasInitScript,
+    skipInit,
+    onToggleInit,
+    branchEditOpen,
+    setBranchEditOpen,
+    branchMode,
+    setBranchMode,
+    branchTarget,
+    setBranchTarget,
+    branches,
+    branchesLoading,
+    targetNeedsConfirm,
+    targetOwnedByOtherSession,
+    targetInUseElsewhere,
+    targetDirty,
+    confirmReuse,
+    onChangeBranch,
+  } = props;
+
+  const providerLabel =
+    PROVIDER_LABEL_LOWER[
+      session.providerPreference.defaultProvider as keyof typeof PROVIDER_LABEL_LOWER
+    ] ?? session.providerPreference.defaultProvider;
 
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        title={session.goal}
-        description="rename, edit budget, or delete this session."
-        size="xl"
-        fixedHeightClass="h-[520px]"
-        fullScreenOnSmall
-        footer={
-          <>
-            {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-            <Button variant="ghost" onClick={onClose}>
-              Close
-            </Button>
-          </>
-        }
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Settings2 size={14} aria-hidden className="text-primary" />}
+        title="General"
+        subtitle="Identity and infrastructure for this session. The goal text the agent actually reads lives in the right-hand context panel."
+      />
+
+      {/* Name */}
+      <Field
+        label="Name"
+        hint="Display name in the sidebar. Renaming doesn't change what the agent sees."
       >
-        <div className="flex h-full min-h-0 gap-0">
-          <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setActive(item.id)}
-                className={`relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === item.id
-                    ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-                }`}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-              </button>
-            ))}
-            <div className="mt-auto pt-3">
-              <button
-                type="button"
-                onClick={() => setActive('danger')}
-                className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === 'danger'
-                    ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
-                    : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
-                }`}
-              >
-                {DANGER_NAV.icon}
-                <span>{DANGER_NAV.label}</span>
-              </button>
-            </div>
-          </nav>
-          <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
-        </div>
-      </Dialog>
-      <Dialog
-        open={branchEditOpen}
-        onClose={() => setBranchEditOpen(false)}
-        title="Change session branch"
-        description="point this session's worktree at a different branch."
-        size="md"
-        footer={
-          <>
-            {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-            <Button variant="ghost" onClick={() => setBranchEditOpen(false)} disabled={busy}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => void onChangeBranch()}
-              disabled={busy || branchesLoading || targetTrimmed.length === 0}
-              variant={targetNeedsConfirm && confirmReuse ? 'warning' : 'primary'}
-            >
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
-                  Switching…
-                </>
-              ) : targetNeedsConfirm && confirmReuse ? (
-                'Confirm switch'
-              ) : (
-                'Switch branch'
-              )}
-            </Button>
-          </>
-        }
-      >
-        <div className="flex flex-col gap-4">
-          <div
-            role="tablist"
-            aria-label="branch source"
-            className="inline-flex rounded-md border border-border bg-subtle p-0.5"
+        <div className="flex gap-2">
+          <Input
+            value={goalDraft}
+            onChange={(e) => setGoalDraft(e.target.value)}
+            placeholder="e.g. refactor auth domain"
+            disabled={busy}
+            className="flex-1"
+          />
+          <Button
+            variant="secondary"
+            onClick={onSaveGoal}
+            disabled={busy || goalDraft.trim() === session.goal.trim() || goalDraft.trim() === ''}
           >
-            {(['existing', 'new'] as const).map((m) => {
-              const active = branchMode === m;
-              return (
-                <button
-                  key={m}
-                  type="button"
-                  role="tab"
-                  aria-selected={active}
-                  onClick={() => {
-                    setBranchMode(m);
-                    setBranchTarget('');
-                    setConfirmReuse(false);
-                  }}
-                  disabled={busy}
-                  className={cn(
-                    'rounded px-3 py-1 text-xs font-medium motion-safe:transition-colors',
-                    active
-                      ? 'bg-background text-foreground shadow-sm'
-                      : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  {m === 'existing' ? 'existing branch' : 'new branch'}
-                </button>
-              );
-            })}
+            Save
+          </Button>
+        </div>
+      </Field>
+
+      {/* Branch — inline change */}
+      <Field
+        label="Branch"
+        hint="Switch this session to a different branch. Existing checkouts with uncommitted work require confirmation."
+      >
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-3">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex flex-1 items-center gap-1.5 truncate rounded-md border border-border-soft bg-background px-2.5 py-1.5 font-mono text-xs text-foreground">
+              <GitBranch size={11} aria-hidden className="shrink-0 text-muted-foreground" />
+              <span className="truncate">{branch ?? 'unknown'}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setBranchEditOpen(!branchEditOpen)}
+              disabled={busy || !workspaceReady}
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs font-medium text-foreground transition-colors hover:border-border hover:bg-muted/50',
+                (busy || !workspaceReady) && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              {branchEditOpen ? (
+                <ChevronUp size={12} aria-hidden />
+              ) : (
+                <ChevronDown size={12} aria-hidden />
+              )}
+              {branchEditOpen ? 'Cancel' : 'Change…'}
+            </button>
           </div>
 
-          {branchMode === 'existing' ? (
-            <Field label="branch" hint="pick from local branches in this workspace.">
-              <select
-                value={branchTarget}
-                onChange={(e) => {
-                  setBranchTarget(e.target.value);
-                  setConfirmReuse(false);
-                }}
-                disabled={busy || branchesLoading}
-                className="rounded-md border border-border bg-background px-3 py-2 text-sm motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+          {branchEditOpen ? (
+            <div className="flex flex-col gap-3 border-t border-border-soft pt-3">
+              <div
+                role="tablist"
+                aria-label="branch source"
+                className="inline-flex w-fit rounded-md border border-border bg-background p-0.5"
               >
-                <option value="">
-                  {branchesLoading
-                    ? 'loading…'
-                    : branches.length === 0
-                      ? 'no local branches'
-                      : 'select branch…'}
-                </option>
-                {branches
-                  .filter((b) => b.name !== branch)
-                  .map((b) => (
-                    <option key={b.name} value={b.name}>
-                      {b.name}
-                      {b.inUse ? ' · in use' : ''}
-                      {b.hasUncommitted ? ' · dirty' : ''}
-                    </option>
-                  ))}
-              </select>
-            </Field>
-          ) : (
-            <Field
-              label="new branch name"
-              hint="creates and switches to a new branch from current HEAD."
-            >
-              <Input
-                value={branchTarget}
-                onChange={(e) => {
-                  setBranchTarget(e.target.value);
-                  setConfirmReuse(false);
-                }}
-                placeholder="feat/something"
-                disabled={busy}
-              />
-            </Field>
-          )}
+                {(['existing', 'new'] as const).map((m) => {
+                  const active = branchMode === m;
+                  return (
+                    <button
+                      key={m}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => setBranchMode(m)}
+                      disabled={busy}
+                      className={cn(
+                        'rounded px-2.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
+                        active
+                          ? 'bg-primary/10 text-primary'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      {m === 'existing' ? 'pick existing' : 'create new'}
+                    </button>
+                  );
+                })}
+              </div>
 
-          {targetNeedsConfirm ? (
-            <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs text-warning">
-              <AlertTriangle size={13} aria-hidden className="mt-0.5 shrink-0" />
-              <div className="flex flex-col gap-1">
-                <span className="font-semibold">heads up</span>
-                <ul className="list-disc pl-4">
-                  {targetOwnedByOtherSession ? (
-                    <li>this branch is already attached to another kay-am session.</li>
-                  ) : null}
-                  {targetInUseElsewhere ? (
-                    <li>this branch is checked out in another git worktree.</li>
-                  ) : null}
-                  {targetDirty ? <li>that worktree has uncommitted changes.</li> : null}
-                </ul>
-                <span className="text-2xs text-warning/80">click again to confirm.</span>
+              {branchMode === 'existing' ? (
+                <select
+                  value={branchTarget}
+                  onChange={(e) => setBranchTarget(e.target.value)}
+                  disabled={busy || branchesLoading}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm font-mono motion-safe:transition-colors hover:border-border-strong focus:outline-none focus:ring-1 focus:ring-primary"
+                >
+                  <option value="">
+                    {branchesLoading
+                      ? 'Loading…'
+                      : branches.length === 0
+                        ? 'No local branches'
+                        : 'Select branch…'}
+                  </option>
+                  {branches
+                    .filter((b) => b.name !== branch)
+                    .map((b) => (
+                      <option key={b.name} value={b.name}>
+                        {b.name}
+                        {b.inUse ? ' · in use' : ''}
+                        {b.hasUncommitted ? ' · dirty' : ''}
+                      </option>
+                    ))}
+                </select>
+              ) : (
+                <Input
+                  value={branchTarget}
+                  onChange={(e) => setBranchTarget(e.target.value)}
+                  placeholder="feat/something"
+                  disabled={busy}
+                  className="font-mono"
+                />
+              )}
+
+              {targetNeedsConfirm ? (
+                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 p-3 text-xs">
+                  <AlertTriangle size={13} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                  <div className="flex flex-col gap-1">
+                    <span className="font-semibold text-foreground">Heads up</span>
+                    <ul className="list-disc pl-4 text-muted-foreground">
+                      {targetOwnedByOtherSession ? (
+                        <li>Already attached to another kay.am session.</li>
+                      ) : null}
+                      {targetInUseElsewhere ? <li>Checked out in another git worktree.</li> : null}
+                      {targetDirty ? <li>That worktree has uncommitted changes.</li> : null}
+                    </ul>
+                    <span className="text-2xs text-warning/80">
+                      Click {confirmReuse ? '"Confirm switch"' : '"Switch branch"'} again to
+                      confirm.
+                    </span>
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setBranchEditOpen(false)}
+                  disabled={busy}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={onChangeBranch}
+                  disabled={busy || branchesLoading || branchTarget.trim().length === 0}
+                  variant={targetNeedsConfirm && confirmReuse ? 'warning' : 'primary'}
+                >
+                  {busy ? (
+                    <>
+                      <Loader2 size={12} className="mr-1.5 animate-spin" aria-hidden />
+                      Switching…
+                    </>
+                  ) : targetNeedsConfirm && confirmReuse ? (
+                    'Confirm switch'
+                  ) : (
+                    'Switch branch'
+                  )}
+                </Button>
               </div>
             </div>
           ) : null}
         </div>
-      </Dialog>
-    </>
+      </Field>
+
+      {/* Provider — read-only */}
+      <Field
+        label="Provider"
+        hint="Set at creation time. Per-turn overrides happen in the chat composer."
+      >
+        <span className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs">
+          <Zap size={11} aria-hidden className="text-muted-foreground" />
+          <span className="font-medium text-foreground">{providerLabel}</span>
+        </span>
+      </Field>
+
+      {/* Init script — only when workspace has one */}
+      {WORKSPACE_FEATURES.initScript && hasInitScript ? (
+        <Field
+          label="Init script"
+          hint="When enabled, a setup agent runs the workspace init script before the first agent fires."
+        >
+          <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
+            <input
+              type="checkbox"
+              checked={!skipInit}
+              onChange={(e) => onToggleInit(e.target.checked)}
+              className="mt-0.5 accent-primary"
+            />
+            <span className="flex flex-col gap-0.5">
+              <span className="flex items-center gap-1.5 font-medium text-foreground">
+                <Terminal size={11} aria-hidden className="text-muted-foreground" />
+                Run workspace init script
+              </span>
+              <span className="text-muted-foreground">
+                Useful for installing deps, hydrating env files, etc.
+              </span>
+            </span>
+          </label>
+        </Field>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Budget                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface BudgetSectionProps {
+  readonly capDraft: string;
+  readonly setCapDraft: (v: string) => void;
+  readonly onSaveCap: () => void;
+  readonly busy: boolean;
+  readonly softCapUsd: number | null;
+  readonly spent: number;
+}
+
+function BudgetSection({
+  capDraft,
+  setCapDraft,
+  onSaveCap,
+  busy,
+  softCapUsd,
+  spent,
+}: BudgetSectionProps) {
+  const pct = softCapUsd && softCapUsd > 0 ? Math.min(1, spent / softCapUsd) : 0;
+  const barTone =
+    pct >= 1 ? 'bg-danger' : pct >= 0.8 ? 'bg-warning' : pct >= 0.5 ? 'bg-info' : 'bg-success';
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<DollarSign size={14} aria-hidden className="text-primary" />}
+        title="Budget"
+        subtitle="Optional spend ceiling. Warning at 80%, error at 100%. The session keeps running unless you stop it."
+      />
+      <Field label="Soft cap (USD)" hint="Leave blank to skip. Increments allowed in cents.">
+        <div className="flex gap-2">
+          <Input
+            type="number"
+            min="0"
+            step="0.01"
+            value={capDraft}
+            onChange={(e) => setCapDraft(e.target.value)}
+            placeholder="2.50"
+            className="flex-1"
+            disabled={busy}
+          />
+          <Button variant="secondary" onClick={onSaveCap} disabled={busy}>
+            Save
+          </Button>
+        </div>
+      </Field>
+      {softCapUsd != null && softCapUsd > 0 ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/50 p-4">
+          <div className="flex items-center justify-between text-xs">
+            <span className="text-muted-foreground">Spent this session</span>
+            <span className="font-mono text-foreground">
+              ${spent.toFixed(2)} / ${softCapUsd.toFixed(2)}
+            </span>
+          </div>
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted/60">
+            <div
+              className={cn('h-full rounded-full transition-all', barTone)}
+              style={{ width: `${pct * 100}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-2xs text-muted-foreground/70">
+            <span>{Math.round(pct * 100)}% used</span>
+            {pct >= 0.8 ? (
+              <span className={pct >= 1 ? 'text-danger' : 'text-warning'}>
+                {pct >= 1 ? 'cap exceeded' : 'approaching cap'}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Danger zone                                                  */
+/* ──────────────────────────────────────────────────────────────────── */
+
+interface DangerSectionProps {
+  readonly archived: boolean;
+  readonly onArchive: () => void;
+  readonly onUnarchive: () => void;
+  readonly onClose: () => void;
+  readonly confirmDelete: boolean;
+  readonly setConfirmDelete: (v: boolean) => void;
+  readonly onDelete: () => void;
+  readonly busy: boolean;
+}
+
+function DangerSection({
+  archived,
+  onArchive,
+  onUnarchive,
+  onClose,
+  confirmDelete,
+  setConfirmDelete,
+  onDelete,
+  busy,
+}: DangerSectionProps) {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<AlertTriangle size={14} aria-hidden className="text-danger" />}
+        title="Danger zone"
+        subtitle="Archive to step away gracefully. Delete only if you're sure — it nukes the worktree, transcripts, and the branch."
+        tone="danger"
+      />
+
+      {/* Archive row */}
+      <div className="flex items-start justify-between gap-4 rounded-lg border border-border-soft bg-background p-4">
+        <div className="flex-1">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+            {archived ? (
+              <ArchiveRestore size={12} aria-hidden className="text-muted-foreground" />
+            ) : (
+              <Archive size={12} aria-hidden className="text-muted-foreground" />
+            )}
+            {archived ? 'Unarchive session' : 'Archive session'}
+          </div>
+          <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+            {archived
+              ? 'Restore this session to the active list. Worktree stays untouched.'
+              : 'Hide from the active list, keep history and worktree intact. Reversible.'}
+          </p>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            if (archived) onUnarchive();
+            else onArchive();
+            onClose();
+          }}
+          disabled={busy}
+        >
+          {archived ? (
+            <>
+              <ArchiveRestore size={13} aria-hidden className="mr-1.5" />
+              Unarchive
+            </>
+          ) : (
+            <>
+              <Archive size={13} aria-hidden className="mr-1.5" />
+              Archive
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Delete row */}
+      <div
+        className={cn(
+          'flex flex-col gap-3 rounded-lg border p-4 transition-colors',
+          confirmDelete ? 'border-danger/50 bg-danger/5' : 'border-border-soft bg-background',
+        )}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+              <Trash2 size={12} aria-hidden className="text-danger" />
+              Delete session
+            </div>
+            <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+              Removes worktree, transcripts, audit logs, and the branch. Cannot be undone.
+            </p>
+          </div>
+          {!confirmDelete ? (
+            <Button variant="danger" onClick={() => setConfirmDelete(true)} disabled={busy}>
+              <Trash2 size={13} aria-hidden className="mr-1.5" />
+              Delete
+            </Button>
+          ) : null}
+        </div>
+
+        {confirmDelete ? (
+          <>
+            <div className="flex items-start gap-2 rounded-md bg-warning/10 px-3 py-2 text-2xs text-warning">
+              <Archive size={12} aria-hidden className="mt-px shrink-0" />
+              <span>Consider archiving instead — keeps history and is reversible.</span>
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setConfirmDelete(false)}
+                disabled={busy}
+              >
+                Cancel
+              </Button>
+              {!archived ? (
+                <Button
+                  variant="warning"
+                  size="sm"
+                  onClick={() => {
+                    onArchive();
+                    setConfirmDelete(false);
+                    onClose();
+                  }}
+                  disabled={busy}
+                >
+                  <Archive size={12} aria-hidden className="mr-1.5" />
+                  Archive instead
+                </Button>
+              ) : null}
+              <Button variant="danger" size="sm" onClick={onDelete} disabled={busy}>
+                {busy ? (
+                  <>
+                    <Loader2 size={12} className="mr-1.5 animate-spin" aria-hidden />
+                    Deleting…
+                  </>
+                ) : (
+                  <>
+                    <Check size={12} aria-hidden className="mr-1.5" />
+                    Confirm delete
+                  </>
+                )}
+              </Button>
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  tone,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  tone?: 'danger';
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'flex h-7 w-7 items-center justify-center rounded-md',
+            tone === 'danger' ? 'bg-danger/10' : 'bg-primary/10',
+          )}
+        >
+          {icon}
+        </span>
+        <h3
+          className={cn(
+            'text-base font-semibold',
+            tone === 'danger' ? 'text-danger' : 'text-foreground',
+          )}
+        >
+          {title}
+        </h3>
+      </div>
+      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }
 
@@ -618,8 +919,8 @@ function Field({
   return (
     <div className="flex flex-col gap-1.5">
       <span className="text-xs font-semibold text-foreground">{label}</span>
+      {hint ? <p className="text-2xs leading-relaxed text-muted-foreground">{hint}</p> : null}
       {children}
-      {hint ? <p className="text-xs leading-relaxed text-muted-foreground">{hint}</p> : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/session/components/config-selects.tsx
+++ b/apps/desktop/src/features/session/components/config-selects.tsx
@@ -54,6 +54,32 @@ function useClickOutside(ref: React.RefObject<HTMLElement | null>, onClose: () =
   }, [ref, onClose]);
 }
 
+/**
+ * Picks the opening direction based on the trigger's viewport position
+ * when the dropdown is about to open. Avoids the bottom-of-scroll-container
+ * trap where `top-full` would push the popover into a scroll region.
+ */
+function useDropdownDirection(
+  triggerRef: React.RefObject<HTMLElement | null>,
+  open: boolean,
+): 'up' | 'down' {
+  const [direction, setDirection] = useState<'up' | 'down'>('down');
+  useEffect(() => {
+    if (!open) return;
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+    setDirection(spaceBelow < 200 && spaceAbove > spaceBelow ? 'up' : 'down');
+  }, [open, triggerRef]);
+  return direction;
+}
+
+const POPUP_BASE =
+  'absolute left-0 z-50 w-full rounded-md border border-border bg-subtle py-0.5 shadow-lg';
+const POPUP_DOWN = 'top-full mt-1';
+const POPUP_UP = 'bottom-full mb-1';
+
 export function ModelSelect({
   provider,
   value,
@@ -68,6 +94,7 @@ export function ModelSelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   const models = [...PROVIDER_CAPABILITIES[provider].models].reverse();
   const tier = modelCostTier(value);
@@ -100,7 +127,9 @@ export function ModelSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[10rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div
+          className={cn(POPUP_BASE, 'min-w-[10rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}
+        >
           {models.map((m) => {
             const active = value === m.id;
             const t = modelCostTier(m.id);
@@ -149,6 +178,7 @@ export function EffortSelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   if (!levels) {
     return (
@@ -184,7 +214,7 @@ export function EffortSelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[8rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div className={cn(POPUP_BASE, 'min-w-[8rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}>
           {levels.map((level) => {
             const active = value === level;
             return (
@@ -229,6 +259,7 @@ export function VerbositySelect({
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   useClickOutside(containerRef, () => setOpen(false));
+  const direction = useDropdownDirection(containerRef, open);
 
   return (
     <div ref={containerRef} className="relative">
@@ -258,7 +289,7 @@ export function VerbositySelect({
         />
       </button>
       {open ? (
-        <div className="absolute left-0 top-full z-50 mt-1 w-full min-w-[7rem] rounded-md border border-border bg-subtle py-0.5 shadow-lg">
+        <div className={cn(POPUP_BASE, 'min-w-[7rem]', direction === 'up' ? POPUP_UP : POPUP_DOWN)}>
           {VERBOSITY_LEVELS.map((level) => {
             const active = value === level;
             return (

--- a/apps/desktop/src/features/session/components/config-selects.tsx
+++ b/apps/desktop/src/features/session/components/config-selects.tsx
@@ -55,23 +55,48 @@ function useClickOutside(ref: React.RefObject<HTMLElement | null>, onClose: () =
 }
 
 /**
- * Picks the opening direction based on the trigger's viewport position
- * when the dropdown is about to open. Avoids the bottom-of-scroll-container
- * trap where `top-full` would push the popover into a scroll region.
+ * Walks up the DOM until it finds an ancestor that clips overflow
+ * (auto/scroll/hidden on Y). That's the box our popover would actually
+ * be cut off by — measuring against `window` is misleading when the
+ * trigger sits inside a Dialog with `overflow: hidden`.
+ */
+function findClippingAncestor(el: HTMLElement | null): HTMLElement | null {
+  let current = el?.parentElement ?? null;
+  while (current) {
+    const style = getComputedStyle(current);
+    const overflowY = style.overflowY;
+    if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'hidden') {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Picks the opening direction based on the trigger's position relative
+ * to its nearest clipping ancestor. Avoids the bottom-of-scroll-container
+ * trap where `top-full` would push the popover into a hidden region.
  */
 function useDropdownDirection(
   triggerRef: React.RefObject<HTMLElement | null>,
   open: boolean,
+  expectedHeight = 200,
 ): 'up' | 'down' {
   const [direction, setDirection] = useState<'up' | 'down'>('down');
   useEffect(() => {
     if (!open) return;
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (!rect) return;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const spaceAbove = rect.top;
-    setDirection(spaceBelow < 200 && spaceAbove > spaceBelow ? 'up' : 'down');
-  }, [open, triggerRef]);
+    const el = triggerRef.current;
+    const rect = el?.getBoundingClientRect();
+    if (!el || !rect) return;
+    const clipper = findClippingAncestor(el);
+    const clipperRect = clipper?.getBoundingClientRect();
+    const bottomBound = clipperRect ? clipperRect.bottom : window.innerHeight;
+    const topBound = clipperRect ? clipperRect.top : 0;
+    const spaceBelow = bottomBound - rect.bottom;
+    const spaceAbove = rect.top - topBound;
+    setDirection(spaceBelow < expectedHeight && spaceAbove > spaceBelow ? 'up' : 'down');
+  }, [open, triggerRef, expectedHeight]);
   return direction;
 }
 

--- a/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
@@ -1,14 +1,19 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Button, Dialog, cn } from '@kay-am/ui';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import {
+  ArrowRight,
   BookOpen,
   Bot,
   Coins,
+  FolderGit2,
   GitBranch,
   Lightbulb,
+  MessageSquare,
   MessagesSquare,
   Palette,
+  Sparkles,
+  Workflow,
   Wrench,
 } from 'lucide-react';
 
@@ -20,20 +25,20 @@ interface GuideDialogProps {
 type Section = 'overview' | 'session' | 'turn' | 'tools' | 'tokens' | 'agents' | 'tips' | 'legenda';
 
 interface NavItem {
-  id: Section;
-  label: string;
-  icon: React.ReactNode;
+  readonly id: Section;
+  readonly label: string;
+  readonly icon: ReactNode;
 }
 
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'overview', label: 'Overview', icon: <BookOpen size={14} aria-hidden /> },
-  { id: 'session', label: 'Sessions', icon: <GitBranch size={14} aria-hidden /> },
-  { id: 'turn', label: 'Turns', icon: <MessagesSquare size={14} aria-hidden /> },
-  { id: 'tools', label: 'Tools', icon: <Wrench size={14} aria-hidden /> },
-  { id: 'tokens', label: 'Tokens & cost', icon: <Coins size={14} aria-hidden /> },
-  { id: 'agents', label: 'Agents', icon: <Bot size={14} aria-hidden /> },
-  { id: 'tips', label: 'Tips', icon: <Lightbulb size={14} aria-hidden /> },
-  { id: 'legenda', label: 'Legend', icon: <Palette size={14} aria-hidden /> },
+  { id: 'overview', label: 'Overview', icon: <BookOpen size={13} aria-hidden /> },
+  { id: 'session', label: 'Sessions', icon: <GitBranch size={13} aria-hidden /> },
+  { id: 'turn', label: 'Turns', icon: <MessagesSquare size={13} aria-hidden /> },
+  { id: 'tools', label: 'Tools', icon: <Wrench size={13} aria-hidden /> },
+  { id: 'tokens', label: 'Tokens & cost', icon: <Coins size={13} aria-hidden /> },
+  { id: 'agents', label: 'Agents', icon: <Bot size={13} aria-hidden /> },
+  { id: 'tips', label: 'Tips', icon: <Lightbulb size={13} aria-hidden /> },
+  { id: 'legenda', label: 'Legend', icon: <Palette size={13} aria-hidden /> },
 ];
 
 export function GuideDialog({ open, onClose }: GuideDialogProps) {
@@ -44,9 +49,11 @@ export function GuideDialog({ open, onClose }: GuideDialogProps) {
       open={open}
       onClose={onClose}
       title="Getting started"
-      description="how kAY.am, sessions, agents, and CLI providers fit together."
+      description="How kAY.am, sessions, agents, and CLI providers fit together."
       size="xl"
-      fixedHeightClass="h-[640px]"
+      className="w-[64rem] max-w-[95vw]"
+      bodyClassName="px-0 py-0 gap-0"
+      fixedHeightClass="h-[720px]"
       fullScreenOnSmall
       footer={
         <Button variant="ghost" onClick={onClose}>
@@ -54,18 +61,18 @@ export function GuideDialog({ open, onClose }: GuideDialogProps) {
         </Button>
       }
     >
-      <div className="flex h-full min-h-0 gap-0">
-        <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
+      <div className="flex h-full min-h-0">
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
           {NAV_ITEMS.map((item) => (
             <button
               key={item.id}
               type="button"
               onClick={() => setActive(item.id)}
               className={cn(
-                'relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+                'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
                 active === item.id
-                  ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                  : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                  ? 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+                  : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
               )}
             >
               {item.icon}
@@ -73,402 +80,741 @@ export function GuideDialog({ open, onClose }: GuideDialogProps) {
             </button>
           ))}
         </nav>
-        <div className="min-w-0 flex-1 overflow-y-auto pl-4 pr-1">
-          <Content section={active} />
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          <Content section={active} onJump={setActive} />
         </div>
       </div>
     </Dialog>
   );
 }
 
-function Content({ section }: { section: Section }) {
+function Content({ section, onJump }: { section: Section; onJump: (s: Section) => void }) {
   switch (section) {
     case 'overview':
-      return (
-        <Article
-          heading="What is kAY.am?"
-          intro={
-            SESSION_FEATURES.budget
-              ? 'kAY.am orchestrates AI coding CLIs (claude, cursor-agent, codex) so you can run multiple agents in parallel against your repo, with budget caps, audit logs, and structured workflows.'
-              : 'kAY.am orchestrates AI coding CLIs (claude, cursor-agent, codex) so you can run multiple agents in parallel against your repo, with audit logs and structured workflows.'
-          }
-        >
-          <P>
-            kAY.am does <Strong>not</Strong> talk to AI providers directly. It spawns the provider's
-            CLI as a subprocess and streams events. That means: your usage, login, and quotas live
-            in the CLI itself; kAY.am just adds the workspace layer on top.
-          </P>
-          <H3>Mental model</H3>
-          <List
-            items={[
-              ['Workspace', 'a git repo on disk. you can connect many.'],
-              [
-                'Session',
-                'a chat with one goal, on its own git worktree + branch. like a feature branch with built-in chat.',
-              ],
-              [
-                'Agent',
-                'one provider/CLI invocation inside a session. a session may have several agents (e.g. one for planning, one for coding).',
-              ],
-              [
-                'Turn',
-                'a single user → assistant exchange inside an agent. tools called inside count as the same turn.',
-              ],
-            ]}
-          />
-        </Article>
-      );
-
+      return <OverviewSection onJump={onJump} />;
     case 'session':
-      return (
-        <Article
-          heading="Sessions"
-          intro="a session is one focused unit of work. it owns a git worktree, a branch, transcripts, and a goal."
-        >
-          <H3>What gets created</H3>
-          <List
-            items={[
-              ['worktree', 'a separate working directory cut from your repo root.'],
-              ['branch', '<prefix>/<slug> derived from the goal. configurable per workspace.'],
-              ['transcript', 'every user message, assistant reply, tool call, and edit is stored.'],
-              ...(SESSION_FEATURES.budget
-                ? ([
-                    [
-                      'budget (optional)',
-                      'soft cap in usd. warning at 80%, error at 100%. session keeps running.',
-                    ],
-                  ] as const)
-                : []),
-            ]}
-          />
-          <H3>When to start a new session</H3>
-          <List
-            items={[
-              [
-                'goal shifts',
-                'if the task changes meaningfully, a new session is cheaper than steering an old one off-track.',
-              ],
-              [
-                'context bloat',
-                'context window getting close to full → start fresh. transferring the relevant decisions takes seconds, fighting a saturated agent costs more.',
-              ],
-              [
-                'parallel exploration',
-                'two ways to solve the same problem? spin two sessions, compare.',
-              ],
-            ]}
-          />
-          <H3>Archive vs delete</H3>
-          <P>
-            <Strong>archive</Strong> hides from the active list, keeps the worktree, transcripts,
-            and audit. <Strong>delete</Strong> removes everything irreversibly. when in doubt,
-            archive.
-          </P>
-        </Article>
-      );
-
+      return <SessionsSection />;
     case 'turn':
-      return (
-        <Article
-          heading="Turns"
-          intro="a turn is one user message + the assistant's full response (which may include many tool calls and edits)."
-        >
-          <H3>How turns are counted</H3>
-          <List
-            items={[
-              [
-                'user → assistant',
-                'each user message you send is one turn. the count in the chat header reflects that.',
-              ],
-              [
-                'tools inside a turn',
-                'when the agent calls grep, edit, run, etc., those are part of the same turn, not separate ones.',
-              ],
-              [
-                'queueing',
-                'while a turn is running you can still type. clicking send queues the message and fires automatically when the current turn ends.',
-              ],
-            ]}
-          />
-          <H3>Why this matters</H3>
-          <P>
-            providers bill per token across all messages in the conversation, not per turn. but from
-            a UX perspective, "i've sent 14 turns and we still don't have a working build" is a
-            useful signal that the session is drifting.
-          </P>
-        </Article>
-      );
-
+      return <TurnsSection />;
     case 'tools':
-      return (
-        <Article
-          heading="Tools"
-          intro="tools are actions the agent takes outside of just talking: reading files, running shell commands, editing code, fetching docs."
-        >
-          <H3>How they show up</H3>
-          <P>
-            in the transcript, a tool invocation collapses to a single row (e.g. <Code>Bash</Code>,{' '}
-            <Code>Read</Code>, <Code>Edit</Code>). click it to expand input/output. consecutive tool
-            rows are visually grouped to keep the chat readable.
-          </P>
-          <H3>Permissions</H3>
-          <P>
-            kAY.am proxies the CLI's permission system. above the input you see{' '}
-            <Code>permissions: X allow / Y deny</Code>. that's the rule set the next turn will run
-            under. click it to manage rules in settings.
-          </P>
-          {WORKSPACE_FEATURES.skills ? (
-            <>
-              <H3>Skills</H3>
-              <P>
-                type <Code>/</Code> in the input to invoke a workspace skill (a pre-defined prompt
-                template stored in <Code>.kay/skills/</Code> or <Code>.claude/skills/</Code>).
-                useful for repeatable flows: release notes, security review, migration plan.
-              </P>
-            </>
-          ) : null}
-        </Article>
-      );
-
+      return <ToolsSection />;
     case 'tokens':
-      return (
-        <Article
-          heading="Tokens & cost"
-          intro="every message, yours and the assistant's, is converted into tokens before billing. roughly 1 token ≈ ¾ of an English word."
-        >
-          <H3>Input vs output</H3>
-          <List
-            items={[
-              [
-                'input tokens',
-                'everything sent into the model: system prompt, conversation history, tool results, your latest message. grows every turn. that is why later turns cost more even if your message is short.',
-              ],
-              [
-                'cached input tokens',
-                'portions of the prompt the provider can re-use from a recent call (Anthropic prompt cache). billed at ~10% of input rate. green numbers in pricing dialog.',
-              ],
-              [
-                'output tokens',
-                'what the model writes back: text + tool calls. the most expensive token category (5–15× input rate).',
-              ],
-            ]}
-          />
-          <H3>Context window</H3>
-          <P>
-            each model has a hard ceiling on how many tokens fit in one call (Opus 4.7 1M, Sonnet
-            4.6 / Haiku 4.5 200k, gpt-4o 128k). the bar under each agent shows how full the current
-            context is. above 75% → the agent starts forgetting; consider summarizing or starting a
-            new session.
-          </P>
-          <H3>Cost colors</H3>
-          <List
-            items={[
-              [
-                'green models',
-                'cheap (haiku, cursor-small). good for grep-heavy / planning steps.',
-              ],
-              ['amber models', 'mid (sonnet, gpt-4o). default for most coding work.'],
-              [
-                'red models',
-                'expensive (opus). reserve for hard reasoning, refactors, last-resort fixes.',
-              ],
-            ]}
-          />
-          <P>
-            the picker sorts <Strong>cheapest first</Strong> on purpose. switching down a tier often
-            costs nothing in quality on routine tasks.
-          </P>
-        </Article>
-      );
-
+      return <TokensSection />;
     case 'agents':
-      return (
-        <Article
-          heading="Agents"
-          intro="an agent is one provider invocation inside a session. a session can host multiple agents, same provider or different ones."
-        >
-          <H3>Why multiple agents per session</H3>
-          <List
-            items={[
-              [
-                'role separation',
-                'spawn a planning agent on Opus, then a coding agent on Sonnet. each keeps its own transcript.',
-              ],
-              [
-                'workflow steps',
-                'a workflow defines ordered steps (e.g. plan → implement → done). each step spawns an agent with its own model + system prompt.',
-              ],
-              [
-                'parallel exploration',
-                'two agents on the same goal, diff their results, pick the better diff at merge time.',
-              ],
-            ]}
-          />
-          <H3>Reading the agent row</H3>
-          <P>
-            the second line on each agent shows:{' '}
-            <Code>model · ↓ input · ↑ output · cost · ⏱ age</Code>. below it, a thin bar = context
-            window utilization. tooltip on the bar gives exact numbers.
-          </P>
-        </Article>
-      );
-
+      return <AgentsSection />;
     case 'tips':
-      return (
-        <Article heading="Tips" intro="patterns that compound across sessions.">
-          <List
-            items={[
-              [
-                'pin one short goal per session',
-                'long open-ended sessions drift. when you notice scope creeping, spin a new one and link via context.',
-              ],
-              [
-                'set a soft cap',
-                'even a generous one. it forces a pause before a runaway agent burns $20 on a bad assumption.',
-              ],
-              [
-                'use cheap models for navigation',
-                'haiku / cursor-small can grep, list, summarize in seconds at 1/15th the price. swap up only when reasoning gets hard.',
-              ],
-              [
-                "queue, don't cancel",
-                "if the agent is mid-tool and you have a follow-up, type it: it'll queue. cancelling mid-turn loses the partial work.",
-              ],
-              [
-                'archive freely',
-                'archive is reversible. the only irreversible move is delete, and you have to confirm twice.',
-              ],
-              [
-                'restart on cli upgrades',
-                'when you update the underlying CLI (claude / cursor-agent / codex), restart kAY.am so it re-detects versions and auth.',
-              ],
-            ]}
-          />
-        </Article>
-      );
-
+      return <TipsSection />;
     case 'legenda':
-      return (
-        <Article heading="Legend" intro="color meanings used throughout the interface.">
-          <H3>Status dots: sessions & agents</H3>
-          <LegendaGrid
-            rows={[
-              { dot: 'bg-muted-foreground/50', label: 'pending', desc: 'not yet started' },
-              { dot: 'bg-info', label: 'running', desc: 'active turn in progress' },
-              { dot: 'bg-success', label: 'completed', desc: 'ended successfully' },
-              { dot: 'bg-danger', label: 'failed', desc: 'ended with error' },
-              {
-                dot: 'bg-muted-foreground/30',
-                label: 'skipped',
-                desc: 'bypassed by workflow logic',
-              },
-            ]}
-          />
-          <H3>Edit types: transcript</H3>
-          <LegendaGrid
-            rows={[
-              { dot: 'bg-primary', label: 'create', desc: 'new file or resource added' },
-              { dot: 'bg-muted-foreground/60', label: 'modify', desc: 'existing file changed' },
-              { dot: 'bg-danger', label: 'delete', desc: 'file or resource removed' },
-            ]}
-          />
-          <H3>Context window bar: CTX fill level</H3>
-          <LegendaGrid
-            rows={[
-              {
-                dot: 'bg-success',
-                label: '< 50%',
-                desc: 'comfortable: plenty of context remaining',
-              },
-              { dot: 'bg-info', label: '50–75%', desc: 'moderate: monitor closely' },
-              { dot: 'bg-warning', label: '75–90%', desc: 'high: consider summarizing soon' },
-              { dot: 'bg-danger', label: '≥ 90%', desc: 'critical: start a new session' },
-            ]}
-          />
-          <H3>Verbosity: output density</H3>
-          <LegendaGrid
-            rows={[
-              { dot: 'bg-success', label: 'brief', desc: 'bare minimum: one-liners only' },
-              { dot: 'bg-info', label: 'normal', desc: 'standard prose with rationale' },
-              { dot: 'bg-danger', label: 'verbose', desc: 'full long-form with alternatives' },
-            ]}
-          />
-          <H3>Permission mode: tool access</H3>
-          <LegendaGrid
-            rows={[
-              { dot: 'bg-danger', label: 'bypass', desc: 'all tools used freely, no prompts' },
-              { dot: 'bg-warning', label: 'edits', desc: 'file edits allowed; bash asks first' },
-              { dot: 'bg-blue-500', label: 'default', desc: 'writes and runs ask for approval' },
-              { dot: 'bg-slate-400', label: 'plan', desc: 'no tool calls executed, read-only' },
-            ]}
-          />
-          <H3>Auto badge</H3>
-          <LegendaGrid
-            rows={[
-              {
-                dot: 'bg-amber-400',
-                label: 'AUTO',
-                desc: 'autorun mode: next action fires without user confirmation',
-              },
-            ]}
-          />
-        </Article>
-      );
+      return <LegendSection />;
   }
 }
 
-function Article({
-  heading,
-  intro,
-  children,
+/* ──────────────────────────────────────────────────────────────────── */
+/* Sections                                                              */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function OverviewSection({ onJump }: { onJump: (s: Section) => void }) {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<BookOpen size={14} aria-hidden className="text-primary" />}
+        title="What is kAY.am?"
+        subtitle={
+          SESSION_FEATURES.budget
+            ? 'kAY.am orchestrates AI coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo — with budget caps, audit logs, and structured workflows.'
+            : 'kAY.am orchestrates AI coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo — with audit logs and structured workflows.'
+        }
+        accent="primary"
+      />
+
+      <Callout tone="info" icon={<Sparkles size={13} />}>
+        kAY.am does <strong className="text-foreground">not</strong> talk to AI providers directly.
+        It spawns the provider's CLI as a subprocess and streams events. Your usage, login, and
+        quotas live in the CLI itself — kAY.am just adds the workspace layer on top.
+      </Callout>
+
+      <div>
+        <Eyebrow>Mental model</Eyebrow>
+        <div className="mt-3 grid grid-cols-2 gap-3">
+          <ConceptCard
+            icon={<FolderGit2 size={14} aria-hidden />}
+            tone="primary"
+            label="Workspace"
+            body="A git repo on disk. You can connect many."
+            onClick={() => onJump('session')}
+          />
+          <ConceptCard
+            icon={<GitBranch size={14} aria-hidden />}
+            tone="success"
+            label="Session"
+            body="A chat with one goal, on its own git worktree + branch. Like a feature branch with built-in chat."
+            onClick={() => onJump('session')}
+          />
+          <ConceptCard
+            icon={<Bot size={14} aria-hidden />}
+            tone="warning"
+            label="Agent"
+            body="One provider/CLI invocation inside a session. A session may host several agents (planning, coding, review…)."
+            onClick={() => onJump('agents')}
+          />
+          <ConceptCard
+            icon={<MessageSquare size={14} aria-hidden />}
+            tone="info"
+            label="Turn"
+            body="A single user → assistant exchange inside an agent. Tools called inside count as the same turn."
+            onClick={() => onJump('turn')}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SessionsSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<GitBranch size={14} aria-hidden className="text-success" />}
+        title="Sessions"
+        subtitle="One focused unit of work. Owns a git worktree, a branch, transcripts, and a goal."
+        accent="success"
+      />
+
+      <Block title="What gets created">
+        <DefinitionList
+          rows={[
+            {
+              term: 'worktree',
+              desc: 'A separate working directory cut from your repo root.',
+              icon: <FolderGit2 size={11} aria-hidden />,
+              tone: 'primary',
+            },
+            {
+              term: 'branch',
+              desc: 'kay/<slug> (or your prefix), derived from the goal. Configurable per workspace.',
+              icon: <GitBranch size={11} aria-hidden />,
+              tone: 'success',
+            },
+            {
+              term: 'transcript',
+              desc: 'Every user message, assistant reply, tool call, and edit is stored.',
+              icon: <MessagesSquare size={11} aria-hidden />,
+              tone: 'info',
+            },
+            ...(SESSION_FEATURES.budget
+              ? [
+                  {
+                    term: 'budget (optional)',
+                    desc: 'Soft cap in USD. Warning at 80%, error at 100%. Session keeps running.',
+                    icon: <Coins size={11} aria-hidden />,
+                    tone: 'warning' as const,
+                  },
+                ]
+              : []),
+          ]}
+        />
+      </Block>
+
+      <Block title="When to start a new session">
+        <DefinitionList
+          rows={[
+            {
+              term: 'Goal shifts',
+              desc: 'If the task changes meaningfully, a new session is cheaper than steering an old one off-track.',
+            },
+            {
+              term: 'Context bloat',
+              desc: 'Context window getting close to full → start fresh. Transferring the relevant decisions takes seconds; fighting a saturated agent costs more.',
+            },
+            {
+              term: 'Parallel exploration',
+              desc: 'Two ways to solve the same problem? Spin two sessions, compare.',
+            },
+          ]}
+        />
+      </Block>
+
+      <Block title="Archive vs delete">
+        <div className="grid grid-cols-2 gap-3">
+          <Tile tone="success" label="Archive">
+            Hides from the active list, keeps the worktree, transcripts, and audit. Reversible.
+          </Tile>
+          <Tile tone="danger" label="Delete">
+            Removes everything irreversibly. When in doubt, archive.
+          </Tile>
+        </div>
+      </Block>
+    </div>
+  );
+}
+
+function TurnsSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<MessagesSquare size={14} aria-hidden className="text-info" />}
+        title="Turns"
+        subtitle="One user message + the assistant's full response (which may include many tool calls and edits)."
+        accent="info"
+      />
+
+      <Block title="How turns are counted">
+        <DefinitionList
+          rows={[
+            {
+              term: 'user → assistant',
+              desc: 'Each user message you send is one turn. The count in the chat header reflects that.',
+            },
+            {
+              term: 'tools inside a turn',
+              desc: 'When the agent calls grep, edit, run, etc., those are part of the same turn — not separate ones.',
+            },
+            {
+              term: 'queueing',
+              desc: 'While a turn is running you can still type. Hitting send queues the message and it fires automatically when the current turn ends.',
+            },
+          ]}
+        />
+      </Block>
+
+      <Callout tone="info" icon={<Lightbulb size={13} />}>
+        Providers bill per token across the whole conversation, not per turn. But from a UX angle,
+        "I've sent 14 turns and we still don't have a working build" is a useful drift signal — time
+        to start a new session.
+      </Callout>
+    </div>
+  );
+}
+
+function ToolsSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Wrench size={14} aria-hidden className="text-warning" />}
+        title="Tools"
+        subtitle="Actions the agent takes outside of just talking: reading files, running shell commands, editing code, fetching docs."
+        accent="warning"
+      />
+
+      <Block title="How they show up">
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          In the transcript, each tool invocation collapses to a single row (
+          <InlineCode>Bash</InlineCode>, <InlineCode>Read</InlineCode>,{' '}
+          <InlineCode>Edit</InlineCode>…). Click to expand input/output. Consecutive tool rows are
+          visually grouped to keep the chat readable.
+        </p>
+      </Block>
+
+      <Block title="Permissions">
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          kAY.am proxies the CLI's permission system. Above the input you see{' '}
+          <InlineCode>permissions: X allow / Y deny</InlineCode> — the rule set the next turn will
+          run under. Click it to manage rules in settings.
+        </p>
+      </Block>
+
+      {WORKSPACE_FEATURES.skills ? (
+        <Block title="Skills">
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Type <InlineCode>/</InlineCode> in the input to invoke a workspace skill — a pre-defined
+            prompt template stored in <InlineCode>.kay/skills/</InlineCode> or{' '}
+            <InlineCode>.claude/skills/</InlineCode>. Useful for repeatable flows: release notes,
+            security reviews, migration plans.
+          </p>
+        </Block>
+      ) : null}
+    </div>
+  );
+}
+
+function TokensSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Coins size={14} aria-hidden className="text-amber-400" />}
+        title="Tokens & cost"
+        subtitle="Every message, yours and the assistant's, is converted into tokens before billing. Roughly 1 token ≈ ¾ of an English word."
+        accent="warning"
+      />
+
+      <Block title="Input vs output">
+        <DefinitionList
+          rows={[
+            {
+              term: 'input tokens',
+              desc: 'Everything sent into the model: system prompt, conversation history, tool results, your latest message. Grows every turn — that is why later turns cost more even if your message is short.',
+            },
+            {
+              term: 'cached input tokens',
+              desc: 'Portions of the prompt the provider can reuse from a recent call (Anthropic prompt cache). Billed at ~10% of input rate. Green numbers in the pricing dialog.',
+            },
+            {
+              term: 'output tokens',
+              desc: 'What the model writes back: text + tool calls. The most expensive category (5–15× input rate).',
+            },
+          ]}
+        />
+      </Block>
+
+      <Block title="Context window">
+        <p className="text-sm leading-relaxed text-muted-foreground">
+          Each model has a hard ceiling on how many tokens fit in one call (Opus 4.7 1M, Sonnet 4.6
+          / Haiku 4.5 200k, gpt-4o 128k). The bar under each agent shows how full the current
+          context is. Above 75% → the agent starts forgetting; consider summarizing or starting a
+          new session.
+        </p>
+      </Block>
+
+      <Block title="Cost colors">
+        <div className="grid grid-cols-3 gap-3">
+          <Tile tone="success" label="Cheap" mono>
+            haiku, cursor-small.
+            <br />
+            Good for grep-heavy / planning steps.
+          </Tile>
+          <Tile tone="warning" label="Mid" mono>
+            sonnet, gpt-4o.
+            <br />
+            Default for most coding work.
+          </Tile>
+          <Tile tone="danger" label="Premium" mono>
+            opus.
+            <br />
+            Reserve for hard reasoning, refactors, last-resort fixes.
+          </Tile>
+        </div>
+        <p className="mt-3 text-2xs leading-relaxed text-muted-foreground/70">
+          The picker sorts <strong className="font-semibold text-foreground">cheapest first</strong>{' '}
+          on purpose. Switching down a tier often costs nothing in quality on routine tasks.
+        </p>
+      </Block>
+    </div>
+  );
+}
+
+function AgentsSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Bot size={14} aria-hidden className="text-warning" />}
+        title="Agents"
+        subtitle="One provider invocation inside a session. A session can host multiple agents, same provider or different ones."
+        accent="warning"
+      />
+
+      <Block title="Why multiple agents per session">
+        <DefinitionList
+          rows={[
+            {
+              term: 'Role separation',
+              desc: 'Spawn a planning agent on Opus, then a coding agent on Sonnet. Each keeps its own transcript.',
+              icon: <Workflow size={11} aria-hidden />,
+              tone: 'primary',
+            },
+            {
+              term: 'Workflow steps',
+              desc: 'A workflow defines ordered steps (plan → implement → done). Each step spawns an agent with its own model + system prompt.',
+              icon: <ArrowRight size={11} aria-hidden />,
+              tone: 'success',
+            },
+            {
+              term: 'Parallel exploration',
+              desc: 'Two agents on the same goal, diff their results, pick the better diff at merge time.',
+              icon: <Sparkles size={11} aria-hidden />,
+              tone: 'info',
+            },
+          ]}
+        />
+      </Block>
+
+      <Block title="Reading the agent row">
+        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/50 p-4 text-xs">
+          <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Second line of each agent
+          </span>
+          <div className="flex flex-wrap items-center gap-2 font-mono text-foreground">
+            <Chip tone="primary">model</Chip>
+            <span className="text-muted-foreground/40">·</span>
+            <Chip tone="info">↓ input</Chip>
+            <span className="text-muted-foreground/40">·</span>
+            <Chip tone="warning">↑ output</Chip>
+            <span className="text-muted-foreground/40">·</span>
+            <Chip tone="success">cost</Chip>
+            <span className="text-muted-foreground/40">·</span>
+            <Chip tone="muted">⏱ age</Chip>
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            Below that line, a thin bar = context window utilization. Hover for exact numbers.
+          </p>
+        </div>
+      </Block>
+    </div>
+  );
+}
+
+function TipsSection() {
+  const tips: ReadonlyArray<{ title: string; body: string }> = [
+    {
+      title: 'Pin one short goal per session',
+      body: 'Long open-ended sessions drift. When scope creeps, spin a new one and link via context.',
+    },
+    {
+      title: 'Set a soft cap',
+      body: 'Even a generous one. It forces a pause before a runaway agent burns $20 on a bad assumption.',
+    },
+    {
+      title: 'Use cheap models for navigation',
+      body: 'Haiku / cursor-small can grep, list, summarize in seconds at 1/15th the price. Swap up only when reasoning gets hard.',
+    },
+    {
+      title: "Queue, don't cancel",
+      body: "If the agent is mid-tool and you have a follow-up, type it: it'll queue. Cancelling mid-turn loses the partial work.",
+    },
+    {
+      title: 'Archive freely',
+      body: 'Archive is reversible. The only irreversible move is delete, and you have to confirm twice.',
+    },
+    {
+      title: 'Restart on CLI upgrades',
+      body: 'When you update the underlying CLI (claude / cursor-agent / codex), restart kAY.am so it re-detects versions and auth.',
+    },
+  ];
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Lightbulb size={14} aria-hidden className="text-amber-400" />}
+        title="Tips"
+        subtitle="Patterns that compound across sessions."
+        accent="warning"
+      />
+      <div className="grid grid-cols-2 gap-3">
+        {tips.map((t, i) => (
+          <div
+            key={t.title}
+            className="flex flex-col gap-1.5 rounded-lg border border-border-soft bg-subtle/40 p-4 transition-colors hover:border-border hover:bg-subtle/60"
+          >
+            <div className="flex items-center gap-2">
+              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-amber-400/15 font-mono text-[10px] font-semibold text-amber-400">
+                {i + 1}
+              </span>
+              <span className="text-sm font-semibold text-foreground">{t.title}</span>
+            </div>
+            <p className="text-xs leading-relaxed text-muted-foreground">{t.body}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function LegendSection() {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<Palette size={14} aria-hidden className="text-primary" />}
+        title="Legend"
+        subtitle="Color meanings used throughout the interface."
+        accent="primary"
+      />
+
+      <LegendBlock title="Status dots — sessions & agents">
+        <LegendaGrid
+          rows={[
+            { dot: 'bg-muted-foreground/50', label: 'pending', desc: 'not yet started' },
+            { dot: 'bg-info', label: 'running', desc: 'active turn in progress' },
+            { dot: 'bg-success', label: 'completed', desc: 'ended successfully' },
+            { dot: 'bg-danger', label: 'failed', desc: 'ended with error' },
+            {
+              dot: 'bg-muted-foreground/30',
+              label: 'skipped',
+              desc: 'bypassed by workflow logic',
+            },
+          ]}
+        />
+      </LegendBlock>
+
+      <LegendBlock title="Edit types — transcript">
+        <LegendaGrid
+          rows={[
+            { dot: 'bg-primary', label: 'create', desc: 'new file or resource added' },
+            { dot: 'bg-muted-foreground/60', label: 'modify', desc: 'existing file changed' },
+            { dot: 'bg-danger', label: 'delete', desc: 'file or resource removed' },
+          ]}
+        />
+      </LegendBlock>
+
+      <LegendBlock title="Context window — CTX fill level">
+        <LegendaGrid
+          rows={[
+            { dot: 'bg-success', label: '< 50%', desc: 'comfortable: plenty of context remaining' },
+            { dot: 'bg-info', label: '50–75%', desc: 'moderate: monitor closely' },
+            { dot: 'bg-warning', label: '75–90%', desc: 'high: consider summarizing soon' },
+            { dot: 'bg-danger', label: '≥ 90%', desc: 'critical: start a new session' },
+          ]}
+        />
+      </LegendBlock>
+
+      <LegendBlock title="Verbosity — output density">
+        <LegendaGrid
+          rows={[
+            { dot: 'bg-success', label: 'brief', desc: 'bare minimum: one-liners only' },
+            { dot: 'bg-info', label: 'normal', desc: 'standard prose with rationale' },
+            { dot: 'bg-danger', label: 'verbose', desc: 'full long-form with alternatives' },
+          ]}
+        />
+      </LegendBlock>
+
+      <LegendBlock title="Permission mode — tool access">
+        <LegendaGrid
+          rows={[
+            { dot: 'bg-danger', label: 'bypass', desc: 'all tools used freely, no prompts' },
+            { dot: 'bg-warning', label: 'edits', desc: 'file edits allowed; bash asks first' },
+            { dot: 'bg-blue-500', label: 'default', desc: 'writes and runs ask for approval' },
+            { dot: 'bg-slate-400', label: 'plan', desc: 'no tool calls executed, read-only' },
+          ]}
+        />
+      </LegendBlock>
+
+      <LegendBlock title="Auto badge">
+        <LegendaGrid
+          rows={[
+            {
+              dot: 'bg-amber-400',
+              label: 'AUTO',
+              desc: 'autorun mode: next action fires without user confirmation',
+            },
+          ]}
+        />
+      </LegendBlock>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+type Tone = 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'muted';
+
+const TONE_BG: Record<Tone, string> = {
+  primary: 'bg-primary/10',
+  success: 'bg-success/10',
+  warning: 'bg-warning/10',
+  danger: 'bg-danger/10',
+  info: 'bg-info/10',
+  muted: 'bg-muted',
+};
+
+const TONE_FG: Record<Tone, string> = {
+  primary: 'text-primary',
+  success: 'text-success',
+  warning: 'text-warning',
+  danger: 'text-danger',
+  info: 'text-info',
+  muted: 'text-muted-foreground',
+};
+
+const TONE_BORDER: Record<Tone, string> = {
+  primary: 'border-primary/20',
+  success: 'border-success/20',
+  warning: 'border-warning/20',
+  danger: 'border-danger/20',
+  info: 'border-info/20',
+  muted: 'border-border-soft',
+};
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  accent = 'primary',
 }: {
-  heading: string;
-  intro: string;
-  children: React.ReactNode;
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  accent?: Tone;
 }) {
   return (
-    <article className="flex flex-col gap-3 pb-6 text-sm leading-relaxed">
-      <h2 className="text-base font-semibold tracking-tight text-foreground">{heading}</h2>
-      <p className="text-muted-foreground">{intro}</p>
-      {children}
-    </article>
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2.5">
+        <span
+          className={cn('flex h-8 w-8 items-center justify-center rounded-md', TONE_BG[accent])}
+        >
+          {icon}
+        </span>
+        <h2 className="text-lg font-semibold tracking-tight text-foreground">{title}</h2>
+      </div>
+      <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }
 
-function H3({ children }: { children: React.ReactNode }) {
+function Eyebrow({ children }: { children: ReactNode }) {
   return (
-    <h3 className="mt-2 text-xs font-semibold uppercase tracking-wide text-foreground/85">
+    <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground/70">
       {children}
-    </h3>
+    </span>
   );
 }
 
-function P({ children }: { children: React.ReactNode }) {
-  return <p className="text-sm leading-relaxed text-muted-foreground">{children}</p>;
-}
-
-function Strong({ children }: { children: React.ReactNode }) {
-  return <strong className="font-semibold text-foreground">{children}</strong>;
-}
-
-function Code({ children }: { children: React.ReactNode }) {
+function Block({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em] text-foreground">
+    <div className="flex flex-col gap-3">
+      <Eyebrow>{title}</Eyebrow>
       {children}
-    </code>
+    </div>
   );
 }
 
-function List({ items }: { items: ReadonlyArray<readonly [string, string]> }) {
+function LegendBlock({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <ul className="flex flex-col gap-1.5">
-      {items.map(([term, desc]) => (
-        <li key={term} className="flex flex-col gap-0.5">
-          <span className="text-sm font-semibold text-foreground">{term}</span>
-          <span className="text-sm leading-relaxed text-muted-foreground">{desc}</span>
+    <div className="flex flex-col gap-2.5 rounded-lg border border-border-soft bg-subtle/40 p-4">
+      <Eyebrow>{title}</Eyebrow>
+      {children}
+    </div>
+  );
+}
+
+function Callout({ tone, icon, children }: { tone: Tone; icon: ReactNode; children: ReactNode }) {
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2.5 rounded-lg border px-3.5 py-3 text-sm leading-relaxed text-muted-foreground',
+        TONE_BG[tone],
+        TONE_BORDER[tone],
+      )}
+    >
+      <span className={cn('mt-0.5 shrink-0', TONE_FG[tone])}>{icon}</span>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function ConceptCard({
+  icon,
+  tone,
+  label,
+  body,
+  onClick,
+}: {
+  icon: ReactNode;
+  tone: Tone;
+  label: string;
+  body: string;
+  onClick?: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex flex-col items-start gap-2 rounded-lg border border-border-soft bg-background p-4 text-left transition-all hover:-translate-y-0.5 hover:border-border hover:shadow-sm"
+    >
+      <span
+        className={cn(
+          'flex h-8 w-8 items-center justify-center rounded-md',
+          TONE_BG[tone],
+          TONE_FG[tone],
+        )}
+      >
+        {icon}
+      </span>
+      <span className="text-sm font-semibold text-foreground">{label}</span>
+      <span className="text-xs leading-relaxed text-muted-foreground">{body}</span>
+    </button>
+  );
+}
+
+interface DefinitionRow {
+  readonly term: string;
+  readonly desc: string;
+  readonly icon?: ReactNode;
+  readonly tone?: Tone;
+}
+
+function DefinitionList({ rows }: { rows: ReadonlyArray<DefinitionRow> }) {
+  return (
+    <ul className="flex flex-col gap-2">
+      {rows.map((row) => (
+        <li
+          key={row.term}
+          className="flex items-start gap-3 rounded-md border border-border-soft bg-subtle/40 px-3 py-2.5"
+        >
+          {row.icon ? (
+            <span
+              className={cn(
+                'mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md',
+                TONE_BG[row.tone ?? 'muted'],
+                TONE_FG[row.tone ?? 'muted'],
+              )}
+            >
+              {row.icon}
+            </span>
+          ) : (
+            <span
+              className={cn(
+                'mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full',
+                TONE_FG[row.tone ?? 'muted'].replace('text-', 'bg-'),
+              )}
+            />
+          )}
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="text-sm font-semibold text-foreground">{row.term}</span>
+            <span className="text-sm leading-relaxed text-muted-foreground">{row.desc}</span>
+          </div>
         </li>
       ))}
     </ul>
+  );
+}
+
+function Tile({
+  tone,
+  label,
+  mono,
+  children,
+}: {
+  tone: Tone;
+  label: string;
+  mono?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-lg border p-3.5',
+        TONE_BG[tone],
+        TONE_BORDER[tone],
+      )}
+    >
+      <span className={cn('text-xs font-semibold uppercase tracking-wide', TONE_FG[tone])}>
+        {label}
+      </span>
+      <span className={cn('text-xs leading-relaxed text-muted-foreground', mono && 'font-mono')}>
+        {children}
+      </span>
+    </div>
+  );
+}
+
+function Chip({ tone, children }: { tone: Tone; children: ReactNode }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-md px-2 py-0.5 text-2xs font-medium',
+        TONE_BG[tone],
+        TONE_FG[tone],
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function InlineCode({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">
+      {children}
+    </code>
   );
 }
 
@@ -483,8 +829,11 @@ function LegendaGrid({ rows }: { rows: ReadonlyArray<LegendaRow> }) {
     <ul className="flex flex-col gap-1">
       {rows.map((row) => (
         <li key={row.label} className="flex items-center gap-2.5">
-          <span aria-hidden className={cn('inline-block h-2 w-2 shrink-0 rounded-full', row.dot)} />
-          <span className="w-20 shrink-0 text-sm font-medium text-foreground">{row.label}</span>
+          <span
+            aria-hidden
+            className={cn('inline-block h-2.5 w-2.5 shrink-0 rounded-full', row.dot)}
+          />
+          <span className="w-24 shrink-0 text-sm font-medium text-foreground">{row.label}</span>
           <span className="text-sm text-muted-foreground">{row.desc}</span>
         </li>
       ))}

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -34,6 +34,7 @@ import {
   useSummarizerStatus,
 } from '../../../../store';
 import { SessionStatusMenu } from '../../../session/components/SessionStatusMenu';
+import { OpenInEditorIconButton } from '../../../session/components/OpenInEditorIconButton';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { DiffViewerDialog } from '../../../permissions/components/DiffViewerDialog';
@@ -58,6 +59,7 @@ export function SessionDetailPanel({
   onNewSession,
 }: SessionDetailPanelProps) {
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId]);
+  const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id as SessionId]?.[0] ?? null);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
   const setSessionUserStatus = useAppStore((s) => s.setSessionUserStatus);
   const renameTask = useAppStore((s) => s.renameTask);
@@ -141,6 +143,7 @@ export function SessionDetailPanel({
             <span>New</span>
           </button>
         ) : null}
+        <OpenInEditorIconButton worktreePath={worktreePath} />
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -12,6 +12,7 @@ import {
   GitPullRequestDraft,
   Loader2,
   MessageSquare,
+  Plus,
   RefreshCw,
   Settings2,
   XCircle,
@@ -42,12 +43,19 @@ interface SessionDetailPanelProps {
   session: Session;
   onOpenSessionSettings: () => void;
   onOpenGithubDetails?: () => void;
+  /**
+   * When provided, renders a "+ New session" affordance in the header. The
+   * sidebar passes this only when the activity bar is collapsed (1 session
+   * total) — so the user always has a discoverable way to add another.
+   */
+  onNewSession?: () => void;
 }
 
 export function SessionDetailPanel({
   session,
   onOpenSessionSettings,
   onOpenGithubDetails,
+  onNewSession,
 }: SessionDetailPanelProps) {
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId]);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
@@ -121,6 +129,18 @@ export function SessionDetailPanel({
             </span>
           )}
         </div>
+        {onNewSession ? (
+          <button
+            type="button"
+            onClick={onNewSession}
+            className="shrink-0 inline-flex items-center gap-1 rounded-md border border-border-soft bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:border-primary/40 hover:bg-primary/5 hover:text-primary"
+            title="new session"
+            aria-label="new session"
+          >
+            <Plus size={11} aria-hidden />
+            <span>New</span>
+          </button>
+        ) : null}
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useState } from 'react';
-import { FolderOpen, Plus, Settings, Unplug, X } from 'lucide-react';
-import { Button, Dialog, cn } from '@kay-am/ui';
+import { useState } from 'react';
+import { FolderOpen, Plus, Settings } from 'lucide-react';
+import { cn } from '@kay-am/ui';
 import type { Workspace, WorkspaceId } from '@kay-am/types';
 import { MAX_WORKSPACES } from '../../../../shared/lib/features';
-import { formatError } from '../../../../shared/lib/errors';
 import { WorkspaceSettingsDialog } from '../WorkspaceSettingsDialog';
 import {
   useAppStore,
@@ -25,14 +24,16 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
-  const [disconnectTarget, setDisconnectTarget] = useState<WorkspaceTarget | null>(null);
   const [settingsTarget, setSettingsTarget] = useState<WorkspaceTarget | null>(null);
 
   const sorted = [...workspaces].sort((a, b) => a.name.localeCompare(b.name));
   const atCap = workspaces.length >= MAX_WORKSPACES;
 
   return (
-    <div className="shrink-0 px-2 py-1.5">
+    // The whole row sits below the OS title-bar drag region. Without this
+    // opt-out, Tauri swallows clicks on the cards (gear / select) before
+    // React ever sees them — that's why both buttons looked dead.
+    <div className="shrink-0 px-2 py-1.5" data-tauri-drag-region="false">
       <span className="mb-1 flex items-center gap-1.5 px-0.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
         <FolderOpen size={11} aria-hidden className="text-primary" />
         Workspaces
@@ -46,7 +47,10 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
           {workspaces.length}/{MAX_WORKSPACES}
         </span>
       </span>
-      <div className="flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none]">
+      <div
+        className="flex items-center gap-1.5 overflow-x-auto [scrollbar-width:none]"
+        data-tauri-drag-region="false"
+      >
         {sorted.map((ws) => (
           <WorkspaceCard
             key={ws.id}
@@ -54,13 +58,13 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
             isActive={ws.id === currentWorkspace?.id}
             onSelect={() => void setCurrentWorkspace(ws.id)}
             onOpenSettings={() => setSettingsTarget({ id: ws.id, name: ws.name })}
-            onDisconnect={() => setDisconnectTarget({ id: ws.id, name: ws.name })}
           />
         ))}
         <button
           type="button"
           onClick={onAddWorkspace}
           disabled={atCap}
+          data-tauri-drag-region="false"
           className={cn(
             'flex shrink-0 items-center justify-center rounded border border-dashed px-2 py-1.5 transition-colors',
             atCap
@@ -77,14 +81,6 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
           <Plus size={12} aria-hidden />
         </button>
       </div>
-      {disconnectTarget ? (
-        <DisconnectWorkspaceDialog
-          workspaceId={disconnectTarget.id}
-          workspaceName={disconnectTarget.name}
-          open
-          onClose={() => setDisconnectTarget(null)}
-        />
-      ) : null}
       {settingsTarget ? (
         <WorkspaceSettingsDialog
           workspaceId={settingsTarget.id}
@@ -102,13 +98,11 @@ function WorkspaceCard({
   isActive,
   onSelect,
   onOpenSettings,
-  onDisconnect,
 }: {
   workspace: Workspace;
   isActive: boolean;
   onSelect: () => void;
   onOpenSettings: () => void;
-  onDisconnect: () => void;
 }) {
   const hasUnread = useWorkspaceHasUnread(workspace.id);
 
@@ -121,6 +115,7 @@ function WorkspaceCard({
           : 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50',
       )}
       title={workspace.name}
+      data-tauri-drag-region="false"
     >
       {hasUnread && !isActive && (
         <span className="pointer-events-none absolute -right-0.5 -top-0.5 h-2 w-2">
@@ -131,6 +126,7 @@ function WorkspaceCard({
       <button
         type="button"
         onClick={onSelect}
+        data-tauri-drag-region="false"
         className="flex items-center gap-1.5 py-1.5 pl-2.5 pr-1"
       >
         <span className="max-w-[100px] truncate">{workspace.name}</span>
@@ -141,91 +137,13 @@ function WorkspaceCard({
           e.stopPropagation();
           onOpenSettings();
         }}
-        className="flex h-full items-center px-0.5 text-muted-foreground/50 transition-colors hover:text-foreground focus-visible:text-foreground"
+        data-tauri-drag-region="false"
+        className="flex h-full items-center px-1.5 text-muted-foreground/50 transition-colors hover:text-foreground focus-visible:text-foreground"
         title={`workspace settings — ${workspace.name}`}
         aria-label={`open workspace settings for ${workspace.name}`}
       >
         <Settings size={11} aria-hidden />
       </button>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDisconnect();
-        }}
-        className="flex h-full items-center pl-0.5 pr-1.5 text-muted-foreground/50 transition-colors hover:text-danger focus-visible:text-danger"
-        title={`disconnect "${workspace.name}"`}
-        aria-label={`disconnect workspace ${workspace.name}`}
-      >
-        <X size={12} aria-hidden />
-      </button>
     </div>
-  );
-}
-
-interface DisconnectWorkspaceDialogProps {
-  workspaceId: WorkspaceId;
-  workspaceName: string;
-  open: boolean;
-  onClose: () => void;
-}
-
-function DisconnectWorkspaceDialog({
-  workspaceId,
-  workspaceName,
-  open,
-  onClose,
-}: DisconnectWorkspaceDialogProps) {
-  const disconnect = useAppStore((s) => s.deleteWorkspace);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (open) setError(null);
-  }, [open]);
-
-  const onConfirm = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await disconnect(workspaceId);
-      onClose();
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const handleClose = () => {
-    if (busy) return;
-    onClose();
-  };
-
-  return (
-    <Dialog
-      open={open}
-      onClose={handleClose}
-      title={`Disconnect "${workspaceName}"?`}
-      description="Hides the workspace from the sidebar. Sessions, transcripts, and worktrees stay safe on disk. Re-add the same path to bring it back."
-      size="sm"
-      footer={
-        <>
-          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-          <Button variant="ghost" onClick={handleClose} disabled={busy}>
-            Cancel
-          </Button>
-          <Button variant="danger" onClick={() => void onConfirm()} disabled={busy}>
-            <Unplug size={13} aria-hidden className="mr-1.5" />
-            {busy ? 'Disconnecting…' : 'Disconnect'}
-          </Button>
-        </>
-      }
-    >
-      <div className="rounded-md border border-border-soft bg-subtle/40 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
-        Nothing is deleted. The repo and all its sessions stay in place — they just stop showing up
-        in the sidebar until you re-add the path.
-      </div>
-    </Dialog>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
@@ -24,15 +24,22 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
+  // Two pieces of state instead of one nullable target so the dialog can
+  // stay mounted across opens. Mount-on-first-click was racing with the
+  // <dialog>.showModal() effect under React 19 strict mode and silently
+  // dropping the open call.
   const [settingsTarget, setSettingsTarget] = useState<WorkspaceTarget | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const openSettings = (target: WorkspaceTarget) => {
+    setSettingsTarget(target);
+    setSettingsOpen(true);
+  };
 
   const sorted = [...workspaces].sort((a, b) => a.name.localeCompare(b.name));
   const atCap = workspaces.length >= MAX_WORKSPACES;
 
   return (
-    // The whole row sits below the OS title-bar drag region. Without this
-    // opt-out, Tauri swallows clicks on the cards (gear / select) before
-    // React ever sees them — that's why both buttons looked dead.
     <div className="shrink-0 px-2 py-1.5" data-tauri-drag-region="false">
       <span className="mb-1 flex items-center gap-1.5 px-0.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
         <FolderOpen size={11} aria-hidden className="text-primary" />
@@ -57,7 +64,7 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
             workspace={ws}
             isActive={ws.id === currentWorkspace?.id}
             onSelect={() => void setCurrentWorkspace(ws.id)}
-            onOpenSettings={() => setSettingsTarget({ id: ws.id, name: ws.name })}
+            onOpenSettings={() => openSettings({ id: ws.id, name: ws.name })}
           />
         ))}
         <button
@@ -85,8 +92,8 @@ export function WorkspaceSelect({ onAddWorkspace }: WorkspaceSelectProps) {
         <WorkspaceSettingsDialog
           workspaceId={settingsTarget.id}
           workspaceName={settingsTarget.name}
-          open
-          onClose={() => setSettingsTarget(null)}
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
         />
       ) : null}
     </div>

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -317,16 +317,18 @@ function GeneralSection({
           <code className="rounded bg-background px-1 font-mono">[a-z0-9-]</code>, up to 16
           characters.
         </p>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
           <input
             type="text"
             value={branchPrefix}
             onChange={(e) => setBranchPrefix(sanitized(e.target.value))}
             placeholder={DEFAULT_BRANCH_PREFIX}
             disabled={busy}
+            maxLength={16}
+            size={16}
             aria-label="branch prefix"
             className={cn(
-              'h-9 w-40 rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground motion-safe:transition-colors',
+              'h-8 rounded-md border border-border bg-background px-2 font-mono text-sm text-foreground motion-safe:transition-colors',
               'placeholder:text-muted-foreground/40',
               'hover:border-border-strong focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
               busy && 'cursor-not-allowed opacity-50',
@@ -334,6 +336,9 @@ function GeneralSection({
           />
           <span className="font-mono text-sm text-muted-foreground/50">/</span>
           <span className="font-mono text-sm text-muted-foreground/40">&lt;slug&gt;</span>
+          <span className="ml-auto font-mono text-2xs tabular-nums text-muted-foreground/60">
+            {branchPrefix.length}/16
+          </span>
         </div>
         <p className="flex items-center gap-1.5 text-2xs text-muted-foreground/70">
           <span>Preview:</span>

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import type { WorkspaceId } from '@kay-am/types';
-import { Button, Dialog, Input, cn } from '@kay-am/ui';
+import { Button, Dialog, cn } from '@kay-am/ui';
 import {
   AlertTriangle,
   Check,
@@ -121,8 +121,9 @@ export function WorkspaceSettingsDialog({
       title="Workspace settings"
       description={workspaceName}
       size="xl"
-      className="w-[64rem] max-w-[95vw]"
+      className="w-[52rem] max-w-[95vw]"
       bodyClassName="px-0 py-0 gap-0"
+      fixedHeightClass="h-[560px]"
       fullScreenOnSmall
       footer={
         <div className="flex w-full items-center gap-2">
@@ -316,19 +317,30 @@ function GeneralSection({
           <code className="rounded bg-background px-1 font-mono">[a-z0-9-]</code>, up to 16
           characters.
         </p>
-        <div className="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary">
-          <Input
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
             value={branchPrefix}
             onChange={(e) => setBranchPrefix(sanitized(e.target.value))}
             placeholder={DEFAULT_BRANCH_PREFIX}
             disabled={busy}
-            className="!h-7 border-0 bg-transparent px-1.5 text-foreground shadow-none focus-visible:ring-0"
+            aria-label="branch prefix"
+            className={cn(
+              'h-9 w-40 rounded-md border border-border bg-background px-3 font-mono text-sm text-foreground motion-safe:transition-colors',
+              'placeholder:text-muted-foreground/40',
+              'hover:border-border-strong focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
+              busy && 'cursor-not-allowed opacity-50',
+            )}
           />
-          <span className="flex select-none items-center text-muted-foreground/50">/</span>
-          <span className="flex select-none items-center text-muted-foreground/40">
-            branch-slug
-          </span>
+          <span className="font-mono text-sm text-muted-foreground/50">/</span>
+          <span className="font-mono text-sm text-muted-foreground/40">&lt;slug&gt;</span>
         </div>
+        <p className="flex items-center gap-1.5 text-2xs text-muted-foreground/70">
+          <span>Preview:</span>
+          <span className="font-mono text-muted-foreground">
+            {branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/refactor-auth-domain
+          </span>
+        </p>
       </div>
     </div>
   );

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -1,7 +1,16 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import type { WorkspaceId } from '@kay-am/types';
 import { Button, Dialog, Input, cn } from '@kay-am/ui';
-import { FolderCode, GitBranch, Terminal, Unplug, Zap } from 'lucide-react';
+import {
+  AlertTriangle,
+  Check,
+  FolderCode,
+  GitBranch,
+  Loader2,
+  Terminal,
+  Unplug,
+  Zap,
+} from 'lucide-react';
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
 import { PhasesPanel } from '../../../../features/phases/components/PhasesPanel';
 import { InitScriptPanel } from '../../../../features/init';
@@ -20,35 +29,11 @@ interface WorkspaceSettingsDialogProps {
 type Section = 'general' | 'skills' | 'init' | 'phases' | 'danger';
 
 interface NavItem {
-  id: Section;
-  label: string;
-  icon: React.ReactNode;
-  beta?: boolean;
-}
-
-const NAV_ITEMS: NavItem[] = [
-  { id: 'general', label: 'General', icon: <FolderCode size={14} aria-hidden /> },
-  ...(WORKSPACE_FEATURES.skills
-    ? [{ id: 'skills' as const, label: 'Skills', icon: <Zap size={14} aria-hidden /> }]
-    : []),
-  ...(WORKSPACE_FEATURES.initScript
-    ? [{ id: 'init' as const, label: 'Init', icon: <Terminal size={14} aria-hidden /> }]
-    : []),
-  { id: 'phases', label: 'Workflows', icon: <GitBranch size={14} aria-hidden />, beta: true },
-];
-
-const DANGER_NAV: NavItem = {
-  id: 'danger',
-  label: 'Disconnect',
-  icon: <Unplug size={14} aria-hidden />,
-};
-
-function BetaChip() {
-  return (
-    <span className="ml-auto rounded-sm bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning">
-      beta
-    </span>
-  );
+  readonly id: Section;
+  readonly label: string;
+  readonly icon: ReactNode;
+  readonly beta?: boolean;
+  readonly tone?: 'danger';
 }
 
 export function WorkspaceSettingsDialog({
@@ -59,11 +44,11 @@ export function WorkspaceSettingsDialog({
 }: WorkspaceSettingsDialogProps) {
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
-
   const disconnect = useAppStore((s) => s.deleteWorkspace);
 
   const [active, setActive] = useState<Section>('general');
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [savedBranchPrefix, setSavedBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
@@ -71,9 +56,17 @@ export function WorkspaceSettingsDialog({
 
   useEffect(() => {
     if (!open) return;
+    setActive('general');
+    setSaveState('idle');
+    setError(null);
     setConfirmDisconnect(false);
     setDisconnecting(false);
-  }, [open]);
+    void loadSetting(settingBranchPrefix(workspaceId)).then((v) => {
+      const value = v ?? DEFAULT_BRANCH_PREFIX;
+      setBranchPrefix(value);
+      setSavedBranchPrefix(value);
+    });
+  }, [open, workspaceId, loadSetting]);
 
   const onDisconnect = async () => {
     setDisconnecting(true);
@@ -87,23 +80,14 @@ export function WorkspaceSettingsDialog({
     }
   };
 
-  useEffect(() => {
-    if (!open) return;
-    setSaveState('idle');
-    setError(null);
-    void loadSetting(settingBranchPrefix(workspaceId)).then((v) =>
-      setBranchPrefix(v ?? DEFAULT_BRANCH_PREFIX),
-    );
-  }, [open, workspaceId, loadSetting]);
-
   const onSave = async () => {
     setSaveState('saving');
     setError(null);
     try {
-      await saveSetting(
-        settingBranchPrefix(workspaceId),
-        branchPrefix.trim() || DEFAULT_BRANCH_PREFIX,
-      );
+      const next = branchPrefix.trim() || DEFAULT_BRANCH_PREFIX;
+      await saveSetting(settingBranchPrefix(workspaceId), next);
+      setSavedBranchPrefix(next);
+      setBranchPrefix(next);
       setSaveState('saved');
     } catch (err) {
       setSaveState('error');
@@ -111,160 +95,396 @@ export function WorkspaceSettingsDialog({
     }
   };
 
-  const needsSave = active === 'general';
+  const branchPrefixDirty = branchPrefix.trim() !== savedBranchPrefix.trim();
 
-  const renderContent = () => {
-    switch (active) {
-      case 'general':
-        return (
-          <div className="flex flex-col gap-4">
-            <div className="text-xs font-semibold tracking-wide text-muted-foreground">
-              Workspace defaults
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <div className="text-xs font-semibold text-foreground">branch prefix</div>
-              <Input
-                value={branchPrefix}
-                onChange={(e) => setBranchPrefix(e.target.value)}
-                placeholder={DEFAULT_BRANCH_PREFIX}
-              />
-              <p className="text-xs leading-relaxed text-muted-foreground">
-                used as the default in the new-session dialog for this workspace.
-              </p>
-            </div>
-          </div>
-        );
-      case 'skills':
-        return <SkillsPanel workspaceId={workspaceId} />;
-      case 'init':
-        return <InitScriptPanel workspaceId={workspaceId} />;
-      case 'phases':
-        return <PhasesPanel workspaceId={workspaceId} />;
-      case 'danger':
-        return (
-          <div className="flex flex-col gap-5">
-            <div>
-              <div className="text-xs font-semibold tracking-wide text-muted-foreground">
-                Disconnect
-              </div>
-              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                Hides the workspace from the sidebar without deleting anything.
-              </p>
-            </div>
-
-            <div
-              className={cn(
-                'flex flex-col gap-3 rounded-md border p-3 transition-colors',
-                confirmDisconnect ? 'border-danger/40 bg-danger/5' : 'border-border-soft',
-              )}
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex-1">
-                  <div className="text-xs font-semibold text-foreground">disconnect workspace</div>
-                  <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
-                    Sessions, transcripts, and worktrees stay safe on disk. Re-add the same path
-                    later to bring it back exactly as you left it.
-                  </p>
-                </div>
-                {!confirmDisconnect ? (
-                  <Button
-                    variant="danger"
-                    onClick={() => setConfirmDisconnect(true)}
-                    disabled={disconnecting}
-                  >
-                    <Unplug size={13} aria-hidden className="mr-1.5" />
-                    Disconnect
-                  </Button>
-                ) : null}
-              </div>
-
-              {confirmDisconnect ? (
-                <div className="flex items-center justify-end gap-2">
-                  <Button
-                    variant="ghost"
-                    onClick={() => setConfirmDisconnect(false)}
-                    disabled={disconnecting}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="danger"
-                    onClick={() => void onDisconnect()}
-                    disabled={disconnecting}
-                  >
-                    {disconnecting ? 'Disconnecting…' : 'Confirm disconnect'}
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          </div>
-        );
-    }
-  };
+  const navItems: ReadonlyArray<NavItem> = [
+    { id: 'general', label: 'General', icon: <FolderCode size={13} aria-hidden /> },
+    ...(WORKSPACE_FEATURES.skills
+      ? ([{ id: 'skills', label: 'Skills', icon: <Zap size={13} aria-hidden /> }] as const)
+      : []),
+    ...(WORKSPACE_FEATURES.initScript
+      ? ([{ id: 'init', label: 'Init', icon: <Terminal size={13} aria-hidden /> }] as const)
+      : []),
+    { id: 'phases', label: 'Workflows', icon: <GitBranch size={13} aria-hidden />, beta: true },
+    {
+      id: 'danger',
+      label: 'Danger zone',
+      icon: <Unplug size={13} aria-hidden />,
+      tone: 'danger',
+    },
+  ];
 
   return (
-    <>
-      <Dialog
-        open={open}
-        onClose={onClose}
-        title={workspaceName}
-        description="Per-workspace defaults, skills, and workflow templates."
-        size="xl"
-        fixedHeightClass="h-[640px]"
-        fullScreenOnSmall
-        footer={
-          <>
-            {saveState === 'saved' ? (
-              <span className="mr-auto text-xs text-success">Saved.</span>
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Workspace settings"
+      description={workspaceName}
+      size="xl"
+      className="w-[64rem] max-w-[95vw]"
+      bodyClassName="px-0 py-0 gap-0"
+      fullScreenOnSmall
+      footer={
+        <div className="flex w-full items-center gap-2">
+          <div className="flex-1 truncate">
+            {error ? (
+              <span className="text-xs text-danger">{error}</span>
+            ) : saveState === 'saved' ? (
+              <span className="inline-flex items-center gap-1 text-xs text-success">
+                <Check size={12} aria-hidden /> Saved
+              </span>
+            ) : branchPrefixDirty && active === 'general' ? (
+              <span className="text-xs text-muted-foreground">Unsaved changes</span>
             ) : null}
-            {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
-            <Button variant="ghost" onClick={onClose}>
-              Close
+          </div>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+          {active === 'general' ? (
+            <Button
+              onClick={() => void onSave()}
+              disabled={saveState === 'saving' || !branchPrefixDirty}
+            >
+              {saveState === 'saving' ? (
+                <>
+                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
+                  Saving…
+                </>
+              ) : (
+                'Save'
+              )}
             </Button>
-            {needsSave ? (
-              <Button onClick={() => void onSave()} disabled={saveState === 'saving'}>
-                {saveState === 'saving' ? 'Saving…' : 'Save'}
-              </Button>
-            ) : null}
-          </>
-        }
-      >
-        <div className="flex h-full min-h-0 gap-0">
-          <nav className="flex w-44 shrink-0 flex-col gap-0.5 overflow-y-auto pr-2">
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => setActive(item.id)}
-                className={`relative flex items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === item.id
-                    ? 'bg-muted font-medium text-foreground before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-primary'
-                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground'
-                }`}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-                {item.beta ? <BetaChip /> : null}
-              </button>
-            ))}
-            <div className="mt-auto pt-3">
-              <button
-                type="button"
-                onClick={() => setActive('danger')}
-                className={`relative flex w-full items-center gap-2 rounded-md py-1.5 pl-3 pr-2 text-left text-sm transition-colors ${
-                  active === 'danger'
-                    ? 'bg-danger/15 font-medium text-danger before:absolute before:left-1 before:top-1.5 before:bottom-1.5 before:w-[3px] before:rounded-full before:bg-danger'
-                    : 'text-danger/80 hover:bg-danger/10 hover:text-danger'
-                }`}
-              >
-                {DANGER_NAV.icon}
-                <span>{DANGER_NAV.label}</span>
-              </button>
-            </div>
-          </nav>
-          <div className="min-w-0 flex-1 overflow-y-auto pl-4">{renderContent()}</div>
+          ) : null}
         </div>
-      </Dialog>
-    </>
+      }
+    >
+      <div className="flex h-full min-h-0">
+        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
+          {navItems
+            .filter((i) => i.tone !== 'danger')
+            .map((item) => (
+              <NavButton
+                key={item.id}
+                item={item}
+                active={active === item.id}
+                onClick={() => setActive(item.id)}
+              />
+            ))}
+          <div className="mt-auto">
+            {navItems
+              .filter((i) => i.tone === 'danger')
+              .map((item) => (
+                <NavButton
+                  key={item.id}
+                  item={item}
+                  active={active === item.id}
+                  onClick={() => setActive(item.id)}
+                />
+              ))}
+          </div>
+        </nav>
+
+        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
+          {active === 'general' ? (
+            <GeneralSection
+              branchPrefix={branchPrefix}
+              setBranchPrefix={setBranchPrefix}
+              busy={saveState === 'saving'}
+            />
+          ) : null}
+
+          {active === 'skills' ? (
+            <SectionShell
+              icon={<Zap size={14} aria-hidden className="text-primary" />}
+              title="Skills"
+              subtitle="Reusable system-prompt fragments and tool kits that every agent in this workspace can opt into."
+            >
+              <SkillsPanel workspaceId={workspaceId} />
+            </SectionShell>
+          ) : null}
+
+          {active === 'init' ? (
+            <SectionShell
+              icon={<Terminal size={14} aria-hidden className="text-primary" />}
+              title="Init script"
+              subtitle="Shell snippet that runs once when a new session's worktree is created — install deps, hydrate env, warm caches."
+            >
+              <InitScriptPanel workspaceId={workspaceId} />
+            </SectionShell>
+          ) : null}
+
+          {active === 'phases' ? (
+            <SectionShell
+              icon={<GitBranch size={14} aria-hidden className="text-primary" />}
+              title="Workflows"
+              subtitle="Multi-agent blueprints offered when creating a session. Each step spawns its own agent in order."
+              beta
+            >
+              <PhasesPanel workspaceId={workspaceId} />
+            </SectionShell>
+          ) : null}
+
+          {active === 'danger' ? (
+            <DangerSection
+              confirmDisconnect={confirmDisconnect}
+              setConfirmDisconnect={setConfirmDisconnect}
+              disconnecting={disconnecting}
+              onDisconnect={() => void onDisconnect()}
+            />
+          ) : null}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Nav button                                                            */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function NavButton({
+  item,
+  active,
+  onClick,
+}: {
+  item: NavItem;
+  active: boolean;
+  onClick: () => void;
+}) {
+  const danger = item.tone === 'danger';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
+        active
+          ? danger
+            ? 'bg-danger/10 font-medium text-danger before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-danger'
+            : 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
+          : danger
+            ? 'text-danger/70 hover:bg-danger/5 hover:text-danger'
+            : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
+      )}
+    >
+      {item.icon}
+      <span className="flex-1">{item.label}</span>
+      {item.beta ? (
+        <span className="rounded bg-warning/20 px-1 py-px text-[9px] font-semibold uppercase tracking-wide text-warning">
+          beta
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: General                                                      */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function GeneralSection({
+  branchPrefix,
+  setBranchPrefix,
+  busy,
+}: {
+  branchPrefix: string;
+  setBranchPrefix: (v: string) => void;
+  busy: boolean;
+}) {
+  const sanitized = (input: string): string =>
+    input
+      .toLowerCase()
+      .replace(/[^a-z0-9-]+/g, '')
+      .replace(/^-+/, '')
+      .slice(0, 16);
+
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<FolderCode size={14} aria-hidden className="text-primary" />}
+        title="General"
+        subtitle="Defaults applied when you create new sessions inside this workspace. Override per-session from the new-session dialog."
+      />
+
+      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
+        <div className="flex items-center gap-2">
+          <GitBranch size={13} aria-hidden className="text-muted-foreground" />
+          <span className="text-xs font-semibold text-foreground">Branch prefix</span>
+        </div>
+        <p className="text-2xs leading-relaxed text-muted-foreground">
+          Used as the default prefix in the new-session dialog. Sanitized to{' '}
+          <code className="rounded bg-background px-1 font-mono">[a-z0-9-]</code>, up to 16
+          characters.
+        </p>
+        <div className="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary">
+          <Input
+            value={branchPrefix}
+            onChange={(e) => setBranchPrefix(sanitized(e.target.value))}
+            placeholder={DEFAULT_BRANCH_PREFIX}
+            disabled={busy}
+            className="!h-7 border-0 bg-transparent px-1.5 text-foreground shadow-none focus-visible:ring-0"
+          />
+          <span className="flex select-none items-center text-muted-foreground/50">/</span>
+          <span className="flex select-none items-center text-muted-foreground/40">
+            branch-slug
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section shell (skills / init / phases reuse this header)              */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionShell({
+  icon,
+  title,
+  subtitle,
+  beta,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  beta?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <SectionHeader icon={icon} title={title} subtitle={subtitle} beta={beta} />
+      <div>{children}</div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Section: Danger zone                                                  */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function DangerSection({
+  confirmDisconnect,
+  setConfirmDisconnect,
+  disconnecting,
+  onDisconnect,
+}: {
+  confirmDisconnect: boolean;
+  setConfirmDisconnect: (v: boolean) => void;
+  disconnecting: boolean;
+  onDisconnect: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-7">
+      <SectionHeader
+        icon={<AlertTriangle size={14} aria-hidden className="text-danger" />}
+        title="Danger zone"
+        subtitle="Hides the workspace from the sidebar. Sessions, transcripts, and worktrees stay safe on disk — re-add the same path later and everything comes back."
+        tone="danger"
+      />
+
+      <div
+        className={cn(
+          'flex flex-col gap-3 rounded-lg border p-4 transition-colors',
+          confirmDisconnect ? 'border-danger/50 bg-danger/5' : 'border-border-soft bg-background',
+        )}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            <div className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+              <Unplug size={12} aria-hidden className="text-danger" />
+              Disconnect workspace
+            </div>
+            <p className="mt-1 text-2xs leading-relaxed text-muted-foreground">
+              Nothing is deleted. The repo and all its sessions stay in place — they just stop
+              showing up in the sidebar until you re-add the path.
+            </p>
+          </div>
+          {!confirmDisconnect ? (
+            <Button
+              variant="danger"
+              onClick={() => setConfirmDisconnect(true)}
+              disabled={disconnecting}
+            >
+              <Unplug size={13} aria-hidden className="mr-1.5" />
+              Disconnect
+            </Button>
+          ) : null}
+        </div>
+
+        {confirmDisconnect ? (
+          <div className="flex items-center justify-end gap-2 border-t border-danger/20 pt-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setConfirmDisconnect(false)}
+              disabled={disconnecting}
+            >
+              Cancel
+            </Button>
+            <Button variant="danger" size="sm" onClick={onDisconnect} disabled={disconnecting}>
+              {disconnecting ? (
+                <>
+                  <Loader2 size={12} className="mr-1.5 animate-spin" aria-hidden />
+                  Disconnecting…
+                </>
+              ) : (
+                <>
+                  <Check size={12} aria-hidden className="mr-1.5" />
+                  Confirm disconnect
+                </>
+              )}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────── */
+/* Building blocks                                                       */
+/* ──────────────────────────────────────────────────────────────────── */
+
+function SectionHeader({
+  icon,
+  title,
+  subtitle,
+  tone,
+  beta,
+}: {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  tone?: 'danger';
+  beta?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'flex h-7 w-7 items-center justify-center rounded-md',
+            tone === 'danger' ? 'bg-danger/10' : 'bg-primary/10',
+          )}
+        >
+          {icon}
+        </span>
+        <h3
+          className={cn(
+            'text-base font-semibold',
+            tone === 'danger' ? 'text-danger' : 'text-foreground',
+          )}
+        >
+          {title}
+        </h3>
+        {beta ? (
+          <span className="rounded bg-warning/20 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-warning">
+            beta
+          </span>
+        ) : null}
+      </div>
+      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
+    </div>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -185,6 +185,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                       <ScrollArea className="min-h-0 flex-1">
                         <AgentsSection task={currentSession} />
                       </ScrollArea>
+                      <NextSuggestionsPlaceholder />
                       <SessionFilesTouchedFooter session={currentSession} />
                     </>
                   ) : (
@@ -273,6 +274,17 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
         onClose={() => setGithubDetailsOpen(false)}
         sessionId={(currentSession?.id as SessionId) ?? null}
       />
+    </div>
+  );
+}
+
+function NextSuggestionsPlaceholder() {
+  return (
+    <div
+      className="shrink-0 border-t border-border-soft px-3 py-1.5 text-2xs italic text-muted-foreground/60"
+      title="next-action suggestions are coming back in a future update"
+    >
+      Next suggestions will be re-added soon.
     </div>
   );
 }
@@ -952,12 +964,6 @@ function AgentsSection({ task }: AgentsSectionProps) {
         <ul className="flex flex-col gap-1 pl-2">{sorted.map(renderAdHocRow)}</ul>
       )}
       {hasActivePlan ? null : <ActivePlanCta sessionId={task.id} />}
-      <div className="mt-2 px-2">
-        <div className="rounded border border-dashed border-border-soft px-3 py-2">
-          <p className="text-2xs font-medium text-muted-foreground">Next</p>
-          <p className="text-2xs text-muted-foreground/60">temporarily disabled</p>
-        </div>
-      </div>
       <div className="pl-2">
         <SpawnAgentControl sessionId={task.id} />
       </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -145,15 +145,20 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
       <div className="flex min-h-0 flex-1">
         {currentWorkspace ? (
           (() => {
-            const hasAnySession = activeSessions.length > 0 || archivedSessions.length > 0;
+            const totalSessions = activeSessions.length + archivedSessions.length;
+            const hasAnySession = totalSessions > 0;
+            // The activity bar only makes sense as a switcher. With a single
+            // session the user never switches — collapse it and expose the
+            // "new session" action inside the detail panel header instead.
+            const showActivityBar = totalSessions > 1;
             return (
               <>
                 <div
                   className={cn(
                     'overflow-hidden transition-[width] duration-300 ease-out',
-                    hasAnySession ? 'w-28' : 'w-0',
+                    showActivityBar ? 'w-28' : 'w-0',
                   )}
-                  aria-hidden={!hasAnySession}
+                  aria-hidden={!showActivityBar}
                 >
                   <SessionActivityBar
                     sessions={activeSessions}
@@ -166,7 +171,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                 <div
                   className={cn(
                     'mr-1.5 mt-1.5 mb-1.5 flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-background transition-[margin-left] duration-300 ease-out dark:bg-muted',
-                    hasAnySession ? 'ml-0' : 'ml-1.5',
+                    showActivityBar ? 'ml-0' : 'ml-1.5',
                   )}
                 >
                   {currentSession ? (
@@ -175,6 +180,7 @@ export function WorkspacesSidebar({ onOpenSettings }: WorkspacesSidebarProps) {
                         session={currentSession}
                         onOpenSessionSettings={() => setSessionSettingsOpen(true)}
                         onOpenGithubDetails={() => setGithubDetailsOpen(true)}
+                        onNewSession={showActivityBar ? undefined : () => setNewSessionOpen(true)}
                       />
                       <ScrollArea className="min-h-0 flex-1">
                         <AgentsSection task={currentSession} />

--- a/apps/desktop/src/features/worktree/BranchCombobox.tsx
+++ b/apps/desktop/src/features/worktree/BranchCombobox.tsx
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@kay-am/ui';
+import { ChevronDown } from 'lucide-react';
+import type { LocalBranchInfo } from './worktree';
+
+interface BranchComboboxProps {
+  readonly branches: ReadonlyArray<LocalBranchInfo>;
+  readonly value: string;
+  readonly onChange: (v: string) => void;
+  readonly disabled: boolean;
+  readonly loading: boolean;
+  /**
+   * Branches to hide from the list (e.g. the current session branch when
+   * we don't want the user picking it again). Filtering happens before
+   * the substring search.
+   */
+  readonly excludeNames?: ReadonlyArray<string>;
+  /**
+   * Vertical anchor for the popup. `'auto'` (default) opens below; `'up'`
+   * opens above. Used by callers where the input sits near the bottom of
+   * a scroll container.
+   */
+  readonly openDirection?: 'down' | 'up';
+}
+
+export function BranchCombobox({
+  branches,
+  value,
+  onChange,
+  disabled,
+  loading,
+  excludeNames,
+  openDirection = 'down',
+}: BranchComboboxProps) {
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [highlightIdx, setHighlightIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const excludeSet = useMemo(() => new Set(excludeNames ?? []), [excludeNames]);
+
+  const filtered = useMemo(
+    () =>
+      branches.filter(
+        (b) => !excludeSet.has(b.name) && b.name.toLowerCase().includes(query.toLowerCase()),
+      ),
+    [branches, excludeSet, query],
+  );
+
+  const select = useCallback(
+    (name: string) => {
+      onChange(name);
+      setQuery(name);
+      setOpen(false);
+    },
+    [onChange],
+  );
+
+  useEffect(() => {
+    if (value && !query) setQuery(value);
+  }, [value, query]);
+
+  useEffect(() => {
+    setHighlightIdx(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || !listRef.current) return;
+    const el = listRef.current.children[highlightIdx] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [highlightIdx, open]);
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (!open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      setOpen(true);
+      e.preventDefault();
+      return;
+    }
+    if (!open) return;
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setHighlightIdx((i) => Math.min(i + 1, filtered.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setHighlightIdx((i) => Math.max(i - 1, 0));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (filtered[highlightIdx]) select(filtered[highlightIdx].name);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setOpen(false);
+        break;
+    }
+  };
+
+  const placeholder = loading
+    ? 'Loading…'
+    : branches.length === 0
+      ? 'No local branches'
+      : 'Search branch…';
+
+  const popupClass = cn(
+    'absolute left-0 z-50 w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg',
+    openDirection === 'up' ? 'bottom-full mb-1 max-h-48' : 'top-full mt-1 max-h-56',
+  );
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div
+        className={cn(
+          'flex h-9 w-full items-center gap-1 rounded-md border border-border bg-background px-1 motion-safe:transition-colors focus-within:border-primary hover:border-border-strong',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          placeholder={placeholder}
+          disabled={disabled || branches.length === 0}
+          aria-label="Branch"
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          autoComplete="off"
+          className="flex-1 truncate bg-transparent px-2 text-sm font-mono text-foreground outline-none placeholder:text-muted-foreground/50 disabled:cursor-not-allowed"
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+            if (!e.target.value) onChange('');
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+        />
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => {
+            if (disabled || branches.length === 0) return;
+            setOpen((v) => !v);
+            inputRef.current?.focus();
+          }}
+          aria-label={open ? 'Close branch list' : 'Open branch list'}
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ChevronDown
+            size={13}
+            aria-hidden
+            className={cn('transition-transform', open && 'rotate-180')}
+          />
+        </button>
+      </div>
+      {open && filtered.length > 0 ? (
+        <ul ref={listRef} role="listbox" className={popupClass}>
+          {filtered.map((b, i) => (
+            <li
+              key={b.name}
+              role="option"
+              aria-selected={highlightIdx === i}
+              onMouseEnter={() => setHighlightIdx(i)}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(b.name);
+              }}
+              className={cn(
+                'flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-sm font-mono',
+                highlightIdx === i ? 'bg-primary/10 text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              <span className="min-w-0 truncate">{b.name}</span>
+              {b.inUse ? <span className="shrink-0 text-2xs text-warning">in use</span> : null}
+              {b.hasUncommitted ? (
+                <span className="shrink-0 text-2xs text-warning">dirty</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {open && !loading && filtered.length === 0 && query ? (
+        <div className={cn(popupClass, 'px-2 py-2 text-xs text-muted-foreground')}>
+          No matching branches
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Sweeping rework of the modal layer so every dialog shares the same visual language: 48–68rem widths, fixed side ladders that don't scroll, content-only scrolling, section headers with icon badges, color tones tied to domain, and consistent danger zones.

### Modals touched
- **New session** — drops the broken issue-link block, rewrites copy, merges branch prefix + slug into a single live-slugified mono input, replaces the workflow segmented control with three descriptive cards (single agent / workflow preset / custom plan), polishes preset + custom panels, widens to 68rem
- **Session settings** — promotes Delete out of the orphan footer slot into a proper Danger zone section, embeds the branch-switch flow inline (no more secondary dialog), adds a budget progress bar with tonal thresholds, fixes auto-height so the dialog doesn't scroll internally
- **Workspace settings** — same visual language, sane 52rem × 560px proportions, branch-prefix input auto-sized to its 16-char cap with live `prefix/<slug>` preview, panels (Skills/Init/Workflows) wrapped in a shared `SectionShell`, Danger zone moved to its own nav item
- **Getting-started guide** — full rewrite with tone & color: Overview now has four tappable concept cards (Workspace/Session/Agent/Turn) that jump to the matching section, archive-vs-delete tiles, cheap/mid/premium tier tiles, agent-row metrics shown as colored chips, tips as a numbered card grid, each Legend group in its own panel

### Sidebar & header changes
- Activity bar collapses when the workspace only has one session; a `+ New` pill in the session header replaces the missing affordance
- Open-in-editor restored as an icon-only button in the session header (replaces what `f3250e1` removed)
- "Next / temporarily disabled" card removed from the agents scroll; replaced with a flat italic line pinned above the files-touched footer
- Workspace cards' gear button works again — the drag-region opt-out lost in `0c970f1` is restored

### Shared bits extracted
- `BranchCombobox` lifted from NewSessionDialog into `features/worktree/` and reused in SessionSettings to kill the last native `<select>`
- Workflow-select popovers (Model / Effort / Verbosity / Agent role) now flip upward when the trigger sits near the bottom of their clipping ancestor (the Dialog itself, not the viewport) — no more popovers forced to scroll the modal

## Test plan
- [ ] Open new-session modal: type a goal, watch the slug live-slugify; switch between Single agent / Workflow preset / Custom plan cards; flip "use existing branch instead"
- [ ] Open a single-session workspace: confirm the activity bar is collapsed and the `+ New` pill spawns the modal
- [ ] Hover the open-in-editor folder icon in the session header; with 1 editor click opens directly, with 2+ it shows the popover
- [ ] Open session settings: rename, expand branch change, confirm reuse warning, archive, delete
- [ ] Open workspace settings via the gear in the workspace card: edit branch prefix (counter updates, save enables only on change), navigate to Danger zone, disconnect
- [ ] Open Getting started guide: tap each concept card on the Overview to verify section jumps; check tiles/chips in Tokens & cost and Agents
- [ ] In the new-session Workflow → Single agent panel, open Model / Effort / Verbosity / Agent role: popovers should flip upward when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)