### PR TITLE
fix(desktop): self-heal session branch cache on agent worktree edits

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ pub fn run() {
   let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
   let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
   let turn_registry = turn::TurnRegistry::new();
+  let script_registry = scripts::ScriptRegistry::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
@@ -37,6 +38,7 @@ pub fn run() {
     .manage(cursor_state)
     .manage(codex_state)
     .manage(turn_registry)
+    .manage(script_registry)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(
@@ -102,6 +104,7 @@ pub fn run() {
       skills::skill_rescan,
       skills::skill_run_script,
       scripts::workspace_script_run,
+      scripts::workspace_script_cancel,
       workflows::workflow_list,
       workflows::workflow_get,
       workflows::workflow_upsert,

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -1,3 +1,9 @@
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Child, Stdio};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
 use serde::Serialize;
 use tauri::State;
 
@@ -13,6 +19,23 @@ pub struct ScriptRunResult {
     pub stderr: String,
     #[serde(rename = "exitCode")]
     pub exit_code: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Process registry
+// ---------------------------------------------------------------------------
+
+type ChildSlot = Arc<Mutex<Option<Child>>>;
+
+/// Keeps a kill handle for every in-flight script run, keyed by `run_id`, so
+/// `workspace_script_cancel` can interrupt one. Mirrors `turn::TurnRegistry`.
+#[derive(Default)]
+pub struct ScriptRegistry(pub Arc<Mutex<HashMap<String, ChildSlot>>>);
+
+impl ScriptRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -71,45 +94,115 @@ impl From<DbError> for ScriptError {
 // Command — run a user-defined workspace script
 // ---------------------------------------------------------------------------
 
-/// Run a workspace script body via `bash -c`, with cwd set to the workspace
-/// root. Captures stdout/stderr/exit. Never errors on a non-zero exit — the
-/// caller renders the exit code as a status (✓ / ✗).
+/// Run a workspace script body via `bash -c`, with cwd set to the caller-
+/// supplied session worktree. Captures stdout/stderr/exit. Never errors on a
+/// non-zero exit — the caller renders the exit code as a status (✓ / ✗).
 ///
-/// Async + spawn_blocking so the bash subprocess doesn't block Tauri's main
-/// thread (which would freeze the entire webview until the script returns).
+/// The child is registered under `run_id` so `workspace_script_cancel` can
+/// kill it. stdout/stderr are drained on separate threads — a chatty script
+/// could otherwise deadlock by filling one pipe buffer while we read the
+/// other — and both reads run with the registry slot unlocked so a concurrent
+/// cancel can lock the slot and land the kill.
 #[tauri::command]
 pub async fn workspace_script_run(
     state: State<'_, Db>,
+    registry: State<'_, ScriptRegistry>,
     script_id: String,
+    run_id: String,
+    cwd: String,
 ) -> Result<ScriptRunResult, ScriptError> {
-    let (body, root) = {
+    let body = {
         let conn = state.0.lock().map_err(|_| ScriptError::Poisoned)?;
         conn.query_row(
-            "SELECT s.body, w.root_path
-             FROM workspace_scripts s
-             JOIN workspaces w ON w.id = s.workspace_id
-             WHERE s.id = ?1
-             LIMIT 1",
+            "SELECT body FROM workspace_scripts WHERE id = ?1 LIMIT 1",
             rusqlite::params![script_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            |row| row.get::<_, String>(0),
         )
         .map_err(|_| ScriptError::NotFound(script_id.clone()))?
     };
 
+    let registry = Arc::clone(&registry.0);
+
     tauri::async_runtime::spawn_blocking(move || {
-        let output = crate::path_env::command("bash")
+        let mut child = crate::path_env::command("bash")
             .arg("-c")
             .arg(&body)
-            .current_dir(&root)
-            .output()
+            .current_dir(&cwd)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
             .map_err(|e| ScriptError::Io(e.to_string()))?;
 
+        let mut stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| ScriptError::Io("no stdout".to_string()))?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| ScriptError::Io("no stderr".to_string()))?;
+
+        let slot: ChildSlot = Arc::new(Mutex::new(Some(child)));
+        registry
+            .lock()
+            .map_err(|_| ScriptError::Poisoned)?
+            .insert(run_id.clone(), Arc::clone(&slot));
+
+        let stderr_thread = thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = stderr.read_to_end(&mut buf);
+            buf
+        });
+        let mut stdout_buf = Vec::new();
+        let _ = stdout.read_to_end(&mut stdout_buf);
+        let stderr_buf = stderr_thread.join().unwrap_or_default();
+
+        // Both pipes are at EOF: the process has exited or is about to, so the
+        // brief slot lock taken to wait can't stall a concurrent cancel.
+        let exit_code = match slot.lock() {
+            Ok(mut guard) => guard
+                .as_mut()
+                .and_then(|c| c.wait().ok())
+                .and_then(|status| status.code())
+                .unwrap_or(-1),
+            Err(_) => -1,
+        };
+        if let Ok(mut map) = registry.lock() {
+            map.remove(&run_id);
+        }
+
         Ok(ScriptRunResult {
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
-            exit_code: output.status.code().unwrap_or(-1),
+            stdout: String::from_utf8_lossy(&stdout_buf).to_string(),
+            stderr: String::from_utf8_lossy(&stderr_buf).to_string(),
+            exit_code,
         })
     })
     .await
     .map_err(|e| ScriptError::Io(e.to_string()))?
+}
+
+// ---------------------------------------------------------------------------
+// Command — interrupt an in-flight workspace script
+// ---------------------------------------------------------------------------
+
+/// Kill the child registered under `run_id`. A run that already finished, or a
+/// never-registered id, is a no-op success — the frontend fires this on a stop
+/// click that can race the run completing on its own.
+#[tauri::command]
+pub fn workspace_script_cancel(
+    registry: State<'_, ScriptRegistry>,
+    run_id: String,
+) -> Result<(), ScriptError> {
+    let slot = {
+        let map = registry.0.lock().map_err(|_| ScriptError::Poisoned)?;
+        map.get(&run_id).cloned()
+    };
+    if let Some(slot) = slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(child) = guard.as_mut() {
+                let _ = child.kill();
+            }
+        }
+    }
+    Ok(())
 }

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -16,6 +16,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     providers: ReadonlyArray<{ id: string; connection: string }>;
     skills: Record<string, never>;
     workspaceScripts: Record<string, never>;
+    sessionWorktrees: Record<string, ReadonlyArray<string>>;
     providerSpendBreakdown: ReadonlyArray<never>;
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
@@ -48,6 +49,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     ],
     skills: {},
     workspaceScripts: {},
+    sessionWorktrees: {},
     providerSpendBreakdown: [],
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -15,6 +15,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     cancelCurrentTurn: typeof cancel;
     providers: ReadonlyArray<{ id: string; connection: string }>;
     skills: Record<string, never>;
+    workspaceScripts: Record<string, never>;
     providerSpendBreakdown: ReadonlyArray<never>;
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
@@ -24,11 +25,18 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     agentDraft: Record<string, string>;
     sessionNudges: Record<string, null>;
     sessionPhaseRuns: Record<string, ReadonlyArray<never>>;
+    phaseTemplates: Record<string, never>;
     setAgentDraft: (agentId: string, value: string) => void;
     clearAgentDraft: (agentId: string) => void;
     dismissSessionNudge: () => Promise<void>;
     acceptSessionNudgeHandoff: () => Promise<void>;
     spawnAgent: () => Promise<void>;
+    runScript: () => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    loadScripts: () => Promise<void>;
+    selectAgent: () => Promise<void>;
+    attachWorkflowToSession: () => Promise<void>;
+    loadPhaseTemplates: () => Promise<void>;
+    loadPhaseRunsForSession: () => Promise<void>;
   }
   const store = create<S>((set) => ({
     sendTurn: send,
@@ -39,6 +47,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
       { id: 'codex', connection: 'connected' },
     ],
     skills: {},
+    workspaceScripts: {},
     providerSpendBreakdown: [],
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},
@@ -48,6 +57,7 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     agentDraft: {},
     sessionNudges: {},
     sessionPhaseRuns: {},
+    phaseTemplates: {},
     setAgentDraft: (agentId, value) =>
       set((s) => ({ agentDraft: { ...s.agentDraft, [agentId]: value } })),
     clearAgentDraft: (agentId) =>
@@ -60,6 +70,12 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     dismissSessionNudge: async () => undefined,
     acceptSessionNudgeHandoff: async () => undefined,
     spawnAgent: async () => undefined,
+    runScript: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    loadScripts: async () => undefined,
+    selectAgent: async () => undefined,
+    attachWorkflowToSession: async () => undefined,
+    loadPhaseTemplates: async () => undefined,
+    loadPhaseRunsForSession: async () => undefined,
   }));
   return { sendTurnMock: send, cancelCurrentTurnMock: cancel, mockStore: store };
 });

