### PR TITLE
fix(desktop): prevent stale transcript render on agent switch

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -212,7 +212,17 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   // empty shell first on session switch and treat the card list as low-priority.
   // Pairs with React.memo on TranscriptCard — together they make session swaps
   // feel instant even with hundreds of turns in history.
-  const deferredItems = useDeferredValue(items);
+  // Tag the deferred value with its agent id: useDeferredValue keeps returning
+  // the previous agent's array for a render or more after a switch — without
+  // the tag the list below would paint the wrong agent's transcript. While it
+  // lags (`transcriptStale`) we render the skeleton instead.
+  const taggedItems = useMemo(
+    () => ({ agentId: selectedAgentId, items }),
+    [selectedAgentId, items],
+  );
+  const deferredTagged = useDeferredValue(taggedItems);
+  const transcriptStale = deferredTagged.agentId !== selectedAgentId;
+  const deferredItems = deferredTagged.items;
   const loading = useSessionLoading(session.id);
   const transcriptCached = useAppStore((s) =>
     selectedAgentId ? s.transcripts[selectedAgentId] !== undefined : true,
@@ -395,8 +405,8 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
           className="flex-1 overflow-y-auto px-10 py-6"
           style={{ scrollbarGutter: 'stable' }}
         >
-          {items.length === 0 ? (
-            loading.transcript ? (
+          {transcriptStale || deferredItems.length === 0 ? (
+            loading.transcript || transcriptStale ? (
               <TranscriptSkeleton />
             ) : isProviderDisconnected ? (
               <div className="flex h-full items-center justify-center">


### PR DESCRIPTION
## Summary

`ChatView` defers the transcript list with `useDeferredValue` for fast paint on switch, but the deferred value keeps returning the **previously-selected agent's** events for a render or more after an agent switch/spawn. The empty-vs-list guard checked the fresh `items` while the `<ul>` rendered the stale `deferredItems` — so spawning a new agent briefly painted the previous chat's first message.

Fix: tag the deferred value with its agent id. While it still lags on the old agent (`transcriptStale`), render the skeleton instead of the wrong transcript. Streaming within an agent stays deferred (perf unchanged); the split-view path is untouched.

## Test plan

- [ ] Spawn a new agent (`@` / sidebar) with a message in an existing session → new chat shows skeleton then your message, never the previous agent's transcript
- [ ] Switch between two populated agents → no flash of the other agent's transcript
- [ ] Long session still paints fast on switch (deferral intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)