### PR TITLE
feat(desktop): cancellable, store-tracked workspace script runs

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub fn run() {
   let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
   let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
   let turn_registry = turn::TurnRegistry::new();
+  let script_registry = scripts::ScriptRegistry::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
@@ -37,6 +38,7 @@ pub fn run() {
     .manage(cursor_state)
     .manage(codex_state)
     .manage(turn_registry)
+    .manage(script_registry)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -102,6 +104,7 @@ pub fn run() {
       skills::skill_rescan,
       skills::skill_run_script,
       scripts::workspace_script_run,
+      scripts::workspace_script_cancel,
       workflows::workflow_list,
       workflows::workflow_get,
       workflows::workflow_upsert,

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Child, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
 use serde::Serialize;
 use tauri::State;
 
@@ -13,6 +19,23 @@ pub struct ScriptRunResult {
     pub stderr: String,
     #[serde(rename = "exitCode")]
     pub exit_code: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Process registry
+// ---------------------------------------------------------------------------
+
+type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+/// Keeps a kill handle for every in-flight script run, keyed by `run_id`, so
+/// `workspace_script_cancel` can interrupt one. Mirrors `turn::TurnRegistry`.
+#[derive(Default)]
+pub struct ScriptRegistry(pub Arc<Mutex<HashMap<String, ChildSlot>>>);
+
+impl ScriptRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -71,45 +94,115 @@ impl From<DbError> for ScriptError {
 // Command — run a user-defined workspace script
 // ---------------------------------------------------------------------------
 
-/// Run a workspace script body via `bash -c`, with cwd set to the workspace
-/// root. Captures stdout/stderr/exit. Never errors on a non-zero exit — the
-/// caller renders the exit code as a status (✓ / ✗).
+/// Run a workspace script body via `bash -c`, with cwd set to the caller-
+/// supplied session worktree. Captures stdout/stderr/exit. Never errors on a
+/// non-zero exit — the caller renders the exit code as a status (✓ / ✗).
 ///
-/// Async + spawn_blocking so the bash subprocess doesn't block Tauri's main
-/// thread (which would freeze the entire webview until the script returns).
+/// The child is registered under `run_id` so `workspace_script_cancel` can
+/// kill it. stdout/stderr are drained on separate threads — a chatty script
+/// could otherwise deadlock by filling one pipe buffer while we read the
+/// other — and both reads run with the registry slot unlocked so a concurrent
+/// cancel can lock the slot and land the kill.
 #[tauri::command]
 pub async fn workspace_script_run(
     state: State<'_, Db>,
+    registry: State<'_, ScriptRegistry>,
     script_id: String,
+    run_id: String,
+    cwd: String,
 ) -> Result<ScriptRunResult, ScriptError> {
-    let (body, root) = {
+    let body = {
         let conn = state.0.lock().map_err(|_| ScriptError::Poisoned)?;
         conn.query_row(
-            "SELECT s.body, w.root_path
-             FROM workspace_scripts s
-             JOIN workspaces w ON w.id = s.workspace_id
-             WHERE s.id = ?1
-             LIMIT 1",
+            "SELECT body FROM workspace_scripts WHERE id = ?1 LIMIT 1",
             rusqlite::params![script_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            |row| row.get::<_, String>(0),
         )
         .map_err(|_| ScriptError::NotFound(script_id.clone()))?
     };
 
+    let registry = Arc::clone(&registry.0);
+
     tauri::async_runtime::spawn_blocking(move || {
-        let output = crate::path_env::command("bash")
+        let mut child = crate::path_env::command("bash")
             .arg("-c")
             .arg(&body)
-            .current_dir(&root)
-            .output()
+            .current_dir(&cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
             .map_err(|e| ScriptError::Io(e.to_string()))?;
 
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ScriptError::Io("no stdout".to_string()))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| ScriptError::Io("no stderr".to_string()))?;
+
+        let slot: ChildSlot = Arc::new(Mutex::new(Some(child)));
+        registry
+            .lock()
+            .map_err(|_| ScriptError::Poisoned)?
+            .insert(run_id.clone(), Arc::clone(&slot));
+
+        let stderr_thread = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stderr.read_to_end(&mut buf);
+            buf
+        });
+        let mut stdout_buf = Vec::new();
+        let _ = stdout.read_to_end(&mut stdout_buf);
+        let stderr_buf = stderr_thread.join().unwrap_or_default();
+
+        // Both pipes are at EOF: the process has exited or is about to, so the
+        // brief slot lock taken to wait can't stall a concurrent cancel.
+        let exit_code = match slot.lock() {
+            Ok(mut guard) => guard
+                .as_mut()
+                .and_then(|c| c.wait().ok())
+                .and_then(|status| status.code())
+                .unwrap_or(-1),
+            Err(_) => -1,
+        };
+        if let Ok(mut map) = registry.lock() {
+            map.remove(&run_id);
+        }
+
         Ok(ScriptRunResult {
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&stdout_buf).to_string(),
+            stderr: String::from_utf8_lossy(&stderr_buf).to_string(),
+            exit_code,
         })
     })
     .await
     .map_err(|e| ScriptError::Io(e.to_string()))?
+}
+
+// ---------------------------------------------------------------------------
+// Command — interrupt an in-flight workspace script
+// ---------------------------------------------------------------------------
+
+/// Kill the child registered under `run_id`. A run that already finished, or a
+/// never-registered id, is a no-op success — the frontend fires this on a stop
+/// click that can race the run completing on its own.
+#[tauri::command]
+pub fn workspace_script_cancel(
+    registry: State<'_, ScriptRegistry>,
+    run_id: String,
+) -> Result<(), ScriptError> {
+    let slot = {
+        let map = registry.0.lock().map_err(|_| ScriptError::Poisoned)?;
+        map.get(&run_id).cloned()
+    };
+    if let Some(slot) = slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.kill();
+            }
+        }
+    }
+    Ok(())
 }

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -16,6 +16,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     providers: ReadonlyArray<{ id: string; connection: string }>;
     skills: Record<string, never>;
     workspaceScripts: Record<string, never>;
