### PR TITLE
chore(repo): drop residual kay-am refs, point urls to goodboy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,43 +25,43 @@ Non-negotiable choices that frame the product. Numbers preserved for cross-refer
 
 Single-provider session with synthetic context and live telemetry. End-to-end Claude session inside a Goodboy-managed worktree.
 
-[v0.1 milestone](https://github.com/akhayam99/kay-am/milestone/1)
+[v0.1 milestone](https://github.com/akhayam99/goodboy/milestone/1)
 
 ### v0.2 — Multi-provider
 
 Cursor + Codex adapters, capability matrix, provider connection UX, summarizer migrated to active-provider CLI.
 
-[v0.2 milestone](https://github.com/akhayam99/kay-am/milestone/2)
+[v0.2 milestone](https://github.com/akhayam99/goodboy/milestone/2)
 
 ### v0.3 — Budget & routing
 
 Per-provider monthly cap, per-session soft cap, automatic fallback when cap hit, threshold alerts, routing engine wired into turn flow.
 
-[v0.3 milestone](https://github.com/akhayam99/kay-am/milestone/3)
+[v0.3 milestone](https://github.com/akhayam99/goodboy/milestone/3)
 
 ### v0.4 — Multi-agent sequential
 
 Declared phases inside a session. Each phase spawns its own agent; synthetic context flows between phases.
 
-[v0.4 milestone](https://github.com/akhayam99/kay-am/milestone/4)
+[v0.4 milestone](https://github.com/akhayam99/goodboy/milestone/4)
 
 ### v0.5 — Skills
 
 Local skill registry (markdown + scripts), slash-command invocation from chat, executable across providers.
 
-[v0.5 milestone](https://github.com/akhayam99/kay-am/milestone/5)
+[v0.5 milestone](https://github.com/akhayam99/goodboy/milestone/5)
 
 ### v0.6 — Permission proxy
 
 Tool-call interception via static rules + audit for Claude. `--dangerously-skip-permissions` removed.
 
-[v0.6 milestone](https://github.com/akhayam99/kay-am/milestone/6)
+[v0.6 milestone](https://github.com/akhayam99/goodboy/milestone/6)
 
 ### v0.7 — Multi-agent parallel
 
 Multiple agents inside a single session on throwaway worktrees, coordinating via shared context. Fan-out / fan-in with merge conflict UI.
 
-[v0.7 milestone](https://github.com/akhayam99/kay-am/milestone/7)
+[v0.7 milestone](https://github.com/akhayam99/goodboy/milestone/7)
 
 ### pre-1.0 — UX polish
 
@@ -147,7 +147,7 @@ Signed binary distribution and everything needed for a public launch.
 - Cursor + Codex permission proxy parity (currently Claude-only)
 - Command palette (⌘K) polish
 
-[v1.0 milestone](https://github.com/akhayam99/kay-am/milestone/8)
+[v1.0 milestone](https://github.com/akhayam99/goodboy/milestone/8)
 
 ---
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"
-repository = "https://github.com/akhayam99/kay-am"
+repository = "https://github.com/akhayam99/goodboy"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/apps/desktop/src/app/components/BootSplash/index.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.tsx
@@ -4,7 +4,7 @@ import { openUrl } from '../../../shared/lib/editor';
 import { DogMascot } from '../../../shared/components/DogMascot';
 
 const GITHUB_NEW_ISSUE_URL =
-  'https://github.com/kay-am/kay-am/issues/new?template=bug_report.md&labels=bug%2Cboot&title=Boot+failure';
+  'https://github.com/akhayam99/goodboy/issues/new?template=bug_report.md&labels=bug%2Cboot&title=Boot+failure';
 
 interface BootSplashProps {
   phase: BootPhase;

--- a/docs/parallel-agents.md
+++ b/docs/parallel-agents.md
@@ -53,7 +53,7 @@ Each phase runs on a new worktree. On completion, Goodboy merges back into main 
 - **Context sharing**: Agents copy parent context once at launch. Real-time parent updates don't propagate to running agents.
 - **Provider quota**: Parallel agents count against your provider subscription cap. Running 3 agents uses 3x the quota.
 
-See [#214](https://github.com/serenis/kay-am/issues/214) for v0.7 integration tests (fan-out/fan-in verified).
+See [#214](https://github.com/akhayam99/goodboy/issues/214) for v0.7 integration tests (fan-out/fan-in verified).
 
 ## Rollback
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Amin Khayam <amin@khayam.dev>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/akhayam99/kay-am.git"
+    "url": "https://github.com/akhayam99/goodboy.git"
   },
   "engines": {
     "node": ">=20",

--- a/packages/core/src/worktree/manager.test.ts
+++ b/packages/core/src/worktree/manager.test.ts
@@ -6,7 +6,7 @@ import { git } from './git';
 import { createWorktree, listWorktrees, removeWorktree, WorktreeError } from './manager';
 
 async function initRepo(): Promise<string> {
-  const dir = await realpath(await mkdtemp(path.join(tmpdir(), 'kayam-wt-')));
+  const dir = await realpath(await mkdtemp(path.join(tmpdir(), 'goodboy-wt-')));
   const repo = path.join(dir, 'demo');
   await git(dir, ['init', '--initial-branch=main', repo]);
   await git(repo, ['config', 'user.email', 'test@example.com']);
@@ -57,7 +57,7 @@ describe('worktree manager', () => {
   });
 
   it('honors a custom parent dir', async () => {
-    const custom = await realpath(await mkdtemp(path.join(tmpdir(), 'kayam-wt-parent-')));
+    const custom = await realpath(await mkdtemp(path.join(tmpdir(), 'goodboy-wt-parent-')));
     const created = await createWorktree({
       repoPath,
       branchPrefix: 'kay',


### PR DESCRIPTION
## Summary

Pre-rename cleanup. The repo will be renamed `kay-am` → `goodboy`; this removes the residual `kay-am` references from the codebase so the rename leaves no stale or broken links behind.

- **Bug fix** — two GitHub URLs pointed at non-existent owners: `kay-am/kay-am` (BootSplash boot-failure issue link) and `serenis/kay-am` (`docs/parallel-agents.md`). Both now point at `akhayam99/goodboy`.
- `package.json` + `Cargo.toml` `repository` url → `goodboy`.
- `ROADMAP.md` — 8 milestone links → `goodboy`.
- `manager.test.ts` — temp-dir prefix `kayam-wt-` → `goodboy-wt-` (cosmetic).
- **Intentionally untouched**: `migrateLegacyStorageKeys()` in `storage-keys.ts` — it bridges old `kayam:`/`kay-am:` localStorage keys to `goodboy:` for pre-rename installs.

The product name was already `Goodboy` everywhere (package names, Tauri identifier, keychain, data dir, storage prefix) — this PR only mops up the lagging `kay-am` repo references.

## Test plan

- [ ] CI typecheck / lint / test green (worktree has no `node_modules`; local typecheck deferred to CI + lefthook)
- [ ] `manager.test.ts` still passes — temp-dir prefix is arbitrary, change is inert
- [ ] After merge: rename the GitHub repo `kay-am` → `goodboy` so the updated URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)