### PR TITLE
feat(desktop): agent role nudges and handoff system

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -19,10 +19,16 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
     agentModelOverride: Record<string, never>;
+    agentKindOverride: Record<string, never>;
     agentRunHistory: Record<string, never>;
     agentDraft: Record<string, string>;
+    sessionNudges: Record<string, null>;
+    sessionPhaseRuns: Record<string, ReadonlyArray<never>>;
     setAgentDraft: (agentId: string, value: string) => void;
     clearAgentDraft: (agentId: string) => void;
+    dismissSessionNudge: () => Promise<void>;
+    acceptSessionNudgeHandoff: () => Promise<void>;
+    spawnAgent: () => Promise<void>;
   }
   const store = create<S>((set) => ({
     sendTurn: send,
@@ -37,8 +43,11 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},
     agentModelOverride: {},
+    agentKindOverride: {},
     agentRunHistory: {},
     agentDraft: {},
+    sessionNudges: {},
+    sessionPhaseRuns: {},
     setAgentDraft: (agentId, value) =>
       set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
     clearAgentDraft: (agentId) =>
@@ -48,6 +57,9 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
         delete next[agentId];
         return { agentDraft: next };
       }),
+    dismissSessionNudge: async () => undefined,
+    acceptSessionNudgeHandoff: async () => undefined,
+    spawnAgent: async () => undefined,
   }));
   return { sendTurnMock: send, cancelCurrentTurnMock: cancel, mockStore: store };
 });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -18,6 +18,9 @@ import type {
   TurnProviderOverride,
 } from '@kay-am/types';
 import { PROVIDER_CAPABILITIES, assessTurnWeight, getDefaultTurnModel } from '@kay-am/core';
+import { insertNudgeEvent, updateNudgeEventOutcome, type NudgeOutcome } from '@kay-am/db';
+import { tauriDatabase } from '../../../../shared/lib/db';
+import type { IsoDateTime } from '@kay-am/types';
 import { useShallow } from 'zustand/react/shallow';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
@@ -36,8 +39,16 @@ import { ProviderUsagePill } from '../ProviderUsagePill';
 import { ModelPicker } from '../ModelPicker';
 import { PermissionModePicker } from '../../../../features/permissions/components/PermissionModePicker';
 import { RightSizeCard } from '../RightSizeCard';
+import { NudgeCard } from '../NudgeCard';
+import { ClipboardCheck } from 'lucide-react';
 import { STORAGE_PREFIXES } from '../../../../shared/lib/storage-keys';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
+import {
+  AGENT_KIND_META,
+  inferAgentKindFromName,
+  type AgentKind,
+} from '../../../session/agent-kind';
+import { detectScopeMismatch, type ScopeMismatch } from '../../utils/scope-mismatch';
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
@@ -198,6 +209,20 @@ function toastMessageForAlert(alert: BudgetAlert): string {
 export function ChatInput({ session, providerDisconnected = false }: ChatInputProps) {
   const sendTurn = useAppStore((s) => s.sendTurn);
   const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
+  const sessionNudge = useAppStore((s) => s.sessionNudges[session.id] ?? null);
+  const dismissSessionNudge = useAppStore((s) => s.dismissSessionNudge);
+  const acceptSessionNudgeHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const agentKindOverride = useAppStore((s) =>
+    selectedAgentId ? (s.agentKindOverride[selectedAgentId] ?? null) : null,
+  );
+  const selectedAgentName = useAppStore((s) => {
+    if (!selectedAgentId) return null;
+    const runs = s.sessionPhaseRuns[session.id] ?? [];
+    return runs.find((r) => r.id === selectedAgentId)?.name ?? null;
+  });
+  const activeAgentKind: AgentKind | null =
+    agentKindOverride ?? (selectedAgentName ? inferAgentKindFromName(selectedAgentName) : null);
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected')),
   );
@@ -267,6 +292,12 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [queued, setQueued] = useState<QueuedTurn | null>(null);
   const [rightSizePending, setRightSizePending] = useState<string | null>(null);
   const [rightSizeDismissed, setRightSizeDismissed] = useState(false);
+  interface ScopePending {
+    readonly content: string;
+    readonly mismatch: ScopeMismatch;
+  }
+  const [scopePending, setScopePending] = useState<ScopePending | null>(null);
+  const [scopeNudgeEventId, setScopeNudgeEventId] = useState<string | null>(null);
   const canSend = !providerDisconnected && value.trim().length > 0;
   const allowOverride = session.providerPreference.allowTurnOverride;
   const defaultProvider = session.providerPreference.defaultProvider;
@@ -394,6 +425,33 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setError(null);
     setLastFailedTurn(null);
 
+    if (!isRunning && scopePending === null && activeAgentKind !== null && !session.workflowId) {
+      const mismatch = detectScopeMismatch(content, activeAgentKind);
+      if (mismatch) {
+        const id = crypto.randomUUID();
+        try {
+          await insertNudgeEvent(tauriDatabase, {
+            id,
+            ts: new Date().toISOString() as IsoDateTime,
+            kind: 'scope-mismatch',
+            contextJson: JSON.stringify({
+              sessionId: session.id,
+              agentKind: activeAgentKind,
+              mismatchKind: mismatch.kind,
+              suggested: mismatch.suggestedAgentKind,
+            }),
+            outcome: null,
+            outcomeTs: null,
+          });
+        } catch {
+          // telemetry is best-effort
+        }
+        setScopeNudgeEventId(id);
+        setScopePending({ content, mismatch });
+        return;
+      }
+    }
+
     if (allowOverride && !isRunning && rightSizeSuggested !== null && rightSizePending === null) {
       setRightSizePending(content);
       return;
@@ -401,6 +459,49 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
     setValue('');
     await sendWith(content, null);
+  };
+
+  const recordScopeOutcome = async (outcome: NudgeOutcome) => {
+    if (!scopeNudgeEventId) return;
+    try {
+      await updateNudgeEventOutcome(
+        tauriDatabase,
+        scopeNudgeEventId,
+        outcome,
+        new Date().toISOString() as IsoDateTime,
+      );
+    } catch {
+      // best-effort
+    }
+    setScopeNudgeEventId(null);
+  };
+
+  const onScopeSpawn = async () => {
+    if (!scopePending) return;
+    const target = scopePending.mismatch.suggestedAgentKind;
+    const content = scopePending.content;
+    setScopePending(null);
+    setValue(content);
+    await recordScopeOutcome('accepted');
+    try {
+      await spawnAgent(session.id, { kindOverride: target });
+    } catch {
+      // ignore — user will see standard error path elsewhere
+    }
+  };
+
+  const onScopeSendAnyway = async () => {
+    if (!scopePending) return;
+    const content = scopePending.content;
+    setScopePending(null);
+    setValue('');
+    await recordScopeOutcome('overridden');
+    await sendWith(content, null);
+  };
+
+  const onScopeDismiss = async () => {
+    setScopePending(null);
+    await recordScopeOutcome('dismissed');
   };
 
   const onUseSuggested = async () => {
@@ -463,6 +564,8 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
     setRightSizePending(null);
     setRightSizeDismissed(false);
+    setScopePending(null);
+    setScopeNudgeEventId(null);
   }, [selectedAgentId]);
 
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
@@ -523,6 +626,66 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
             onUseSuggested={() => void onUseSuggested()}
             onKeepCurrent={() => void onKeepCurrent()}
             onChangeModel={onChangeModel}
