### PR TITLE
feat(desktop): prefix quick-actions in the chat composer

### DIFF
--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -15,6 +15,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     cancelCurrentTurn: typeof cancel;
     providers: ReadonlyArray<{ id: string; connection: string }>;
     skills: Record<string, never>;
+    workspaceScripts: Record<string, never>;
     providerSpendBreakdown: ReadonlyArray<never>;
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
@@ -24,11 +25,18 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     agentDraft: Record<string, string>;
     sessionNudges: Record<string, null>;
     sessionPhaseRuns: Record<string, ReadonlyArray<never>>;
+    phaseTemplates: Record<string, never>;
     setAgentDraft: (agentId: string, value: string) => void;
     clearAgentDraft: (agentId: string) => void;
     dismissSessionNudge: () => Promise<void>;
     acceptSessionNudgeHandoff: () => Promise<void>;
     spawnAgent: () => Promise<void>;
+    runScript: () => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    loadScripts: () => Promise<void>;
+    selectAgent: () => Promise<void>;
+    attachWorkflowToSession: () => Promise<void>;
+    loadPhaseTemplates: () => Promise<void>;
+    loadPhaseRunsForSession: () => Promise<void>;
   }
   const store = create<S>((set) => ({
     sendTurn: send,
@@ -39,6 +47,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
       { id: 'codex', connection: 'connected' },
     ],
     skills: {},
+    workspaceScripts: {},
     providerSpendBreakdown: [],
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},
@@ -48,6 +57,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     agentDraft: {},
     sessionNudges: {},
     sessionPhaseRuns: {},
+    phaseTemplates: {},
     setAgentDraft: (agentId, value) =>
       set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
     clearAgentDraft: (agentId) =>
@@ -60,6 +70,12 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     dismissSessionNudge: async () => undefined,
     acceptSessionNudgeHandoff: async () => undefined,
     spawnAgent: async () => undefined,
+    runScript: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    loadScripts: async () => undefined,
+    selectAgent: async () => undefined,
+    attachWorkflowToSession: async () => undefined,
+    loadPhaseTemplates: async () => undefined,
+    loadPhaseRunsForSession: async () => undefined,
   }));
   return { sendTurnMock: send, cancelCurrentTurnMock: cancel, mockStore: store };
 });

--- a/apps/desktop/src/__tests__/a11y/smoke.test.tsx
+++ b/apps/desktop/src/__tests__/a11y/smoke.test.tsx
@@ -95,7 +95,7 @@ import { SettingsDialog } from '../../features/settings/components/SettingsDialo
 import { WorkspacesSidebar } from '../../features/workspace/components/WorkspacesSidebar';
 import { StatusBar } from '../../app/components/StatusBar';
 import { SkillsPanel } from '../../features/skills/components/SkillsPanel';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover } from '../../features/quick-actions';
 import { ToastProvider } from '../../app/components/Toast';
 
 afterEach(cleanup);
@@ -170,10 +170,15 @@ describe('a11y smoke — SkillsPanel', () => {
   });
 });
 
