### PR TITLE
fix(desktop): self-heal session branch in detail panel on direct git changes

### DIFF
--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -131,6 +131,34 @@ export function ContextPanel({
 
   const workingDir = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
 
+  // Self-heal the branch cache: an agent can `git switch` directly in the
+  // worktree, moving HEAD without going through changeSessionBranch, which
+  // leaves the sidebar footer chip on a stale branch. Read the real branch off
+  // worktree_status and write it back. Re-runs after each turn (summarizer
+  // tick) and on file-count changes — the moments a branch switch is likely.
+  const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
+  useEffect(() => {
+    if (!isActive || !workingDir) return;
+    let cancelled = false;
+    worktreeStatus(workingDir)
+      .then((status) => {
+        if (!cancelled && status.branch) {
+          void reconcileSessionBranch(session.id as SessionId, status.branch);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isActive,
+    workingDir,
+    session.id,
+    filesTouched.count,
+    summarizer.lastUpdate,
+    reconcileSessionBranch,
+  ]);
+
   const slotsByKey = new Map<string, ContextSlot>(
     slots.map((s) => [s.key, s.key === 'files_touched' ? normalizeFilesSlot(s, workingDir) : s]),
   );

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -459,6 +459,7 @@ export interface AppActions {
     sessionId: SessionId,
     args: { branch: string; createNew: boolean },
   ): Promise<void>;
+  reconcileSessionBranch(sessionId: SessionId, observedBranch: string): Promise<void>;
   setSessionAutoRun(sessionId: SessionId, autoRun: boolean): Promise<void>;
   attachWorkflowToSession(
     sessionId: SessionId,
@@ -1986,9 +1987,41 @@ export const useAppStore = create<AppStore>((set, get) => ({
       createNew,
     });
     await updateSessionWorktreeBranch(tauriDatabase, sessionId, primary.parallelIndex, target);
-    set((state) => ({
-      sessionBranches: { ...state.sessionBranches, [sessionId]: target },
-    }));
+    set((state) => {
+      // Branch changed → the cached PR/detail belong to the old branch. Drop
+      // the entry so the ContextPanel effect refetches against the new branch.
+      const nextGithub = { ...state.sessionGithub };
+      delete nextGithub[sessionId];
+      return {
+        sessionBranches: { ...state.sessionBranches, [sessionId]: target },
+        sessionGithub: nextGithub,
+      };
+    });
+  },
+
+  reconcileSessionBranch: async (sessionId, observedBranch) => {
+    // Catch the branch cache up to git reality. changeSessionBranch keeps DB +
+    // store in sync, but an agent running `git switch` directly in the worktree
+    // shell bypasses it — HEAD moves while sessionBranches stays frozen.
+    const trimmed = observedBranch.trim();
+    if (!trimmed) return;
+    if (get().sessionBranches[sessionId] === trimmed) return;
+    const worktrees = await listWorktreesForSession(tauriDatabase, sessionId);
+    const primary = worktrees[0];
+    if (!primary) return;
+    if (primary.branch !== trimmed) {
+      await updateSessionWorktreeBranch(tauriDatabase, sessionId, primary.parallelIndex, trimmed);
+    }
+    set((state) => {
+      // Branch moved → drop the stale PR cache so the ContextPanel effect
+      // refetches for the new branch (same as changeSessionBranch).
+      const nextGithub = { ...state.sessionGithub };
+      delete nextGithub[sessionId];
+      return {
+        sessionBranches: { ...state.sessionBranches, [sessionId]: trimmed },
+        sessionGithub: nextGithub,
+      };
+    });
   },
 
   loadTranscript: async (agentId, sessionId) => {


### PR DESCRIPTION
## Summary
- session detail panel now self-corrects displayed branch name when workspace branch changes via direct git (outside goodboy)
- ContextPanel useEffect polls `worktreeStatus()`, detects divergence, triggers `reconcileSessionBranch()`
- clears stale PR cache on branch change so github card refreshes

## Files changed
- `apps/desktop/src/features/context/components/ContextPanel/index.tsx` — detection logic
- `apps/desktop/src/store/store.ts` — reconciliation + cache clearing

## Test plan
- [ ] switch branch via terminal in workspace worktree
- [ ] verify detail panel updates branch name without manual refresh
- [ ] verify PR card clears/refreshes after branch change
- [ ] confirm no regressions in normal session flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)