### PR TITLE
feat(desktop): move workflow choice out of session creation

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
   open=""
 >
   <div
-    class="flex min-h-0 flex-col h-[680px] w-[68rem] max-w-[95vw]"
+    class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
@@ -26,7 +26,7 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
           class="text-xs leading-relaxed text-muted-foreground"
           id="_r_4_-desc"
         >
-          Creates a worktree on a fresh branch from the workspace root.
+          Creates a worktree on a fresh branch. Configure workflow and agents from the session panel afterwards.
         </p>
       </div>
       <button
@@ -43,327 +43,171 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm px-0 py-0 gap-0"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
     >
       <div
-        class="flex h-full min-h-0"
+        class="flex flex-col gap-7"
       >
-        <nav
-          class="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5"
+        <section
+          class="flex flex-col gap-2.5"
         >
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary"
-            title="goal is required"
-            type="button"
+          <header
+            class="flex items-start gap-2.5"
           >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-target"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                r="6"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                r="2"
-              />
-            </svg>
             <span
-              class="flex-1"
+              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10"
             >
-              Goal
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-target text-primary"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="6"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="2"
+                />
+              </svg>
             </span>
-            <svg
-              aria-label="goal required"
-              class="lucide lucide-triangle-alert text-warning"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
-            title="provider is required"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-zap"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Provider
-            </span>
-            <svg
-              aria-label="provider required"
-              class="lucide lucide-triangle-alert text-warning"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-layers"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-              />
-              <path
-                d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-              />
-              <path
-                d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Workflow
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
-              />
-            </svg>
-          </button>
-        </nav>
-        <div
-          class="min-w-0 flex-1 overflow-y-auto px-8 py-6"
-        >
-          <div
-            class="flex flex-col gap-7"
-          >
             <div
-              class="flex flex-col gap-1.5"
+              class="flex flex-col gap-0.5"
             >
-              <div
-                class="flex items-center gap-2"
+              <h3
+                class="text-sm font-semibold text-foreground"
               >
-                <span
-                  class="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-target text-primary"
-                    fill="none"
-                    height="14"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="14"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                    />
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="6"
-                    />
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="2"
-                    />
-                  </svg>
-                </span>
-                <h3
-                  class="text-base font-semibold text-foreground"
-                >
-                  What needs to get done?
-                </h3>
-              </div>
+                Goal
+              </h3>
               <p
-                class="max-w-2xl text-xs leading-relaxed text-muted-foreground"
+                class="text-2xs leading-relaxed text-muted-foreground"
               >
-                Describe the task in plain English. We'll create a worktree and route it to an agent.
+                What this session should accomplish. Be specific — agents lean on it for context.
               </p>
             </div>
-            <div
-              class="flex flex-col gap-2"
+          </header>
+          <div>
+            <textarea
+              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+              placeholder="Refactor auth domain to extract token validation into a shared module…"
+              style="overflow-y: hidden;"
+            />
+          </div>
+        </section>
+        <section
+          class="flex flex-col gap-2.5"
+        >
+          <header
+            class="flex items-start gap-2.5"
+          >
+            <span
+              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10"
             >
-              <textarea
-                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md text-sm leading-relaxed"
-                placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
-                style="overflow-y: hidden;"
-              />
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground/70"
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-git-branch text-success"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Tip: a clear, imperative sentence yields a better branch name and helps agents stay focused.
+                <path
+                  d="M15 6a9 9 0 0 0-9 9V3"
+                />
+                <circle
+                  cx="18"
+                  cy="6"
+                  r="3"
+                />
+                <circle
+                  cx="6"
+                  cy="18"
+                  r="3"
+                />
+              </svg>
+            </span>
+            <div
+              class="flex flex-col gap-0.5"
+            >
+              <h3
+                class="text-sm font-semibold text-foreground"
+              >
+                Branch
+              </h3>
+              <p
+                class="text-2xs leading-relaxed text-muted-foreground"
+              >
+                Each session lives on its own git worktree. Pick a fresh branch or attach to an existing one.
               </p>
             </div>
+          </header>
+          <div>
             <div
-              class="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4"
+              class="flex flex-col gap-2.5"
             >
               <div
-                class="flex items-center justify-between gap-2"
+                aria-label="branch source"
+                class="inline-flex shrink-0 rounded border border-border bg-background p-0.5"
+                role="tablist"
               >
-                <div
-                  class="flex items-center gap-2"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-git-branch text-muted-foreground"
-                    fill="none"
-                    height="13"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="13"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 6a9 9 0 0 0-9 9V3"
-                    />
-                    <circle
-                      cx="18"
-                      cy="6"
-                      r="3"
-                    />
-                    <circle
-                      cx="6"
-                      cy="18"
-                      r="3"
-                    />
-                  </svg>
-                  <span
-                    class="text-xs font-semibold text-foreground"
-                  >
-                    Branch
-                  </span>
-                </div>
                 <button
-                  class="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+                  aria-selected="true"
+                  class="rounded px-2 py-0.5 text-2xs font-medium motion-safe:transition-colors bg-muted text-foreground shadow-sm"
+                  role="tab"
                   type="button"
                 >
-                  use existing branch instead
+                  New
+                </button>
+                <button
+                  aria-selected="false"
+                  class="rounded px-2 py-0.5 text-2xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
+                  role="tab"
+                  type="button"
+                >
+                  Existing
                 </button>
               </div>
               <div
-                class="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary"
+                class="flex items-center gap-1.5"
               >
-                <input
-                  aria-label="Branch prefix"
-                  class="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
-                  placeholder="kay"
-                  title="Branch prefix (editable). Saved per workspace."
-                  type="text"
-                  value="kay"
-                />
                 <span
-                  class="flex select-none items-center text-muted-foreground/50"
+                  class="shrink-0 text-xs text-muted-foreground font-mono"
                 >
-                  /
+                  kay/
                 </span>
                 <input
                   aria-label="Branch slug"
-                  class="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                  class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
                   type="text"
                   value=""
                 />
                 <button
                   aria-label="Generate branch name"
-                  class="flex shrink-0 items-center justify-center rounded px-2 transition-colors cursor-not-allowed text-muted-foreground/30"
+                  class="shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors cursor-not-allowed text-muted-foreground/30"
                   disabled=""
-                  title="Generate a better name from your goal"
+                  title="Generate from goal"
                   type="button"
                 >
                   <svg
@@ -406,21 +250,9 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
                   </svg>
                 </button>
               </div>
-              <p
-                class="flex items-center gap-1.5 text-2xs text-muted-foreground/70"
-              >
-                <span>
-                  Preview:
-                </span>
-                <span
-                  class="font-mono text-muted-foreground"
-                >
-                  kay/branch-slug
-                </span>
-              </p>
             </div>
           </div>
-        </div>
+        </section>
       </div>
     </div>
     <footer
@@ -430,38 +262,8 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
         class="flex w-full items-center gap-2"
       >
         <div
-          class="flex-1"
-        >
-          <span
-            class="inline-flex items-center gap-1 text-xs text-warning"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-triangle-alert"
-              fill="none"
-              height="12"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="12"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-            Complete: 
-            Goal, Provider
-          </span>
-        </div>
+          class="flex-1 text-xs text-danger"
+        />
         <button
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
           type="button"
@@ -471,7 +273,6 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
         <button
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
           disabled=""
-          title="Complete: Goal, Provider"
           type="button"
         >
           Create session
@@ -2371,7 +2172,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
   open=""
 >
   <div
-    class="flex min-h-0 flex-col h-[680px] w-[68rem] max-w-[95vw]"
+    class="flex flex-col max-h-[85vh] min-h-[28rem] w-[44rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 px-6 py-4 border-b border-border-soft"
@@ -2389,7 +2190,7 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
           class="text-xs leading-relaxed text-muted-foreground"
           id="_r_5_-desc"
         >
-          Creates a worktree on a fresh branch from the workspace root.
+          Creates a worktree on a fresh branch. Configure workflow and agents from the session panel afterwards.
         </p>
       </div>
       <button
@@ -2406,327 +2207,171 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
       </button>
     </header>
     <div
-      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm px-0 py-0 gap-0"
+      class="flex min-h-0 flex-1 flex-col overflow-y-auto text-sm gap-4 px-6 py-5"
     >
       <div
-        class="flex h-full min-h-0"
+        class="flex flex-col gap-7"
       >
-        <nav
-          class="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5"
+        <section
+          class="flex flex-col gap-2.5"
         >
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary"
-            title="goal is required"
-            type="button"
+          <header
+            class="flex items-start gap-2.5"
           >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-target"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <circle
-                cx="12"
-                cy="12"
-                r="10"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                r="6"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                r="2"
-              />
-            </svg>
             <span
-              class="flex-1"
+              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10"
             >
-              Goal
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-target text-primary"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="6"
+                />
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="2"
+                />
+              </svg>
             </span>
-            <svg
-              aria-label="goal required"
-              class="lucide lucide-triangle-alert text-warning"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
-            title="provider is required"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-zap"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Provider
-            </span>
-            <svg
-              aria-label="provider required"
-              class="lucide lucide-triangle-alert text-warning"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-          </button>
-          <button
-            class="relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors text-muted-foreground hover:bg-background/60 hover:text-foreground"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-layers"
-              fill="none"
-              height="13"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="13"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12.83 2.18a2 2 0 0 0-1.66 0L2.6 6.08a1 1 0 0 0 0 1.83l8.58 3.91a2 2 0 0 0 1.66 0l8.58-3.9a1 1 0 0 0 0-1.83z"
-              />
-              <path
-                d="M2 12a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 12"
-              />
-              <path
-                d="M2 17a1 1 0 0 0 .58.91l8.6 3.91a2 2 0 0 0 1.65 0l8.58-3.9A1 1 0 0 0 22 17"
-              />
-            </svg>
-            <span
-              class="flex-1"
-            >
-              Workflow
-            </span>
-            <svg
-              aria-label="filled"
-              class="lucide lucide-check text-success"
-              fill="none"
-              height="11"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="11"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M20 6 9 17l-5-5"
-              />
-            </svg>
-          </button>
-        </nav>
-        <div
-          class="min-w-0 flex-1 overflow-y-auto px-8 py-6"
-        >
-          <div
-            class="flex flex-col gap-7"
-          >
             <div
-              class="flex flex-col gap-1.5"
+              class="flex flex-col gap-0.5"
             >
-              <div
-                class="flex items-center gap-2"
+              <h3
+                class="text-sm font-semibold text-foreground"
               >
-                <span
-                  class="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-target text-primary"
-                    fill="none"
-                    height="14"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="14"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="10"
-                    />
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="6"
-                    />
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="2"
-                    />
-                  </svg>
-                </span>
-                <h3
-                  class="text-base font-semibold text-foreground"
-                >
-                  What needs to get done?
-                </h3>
-              </div>
+                Goal
+              </h3>
               <p
-                class="max-w-2xl text-xs leading-relaxed text-muted-foreground"
+                class="text-2xs leading-relaxed text-muted-foreground"
               >
-                Describe the task in plain English. We'll create a worktree and route it to an agent.
+                What this session should accomplish. Be specific — agents lean on it for context.
               </p>
             </div>
-            <div
-              class="flex flex-col gap-2"
+          </header>
+          <div>
+            <textarea
+              class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-sm leading-5 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md"
+              placeholder="Refactor auth domain to extract token validation into a shared module…"
+              style="overflow-y: hidden;"
+            />
+          </div>
+        </section>
+        <section
+          class="flex flex-col gap-2.5"
+        >
+          <header
+            class="flex items-start gap-2.5"
+          >
+            <span
+              class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10"
             >
-              <textarea
-                class="w-full rounded-md border border-border/30 bg-background px-2.5 py-2 text-foreground shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:border-primary/40 focus-visible:ring-1 focus-visible:ring-primary/15 disabled:opacity-50 resize-none transition-[border-color,box-shadow] focus-visible:shadow-md text-sm leading-relaxed"
-                placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
-                style="overflow-y: hidden;"
-              />
-              <p
-                class="text-2xs leading-relaxed text-muted-foreground/70"
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-git-branch text-success"
+                fill="none"
+                height="14"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="14"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Tip: a clear, imperative sentence yields a better branch name and helps agents stay focused.
+                <path
+                  d="M15 6a9 9 0 0 0-9 9V3"
+                />
+                <circle
+                  cx="18"
+                  cy="6"
+                  r="3"
+                />
+                <circle
+                  cx="6"
+                  cy="18"
+                  r="3"
+                />
+              </svg>
+            </span>
+            <div
+              class="flex flex-col gap-0.5"
+            >
+              <h3
+                class="text-sm font-semibold text-foreground"
+              >
+                Branch
+              </h3>
+              <p
+                class="text-2xs leading-relaxed text-muted-foreground"
+              >
+                Each session lives on its own git worktree. Pick a fresh branch or attach to an existing one.
               </p>
             </div>
+          </header>
+          <div>
             <div
-              class="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4"
+              class="flex flex-col gap-2.5"
             >
               <div
-                class="flex items-center justify-between gap-2"
+                aria-label="branch source"
+                class="inline-flex shrink-0 rounded border border-border bg-background p-0.5"
+                role="tablist"
               >
-                <div
-                  class="flex items-center gap-2"
-                >
-                  <svg
-                    aria-hidden="true"
-                    class="lucide lucide-git-branch text-muted-foreground"
-                    fill="none"
-                    height="13"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    viewBox="0 0 24 24"
-                    width="13"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M15 6a9 9 0 0 0-9 9V3"
-                    />
-                    <circle
-                      cx="18"
-                      cy="6"
-                      r="3"
-                    />
-                    <circle
-                      cx="6"
-                      cy="18"
-                      r="3"
-                    />
-                  </svg>
-                  <span
-                    class="text-xs font-semibold text-foreground"
-                  >
-                    Branch
-                  </span>
-                </div>
                 <button
-                  class="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
+                  aria-selected="true"
+                  class="rounded px-2 py-0.5 text-2xs font-medium motion-safe:transition-colors bg-muted text-foreground shadow-sm"
+                  role="tab"
                   type="button"
                 >
-                  use existing branch instead
+                  New
+                </button>
+                <button
+                  aria-selected="false"
+                  class="rounded px-2 py-0.5 text-2xs font-medium motion-safe:transition-colors text-muted-foreground hover:text-foreground"
+                  role="tab"
+                  type="button"
+                >
+                  Existing
                 </button>
               </div>
               <div
-                class="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary"
+                class="flex items-center gap-1.5"
               >
-                <input
-                  aria-label="Branch prefix"
-                  class="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
-                  placeholder="kay"
-                  title="Branch prefix (editable). Saved per workspace."
-                  type="text"
-                  value="kay"
-                />
                 <span
-                  class="flex select-none items-center text-muted-foreground/50"
+                  class="shrink-0 text-xs text-muted-foreground font-mono"
                 >
-                  /
+                  kay/
                 </span>
                 <input
                   aria-label="Branch slug"
-                  class="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
+                  class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
                   type="text"
                   value=""
                 />
                 <button
                   aria-label="Generate branch name"
-                  class="flex shrink-0 items-center justify-center rounded px-2 transition-colors cursor-not-allowed text-muted-foreground/30"
+                  class="shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors cursor-not-allowed text-muted-foreground/30"
                   disabled=""
-                  title="Generate a better name from your goal"
+                  title="Generate from goal"
                   type="button"
                 >
                   <svg
@@ -2769,21 +2414,9 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
                   </svg>
                 </button>
               </div>
-              <p
-                class="flex items-center gap-1.5 text-2xs text-muted-foreground/70"
-              >
-                <span>
-                  Preview:
-                </span>
-                <span
-                  class="font-mono text-muted-foreground"
-                >
-                  kay/branch-slug
-                </span>
-              </p>
             </div>
           </div>