+          />
+        ) : null}
+        {scopePending !== null && activeAgentKind !== null ? (
+          <NudgeCard
+            severity="warning"
+            ariaLabel="scope mismatch suggestion"
+            testId="scope-mismatch-nudge"
+            title={
+              <>
+                you're on <strong>{AGENT_KIND_META[activeAgentKind].label.toLowerCase()}</strong>.
+                this request fits{' '}
+                <strong>
+                  {AGENT_KIND_META[scopePending.mismatch.suggestedAgentKind].label.toLowerCase()}
+                </strong>{' '}
+                better.
+              </>
+            }
+            body={
+              <>
+                spawn a{' '}
+                {AGENT_KIND_META[scopePending.mismatch.suggestedAgentKind].label.toLowerCase()}{' '}
+                agent, or send anyway.
+              </>
+            }
+            primary={{
+              label: `spawn ${AGENT_KIND_META[scopePending.mismatch.suggestedAgentKind].label.toLowerCase()}`,
+              onClick: () => void onScopeSpawn(),
+              testId: 'scope-mismatch-spawn',
+            }}
+            secondary={{
+              label: 'send anyway',
+              onClick: () => void onScopeSendAnyway(),
+              testId: 'scope-mismatch-override',
+            }}
+            onDismiss={() => void onScopeDismiss()}
+          />
+        ) : null}
+        {sessionNudge?.kind === 'plan-ready' && !session.workflowId ? (
+          <NudgeCard
+            severity="success"
+            ariaLabel="plan ready to implement"
+            testId="plan-ready-nudge"
+            icon={<ClipboardCheck size={12} aria-hidden />}
+            title={
+              <>
+                Plan looks ready: <strong>{sessionNudge.planTitle}</strong>. Spawn an implementer to
+                execute it?
+              </>
+            }
+            primary={{
+              label: 'Spawn implementer',
+              onClick: () => void acceptSessionNudgeHandoff(session.id),
+              testId: 'plan-ready-accept',
+            }}
+            secondary={{
+              label: 'Not now',
+              onClick: () => void dismissSessionNudge(session.id, 'dismissed'),
+              testId: 'plan-ready-dismiss',
+            }}
+            onDismiss={() => void dismissSessionNudge(session.id, 'dismissed')}
           />
         ) : null}
         <div