--- a/apps/desktop/src/__tests__/a11y/smoke.test.tsx
+++ b/apps/desktop/src/__tests__/a11y/smoke.test.tsx
@@ -95,7 +95,7 @@ import { SettingsDialog } from '../../features/settings/components/SettingsDialo
 import { WorkspacesSidebar } from '../../features/workspace/components/WorkspacesSidebar';
 import { StatusBar } from '../../app/components/StatusBar';
 import { SkillsPanel } from '../../features/skills/components/SkillsPanel';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover } from '../../features/quick-actions';
 import { ToastProvider } from '../../app/components/Toast';
 
 afterEach(cleanup);
@@ -170,10 +170,15 @@ describe('a11y smoke — SkillsPanel', () => {
   });
 });
 
-describe('a11y smoke — SlashCommandPopover', () => {
-  it('no violations (no skills / empty items)', async () => {
+describe('a11y smoke — QuickActionsPopover', () => {
+  it('no violations (empty items)', async () => {
     const { container } = render(
-      <SlashCommandPopover items={[]} query="" onSelect={vi.fn()} onDismiss={vi.fn()} />,
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="no scripts"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
     );
     const { violations } = await runA11yCheck(container);
     expect(violations).toHaveLength(0);

--- a/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
@@ -76,7 +76,7 @@ import userEvent from '@testing-library/user-event';
 import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
 import { EndSessionDialog } from '../../features/session/components/EndSessionDialog';
 import { NewSessionDialog } from '../../features/session/components/NewSessionDialog';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover, type QuickActionItem } from '../../features/quick-actions';
 import { ToastProvider } from '../../app/components/Toast';
 
 afterEach(cleanup);
@@ -197,47 +197,62 @@ describe('keyboard — NewSessionDialog', () => {
   });
 });
 
-describe('keyboard — SlashCommandPopover arrow / tab navigation', () => {
-  const items = [
-    { name: 'review', description: 'code review' },
-    { name: 'test', description: 'run tests' },
-    { name: 'deploy', description: 'deploy to env' },
+describe('keyboard — QuickActionsPopover arrow / tab navigation', () => {
+  const items: ReadonlyArray<QuickActionItem> = [
+    { id: 'review', label: 'review', sublabel: 'code review', group: 'skill', perform: vi.fn() },
+    { id: 'test', label: 'test', sublabel: 'run tests', group: 'skill', perform: vi.fn() },
+    { id: 'deploy', label: 'deploy', sublabel: 'deploy to env', group: 'skill', perform: vi.fn() },
   ];
 
   it('ArrowDown advances active index and calls onSelect with Enter', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'ArrowDown' });
     fireEvent.keyDown(window, { key: 'Enter' });
     // After one ArrowDown from index 0, active is 1 → 'test'
-    expect(onSelect).toHaveBeenCalledWith('test');
+    expect(onSelect).toHaveBeenCalledWith(items[1]);
   });
 
   it('ArrowUp wraps active index back (stays at 0 from 0)', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'ArrowUp' });
     fireEvent.keyDown(window, { key: 'Enter' });
     // ArrowUp from 0 stays at 0 → 'review'
-    expect(onSelect).toHaveBeenCalledWith('review');
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
   it('Tab key selects the active item', () => {
     const onSelect = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={onSelect} onDismiss={vi.fn()} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={onSelect} onDismiss={vi.fn()} />,
+    );
     fireEvent.keyDown(window, { key: 'Tab' });
-    expect(onSelect).toHaveBeenCalledWith('review');
+    expect(onSelect).toHaveBeenCalledWith(items[0]);
   });
 
   it('Escape calls onDismiss', () => {
     const onDismiss = vi.fn();
-    render(<SlashCommandPopover items={items} query="" onSelect={vi.fn()} onDismiss={onDismiss} />);
+    render(
+      <QuickActionsPopover items={items} emptyHint="" onSelect={vi.fn()} onDismiss={onDismiss} />,
+    );
     fireEvent.keyDown(window, { key: 'Escape' });
     expect(onDismiss).toHaveBeenCalledOnce();
   });
 
-  it('renders empty state when no items match query', () => {
-    render(<SlashCommandPopover items={[]} query="xyz" onSelect={vi.fn()} onDismiss={vi.fn()} />);
-    expect(screen.getByText(/no skills/i)).toBeDefined();
+  it('renders empty hint when there are no items', () => {
+    render(
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="nothing here"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/nothing here/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -203,8 +203,11 @@ exports[`snapshot — empty states > NewSessionDialog: no workflows 1`] = `
                 </span>
                 <input
                   aria-label="Branch slug"
+                  autocapitalize="off"
+                  autocorrect="off"
                   class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
+                  spellcheck="false"
                   type="text"
                   value=""
                 />
@@ -2301,8 +2304,11 @@ exports[`snapshot — error states > NewSessionDialog: form error 1`] = `
                 </span>
                 <input
                   aria-label="Branch slug"
+                  autocapitalize="off"
+                  autocorrect="off"
                   class="w-full rounded-md border border-border bg-background px-2.5 text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:opacity-50 h-8 flex-1 font-mono text-sm"
                   placeholder="branch-slug"
+                  spellcheck="false"
                   type="text"
                   value=""
                 />

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -462,7 +462,7 @@ exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
 </div>
 `;
 
-exports[`snapshot — empty states > SlashCommandPopover: no skills / empty items 1`] = `
+exports[`snapshot — empty states > QuickActionsPopover: no skills / empty items 1`] = `
 <div
   class="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md"
 >

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -103,7 +103,7 @@ import { BootSplash } from '../../app/components/BootSplash';
 import { NewSessionDialog } from '../../features/session/components/NewSessionDialog';
 import { EndSessionDialog } from '../../features/session/components/EndSessionDialog';
 import { SkillsPanel } from '../../features/skills/components/SkillsPanel';
-import { SlashCommandPopover } from '../../features/chat/components/SlashCommandPopover';
+import { QuickActionsPopover } from '../../features/quick-actions';
 import { WorkspacesSidebar } from '../../features/workspace/components/WorkspacesSidebar';
 import { BudgetRulesPanel } from '../../features/budget/components/BudgetRulesPanel';
 import { ProvidersPanel } from '../../features/providers/components/ProvidersPanel';
@@ -153,9 +153,14 @@ describe('snapshot — empty states', () => {
     expect(container.firstChild).toMatchSnapshot();
   });
 
-  it('SlashCommandPopover: no skills / empty items', () => {
+  it('QuickActionsPopover: no skills / empty items', () => {
     const { container } = render(
-      <SlashCommandPopover items={[]} query="" onSelect={vi.fn()} onDismiss={vi.fn()} />,
+      <QuickActionsPopover
+        items={[]}
+        emptyHint="no skills. create one in settings"
+        onSelect={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -256,6 +256,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     useShallow((s) => s.workspaceScripts[session.workspaceId] ?? EMPTY_ARRAY),
   );
   const runScript = useAppStore((s) => s.runScript);
+  const sessionWorktree = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const workspaceWorkflows = useAppStore(
     useShallow((s) => s.phaseTemplates[session.workspaceId] ?? EMPTY_ARRAY),
@@ -368,12 +369,16 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const onPickScript = useCallback(
     async (script: WorkspaceScript) => {
+      if (!sessionWorktree) {
+        showToast('warning', `${script.name} — open a session worktree to run scripts`);
+        return;
+      }
       const seq = ++runSeqRef.current;
       setValue('');
       setShowPopover(false);
       setScriptResult({ script, status: 'pending', result: null });
       try {
-        const result = await runScript(script.id);
+        const result = await runScript(session.id, script.id, sessionWorktree);
         if (runSeqRef.current !== seq) return;
         setScriptResult({
           script,
@@ -389,7 +394,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
         });
       }
     },
-    [runScript, setValue],
+    [runScript, setValue, session.id, sessionWorktree, showToast],
   );
 
   const onPickSkill = useCallback(

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -10,13 +10,17 @@ import {
 import { Send, Square, X } from 'lucide-react';
 import { Divider, Textarea } from '@goodboy/ui';
 import type {
+  Agent,
   AgentId,
   BudgetAlert,
   BudgetAlertKind,
   ProviderId,
   Session,
   SessionId,
+  Skill,
   TurnProviderOverride,
+  Workflow,
+  WorkspaceScript,
 } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES, assessTurnWeight, getDefaultTurnModel } from '@goodboy/core';
 import { insertNudgeEvent, updateNudgeEventOutcome, type NudgeOutcome } from '@goodboy/db';
@@ -27,7 +31,17 @@ import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
 import { RoutingIndicator } from '../RoutingIndicator';
 import { useToast, type ToastKind } from '../../../../app/components/Toast';
-import { SlashCommandPopover } from '../SlashCommandPopover';
+import {
+  QuickActionsPopover,
+  ScriptResultRow,
+  buildAgentActions,
+  buildScriptActions,
+  buildSkillActions,
+  buildWorkflowActions,
+  parseQuery,
+  type QuickActionItem,
+  type ScriptResultState,
+} from '../../../quick-actions';
 import {
   type VerbosityLevel,
   readVerbosity,
@@ -53,7 +67,14 @@ import { detectScopeMismatch, type ScopeMismatch } from '../../utils/scope-misma
 
 const RUNNING_KINDS = new Set(['starting', 'running']);
 
-const SLASH_MODE_RE = /^\s*\/[a-z0-9-]*$/;
+// Prefix-mode trigger for the in-chat quick-actions popover: a leading
+// $ / ~ @ followed by a single space-free token. A space closes the popover
+// so the message sends normally.
+const CHAT_PREFIX_RE = /^\s*[$/~@][^\s]*$/;
+
+// Idle-state composer placeholder — shows the whole prefix grammar at once
+// so the user is taught every quick-action up front, not over time.
+const CHAT_PLACEHOLDER = 'Message Claude — $ scripts · ~ workflows · @ agents';
 
 const EFFORT_STORAGE_PREFIX = STORAGE_PREFIXES.effort;
 const MODEL_STORAGE_PREFIX = STORAGE_PREFIXES.model;
@@ -231,6 +252,21 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const workspaceSkills = useAppStore(
     useShallow((s) => s.skills[session.workspaceId] ?? EMPTY_ARRAY),
   );
+  const workspaceScripts = useAppStore(
+    useShallow((s) => s.workspaceScripts[session.workspaceId] ?? EMPTY_ARRAY),
+  );
+  const runScript = useAppStore((s) => s.runScript);
+  const loadScripts = useAppStore((s) => s.loadScripts);
+  const workspaceWorkflows = useAppStore(
+    useShallow((s) => s.phaseTemplates[session.workspaceId] ?? EMPTY_ARRAY),
+  ) as ReadonlyArray<Workflow>;
+  const sessionAgents = useAppStore(
+    useShallow((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY),
+  ) as ReadonlyArray<Agent>;
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const attachWorkflowToSession = useAppStore((s) => s.attachWorkflowToSession);
+  const loadPhaseTemplates = useAppStore((s) => s.loadPhaseTemplates);
+  const loadPhaseRunsForSession = useAppStore((s) => s.loadPhaseRunsForSession);
 
   const { showToast } = useToast();
   const value = useAppStore((s) => (selectedAgentId ? (s.agentDraft[selectedAgentId] ?? '') : ''));
@@ -260,10 +296,12 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
   const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
   const [showPopover, setShowPopover] = useState(false);
+  const [scriptResult, setScriptResult] = useState<ScriptResultState | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const runSeqRef = useRef(0);
 
-  const slashQuery = SLASH_MODE_RE.test(value) ? value.trimStart().slice(1) : null;
-  const isSlashMode = slashQuery !== null;
+  const parsed = useMemo(() => parseQuery(value), [value]);
+  const inPrefixMode = CHAT_PREFIX_RE.test(value);
 
   const selectedAgentState = useAppStore((s) =>
     selectedAgentId ? (s.agentTurnState[selectedAgentId] ?? null) : null,
@@ -325,17 +363,132 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const onValueChange = (next: string) => {
     setValue(next);
-    setShowPopover(SLASH_MODE_RE.test(next));
+    setShowPopover(CHAT_PREFIX_RE.test(next));
   };
 
-  const onSkillSelect = useCallback(
-    (name: string) => {
-      setValue(`/${name} `);
+  const onPickScript = useCallback(
+    async (script: WorkspaceScript) => {
+      const seq = ++runSeqRef.current;
+      setValue('');
+      setShowPopover(false);
+      setScriptResult({ script, status: 'pending', result: null });
+      try {
+        const result = await runScript(script.id);
+        if (runSeqRef.current !== seq) return;
+        setScriptResult({
+          script,
+          status: result.exitCode === 0 ? 'ok' : 'error',
+          result,
+        });
+      } catch (err) {
+        if (runSeqRef.current !== seq) return;
+        setScriptResult({
+          script,
+          status: 'error',
+          result: { stdout: '', stderr: formatError(err), exitCode: -1 },
+        });
+      }
+    },
+    [runScript, setValue],
+  );
+
+  const onPickSkill = useCallback(
+    (skill: Skill) => {
+      setValue(`/${skill.name} `);
       setShowPopover(false);
       wrapperRef.current?.querySelector('textarea')?.focus();
     },
     [setValue],
   );
+
+  const onPickWorkflow = useCallback(
+    async (workflow: Workflow) => {
+      setValue('');
+      setShowPopover(false);
+      try {
+        await attachWorkflowToSession(session.id, workflow.id);
+        showToast('success', `workflow "${workflow.name}" started`);
+      } catch (err) {
+        showToast('error', formatError(err));
+      }
+    },
+    [attachWorkflowToSession, session.id, showToast, setValue],
+  );
+
+  const onSwitchAgent = useCallback(
+    (agent: Agent) => {
+      setValue('');
+      setShowPopover(false);
+      void selectAgent(session.id, agent.id);
+    },
+    [selectAgent, session.id, setValue],
+  );
+
+  const onSpawnAgent = useCallback(async () => {
+    setValue('');
+    setShowPopover(false);
+    try {
+      await spawnAgent(session.id, {});
+      showToast('success', 'new agent spawned');
+    } catch (err) {
+      showToast('error', formatError(err));
+    }
+  }, [spawnAgent, session.id, showToast, setValue]);
+
+  const quickItems = useMemo<ReadonlyArray<QuickActionItem> | null>(() => {
+    const symbol = parsed.prefix?.symbol;
+    if (symbol === '$') {
+      return buildScriptActions(workspaceScripts, (script) => void onPickScript(script));
+    }
+    if (symbol === '~') {
+      if (session.workflowId) return [];
+      return buildWorkflowActions(workspaceWorkflows, (workflow) => void onPickWorkflow(workflow));
+    }
+    if (symbol === '@') {
+      return buildAgentActions(sessionAgents, onSwitchAgent, () => void onSpawnAgent());
+    }
+    if (symbol === '/' && WORKSPACE_FEATURES.skills) {
+      return buildSkillActions(workspaceSkills, onPickSkill);
+    }
+    return null;
+  }, [
+    parsed.prefix,
+    session.workflowId,
+    workspaceScripts,
+    workspaceWorkflows,
+    sessionAgents,
+    workspaceSkills,
+    onPickScript,
+    onPickWorkflow,
+    onSwitchAgent,
+    onSpawnAgent,
+    onPickSkill,
+  ]);
+
+  const filteredQuickItems = useMemo<ReadonlyArray<QuickActionItem>>(() => {
+    if (!quickItems) return EMPTY_ARRAY;
+    const q = parsed.query.toLowerCase();
+    if (q.length === 0) return quickItems;
+    return quickItems.filter(
+      (it) =>
+        it.label.toLowerCase().includes(q) || (it.sublabel?.toLowerCase().includes(q) ?? false),
+    );
+  }, [quickItems, parsed.query]);
+
+  const popoverOpen = showPopover && inPrefixMode && quickItems !== null;
+  const quickEmptyHint =
+    parsed.prefix?.symbol === '$'
+      ? 'no scripts. add them in workspace settings.'
+      : parsed.prefix?.symbol === '~'
+        ? session.workflowId
+          ? 'this session already has a workflow.'
+          : 'no workflows. create one in workspace settings.'
+        : parsed.prefix?.symbol === '@'
+          ? 'no agents in this session.'
+          : 'no skills. create one in settings.';
+
+  const onQuickActionSelect = useCallback((item: QuickActionItem) => item.perform(), []);
+  const dismissPopover = useCallback(() => setShowPopover(false), []);
 
   const setEffort = (level: EffortLevel) => {
     setEffortState(level);
@@ -568,15 +721,32 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     setScopeNudgeEventId(null);
   }, [selectedAgentId]);
 
+  // Load workspace scripts + workflows so the `$` and `~` quick-actions can
+  // list them.
+  useEffect(() => {
+    void loadScripts(session.workspaceId);
+    void loadPhaseTemplates(session.workspaceId);
+  }, [session.workspaceId, loadScripts, loadPhaseTemplates]);
+
+  // Load this session's agents so the `@` quick-action can list them.
+  useEffect(() => {
+    void loadPhaseRunsForSession(session.id);
+  }, [session.id, loadPhaseRunsForSession]);
+
+  // Script results are session-scoped — drop them when the session changes.
+  useEffect(() => {
+    setScriptResult(null);
+  }, [session.id]);
+
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (
-      showPopover &&
+      popoverOpen &&
       (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'Tab')
     ) {
       event.preventDefault();
       return;
     }
-    if (event.key === 'Enter' && !event.shiftKey && !showPopover) {
+    if (event.key === 'Enter' && !event.shiftKey && !popoverOpen) {
       event.preventDefault();
       void onSend();
     }
@@ -710,17 +880,20 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
           />
         ) : null}
         <SuggestionStack items={suggestions} />
+        {scriptResult ? (
+          <ScriptResultRow state={scriptResult} onDismiss={() => setScriptResult(null)} />
+        ) : null}
         <div
           className="flex flex-col rounded-[6px] bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15 dark:bg-muted/40"
           style={{ boxShadow: '0 8px 32px -16px oklch(0 0 0 / 0.25)' }}
         >
           <div className="relative" ref={wrapperRef}>
-            {WORKSPACE_FEATURES.skills && showPopover && isSlashMode ? (
-              <SlashCommandPopover
-                items={workspaceSkills}
-                query={slashQuery}
-                onSelect={onSkillSelect}
-                onDismiss={() => setShowPopover(false)}
+            {popoverOpen ? (
+              <QuickActionsPopover
+                items={filteredQuickItems}
+                emptyHint={quickEmptyHint}
+                onSelect={onQuickActionSelect}
+                onDismiss={dismissPopover}
               />
             ) : null}
             <Textarea
@@ -734,7 +907,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
                     ? queued
                       ? 'Message queued. Type to replace.'
                       : 'Turn running. Type to queue next message.'
-                    : 'Message Claude. Shift+enter for newline.'
+                    : CHAT_PLACEHOLDER
               }
               disabled={providerDisconnected}
               autoGrow

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -212,7 +212,17 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   // empty shell first on session switch and treat the card list as low-priority.
   // Pairs with React.memo on TranscriptCard — together they make session swaps
   // feel instant even with hundreds of turns in history.
-  const deferredItems = useDeferredValue(items);
+  // Tag the deferred value with its agent id: useDeferredValue keeps returning
+  // the previous agent's array for a render or more after a switch — without
+  // the tag the list below would paint the wrong agent's transcript. While it
+  // lags (`transcriptStale`) we render the skeleton instead.
+  const taggedItems = useMemo(
+    () => ({ agentId: selectedAgentId, items }),
+    [selectedAgentId, items],
+  );
+  const deferredTagged = useDeferredValue(taggedItems);
+  const transcriptStale = deferredTagged.agentId !== selectedAgentId;
+  const deferredItems = deferredTagged.items;
   const loading = useSessionLoading(session.id);
   const transcriptCached = useAppStore((s) =>
     selectedAgentId ? s.transcripts[selectedAgentId] !== undefined : true,
@@ -395,8 +405,8 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
           className="flex-1 overflow-y-auto px-10 py-6"
           style={{ scrollbarGutter: 'stable' }}
         >
-          {items.length === 0 ? (
-            loading.transcript ? (
+          {transcriptStale || deferredItems.length === 0 ? (
+            loading.transcript || transcriptStale ? (
               <TranscriptSkeleton />
             ) : isProviderDisconnected ? (
               <div className="flex h-full items-center justify-center">

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -131,6 +131,34 @@ export function ContextPanel({
 
   const workingDir = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
 
+  // Self-heal the branch cache: an agent can `git switch` directly in the
+  // worktree, moving HEAD without going through changeSessionBranch, which
+  // leaves the sidebar footer chip on a stale branch. Read the real branch off
+  // worktree_status and write it back. Re-runs after each turn (summarizer
+  // tick) and on file-count changes — the moments a branch switch is likely.
+  const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
+  useEffect(() => {
+    if (!isActive || !workingDir) return;
+    let cancelled = false;
+    worktreeStatus(workingDir)
+      .then((status) => {
+        if (!cancelled && status.branch) {
+          void reconcileSessionBranch(session.id as SessionId, status.branch);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isActive,
+    workingDir,
+    session.id,
+    filesTouched.count,
+    summarizer.lastUpdate,
+    reconcileSessionBranch,
+  ]);
+
   const slotsByKey = new Map<string, ContextSlot>(
     slots.map((s) => [s.key, s.key === 'files_touched' ? normalizeFilesSlot(s, workingDir) : s]),
   );

--- a/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
+++ b/apps/desktop/src/features/quick-actions/QuickActionsPopover/index.tsx
@@ -1,47 +1,43 @@
 import { useEffect, useRef, useState } from 'react';
+import type { QuickActionItem } from '../types';
 
-interface SkillItem {
-  readonly name: string;
-  readonly description: string;
-}
-
-interface SlashCommandPopoverProps {
-  readonly items: ReadonlyArray<SkillItem>;
-  readonly query: string;
-  readonly onSelect: (name: string) => void;
+interface QuickActionsPopoverProps {
+  readonly items: ReadonlyArray<QuickActionItem>;
+  readonly emptyHint: string;
+  readonly onSelect: (item: QuickActionItem) => void;
   readonly onDismiss: () => void;
 }
 
-function fuzzyMatch(name: string, query: string): boolean {
-  return name.toLowerCase().includes(query.toLowerCase());
-}
-
-export function SlashCommandPopover({
+/**
+ * Generic prefix-action picker rendered inline above the composer. Renders
+ * whatever `QuickActionItem[]` it is handed and reports the chosen one —
+ * the behavior lives in `item.perform`, not here.
+ */
+export function QuickActionsPopover({
   items,
-  query,
+  emptyHint,
   onSelect,
   onDismiss,
-}: SlashCommandPopoverProps) {
-  const filtered = items.filter((item) => fuzzyMatch(item.name, query));
+}: QuickActionsPopoverProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     setActiveIndex(0);
-  }, [query]);
+  }, [items]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        setActiveIndex((i) => Math.min(i + 1, filtered.length - 1));
+        setActiveIndex((i) => Math.min(i + 1, items.length - 1));
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
         setActiveIndex((i) => Math.max(i - 1, 0));
       } else if (e.key === 'Enter' || e.key === 'Tab') {
         e.preventDefault();
-        const item = filtered[activeIndex];
-        if (item) onSelect(item.name);
+        const item = items[activeIndex];
+        if (item) onSelect(item);
       } else if (e.key === 'Escape') {
         e.preventDefault();
         onDismiss();
@@ -49,7 +45,7 @@ export function SlashCommandPopover({
     };
     window.addEventListener('keydown', handler, { capture: true });
     return () => window.removeEventListener('keydown', handler, { capture: true });
-  }, [filtered, activeIndex, onSelect, onDismiss]);
+  }, [items, activeIndex, onSelect, onDismiss]);
 
   useEffect(() => {
     const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
@@ -58,25 +54,25 @@ export function SlashCommandPopover({
 
   return (
     <div className="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md">
-      {filtered.length === 0 ? (
-        <p className="px-3 py-2 text-xs text-muted-foreground">no skills. create one in settings</p>
+      {items.length === 0 ? (
+        <p className="px-3 py-2 text-xs text-muted-foreground">{emptyHint}</p>
       ) : (
         <ul ref={listRef} className="max-h-48 overflow-y-auto py-1">
-          {filtered.map((item, i) => (
+          {items.map((item, i) => (
             <li
-              key={item.name}
+              key={item.id}
               className={`flex cursor-pointer flex-col gap-0.5 px-3 py-2 ${
-                i === activeIndex ? 'bg-accent' : 'hover:bg-accent/50'
+                i === activeIndex ? 'bg-muted' : 'hover:bg-muted/50'
               }`}
               onMouseEnter={() => setActiveIndex(i)}
               onMouseDown={(e) => {
                 e.preventDefault();
-                onSelect(item.name);
+                onSelect(item);
               }}
             >
-              <span className="text-xs font-medium text-foreground">/{item.name}</span>
-              {item.description ? (
-                <span className="text-xs text-muted-foreground">{item.description}</span>
+              <span className="truncate text-xs font-medium text-foreground">{item.label}</span>
+              {item.sublabel ? (
+                <span className="truncate text-2xs text-muted-foreground">{item.sublabel}</span>
               ) : null}
             </li>
           ))}

--- a/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
+++ b/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
@@ -1,0 +1,102 @@
+import { useRef, useState } from 'react';
+import { ScrollText, X } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { WorkspaceScript } from '@goodboy/types';
+import type { ScriptRunResult } from '../../scripts';
+
+export interface ScriptResultState {
+  readonly script: WorkspaceScript;
+  readonly status: 'pending' | 'ok' | 'error';
+  readonly result: ScriptRunResult | null;
+}
+
+interface ScriptResultRowProps {
+  readonly state: ScriptResultState;
+  readonly onDismiss: () => void;
+}
+
+/**
+ * Sticky result of a `$` quick-action script run, shown above the composer.
+ * Never sent to the LLM — stays until dismissed or replaced by the next run.
+ */
+export function ScriptResultRow({ state, onDismiss }: ScriptResultRowProps) {
+  const { script, status, result } = state;
+  const [outputOpen, setOutputOpen] = useState(false);
+
+  // Default the disclosure open on a failed run — the user almost always
+  // wants to see why. Successful runs stay collapsed.
+  const prevResultRef = useRef<ScriptRunResult | null>(null);
+  if (result !== prevResultRef.current) {
+    prevResultRef.current = result;
+    setOutputOpen(result !== null && result.exitCode !== 0);
+  }
+
+  const hasOutput = result !== null && (result.stdout.length > 0 || result.stderr.length > 0);
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col rounded-[6px] bg-subtle/80 ring-1 ring-border-soft',
+        status === 'pending' && 'spin-border spin-border-info',
+      )}
+    >
+      <div className="flex items-center gap-2 px-3 py-1.5">
+        <Dot status={status} />
+        <span className="min-w-0 flex-1 truncate text-xs">
+          <span className="text-muted-foreground">
+            {status === 'pending' ? 'running ' : 'ran '}
+          </span>
+          <span className="font-medium text-foreground">{script.name}</span>
+          {result !== null ? (
+            <span className="text-muted-foreground"> · exit {result.exitCode}</span>
+          ) : null}
+        </span>
+        {hasOutput ? (
+          <button
+            type="button"
+            onClick={() => setOutputOpen((v) => !v)}
+            aria-expanded={outputOpen}
+            title={outputOpen ? 'hide output' : 'show output'}
+            className={cn(
+              'flex size-6 shrink-0 items-center justify-center rounded transition-colors',
+              outputOpen
+                ? 'bg-primary/15 text-primary ring-1 ring-inset ring-primary/30'
+                : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground',
+            )}
+          >
+            <ScrollText size={12} aria-hidden />
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onDismiss}
+          title="dismiss"
+          aria-label="dismiss script result"
+          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        >
+          <X size={12} aria-hidden />
+        </button>
+      </div>
+      {hasOutput && outputOpen && result !== null ? (
+        <pre className="mx-3 mb-2 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-background px-2 py-1.5 font-mono text-2xs leading-relaxed text-foreground/80">
+          {result.stdout}
+          {result.stderr ? (
+            <span className="text-danger">
+              {result.stdout ? '\n' : ''}
+              {result.stderr}
+            </span>
+          ) : null}
+        </pre>
+      ) : null}
+    </div>
+  );
+}
+
+function Dot({ status }: { readonly status: ScriptResultState['status'] }) {
+  const color = status === 'ok' ? 'bg-success' : status === 'error' ? 'bg-danger' : 'bg-border';
+  const label =
+    status === 'ok' ? 'script succeeded' : status === 'error' ? 'script failed' : 'script running';
+  return (
+    <span className={cn('size-2 shrink-0 rounded-full', color)} role="img" aria-label={label} />
+  );
+}

--- a/apps/desktop/src/features/quick-actions/grammar.ts
+++ b/apps/desktop/src/features/quick-actions/grammar.ts
@@ -1,0 +1,45 @@
+/**
+ * Prefix grammar shared by the command palette (⌘K) and the in-chat
+ * quick-actions popover — single source so the two never drift.
+ */
+
+export type QuickActionGroup =
+  | 'agent'
+  | 'session'
+  | 'workspace'
+  | 'skill'
+  | 'workflow'
+  | 'script'
+  | 'action'
+  | 'help';
+
+export interface PrefixMeta {
+  readonly symbol: string;
+  readonly hint: string;
+  readonly group: QuickActionGroup;
+}
+
+export const PREFIXES: ReadonlyArray<PrefixMeta> = [
+  { symbol: '@', hint: 'agents in current session', group: 'agent' },
+  { symbol: '#', hint: 'sessions', group: 'session' },
+  { symbol: ':', hint: 'workspaces', group: 'workspace' },
+  { symbol: '/', hint: 'skills', group: 'skill' },
+  { symbol: '~', hint: 'workflows', group: 'workflow' },
+  { symbol: '$', hint: 'scripts', group: 'script' },
+  { symbol: '>', hint: 'actions', group: 'action' },
+  { symbol: '?', hint: 'help & shortcuts', group: 'help' },
+];
+
+export interface ParsedQuery {
+  readonly prefix: PrefixMeta | null;
+  readonly query: string;
+}
+
+export function parseQuery(raw: string): ParsedQuery {
+  const trimmed = raw.trimStart();
+  if (trimmed.length === 0) return { prefix: null, query: '' };
+  const ch = trimmed[0]!;
+  const meta = PREFIXES.find((p) => p.symbol === ch);
+  if (meta) return { prefix: meta, query: trimmed.slice(1).trim() };
+  return { prefix: null, query: trimmed };
+}

--- a/apps/desktop/src/features/quick-actions/index.ts
+++ b/apps/desktop/src/features/quick-actions/index.ts
@@ -1,0 +1,12 @@
+export { PREFIXES, parseQuery } from './grammar';
+export type { ParsedQuery, PrefixMeta, QuickActionGroup } from './grammar';
+export type { QuickActionItem } from './types';
+export {
+  buildAgentActions,
+  buildScriptActions,
+  buildSkillActions,
+  buildWorkflowActions,
+} from './registry';
+export { QuickActionsPopover } from './QuickActionsPopover';
+export { ScriptResultRow } from './ScriptResultRow';
+export type { ScriptResultState } from './ScriptResultRow';

--- a/apps/desktop/src/features/quick-actions/registry.ts
+++ b/apps/desktop/src/features/quick-actions/registry.ts
@@ -1,0 +1,75 @@
+import type { Agent, Skill, Workflow, WorkspaceScript } from '@goodboy/types';
+import type { QuickActionItem } from './types';
+
+function firstLine(body: string): string | undefined {
+  const line = body.trim().split('\n', 1)[0]?.trim();
+  return line ? line : undefined;
+}
+
+/** Maps workspace scripts to quick-action rows. `onPick` owns the run. */
+export function buildScriptActions(
+  scripts: ReadonlyArray<WorkspaceScript>,
+  onPick: (script: WorkspaceScript) => void,
+): ReadonlyArray<QuickActionItem> {
+  return scripts.map((script) => ({
+    id: `script:${script.id}`,
+    label: script.name,
+    sublabel: firstLine(script.body),
+    group: 'script',
+    perform: () => onPick(script),
+  }));
+}
+
+/** Maps workspace skills to quick-action rows. `onPick` pre-fills the input. */
+export function buildSkillActions(
+  skills: ReadonlyArray<Skill>,
+  onPick: (skill: Skill) => void,
+): ReadonlyArray<QuickActionItem> {
+  return skills.map((skill) => ({
+    id: `skill:${skill.id}`,
+    label: skill.name,
+    sublabel: skill.description || undefined,
+    group: 'skill',
+    perform: () => onPick(skill),
+  }));
+}
+
+/** Maps workspace workflows to quick-action rows. `onPick` starts the workflow. */
+export function buildWorkflowActions(
+  workflows: ReadonlyArray<Workflow>,
+  onPick: (workflow: Workflow) => void,
+): ReadonlyArray<QuickActionItem> {
+  return workflows.map((workflow) => ({
+    id: `workflow:${workflow.id}`,
+    label: workflow.name,
+    sublabel:
+      workflow.description ||
+      `${workflow.steps.length} step${workflow.steps.length === 1 ? '' : 's'}`,
+    group: 'workflow',
+    perform: () => onPick(workflow),
+  }));
+}
+
+/**
+ * Maps session agents to switch rows, plus a trailing "spawn new agent" row.
+ * `onSwitch` navigates to an existing agent; `onSpawn` creates a fresh one.
+ */
+export function buildAgentActions(
+  agents: ReadonlyArray<Agent>,
+  onSwitch: (agent: Agent) => void,
+  onSpawn: () => void,
+): ReadonlyArray<QuickActionItem> {
+  const switches = agents
+    .filter((agent) => agent.deletedAt === undefined)
+    .map<QuickActionItem>((agent) => ({
+      id: `agent:${agent.id}`,
+      label: agent.name,
+      sublabel: agent.status,
+      group: 'agent',
+      perform: () => onSwitch(agent),
+    }));
+  return [
+    ...switches,
+    { id: 'agent:spawn', label: '+ spawn new agent', group: 'agent', perform: onSpawn },
+  ];
+}

--- a/apps/desktop/src/features/quick-actions/types.ts
+++ b/apps/desktop/src/features/quick-actions/types.ts
@@ -1,0 +1,14 @@
+import type { QuickActionGroup } from './grammar';
+
+/**
+ * One selectable row in the quick-actions popover. `perform` carries the
+ * behavior — exec a script, pre-fill a skill — so the popover stays a
+ * generic renderer.
+ */
+export interface QuickActionItem {
+  readonly id: string;
+  readonly label: string;
+  readonly sublabel?: string;
+  readonly group: QuickActionGroup;
+  readonly perform: () => void;
+}

--- a/apps/desktop/src/features/scripts/components/RunScriptControl/index.tsx
+++ b/apps/desktop/src/features/scripts/components/RunScriptControl/index.tsx
@@ -1,14 +1,15 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { cn, Divider, Popover } from '@goodboy/ui';
-import type { WorkspaceId, WorkspaceScript } from '@goodboy/types';
-import { Play, ScrollText, Terminal } from 'lucide-react';
-import { formatError } from '../../../../shared/lib/errors';
+import type { SessionId, WorkspaceId, WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
+import { Play, ScrollText, Square, Terminal } from 'lucide-react';
 import { useAppStore } from '../../../../store';
-import type { ScriptRunResult, ScriptRunStatus } from '../../scripts';
+import type { ScriptRunRecord, ScriptRunStatus } from '../../scripts';
 
 interface RunScriptControlProps {
+  readonly sessionId: SessionId;
   readonly workspaceId: WorkspaceId;
+  readonly worktreePath: string | null;
 }
 
 interface PopoverAnchor {
@@ -16,24 +17,19 @@ interface PopoverAnchor {
   readonly top: number;
 }
 
-interface RunState {
-  readonly status: ScriptRunStatus;
-  readonly result: ScriptRunResult | null;
-}
-
-const IDLE: RunState = { status: 'idle', result: null };
-
-export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
+export function RunScriptControl({ sessionId, workspaceId, worktreePath }: RunScriptControlProps) {
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const scripts = useAppStore((s) => s.workspaceScripts[workspaceId]);
+  const runs = useAppStore((s) => s.scriptRuns[sessionId]);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const runScript = useAppStore((s) => s.runScript);
+  const cancelScript = useAppStore((s) => s.cancelScript);
 
-  const [runState, setRunState] = useState<Record<string, RunState>>({});
+  const isRunning = runs ? Object.values(runs).some((r) => r.status === 'pending') : false;
 
   useEffect(() => {
     void loadScripts(workspaceId);
@@ -77,25 +73,18 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
   };
 
   const onRun = useCallback(
-    async (script: WorkspaceScript) => {
-      setRunState((prev) => ({ ...prev, [script.id]: { status: 'pending', result: null } }));
-      try {
-        const result = await runScript(script.id);
-        setRunState((prev) => ({
-          ...prev,
-          [script.id]: { status: result.exitCode === 0 ? 'ok' : 'error', result },
-        }));
-      } catch (err) {
-        setRunState((prev) => ({
-          ...prev,
-          [script.id]: {
-            status: 'error',
-            result: { stdout: '', stderr: formatError(err), exitCode: -1 },
-          },
-        }));
-      }
+    (script: WorkspaceScript) => {
+      if (!worktreePath) return;
+      void runScript(sessionId, script.id, worktreePath);
     },
-    [runScript],
+    [runScript, sessionId, worktreePath],
+  );
+
+  const onCancel = useCallback(
+    (scriptId: WorkspaceScriptId) => {
+      void cancelScript(sessionId, scriptId);
+    },
+    [cancelScript, sessionId],
   );
 
   const list = scripts ?? [];
@@ -123,21 +112,23 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
               </p>
             ) : (
               <ul className="flex flex-col px-1.5">
-                {list.map((script, i) => {
-                  const run = runState[script.id] ?? IDLE;
-                  return (
-                    <Fragment key={script.id}>
-                      {i > 0 ? (
-                        <li aria-hidden className="px-1.5">
-                          <Divider />
-                        </li>
-                      ) : null}
-                      <li>
-                        <ScriptRow script={script} run={run} onRun={() => void onRun(script)} />
+                {list.map((script, i) => (
+                  <Fragment key={script.id}>
+                    {i > 0 ? (
+                      <li aria-hidden className="px-1.5">
+                        <Divider />
                       </li>
-                    </Fragment>
-                  );
-                })}
+                    ) : null}
+                    <li>
+                      <ScriptRow
+                        script={script}
+                        run={runs?.[script.id] ?? null}
+                        onRun={() => onRun(script)}
+                        onCancel={() => onCancel(script.id)}
+                      />
+                    </li>
+                  </Fragment>
+                ))}
               </ul>
             )}
           </Popover>,
@@ -151,11 +142,17 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
         ref={triggerRef}
         type="button"
         onClick={onToggle}
-        title="run workspace script"
+        disabled={!worktreePath}
+        title={worktreePath ? 'run workspace script' : 'session has no worktree yet'}
         aria-label="run workspace script"
         aria-haspopup="menu"
         aria-expanded={open}
-        className="shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+        className={cn(
+          'shrink-0 rounded p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/60',
+          // Animated primary ring while any script in this session runs — the
+          // signal survives the popover being closed.
+          isRunning && 'spin-border spin-border-primary',
+        )}
       >
         <Terminal size={13} aria-hidden />
       </button>
@@ -166,21 +163,24 @@ export function RunScriptControl({ workspaceId }: RunScriptControlProps) {
 
 interface ScriptRowProps {
   readonly script: WorkspaceScript;
-  readonly run: RunState;
+  readonly run: ScriptRunRecord | null;
   readonly onRun: () => void;
+  readonly onCancel: () => void;
 }
 
-function ScriptRow({ script, run, onRun }: ScriptRowProps) {
-  const isPending = run.status === 'pending';
+function ScriptRow({ script, run, onRun, onCancel }: ScriptRowProps) {
+  const status: ScriptRunStatus = run?.status ?? 'idle';
+  const result = run?.result ?? null;
+  const isPending = status === 'pending';
   const preview = script.body.trim().split('\n')[0] ?? '';
-  const hasOutput = run.result !== null;
+  const hasOutput = result !== null;
   // Default the disclosure open on a failed run — the user almost always
-  // wants to see why it failed. Successful runs stay collapsed.
+  // wants to see why it failed. Successful and cancelled runs stay collapsed.
   const [outputOpen, setOutputOpen] = useState(false);
-  const prevResultRef = useRef(run.result);
-  if (run.result !== prevResultRef.current) {
-    prevResultRef.current = run.result;
-    setOutputOpen(run.result !== null && run.result.exitCode !== 0);
+  const prevResultRef = useRef(result);
+  if (result !== prevResultRef.current) {
+    prevResultRef.current = result;
+    setOutputOpen(result !== null && result.exitCode !== 0 && status !== 'cancelled');
   }
 
   return (
@@ -195,7 +195,7 @@ function ScriptRow({ script, run, onRun }: ScriptRowProps) {
       )}
     >
       <div className="flex items-center gap-2 px-2 py-2">
-        <StatusDot status={run.status} />
+        <StatusDot status={status} />
         <button
           type="button"
           role="menuitem"
@@ -224,31 +224,42 @@ function ScriptRow({ script, run, onRun }: ScriptRowProps) {
             <ScrollText size={13} aria-hidden />
           </button>
         ) : null}
-        <button
-          type="button"
-          onClick={onRun}
-          disabled={isPending}
-          title={isPending ? 'script running…' : 'run script'}
-          aria-label="run script"
-          className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-muted-foreground/50 group-hover:text-muted-foreground"
-        >
-          <Play size={13} aria-hidden />
-        </button>
+        {isPending ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            title="stop script"
+            aria-label="stop script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-danger transition-colors hover:bg-danger/10"
+          >
+            <Square size={11} fill="currentColor" aria-hidden />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onRun}
+            title="run script"
+            aria-label="run script"
+            className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-primary group-hover:text-muted-foreground"
+          >
+            <Play size={13} aria-hidden />
+          </button>
+        )}
       </div>
       {hasOutput && outputOpen ? (
         <pre
           id={`script-out-${script.id}`}
           className="mx-2 mb-2 max-h-32 overflow-auto whitespace-pre-wrap break-all rounded bg-background px-2 py-1.5 font-mono text-2xs leading-relaxed text-foreground/80"
         >
-          <span className="block text-muted-foreground/70">exit {run.result!.exitCode}</span>
-          {run.result!.stdout}
-          {run.result!.stderr ? (
+          <span className="block text-muted-foreground/70">exit {result!.exitCode}</span>
+          {result!.stdout}
+          {result!.stderr ? (
             <span className="text-danger">
-              {run.result!.stdout ? '\n' : ''}
-              {run.result!.stderr}
+              {result!.stdout ? '\n' : ''}
+              {result!.stderr}
             </span>
           ) : null}
-          {!run.result!.stdout && !run.result!.stderr ? '(no output)' : null}
+          {!result!.stdout && !result!.stderr ? '(no output)' : null}
         </pre>
       ) : null}
     </div>
@@ -270,6 +281,15 @@ function StatusDot({ status }: { status: ScriptRunStatus }) {
       <span
         className="size-2 shrink-0 rounded-full bg-danger"
         aria-label="last run failed"
+        role="img"
+      />
+    );
+  }
+  if (status === 'cancelled') {
+    return (
+      <span
+        className="size-2 shrink-0 rounded-full bg-muted-foreground/50"
+        aria-label="last run cancelled"
         role="img"
       />
     );

--- a/apps/desktop/src/features/scripts/scripts.ts
+++ b/apps/desktop/src/features/scripts/scripts.ts
@@ -9,8 +9,24 @@ export interface ScriptRunResult {
 }
 
 /** Run state for a script row in the Scripts panel. */
-export type ScriptRunStatus = 'idle' | 'pending' | 'ok' | 'error';
+export type ScriptRunStatus = 'idle' | 'pending' | 'ok' | 'error' | 'cancelled';
 
-export async function invokeScriptRun(scriptId: WorkspaceScriptId): Promise<ScriptRunResult> {
-  return invoke<ScriptRunResult>('workspace_script_run', { scriptId });
+/** A tracked script run for one (session, script) pair, held in the store. */
+export interface ScriptRunRecord {
+  readonly status: ScriptRunStatus;
+  readonly result: ScriptRunResult | null;
+  readonly runId: string;
+}
+
+export async function invokeScriptRun(
+  scriptId: WorkspaceScriptId,
+  runId: string,
+  cwd: string,
+): Promise<ScriptRunResult> {
+  return invoke<ScriptRunResult>('workspace_script_run', { scriptId, runId, cwd });
+}
+
+/** Interrupt an in-flight script run. No-op if the run already finished. */
+export async function invokeScriptCancel(runId: string): Promise<void> {
+  return invoke<void>('workspace_script_cancel', { runId });
 }

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -14,22 +14,14 @@ import {
   inferAgentKindFromName,
   type AgentKind,
 } from '../../agent-kind';
+import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-actions';
 
 /**
  * Categorized palette with a prefix-routed grammar — the Raycast / Linear
  * model. Empty input shows all sources; typing a prefix (@ # : / ~ $ ?)
  * scopes the result list to one source. Plan section A.2.
  */
-type PaletteGroup =
-  | 'recents'
-  | 'workspace'
-  | 'session'
-  | 'agent'
-  | 'skill'
-  | 'workflow'
-  | 'script'
-  | 'action'
-  | 'help';
+type PaletteGroup = QuickActionGroup | 'recents';
 
 interface PaletteItem {
   readonly id: string;
@@ -40,23 +32,6 @@ interface PaletteItem {
   readonly icon?: string;
   readonly onSelect: () => void;
 }
-
-interface PrefixMeta {
-  readonly symbol: string;
-  readonly hint: string;
-  readonly group: PaletteGroup;
-}
-
-const PREFIXES: ReadonlyArray<PrefixMeta> = [
-  { symbol: '@', hint: 'agents in current session', group: 'agent' },
-  { symbol: '#', hint: 'sessions', group: 'session' },
-  { symbol: ':', hint: 'workspaces', group: 'workspace' },
-  { symbol: '/', hint: 'skills', group: 'skill' },
-  { symbol: '~', hint: 'workflows', group: 'workflow' },
-  { symbol: '$', hint: 'scripts', group: 'script' },
-  { symbol: '>', hint: 'actions', group: 'action' },
-  { symbol: '?', hint: 'help & shortcuts', group: 'help' },
-];
 
 const GROUP_LABELS: Record<PaletteGroup, string> = {
   recents: 'Recents',
@@ -81,22 +56,6 @@ const GROUP_ORDER: ReadonlyArray<PaletteGroup> = [
   'action',
   'help',
 ];
-
-interface ParsedQuery {
-  readonly prefix: PrefixMeta | null;
-  readonly query: string;
-}
-
-function parseQuery(raw: string): ParsedQuery {
-  const trimmed = raw.trimStart();
-  if (trimmed.length === 0) return { prefix: null, query: '' };
-  const ch = trimmed[0]!;
-  const meta = PREFIXES.find((p) => p.symbol === ch);
-  if (meta) {
-    return { prefix: meta, query: trimmed.slice(1).trim() };
-  }
-  return { prefix: null, query: trimmed };
-}
 
 function fuzzyScore(query: string, text: string): number {
   if (query.length === 0) return 1;

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -15,6 +15,7 @@ import {
   type AgentKind,
 } from '../../agent-kind';
 import { PREFIXES, parseQuery, type QuickActionGroup } from '../../../quick-actions';
+import { useToast } from '../../../../app/components/Toast';
 
 /**
  * Categorized palette with a prefix-routed grammar — the Raycast / Linear
@@ -108,6 +109,11 @@ export function CommandPalette({
     currentSession ? (s.sessionPhaseRuns[currentSession.id] ?? EMPTY_ARRAY) : EMPTY_ARRAY,
   ) as ReadonlyArray<Agent>;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
+  const runScript = useAppStore((s) => s.runScript);
+  const sessionWorktree = useAppStore((s) =>
+    currentSession ? (s.sessionWorktrees[currentSession.id]?.[0] ?? null) : null,
+  );
+  const { showToast } = useToast();
 
   const parsed = useMemo(() => parseQuery(query), [query]);
 
@@ -192,11 +198,18 @@ export function CommandPalette({
         sublabel: 'workspace script',
         group: 'script',
         onSelect: () => {
-          window.dispatchEvent(
-            new CustomEvent('goodboy:open-workspace-settings', {
-              detail: { section: 'scripts' },
-            }),
-          );
+          if (!currentSession || !sessionWorktree) {
+            showToast('warning', `${sc.name} — open a session worktree to run scripts`);
+            return;
+          }
+          void runScript(currentSession.id, sc.id, sessionWorktree).then((result) => {
+            showToast(
+              result.exitCode === 0 ? 'success' : 'error',
+              result.exitCode === 0
+                ? `${sc.name} — done`
+                : `${sc.name} — exited ${result.exitCode}`,
+            );
+          });
         },
       });
     }
@@ -240,6 +253,9 @@ export function CommandPalette({
     workflows,
     scripts,
     currentSession,
+    sessionWorktree,
+    runScript,
+    showToast,
     agentKindOverride,
     setCurrentWorkspace,
     setCurrentSession,

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -91,6 +91,18 @@ function slugifyLive(input: string): string {
     .replace(/-+$/, '');
 }
 
+// Live sanitizer for the hand-typed branch slug. Unlike slugifyLive (which
+// derives a slug from the prose goal) this preserves the user's casing — an
+// uppercase branch stays uppercase. Any run of spaces or disallowed chars
+// collapses to a single dash so e.g. ten spaces yield one dash.
+function sanitizeBranchSlug(input: string): string {
+  return input
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '')
+    .slice(0, SLUG_MAX_LEN);
+}
+
 function sanitizePrefix(input: string): string {
   return input
     .toLowerCase()
@@ -314,12 +326,15 @@ export function NewSessionDialog({ open, onClose, workspaceId }: NewSessionDialo
                   <Input
                     value={branchSlug}
                     onChange={(e) => {
-                      setBranchSlug(e.target.value);
+                      setBranchSlug(sanitizeBranchSlug(e.target.value));
                       setSlugTouched(true);
                     }}
                     placeholder="branch-slug"
                     className="h-8 flex-1 font-mono text-sm"
                     disabled={busy}
+                    autoCapitalize="off"
+                    autoCorrect="off"
+                    spellCheck={false}
                     aria-label="Branch slug"
                   />
                 )}

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -85,7 +85,11 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
           )}
         </div>
         <OpenInEditorIconButton worktreePath={worktreePath} />
-        <RunScriptControl workspaceId={session.workspaceId} />
+        <RunScriptControl
+          sessionId={session.id as SessionId}
+          workspaceId={session.workspaceId}
+          worktreePath={worktreePath}
+        />
         <button
           type="button"
           onClick={onOpenSessionSettings}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -178,7 +178,13 @@ import {
   resolveSkillInvocation,
   type SkillUpsertArgs,
 } from '../features/skills/skills';
-import { invokeScriptRun, type ScriptRunResult } from '../features/scripts/scripts';
+import {
+  invokeScriptRun,
+  invokeScriptCancel,
+  type ScriptRunResult,
+  type ScriptRunRecord,
+  type ScriptRunStatus,
+} from '../features/scripts/scripts';
 import {
   invokePermissionRuleList,
   invokePermissionRuleUpsert,
@@ -313,6 +319,9 @@ export interface AppState {
   readonly systemAlerts: ReadonlyArray<SystemAlert>;
   readonly skills: Readonly<Record<WorkspaceId, ReadonlyArray<Skill>>>;
   readonly workspaceScripts: Readonly<Record<WorkspaceId, ReadonlyArray<WorkspaceScript>>>;
+  readonly scriptRuns: Readonly<
+    Record<SessionId, Readonly<Record<WorkspaceScriptId, ScriptRunRecord>>>
+  >;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly sessionPhaseRuns: Readonly<Record<SessionId, ReadonlyArray<Agent>>>;
   readonly selectedAgentId: Readonly<Record<SessionId, AgentId | null>>;
@@ -499,7 +508,12 @@ export interface AppActions {
     body: string;
   }): Promise<void>;
   deleteScript(scriptId: WorkspaceScriptId, workspaceId: WorkspaceId): Promise<void>;
-  runScript(scriptId: WorkspaceScriptId): Promise<ScriptRunResult>;
+  runScript(
+    sessionId: SessionId,
+    scriptId: WorkspaceScriptId,
+    cwd: string,
+  ): Promise<ScriptRunResult>;
+  cancelScript(sessionId: SessionId, scriptId: WorkspaceScriptId): Promise<void>;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
   savePhaseTemplate(template: PhaseTemplateUpsertArgs): Promise<void>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
@@ -639,6 +653,7 @@ const initialState: AppState = {
   budgetAlerts: [],
   skills: {},
   workspaceScripts: {},
+  scriptRuns: {},
   phaseTemplates: {},
   sessionPhaseRuns: {},
   selectedAgentId: {},
@@ -3381,8 +3396,51 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
 
-  runScript: async (scriptId) => {
-    return invokeScriptRun(scriptId);
+  runScript: async (sessionId, scriptId, cwd) => {
+    const runId = crypto.randomUUID();
+
+    const writeRun = (record: ScriptRunRecord) =>
+      set((state) => ({
+        scriptRuns: {
+          ...state.scriptRuns,
+          [sessionId]: { ...state.scriptRuns[sessionId], [scriptId]: record },
+        },
+      }));
+
+    writeRun({ status: 'pending', result: null, runId });
+
+    const settle = (status: ScriptRunStatus, result: ScriptRunResult): ScriptRunResult => {
+      const curr = get().scriptRuns[sessionId]?.[scriptId];
+      // A newer run for this script took the slot — leave it untouched.
+      if (!curr || curr.runId !== runId) return result;
+      // A user cancel wins over the exit code the kill produces.
+      writeRun({
+        status: curr.status === 'cancelled' ? 'cancelled' : status,
+        result,
+        runId,
+      });
+      return result;
+    };
+
+    try {
+      const result = await invokeScriptRun(scriptId, runId, cwd);
+      return settle(result.exitCode === 0 ? 'ok' : 'error', result);
+    } catch (err) {
+      return settle('error', { stdout: '', stderr: formatError(err), exitCode: -1 });
+    }
+  },
+
+  cancelScript: async (sessionId, scriptId) => {
+    const curr = get().scriptRuns[sessionId]?.[scriptId];
+    if (!curr || curr.status !== 'pending') return;
+    const cancelled: ScriptRunRecord = { ...curr, status: 'cancelled' };
+    set((state) => ({
+      scriptRuns: {
+        ...state.scriptRuns,
+        [sessionId]: { ...state.scriptRuns[sessionId], [scriptId]: cancelled },
+      },
+    }));
+    await invokeScriptCancel(curr.runId);
   },
 
   loadPhaseTemplates: async (workspaceId) => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -450,6 +450,7 @@ export interface AppActions {
     sessionId: SessionId,
     args: { branch: string; createNew: boolean },
   ): Promise<void>;
+  reconcileSessionBranch(sessionId: SessionId, observedBranch: string): Promise<void>;
   setSessionAutoRun(sessionId: SessionId, autoRun: boolean): Promise<void>;
   attachWorkflowToSession(
     sessionId: SessionId,
@@ -1971,9 +1972,41 @@ export const useAppStore = create<AppStore>((set, get) => ({
       createNew,
     });
     await updateSessionWorktreeBranch(tauriDatabase, sessionId, primary.parallelIndex, target);
-    set((state) => ({
-      sessionBranches: { ...state.sessionBranches, [sessionId]: target },
-    }));
+    set((state) => {
+      // Branch changed → the cached PR/detail belong to the old branch. Drop
+      // the entry so the ContextPanel effect refetches against the new branch.
+      const nextGithub = { ...state.sessionGithub };
+      delete nextGithub[sessionId];
+      return {
+        sessionBranches: { ...state.sessionBranches, [sessionId]: target },
+        sessionGithub: nextGithub,
+      };
+    });
+  },
+
+  reconcileSessionBranch: async (sessionId, observedBranch) => {
+    // Catch the branch cache up to git reality. changeSessionBranch keeps DB +
+    // store in sync, but an agent running `git switch` directly in the worktree
+    // shell bypasses it — HEAD moves while sessionBranches stays frozen.
+    const trimmed = observedBranch.trim();
+    if (!trimmed) return;
+    if (get().sessionBranches[sessionId] === trimmed) return;
+    const worktrees = await listWorktreesForSession(tauriDatabase, sessionId);
+    const primary = worktrees[0];
+    if (!primary) return;
+    if (primary.branch !== trimmed) {
+      await updateSessionWorktreeBranch(tauriDatabase, sessionId, primary.parallelIndex, trimmed);
+    }
+    set((state) => {
+      // Branch moved → drop the stale PR cache so the ContextPanel effect
+      // refetches for the new branch (same as changeSessionBranch).
+      const nextGithub = { ...state.sessionGithub };
+      delete nextGithub[sessionId];
+      return {
+        sessionBranches: { ...state.sessionBranches, [sessionId]: trimmed },
+        sessionGithub: nextGithub,
+      };
+    });
   },
 
   loadTranscript: async (agentId, sessionId) => {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -276,6 +276,7 @@ dialog[open]::backdrop {
 
 .spin-border-info  { --spin-border-color: var(--color-info); }
 .spin-border-danger { --spin-border-color: var(--color-danger); }
+.spin-border-primary { --spin-border-color: var(--color-primary); }
 
 .animate-border-pulse {
   animation: border-pulse 2.8s ease-in-out infinite;


### PR DESCRIPTION
When an agent runs `git switch` directly in a worktree (bypassing changeSessionBranch), the cached sessionBranches stays frozen while HEAD moves. The sidebar footer branch chip shows stale state.

Add a reconciliation effect in ContextPanel that polls worktree_status and syncs the cache when divergence is detected. Runs on summarizer updates and file-count changes (moments a branch switch is likely).

Also clears sessionGithub cache on branch changes so stale PR data doesn't persist.