-        </div>
+        </section>
       </div>
     </div>
     <footer
@@ -2793,38 +2426,8 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
         class="flex w-full items-center gap-2"
       >
         <div
-          class="flex-1"
-        >
-          <span
-            class="inline-flex items-center gap-1 text-xs text-warning"
-          >
-            <svg
-              aria-hidden="true"
-              class="lucide lucide-triangle-alert"
-              fill="none"
-              height="12"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              viewBox="0 0 24 24"
-              width="12"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
-              />
-              <path
-                d="M12 9v4"
-              />
-              <path
-                d="M12 17h.01"
-              />
-            </svg>
-            Complete: 
-            Goal, Provider
-          </span>
-        </div>
+          class="flex-1 text-xs text-danger"
+        />
         <button
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 text-foreground hover:bg-muted h-8 px-3 text-sm"
           type="button"
@@ -2834,7 +2437,6 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
         <button
           class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 px-3 text-sm"
           disabled=""
-          title="Complete: Goal, Provider"
           type="button"
         >
           Create session

--- a/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, cn } from '@kay-am/ui';
+import { Button, Textarea, cn } from '@kay-am/ui';
 import { PlannerClient, type PlannerOutput, defaultsForRole } from '@kay-am/core';
 import type {
   AgentEffort,
@@ -153,16 +153,18 @@ export function PlannerWidget({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="relative rounded-md border border-border/30 bg-background shadow-sm transition-[border-color,box-shadow] focus-within:border-primary/40 focus-within:shadow-md focus-within:ring-1 focus-within:ring-primary/15">
-        <textarea
-          value={theme}
-          onChange={(e) => setTheme(e.target.value)}
-          placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
-          rows={5}
-          className="block w-full resize-none border-0 bg-transparent px-3 pb-12 pt-3 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
-        />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-end p-2">
-          <div className="pointer-events-auto">
+      <div className="rounded-2xl bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15">
+        <div className="relative">
+          <Textarea
+            value={theme}
+            onChange={(e) => setTheme(e.target.value)}
+            placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
+            autoGrow
+            minRows={5}
+            maxRows={10}
+            className="min-h-24 resize-none border-0 bg-transparent px-4 pt-3 pb-12 text-sm shadow-none focus-visible:ring-0"
+          />
+          <div className="absolute bottom-2.5 right-2.5">
             <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
               {planButtonLabel}
             </Button>

--- a/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
@@ -153,18 +153,26 @@ export function PlannerWidget({
 
   return (
     <div className="flex flex-col gap-2">
-      <Textarea
-        value={theme}
-        onChange={(e) => setTheme(e.target.value)}
-        placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
-        autoGrow
-        maxRows={5}
-      />
-      <div className="flex items-center justify-end gap-2">
-        <span className="mr-auto text-2xs text-muted-foreground/60">cheap-tier · {providerId}</span>
-        <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
-          {planButtonLabel}
-        </Button>
+      <div className="relative rounded-md border border-border/30 bg-background shadow-sm transition-[border-color,box-shadow] focus-within:border-primary/40 focus-within:shadow-md focus-within:ring-1 focus-within:ring-primary/15">
+        <Textarea
+          value={theme}
+          onChange={(e) => setTheme(e.target.value)}
+          placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
+          autoGrow
+          minRows={5}
+          maxRows={10}
+          className="!border-0 !shadow-none !bg-transparent pb-12 focus-visible:!ring-0 focus-visible:!shadow-none focus-visible:!border-0"
+        />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-end p-2">
+          <div className="pointer-events-auto">
+            <Button size="sm" onClick={onPlan} disabled={busy || theme.trim().length === 0}>
+              {planButtonLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-end px-1">
+        <span className="text-2xs text-muted-foreground/60">cheap-tier · {providerId}</span>
       </div>
       {error ? (
         <p role="alert" className="text-xs text-danger">

--- a/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlannerWidget/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { Button, Textarea, cn } from '@kay-am/ui';
+import { Button, cn } from '@kay-am/ui';
 import { PlannerClient, type PlannerOutput, defaultsForRole } from '@kay-am/core';
 import type {
   AgentEffort,
@@ -154,14 +154,12 @@ export function PlannerWidget({
   return (
     <div className="flex flex-col gap-2">
       <div className="relative rounded-md border border-border/30 bg-background shadow-sm transition-[border-color,box-shadow] focus-within:border-primary/40 focus-within:shadow-md focus-within:ring-1 focus-within:ring-primary/15">
-        <Textarea
+        <textarea
           value={theme}
           onChange={(e) => setTheme(e.target.value)}
           placeholder="describe the theme: e.g. migrate auth to oauth, add dark mode toggle…"
-          autoGrow
-          minRows={5}
-          maxRows={10}
-          className="!border-0 !shadow-none !bg-transparent pb-12 focus-visible:!ring-0 focus-visible:!shadow-none focus-visible:!border-0"
+          rows={5}
+          className="block w-full resize-none border-0 bg-transparent px-3 pb-12 pt-3 text-sm leading-5 text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-0"
         />
         <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-end p-2">
           <div className="pointer-events-auto">

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -339,6 +339,7 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
                 onChange={setExistingBranch}
                 disabled={busy || branchesLoading}
                 loading={branchesLoading}
+                openDirection="up"
               />
             )}
           </div>

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,56 +1,11 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useState } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
-import {
-  AlertTriangle,
-  Bot,
-  Check,
-  ChevronDown,
-  DollarSign,
-  GitBranch,
-  Layers,
-  Loader2,
-  Sparkles,
-  Terminal,
-  Target,
-  Wand2,
-  Zap,
-  X,
-} from 'lucide-react';
-import type {
-  Workflow,
-  WorkflowId,
-  ProviderId,
-  SessionId,
-  SessionProviderPreference,
-  WorkspaceId,
-} from '@kay-am/types';
-import { getDefaultTurnModel } from '@kay-am/core';
-import { shortModel } from '../../../../features/session/agent-row-format';
-import {
-  AGENT_KIND_META,
-  AGENT_KIND_ORDER,
-  AGENT_KIND_PALETTE,
-  inferAgentKindFromName,
-  type AgentKind,
-} from '../../../../features/session/agent-kind';
-import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
-import {
-  type EffortLevel,
-  type VerbosityLevel,
-  modelEffortLevels,
-  InlineField,
-  ModelSelect,
-  EffortSelect,
-  VerbositySelect,
-} from '../config-selects';
+import { Loader2, Wand2 } from 'lucide-react';
+import type { ProviderId, WorkspaceId } from '@kay-am/types';
 import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../../../../features/settings/settings';
-import { STORAGE_PREFIXES } from '../../../../shared/lib/storage-keys';
-import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
-import { EMPTY_ARRAY, useAppStore } from '../../../../store';
-import { PlannerWidget } from '../../../../features/plans/components/PlannerWidget';
+import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
-import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
 import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 
@@ -77,44 +32,6 @@ function formatError(err: unknown): string {
 }
 
 const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
-
-type WorkflowMode = 'single' | 'preset' | 'custom';
-
-interface WorkflowModeMeta {
-  readonly id: WorkflowMode;
-  readonly label: string;
-  readonly tagline: string;
-  readonly description: string;
-  readonly icon: typeof Bot;
-  readonly beta?: boolean;
-}
-
-const WORKFLOW_MODES: ReadonlyArray<WorkflowModeMeta> = [
-  {
-    id: 'single',
-    label: 'Single agent',
-    tagline: 'Solo chat session',
-    description:
-      'One agent, one conversation. Spawn more agents from the sidebar as the work unfolds.',
-    icon: Bot,
-  },
-  {
-    id: 'preset',
-    label: 'Workflow preset',
-    tagline: 'Run a saved blueprint',
-    description: 'Pick a preset workflow. Each step spawns its own agent in order.',
-    icon: Layers,
-    beta: true,
-  },
-  {
-    id: 'custom',
-    label: 'Custom plan',
-    tagline: 'Designed for this goal',
-    description: 'Let the planner draft a workflow tailored to your goal, then run it.',
-    icon: Sparkles,
-    beta: true,
-  },
-];
 
 function pickDefaultProvider(connectedIds: ReadonlySet<ProviderId>): ProviderId {
   for (const id of PROVIDER_ORDER) {
@@ -222,28 +139,16 @@ async function generateBranchSlug(goal: string, providerId: ProviderId): Promise
     .join('-');
 }
 
-export function NewSessionDialog({
-  open,
-  onClose,
-  workspaceId,
-  onOpenSettings,
-}: NewSessionDialogProps) {
+export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialogProps) {
   const createSession = useAppStore((s) => s.createSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
-  const setSessionBudget = useAppStore((s) => s.setSessionBudget);
-  const { showToast } = useToast();
   const providers = useAppStore((s) => s.providers);
+  const { showToast } = useToast();
   const settingKey = settingBranchPrefix(workspaceId);
-  const phaseTemplates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? EMPTY_ARRAY);
-  const loadInitScript = useAppStore((s) => s.loadInitScript);
-  const workspaceInitScript = useAppStore((s) => s.workspaceInitScripts?.[workspaceId] ?? null);
+  const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
 
   const [goal, setGoal] = useState('');
-
   const [branchSlug, setBranchSlug] = useState('');
-  // Tracks whether the user has manually edited the slug. While false, the
-  // slug stays linked to the goal (live slugify). Once true, edits no longer
-  // overwrite their manual value.
   const [slugTouched, setSlugTouched] = useState(false);
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [slugGenerating, setSlugGenerating] = useState(false);
@@ -251,72 +156,12 @@ export function NewSessionDialog({
   const [existingBranches, setExistingBranches] = useState<ReadonlyArray<LocalBranchInfo>>([]);
   const [existingBranch, setExistingBranch] = useState<string>('');
   const [branchesLoading, setBranchesLoading] = useState(false);
-  const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
-
-  const [softCapRaw, setSoftCapRaw] = useState('');
-  const [workflowMode, setWorkflowMode] = useState<WorkflowMode>('single');
-  const [presetTemplateId, setPresetTemplateId] = useState<WorkflowId | ''>('');
-  const [customTemplateId, setCustomTemplateId] = useState<WorkflowId | ''>('');
-  const selectedPhaseTemplateId =
-    workflowMode === 'preset'
-      ? presetTemplateId
-      : workflowMode === 'custom'
-        ? customTemplateId
-        : '';
-  const setSelectedPhaseTemplateId =
-    workflowMode === 'preset' ? setPresetTemplateId : setCustomTemplateId;
-  const [firstAgentKind, setFirstAgentKind] = useState<AgentKind>('generic');
-  const [autoRun, setAutoRun] = useState(false);
-  const [effort, setEffort] = useState<EffortLevel>('medium');
-  const [verbosity, setVerbosity] = useState<VerbosityLevel>('normal');
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const [hasCustomPlan, setHasCustomPlan] = useState(false);
-  const [pendingProviderSwitch, setPendingProviderSwitch] = useState<ProviderId | null>(null);
-  const [initEnabled, setInitEnabled] = useState(true);
-  const [initContent, setInitContent] = useState('');
-
-  const [selectedProvider, setSelectedProvider] = useState<ProviderId>(() => {
-    const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
-    return pickDefaultProvider(ids);
-  });
-
-  const requestProviderChange = (nextProvider: ProviderId) => {
-    if (nextProvider === selectedProvider) return;
-    if (hasCustomPlan || customTemplateId !== '' || presetTemplateId !== '') {
-      setPendingProviderSwitch(nextProvider);
-    } else {
-      setSelectedProvider(nextProvider);
-    }
-  };
-
-  const confirmProviderSwitch = () => {
-    if (!pendingProviderSwitch) return;
-    setSelectedProvider(pendingProviderSwitch);
-    setPresetTemplateId('');
-    setCustomTemplateId('');
-    setHasCustomPlan(false);
-    setPendingProviderSwitch(null);
-  };
-  const [selectedModel, setSelectedModel] = useState<string>(() =>
-    getDefaultTurnModel(
-      pickDefaultProvider(
-        new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
-      ),
-    ),
+  const defaultProvider = pickDefaultProvider(
+    new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
-
-  useEffect(() => {
-    setSelectedModel(getDefaultTurnModel(selectedProvider));
-  }, [selectedProvider]);
-
-  useEffect(() => {
-    const levels = modelEffortLevels(selectedModel);
-    if (levels && !levels.includes(effort)) {
-      setEffort(levels.includes('medium') ? 'medium' : levels[0]!);
-    }
-  }, [selectedModel, effort]);
 
   useEffect(() => {
     if (!open) return;
@@ -326,28 +171,11 @@ export function NewSessionDialog({
     setSlugGenerating(false);
     setBranchMode('new');
     setExistingBranch('');
-    setSoftCapRaw('');
-    setPresetTemplateId('');
-    setCustomTemplateId('');
-    setHasCustomPlan(false);
-    setFirstAgentKind('generic');
-    setWorkflowMode('single');
-    setAutoRun(false);
-    setEffort('medium');
-    setVerbosity('normal');
     setError(null);
-    setInitEnabled(true);
-    setInitContent('');
+    setBusy(false);
     void loadSetting(settingKey).then((value) => {
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
-    if (WORKSPACE_FEATURES.initScript && loadInitScript) {
-      void loadInitScript(workspaceId);
-    }
-    const ids = new Set(providers.filter((p) => p.connection === 'connected').map((p) => p.id));
-    const provider = pickDefaultProvider(ids);
-    setSelectedProvider(provider);
-    setSelectedModel(getDefaultTurnModel(provider));
     if (workspace?.rootPath) {
       setBranchesLoading(true);
       listLocalBranches(workspace.rootPath)
@@ -355,13 +183,8 @@ export function NewSessionDialog({
         .catch(() => setExistingBranches([]))
         .finally(() => setBranchesLoading(false));
     }
-  }, [open, settingKey, loadSetting, providers, workspaceId, workspace?.rootPath, loadInitScript]);
+  }, [open, settingKey, loadSetting, workspaceId, workspace?.rootPath]);
 
-  useEffect(() => {
-    if (open && workspaceInitScript) setInitContent(workspaceInitScript);
-  }, [open, workspaceInitScript]);
-
-  // Live slug derivation from goal while the user hasn't manually edited it.
   useEffect(() => {
     if (slugTouched) return;
     setBranchSlug(slugifyLive(goal));
@@ -371,7 +194,7 @@ export function NewSessionDialog({
     const trimmed = goal.trim();
     if (!trimmed || slugGenerating) return;
     setSlugGenerating(true);
-    generateBranchSlug(trimmed, selectedProvider)
+    generateBranchSlug(trimmed, defaultProvider)
       .then((slug) => {
         setBranchSlug(slug);
         setSlugTouched(true);
@@ -384,63 +207,24 @@ export function NewSessionDialog({
       });
   };
 
-  const reset = () => {
-    setGoal('');
-    setBranchSlug('');
-    setSlugTouched(false);
-    setSlugGenerating(false);
-    setSoftCapRaw('');
-    setPresetTemplateId('');
-    setCustomTemplateId('');
-    setHasCustomPlan(false);
-    setFirstAgentKind('generic');
-    setWorkflowMode('single');
-    setAutoRun(false);
-    setEffort('medium');
-    setVerbosity('normal');
-    setInitEnabled(true);
-    setInitContent('');
-    setError(null);
-  };
+  const branchReady =
+    branchMode === 'new' ? isValidBranchSlug(branchSlug) : existingBranch.trim().length > 0;
+  const goalReady = goal.trim().length > 0;
+  const canCreate = goalReady && branchReady && !busy;
 
   const onCreate = async () => {
     setError(null);
     setBusy(true);
     try {
-      const providerPreference: SessionProviderPreference = {
-        defaultProvider: selectedProvider,
-        defaultModel: selectedModel,
-        allowTurnOverride: true,
-      };
-      const hasWorkflow = selectedPhaseTemplateId !== '';
       const useExisting = branchMode === 'existing' && existingBranch.trim().length > 0;
       const { session } = await createSession({
         workspaceId,
         goal,
-        branchPrefix: branchPrefix.trim() || DEFAULT_BRANCH_PREFIX,
+        branchPrefix: sanitizePrefix(branchPrefix).trim() || DEFAULT_BRANCH_PREFIX,
         branchSlug: branchSlug.trim() || undefined,
         ...(useExisting ? { existingBranch: existingBranch.trim() } : {}),
-        providerPreference,
-        ...(hasWorkflow ? { workflowId: selectedPhaseTemplateId as WorkflowId } : {}),
-        ...(hasWorkflow && autoRun ? { autoRun: true } : {}),
-        ...(!hasWorkflow ? { firstAgentKind, firstAgentModel: selectedModel } : {}),
-        ...(!initEnabled ? { skipInit: true } : {}),
-        ...(initContent !== (workspaceInitScript ?? '')
-          ? { initContentOverride: initContent }
-          : {}),
       });
-      const parsedCap = parseCap(softCapRaw);
-      if (parsedCap !== null) {
-        await setSessionBudget(session.id as SessionId, parsedCap);
-      }
-      try {
-        localStorage.setItem(`${STORAGE_PREFIXES.effort}${session.id}`, effort);
-        localStorage.setItem(`${STORAGE_PREFIXES.verbosity}${session.id}`, verbosity);
-      } catch {
-        // localStorage unavailable
-      }
       showToast('success', `session created: ${session.goal}`);
-      reset();
       onClose();
     } catch (err) {
       setError(formatError(err));
@@ -449,116 +233,20 @@ export function NewSessionDialog({
     }
   };
 
-  const connectedProviderIds = new Set(
-    providers.filter((p) => p.connection === 'connected').map((p) => p.id),
-  );
-
-  type SectionId = 'goal' | 'budget' | 'workflow' | 'provider' | 'init';
-  const [activeSection, setActiveSection] = useState<SectionId>('goal');
-
-  const branchReady =
-    branchMode === 'new' ? isValidBranchSlug(branchSlug) : existingBranch.trim().length > 0;
-  const goalReady = goal.trim().length > 0 && branchReady;
-  const budgetReady = softCapRaw.trim().length > 0;
-  const workflowReady =
-    workflowMode === 'single' ||
-    selectedPhaseTemplateId !== '' ||
-    (workflowMode === 'custom' && hasCustomPlan);
-  const providerReady = connectedProviderIds.has(selectedProvider);
-
-  const sections: ReadonlyArray<{
-    id: SectionId;
-    label: string;
-    icon: ReactNode;
-    ready: boolean;
-    required: boolean;
-  }> = [
-    {
-      id: 'goal',
-      label: 'Goal',
-      icon: <Target size={13} aria-hidden />,
-      ready: goalReady,
-      required: true,
-    },
-    {
-      id: 'provider',
-      label: 'Provider',
-      icon: <Zap size={13} aria-hidden />,
-      ready: providerReady,
-      required: true,
-    },
-    {
-      id: 'workflow',
-      label: 'Workflow',
-      icon: <Layers size={13} aria-hidden />,
-      ready: workflowReady,
-      required: true,
-    },
-    ...(WORKSPACE_FEATURES.initScript && workspaceInitScript
-      ? [
-          {
-            id: 'init' as const,
-            label: 'Init',
-            icon: <Terminal size={13} aria-hidden />,
-            ready: initEnabled,
-            required: false,
-          },
-        ]
-      : []),
-    ...(SESSION_FEATURES.budget
-      ? [
-          {
-            id: 'budget' as const,
-            label: 'Budget',
-            icon: <DollarSign size={13} aria-hidden />,
-            ready: budgetReady,
-            required: false,
-          },
-        ]
-      : []),
-  ];
-
-  const onWorkflowModeChange = (next: WorkflowMode) => {
-    setWorkflowMode(next);
-  };
-
-  const missingRequired = sections.filter((s) => s.required && !s.ready);
-  const canCreate = missingRequired.length === 0 && !busy;
-
   return (
     <Dialog
       open={open}
       onClose={onClose}
       title="New session"
-      description="Creates a worktree on a fresh branch from the workspace root."
-      size="xl"
-      className="w-[68rem] max-w-[95vw]"
-      fixedHeightClass="h-[680px]"
-      bodyClassName="px-0 py-0 gap-0"
+      description="Creates a worktree on a fresh branch. Configure workflow and agents from the session panel afterwards."
+      size="md"
       footer={
         <div className="flex w-full items-center gap-2">
-          <div className="flex-1">
-            {error ? (
-              <span className="text-xs text-danger">{error}</span>
-            ) : missingRequired.length > 0 ? (
-              <span className="inline-flex items-center gap-1 text-xs text-warning">
-                <AlertTriangle size={12} aria-hidden />
-                Complete: {missingRequired.map((s) => s.label).join(', ')}
-              </span>
-            ) : null}
-          </div>
+          <div className="flex-1 text-xs text-danger">{error ?? ''}</div>
           <Button variant="ghost" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button
-            onClick={() => void onCreate()}
-            disabled={!canCreate}
-            title={
-              missingRequired.length > 0
-                ? `Complete: ${missingRequired.map((s) => s.label).join(', ')}`
-                : undefined
-            }
-          >
+          <Button onClick={() => void onCreate()} disabled={!canCreate}>
             {busy ? (
               <>
                 <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
@@ -571,1142 +259,135 @@ export function NewSessionDialog({
         </div>
       }
     >
-      <div className="flex h-full min-h-0">
-        {/* Fixed ladder — never scrolls */}
-        <nav className="flex w-48 shrink-0 flex-col gap-0.5 border-r border-border-soft bg-subtle/40 px-3 py-5">
-          {sections.map((s) => (
-            <button
-              key={s.id}
-              type="button"
-              onClick={() => setActiveSection(s.id as SectionId)}
-              title={s.required && !s.ready ? `${s.label.toLowerCase()} is required` : undefined}
-              className={cn(
-                'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
-                activeSection === s.id
-                  ? 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
-                  : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
-              )}
-            >
-              {s.icon}
-              <span className="flex-1">{s.label}</span>
-              {s.ready ? (
-                <Check size={11} className="text-success" aria-label="filled" />
-              ) : s.required ? (
-                <AlertTriangle
-                  size={11}
-                  className="text-warning"
-                  aria-label={`${s.label.toLowerCase()} required`}
-                />
-              ) : null}
-            </button>
-          ))}
-        </nav>
-
-        {/* Only this column scrolls */}
-        <div className="min-w-0 flex-1 overflow-y-auto px-8 py-6">
-          {activeSection === 'goal' ? (
-            <GoalSection
-              goal={goal}
-              setGoal={setGoal}
-              branchSlug={branchSlug}
-              setBranchSlug={(v) => {
-                setBranchSlug(v);
-                setSlugTouched(true);
-              }}
-              slugGenerating={slugGenerating}
-              branchPrefix={branchPrefix}
-              setBranchPrefix={setBranchPrefix}
-              branchMode={branchMode}
-              setBranchMode={setBranchMode}
-              existingBranches={existingBranches}
-              existingBranch={existingBranch}
-              setExistingBranch={setExistingBranch}
-              branchesLoading={branchesLoading}
-              busy={busy}
-              onGenerateSlug={handleGenerateSlug}
-            />
-          ) : null}
-
-          {activeSection === 'workflow' ? (
-            <WorkflowSection
-              workflowMode={workflowMode}
-              onModeChange={onWorkflowModeChange}
-              phaseTemplates={phaseTemplates}
-              selectedPhaseTemplateId={selectedPhaseTemplateId}
-              setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
-              customTemplateId={customTemplateId}
-              setCustomTemplateId={setCustomTemplateId}
-              workspaceId={workspaceId}
-              selectedProvider={selectedProvider}
-              selectedModel={selectedModel}
-              setSelectedModel={setSelectedModel}
-              firstAgentKind={firstAgentKind}
-              setFirstAgentKind={setFirstAgentKind}
-              effort={effort}
-              setEffort={setEffort}
-              verbosity={verbosity}
-              setVerbosity={setVerbosity}
-              autoRun={autoRun}
-              setAutoRun={setAutoRun}
-              goal={goal}
-              busy={busy}
-              providerReady={providerReady}
-              onPlanChange={setHasCustomPlan}
-            />
-          ) : null}
-
-          {activeSection === 'provider' ? (
-            <ProviderSection
-              connectedProviderIds={connectedProviderIds}
-              selectedProvider={selectedProvider}
-              onRequestChange={requestProviderChange}
-              pendingProviderSwitch={pendingProviderSwitch}
-              onCancelSwitch={() => setPendingProviderSwitch(null)}
-              onConfirmSwitch={confirmProviderSwitch}
-              onClose={onClose}
-              onOpenSettings={onOpenSettings}
-            />
-          ) : null}
-
-          {activeSection === 'init' ? (
-            <InitSection
-              initEnabled={initEnabled}
-              setInitEnabled={setInitEnabled}
-              initContent={initContent}
-              setInitContent={setInitContent}
-              busy={busy}
-            />
-          ) : null}
-
-          {activeSection === 'budget' ? (
-            <BudgetSection softCapRaw={softCapRaw} setSoftCapRaw={setSoftCapRaw} busy={busy} />
-          ) : null}
-        </div>
+      <div className="flex flex-col gap-4">
+        <Field label="Goal" hint="What this session should accomplish.">
+          <Textarea
+            value={goal}
+            placeholder="Refactor auth domain"
+            onChange={(e) => setGoal(e.target.value)}
+            autoGrow
+            minRows={4}
+            maxRows={12}
+            autoFocus
+            disabled={busy}
+          />
+        </Field>
+        <Field label="Branch" hint="Worktree branch for this session.">
+          <div className="flex flex-col gap-2">
+            <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
+            {branchMode === 'new' ? (
+              <div className="flex items-center gap-1.5">
+                <span className="shrink-0 text-xs text-muted-foreground font-mono">
+                  {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
+                </span>
+                {slugGenerating ? (
+                  <span className="flex h-8 flex-1 animate-pulse items-center rounded border border-border bg-subtle px-2">
+                    <span className="h-2 w-full rounded bg-muted-foreground/20" />
+                  </span>
+                ) : (
+                  <Input
+                    value={branchSlug}
+                    onChange={(e) => {
+                      setBranchSlug(e.target.value);
+                      setSlugTouched(true);
+                    }}
+                    placeholder="branch-slug"
+                    className="h-8 flex-1 font-mono text-sm"
+                    disabled={busy}
+                    aria-label="Branch slug"
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={handleGenerateSlug}
+                  disabled={!goal.trim() || slugGenerating || busy}
+                  title="Generate from goal"
+                  aria-label="Generate branch name"
+                  className={cn(
+                    'shrink-0 rounded-md border border-border px-2 py-1.5 text-xs transition-colors',
+                    goal.trim() && !slugGenerating && !busy
+                      ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      : 'cursor-not-allowed text-muted-foreground/30',
+                  )}
+                >
+                  <Wand2 size={13} aria-hidden />
+                </button>
+              </div>
+            ) : (
+              <BranchCombobox
+                branches={existingBranches}
+                value={existingBranch}
+                onChange={setExistingBranch}
+                disabled={busy || branchesLoading}
+                loading={branchesLoading}
+              />
+            )}
+          </div>
+        </Field>
       </div>
     </Dialog>
   );
 }
 
-/* ──────────────────────────────────────────────────────────────────── */
-/* Section: Goal + branch                                                */
-/* ──────────────────────────────────────────────────────────────────── */
-
-interface GoalSectionProps {
-  readonly goal: string;
-  readonly setGoal: (v: string) => void;
-  readonly branchSlug: string;
-  readonly setBranchSlug: (v: string) => void;
-  readonly slugGenerating: boolean;
-  readonly branchPrefix: string;
-  readonly setBranchPrefix: (v: string) => void;
-  readonly branchMode: 'new' | 'existing';
-  readonly setBranchMode: (m: 'new' | 'existing') => void;
-  readonly existingBranches: ReadonlyArray<LocalBranchInfo>;
-  readonly existingBranch: string;
-  readonly setExistingBranch: (v: string) => void;
-  readonly branchesLoading: boolean;
-  readonly busy: boolean;
-  readonly onGenerateSlug: () => void;
-}
-
-function GoalSection({
-  goal,
-  setGoal,
-  branchSlug,
-  setBranchSlug,
-  slugGenerating,
-  branchPrefix,
-  setBranchPrefix,
-  branchMode,
-  setBranchMode,
-  existingBranches,
-  existingBranch,
-  setExistingBranch,
-  branchesLoading,
-  busy,
-  onGenerateSlug,
-}: GoalSectionProps) {
-  // Live-derived slug used when goal is set. Visible-only branch preview
-  // string so the user sees the final shape.
-  const fullBranch = `${branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/${branchSlug || 'branch-slug'}`;
-
-  return (
-    <div className="flex flex-col gap-7">
-      <SectionHeader
-        icon={<Target size={14} aria-hidden className="text-primary" />}
-        title="What needs to get done?"
-        subtitle="Describe the task in plain English. We'll create a worktree and route it to an agent."
-      />
-
-      <div className="flex flex-col gap-2">
-        <Textarea
-          value={goal}
-          placeholder="e.g. Refactor the auth middleware to use the new session adapter and drop the legacy cookie path."
-          onChange={(e) => setGoal(e.target.value)}
-          autoGrow
-          minRows={4}
-          maxRows={14}
-          autoFocus
-          disabled={busy}
-          className="text-sm leading-relaxed"
-        />
-        <p className="text-2xs leading-relaxed text-muted-foreground/70">
-          Tip: a clear, imperative sentence yields a better branch name and helps agents stay
-          focused.
-        </p>
-      </div>
-
-      {/* Branch — compact, prefix + slug live preview */}
-      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
-            <GitBranch size={13} aria-hidden className="text-muted-foreground" />
-            <span className="text-xs font-semibold text-foreground">Branch</span>
-          </div>
-          <button
-            type="button"
-            onClick={() => setBranchMode(branchMode === 'new' ? 'existing' : 'new')}
-            className="text-2xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
-          >
-            {branchMode === 'new' ? 'use existing branch instead' : 'create new branch instead'}
-          </button>
-        </div>
-
-        {branchMode === 'new' ? (
-          <>
-            <div className="flex items-stretch gap-1 rounded-md border border-border bg-background px-1.5 py-1 font-mono text-sm focus-within:border-primary">
-              <input
-                type="text"
-                value={branchPrefix}
-                onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
-                disabled={busy}
-                placeholder={DEFAULT_BRANCH_PREFIX}
-                aria-label="Branch prefix"
-                title="Branch prefix (editable). Saved per workspace."
-                className="w-[5.5rem] bg-transparent px-1.5 py-1 text-muted-foreground outline-none placeholder:text-muted-foreground/40"
-              />
-              <span className="flex select-none items-center text-muted-foreground/50">/</span>
-              {slugGenerating ? (
-                <span className="flex flex-1 animate-pulse items-center px-1.5">
-                  <span className="h-2 w-1/2 rounded bg-muted-foreground/20" />
-                </span>
-              ) : (
-                <input
-                  type="text"
-                  value={branchSlug}
-                  onChange={(e) => setBranchSlug(slugifyLive(e.target.value))}
-                  placeholder="branch-slug"
-                  disabled={busy}
-                  aria-label="Branch slug"
-                  className="flex-1 bg-transparent px-1.5 py-1 text-foreground outline-none placeholder:text-muted-foreground/40"
-                />
-              )}
-              <button
-                type="button"
-                onClick={onGenerateSlug}
-                disabled={!goal.trim() || slugGenerating || busy}
-                title="Generate a better name from your goal"
-                aria-label="Generate branch name"
-                className={cn(
-                  'flex shrink-0 items-center justify-center rounded px-2 transition-colors',
-                  goal.trim() && !slugGenerating && !busy
-                    ? 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                    : 'cursor-not-allowed text-muted-foreground/30',
-                )}
-              >
-                <Wand2 size={13} aria-hidden />
-              </button>
-            </div>
-            <p className="flex items-center gap-1.5 text-2xs text-muted-foreground/70">
-              <span>Preview:</span>
-              <span className="font-mono text-muted-foreground">{fullBranch}</span>
-            </p>
-          </>
-        ) : (
-          <BranchCombobox
-            branches={existingBranches}
-            value={existingBranch}
-            onChange={setExistingBranch}
-            disabled={busy || branchesLoading}
-            loading={branchesLoading}
-          />
-        )}
-      </div>
-    </div>
-  );
-}
-
-/* ──────────────────────────────────────────────────────────────────── */
-/* Section: Workflow                                                     */
-/* ──────────────────────────────────────────────────────────────────── */
-
-interface WorkflowSectionProps {
-  readonly workflowMode: WorkflowMode;
-  readonly onModeChange: (m: WorkflowMode) => void;
-  readonly phaseTemplates: ReadonlyArray<Workflow>;
-  readonly selectedPhaseTemplateId: WorkflowId | '';
-  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
-  readonly customTemplateId: WorkflowId | '';
-  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
-  readonly workspaceId: WorkspaceId;
-  readonly selectedProvider: ProviderId;
-  readonly selectedModel: string;
-  readonly setSelectedModel: (m: string) => void;
-  readonly firstAgentKind: AgentKind;
-  readonly setFirstAgentKind: (k: AgentKind) => void;
-  readonly effort: EffortLevel;
-  readonly setEffort: (e: EffortLevel) => void;
-  readonly verbosity: VerbosityLevel;
-  readonly setVerbosity: (v: VerbosityLevel) => void;
-  readonly autoRun: boolean;
-  readonly setAutoRun: (v: boolean) => void;
-  readonly goal: string;
-  readonly busy: boolean;
-  readonly providerReady: boolean;
-  readonly onPlanChange: (v: boolean) => void;
-}
-
-function WorkflowSection(props: WorkflowSectionProps) {
-  const {
-    workflowMode,
-    onModeChange,
-    phaseTemplates,
-    selectedPhaseTemplateId,
-    setSelectedPhaseTemplateId,
-    customTemplateId,
-    setCustomTemplateId,
-    workspaceId,
-    selectedProvider,
-    selectedModel,
-    setSelectedModel,
-    firstAgentKind,
-    setFirstAgentKind,
-    effort,
-    setEffort,
-    verbosity,
-    setVerbosity,
-    autoRun,
-    setAutoRun,
-    goal,
-    busy,
-    providerReady,
-    onPlanChange,
-  } = props;
-
-  return (
-    <div className="flex flex-col gap-6">
-      <SectionHeader
-        icon={<Layers size={14} aria-hidden className="text-primary" />}
-        title="How should the session run?"
-        subtitle="Pick a shape. You can always evolve it once the session is live."
-      />
-
-      {/* 3-card grid */}
-      <div className="grid grid-cols-3 gap-3">
-        {WORKFLOW_MODES.map((m) => {
-          const Icon = m.icon;
-          const active = workflowMode === m.id;
-          return (
-            <button
-              key={m.id}
-              type="button"
-              onClick={() => onModeChange(m.id)}
-              aria-pressed={active}
-              className={cn(
-                'group relative flex flex-col items-start gap-2 rounded-lg border p-3.5 text-left transition-all',
-                active
-                  ? 'border-primary bg-primary/5 shadow-sm ring-1 ring-primary/20'
-                  : 'border-border-soft bg-background hover:-translate-y-0.5 hover:border-border hover:bg-subtle/40 hover:shadow-sm',
-              )}
-            >
-              <div className="flex w-full items-center justify-between">
-                <span
-                  className={cn(
-                    'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
-                    active
-                      ? 'bg-primary/15 text-primary'
-                      : 'bg-muted/60 text-muted-foreground group-hover:bg-muted',
-                  )}
-                >
-                  <Icon size={15} aria-hidden />
-                </span>
-                <div className="flex items-center gap-1">
-                  {m.beta ? (
-                    <span className="rounded bg-warning/20 px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide text-warning">
-                      beta
-                    </span>
-                  ) : null}
-                  {active ? (
-                    <span className="flex h-4 w-4 items-center justify-center rounded-full bg-primary text-primary-foreground">
-                      <Check size={10} aria-hidden />
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-              <div className="flex flex-col gap-0.5">
-                <span
-                  className={cn(
-                    'text-sm font-semibold leading-tight',
-                    active ? 'text-foreground' : 'text-foreground/90',
-                  )}
-                >
-                  {m.label}
-                </span>
-                <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
-                  {m.tagline}
-                </span>
-              </div>
-              <p className="text-2xs leading-relaxed text-muted-foreground">{m.description}</p>
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Mode-specific body */}
-      <div className="rounded-lg border border-border-soft bg-subtle/30 p-4">
-        {workflowMode === 'single' ? (
-          <SingleAgentPanel
-            firstAgentKind={firstAgentKind}
-            setFirstAgentKind={setFirstAgentKind}
-            selectedProvider={selectedProvider}
-            selectedModel={selectedModel}
-            setSelectedModel={setSelectedModel}
-            effort={effort}
-            setEffort={setEffort}
-            verbosity={verbosity}
-            setVerbosity={setVerbosity}
-            providerReady={providerReady}
-            busy={busy}
-          />
-        ) : null}
-
-        {workflowMode === 'preset' ? (
-          <PresetPanel
-            phaseTemplates={phaseTemplates}
-            selectedPhaseTemplateId={selectedPhaseTemplateId}
-            setSelectedPhaseTemplateId={setSelectedPhaseTemplateId}
-            onSwitchToCustom={() => onModeChange('custom')}
-            busy={busy}
-          />
-        ) : null}
-
-        {workflowMode === 'custom' ? (
-          <CustomPanel
-            phaseTemplates={phaseTemplates}
-            customTemplateId={customTemplateId}
-            setCustomTemplateId={setCustomTemplateId}
-            workspaceId={workspaceId}
-            selectedProvider={selectedProvider}
-            goal={goal}
-            onPlanChange={onPlanChange}
-          />
-        ) : null}
-      </div>
-
-      {workflowMode !== 'single' && selectedPhaseTemplateId !== '' ? (
-        <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
-          <input
-            type="checkbox"
-            checked={autoRun}
-            onChange={(e) => setAutoRun(e.target.checked)}
-            className="mt-0.5 accent-primary"
-          />
-          <span className="flex flex-col gap-0.5">
-            <span className="flex items-center gap-1.5 font-medium text-foreground">
-              Run autonomously
-              <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                beta
-              </span>
-            </span>
-            <span className="text-muted-foreground">
-              Auto-spawn each step on completion. Pauses on error or budget exceed.
-            </span>
-          </span>
-        </label>
-      ) : null}
-    </div>
-  );
-}
-
-interface SingleAgentPanelProps {
-  readonly firstAgentKind: AgentKind;
-  readonly setFirstAgentKind: (k: AgentKind) => void;
-  readonly selectedProvider: ProviderId;
-  readonly selectedModel: string;
-  readonly setSelectedModel: (m: string) => void;
-  readonly effort: EffortLevel;
-  readonly setEffort: (e: EffortLevel) => void;
-  readonly verbosity: VerbosityLevel;
-  readonly setVerbosity: (v: VerbosityLevel) => void;
-  readonly providerReady: boolean;
-  readonly busy: boolean;
-}
-
-function SingleAgentPanel({
-  firstAgentKind,
-  setFirstAgentKind,
-  selectedProvider,
-  selectedModel,
-  setSelectedModel,
-  effort,
-  setEffort,
-  verbosity,
-  setVerbosity,
-  providerReady,
-  busy,
-}: SingleAgentPanelProps) {
-  return (
-    <div className="flex flex-col gap-4">
-      <PanelHeader
-        title="Configure the first agent"
-        subtitle="One conversation, ready to talk. You can spawn more agents from the sidebar anytime."
-      />
-      <Field label="Agent role" hint="Sets the system prompt and default tools.">
-        <AgentKindSelect value={firstAgentKind} onChange={setFirstAgentKind} disabled={busy} />
-      </Field>
-      <div className="grid grid-cols-3 gap-3">
-        <InlineField label="Model">
-          <ModelSelect
-            provider={selectedProvider}
-            value={selectedModel}
-            onChange={setSelectedModel}
-            disabled={busy || !providerReady}
-          />
-        </InlineField>
-        <InlineField label="Effort">
-          <EffortSelect model={selectedModel} value={effort} onChange={setEffort} disabled={busy} />
-        </InlineField>
-        <InlineField label="Verbosity">
-          <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
-        </InlineField>
-      </div>
-    </div>
-  );
-}
-
-interface PresetPanelProps {
-  readonly phaseTemplates: ReadonlyArray<Workflow>;
-  readonly selectedPhaseTemplateId: WorkflowId | '';
-  readonly setSelectedPhaseTemplateId: (id: WorkflowId | '') => void;
-  readonly onSwitchToCustom: () => void;
-  readonly busy: boolean;
-}
-
-function PresetPanel({
-  phaseTemplates,
-  selectedPhaseTemplateId,
-  setSelectedPhaseTemplateId,
-  onSwitchToCustom,
-  busy,
-}: PresetPanelProps) {
-  if (phaseTemplates.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-3 px-4 py-8 text-center">
-        <Layers size={28} className="text-muted-foreground/30" aria-hidden />
-        <div className="flex flex-col gap-1">
-          <p className="text-sm font-medium text-foreground">No workflow presets yet</p>
-          <p className="max-w-xs text-2xs leading-relaxed text-muted-foreground">
-            Workspaces ship with a small library. If yours is empty, design one with the planner.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onSwitchToCustom}
-          className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/5 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
-        >
-          <Sparkles size={11} aria-hidden /> Switch to custom plan
-        </button>
-      </div>
-    );
-  }
-  const selected = phaseTemplates.find((t) => t.id === selectedPhaseTemplateId) ?? null;
-  return (
-    <div className="flex flex-col gap-4">
-      <PanelHeader
-        title="Pick a blueprint"
-        subtitle={`${phaseTemplates.length} preset${phaseTemplates.length === 1 ? '' : 's'} available in this workspace. Each preset runs its steps in order.`}
-      />
-      <div className="flex flex-col gap-2">
-        {phaseTemplates.map((t) => {
-          const active = selectedPhaseTemplateId === t.id;
-          const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
-          return (
-            <button
-              key={t.id}
-              type="button"
-              disabled={busy}
-              onClick={() => setSelectedPhaseTemplateId(active ? '' : t.id)}
-              className={cn(
-                'flex flex-col gap-2 rounded-md border px-3 py-2.5 text-left transition-colors',
-                active
-                  ? 'border-primary bg-primary/5'
-                  : 'border-border-soft bg-background hover:border-border hover:bg-subtle/40',
-              )}
-            >
-              <div className="flex items-center gap-2">
-                <span
-                  className={cn(
-                    'flex size-4 shrink-0 items-center justify-center rounded-full',
-                    active
-                      ? 'bg-primary text-primary-foreground'
-                      : 'bg-muted text-muted-foreground/40',
-                  )}
-                >
-                  {active ? <Check size={10} aria-hidden /> : null}
-                </span>
-                <span className="flex-1 truncate text-xs font-semibold text-foreground">
-                  {t.name}
-                </span>
-                <span className="shrink-0 text-2xs text-muted-foreground">
-                  {sorted.length} step{sorted.length === 1 ? '' : 's'}
-                </span>
-              </div>
-              {t.description ? (
-                <p className="pl-6 text-2xs leading-relaxed text-muted-foreground">
-                  {t.description}
-                </p>
-              ) : null}
-              {sorted.length > 0 ? (
-                <div className="flex flex-wrap items-center gap-1 pl-6">
-                  {sorted.map((step, i) => {
-                    const kind = inferAgentKindFromName(step.name);
-                    const pal = AGENT_KIND_PALETTE[kind];
-                    return (
-                      <span key={step.id} className="flex items-center gap-1">
-                        {i > 0 ? (
-                          <span className="text-2xs text-muted-foreground/40">→</span>
-                        ) : null}
-                        <span
-                          className={cn(
-                            'inline-flex items-center gap-1 rounded-full bg-background px-1.5 py-0.5 text-2xs',
-                            pal.fg,
-                          )}
-                        >
-                          <span className={cn('size-1.5 rounded-full', pal.bg)} />
-                          {step.name}
-                        </span>
-                      </span>
-                    );
-                  })}
-                </div>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
-      {selected ? <WorkflowPreview template={selected} /> : null}
-    </div>
-  );
-}
-
-interface CustomPanelProps {
-  readonly phaseTemplates: ReadonlyArray<Workflow>;
-  readonly customTemplateId: WorkflowId | '';
-  readonly setCustomTemplateId: (id: WorkflowId | '') => void;
-  readonly workspaceId: WorkspaceId;
-  readonly selectedProvider: ProviderId;
-  readonly goal: string;
-  readonly onPlanChange: (v: boolean) => void;
-}
-
-function CustomPanel({
-  phaseTemplates,
-  customTemplateId,
-  setCustomTemplateId,
-  workspaceId,
-  selectedProvider,
-  goal,
-  onPlanChange,
-}: CustomPanelProps) {
-  if (customTemplateId !== '') {
-    const customTemplate = phaseTemplates.find((t) => t.id === customTemplateId) ?? null;
-    return (
-      <div className="flex flex-col gap-4">
-        <PanelHeader
-          title="Custom plan ready"
-          subtitle={
-            customTemplate
-              ? `Planner produced a workflow with ${customTemplate.steps.length} step${customTemplate.steps.length === 1 ? '' : 's'}. Review below.`
-              : 'Planner produced a workflow. Review below.'
-          }
-        />
-        <WorkflowPreview template={customTemplate} />
-        <div>
-          <button
-            type="button"
-            onClick={() => setCustomTemplateId('')}
-            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-2xs font-medium text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-          >
-            <Sparkles size={11} aria-hidden /> Re-plan
-          </button>
-        </div>
-      </div>
-    );
-  }
-  return (
-    <div className="flex flex-col gap-4">
-      <PanelHeader
-        title="Design a plan from your goal"
-        subtitle="The planner drafts a sequence of agents tailored to what you typed. Tune it before locking it in."
-      />
-      <PlannerWidget
-        workspaceId={workspaceId}
-        providerId={selectedProvider}
-        initialTheme={goal}
-        onWorkflowReady={(workflowId) => setCustomTemplateId(workflowId)}
-        onPlanChange={onPlanChange}
-      />
-    </div>
-  );
-}
-
-/* ──────────────────────────────────────────────────────────────────── */
-/* Section: Provider                                                     */
-/* ──────────────────────────────────────────────────────────────────── */
-
-interface ProviderSectionProps {
-  readonly connectedProviderIds: ReadonlySet<ProviderId>;
-  readonly selectedProvider: ProviderId;
-  readonly onRequestChange: (id: ProviderId) => void;
-  readonly pendingProviderSwitch: ProviderId | null;
-  readonly onCancelSwitch: () => void;
-  readonly onConfirmSwitch: () => void;
-  readonly onClose: () => void;
-  readonly onOpenSettings: () => void;
-}
-
-function ProviderSection({
-  connectedProviderIds,
-  selectedProvider,
-  onRequestChange,
-  pendingProviderSwitch,
-  onCancelSwitch,
-  onConfirmSwitch,
-  onClose,
-}: ProviderSectionProps) {
-  return (
-    <div className="flex flex-col gap-5">
-      <SectionHeader
-        icon={<Zap size={14} aria-hidden className="text-primary" />}
-        title="Which provider should drive this session?"
-        subtitle="Affects model availability and routing. You can override per-turn later."
-      />
-      <div className="grid grid-cols-3 gap-2">
-        {PROVIDER_ORDER.map((id) => {
-          const connected = connectedProviderIds.has(id);
-          const selected = selectedProvider === id;
-          return (
-            <button
-              key={id}
-              type="button"
-              disabled={!connected}
-              onClick={() => onRequestChange(id)}
-              className={cn(
-                'flex flex-col items-center gap-1.5 rounded-md border px-3 py-3 text-sm transition-colors',
-                selected && connected
-                  ? 'border-primary bg-primary/5 font-medium text-foreground'
-                  : connected
-                    ? 'border-border-soft bg-subtle text-muted-foreground hover:border-border hover:bg-muted/50'
-                    : 'cursor-not-allowed border-border-soft/50 bg-subtle/50 text-muted-foreground/40',
-              )}
-            >
-              <span className="flex items-center gap-1.5">
-                {connected ? (
-                  <span
-                    className={cn(
-                      'size-1.5 rounded-full',
-                      selected ? 'bg-success' : 'bg-muted-foreground/40',
-                    )}
-                  />
-                ) : (
-                  <X size={10} className="text-danger/60" aria-hidden />
-                )}
-                {PROVIDER_LABEL_LOWER[id]}
-                {id !== 'anthropic' ? (
-                  <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                    beta
-                  </span>
-                ) : null}
-              </span>
-              {!connected ? (
-                <span
-                  role="button"
-                  tabIndex={0}
-                  className="text-2xs text-primary/70 underline"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onClose();
-                    window.dispatchEvent(
-                      new CustomEvent('kayam:open-settings', {
-                        detail: { section: 'providers' },
-                      }),
-                    );
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      e.stopPropagation();
-                      onClose();
-                      window.dispatchEvent(
-                        new CustomEvent('kayam:open-settings', {
-                          detail: { section: 'providers' },
-                        }),
-                      );
-                    }
-                  }}
-                >
-                  Connect
-                </span>
-              ) : null}
-            </button>
-          );
-        })}
-      </div>
-      {pendingProviderSwitch ? (
-        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2.5">
-          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warning" aria-hidden />
-          <div className="flex flex-1 flex-col gap-1.5">
-            <p className="text-xs font-medium text-foreground">
-              Switching provider will discard your custom workflow.
-            </p>
-            <div className="flex gap-2">
-              <Button size="sm" variant="ghost" onClick={onCancelSwitch}>
-                Cancel
-              </Button>
-              <Button size="sm" onClick={onConfirmSwitch}>
-                Switch provider
-              </Button>
-            </div>
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-/* ──────────────────────────────────────────────────────────────────── */
-/* Section: Init                                                         */
-/* ──────────────────────────────────────────────────────────────────── */
-
-interface InitSectionProps {
-  readonly initEnabled: boolean;
-  readonly setInitEnabled: (v: boolean) => void;
-  readonly initContent: string;
-  readonly setInitContent: (v: string) => void;
-  readonly busy: boolean;
-}
-
-function InitSection({
-  initEnabled,
-  setInitEnabled,
-  initContent,
-  setInitContent,
-  busy,
-}: InitSectionProps) {
-  return (
-    <div className="flex flex-col gap-5">
-      <SectionHeader
-        icon={<Terminal size={14} aria-hidden className="text-primary" />}
-        title="Init script"
-        subtitle="Workspace setup that runs before agents start. Edit for this session only."
-      />
-      <label className="flex cursor-pointer items-start gap-2 rounded-md border border-border-soft bg-background px-3 py-2.5 text-xs">
-        <input
-          type="checkbox"
-          checked={initEnabled}
-          onChange={(e) => setInitEnabled(e.target.checked)}
-          className="mt-0.5 accent-primary"
-        />
-        <span className="flex flex-col gap-0.5">
-          <span className="font-medium text-foreground">Run init script</span>
-          <span className="text-muted-foreground">
-            Execute workspace setup before agents start.
-          </span>
-        </span>
-      </label>
-      <Field label="Script" hint="Edit for this session only. Changes won't save to workspace.">
-        <Textarea
-          value={initContent}
-          onChange={(e) => setInitContent(e.target.value)}
-          className="min-h-[220px] resize-y font-mono text-xs"
-          disabled={!initEnabled || busy}
-          spellCheck={false}
-          autoCorrect="off"
-          autoCapitalize="off"
-          rows={10}
-        />
-      </Field>
-    </div>
-  );
-}
-
-/* ──────────────────────────────────────────────────────────────────── */
-/* Section: Budget                                                       */
-/* ──────────────────────────────────────────────────────────────────── */
-
-interface BudgetSectionProps {
-  readonly softCapRaw: string;
-  readonly setSoftCapRaw: (v: string) => void;
-  readonly busy: boolean;
-}
-
-function BudgetSection({ softCapRaw, setSoftCapRaw, busy }: BudgetSectionProps) {
-  return (
-    <div className="flex flex-col gap-5">
-      <SectionHeader
-        icon={<DollarSign size={14} aria-hidden className="text-primary" />}
-        title="Soft cap"
-        subtitle="Optional spend limit. Session gets flagged once exceeded — agents keep running."
-      />
-      <Field label="Soft cap (USD)" hint="Leave blank to skip.">
-        <Input
-          value={softCapRaw}
-          onChange={(e) => setSoftCapRaw(e.target.value)}
-          placeholder="5.00"
-          type="number"
-          min="0"
-          step="0.01"
-          disabled={busy}
-        />
-      </Field>
-    </div>
-  );
-}
-
-/* ──────────────────────────────────────────────────────────────────── */
-/* Building blocks                                                       */
-/* ──────────────────────────────────────────────────────────────────── */
-
-function SectionHeader({
-  icon,
-  title,
-  subtitle,
-}: {
-  icon: ReactNode;
-  title: string;
-  subtitle: string;
-}) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-2">
-        <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/10">
-          {icon}
-        </span>
-        <h3 className="text-base font-semibold text-foreground">{title}</h3>
-      </div>
-      <p className="max-w-2xl text-xs leading-relaxed text-muted-foreground">{subtitle}</p>
-    </div>
-  );
-}
-
-function PanelHeader({ title, subtitle }: { title: string; subtitle: string }) {
-  return (
-    <div className="flex flex-col gap-0.5">
-      <span className="text-xs font-semibold text-foreground">{title}</span>
-      <p className="text-2xs leading-relaxed text-muted-foreground">{subtitle}</p>
-    </div>
-  );
-}
-
 function Field({
   label,
-  labelSuffix,
   hint,
   children,
 }: {
   label: string;
-  labelSuffix?: React.ReactNode;
   hint?: string;
   children: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-1.5">
-      <span className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
-        {label}
-        {labelSuffix}
-      </span>
+      <span className="text-xs font-semibold text-foreground">{label}</span>
       {hint ? <p className="text-2xs leading-relaxed text-muted-foreground">{hint}</p> : null}
       {children}
     </div>
   );
 }
 
-function WorkflowPreview({ template }: { template: Workflow | null }) {
-  if (!template) return null;
-  if (template.steps.length === 0) {
-    return (
-      <p className="rounded-md bg-subtle px-3 py-2 text-xs text-muted-foreground">
-        This workflow has no steps yet. Add some via the planner above.
-      </p>
-    );
-  }
-  const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-  return (
-    <div className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-background p-3">
-      <div className="flex items-baseline justify-between">
-        <span className="text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
-          will spawn {template.steps.length} agent
-          {template.steps.length === 1 ? '' : 's'}
-        </span>
-        {template.description ? (
-          <span className="truncate text-2xs text-muted-foreground/70">{template.description}</span>
-        ) : null}
-      </div>
-      <ol className="flex flex-col gap-1">
-        {sortedSteps.map((step, i) => {
-          const model = step.modelOverride ? shortModel(step.modelOverride) : null;
-          const eff = step.effort ?? null;
-          const verb = step.verbosity ?? null;
-          return (
-            <li
-              key={step.id}
-              className="flex items-center gap-2 rounded-md bg-subtle px-2 py-1 text-xs"
-            >
-              <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
-              <span
-                className={cn(
-                  'size-1.5 shrink-0 rounded-full',
-                  AGENT_KIND_PALETTE[inferAgentKindFromName(step.name)].bg,
-                )}
-              />
-              <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
-              {model || eff || verb ? (
-                <span className="shrink-0 rounded-full bg-background px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-                  {[model, eff, verb ? `v:${verb}` : null].filter(Boolean).join(' · ')}
-                </span>
-              ) : null}
-            </li>
-          );
-        })}
-      </ol>
-      <p className="text-2xs text-muted-foreground/70">
-        each agent runs in its own chat thread. you decide which one gets the next turn.
-      </p>
-    </div>
-  );
-}
-
-function AgentKindSelect({
-  value,
+function BranchModeToggle({
+  mode,
   onChange,
   disabled,
 }: {
-  value: AgentKind;
-  onChange: (kind: AgentKind) => void;
+  mode: 'new' | 'existing';
+  onChange: (next: 'new' | 'existing') => void;
   disabled: boolean;
 }) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [direction, setDirection] = useState<'up' | 'down'>('down');
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    const el = containerRef.current;
-    const rect = el?.getBoundingClientRect();
-    if (!el || !rect) return;
-    // Walk up to the nearest clipping ancestor — the Dialog's
-    // overflow-hidden wrapper would clip the popover otherwise.
-    let clipper: HTMLElement | null = el.parentElement;
-    while (clipper) {
-      const overflowY = getComputedStyle(clipper).overflowY;
-      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'hidden') break;
-      clipper = clipper.parentElement;
-    }
-    const clipperRect = clipper?.getBoundingClientRect();
-    const bottomBound = clipperRect ? clipperRect.bottom : window.innerHeight;
-    const topBound = clipperRect ? clipperRect.top : 0;
-    const spaceBelow = bottomBound - rect.bottom;
-    const spaceAbove = rect.top - topBound;
-    // ~280px tall popup; flip up when below is tight.
-    setDirection(spaceBelow < 300 && spaceAbove > spaceBelow ? 'up' : 'down');
-  }, [open]);
-
-  const meta = AGENT_KIND_META[value];
-  const palette = AGENT_KIND_PALETTE[value];
-
+  const modes: ReadonlyArray<{ id: 'new' | 'existing'; label: string }> = [
+    { id: 'new', label: 'New' },
+    { id: 'existing', label: 'Existing' },
+  ];
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={() => setOpen(!open)}
-        className={cn(
-          'flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left text-xs transition-colors',
-          open
-            ? 'border-primary bg-primary/5'
-            : 'border-border-soft bg-background hover:border-border hover:bg-muted/50',
-          disabled && 'cursor-not-allowed opacity-50',
-        )}
-      >
-        <span className={cn('size-2 shrink-0 rounded-full', palette.bg)} aria-hidden />
-        <span className="shrink-0 font-medium text-foreground">{meta.label}</span>
-        <span className="flex-1 truncate text-muted-foreground/70">{meta.hint}</span>
-        <ChevronDown
-          size={12}
-          className={cn(
-            'shrink-0 text-muted-foreground transition-transform',
-            open && 'rotate-180',
-          )}
-          aria-hidden
-        />
-      </button>
-      {open ? (
-        <div
-          className={cn(
-            'absolute left-0 z-50 max-h-[280px] w-full overflow-y-auto rounded-md border border-border bg-subtle py-0.5 shadow-lg',
-            direction === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
-          )}
-        >
-          {[...AGENT_KIND_ORDER]
-            .filter((k) => k !== 'init')
-            .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))
-            .map((kind) => {
-              const m = AGENT_KIND_META[kind];
-              const p = AGENT_KIND_PALETTE[kind];
-              const active = value === kind;
-              return (
-                <button
-                  key={kind}
-                  type="button"
-                  onClick={() => {
-                    onChange(kind);
-                    setOpen(false);
-                  }}
-                  className={cn(
-                    'flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors',
-                    active
-                      ? 'bg-primary/10 text-foreground'
-                      : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
-                  )}
-                >
-                  <span className={cn('size-2 shrink-0 rounded-full', p.bg)} aria-hidden />
-                  <span
-                    className={cn(
-                      'shrink-0 font-medium',
-                      active ? 'text-foreground' : 'text-foreground/80',
-                    )}
-                  >
-                    {m.label}
-                  </span>
-                  <span className="flex-1 truncate text-muted-foreground/60">{m.hint}</span>
-                  {active ? (
-                    <Check size={11} className="shrink-0 text-primary" aria-hidden />
-                  ) : null}
-                </button>
-              );
-            })}
-        </div>
-      ) : null}
+    <div
+      role="tablist"
+      aria-label="branch source"
+      className="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
+    >
+      {modes.map((m) => {
+        const active = mode === m.id;
+        return (
+          <button
+            key={m.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={disabled}
+            onClick={() => onChange(m.id)}
+            className={cn(
+              'rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
+              active
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground',
+              disabled && 'cursor-not-allowed opacity-50',
+            )}
+          >
+            {m.label}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -1,7 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Dialog, Input, Textarea, cn } from '@kay-am/ui';
-import { Loader2, Wand2 } from 'lucide-react';
+import { GitBranch, Loader2, Target, Wand2 } from 'lucide-react';
 import type { ProviderId, WorkspaceId } from '@kay-am/types';
 import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../../../../features/settings/settings';
 import { useAppStore } from '../../../../store';
@@ -239,7 +239,7 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
       onClose={onClose}
       title="New session"
       description="Creates a worktree on a fresh branch. Configure workflow and agents from the session panel afterwards."
-      size="md"
+      size="lg"
       footer={
         <div className="flex w-full items-center gap-2">
           <div className="flex-1 text-xs text-danger">{error ?? ''}</div>
@@ -259,11 +259,16 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
         </div>
       }
     >
-      <div className="flex flex-col gap-4">
-        <Field label="Goal" hint="What this session should accomplish.">
+      <div className="flex flex-col gap-5">
+        <SectionCard
+          icon={<Target size={14} aria-hidden className="text-primary" />}
+          tone="primary"
+          title="Goal"
+          subtitle="What this session should accomplish. Be specific — agents lean on it for context."
+        >
           <Textarea
             value={goal}
-            placeholder="Refactor auth domain"
+            placeholder="Refactor auth domain to extract token validation into a shared module…"
             onChange={(e) => setGoal(e.target.value)}
             autoGrow
             minRows={4}
@@ -271,9 +276,15 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
             autoFocus
             disabled={busy}
           />
-        </Field>
-        <Field label="Branch" hint="Worktree branch for this session.">
-          <div className="flex flex-col gap-2">
+        </SectionCard>
+
+        <SectionCard
+          icon={<GitBranch size={14} aria-hidden className="text-success" />}
+          tone="success"
+          title="Branch"
+          subtitle="Each session lives on its own git worktree. Pick a fresh branch or attach to an existing one."
+        >
+          <div className="flex flex-col gap-2.5">
             <BranchModeToggle mode={branchMode} onChange={setBranchMode} disabled={busy} />
             {branchMode === 'new' ? (
               <div className="flex items-center gap-1.5">
@@ -323,27 +334,50 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
               />
             )}
           </div>
-        </Field>
+        </SectionCard>
       </div>
     </Dialog>
   );
 }
 
-function Field({
-  label,
-  hint,
+type Tone = 'primary' | 'success';
+
+const TONE_BG: Record<Tone, string> = {
+  primary: 'bg-primary/10',
+  success: 'bg-success/10',
+};
+
+function SectionCard({
+  icon,
+  tone,
+  title,
+  subtitle,
   children,
 }: {
-  label: string;
-  hint?: string;
-  children: React.ReactNode;
+  icon: ReactNode;
+  tone: Tone;
+  title: string;
+  subtitle: string;
+  children: ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <span className="text-xs font-semibold text-foreground">{label}</span>
-      {hint ? <p className="text-2xs leading-relaxed text-muted-foreground">{hint}</p> : null}
-      {children}
-    </div>
+    <section className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+      <header className="flex items-start gap-2.5">
+        <span
+          className={cn(
+            'mt-0.5 flex h-7 w-7 items-center justify-center rounded-md',
+            TONE_BG[tone],
+          )}
+        >
+          {icon}
+        </span>
+        <div className="flex flex-col gap-0.5">
+          <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+          <p className="text-2xs leading-relaxed text-muted-foreground">{subtitle}</p>
+        </div>
+      </header>
+      <div className="pl-[2.375rem]">{children}</div>
+    </section>
   );
 }
 
@@ -364,7 +398,7 @@ function BranchModeToggle({
     <div
       role="tablist"
       aria-label="branch source"
-      className="inline-flex shrink-0 rounded border border-border bg-subtle p-0.5"
+      className="inline-flex shrink-0 rounded border border-border bg-background p-0.5"
     >
       {modes.map((m) => {
         const active = mode === m.id;
@@ -377,9 +411,9 @@ function BranchModeToggle({
             disabled={disabled}
             onClick={() => onChange(m.id)}
             className={cn(
-              'rounded px-1.5 py-0.5 text-2xs font-medium motion-safe:transition-colors',
+              'rounded px-2 py-0.5 text-2xs font-medium motion-safe:transition-colors',
               active
-                ? 'bg-background text-foreground shadow-sm'
+                ? 'bg-muted text-foreground shadow-sm'
                 : 'text-muted-foreground hover:text-foreground',
               disabled && 'cursor-not-allowed opacity-50',
             )}

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -156,6 +156,7 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
   const [existingBranches, setExistingBranches] = useState<ReadonlyArray<LocalBranchInfo>>([]);
   const [existingBranch, setExistingBranch] = useState<string>('');
   const [branchesLoading, setBranchesLoading] = useState(false);
+  const [branchesLoaded, setBranchesLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -171,19 +172,26 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
     setSlugGenerating(false);
     setBranchMode('new');
     setExistingBranch('');
+    setExistingBranches([]);
+    setBranchesLoaded(false);
     setError(null);
     setBusy(false);
     void loadSetting(settingKey).then((value) => {
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
-    if (workspace?.rootPath) {
-      setBranchesLoading(true);
-      listLocalBranches(workspace.rootPath)
-        .then(setExistingBranches)
-        .catch(() => setExistingBranches([]))
-        .finally(() => setBranchesLoading(false));
-    }
-  }, [open, settingKey, loadSetting, workspaceId, workspace?.rootPath]);
+  }, [open, settingKey, loadSetting, workspaceId]);
+
+  useEffect(() => {
+    if (!open || branchMode !== 'existing' || branchesLoaded || !workspace?.rootPath) return;
+    setBranchesLoading(true);
+    listLocalBranches(workspace.rootPath)
+      .then(setExistingBranches)
+      .catch(() => setExistingBranches([]))
+      .finally(() => {
+        setBranchesLoading(false);
+        setBranchesLoaded(true);
+      });
+  }, [open, branchMode, branchesLoaded, workspace?.rootPath]);
 
   useEffect(() => {
     if (slugTouched) return;

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -99,6 +99,8 @@ function sanitizePrefix(input: string): string {
     .slice(0, 16);
 }
 
+const EMPTY_LOCAL_BRANCHES: ReadonlyArray<LocalBranchInfo> = [];
+
 function isValidBranchSlug(slug: string): boolean {
   const s = slug.trim();
   if (!s) return false;
@@ -172,14 +174,19 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
     setSlugGenerating(false);
     setBranchMode('new');
     setExistingBranch('');
-    setExistingBranches([]);
-    setBranchesLoaded(false);
     setError(null);
     setBusy(false);
     void loadSetting(settingKey).then((value) => {
       setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
     });
   }, [open, settingKey, loadSetting, workspaceId]);
+
+  // Drop the cached branch list when the workspace changes (different repo →
+  // different branches). Reuse the cache across reopens of the same workspace.
+  useEffect(() => {
+    setExistingBranches(EMPTY_LOCAL_BRANCHES);
+    setBranchesLoaded(false);
+  }, [workspaceId]);
 
   useEffect(() => {
     if (!open || branchMode !== 'existing' || branchesLoaded || !workspace?.rootPath) return;

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -267,8 +267,8 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
         </div>
       }
     >
-      <div className="flex flex-col gap-5">
-        <SectionCard
+      <div className="flex flex-col gap-7">
+        <Section
           icon={<Target size={14} aria-hidden className="text-primary" />}
           tone="primary"
           title="Goal"
@@ -284,9 +284,9 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
             autoFocus
             disabled={busy}
           />
-        </SectionCard>
+        </Section>
 
-        <SectionCard
+        <Section
           icon={<GitBranch size={14} aria-hidden className="text-success" />}
           tone="success"
           title="Branch"
@@ -343,7 +343,7 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
               />
             )}
           </div>
-        </SectionCard>
+        </Section>
       </div>
     </Dialog>
   );
@@ -356,7 +356,7 @@ const TONE_BG: Record<Tone, string> = {
   success: 'bg-success/10',
 };
 
-function SectionCard({
+function Section({
   icon,
   tone,
   title,
@@ -370,11 +370,11 @@ function SectionCard({
   children: ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+    <section className="flex flex-col gap-2.5">
       <header className="flex items-start gap-2.5">
         <span
           className={cn(
-            'mt-0.5 flex h-7 w-7 items-center justify-center rounded-md',
+            'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
             TONE_BG[tone],
           )}
         >
@@ -385,7 +385,7 @@ function SectionCard({
           <p className="text-2xs leading-relaxed text-muted-foreground">{subtitle}</p>
         </div>
       </header>
-      <div className="pl-[2.375rem]">{children}</div>
+      <div>{children}</div>
     </section>
   );
 }

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, cn } from '@kay-am/ui';
-import { Check, Layers, Sparkles, AlertTriangle, Wand2 } from 'lucide-react';
+import { Check, Layers, Sparkles, AlertTriangle } from 'lucide-react';
 import type { ProviderId, Session, Workflow, WorkflowId } from '@kay-am/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { PlannerWidget } from '../../../plans/components/PlannerWidget';
@@ -198,19 +198,6 @@ function ModeCard({
 function CustomIntro({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/5 px-3.5 py-3">
-        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/15">
-          <Wand2 size={15} className="text-primary" aria-hidden />
-        </span>
-        <div className="flex flex-col gap-0.5">
-          <h3 className="text-sm font-semibold text-foreground">Design with the planner</h3>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Describe what this session should accomplish. The planner drafts a step-by-step workflow
-            tailored to the goal — you tweak the model, effort, and verbosity per step before
-            spawning.
-          </p>
-        </div>
-      </div>
       <div className="rounded-lg border border-border-soft bg-subtle/40 p-4">{children}</div>
       <div className="grid grid-cols-3 gap-2">
         <PlannerHint

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -70,7 +70,6 @@ export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDia
       title="Start a workflow"
       description="Pick a saved preset or design a fresh workflow with the planner."
       size="xl"
-      fixedHeightClass="h-[600px]"
       footer={
         <div className="flex w-full items-center gap-3">
           <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
@@ -105,8 +104,8 @@ export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDia
         </div>
       }
     >
-      <div className="flex h-full min-h-0 flex-col gap-4">
-        <div className="grid shrink-0 grid-cols-2 gap-3">
+      <div className="flex flex-col gap-4">
+        <div className="grid grid-cols-2 gap-3">
           <ModeCard
             active={mode === 'preset'}
             onClick={() => setMode('preset')}
@@ -124,7 +123,7 @@ export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDia
           />
         </div>
 
-        <div className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 py-px">
+        <div>
           {mode === 'preset' ? (
             <PresetPicker
               templates={phaseTemplates}

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, cn } from '@kay-am/ui';
-import { Check, Layers, Sparkles, AlertTriangle } from 'lucide-react';
+import { Check, Layers, Sparkles, AlertTriangle, Wand2 } from 'lucide-react';
 import type { ProviderId, Session, Workflow, WorkflowId } from '@kay-am/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { PlannerWidget } from '../../../plans/components/PlannerWidget';
@@ -138,12 +138,14 @@ export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDia
               onReset={() => setCustomId('')}
             />
           ) : (
-            <PlannerWidget
-              workspaceId={session.workspaceId}
-              providerId={providerId}
-              initialTheme={session.goal}
-              onWorkflowReady={(workflowId) => setCustomId(workflowId)}
-            />
+            <CustomIntro>
+              <PlannerWidget
+                workspaceId={session.workspaceId}
+                providerId={providerId}
+                initialTheme={session.goal}
+                onWorkflowReady={(workflowId) => setCustomId(workflowId)}
+              />
+            </CustomIntro>
           )}
         </div>
       </div>
@@ -190,6 +192,87 @@ function ModeCard({
       </div>
       <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
     </button>
+  );
+}
+
+function CustomIntro({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/5 px-3.5 py-3">
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/15">
+          <Wand2 size={15} className="text-primary" aria-hidden />
+        </span>
+        <div className="flex flex-col gap-0.5">
+          <h3 className="text-sm font-semibold text-foreground">Design with the planner</h3>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Describe what this session should accomplish. The planner drafts a step-by-step workflow
+            tailored to the goal — you tweak the model, effort, and verbosity per step before
+            spawning.
+          </p>
+        </div>
+      </div>
+      <div className="rounded-lg border border-border-soft bg-subtle/40 p-4">{children}</div>
+      <div className="grid grid-cols-3 gap-2">
+        <PlannerHint
+          tone="primary"
+          eyebrow="Step 1"
+          title="Describe the goal"
+          body="Paste a goal or refine the prefilled one."
+        />
+        <PlannerHint
+          tone="info"
+          eyebrow="Step 2"
+          title="Generate plan"
+          body="Cheap-tier model drafts ordered steps with roles."
+        />
+        <PlannerHint
+          tone="success"
+          eyebrow="Step 3"
+          title="Tweak & spawn"
+          body="Override models per step, then spawn the workflow."
+        />
+      </div>
+    </div>
+  );
+}
+
+const HINT_TONE_BG: Record<'primary' | 'info' | 'success', string> = {
+  primary: 'bg-primary/10',
+  info: 'bg-info/10',
+  success: 'bg-success/10',
+};
+
+const HINT_TONE_FG: Record<'primary' | 'info' | 'success', string> = {
+  primary: 'text-primary',
+  info: 'text-info',
+  success: 'text-success',
+};
+
+function PlannerHint({
+  tone,
+  eyebrow,
+  title,
+  body,
+}: {
+  tone: 'primary' | 'info' | 'success';
+  eyebrow: string;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border border-border-soft bg-background p-2.5">
+      <span
+        className={cn(
+          'w-fit rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider',
+          HINT_TONE_BG[tone],
+          HINT_TONE_FG[tone],
+        )}
+      >
+        {eyebrow}
+      </span>
+      <span className="text-xs font-semibold text-foreground">{title}</span>
+      <span className="text-2xs leading-relaxed text-muted-foreground">{body}</span>
+    </div>
   );
 }
 

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -198,7 +198,7 @@ function ModeCard({
 function CustomIntro({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-3">
-      <div className="rounded-lg border border-border-soft bg-subtle/40 p-4">{children}</div>
+      {children}
       <div className="grid grid-cols-3 gap-2">
         <PlannerHint
           tone="primary"

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useState } from 'react';
+import { Button, Dialog, cn } from '@kay-am/ui';
+import { Check, Layers, Sparkles, AlertTriangle } from 'lucide-react';
+import type { ProviderId, Session, Workflow, WorkflowId } from '@kay-am/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { PlannerWidget } from '../../../plans/components/PlannerWidget';
+import { shortModel } from '../../agent-row-format';
+import { AGENT_KIND_PALETTE, inferAgentKindFromName } from '../../agent-kind';
+import { formatError } from '../../../../shared/lib/errors';
+import { useToast } from '../../../../app/components/Toast';
+
+interface StartWorkflowDialogProps {
+  open: boolean;
+  onClose: () => void;
+  session: Session;
+}
+
+type Mode = 'preset' | 'custom';
+
+export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDialogProps) {
+  const phaseTemplates = useAppStore(
+    (s) => s.phaseTemplates[session.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const attachWorkflowToSession = useAppStore((s) => s.attachWorkflowToSession);
+  const { showToast } = useToast();
+
+  const [mode, setMode] = useState<Mode>('preset');
+  const [presetId, setPresetId] = useState<WorkflowId | ''>('');
+  const [customId, setCustomId] = useState<WorkflowId | ''>('');
+  const [autoRun, setAutoRun] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setMode('preset');
+    setPresetId('');
+    setCustomId('');
+    setAutoRun(false);
+    setBusy(false);
+    setError(null);
+  }, [open]);
+
+  const providerId: ProviderId = session.providerPreference.defaultProvider;
+
+  const selectedId = mode === 'preset' ? presetId : customId;
+  const selectedTemplate =
+    selectedId !== '' ? (phaseTemplates.find((t) => t.id === selectedId) ?? null) : null;
+  const canSpawn = selectedId !== '' && !busy;
+
+  const onSpawn = async () => {
+    if (selectedId === '') return;
+    setError(null);
+    setBusy(true);
+    try {
+      await attachWorkflowToSession(session.id, selectedId as WorkflowId, { autoRun });
+      showToast('success', `workflow started: ${selectedTemplate?.name ?? 'workflow'}`);
+      onClose();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Start a workflow"
+      description="Pick a saved preset or design a fresh workflow with the planner."
+      size="xl"
+      fixedHeightClass="h-[600px]"
+      footer={
+        <div className="flex w-full items-center gap-3">
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              checked={autoRun}
+              onChange={(e) => setAutoRun(e.target.checked)}
+              className="accent-primary"
+              disabled={busy}
+            />
+            <span className="flex items-center gap-1.5">
+              Auto-run
+              <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+                beta
+              </span>
+            </span>
+          </label>
+          <div className="flex-1">
+            {error ? (
+              <span className="inline-flex items-center gap-1 text-xs text-danger">
+                <AlertTriangle size={12} aria-hidden />
+                {error}
+              </span>
+            ) : null}
+          </div>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={() => void onSpawn()} disabled={!canSpawn}>
+            Spawn workflow
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <div className="grid shrink-0 grid-cols-2 gap-3">
+          <ModeCard
+            active={mode === 'preset'}
+            onClick={() => setMode('preset')}
+            icon={<Layers size={16} className="text-primary" aria-hidden />}
+            title="Preset"
+            description="Pick from saved workflows. Each step spawns its own agent."
+          />
+          <ModeCard
+            active={mode === 'custom'}
+            onClick={() => setMode('custom')}
+            icon={<Sparkles size={16} className="text-primary" aria-hidden />}
+            title="Custom"
+            description="Design a new workflow with the planner, then run it."
+            beta
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {mode === 'preset' ? (
+            <PresetPicker
+              templates={phaseTemplates}
+              value={presetId}
+              onChange={setPresetId}
+              disabled={busy}
+            />
+          ) : customId !== '' ? (
+            <CustomReady
+              template={phaseTemplates.find((t) => t.id === customId) ?? null}
+              onReset={() => setCustomId('')}
+            />
+          ) : (
+            <PlannerWidget
+              workspaceId={session.workspaceId}
+              providerId={providerId}
+              initialTheme={session.goal}
+              onWorkflowReady={(workflowId) => setCustomId(workflowId)}
+            />
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}
+
+function ModeCard({
+  active,
+  onClick,
+  icon,
+  title,
+  description,
+  beta,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  beta?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'flex flex-col items-start gap-2 rounded-lg border p-4 text-left transition-colors',
+        active
+          ? 'border-primary bg-primary/5'
+          : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+      )}
+    >
+      <div className="flex w-full items-center gap-2">
+        {icon}
+        <span className="text-sm font-semibold text-foreground">{title}</span>
+        {beta ? (
+          <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+            beta
+          </span>
+        ) : null}
+        {active ? <Check size={13} className="ml-auto text-primary" aria-hidden /> : null}
+      </div>
+      <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+    </button>
+  );
+}
+
+function PresetPicker({
+  templates,
+  value,
+  onChange,
+  disabled,
+}: {
+  templates: ReadonlyArray<Workflow>;
+  value: WorkflowId | '';
+  onChange: (id: WorkflowId | '') => void;
+  disabled: boolean;
+}) {
+  if (templates.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-md border border-dashed border-border-soft bg-subtle px-6 py-10 text-center">
+        <Layers size={22} className="text-muted-foreground/30" aria-hidden />
+        <p className="text-sm font-medium text-foreground">No workflow presets yet</p>
+        <p className="max-w-[18rem] text-xs leading-relaxed text-muted-foreground">
+          Switch to <span className="font-medium text-foreground">Custom</span> to design your first
+          workflow with the planner.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {templates.map((t) => {
+        const active = value === t.id;
+        const sorted = [...t.steps].sort((a, b) => a.ordinal - b.ordinal);
+        return (
+          <li key={t.id}>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => onChange(active ? '' : t.id)}
+              className={cn(
+                'flex w-full flex-col gap-1.5 rounded-md border px-3 py-2.5 text-left transition-colors',
+                active
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+                disabled && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="flex-1 truncate text-sm font-medium text-foreground">
+                  {t.name}
+                </span>
+                <span className="shrink-0 text-2xs text-muted-foreground">
+                  {t.steps.length} step{t.steps.length === 1 ? '' : 's'}
+                </span>
+                {active ? <Check size={12} className="shrink-0 text-primary" aria-hidden /> : null}
+              </div>
+              {t.description ? (
+                <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+                  {t.description}
+                </p>
+              ) : null}
+              {sorted.length > 0 ? (
+                <div className="flex flex-wrap items-center gap-1">
+                  {sorted.map((step, i) => {
+                    const kind = inferAgentKindFromName(step.name);
+                    const pal = AGENT_KIND_PALETTE[kind];
+                    return (
+                      <span key={step.id} className="flex items-center gap-0.5">
+                        {i > 0 ? (
+                          <span className="text-2xs text-muted-foreground/40">→</span>
+                        ) : null}
+                        <span
+                          className={cn(
+                            'inline-flex max-w-[8rem] items-center gap-1 truncate rounded bg-background px-1.5 py-0.5 text-2xs font-mono',
+                            pal.fg,
+                          )}
+                        >
+                          {step.name}
+                        </span>
+                      </span>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function CustomReady({ template, onReset }: { template: Workflow | null; onReset: () => void }) {
+  if (!template) return null;
+  const sorted = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-1.5 text-xs">
+        <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
+          <Check size={10} className="text-success" />
+        </span>
+        <span className="font-medium text-foreground">
+          Workflow ready · {sorted.length} step{sorted.length === 1 ? '' : 's'}
+        </span>
+        <button
+          type="button"
+          onClick={onReset}
+          className="ml-auto flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+        >
+          <Sparkles size={10} aria-hidden /> Re-design
+        </button>
+      </div>
+      <div className="rounded-md bg-subtle p-3">
+        <ol className="flex flex-col gap-1">
+          {sorted.map((step, i) => {
+            const model = step.modelOverride ? shortModel(step.modelOverride) : null;
+            return (
+              <li
+                key={step.id}
+                className="flex items-center gap-2 rounded-md bg-background px-2 py-1 text-xs"
+              >
+                <span className="font-mono text-2xs text-muted-foreground">{i + 1}.</span>
+                <span
+                  className={cn(
+                    'size-1.5 shrink-0 rounded-full',
+                    AGENT_KIND_PALETTE[inferAgentKindFromName(step.name)].bg,
+                  )}
+                />
+                <span className="flex-1 truncate font-medium text-foreground">{step.name}</span>
+                {model ? (
+                  <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
+                    {model}
+                  </span>
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -124,7 +124,7 @@ export function StartWorkflowDialog({ open, onClose, session }: StartWorkflowDia
           />
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="-mx-1 min-h-0 flex-1 overflow-y-auto px-1 py-px">
           {mode === 'preset' ? (
             <PresetPicker
               templates={phaseTemplates}

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -434,15 +434,15 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
   if (filesTouchedCount === 0 && (loading.transcript || loading.agents)) {
     return (
       <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
+        <SessionCostChip sessionId={session.id} />
         <div
           role="status"
           aria-label="loading files touched"
-          className="inline-flex flex-1 items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
+          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
         >
           <div className="h-2.5 w-2.5 animate-pulse rounded-sm bg-muted" />
           <div className="h-2.5 w-12 animate-pulse rounded bg-muted" />
         </div>
-        <SessionCostChip sessionId={session.id} />
       </div>
     );
   }
@@ -450,6 +450,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
   return (
     <>
       <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
+        <SessionCostChip sessionId={session.id} />
         <button
           type="button"
           onClick={() => {
@@ -458,7 +459,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
           }}
           disabled={!workingDir}
           className={cn(
-            'flex flex-1 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+            'ml-auto flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
             !workingDir
               ? 'cursor-not-allowed text-muted-foreground/50'
               : filesTouchedCount === 0
@@ -508,7 +509,6 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
             </span>
           </span>
         </button>
-        <SessionCostChip sessionId={session.id} />
       </div>
 
       <DiffViewerDialog

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -61,8 +61,20 @@ export function SessionDetailPanel({
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId]);
   const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id as SessionId]?.[0] ?? null);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
+  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const setSessionUserStatus = useAppStore((s) => s.setSessionUserStatus);
   const renameTask = useAppStore((s) => s.renameTask);
+
+  // Kick off a GitHub PR fetch the first time we render this session with a
+  // resolved branch. The sidebar-wide warmup only runs once on app mount and
+  // can miss sessions whose branch loads later, leaving the card stuck on
+  // "loading github…" forever.
+  useEffect(() => {
+    if (!branch) return;
+    if (github && github.fetchedAt !== null) return;
+    if (github?.loading) return;
+    void refreshSessionPr(session.id as SessionId);
+  }, [session.id, branch, github, refreshSessionPr]);
 
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState('');
@@ -97,7 +109,11 @@ export function SessionDetailPanel({
   };
 
   const pr = github?.pr ?? null;
-  const prLoading = !github || github.loading || (github.fetchedAt === null && !github.error);
+  // Without a resolved branch we can't even kick off a fetch — fall through to
+  // the "no PR yet" empty state instead of pinning the card to "loading…".
+  const prLoading = branch
+    ? !github || github.loading || (github.fetchedAt === null && !github.error)
+    : false;
 
   return (
     <div className="flex shrink-0 flex-col gap-2 px-3 pt-3 pb-2">

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -38,6 +38,7 @@ import { OpenInEditorIconButton } from '../../../session/components/OpenInEditor
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { DiffViewerDialog } from '../../../permissions/components/DiffViewerDialog';
+import { PricingDialog } from '../../../providers/components/PricingDialog';
 import { worktreeStatus } from '../../../worktree/worktree';
 
 interface SessionDetailPanelProps {
@@ -236,6 +237,7 @@ function SessionCostChip({ sessionId }: { sessionId: SessionId }) {
   const telemetry = useAppStore(
     (s) => s.sessionTelemetry[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
   );
+  const [pricingOpen, setPricingOpen] = useState(false);
   const sessionCost = useMemo(() => {
     let sum = 0;
     for (const rec of telemetry) {
@@ -246,12 +248,17 @@ function SessionCostChip({ sessionId }: { sessionId: SessionId }) {
   }, [telemetry]);
   const label = sessionCost === 0 ? '$0' : `$${sessionCost.toFixed(2)}`;
   return (
-    <span
-      title={`Estimated cost for this session: ${label} (excluding summarizer)`}
-      className="inline-flex shrink-0 items-center text-2xs font-mono text-muted-foreground"
-    >
-      {label}
-    </span>
+    <>
+      <button
+        type="button"
+        onClick={() => setPricingOpen(true)}
+        title={`Estimated cost for this session: ${label} (excluding summarizer) — click for spend breakdown`}
+        className="inline-flex shrink-0 items-center rounded-md border border-success/20 bg-success/10 px-2 py-1 font-mono text-2xs text-success transition-colors hover:border-success/40 hover:bg-success/15"
+      >
+        {label}
+      </button>
+      <PricingDialog open={pricingOpen} onClose={() => setPricingOpen(false)} />
+    </>
   );
 }
 
@@ -433,12 +440,12 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
 
   if (filesTouchedCount === 0 && (loading.transcript || loading.agents)) {
     return (
-      <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
+      <div className="flex shrink-0 items-center gap-3 border-t border-border-soft px-3 py-2">
         <SessionCostChip sessionId={session.id} />
         <div
           role="status"
           aria-label="loading files touched"
-          className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
+          className="flex flex-1 items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
         >
           <div className="h-2.5 w-2.5 animate-pulse rounded-sm bg-muted" />
           <div className="h-2.5 w-12 animate-pulse rounded bg-muted" />
@@ -449,7 +456,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
 
   return (
     <>
-      <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
+      <div className="flex shrink-0 items-center gap-3 border-t border-border-soft px-3 py-2">
         <SessionCostChip sessionId={session.id} />
         <button
           type="button"
@@ -459,7 +466,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
           }}
           disabled={!workingDir}
           className={cn(
-            'ml-auto flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+            'flex flex-1 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
             !workingDir
               ? 'cursor-not-allowed text-muted-foreground/50'
               : filesTouchedCount === 0

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -171,14 +171,10 @@ export function SessionDetailPanel({
         </button>
       </div>
 
-      {/* subtitle row: branch (click to copy) + session cost + refresh github */}
+      {/* subtitle row: branch (click to copy) + refresh github */}
       {branch && (
         <div className="flex items-center gap-1">
           <BranchChip branch={branch} />
-          <span aria-hidden className="text-muted-foreground/30">
-            ·
-          </span>
-          <SessionCostChip sessionId={session.id as SessionId} />
           <span className="flex-1" />
           <GithubRefreshButton sessionId={session.id as SessionId} />
         </div>
@@ -252,9 +248,8 @@ function SessionCostChip({ sessionId }: { sessionId: SessionId }) {
   return (
     <span
       title={`Estimated cost for this session: ${label} (excluding summarizer)`}
-      className="inline-flex items-center gap-0.5 text-2xs font-mono text-muted-foreground"
+      className="inline-flex shrink-0 items-center text-2xs font-mono text-muted-foreground"
     >
-      <span className="text-muted-foreground/60">∑</span>
       {label}
     </span>
   );
@@ -438,22 +433,23 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
 
   if (filesTouchedCount === 0 && (loading.transcript || loading.agents)) {
     return (
-      <div className="shrink-0 border-t border-border-soft px-3 py-2">
+      <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
         <div
           role="status"
           aria-label="loading files touched"
-          className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
+          className="inline-flex flex-1 items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1"
         >
           <div className="h-2.5 w-2.5 animate-pulse rounded-sm bg-muted" />
           <div className="h-2.5 w-12 animate-pulse rounded bg-muted" />
         </div>
+        <SessionCostChip sessionId={session.id} />
       </div>
     );
   }
 
   return (
     <>
-      <div className="shrink-0 border-t border-border-soft px-3 py-2">
+      <div className="flex shrink-0 items-center gap-2 border-t border-border-soft px-3 py-2">
         <button
           type="button"
           onClick={() => {
@@ -462,7 +458,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
           }}
           disabled={!workingDir}
           className={cn(
-            'flex w-full items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
+            'flex flex-1 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-xs transition-colors',
             !workingDir
               ? 'cursor-not-allowed text-muted-foreground/50'
               : filesTouchedCount === 0
@@ -512,6 +508,7 @@ export function SessionFilesTouchedFooter({ session }: SessionFilesTouchedFooter
             </span>
           </span>
         </button>
+        <SessionCostChip sessionId={session.id} />
       </div>
 
       <DiffViewerDialog

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { Button, Dialog, Input, ScrollArea, cn } from '@kay-am/ui';
 import {
@@ -1001,39 +1002,111 @@ interface SpawnAgentControlProps {
   sessionId: SessionId;
 }
 
+interface PopoverAnchor {
+  readonly left: number;
+  readonly top: number | null;
+  readonly bottom: number | null;
+  readonly direction: 'up' | 'down';
+}
+
 function SpawnAgentControl({ sessionId }: SpawnAgentControlProps) {
   const [open, setOpen] = useState(false);
-  const [direction, setDirection] = useState<'up' | 'down'>('up');
-  const ref = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
+
+  const computeAnchor = useCallback((): PopoverAnchor | null => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return null;
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const direction: 'up' | 'down' = spaceBelow > spaceAbove ? 'down' : 'up';
+    const left = rect.right + 4;
+    if (direction === 'down') {
+      return { left, top: rect.top, bottom: null, direction };
+    }
+    return { left, top: null, bottom: window.innerHeight - rect.bottom, direction };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
     const onDocClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (menuRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    const onReanchor = () => {
+      const next = computeAnchor();
+      if (next) setAnchor(next);
+      else setOpen(false);
     };
     window.addEventListener('mousedown', onDocClick);
-    return () => window.removeEventListener('mousedown', onDocClick);
-  }, [open]);
+    window.addEventListener('resize', onReanchor);
+    window.addEventListener('scroll', onReanchor, true);
+    return () => {
+      window.removeEventListener('mousedown', onDocClick);
+      window.removeEventListener('resize', onReanchor);
+      window.removeEventListener('scroll', onReanchor, true);
+    };
+  }, [open, computeAnchor]);
 
   const onToggle = () => {
     if (!open) {
-      const rect = triggerRef.current?.getBoundingClientRect();
-      if (rect) {
-        const spaceAbove = rect.top;
-        const spaceBelow = window.innerHeight - rect.bottom;
-        // Open in the direction with more room. Trigger near the top of
-        // the viewport → open downward (avoids clipping under the sticky
-        // panel header); trigger near the bottom → open upward.
-        setDirection(spaceBelow > spaceAbove ? 'down' : 'up');
-      }
+      const next = computeAnchor();
+      if (next) setAnchor(next);
     }
     setOpen((v) => !v);
   };
 
+  const menu =
+    open && anchor
+      ? createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            style={{
+              position: 'fixed',
+              left: anchor.left,
+              ...(anchor.top !== null ? { top: anchor.top } : {}),
+              ...(anchor.bottom !== null ? { bottom: anchor.bottom } : {}),
+            }}
+            className="z-50 w-64 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft"
+          >
+            <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">
+              by role
+            </div>
+            {[...AGENT_KIND_ORDER]
+              .filter((k) => k !== 'init')
+              .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))
+              .map((kind) => {
+                const meta = AGENT_KIND_META[kind];
+                const palette = AGENT_KIND_PALETTE[kind];
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setOpen(false);
+                      void spawnAgent(sessionId, { kindOverride: kind });
+                    }}
+                    className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted"
+                  >
+                    <span className={cn('size-2 shrink-0 rounded-full', palette.bg)} aria-hidden />
+                    <span className="font-medium text-foreground">{meta.label}</span>
+                    <span className="truncate text-2xs text-muted-foreground">{meta.hint}</span>
+                  </button>
+                );
+              })}
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
-    <div className="relative mt-1" ref={ref}>
+    <div className="relative mt-1">
       <button
         ref={triggerRef}
         type="button"
@@ -1045,42 +1118,7 @@ function SpawnAgentControl({ sessionId }: SpawnAgentControlProps) {
         <Plus size={13} aria-hidden />
         Spawn agent
       </button>
-      {open ? (
-        <div
-          role="menu"
-          className={cn(
-            'absolute left-full z-20 ml-1 w-64 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft',
-            direction === 'up' ? 'bottom-0' : 'top-0',
-          )}
-        >
-          <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">
-            by role
-          </div>
-          {[...AGENT_KIND_ORDER]
-            .filter((k) => k !== 'init')
-            .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))
-            .map((kind) => {
-              const meta = AGENT_KIND_META[kind];
-              const palette = AGENT_KIND_PALETTE[kind];
-              return (
-                <button
-                  key={kind}
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    setOpen(false);
-                    void spawnAgent(sessionId, { kindOverride: kind });
-                  }}
-                  className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted"
-                >
-                  <span className={cn('size-2 shrink-0 rounded-full', palette.bg)} aria-hidden />
-                  <span className="font-medium text-foreground">{meta.label}</span>
-                  <span className="truncate text-2xs text-muted-foreground">{meta.hint}</span>
-                </button>
-              );
-            })}
-        </div>
-      ) : null}
+      {menu}
     </div>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -54,6 +54,7 @@ import {
   useWorkspaces,
 } from '../../../../store';
 import { NewSessionDialog } from '../../../session/components/NewSessionDialog';
+import { StartWorkflowDialog } from '../../../session/components/StartWorkflowDialog';
 import { pickNextWorkflowStep } from '../../../../features/workflow/components/WorkflowNextStepCta';
 import {
   computeLatestTelemetryByAgentId,
@@ -668,6 +669,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
     (slots.find((s) => s.key === 'open_questions')?.value?.trim().length ?? 0) > 0;
   const summarizerBusy = useAppStore((s) => s.summarizerStatus[task.id]?.status === 'running');
   const [spawnError, setSpawnError] = useState<string | null>(null);
+  const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
   const [editingId, setEditingId] = useState<AgentId | null>(null);
 
   const sorted = useMemo(() => [...phaseRuns].sort((a, b) => a.ordinal - b.ordinal), [phaseRuns]);
@@ -876,6 +878,24 @@ function AgentsSection({ task }: AgentsSectionProps) {
           </div>
         </>
       ) : null}
+      {!workflow ? (
+        <div className={cn('flex flex-col gap-1.5', initAgent && 'mt-6')}>
+          <header className="flex items-center justify-between gap-2 pb-1.5">
+            <span className={SECTION_LABEL}>
+              <Layers size={11} aria-hidden className="text-primary" />
+              Workflow
+            </span>
+          </header>
+          <button
+            type="button"
+            onClick={() => setStartWorkflowOpen(true)}
+            className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+          >
+            <Plus size={13} aria-hidden />
+            Start a workflow
+          </button>
+        </div>
+      ) : null}
       {workflow && workflowAgents.length > 0 ? (
         <>
           <header
@@ -924,7 +944,7 @@ function AgentsSection({ task }: AgentsSectionProps) {
       <header
         className={cn(
           'flex items-center justify-between gap-2 pb-1.5',
-          ((workflow && workflowAgents.length > 0) || initAgent) && 'mt-6',
+          ((workflow && workflowAgents.length > 0) || initAgent || !workflow) && 'mt-6',
         )}
       >
         <span className={SECTION_LABEL}>
@@ -968,6 +988,11 @@ function AgentsSection({ task }: AgentsSectionProps) {
         <SpawnAgentControl sessionId={task.id} />
       </div>
       {spawnError ? <p className="mt-1 px-2 text-2xs text-danger">{spawnError}</p> : null}
+      <StartWorkflowDialog
+        open={startWorkflowOpen}
+        onClose={() => setStartWorkflowOpen(false)}
+        session={task}
+      />
     </section>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1049,8 +1049,8 @@ function SpawnAgentControl({ sessionId }: SpawnAgentControlProps) {
         <div
           role="menu"
           className={cn(
-            'absolute left-0 right-0 z-20 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft',
-            direction === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
+            'absolute left-full z-20 ml-1 w-64 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft',
+            direction === 'up' ? 'bottom-0' : 'top-0',
           )}
         >
           <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1072,7 +1072,7 @@ function SpawnAgentControl({ sessionId }: SpawnAgentControlProps) {
               ...(anchor.top !== null ? { top: anchor.top } : {}),
               ...(anchor.bottom !== null ? { bottom: anchor.bottom } : {}),
             }}
-            className="z-50 w-64 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft"
+            className="z-50 w-80 max-h-72 overflow-y-auto rounded bg-subtle py-1 text-xs shadow-lg ring-1 ring-border-soft"
           >
             <div className="px-2.5 pb-1 pt-1.5 text-2xs uppercase tracking-wide text-muted-foreground/70">
               by role

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -54,6 +54,7 @@ import {
   updateProviderRunStatus,
   updateSessionPermissionMode,
   updateSessionAutoRun,
+  updateSessionWorkflow,
   updateSessionTitleUserEdited,
   updateSessionUserStatus,
   updateSessionSkipInit,
@@ -414,6 +415,11 @@ export interface AppActions {
     args: { branch: string; createNew: boolean },
   ): Promise<void>;
   setSessionAutoRun(sessionId: SessionId, autoRun: boolean): Promise<void>;
+  attachWorkflowToSession(
+    sessionId: SessionId,
+    workflowId: WorkflowId,
+    options?: { autoRun?: boolean },
+  ): Promise<void>;
   setSessionUserStatus(sessionId: SessionId, status: SessionUserStatus): Promise<void>;
   activateWorkflowAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
   maybeAutoAdvanceWorkflow(sessionId: SessionId): Promise<void>;
@@ -1735,22 +1741,21 @@ export const useAppStore = create<AppStore>((set, get) => ({
         });
         prespawnedRuns = [fallback];
       }
-    } else {
-      const agentName = firstAgentKind
-        ? AGENT_KIND_META[firstAgentKind].label.toLowerCase()
-        : 'agent 1';
-      const model =
-        requestedModel ?? (firstAgentKind ? AGENT_KIND_DEFAULTS[firstAgentKind].model : null);
+    } else if (firstAgentKind !== undefined) {
+      const agentName = AGENT_KIND_META[firstAgentKind].label.toLowerCase();
+      const model = requestedModel ?? AGENT_KIND_DEFAULTS[firstAgentKind].model;
       const singleAgent = await invokePhaseRunInsert({
         sessionId: session.id,
         ordinal: 0,
         name: agentName,
         status: 'pending',
-        ...(firstAgentKind !== undefined && { kind: firstAgentKind }),
+        kind: firstAgentKind,
       });
       if (model !== null) agentModelOverrides[singleAgent.id] = model;
-      if (firstAgentKind !== undefined) agentKindOverrides[singleAgent.id] = firstAgentKind;
+      agentKindOverrides[singleAgent.id] = firstAgentKind;
       prespawnedRuns = [singleAgent];
+    } else {
+      prespawnedRuns = [];
     }
 
     let initAgentId: AgentId | null = null;
@@ -1772,7 +1777,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       prespawnedRuns = [initAgent, ...prespawnedRuns];
     }
 
-    const firstAgent = prespawnedRuns[0]!;
+    const firstAgent = prespawnedRuns[0] ?? null;
     const transcriptEntries: Record<string, ReadonlyArray<never>> = {};
     const turnStateEntries: Record<string, { kind: 'draft' }> = {};
     for (const agent of prespawnedRuns) {
@@ -1798,7 +1803,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
         [session.id]: goalText.length > 0 ? [{ key: 'goal', value: goalText, enabled: true }] : [],
       },
       sessionPhaseRuns: { ...state.sessionPhaseRuns, [session.id]: prespawnedRuns },
-      selectedAgentId: { ...state.selectedAgentId, [session.id]: firstAgent.id },
+      selectedAgentId: firstAgent
+        ? { ...state.selectedAgentId, [session.id]: firstAgent.id }
+        : state.selectedAgentId,
       transcripts: { ...state.transcripts, ...transcriptEntries },
       messages: { ...state.messages, [session.id]: [] },
       agentTurnState: { ...state.agentTurnState, ...turnStateEntries },
@@ -3734,6 +3741,65 @@ export const useAppStore = create<AppStore>((set, get) => ({
         s.id === sessionId ? { ...s, autoRun, updatedAt: now } : s,
       ),
     }));
+    if (autoRun) void get().maybeAutoAdvanceWorkflow(sessionId);
+  },
+
+  attachWorkflowToSession: async (sessionId, workflowId, options) => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) throw new Error(`session not found: ${sessionId}`);
+    if (session.workflowId) throw new Error('session already has a workflow');
+
+    const templates = get().phaseTemplates[session.workspaceId] ?? [];
+    const template = templates.find((t) => t.id === workflowId);
+    if (!template) throw new Error(`workflow not found: ${workflowId}`);
+
+    const autoRun = options?.autoRun === true;
+    const now = new Date().toISOString() as IsoDateTime;
+    await updateSessionWorkflow(tauriDatabase, sessionId, workflowId, autoRun, now);
+
+    const existingRuns = get().sessionPhaseRuns[sessionId] ?? [];
+    const baseOrdinal = existingRuns.reduce((max, r) => Math.max(max, r.ordinal), -1);
+    const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+    const newAgents: Agent[] = [];
+    const agentModelOverrides: Record<string, string> = {};
+    const agentKindOverrides: Record<string, string> = {};
+    for (let i = 0; i < sortedSteps.length; i += 1) {
+      const step = sortedSteps[i]!;
+      const kind = inferAgentKindFromName(step.name);
+      const agent = await invokePhaseRunInsert({
+        sessionId,
+        stepId: step.id,
+        ordinal: baseOrdinal + 1 + i,
+        name: step.name,
+        status: 'pending',
+        kind,
+      });
+      agentModelOverrides[agent.id] = step.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model;
+      agentKindOverrides[agent.id] = kind;
+      newAgents.push(agent);
+    }
+
+    const transcriptEntries: Record<string, ReadonlyArray<never>> = {};
+    const turnStateEntries: Record<string, { kind: 'draft' }> = {};
+    for (const agent of newAgents) {
+      transcriptEntries[agent.id] = [];
+      turnStateEntries[agent.id] = { kind: 'draft' };
+    }
+
+    set((state) => ({
+      sessions: state.sessions.map((s) =>
+        s.id === sessionId ? { ...s, workflowId, autoRun, updatedAt: now } : s,
+      ),
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: [...existingRuns, ...newAgents],
+      },
+      transcripts: { ...state.transcripts, ...transcriptEntries },
+      agentTurnState: { ...state.agentTurnState, ...turnStateEntries },
+      agentModelOverride: { ...state.agentModelOverride, ...agentModelOverrides },
+      agentKindOverride: { ...state.agentKindOverride, ...agentKindOverrides },
+    }));
+
     if (autoRun) void get().maybeAutoAdvanceWorkflow(sessionId);
   },
 

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -290,7 +290,7 @@ describe('createSession — workflow stepper seeding (#424)', () => {
     expect(state.sessionPhaseRuns[sid]?.every((r) => r.status === 'pending')).toBe(true);
   });
 
-  it('falls back to a single generic "agent 1" when no workflow is attached', async () => {
+  it('pre-spawns nothing when no workflow and no firstAgentKind are passed', async () => {
     const { useAppStore } = await import('./store');
     useAppStore.setState({ currentWorkspaceId: WS_ID, phaseTemplates: {} });
 
@@ -300,10 +300,12 @@ describe('createSession — workflow stepper seeding (#424)', () => {
       branchPrefix: 'kay',
     });
 
-    expect(phaseRunInsertSpy).toHaveBeenCalledTimes(1);
-    const args = phaseRunInsertSpy.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(args['name']).toBe('agent 1');
-    expect(args['stepId']).toBeUndefined();
+    // The session is created empty — the user explicitly spawns an agent or
+    // starts a workflow from the panel after creation. No placeholder.
+    expect(phaseRunInsertSpy).not.toHaveBeenCalled();
+    const state = useAppStore.getState();
+    const sid = state.currentSessionId as SessionId;
+    expect(state.sessionPhaseRuns[sid] ?? []).toHaveLength(0);
   });
 
   it('spawnAgent creates a new agent when called for a step (e.g. retry)', async () => {

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,6 +19,7 @@ export {
   updateSessionState,
   updateSessionPermissionMode,
   updateSessionAutoRun,
+  updateSessionWorkflow,
   updateSessionSkipInit,
   updateSessionTitleUserEdited,
   updateSessionUserStatus,

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -191,6 +191,19 @@ export async function updateSessionAutoRun(
   ]);
 }
 
+export async function updateSessionWorkflow(
+  db: Database,
+  id: SessionId,
+  workflowId: WorkflowId | null,
+  autoRun: boolean,
+  updatedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute(
+    'UPDATE sessions SET workflow_id = ?, auto_run = ?, updated_at = ? WHERE id = ?',
+    [workflowId, autoRun ? 1 : 0, Date.parse(updatedAt), id],
+  );
+}
+
 export async function updateSessionUserStatus(
   db: Database,
   id: SessionId,


### PR DESCRIPTION
## Summary

- **NewSessionDialog** stripped down to **goal + branch** only. No more workflow modes, provider picker, init editor, or budget — those live elsewhere or get configured after creation.
- New **"Start a workflow" CTA** in the session sidebar (under the Workflow header) opens a dedicated modal: two cards (preset / custom), preset picker, embedded planner for custom plans, auto-run toggle in the footer.
- **createSession** no longer pre-spawns a placeholder ad-hoc agent when no workflow + no firstAgentKind are passed — the session starts empty and the user explicitly spawns agents or starts a workflow from the panel.
- New store action **`attachWorkflowToSession`** + DB helper **`updateSessionWorkflow`** to wire a workflow into an existing session and pre-spawn its step agents.
- **Init script** behavior unchanged: still auto-runs at session creation if the workspace has one configured.

## Why

Today the new-session dialog crams workflow mode, preset/custom, provider, init script, budget, agent kind, model, effort, verbosity into one form. Friction is high and the user often just wants a goal + branch up front. Workflow choice belongs *inside* the session, when the user has more context.

## Test plan

- [ ] Open New session → only Goal + Branch fields visible.
- [ ] Create session → lands in panel with no agents, "Start a workflow" CTA visible.
- [ ] Click "Start a workflow" → modal opens with preset card selected.
- [ ] Pick a preset → "Spawn workflow" enables → click → workflow agents appear in sidebar.
- [ ] New session → "Start a workflow" → switch to Custom card → planner produces workflow → spawn.
- [ ] Spawn an ad-hoc agent before starting a workflow → both coexist (ad-hoc in Agents, workflow steps in Workflow).
- [ ] Workspace with init script → init agent still pre-spawns at session creation.
- [ ] Auto-run checkbox in workflow modal footer → workflow advances autonomously after first step.

⚠️ NewSessionDialog snapshot + keyboard tests reference the old fields and will need regenerating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)