--- a/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/HandoffChip/index.tsx
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import { ArrowRight } from 'lucide-react';
+import type { PlanId, SessionId } from '@kay-am/types';
+import { extractHandoff } from '@kay-am/core';
+import { useAppStore } from '../../../../store';
+import { AGENT_KIND_META } from '../../../session/agent-kind';
+
+interface HandoffChipProps {
+  readonly assistantText: string;
+  readonly sessionId: SessionId;
+}
+
+export function HandoffChip({ assistantText, sessionId }: HandoffChipProps) {
+  const handoff = useMemo(() => extractHandoff(assistantText), [assistantText]);
+  const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId) ?? null);
+  const sessionNudge = useAppStore((s) => s.sessionNudges[sessionId] ?? null);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+  const acceptHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
+
+  if (!handoff || !session) return null;
+  // Handoff suggestions are noise inside a workflow — the next step is
+  // already defined by the workflow itself.
+  if (session.workflowId) return null;
+
+  const meta = AGENT_KIND_META[handoff.kind];
+  const isActiveNudge =
+    sessionNudge?.kind === 'handoff-suggested' && sessionNudge.targetKind === handoff.kind;
+
+  const onClick = () => {
+    if (isActiveNudge) {
+      void acceptHandoff(sessionId);
+      return;
+    }
+    void spawnAgent(sessionId, {
+      kindOverride: handoff.kind,
+      ...(handoff.planId ? { triggeredPlanId: handoff.planId as PlanId } : {}),
+    });
+  };
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid="handoff-chip"
+        className="inline-flex items-center gap-1.5 rounded-full border border-info/40 bg-info/10 px-2.5 py-1 text-[11px] font-medium text-info hover:bg-info/20"
+      >
+        <ArrowRight size={11} aria-hidden />
+        <span>spawn {meta.label.toLowerCase()}</span>
+        {handoff.reason ? <span className="text-muted-foreground">— {handoff.reason}</span> : null}
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/chat/components/NudgeCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/NudgeCard/index.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@kay-am/ui';
+
+export type NudgeSeverity = 'info' | 'warning' | 'success';
+
+export interface NudgeAction {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly testId?: string;
+}
+
+export interface NudgeCardProps {
+  readonly severity: NudgeSeverity;
+  readonly icon?: ReactNode;
+  readonly title: ReactNode;
+  readonly body?: ReactNode;
+  readonly primary?: NudgeAction;
+  readonly secondary?: NudgeAction;
+  readonly tertiary?: NudgeAction;
+  readonly onDismiss?: () => void;
+  readonly ariaLabel: string;
+  readonly testId?: string;
+  readonly autoFocusPrimary?: boolean;
+}
+
+const SEVERITY_FRAME: Record<NudgeSeverity, string> = {
+  info: 'border-info/40 bg-info/10',
+  warning: 'border-warning/40 bg-warning/10',
+  success: 'border-success/40 bg-success/10',
+};
+
+const SEVERITY_PRIMARY: Record<NudgeSeverity, string> = {
+  info: 'bg-info text-info-foreground',
+  warning: 'bg-warning text-warning-foreground',
+  success: 'bg-success text-success-foreground',
+};
+
+const SEVERITY_ICON: Record<NudgeSeverity, string> = {
+  info: 'text-info',
+  warning: 'text-warning',
+  success: 'text-success',
+};
+
+export function NudgeCard({
+  severity,
+  icon,
+  title,
+  body,
+  primary,
+  secondary,
+  tertiary,
+  onDismiss,
+  ariaLabel,
+  testId,
+  autoFocusPrimary = false,
+}: NudgeCardProps) {
+  const primaryBtnRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (!autoFocusPrimary) return;
+    const activeIsInput =
+      typeof document !== 'undefined' &&
+      document.activeElement instanceof HTMLElement &&
+      /^(input|textarea)$/i.test(document.activeElement.tagName);
+    if (activeIsInput) return;
+    const handle = window.setTimeout(() => {
+      primaryBtnRef.current?.focus();
+    }, 300);
+    return () => window.clearTimeout(handle);
+  }, [autoFocusPrimary]);
+
+  return (
+    <section
+      className={cn('relative rounded border px-2.5 py-2 text-[11px]', SEVERITY_FRAME[severity])}
+      data-testid={testId}
+      aria-label={ariaLabel}
+    >
+      {onDismiss ? (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="dismiss"
+          className="absolute right-1.5 top-1.5 inline-flex h-5 w-5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+          data-testid={testId ? `${testId}-dismiss` : undefined}
+        >
+          <X size={12} aria-hidden />
+        </button>
+      ) : null}
+      <div className="flex items-start gap-2 pr-5">
+        {icon ? (
+          <span className={cn('mt-0.5 shrink-0', SEVERITY_ICON[severity])} aria-hidden>
+            {icon}
+          </span>
+        ) : null}
+        <div className="flex-1">
+          <p className="text-foreground">{title}</p>
+          {body ? <p className="mt-0.5 text-muted-foreground">{body}</p> : null}
+          {primary || secondary || tertiary ? (
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              {primary ? (
+                <button
+                  ref={primaryBtnRef}
+                  type="button"
+                  onClick={primary.onClick}
+                  data-testid={primary.testId}
+                  className={cn(
+                    'rounded px-2 py-0.5 text-[10px] font-semibold hover:opacity-90',
+                    SEVERITY_PRIMARY[severity],
+                  )}
+                >
+                  {primary.label}
+                </button>
+              ) : null}
+              {secondary ? (
+                <button
+                  type="button"
+                  onClick={secondary.onClick}
+                  data-testid={secondary.testId}
+                  className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
+                >
+                  {secondary.label}
+                </button>
+              ) : null}
+              {tertiary ? (
+                <button
+                  type="button"
+                  onClick={tertiary.onClick}
+                  data-testid={tertiary.testId}
+                  className="rounded px-2 py-0.5 text-[10px] font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  {tertiary.label}
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/features/chat/components/RightSizeCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/RightSizeCard/index.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { Sparkles } from 'lucide-react';
 import { cn } from '@kay-am/ui';
 import { modelLabel, modelTier, TIER_TEXT } from '../../utils/chat-constants';
+import { NudgeCard } from '../NudgeCard';
 
 export interface RightSizeCardProps {
   readonly currentModel: string;
@@ -17,55 +18,41 @@ export function RightSizeCard({
   onKeepCurrent,
   onChangeModel,
 }: RightSizeCardProps) {
-  const suggestBtnRef = useRef<HTMLButtonElement>(null);
-  useEffect(() => {
-    suggestBtnRef.current?.focus();
-  }, []);
-
   return (
-    <section
-      className="rounded border border-info/40 bg-info/10 px-2.5 py-2 text-[11px]"
-      data-testid="right-size-card"
-      aria-label="model right-sizing suggestion"
-    >
-      <p className="mb-2 text-foreground">
-        This looks light. Run with{' '}
-        <span className={cn('font-semibold', TIER_TEXT[modelTier(suggestedModel)])}>
-          {modelLabel(suggestedModel)}
-        </span>{' '}
-        instead of{' '}
-        <span className={cn('font-semibold', TIER_TEXT[modelTier(currentModel)])}>
-          {modelLabel(currentModel)}
-        </span>
-        ?
-      </p>
-      <div className="flex gap-2">
-        <button
-          ref={suggestBtnRef}
-          type="button"
-          onClick={onUseSuggested}
-          className="rounded bg-info px-2 py-0.5 text-[10px] font-semibold text-info-foreground hover:opacity-90"
-          data-testid="right-size-use-suggested"
-        >
-          Use {modelLabel(suggestedModel)}
-        </button>
-        <button
-          type="button"
-          onClick={onKeepCurrent}
-          className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
-          data-testid="right-size-keep-current"
-        >
-          Keep {modelLabel(currentModel)}
-        </button>
-        <button
-          type="button"
-          onClick={onChangeModel}
-          className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-muted-foreground hover:bg-muted hover:text-foreground"
-          data-testid="right-size-change-model"
-        >
-          Change model…
-        </button>
-      </div>
-    </section>
+    <NudgeCard
+      severity="info"
+      icon={<Sparkles size={12} aria-hidden />}
+      ariaLabel="model right-sizing suggestion"
+      testId="right-size-card"
+      autoFocusPrimary
+      title={
+        <>
+          This looks light. Run with{' '}
+          <span className={cn('font-semibold', TIER_TEXT[modelTier(suggestedModel)])}>
+            {modelLabel(suggestedModel)}
+          </span>{' '}
+          instead of{' '}
+          <span className={cn('font-semibold', TIER_TEXT[modelTier(currentModel)])}>
+            {modelLabel(currentModel)}
+          </span>
+          ?
+        </>
+      }
+      primary={{
+        label: `Use ${modelLabel(suggestedModel)}`,
+        onClick: onUseSuggested,
+        testId: 'right-size-use-suggested',
+      }}
+      secondary={{
+        label: `Keep ${modelLabel(currentModel)}`,
+        onClick: onKeepCurrent,
+        testId: 'right-size-keep-current',
+      }}
+      tertiary={{
+        label: 'Change model…',
+        onClick: onChangeModel,
+        testId: 'right-size-change-model',
+      }}
+    />
   );
 }

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -9,6 +9,7 @@ import { PhaseTransitionCard } from '../PhaseTransitionCard';
 import { PermissionRequestCard } from '../../../../features/permissions/components/PermissionRequestCard';
 import { PermissionDecisionCard } from '../../../../features/permissions/components/PermissionDecisionCard';
 import { displayPath } from '../../../../shared/utils/display-path';
+import { HandoffChip } from '../HandoffChip';
 
 const EDIT_LABEL: Record<'create' | 'modify' | 'delete', string> = {
   create: 'created',
@@ -37,7 +38,7 @@ function TranscriptCardImpl({
     case 'user_text':
       return <UserText text={item.text} at={item.at} />;
     case 'assistant_text':
-      return <AssistantText text={item.text} />;
+      return <AssistantText text={item.text} sessionId={sessionId} />;
     case 'tool_call':
       return <ToolCall item={item} />;
     case 'file_edit':
@@ -174,13 +175,20 @@ function formatCostUsd(cost: number): string {
   return `$${cost.toFixed(2)}`;
 }
 
-function AssistantText({ text }: { text: string }) {
+const HANDOFF_MARKER_RE = /<<handoff\s+[^>]+?>>/g;
+
+function AssistantText({ text, sessionId }: { text: string; sessionId: SessionId | null }) {
+  const displayText = text
+    .replace(HANDOFF_MARKER_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
   return (
     <div className="group relative text-[13px]">
       <div className="absolute -right-1 -top-1 opacity-0 motion-safe:transition-opacity group-hover:opacity-100">
         <CopyButton value={text} label="message" />
       </div>
-      <Markdown text={text} />
+      <Markdown text={displayText} />
+      {sessionId ? <HandoffChip assistantText={text} sessionId={sessionId} /> : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/chat/utils/scope-mismatch.test.ts
+++ b/apps/desktop/src/features/chat/utils/scope-mismatch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { detectScopeMismatch } from './scope-mismatch';
+
+describe('detectScopeMismatch', () => {
+  describe('planner', () => {
+    it('flags imperative "implementa" with no planning frame', () => {
+      const r = detectScopeMismatch('implementa la nuova feature', 'planner');
+      expect(r?.kind).toBe('planner-asked-to-implement');
+      expect(r?.suggestedAgentKind).toBe('implementer');
+    });
+
+    it('flags "fixa il bug"', () => {
+      expect(detectScopeMismatch('fixa il bug nel login', 'planner')?.kind).toBe(
+        'planner-asked-to-implement',
+      );
+    });
+
+    it('does NOT flag "fammi un piano così posso implementare"', () => {
+      expect(detectScopeMismatch('fammi un piano così posso implementare', 'planner')).toBeNull();
+    });
+
+    it('does NOT flag "spiega come implementare"', () => {
+      expect(detectScopeMismatch('spiega come implementare auth', 'planner')).toBeNull();
+    });
+
+    it('does NOT flag mid-sentence mention without imperative lead', () => {
+      expect(
+        detectScopeMismatch('mi serve un piano per il refactor del modulo auth', 'planner'),
+      ).toBeNull();
+    });
+
+    it('does NOT flag plain question', () => {
+      expect(detectScopeMismatch('come funziona il modulo auth?', 'planner')).toBeNull();
+    });
+  });
+
+  describe('implementer / debugger / tester', () => {
+    it('flags "fammi un piano" on implementer', () => {
+      const r = detectScopeMismatch('fammi un piano per il refactor', 'implementer');
+      expect(r?.kind).toBe('implementer-asked-to-plan');
+      expect(r?.suggestedAgentKind).toBe('planner');
+    });
+
+    it('flags "design the migration" on debugger', () => {
+      expect(detectScopeMismatch('design the migration steps', 'debugger')?.kind).toBe(
+        'implementer-asked-to-plan',
+      );
+    });
+
+    it('does NOT flag when message also asks for implementation', () => {
+      expect(
+        detectScopeMismatch('fammi un piano e poi implementa il primo step', 'implementer'),
+      ).toBeNull();
+    });
+  });
+
+  describe('out-of-scope kinds', () => {
+    it('returns null for generic', () => {
+      expect(detectScopeMismatch('implementa tutto', 'generic')).toBeNull();
+    });
+
+    it('returns null for init', () => {
+      expect(detectScopeMismatch('fammi un piano', 'init')).toBeNull();
+    });
+  });
+
+  it('returns null for empty input', () => {
+    expect(detectScopeMismatch('   ', 'planner')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/chat/utils/scope-mismatch.ts
+++ b/apps/desktop/src/features/chat/utils/scope-mismatch.ts
@@ -1,0 +1,55 @@
+import type { AgentKind } from '../../session/agent-kind';
+
+export type ScopeMismatchKind = 'planner-asked-to-implement' | 'implementer-asked-to-plan';
+
+export interface ScopeMismatch {
+  readonly kind: ScopeMismatchKind;
+  readonly suggestedAgentKind: AgentKind;
+}
+
+/**
+ * Imperative verbs that mean "do the thing", not "design it". Anchored to the
+ * start (allowing only leading whitespace and punctuation) so casual mentions
+ * mid-sentence don't trip the check. Italian + English mixed because the user
+ * messages tend to be either or both.
+ */
+const IMPLEMENT_VERB_RE =
+  /^[\s,.!?]*(?:implementa|implementalo|implement(?:s|ing)?|scrivi(?:lo)?|scrivimi|fixa|fixami|fixalo|fix(?:e|alo|the|it|this)?|modifica(?:lo)?|aggiungi|aggiungimi|crea(?:lo|mi)?(?:\s+il(?:\s+\w+)?)?|build|refactor|patch)\b/i;
+
+const PLAN_VERB_RE =
+  /^[\s,.!?]*(?:pianifica(?:lo|mi)?|fammi\s+un\s+piano|fammi\s+il\s+piano|progetta(?:lo|mi)?|design(?:a|ami|mi)?|plan\s+(?:out|this)?|outline(?:\s+the)?|spec(?:c?a|out)?)\b/i;
+
+/**
+ * Framing words that signal the user is asking about HOW or WHAT, not asking
+ * the agent to perform the action. "Fammi un piano così posso implementare"
+ * contains "implementare" but the framing is clearly planning.
+ */
+const PLANNING_FRAME_RE =
+  /\b(piano|plan|come|how|spiega|explain|design|architett|approach|strategia|strategy|cosa\s+serve|what\s+(?:do\s+)?we\s+need)\b/i;
+
+const IMPLEMENT_FRAME_RE =
+  /\b(implementa(?:lo)?|implement(?:s|ing|ed)?|scrivi(?:lo|mi)?|write\s+(?:code|the\s+function|it))\b/i;
+
+/**
+ * Detect a scope mismatch between the agent kind and the user's intent. Pure,
+ * conservative heuristic. Returns null when the message is plainly aligned or
+ * when the agent kind doesn't have a guarded scope (init, generic).
+ */
+export function detectScopeMismatch(input: string, agentKind: AgentKind): ScopeMismatch | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+
+  if (agentKind === 'planner') {
+    if (IMPLEMENT_VERB_RE.test(trimmed) && !PLANNING_FRAME_RE.test(trimmed)) {
+      return { kind: 'planner-asked-to-implement', suggestedAgentKind: 'implementer' };
+    }
+  }
+
+  if (agentKind === 'implementer' || agentKind === 'debugger' || agentKind === 'tester') {
+    if (PLAN_VERB_RE.test(trimmed) && !IMPLEMENT_FRAME_RE.test(trimmed)) {
+      return { kind: 'implementer-asked-to-plan', suggestedAgentKind: 'planner' };
+    }
+  }
+
+  return null;
+}

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -96,7 +96,7 @@ export const AGENT_KIND_DEFAULTS: Record<
     model: 'claude-haiku-4-5',
     effort: 'low',
     systemPrompt:
-      'you are a scout agent. explore the codebase, answer questions, locate files and symbols. ALLOWED: read files, search, summarize findings, report structure. FORBIDDEN: editing files, writing code, creating plans, running tests. if you catch yourself doing a forbidden action, stop and say "this is outside my scope — spawn an implementer or planner agent".',
+      'you are a scout agent. explore the codebase, answer questions, locate files and symbols. ALLOWED: read files, search, summarize findings, report structure. FORBIDDEN: editing files, writing code, creating plans, running tests. if you catch yourself doing a forbidden action, stop and say "this is outside my scope — spawn an implementer or planner agent". when your exploration is complete and the user clearly needs implementation or planning next, emit a single self-closing `<<handoff kind=implementer reason="..." >>` or `<<handoff kind=planner reason="..." >>` marker on its own line.',
   },
   docs: {
     model: 'claude-haiku-4-5',
@@ -132,13 +132,13 @@ export const AGENT_KIND_DEFAULTS: Record<
     model: 'claude-sonnet-4-5',
     effort: 'medium',
     systemPrompt:
-      'you are a review agent. read the diff, identify bugs, style issues, and correctness concerns. ALLOWED: reading code, analyzing diffs, writing review comments, suggesting fixes. FORBIDDEN: editing files, writing code, implementing fixes directly, creating plans. present findings as a structured review. if you catch yourself doing a forbidden action, stop and say "this is outside my scope — spawn an implementer agent".',
+      'you are a review agent. read the diff, identify bugs, style issues, and correctness concerns. ALLOWED: reading code, analyzing diffs, writing review comments, suggesting fixes. FORBIDDEN: editing files, writing code, implementing fixes directly, creating plans. present findings as a structured review. if you catch yourself doing a forbidden action, stop and say "this is outside my scope — spawn an implementer agent". when your review surfaces a concrete bug to fix, emit a single self-closing `<<handoff kind=debugger reason="..." >>` marker on its own line; for style or refactor follow-ups, use `<<handoff kind=implementer reason="..." >>`.',
   },
   planner: {
     model: 'claude-opus-4-5',
     effort: 'high',
     systemPrompt:
-      'you are a planning agent. analyze the goal, break it into ordered steps, identify risks and dependencies. do not implement — produce a plan the implementer agent will execute. be concise. ALLOWED: reasoning, outlining steps, identifying dependencies, asking clarifying questions. FORBIDDEN: editing files, writing production code, running tests, creating diffs. wrap your final plan in <<plan>>...<</plan>> markers so it can be captured as a session artifact. the first line of the plan body is the title; the rest is markdown. emit exactly one plan block per turn.',
+      'you are a planning agent. analyze the goal, break it into ordered steps, identify risks and dependencies. do not implement — produce a plan the implementer agent will execute. be concise. ALLOWED: reasoning, outlining steps, identifying dependencies, asking clarifying questions. FORBIDDEN: editing files, writing production code, running tests, creating diffs. wrap your final plan in <<plan>>...<</plan>> markers so it can be captured as a session artifact. the first line of the plan body is the title; the rest is markdown. emit exactly one plan block per turn. when the plan is complete and has no open questions, also emit a single self-closing marker `<<handoff kind=implementer reason="..." >>` on its own line — the desktop UI shows it as a CTA to spawn an implementer agent. do not emit handoff if you still need user input.',
   },
 };
 

--- a/apps/desktop/src/store/slices/nudges.slice.ts
+++ b/apps/desktop/src/store/slices/nudges.slice.ts
@@ -1,0 +1,63 @@
+import { updateNudgeEventOutcome, type NudgeOutcome } from '@kay-am/db';
+import type { IsoDateTime, SessionId } from '@kay-am/types';
+import { tauriDatabase } from '../../shared/lib/db';
+import { formatError } from '../../shared/lib/errors';
+import type { AppStore } from '../store';
+
+type SetFn = (p: Partial<AppStore> | ((s: AppStore) => Partial<AppStore>)) => void;
+type GetFn = () => AppStore;
+
+async function recordOutcome(id: string, outcome: NudgeOutcome): Promise<void> {
+  try {
+    await updateNudgeEventOutcome(
+      tauriDatabase,
+      id,
+      outcome,
+      new Date().toISOString() as IsoDateTime,
+    );
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn(`[nudge-event] update failed: ${formatError(err)}`);
+    }
+  }
+}
+
+export function createNudgesSlice(set: SetFn, get: GetFn) {
+  return {
+    dismissSessionNudge: async (
+      sessionId: SessionId,
+      outcome: 'accepted' | 'dismissed' = 'dismissed',
+    ) => {
+      const nudge = get().sessionNudges[sessionId] ?? null;
+      if (!nudge) return;
+      set((state) => ({
+        sessionNudges: { ...state.sessionNudges, [sessionId]: null },
+      }));
+      await recordOutcome(nudge.id, outcome);
+    },
+
+    acceptSessionNudgeHandoff: async (sessionId: SessionId) => {
+      const nudge = get().sessionNudges[sessionId] ?? null;
+      if (!nudge) return;
+      set((state) => ({
+        sessionNudges: { ...state.sessionNudges, [sessionId]: null },
+      }));
+      await recordOutcome(nudge.id, 'accepted');
+      if (nudge.kind === 'plan-ready') {
+        if (nudge.planId !== null) {
+          await get().spawnAgent(sessionId, {
+            triggeredPlanId: nudge.planId,
+            kindOverride: 'implementer',
+          });
+        } else {
+          await get().spawnAgent(sessionId, { kindOverride: 'implementer' });
+        }
+      } else {
+        await get().spawnAgent(sessionId, {
+          kindOverride: nudge.targetKind,
+          ...(nudge.planId !== null && { triggeredPlanId: nudge.planId }),
+        });
+      }
+    },
+  };
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -64,9 +64,12 @@ import {
   deleteInitScript,
   listInitScriptHistory,
   upsertContextSlot,
+  insertNudgeEvent,
   type Notification,
   type NotificationKind,
   type NotificationSeverity,
+  type NudgeEvent,
+  type NudgeKind,
   type TelemetrySummary,
 } from '@kay-am/db';
 import type {
@@ -124,10 +127,13 @@ import type {
 } from '@kay-am/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@kay-am/types';
 import {
+  assessPlanReadiness,
   computeCostUsd,
   computeCodexCostUsd,
   computeCursorCostUsd,
+  extractHandoff,
   extractPlanFromMarker,
+  type ExtractedHandoff,
 } from '@kay-am/core';
 import { runDbMigrations, tauriDatabase, wipeDb } from '../shared/lib/db';
 import {
@@ -218,6 +224,7 @@ import {
 import { slotsForKind } from '../features/providers/slot-routing';
 import { estimateTokens } from '../shared/utils/estimate-tokens';
 import { createNotificationsSlice } from './slices/notifications.slice';
+import { createNudgesSlice } from './slices/nudges.slice';
 import { createPlansSlice } from './slices/plans.slice';
 import { createBudgetSlice, buildProviderSpendBreakdown } from './slices/budget.slice';
 import { createSkillsSlice } from './slices/skills.slice';
@@ -243,6 +250,23 @@ export interface SystemAlert {
   readonly message: string;
   readonly createdAt: string;
 }
+
+export type SessionNudge =
+  | {
+      readonly kind: 'plan-ready';
+      readonly id: string;
+      readonly agentId: AgentId;
+      readonly planId: PlanId | null;
+      readonly planTitle: string;
+    }
+  | {
+      readonly kind: 'handoff-suggested';
+      readonly id: string;
+      readonly agentId: AgentId;
+      readonly targetKind: AgentKind;
+      readonly reason: string;
+      readonly planId: PlanId | null;
+    };
 
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from './preamble';
 import type { ProviderSpendEntry } from './slices/budget.slice';
@@ -325,6 +349,12 @@ export interface AppState {
   readonly notifications: ReadonlyArray<Notification>;
   readonly sessionPlans: Readonly<Record<SessionId, ReadonlyArray<PlanWithCount>>>;
   readonly planConsumptions: Readonly<Record<PlanId, ReadonlyArray<PlanConsumption>>>;
+  /**
+   * Per-session pending nudges surfaced to the chat input area. Cleared on
+   * dismiss or when the user acts on the suggestion. Not persisted across
+   * app restarts on purpose — nudges expire with the session lifetime.
+   */
+  readonly sessionNudges: Readonly<Record<SessionId, SessionNudge | null>>;
   /**
    * Per-session loading flags. Each block (agents, transcript, telemetry,
    * slots, plans, summary) starts true on session switch and is flipped off
@@ -557,6 +587,8 @@ export interface AppActions {
   abandonPlan(sessionId: SessionId, planId: PlanId): Promise<void>;
   loadConsumptionsForPlan(planId: PlanId): Promise<void>;
   runPlan(sessionId: SessionId, planId: PlanId): Promise<void>;
+  dismissSessionNudge(sessionId: SessionId, outcome?: 'accepted' | 'dismissed'): Promise<void>;
+  acceptSessionNudgeHandoff(sessionId: SessionId): Promise<void>;
 }
 
 export type AppStore = AppState & AppActions;
@@ -617,6 +649,7 @@ const initialState: AppState = {
   diffComments: {},
   notifications: [],
   sessionPlans: {},
+  sessionNudges: {},
   planConsumptions: {},
   sessionLoading: {},
 };
@@ -917,10 +950,10 @@ async function capturePlanFromTurn(
   sessionId: SessionId,
   agentId: AgentId,
   assistantText: string,
-): Promise<void> {
+): Promise<PlanWithCount | null> {
   try {
     const extracted = extractPlanFromMarker(assistantText);
-    if (!extracted) return;
+    if (!extracted) return null;
     await invokeUpsertPlan({
       sessionId,
       agentId,
@@ -931,10 +964,98 @@ async function capturePlanFromTurn(
     set((state) => ({
       sessionPlans: { ...state.sessionPlans, [sessionId]: refreshed },
     }));
+    return (
+      refreshed.find((p) => p.title === extracted.title && p.bodyMd === extracted.bodyMd) ??
+      refreshed[0] ??
+      null
+    );
   } catch (err) {
     if (import.meta.env.DEV) {
       console.warn(`[plan-capture] failed for session ${sessionId}: ${formatError(err)}`);
     }
+    return null;
+  }
+}
+
+async function recordNudgeShown(
+  kind: NudgeKind,
+  context: Record<string, unknown>,
+): Promise<string> {
+  const id = crypto.randomUUID();
+  const event: NudgeEvent = {
+    id,
+    ts: new Date().toISOString() as IsoDateTime,
+    kind,
+    contextJson: JSON.stringify(context),
+    outcome: null,
+    outcomeTs: null,
+  };
+  try {
+    await insertNudgeEvent(tauriDatabase, event);
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn(`[nudge-event] insert failed: ${formatError(err)}`);
+    }
+  }
+  return id;
+}
+
+async function emitTurnNudges(
+  set: SetFn,
+  get: () => AppStore,
+  sessionId: SessionId,
+  agentId: AgentId,
+  assistantText: string,
+  capturedPlan: PlanWithCount | null,
+): Promise<void> {
+  const session = get().sessions.find((s) => s.id === sessionId);
+  if (!session) return;
+  const inWorkflow = session.workflowId !== null && session.workflowId !== undefined;
+
+  let nextNudge: SessionNudge | null = null;
+
+  const handoff: ExtractedHandoff | null = extractHandoff(assistantText);
+  if (handoff && !inWorkflow) {
+    const id = await recordNudgeShown('handoff-suggested', {
+      sessionId,
+      agentId,
+      targetKind: handoff.kind,
+      reason: handoff.reason,
+      planId: handoff.planId,
+    });
+    nextNudge = {
+      kind: 'handoff-suggested',
+      id,
+      agentId,
+      targetKind: handoff.kind,
+      reason: handoff.reason,
+      planId: (handoff.planId as PlanId | null) ?? null,
+    };
+  } else if (capturedPlan && !inWorkflow) {
+    const readiness = assessPlanReadiness({
+      planBody: capturedPlan.bodyMd,
+      assistantText,
+    });
+    if (readiness.ready) {
+      const id = await recordNudgeShown('plan-ready', {
+        sessionId,
+        agentId,
+        planId: capturedPlan.id,
+      });
+      nextNudge = {
+        kind: 'plan-ready',
+        id,
+        agentId,
+        planId: capturedPlan.id,
+        planTitle: capturedPlan.title,
+      };
+    }
+  }
+
+  if (nextNudge !== null) {
+    set((state) => ({
+      sessionNudges: { ...state.sessionNudges, [sessionId]: nextNudge },
+    }));
   }
 }
 
@@ -1095,6 +1216,7 @@ let hydratePromise: Promise<void> | null = null;
 export const useAppStore = create<AppStore>((set, get) => ({
   ...initialState,
   ...createNotificationsSlice(set, get),
+  ...createNudgesSlice(set, get),
   ...createPlansSlice(set, get),
   ...createBudgetSlice(set, get),
   ...createSkillsSlice(set, get),
@@ -2825,7 +2947,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     if (!lastError && !turnWasCancelled && assistantText.length > 0) {
       enqueueSummarizer(set, get, sessionId, resolvedPrompt, assistantText);
-      void capturePlanFromTurn(set, sessionId, activeAgentId, assistantText);
+      void capturePlanFromTurn(set, sessionId, activeAgentId, assistantText).then((plan) =>
+        emitTurnNudges(set, get, sessionId, activeAgentId, assistantText, plan),
+      );
       const driftViolations = detectDrift({
         agentKind: earlyAgentKind,
         assistantText,

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { TurnEvent } from '@kay-am/types';
 import {
+  assessPlanReadiness,
   extractFilesTouched,
+  extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
   mergeIntoSlot,
@@ -176,5 +178,75 @@ describe('mergeIntoSlot', () => {
 
   it('treats whitespace-only as duplicate when stripped', () => {
     expect(mergeIntoSlot('foo', ['  foo  '])).toBe('foo');
+  });
+});
+
+describe('extractHandoff', () => {
+  it('returns null when no marker is present', () => {
+    expect(extractHandoff('just chat text')).toBeNull();
+  });
+
+  it('parses self-closing marker with quoted reason', () => {
+    const text = 'plan emitted. <<handoff kind=implementer reason="plan ready" plan=abc>>';
+    expect(extractHandoff(text)).toEqual({
+      kind: 'implementer',
+      reason: 'plan ready',
+      planId: 'abc',
+    });
+  });
+
+  it('parses without a plan attribute', () => {
+    const text = '<<handoff kind=debugger reason="error reproduced">>';
+    expect(extractHandoff(text)).toEqual({
+      kind: 'debugger',
+      reason: 'error reproduced',
+      planId: null,
+    });
+  });
+
+  it('rejects unknown kinds', () => {
+    const text = '<<handoff kind=hacker reason=yo>>';
+    expect(extractHandoff(text)).toBeNull();
+  });
+
+  it('returns the last marker when multiple appear', () => {
+    const text =
+      '<<handoff kind=scout reason="early">> ... <<handoff kind=implementer reason="final">>';
+    expect(extractHandoff(text)?.kind).toBe('implementer');
+  });
+});
+
+describe('assessPlanReadiness', () => {
+  const body = '1. step one\n2. step two';
+
+  it('marks ready when body has multiple steps and no open questions', () => {
+    expect(
+      assessPlanReadiness({ planBody: body, assistantText: `<<plan>>${body}<</plan>>` }),
+    ).toEqual({ ready: true, reason: null });
+  });
+
+  it('rejects when body has TODO', () => {
+    const b = '1. step one\n2. TODO refine';
+    expect(assessPlanReadiness({ planBody: b, assistantText: '' }).reason).toBe(
+      'incomplete-markers',
+    );
+  });
+
+  it('rejects when body has only one step', () => {
+    expect(assessPlanReadiness({ planBody: '1. only step', assistantText: '' }).reason).toBe(
+      'too-few-steps',
+    );
+  });
+
+  it('rejects when assistant text outside plan asks an open question', () => {
+    const text = `<<plan>>${body}<</plan>>\n\nvuoi che continui?`;
+    expect(assessPlanReadiness({ planBody: body, assistantText: text }).reason).toBe(
+      'has-open-question',
+    );
+  });
+
+  it('does not count open-question phrases that appear inside the plan body', () => {
+    const text = `<<plan>>${body}\n\nshould i clarify before step 2?<</plan>>`;
+    expect(assessPlanReadiness({ planBody: body, assistantText: text }).ready).toBe(true);
   });
 });

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -1,4 +1,5 @@
 import type { TurnEvent } from '@kay-am/types';
+import type { AgentKindLabel } from '../first-turn-classifier';
 
 // Extractors that turn raw turn output into ContextPanel updates. Each
 // exported fn is pure — caller persists via the ContextEngine. Split kept
@@ -24,6 +25,8 @@ const DECISION_RE = /<<ctx-decision>>([\s\S]*?)<<\/ctx-decision>>/g;
 const QUESTION_RE = /<<ctx-question>>([\s\S]*?)<<\/ctx-question>>/g;
 const RESOLVED_RE = /<<ctx-resolved>>([\s\S]*?)<<\/ctx-resolved>>/g;
 const PLAN_RE = /<<plan>>([\s\S]*?)<<\/plan>>/g;
+const HANDOFF_RE = /<<handoff\s+([^>]+?)>>/g;
+const HANDOFF_ATTR_RE = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+))/g;
 
 /**
  * Pull agent-emitted markers out of an assistant turn's full text. Agents
@@ -88,6 +91,97 @@ function parsePlanBody(raw: string): ExtractedPlan | null {
   let bodyMd = restLines.join('\n').replace(/^\n+/, '').replace(/\n+$/, '');
   if (bodyMd.length === 0) bodyMd = title;
   return { title, bodyMd };
+}
+
+const HANDOFF_KINDS: ReadonlySet<AgentKindLabel> = new Set([
+  'init',
+  'planner',
+  'scout',
+  'implementer',
+  'debugger',
+  'tester',
+  'docs',
+  'reviewer',
+  'generic',
+]);
+
+export interface ExtractedHandoff {
+  readonly kind: AgentKindLabel;
+  readonly reason: string;
+  readonly planId: string | null;
+}
+
+/**
+ * Parse the last `<<handoff kind=... reason="..." plan=...>>` marker out of an
+ * assistant turn. Agents emit it when they consider their scope done and want
+ * to suggest the next agent. Self-closing format. Unknown kinds are rejected.
+ */
+export function extractHandoff(assistantText: string): ExtractedHandoff | null {
+  HANDOFF_RE.lastIndex = 0;
+  let last: ExtractedHandoff | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = HANDOFF_RE.exec(assistantText)) !== null) {
+    const inner = m[1] ?? '';
+    const attrs = parseHandoffAttrs(inner);
+    const kindRaw = attrs.kind?.toLowerCase() ?? '';
+    if (!HANDOFF_KINDS.has(kindRaw as AgentKindLabel)) continue;
+    last = {
+      kind: kindRaw as AgentKindLabel,
+      reason: attrs.reason?.trim() ?? '',
+      planId: attrs.plan?.trim() || null,
+    };
+  }
+  return last;
+}
+
+function parseHandoffAttrs(inner: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  HANDOFF_ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = HANDOFF_ATTR_RE.exec(inner)) !== null) {
+    const key = (m[1] ?? '').toLowerCase();
+    const value = m[2] ?? m[3] ?? m[4] ?? '';
+    if (key.length > 0) out[key] = value;
+  }
+  return out;
+}
+
+const PLAN_OPEN_QUESTION_RE =
+  /\b(vuoi che|ti torna|che ne dici|should i|let me know|do you want|shall i|wdyt|preferisci)\b/i;
+const PLAN_INCOMPLETE_RE = /\b(TODO|TBD|FIXME|\?\?)\b/i;
+const PLAN_STEP_RE = /^\s*(?:\d+[.)]|[-*])\s+\S/m;
+
+export interface PlanReadinessInput {
+  readonly planBody: string;
+  readonly assistantText: string;
+}
+
+export interface PlanReadinessResult {
+  readonly ready: boolean;
+  readonly reason: 'has-open-question' | 'incomplete-markers' | 'too-few-steps' | null;
+}
+
+/**
+ * Heuristic check for whether a freshly emitted plan looks complete enough to
+ * justify suggesting the implementer agent. Conservative on purpose — false
+ * positives mean noisy nudges. Three rejections:
+ *   - body contains TODO / TBD / FIXME / ??
+ *   - body has fewer than 2 bulleted/numbered steps
+ *   - assistant text outside the plan block asks an open question
+ */
+export function assessPlanReadiness(input: PlanReadinessInput): PlanReadinessResult {
+  if (PLAN_INCOMPLETE_RE.test(input.planBody)) {
+    return { ready: false, reason: 'incomplete-markers' };
+  }
+  const stepLines = input.planBody.split('\n').filter((line) => PLAN_STEP_RE.test(line));
+  if (stepLines.length < 2) {
+    return { ready: false, reason: 'too-few-steps' };
+  }
+  const outsidePlan = input.assistantText.replace(PLAN_RE, '').trim();
+  if (PLAN_OPEN_QUESTION_RE.test(outsidePlan)) {
+    return { ready: false, reason: 'has-open-question' };
+  }
+  return { ready: true, reason: null };
 }
 
 function extractAll(text: string, re: RegExp): ReadonlyArray<string> {

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -9,12 +9,17 @@ export {
   type SlotKey,
 } from './slots';
 export {
+  assessPlanReadiness,
   extractFilesTouched,
+  extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
   mergeIntoSlot,
   removeFromSlot,
+  type ExtractedHandoff,
   type ExtractedPlan,
+  type PlanReadinessInput,
+  type PlanReadinessResult,
 } from './extractors';
 export {
   autoPopulateContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,8 +22,10 @@ export {
   SLOT_KEYS,
   SLOT_LABELS,
   assertSlotKey,
+  assessPlanReadiness,
   autoPopulateContext,
   extractFilesTouched,
+  extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
   isSlotKey,
@@ -33,7 +35,10 @@ export {
   type AutoPopulateInput,
   type AutoPopulateResult,
   type ContextEngineDeps,
+  type ExtractedHandoff,
   type ExtractedPlan,
+  type PlanReadinessInput,
+  type PlanReadinessResult,
   type SlotKey,
 } from './context';
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -138,6 +138,15 @@ export {
   type NotificationSeverity,
 } from './queries/notification';
 export {
+  insertNudgeEvent,
+  updateNudgeEventOutcome,
+  listNudgeEvents,
+  type ListNudgeEventsOptions,
+  type NudgeEvent,
+  type NudgeKind,
+  type NudgeOutcome,
+} from './queries/nudge-event';
+export {
   listPlansForSession,
   upsertPlan,
   updatePlanStatus,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -32,6 +32,7 @@ import { m031RenameSoftDeletePersist } from './m031-rename-soft-delete-persist';
 import { m032SessionUserStatus } from './m032-session-user-status';
 import { m033WorkspaceInitScripts } from './m033-workspace-init-scripts';
 import { m034WorkspaceDisconnectedAt } from './m034-workspace-disconnected-at';
+import { m035NudgeEvents } from './m035-nudge-events';
 
 export interface Migration {
   readonly version: number;
@@ -73,4 +74,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 32, sql: m032SessionUserStatus },
   { version: 33, sql: m033WorkspaceInitScripts },
   { version: 34, sql: m034WorkspaceDisconnectedAt },
+  { version: 35, sql: m035NudgeEvents },
 ];

--- a/packages/db/src/migrations/m035-nudge-events.ts
+++ b/packages/db/src/migrations/m035-nudge-events.ts
@@ -1,0 +1,11 @@
+export const m035NudgeEvents = /* sql */ `
+CREATE TABLE IF NOT EXISTS nudge_events (
+  id TEXT PRIMARY KEY NOT NULL,
+  ts TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  context_json TEXT,
+  outcome TEXT,
+  outcome_ts TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_nudge_kind_ts ON nudge_events(kind, ts);
+`;

--- a/packages/db/src/queries/nudge-event.ts
+++ b/packages/db/src/queries/nudge-event.ts
@@ -1,0 +1,92 @@
+import type { IsoDateTime } from '@kay-am/types';
+import type { Database } from '../client';
+
+export type NudgeKind = 'model-rightsize' | 'scope-mismatch' | 'plan-ready' | 'handoff-suggested';
+
+export type NudgeOutcome = 'accepted' | 'dismissed' | 'overridden' | 'ignored';
+
+export interface NudgeEvent {
+  readonly id: string;
+  readonly ts: IsoDateTime;
+  readonly kind: NudgeKind;
+  readonly contextJson: string | null;
+  readonly outcome: NudgeOutcome | null;
+  readonly outcomeTs: IsoDateTime | null;
+}
+
+interface NudgeEventRow {
+  id: string;
+  ts: string;
+  kind: string;
+  context_json: string | null;
+  outcome: string | null;
+  outcome_ts: string | null;
+}
+
+function toNudgeEvent(row: NudgeEventRow): NudgeEvent {
+  return {
+    id: row.id,
+    ts: row.ts as IsoDateTime,
+    kind: row.kind as NudgeKind,
+    contextJson: row.context_json,
+    outcome: row.outcome ? (row.outcome as NudgeOutcome) : null,
+    outcomeTs: row.outcome_ts ? (row.outcome_ts as IsoDateTime) : null,
+  };
+}
+
+export async function insertNudgeEvent(db: Database, event: NudgeEvent): Promise<void> {
+  await db.execute(
+    `INSERT INTO nudge_events (id, ts, kind, context_json, outcome, outcome_ts)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [
+      event.id,
+      event.ts,
+      event.kind,
+      event.contextJson ?? null,
+      event.outcome ?? null,
+      event.outcomeTs ?? null,
+    ],
+  );
+}
+
+export async function updateNudgeEventOutcome(
+  db: Database,
+  id: string,
+  outcome: NudgeOutcome,
+  outcomeTs: IsoDateTime,
+): Promise<void> {
+  await db.execute(`UPDATE nudge_events SET outcome = ?, outcome_ts = ? WHERE id = ?`, [
+    outcome,
+    outcomeTs,
+    id,
+  ]);
+}
+
+export interface ListNudgeEventsOptions {
+  readonly sinceTs?: IsoDateTime;
+  readonly kind?: NudgeKind;
+  readonly limit?: number;
+}
+
+export async function listNudgeEvents(
+  db: Database,
+  opts: ListNudgeEventsOptions = {},
+): Promise<ReadonlyArray<NudgeEvent>> {
+  const where: string[] = [];
+  const params: Array<string> = [];
+  if (opts.sinceTs) {
+    where.push('ts >= ?');
+    params.push(opts.sinceTs);
+  }
+  if (opts.kind) {
+    where.push('kind = ?');
+    params.push(opts.kind);
+  }
+  const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+  const limitClause = opts.limit && opts.limit > 0 ? `LIMIT ${Math.floor(opts.limit)}` : '';
+  const rows = await db.select<NudgeEventRow>(
+    `SELECT * FROM nudge_events ${whereClause} ORDER BY ts DESC ${limitClause}`,
+    params,
+  );
+  return rows.map(toNudgeEvent);
+}


### PR DESCRIPTION
## Summary

Implements the MVP slice of [#589](https://github.com/akhayam99/kay-am/issues/589) — agent role guardrails and handoff UX. Five commits, grouped by layer:

1. **core** — `extractHandoff()` parses `<<handoff kind=... reason="..." plan=...>>` self-closing markers; `assessPlanReadiness()` heuristic judges plan completeness (no TODO/TBD, ≥2 steps, no trailing open question). Planner / scout / reviewer system prompts teach the marker.
2. **db** — migration `m035-nudge-events` plus insert / update / list query helpers. Local-only telemetry that records when a nudge was shown, the trigger context, and the outcome (`accepted` / `dismissed` / `overridden` / `ignored`).
3. **desktop UI** — generic `NudgeCard` with `info` / `warning` / `success` severity variants; `RightSizeCard` becomes a thin wrapper.
4. **desktop store** — turn finalization extracts `<<handoff>>` and assesses plan readiness, populating a `SessionNudge` and a `nudge_events` row. Handoff markers also render as an inline CTA chip in the assistant message (stripped from the markdown) — clicking spawns the suggested agent.
5. **desktop chat input** — `detectScopeMismatch()` flags imperative implementation verbs sent to a planner (and the symmetric "fammi un piano" to implementer / debugger / tester); framed phrasings like "fammi un piano così posso implementare" are deliberately allowed through. Plan-ready surfaces as a success nudge above the input. All three nudges record into `nudge_events`. Handoff and scope nudges are suppressed inside an active workflow — the workflow already dictates the next step.

## Out of scope (deferred per #589)

- Per-instance "don't show again" persistence
- Global settings toggles per nudge category
- Remote telemetry / insights modal

## Test plan

- [ ] `pnpm test` in `packages/core` (new `extractHandoff` + `assessPlanReadiness` tests pass — verified locally, 579/579)
- [ ] `pnpm test` in `apps/desktop` (new `scope-mismatch.test.ts` passes, 12/12 — verified locally; pre-existing failures on `store.workflow-stepper` and `NewSessionDialog` snapshots are unrelated to this PR and trace back to `main`)
- [ ] Manual smoke: planner emits `<<handoff kind=implementer reason="...">>` after `<<plan>>` → handoff chip appears under the assistant message in the transcript; clicking spawns an implementer
- [ ] Manual smoke: emit a 2-step plan with no trailing question → plan-ready nudge surfaces above the chat input
- [ ] Manual smoke: type "implementa la feature X" on a planner agent → scope-mismatch warning nudge appears; "send anyway" still sends; "spawn implementer" creates the right agent
- [ ] Manual smoke: same nudges are NOT shown when `session.workflowId` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)