+    sessionWorktrees: Record<string, ReadonlyArray<string>>;
     providerSpendBreakdown: ReadonlyArray<never>;
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
@@ -48,6 +49,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     ],
     skills: {},
     workspaceScripts: {},
+    sessionWorktrees: {},
     providerSpendBreakdown: [],
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -256,6 +256,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     useShallow((s) => s.workspaceScripts[session.workspaceId] ?? EMPTY_ARRAY),
   );
   const runScript = useAppStore((s) => s.runScript);
+  const sessionWorktree = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const workspaceWorkflows = useAppStore(
     useShallow((s) => s.phaseTemplates[session.workspaceId] ?? EMPTY_ARRAY),
@@ -368,12 +369,16 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const onPickScript = useCallback(
     async (script: WorkspaceScript) => {
+      if (!sessionWorktree) {
+        showToast('warning', `${script.name} — open a session worktree to run scripts`);
+        return;
+      }
       const seq = ++runSeqRef.current;
       setValue('');
       setShowPopover(false);
       setScriptResult({ script, status: 'pending', result: null });
       try {
-        const result = await runScript(script.id);
+        const result = await runScript(session.id, script.id, sessionWorktree);
         if (runSeqRef.current !== seq) return;
         setScriptResult({
           script,
@@ -389,7 +394,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         });
       }
     },
-    [runScript, setValue],
+    [runScript, setValue, session.id, sessionWorktree, showToast],
   );
 
   const onPickSkill = useCallback(

--- a/apps/desktop/src/features/scripts/components/RunScriptControl/index.tsx
+++ b/apps/desktop/src/features/scripts/components/RunScriptControl/index.tsx
@@ -1,14 +1,15 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { cn, Divider, Popover } from '@goodboy/ui';
-import type { WorkspaceId, WorkspaceScript } from '@goodboy/types';
-import { Play, ScrollText, Terminal } from 'lucide-react';
-import { formatError } from '../../../../shared/lib/errors';
+import type { SessionId, WorkspaceId, WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
+import { Play, ScrollText, Square, Terminal } from 'lucide-react';
 import { useAppStore } from '../../../../store';
-import type { ScriptRunResult, ScriptRunStatus } from '../../scripts';
+import type { ScriptRunRecord, ScriptRunStatus } from '../../scripts';
 
 interface RunScriptControlProps {
+  readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
+  readonly worktreePath: string | null;
 }
 
 interface PopoverAnchor {
@@ -16,24 +17,19 @@ interface PopoverAnchor {
   readonly top: number;
 }
 
-interface RunState {
-  readonly status: ScriptRunStatus;
-  readonly result: ScriptRunResult | null;
-}
-
-const IDLE: RunState = { status: 'idle', result: null };
-
-export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
+export function RunScriptControl({ sessionId, workspaceId, worktreePath }: RunScriptControlProps) {
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const scripts = useAppStore((s) => s.workspaceScripts[workspaceId]);
+  const runs = useAppStore((s) => s.scriptRuns[sessionId]);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const runScript = useAppStore((s) => s.runScript);
+  const cancelScript = useAppStore((s) => s.cancelScript);
 
-  const [runState, setRunState] = useState<Record<string, RunState>>({});
+  const isRunning = runs ? Object.values(runs).some((r) => r.status === 'pending') : false;
 
   useEffect(() => {
     void loadScripts(workspaceId);
@@ -77,25 +73,18 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
   };
 
   const onRun = useCallback(
-    async (script: WorkspaceScript) => {
-      setRunState((prev) => ({ ...prev, [script.id]: { status: 'pending', result: null } }));
-      try {
-        const result = await runScript(script.id);
-        setRunState((prev) => ({
-          ...prev,
-          [script.id]: { status: result.exitCode === 0 ? 'ok' : 'error', result },
-        }));
-      } catch (err) {
-        setRunState((prev) => ({
-          ...prev,
-          [script.id]: {
-            status: 'error',
-            result: { stdout: '', stderr: formatError(err), exitCode: -1 },
-          },
-        }));
-      }
+    (script: WorkspaceScript) => {
+      if (!worktreePath) return;
+      void runScript(sessionId, script.id, worktreePath);
     },
-    [runScript],
+    [runScript, sessionId, worktreePath],
+  );
+
+  const onCancel = useCallback(
+    (scriptId: WorkspaceScriptId) => {
+      void cancelScript(sessionId, scriptId);
+    },
+    [cancelScript, sessionId],
   );
 
   const list = scripts ?? [];
@@ -123,21 +112,23 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
               </p>
             ) : (
               <ul className="flex flex-col px-1.5">
-                {list.map((script, i) => {
-                  const run = runState[script.id] ?? IDLE;
-                  return (
-                    <Fragment key={script.id}>
-                      {i > 0 ? (
-                        <li aria-hidden className="px-1.5">
-                          <Divider />
-                        </li>
-                      ) : null}
-                      <li>
-                        <ScriptRow script={script} run={run} onRun={() => void onRun(script)} />
+                {list.map((script, i) => (
+                  <Fragment key={script.id}>
+                    {i > 0 ? (
+                      <li aria-hidden className="px-1.5">
+                        <Divider />
                       </li>
-                    </Fragment>
-                  );
-                })}
+                    ) : null}
+                    <li>
+                      <ScriptRow
+                        script={script}
+                        run={runs?.[script.id] ?? null}
+                        onRun={() => onRun(script)}
+                        onCancel={() => onCancel(script.id)}
+                      />
+                    </li>
+                  </Fragment>
+                ))}
               </ul>
             )}
           </Popover>,
@@ -151,11 +142,17 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
         ref={triggerRef}
         type="button"
         onClick={onToggle}
-        title="run workspace script"
+        disabled={!worktreePath}
+        title={worktreePath ? 'run workspace script' : 'session has no worktree yet'}
         aria-label="run workspace script"
         aria-haspopup="menu"
         aria-expanded={open}
-        className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        className={cn(
+          'shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/60',
+          // Animated primary ring while any script in this session runs — the
+          // signal survives the popover being closed.
+          isRunning && 'spin-border spin-border-primary',
+        )}
       >
         <Terminal size={13} aria-hidden />
       </button>
@@ -166,21 +163,24 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
 
 interface ScriptRowProps {
   readonly script: WorkspaceScript;
-  readonly run: RunState;
+  readonly run: ScriptRunRecord | null;
   readonly onRun: () => void;
+  readonly onCancel: () => void;
 }
 
-function ScriptRow({ script, run, onRun }: ScriptRowProps) {
-  const isPending = run.status === 'pending';
+function ScriptRow({ script, run, onRun, onCancel }: ScriptRowProps) {
+  const status: ScriptRunStatus = run?.status ?? 'idle';
+  const result = run?.result ?? null;
+  const isPending = status === 'pending';
   const preview = script.body.trim().split('\n')[0] ?? '';
-  const hasOutput = run.result !== null;
+  const hasOutput = result !== null;
   // Default the disclosure open on a failed run — the user almost always
-  // wants to see why it failed. Successful runs stay collapsed.
+  // wants to see why it failed. Successful and cancelled runs stay collapsed.
   const [outputOpen, setOutputOpen] = useState(false);
-  const prevResultRef = useRef(run.result);
-  if (run.result !== prevResultRef.current) {
-    prevResultRef.current = run.result;
-    setOutputOpen(run.result !== null && run.result.exitCode !== 0);
+  const prevResultRef = useRef(result);
+  if (result !== prevResultRef.current) {
+    prevResultRef.current = result;
+    setOutputOpen(result !== null && result.exitCode !== 0 && status !== 'cancelled');
   }
 
   return (
@@ -195,7 +195,7 @@ function ScriptRow({ script, run, onRun }: ScriptRowProps) {
       )}
     >
       <div className="flex items-center gap-2 px-2 py-2">
-        <StatusDot status={run.status} />
+        <StatusDot status={status} />
         <button
           type="button"
           role="menuitem"
@@ -224,31 +224,42 @@ function ScriptRow({ script, run, onRun }: ScriptRowProps) {
             <ScrollText size={13} aria-hidden />
           </button>
         ) : null}
-        <button
-          type="button"
-          onClick={onRun}
-          disabled={isPending}
-          title={isPending ? 'script running…' : 'run script'}
-          aria-label="run script"
-          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground/50 group-hover:text-muted-foreground"
-        >
-          <Play size={13} aria-hidden />
-        </button>
+        {isPending ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            title="stop script"
+            aria-label="stop script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
+          >
+            <Square size={11} fill="currentColor" aria-hidden />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onRun}
+            title="run script"
+            aria-label="run script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground"
+          >
+            <Play size={13} aria-hidden />
+          </button>
+        )}
       </div>
       {hasOutput && outputOpen ? (
         <pre
           id={`script-out-${script.id}`}
           className="mx-2 mb-2 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-background px-2 py-1.5 font-mono text-2xs leading-relaxed text-foreground/80"
         >
-          <span className="block text-muted-foreground/70">exit {run.result!.exitCode}</span>
-          {run.result!.stdout}
-          {run.result!.stderr ? (
+          <span className="block text-muted-foreground/70">exit {result!.exitCode}</span>
+          {result!.stdout}
+          {result!.stderr ? (
             <span className="text-danger">
-              {run.result!.stdout ? '\n' : ''}
-              {run.result!.stderr}
+              {result!.stdout ? '\n' : ''}
+              {result!.stderr}
             </span>
           ) : null}
-          {!run.result!.stdout && !run.result!.stderr ? '(no output)' : null}
+          {!result!.stdout && !result!.stderr ? '(no output)' : null}
         </pre>
       ) : null}
     </div>
@@ -270,6 +281,15 @@ function StatusDot({ status }: { status: ScriptRunStatus }) {
       <span
         className="size-2 shrink-0 rounded-full bg-danger"
         aria-label="last run failed"
+        role="img"
+      />
+    );
+  }
+  if (status === 'cancelled') {
+    return (
+      <span
+        className="size-2 shrink-0 rounded-full bg-muted-foreground/50"
+        aria-label="last run cancelled"
         role="img"
       />
     );

--- a/apps/desktop/src/features/scripts/scripts.ts
+++ b/apps/desktop/src/features/scripts/scripts.ts
@@ -9,8 +9,24 @@ export interface ScriptRunResult {
 }
 
 /** Run state for a script row in the Scripts panel. */
-export type ScriptRunStatus = 'idle' | 'pending' | 'ok' | 'error';
+export type ScriptRunStatus = 'idle' | 'pending' | 'ok' | 'error' | 'cancelled';
 
-export async function invokeScriptRun(scriptId: WorkspaceScriptId): Promise<ScriptRunResult> {
-  return invoke<ScriptRunResult>('workspace_script_run', { scriptId });
+/** A tracked script run for one (session, script) pair, held in the store. */
+export interface ScriptRunRecord {
+  readonly status: ScriptRunStatus;
+  readonly result: ScriptRunResult | null;
+  readonly runId: string;
+}
+
+export async function invokeScriptRun(
+  scriptId: WorkspaceScriptId,
+  runId: string,
+  cwd: string,
+): Promise<ScriptRunResult> {
+  return invoke<ScriptRunResult>('workspace_script_run', { scriptId, runId, cwd });
+}
+
+/** Interrupt an in-flight script run. No-op if the run already finished. */
+export async function invokeScriptCancel(runId: string): Promise<void> {
+  return invoke<void>('workspace_script_cancel', { runId });
 }

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -15,6 +15,7 @@ import {
   type AgentKind,
 } from '../../agent-kind';
 import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-actions';
+import { useToast } from '../../../../app/components/Toast';
 
 /**
  * Categorized palette with a prefix-routed grammar — the Raycast / Linear
@@ -108,6 +109,11 @@ export function CommandPalette({
     currentSession ? (s.sessionPhaseRuns[currentSession.id] ?? EMPTY_ARRAY) : EMPTY_ARRAY,
   ) as ReadonlyArray<Agent>;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
+  const runScript = useAppStore((s) => s.runScript);
+  const sessionWorktree = useAppStore((s) =>
+    currentSession ? (s.sessionWorktrees[currentSession.id]?.[0] ?? null) : null,
+  );
+  const { showToast } = useToast();
 
   const parsed = useMemo(() => parseQuery(query), [query]);
 
@@ -192,11 +198,18 @@ export function CommandPalette({
         sublabel: 'workspace script',
         group: 'script',
         onSelect: () => {
-          window.dispatchEvent(
-            new CustomEvent('goodboy:open-workspace-settings', {
-              detail: { section: 'scripts' },
-            }),
-          );
+          if (!currentSession || !sessionWorktree) {
+            showToast('warning', `${sc.name} — open a session worktree to run scripts`);
+            return;
+          }
+          void runScript(currentSession.id, sc.id, sessionWorktree).then((result) => {
+            showToast(
+              result.exitCode === 0 ? 'success' : 'error',
+              result.exitCode === 0
+                ? `${sc.name} — done`
+                : `${sc.name} — exited ${result.exitCode}`,
+            );
+          });
         },
       });
     }
@@ -240,6 +253,9 @@ export function CommandPalette({
     workflows,
     scripts,
     currentSession,
+    sessionWorktree,
+    runScript,
+    showToast,
     agentKindOverride,
     setCurrentWorkspace,
     setCurrentSession,

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -85,7 +85,11 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
           )}
         </div>
         <OpenInEditorIconButton worktreePath={worktreePath} />
-        <RunScriptControl workspaceId={session.workspaceId} />
+        <RunScriptControl
+          sessionId={session.id as SessionId}
+          workspaceId={session.workspaceId}
+          worktreePath={worktreePath}
+        />
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -178,7 +178,13 @@ import {
   resolveSkillInvocation,
   type SkillUpsertArgs,
 } from '../features/skills/skills';
-import { invokeScriptRun, type ScriptRunResult } from '../features/scripts/scripts';
+import {
+  invokeScriptRun,
+  invokeScriptCancel,
+  type ScriptRunResult,
+  type ScriptRunRecord,
+  type ScriptRunStatus,
+} from '../features/scripts/scripts';
 import {
   invokePermissionRuleList,
   invokePermissionRuleUpsert,
@@ -313,6 +319,9 @@ export interface AppState {
   readonly systemAlerts: ReadonlyArray<SystemAlert>;
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly workspaceScripts: Readonly<Record<WorkspaceId, ReadonlyArray<WorkspaceScript>>>;
+  readonly scriptRuns: Readonly<
+    Record<SessionId, Readonly<Record<WorkspaceScriptId, ScriptRunRecord>>>
+  >;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<Agent>>>;
   readonly selectedAgentId: Readonly<Record<SessionId, AgentId | null>>;
@@ -498,7 +507,12 @@ export interface AppActions {
     body: string;
   }): Promise<void>;
   deleteScript(scriptId: WorkspaceScriptId, workspaceId: WorkspaceId): Promise<void>;
-  runScript(scriptId: WorkspaceScriptId): Promise<ScriptRunResult>;
+  runScript(
+    sessionId: SessionId,
+    scriptId: WorkspaceScriptId,
+    cwd: string,
+  ): Promise<ScriptRunResult>;
+  cancelScript(sessionId: SessionId, scriptId: WorkspaceScriptId): Promise<void>;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
   savePhaseTemplate(template: PhaseTemplateUpsertArgs): Promise<void>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
@@ -638,6 +652,7 @@ const initialState: AppState = {
   budgetAlerts: [],
   skills: {},
   workspaceScripts: {},
+  scriptRuns: {},
   phaseTemplates: {},
   sessionPhaseRuns: {},
   selectedAgentId: {},
@@ -3348,8 +3363,51 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
-  runScript: async (scriptId) => {
-    return invokeScriptRun(scriptId);
+  runScript: async (sessionId, scriptId, cwd) => {
+    const runId = crypto.randomUUID();
+
+    const writeRun = (record: ScriptRunRecord) =>
+      set((state) => ({
+        scriptRuns: {
+          ...state.scriptRuns,
+          [sessionId]: { ...state.scriptRuns[sessionId], [scriptId]: record },
+        },
+      }));
+
+    writeRun({ status: 'pending', result: null, runId });
+
+    const settle = (status: ScriptRunStatus, result: ScriptRunResult): ScriptRunResult => {
+      const curr = get().scriptRuns[sessionId]?.[scriptId];
+      // A newer run for this script took the slot — leave it untouched.
+      if (!curr || curr.runId !== runId) return result;
+      // A user cancel wins over the exit code the kill produces.
+      writeRun({
+        status: curr.status === 'cancelled' ? 'cancelled' : status,
+        result,
+        runId,
+      });
+      return result;
+    };
+
+    try {
+      const result = await invokeScriptRun(scriptId, runId, cwd);
+      return settle(result.exitCode === 0 ? 'ok' : 'error', result);
+    } catch (err) {
+      return settle('error', { stdout: '', stderr: formatError(err), exitCode: -1 });
+    }
+  },
+
+  cancelScript: async (sessionId, scriptId) => {
+    const curr = get().scriptRuns[sessionId]?.[scriptId];
+    if (!curr || curr.status !== 'pending') return;
+    const cancelled: ScriptRunRecord = { ...curr, status: 'cancelled' };
+    set((state) => ({
+      scriptRuns: {
+        ...state.scriptRuns,
+        [sessionId]: { ...state.scriptRuns[sessionId], [scriptId]: cancelled },
+      },
+    }));
+    await invokeScriptCancel(curr.runId);
   },
 
   loadPhaseTemplates: async (workspaceId) => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -276,6 +276,7 @@ dialog[open]::backdrop {
 
 .spin-border-info  { --spin-border-color: var(--color-info); }
 .spin-border-danger { --spin-border-color: var(--color-danger); }
+.spin-border-primary { --spin-border-color: var(--color-primary); }
 
 .animate-border-pulse {
   animation: border-pulse 2.8s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- Integrates the cancellable / store-tracked script-run WIP from `ak/hardcore-hopper-0cdf49` on top of the quick-actions composer (#603).
- Script runs are keyed by `(session, script)` in a new `scriptRuns` store slice with a per-run id; an in-flight `bash` subprocess can be killed via `cancelScript` → `workspace_script_cancel`.
- Rust: each child registered under its `run_id` in a `ScriptRegistry`; stdout/stderr drained on separate threads to avoid pipe-buffer deadlock.
- `runScript` signature is now `(sessionId, scriptId, cwd)` — reconciled with the `$`-run from the chat composer (#603), which passes the session worktree as cwd and toasts if the session has none.
- `RunScriptControl` gains a stop button + cancelled status; ⌘K palette `$` now runs the script instead of only deep-linking.

## Test plan
- [ ] Run a script from the chat composer (`$`) — sticky result row, success/fail.
- [ ] Run a script from the Scripts panel — stop button kills an in-flight run, status shows `cancelled`.
- [ ] Run a script from ⌘K palette — toast on done/exit.
- [ ] Session with no worktree — composer and palette toast a warning, panel button disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)