-describe('a11y smoke — SlashCommandPopover', () => {
-  it('no violations (no skills / empty items)', async () => {
+describe('a11y smoke — QuickActionsPopover', () => {
+  it('no violations (empty items)', async () => {
     const { container } = render(
-      <SlashCommandPopover items={[]} query="" onSelect={vi.fn()} onDismiss={vi.fn()} />,
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="no scripts"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
     );
     const { violations } = await runA11yCheck(container);
     expect(violations).toHaveLength(0);

--- a/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
@@ -76,7 +76,7 @@ import userEvent from '@testing-library/user-event';
 import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
 import { EndSessionDialog } from '../../features/session/components/EndSessionDialog';
 import { NewSessionDialog } from '../../features/session/components/NewSessionDialog';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover, type QuickActionItem } from '../../features/quick-actions';
 import { ToastProvider } from '../../app/components/Toast';
 
 afterEach(cleanup);
@@ -197,47 +197,62 @@ describe('keyboard — NewSessionDialog', () => {
   });
 });
 
-describe('keyboard — SlashCommandPopover arrow / tab navigation', () => {
-  const items = [
-    { name: 'review', description: 'code review' },
-    { name: 'test', description: 'run tests' },
-    { name: 'deploy', description: 'deploy to env' },
+describe('keyboard — QuickActionsPopover arrow / tab navigation', () => {
+  const items: ReadonlyArray<QuickActionItem> = [
+    { id: 'review', label: 'review', sublabel: 'code review', group: 'skill', perform: vi.fn() },
+    { id: 'test', label: 'test', sublabel: 'run tests', group: 'skill', perform: vi.fn() },
+    { id: 'deploy', label: 'deploy', sublabel: 'deploy to env', group: 'skill', perform: vi.fn() },
   ];
 
   it('ArrowDown advances active index and calls onSelect with Enter', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'ArrowDown' });
     fireEvent.keyDown(window, { key: 'Enter' });
     // After one ArrowDown from index 0, active is 1 → 'test'
-    expect(onSelect).toHaveBeenCalledWith('test');
+    expect(onSelect).toHaveBeenCalledWith(items[1]);
   });
 
   it('ArrowUp wraps active index back (stays at 0 from 0)', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'ArrowUp' });
     fireEvent.keyDown(window, { key: 'Enter' });
     // ArrowUp from 0 stays at 0 → 'review'
-    expect(onSelect).toHaveBeenCalledWith('review');
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
   it('Tab key selects the active item', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'Tab' });
-    expect(onSelect).toHaveBeenCalledWith('review');
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
   it('Escape calls onDismiss', () => {
     const onDismiss = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={vi.fn()} onDismiss={onDismiss} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={vi.fn()} onDismiss={onDismiss} />,
+    );
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
-  it('renders empty state when no items match query', () => {
-    render(<SlashCommandPopover items={[]} query="xyz" onSelect={vi.fn()} onDismiss={vi.fn()} />);
-    expect(screen.getByText(/no skills/i)).toBeDefined();
+  it('renders empty hint when there are no items', () => {
+    render(
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="nothing here"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/nothing here/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -459,7 +459,7 @@ exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
 </div>
 `;
 
-exports[`snapshot — empty states > SlashCommandPopover: no skills / empty items 1`] = `
+exports[`snapshot — empty states > QuickActionsPopover: no skills / empty items 1`] = `
 <div
   class="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md"
 >

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -103,7 +103,7 @@ import { BootSplash } from '../../app/components/BootSplash';
 import { NewSessionDialog } from '../../features/session/components/NewSessionDialog';
 import { EndSessionDialog } from '../../features/session/components/EndSessionDialog';
 import { SkillsPanel } from '../../features/skills/components/SkillsPanel';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover } from '../../features/quick-actions';
 import { WorkspacesSidebar } from '../../features/workspace/components/WorkspacesSidebar';
 import { BudgetRulesPanel } from '../../features/budget/components/BudgetRulesPanel';
 import { ProvidersPanel } from '../../features/providers/components/ProvidersPanel';
@@ -153,9 +153,14 @@ describe('snapshot — empty states', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('SlashCommandPopover: no skills / empty items', () => {
+  it('QuickActionsPopover: no skills / empty items', () => {
     const { container } = render(
-      <SlashCommandPopover items={[]} query="" onSelect={vi.fn()} onDismiss={vi.fn()} />,
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="no skills. create one in settings"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -72,13 +72,9 @@ const RUNNING_KINDS = new Set(['starting', 'running']);
 // so the message sends normally.
 const CHAT_PREFIX_RE = /^\s*[$/~@][^\s]*$/;
 
-// Idle-state composer placeholder, rotated to teach the prefix grammar.
-const CHAT_TIPS: ReadonlyArray<string> = [
-  'Message Claude. Shift + Enter for a new line.',
-  'Type $ to run a workspace script.',
-  'Type @ to switch or spawn an agent.',
-  'Type ~ to start a workflow.',
-];
+// Idle-state composer placeholder — shows the whole prefix grammar at once
+// so the user is taught every quick-action up front, not over time.
+const CHAT_PLACEHOLDER = 'Message Claude — $ scripts · ~ workflows · @ agents';
 
 const EFFORT_STORAGE_PREFIX = STORAGE_PREFIXES.effort;
 const MODEL_STORAGE_PREFIX = STORAGE_PREFIXES.model;
@@ -301,7 +297,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
   const [scriptResult, setScriptResult] = useState<ScriptResultState | null>(null);
-  const [tipIndex, setTipIndex] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const runSeqRef = useRef(0);
 
@@ -743,15 +738,6 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setScriptResult(null);
   }, [session.id]);
 
-  // Rotate the idle placeholder to teach the prefix grammar.
-  useEffect(() => {
-    if (providerDisconnected || isRunning) return;
-    const id = setInterval(() => {
-      setTipIndex((i) => (i + 1) % CHAT_TIPS.length);
-    }, 5000);
-    return () => clearInterval(id);
-  }, [providerDisconnected, isRunning]);
-
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (
       popoverOpen &&
@@ -921,7 +907,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
                     ? queued
                       ? 'Message queued. Type to replace.'
                       : 'Turn running. Type to queue next message.'
-                    : (CHAT_TIPS[tipIndex] ?? 'Message Claude.')
+                    : CHAT_PLACEHOLDER
               }
               disabled={providerDisconnected}
               autoGrow

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -10,13 +10,17 @@ import {
 import { Send, Square, X } from 'lucide-react';
 import { Divider, Textarea } from '@goodboy/ui';
 import type {
+  Agent,
   AgentId,
   BudgetAlert,
   BudgetAlertKind,
   ProviderId,
   Session,
   SessionId,
+  Skill,
   TurnProviderOverride,
+  Workflow,
+  WorkspaceScript,
 } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES, assessTurnWeight, getDefaultTurnModel } from '@goodboy/core';
 import { insertNudgeEvent, updateNudgeEventOutcome, type NudgeOutcome } from '@goodboy/db';
@@ -27,7 +31,17 @@ import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
 import { RoutingIndicator } from '../RoutingIndicator';
 import { useToast, type ToastKind } from '../../../../app/components/Toast';
-import { SlashCommandPopover } from '../SlashCommandPopover';
+import {
+  QuickActionsPopover,
+  ScriptResultRow,
+  buildAgentActions,
+  buildScriptActions,
+  buildSkillActions,
+  buildWorkflowActions,
+  parseQuery,
+  type QuickActionItem,
+  type ScriptResultState,
+} from '../../../quick-actions';
 import {
   type VerbosityLevel,
   readVerbosity,
@@ -53,7 +67,18 @@ import { detectScopeMismatch, type ScopeMismatch } from '../../utils/scope-misma
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
-const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
+// Prefix-mode trigger for the in-chat quick-actions popover: a leading
+// $ / ~ @ followed by a single space-free token. A space closes the popover
+// so the message sends normally.
+const CHAT_PREFIX_RE = /^\s*[$/~@][^\s]*$/;
+
+// Idle-state composer placeholder, rotated to teach the prefix grammar.
+const CHAT_TIPS: ReadonlyArray<string> = [
+  'Message Claude. Shift + Enter for a new line.',
+  'Type $ to run a workspace script.',
+  'Type @ to switch or spawn an agent.',
+  'Type ~ to start a workflow.',
+];
 
 const EFFORT_STORAGE_PREFIX = STORAGE_PREFIXES.effort;
 const MODEL_STORAGE_PREFIX = STORAGE_PREFIXES.model;
@@ -231,6 +256,21 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const workspaceSkills = useAppStore(
     useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
   );
+  const workspaceScripts = useAppStore(
+    useShallow((s) => s.workspaceScripts[session.workspaceId] ?? EMPTY_ARRAY),
+  );
+  const runScript = useAppStore((s) => s.runScript);
+  const loadScripts = useAppStore((s) => s.loadScripts);
+  const workspaceWorkflows = useAppStore(
+    useShallow((s) => s.phaseTemplates[session.workspaceId] ?? EMPTY_ARRAY),
+  ) as ReadonlyArray<Workflow>;
+  const sessionAgents = useAppStore(
+    useShallow((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY),
+  ) as ReadonlyArray<Agent>;
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const attachWorkflowToSession = useAppStore((s) => s.attachWorkflowToSession);
+  const loadPhaseTemplates = useAppStore((s) => s.loadPhaseTemplates);
+  const loadPhaseRunsForSession = useAppStore((s) => s.loadPhaseRunsForSession);
 
   const { showToast } = useToast();
   const value = useAppStore((s) => (selectedAgentId ? (s.agentDraft[selectedAgentId] ?? '') : ''));
@@ -260,10 +300,13 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
+  const [scriptResult, setScriptResult] = useState<ScriptResultState | null>(null);
+  const [tipIndex, setTipIndex] = useState(0);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const runSeqRef = useRef(0);
 
-  const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
-  const isSlashMode = slashQuery !== null;
+  const parsed = useMemo(() => parseQuery(value), [value]);
+  const inPrefixMode = CHAT_PREFIX_RE.test(value);
 
   const selectedAgentState = useAppStore((s) =>
     selectedAgentId ? (s.agentTurnState[selectedAgentId] ?? null) : null,
@@ -325,17 +368,132 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const onValueChange = (next: string) => {
     setValue(next);
-    setShowPopover(SLASH_MODE_RE.test(next));
+    setShowPopover(CHAT_PREFIX_RE.test(next));
   };
 
-  const onSkillSelect = useCallback(
-    (name: string) => {
-      setValue(`/${name} `);
+  const onPickScript = useCallback(
+    async (script: WorkspaceScript) => {
+      const seq = ++runSeqRef.current;
+      setValue('');
+      setShowPopover(false);
+      setScriptResult({ script, status: 'pending', result: null });
+      try {
+        const result = await runScript(script.id);
+        if (runSeqRef.current !== seq) return;
+        setScriptResult({
+          script,
+          status: result.exitCode === 0 ? 'ok' : 'error',
+          result,
+        });
+      } catch (err) {
+        if (runSeqRef.current !== seq) return;
+        setScriptResult({
+          script,
+          status: 'error',
+          result: { stdout: '', stderr: formatError(err), exitCode: -1 },
+        });
+      }
+    },
+    [runScript, setValue],
+  );
+
+  const onPickSkill = useCallback(
+    (skill: Skill) => {
+      setValue(`/${skill.name} `);
       setShowPopover(false);
       wrapperRef.current?.querySelector('textarea')?.focus();
     },
     [setValue],
   );
+
+  const onPickWorkflow = useCallback(
+    async (workflow: Workflow) => {
+      setValue('');
+      setShowPopover(false);
+      try {
+        await attachWorkflowToSession(session.id, workflow.id);
+        showToast('success', `workflow "${workflow.name}" started`);
+      } catch (err) {
+        showToast('error', formatError(err));
+      }
+    },
+    [attachWorkflowToSession, session.id, showToast, setValue],
+  );
+
+  const onSwitchAgent = useCallback(
+    (agent: Agent) => {
+      setValue('');
+      setShowPopover(false);
+      void selectAgent(session.id, agent.id);
+    },
+    [selectAgent, session.id, setValue],
+  );
+
+  const onSpawnAgent = useCallback(async () => {
+    setValue('');
+    setShowPopover(false);
+    try {
+      await spawnAgent(session.id, {});
+      showToast('success', 'new agent spawned');
+    } catch (err) {
+      showToast('error', formatError(err));
+    }
+  }, [spawnAgent, session.id, showToast, setValue]);
+
+  const quickItems = useMemo<ReadonlyArray<QuickActionItem> | null>(() => {
+    const symbol = parsed.prefix?.symbol;
+    if (symbol === '$') {
+      return buildScriptActions(workspaceScripts, (script) => void onPickScript(script));
+    }
+    if (symbol === '~') {
+      if (session.workflowId) return [];
+      return buildWorkflowActions(workspaceWorkflows, (workflow) => void onPickWorkflow(workflow));
+    }
+    if (symbol === '@') {
+      return buildAgentActions(sessionAgents, onSwitchAgent, () => void onSpawnAgent());
+    }
+    if (symbol === '/' && WORKSPACE_FEATURES.skills) {
+      return buildSkillActions(workspaceSkills, onPickSkill);
+    }
+    return null;
+  }, [
+    parsed.prefix,
+    session.workflowId,
+    workspaceScripts,
+    workspaceWorkflows,
+    sessionAgents,
+    workspaceSkills,
+    onPickScript,
+    onPickWorkflow,
+    onSwitchAgent,
+    onSpawnAgent,
+    onPickSkill,
+  ]);
+
+  const filteredQuickItems = useMemo<ReadonlyArray<QuickActionItem>>(() => {
+    if (!quickItems) return EMPTY_ARRAY;
+    const q = parsed.query.toLowerCase();
+    if (q.length === 0) return quickItems;
+    return quickItems.filter(
+      (it) =>
+        it.label.toLowerCase().includes(q) || (it.sublabel?.toLowerCase().includes(q) ?? false),
+    );
+  }, [quickItems, parsed.query]);
+
+  const popoverOpen = showPopover && inPrefixMode && quickItems !== null;
+  const quickEmptyHint =
+    parsed.prefix?.symbol === '$'
+      ? 'no scripts. add them in workspace settings.'
+      : parsed.prefix?.symbol === '~'
+        ? session.workflowId
+          ? 'this session already has a workflow.'
+          : 'no workflows. create one in workspace settings.'
+        : parsed.prefix?.symbol === '@'
+          ? 'no agents in this session.'
+          : 'no skills. create one in settings.';
+
+  const onQuickActionSelect = useCallback((item: QuickActionItem) => item.perform(), []);
+  const dismissPopover = useCallback(() => setShowPopover(false), []);
 
   const setEffort = (level: EffortLevel) => {
     setEffortState(level);
@@ -568,15 +726,41 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setScopeNudgeEventId(null);
   }, [selectedAgentId]);
 
+  // Load workspace scripts + workflows so the `$` and `~` quick-actions can
+  // list them.
+  useEffect(() => {
+    void loadScripts(session.workspaceId);
+    void loadPhaseTemplates(session.workspaceId);
+  }, [session.workspaceId, loadScripts, loadPhaseTemplates]);
+
+  // Load this session's agents so the `@` quick-action can list them.
+  useEffect(() => {
+    void loadPhaseRunsForSession(session.id);
+  }, [session.id, loadPhaseRunsForSession]);
+
+  // Script results are session-scoped — drop them when the session changes.
+  useEffect(() => {
+    setScriptResult(null);
+  }, [session.id]);
+
+  // Rotate the idle placeholder to teach the prefix grammar.
+  useEffect(() => {
+    if (providerDisconnected || isRunning) return;
+    const id = setInterval(() => {
+      setTipIndex((i) => (i + 1) % CHAT_TIPS.length);
+    }, 5000);
+    return () => clearInterval(id);
+  }, [providerDisconnected, isRunning]);
+
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (
-      showPopover &&
+      popoverOpen &&
       (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'Tab')
     ) {
       event.preventDefault();
       return;
     }
-    if (event.key === 'Enter' && !event.shiftKey && !showPopover) {
+    if (event.key === 'Enter' && !event.shiftKey && !popoverOpen) {
       event.preventDefault();
       void onSend();
     }
@@ -710,17 +894,20 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           />
         ) : null}
         <SuggestionStack items={suggestions} />
+        {scriptResult ? (
+          <ScriptResultRow state={scriptResult} onDismiss={() => setScriptResult(null)} />
+        ) : null}
         <div
           className="flex flex-col rounded-[6px] bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15 dark:bg-muted/40"
           style={{ boxShadow: '0 8px 32px -16px oklch(0 0 0 / 0.25)' }}
         >
           <div className="relative" ref={wrapperRef}>
-            {WORKSPACE_FEATURES.skills && showPopover && isSlashMode ? (
-              <SlashCommandPopover
-                items={workspaceSkills}
-                query={slashQuery}
-                onSelect={onSkillSelect}
-                onDismiss={() => setShowPopover(false)}
+            {popoverOpen ? (
+              <QuickActionsPopover
+                items={filteredQuickItems}
+                emptyHint={quickEmptyHint}
+                onSelect={onQuickActionSelect}
+                onDismiss={dismissPopover}
               />
             ) : null}
             <Textarea
@@ -734,7 +921,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
                     ? queued
                       ? 'Message queued. Type to replace.'
                       : 'Turn running. Type to queue next message.'
-                    : 'Message Claude. Shift+enter for newline.'
+                    : (CHAT_TIPS[tipIndex] ?? 'Message Claude.')
               }
               disabled={providerDisconnected}
               autoGrow

--- a/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
+++ b/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
@@ -1,47 +1,43 @@
 import { useEffect, useRef, useState } from 'react';
+import type { QuickActionItem } from '../types';
 
-interface SkillItem {
-  readonly name: string;
-  readonly description: string;
-}
-
-interface SlashCommandPopoverProps {
-  readonly items: ReadonlyArray<SkillItem>;
-  readonly query: string;
-  readonly onSelect: (name: string) => void;
+interface QuickActionsPopoverProps {
+  readonly items: ReadonlyArray<QuickActionItem>;
+  readonly emptyHint: string;
+  readonly onSelect: (item: QuickActionItem) => void;
   readonly onDismiss: () => void;
 }
 
-function fuzzyMatch(name: string, query: string): boolean {
-  return name.toLowerCase().includes(query.toLowerCase());
-}
-
-export function SlashCommandPopover({
+/**
+ * Generic prefix-action picker rendered inline above the composer. Renders
+ * whatever `QuickActionItem[]` it is handed and reports the chosen one —
+ * the behavior lives in `item.perform`, not here.
+ */
+export function QuickActionsPopover({
   items,
-  query,
+  emptyHint,
   onSelect,
   onDismiss,
-}: SlashCommandPopoverProps) {
-  const filtered = items.filter((item) => fuzzyMatch(item.name, query));
+}: QuickActionsPopoverProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [query]);
+  }, [items]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+        setActiveIndex((i) => Math.min(i + 1, items.length - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         setActiveIndex((i) => Math.max(i - 1, 0));
       } else if (e.key === 'Enter' || e.key === 'Tab') {
         e.preventDefault();
-        const item = filtered[activeIndex];
-        if (item) onSelect(item.name);
+        const item = items[activeIndex];
+        if (item) onSelect(item);
       } else if (e.key === 'Escape') {
         e.preventDefault();
         onDismiss();
@@ -49,7 +45,7 @@ export function SlashCommandPopover({
     };
     window.addEventListener('keydown', handler, { capture: true });
     return () => window.removeEventListener('keydown', handler, { capture: true });
-  }, [filtered, activeIndex, onSelect, onDismiss]);
+  }, [items, activeIndex, onSelect, onDismiss]);
 
   useEffect(() => {
     const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
@@ -58,25 +54,25 @@ export function SlashCommandPopover({
 
   return (
     <div className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md">
-      {filtered.length === 0 ? (
-        <p className="px-3 py-2 text-xs text-muted-foreground">no skills. create one in settings</p>
+      {items.length === 0 ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">{emptyHint}</p>
       ) : (
         <ul ref={listRef} className="max-h-48 overflow-y-auto py-1">
-          {filtered.map((item, i) => (
+          {items.map((item, i) => (
             <li
-              key={item.name}
+              key={item.id}
               className={`flex cursor-pointer flex-col gap-0.5 px-3 py-2 ${
                 i === activeIndex ? 'bg-accent' : 'hover:bg-accent/50'
               }`}
               onMouseEnter={() => setActiveIndex(i)}
               onMouseDown={(e) => {
                 e.preventDefault();
-                onSelect(item.name);
+                onSelect(item);
               }}
             >
-              <span className="text-xs font-medium text-foreground">/{item.name}</span>
-              {item.description ? (
-                <span className="text-xs text-muted-foreground">{item.description}</span>
+              <span className="truncate text-xs font-medium text-foreground">{item.label}</span>
+              {item.sublabel ? (
+                <span className="truncate text-2xs text-muted-foreground">{item.sublabel}</span>
               ) : null}
             </li>
           ))}

--- a/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
+++ b/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
@@ -62,7 +62,7 @@ export function QuickActionsPopover({
             <li
               key={item.id}
               className={`flex cursor-pointer flex-col gap-0.5 px-3 py-2 ${
-                i === activeIndex ? 'bg-accent' : 'hover:bg-accent/50'
+                i === activeIndex ? 'bg-muted' : 'hover:bg-muted/50'
               }`}
               onMouseEnter={() => setActiveIndex(i)}
               onMouseDown={(e) => {

--- a/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
+++ b/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
@@ -1,0 +1,102 @@
+import { useRef, useState } from 'react';
+import { ScrollText, X } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { WorkspaceScript } from '@goodboy/types';
+import type { ScriptRunResult } from '../../scripts';
+
+export interface ScriptResultState {
+  readonly script: WorkspaceScript;
+  readonly status: 'pending' | 'ok' | 'error';
+  readonly result: ScriptRunResult | null;
+}
+
+interface ScriptResultRowProps {
+  readonly state: ScriptResultState;
+  readonly onDismiss: () => void;
+}
+
+/**
+ * Sticky result of a `$` quick-action script run, shown above the composer.
+ * Never sent to the LLM — stays until dismissed or replaced by the next run.
+ */
+export function ScriptResultRow({ state, onDismiss }: ScriptResultRowProps) {
+  const { script, status, result } = state;
+  const [outputOpen, setOutputOpen] = useState(false);
+
+  // Default the disclosure open on a failed run — the user almost always
+  // wants to see why. Successful runs stay collapsed.
+  const prevResultRef = useRef<ScriptRunResult | null>(null);
+  if (result !== prevResultRef.current) {
+    prevResultRef.current = result;
+    setOutputOpen(result !== null && result.exitCode !== 0);
+  }
+
+  const hasOutput = result !== null && (result.stdout.length > 0 || result.stderr.length > 0);
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col rounded-[6px] bg-subtle/80 ring-1 ring-border-soft',
+        status === 'pending' && 'spin-border spin-border-info',
+      )}
+    >
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        <Dot status={status} />
+        <span className="min-w-0 flex-1 truncate text-xs">
+          <span className="text-muted-foreground">
+            {status === 'pending' ? 'running ' : 'ran '}
+          </span>
+          <span className="font-medium text-foreground">{script.name}</span>
+          {result !== null ? (
+            <span className="text-muted-foreground"> · exit {result.exitCode}</span>
+          ) : null}
+        </span>
+        {hasOutput ? (
+          <button
+            type="button"
+            onClick={() => setOutputOpen((v) => !v)}
+            aria-expanded={outputOpen}
+            title={outputOpen ? 'hide output' : 'show output'}
+            className={cn(
+              'flex size-6 shrink-0 items-center justify-center rounded transition-colors',
+              outputOpen
+                ? 'bg-primary/15 text-primary ring-1 ring-inset ring-primary/30'
+                : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
+            )}
+          >
+            <ScrollText size={12} aria-hidden />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onDismiss}
+          title="dismiss"
+          aria-label="dismiss script result"
+          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        >
+          <X size={12} aria-hidden />
+        </button>
+      </div>
+      {hasOutput && outputOpen && result !== null ? (
+        <pre className="mx-3 mb-2 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-background px-2 py-1.5 font-mono text-2xs leading-relaxed text-foreground/80">
+          {result.stdout}
+          {result.stderr ? (
+            <span className="text-danger">
+              {result.stdout ? '\n' : ''}
+              {result.stderr}
+            </span>
+          ) : null}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+function Dot({ status }: { readonly status: ScriptResultState['status'] }) {
+  const color = status === 'ok' ? 'bg-success' : status === 'error' ? 'bg-danger' : 'bg-border';
+  const label =
+    status === 'ok' ? 'script succeeded' : status === 'error' ? 'script failed' : 'script running';
+  return (
+    <span className={cn('size-2 shrink-0 rounded-full', color)} role="img" aria-label={label} />
+  );
+}

--- a/apps/desktop/src/features/quick-actions/grammar.ts
+++ b/apps/desktop/src/features/quick-actions/grammar.ts
@@ -1,0 +1,45 @@
+/**
+ * Prefix grammar shared by the command palette (⌘K) and the in-chat
+ * quick-actions popover — single source so the two never drift.
+ */
+
+export type QuickActionGroup =
+  | 'agent'
+  | 'session'
+  | 'workspace'
+  | 'skill'
+  | 'workflow'
+  | 'script'
+  | 'action'
+  | 'help';
+
+export interface PrefixMeta {
+  readonly symbol: string;
+  readonly hint: string;
+  readonly group: QuickActionGroup;
+}
+
+export const PREFIXES: ReadonlyArray<PrefixMeta> = [
+  { symbol: '@', hint: 'agents in current session', group: 'agent' },
+  { symbol: '#', hint: 'sessions', group: 'session' },
+  { symbol: ':', hint: 'workspaces', group: 'workspace' },
+  { symbol: '/', hint: 'skills', group: 'skill' },
+  { symbol: '~', hint: 'workflows', group: 'workflow' },
+  { symbol: '$', hint: 'scripts', group: 'script' },
+  { symbol: '>', hint: 'actions', group: 'action' },
+  { symbol: '?', hint: 'help & shortcuts', group: 'help' },
+];
+
+export interface ParsedQuery {
+  readonly prefix: PrefixMeta | null;
+  readonly query: string;
+}
+
+export function parseQuery(raw: string): ParsedQuery {
+  const trimmed = raw.trimStart();
+  if (trimmed.length === 0) return { prefix: null, query: '' };
+  const ch = trimmed[0]!;
+  const meta = PREFIXES.find((p) => p.symbol === ch);
+  if (meta) return { prefix: meta, query: trimmed.slice(1).trim() };
+  return { prefix: null, query: trimmed };
+}

--- a/apps/desktop/src/features/quick-actions/index.ts
+++ b/apps/desktop/src/features/quick-actions/index.ts
@@ -1,0 +1,12 @@
+export { PREFIXES, parseQuery } from './grammar';
+export type { ParsedQuery, PrefixMeta, QuickActionGroup } from './grammar';
+export type { QuickActionItem } from './types';
+export {
+  buildAgentActions,
+  buildScriptActions,
+  buildSkillActions,
+  buildWorkflowActions,
+} from './registry';
+export { QuickActionsPopover } from './QuickActionsPopover';
+export { ScriptResultRow } from './ScriptResultRow';
+export type { ScriptResultState } from './ScriptResultRow';

--- a/apps/desktop/src/features/quick-actions/registry.ts
+++ b/apps/desktop/src/features/quick-actions/registry.ts
@@ -1,0 +1,75 @@
+import type { Agent, Skill, Workflow, WorkspaceScript } from '@goodboy/types';
+import type { QuickActionItem } from './types';
+
+function firstLine(body: string): string | undefined {
+  const line = body.trim().split('\n', 1)[0]?.trim();
+  return line ? line : undefined;
+}
+
+/** Maps workspace scripts to quick-action rows. `onPick` owns the run. */
+export function buildScriptActions(
+  scripts: ReadonlyArray<WorkspaceScript>,
+  onPick: (script: WorkspaceScript) => void,
+): ReadonlyArray<QuickActionItem> {
+  return scripts.map((script) => ({
+    id: `script:${script.id}`,
+    label: script.name,
+    sublabel: firstLine(script.body),
+    group: 'script',
+    perform: () => onPick(script),
+  }));
+}
+
+/** Maps workspace skills to quick-action rows. `onPick` pre-fills the input. */
+export function buildSkillActions(
+  skills: ReadonlyArray<Skill>,
+  onPick: (skill: Skill) => void,
+): ReadonlyArray<QuickActionItem> {
+  return skills.map((skill) => ({
+    id: `skill:${skill.id}`,
+    label: skill.name,
+    sublabel: skill.description || undefined,
+    group: 'skill',
+    perform: () => onPick(skill),
+  }));
+}
+
+/** Maps workspace workflows to quick-action rows. `onPick` starts the workflow. */
+export function buildWorkflowActions(
+  workflows: ReadonlyArray<Workflow>,
+  onPick: (workflow: Workflow) => void,
+): ReadonlyArray<QuickActionItem> {
+  return workflows.map((workflow) => ({
+    id: `workflow:${workflow.id}`,
+    label: workflow.name,
+    sublabel:
+      workflow.description ||
+      `${workflow.steps.length} step${workflow.steps.length === 1 ? '' : 's'}`,
+    group: 'workflow',
+    perform: () => onPick(workflow),
+  }));
+}
+
+/**
+ * Maps session agents to switch rows, plus a trailing "spawn new agent" row.
+ * `onSwitch` navigates to an existing agent; `onSpawn` creates a fresh one.
+ */
+export function buildAgentActions(
+  agents: ReadonlyArray<Agent>,
+  onSwitch: (agent: Agent) => void,
+  onSpawn: () => void,
+): ReadonlyArray<QuickActionItem> {
+  const switches = agents
+    .filter((agent) => agent.deletedAt === undefined)
+    .map<QuickActionItem>((agent) => ({
+      id: `agent:${agent.id}`,
+      label: agent.name,
+      sublabel: agent.status,
+      group: 'agent',
+      perform: () => onSwitch(agent),
+    }));
+  return [
+    ...switches,
+    { id: 'agent:spawn', label: '+ spawn new agent', group: 'agent', perform: onSpawn },
+  ];
+}

--- a/apps/desktop/src/features/quick-actions/types.ts
+++ b/apps/desktop/src/features/quick-actions/types.ts
@@ -1,0 +1,14 @@
+import type { QuickActionGroup } from './grammar';
+
+/**
+ * One selectable row in the quick-actions popover. `perform` carries the
+ * behavior — exec a script, pre-fill a skill — so the popover stays a
+ * generic renderer.
+ */
+export interface QuickActionItem {
+  readonly id: string;
+  readonly label: string;
+  readonly sublabel?: string;
+  readonly group: QuickActionGroup;
+  readonly perform: () => void;
+}

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -14,22 +14,14 @@ import {
   inferAgentKindFromName,
   type AgentKind,
 } from '../../agent-kind';
+import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-actions';
 
 /**
  * Categorized palette with a prefix-routed grammar — the Raycast / Linear
  * model. Empty input shows all sources; typing a prefix (@ # : / ~ $ ?)
  * scopes the result list to one source. Plan section A.2.
  */
-type PaletteGroup =
-  | 'recents'
-  | 'workspace'
-  | 'session'
-  | 'agent'
-  | 'skill'
-  | 'workflow'
-  | 'script'
-  | 'action'
-  | 'help';
+type PaletteGroup = QuickActionGroup | 'recents';
 
 interface PaletteItem {
   readonly id: string;
@@ -40,23 +32,6 @@ interface PaletteItem {
   readonly icon?: string;
   readonly onSelect: () => void;
 }
-
-interface PrefixMeta {
-  readonly symbol: string;
-  readonly hint: string;
-  readonly group: PaletteGroup;
-}
-
-const PREFIXES: ReadonlyArray<PrefixMeta> = [
-  { symbol: '@', hint: 'agents in current session', group: 'agent' },
-  { symbol: '#', hint: 'sessions', group: 'session' },
-  { symbol: ':', hint: 'workspaces', group: 'workspace' },
-  { symbol: '/', hint: 'skills', group: 'skill' },
-  { symbol: '~', hint: 'workflows', group: 'workflow' },
-  { symbol: '$', hint: 'scripts', group: 'script' },
-  { symbol: '>', hint: 'actions', group: 'action' },
-  { symbol: '?', hint: 'help & shortcuts', group: 'help' },
-];
 
 const GROUP_LABELS: Record<PaletteGroup, string> = {
   recents: 'Recents',
@@ -81,22 +56,6 @@ const GROUP_ORDER: ReadonlyArray<PaletteGroup> = [
   'action',
   'help',
 ];
-
-interface ParsedQuery {
-  readonly prefix: PrefixMeta | null;
-  readonly query: string;
-}
-
-function parseQuery(raw: string): ParsedQuery {
-  const trimmed = raw.trimStart();
-  if (trimmed.length === 0) return { prefix: null, query: '' };
-  const ch = trimmed[0]!;
-  const meta = PREFIXES.find((p) => p.symbol === ch);
-  if (meta) {
-    return { prefix: meta, query: trimmed.slice(1).trim() };
-  }
-  return { prefix: null, query: trimmed };
-}
 
 function fuzzyScore(query: string, text: string): number {
   if (query.length === 0) return 1;


### PR DESCRIPTION
## Summary

Prefix quick-actions in the chat composer — type a prefix to act without leaving it:

- `$` runs a workspace script (sticky result row, no LLM turn)
- `~` starts a workflow on the current session
- `@` switches between session agents or spawns a new one
- `/` skills (gated on `WORKSPACE_FEATURES.skills`)

New shared `quick-actions/` module — `grammar.ts` is the single prefix source, now also consumed by the ⌘K command palette so the grammar is no longer duplicated. The idle placeholder rotates to teach the prefixes. `SlashCommandPopover` is replaced by the generic `QuickActionsPopover`; its tests are migrated.

## Notes

- Agent-spawn provenance chip was dropped — a bare `@`+spawn has no meaningful origin story; `@`/`~` give a toast instead. Worth revisiting once a script→agent spawn exists.
- Fase 3 (`>` actions + full CommandPalette-on-registry refactor) is **not** in this PR — the `>` action set still needs scoping. Draft until that's decided and the rest is tested.

## Test plan

- [ ] `$` lists workspace scripts; selecting runs it; result row shows ✓/✗ + exit code + collapsible output
- [ ] `~` lists workflows; selecting starts it on the session (+ toast); gated when the session already has a workflow
- [ ] `@` lists session agents (switch) + a "spawn new agent" row (spawn navigates + toast)
- [ ] rotating placeholder cycles the prefix tips
- [ ] ⌘K command palette still works (shared grammar)
- [ ] `/ak-check` — typecheck + test suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)