### PR TITLE
fix(desktop): sanitize branch slug live, keep user casing

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -203,8 +203,11 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
                 </span>
                 <input
                   aria-label="Branch slug"
+                  autocapitalize="off"
+                  autocorrect="off"
                   class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
+                  spellcheck="false"
                   type="text"
                   value=""
                 />
@@ -2301,8 +2304,11 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
                 </span>
                 <input
                   aria-label="Branch slug"
+                  autocapitalize="off"
+                  autocorrect="off"
                   class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
+                  spellcheck="false"
                   type="text"
                   value=""
                 />

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -91,6 +91,18 @@ function slugifyLive(input: string): string {
     .replace(/-+$/, '');
 }
 
+// Live sanitizer for the hand-typed branch slug. Unlike slugifyLive (which
+// derives a slug from the prose goal) this preserves the user's casing — an
+// uppercase branch stays uppercase. Any run of spaces or disallowed chars
+// collapses to a single dash so e.g. ten spaces yield one dash.
+function sanitizeBranchSlug(input: string): string {
+  return input
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '')
+    .slice(0, SLUG_MAX_LEN);
+}
+
 function sanitizePrefix(input: string): string {
   return input
     .toLowerCase()
@@ -314,12 +326,15 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
                   <Input
                     value={branchSlug}
                     onChange={(e) => {
-                      setBranchSlug(e.target.value);
+                      setBranchSlug(sanitizeBranchSlug(e.target.value));
                       setSlugTouched(true);
                     }}
                     placeholder="branch-slug"
                     className="h-8 flex-1 font-mono text-sm"
                     disabled={busy}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
                     aria-label="Branch slug"
                   />
                 )}


### PR DESCRIPTION
## Summary
- Branch slug input in the New Session dialog now sanitizes on every keystroke — any run of spaces or disallowed characters collapses to a single dash.
- User casing is preserved: an uppercase slug stays uppercase, lowercase stays lowercase (no forced lowercasing).
- Disabled the macOS webview `autoCapitalize`/`autoCorrect`/`spellCheck` on the field, which was capitalizing the first letter against the user's intent.

Previously the hand-typed slug stored the raw input value, so punctuation and whitespace were never normalized.

## Test plan
- [ ] Type a slug with spaces and commas → each run becomes a single dash
- [ ] Type ~10 consecutive spaces → exactly one dash
- [ ] Type lowercase → stays lowercase; type uppercase → stays uppercase
- [ ] First letter is no longer auto-capitalized by the webview

🤖 Generated with [Claude Code](https://claude.com/claude-code)