### PR TITLE
fix(desktop): yellow border persists after agent finishes in view

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -228,6 +228,19 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     selectedAgentId ? s.transcripts[selectedAgentId] !== undefined : true,
   );
   const selectAgent = useAppStore((s) => s.selectAgent);
+  const markAgentViewed = useAppStore((s) => s.markAgentViewed);
+  const selectedAgentLastFinishedAt = useAppStore((s) =>
+    selectedAgentId
+      ? (s.sessionPhaseRuns[session.id]?.find((r) => r.id === selectedAgentId)?.lastFinishedAt ??
+        null)
+      : null,
+  );
+  const selectedAgentLastViewedAt = useAppStore((s) =>
+    selectedAgentId
+      ? (s.sessionPhaseRuns[session.id]?.find((r) => r.id === selectedAgentId)?.lastViewedAt ??
+        null)
+      : null,
+  );
 
   // Lazy transcript load: only fires when this view is the active one. With
   // keep-alive, hidden ChatView instances stay mounted but must not preload
@@ -236,6 +249,24 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     if (!isActive || !selectedAgentId || transcriptCached) return;
     void selectAgent(session.id, selectedAgentId);
   }, [isActive, selectedAgentId, transcriptCached, selectAgent, session.id]);
+
+  // Passive viewed-stamping: covers cases where the user watches an agent
+  // finish in place, or revisits a session whose transcript is already cached.
+  // selectAgent only fires on click/load, missing those two paths.
+  useEffect(() => {
+    if (!isActive || !selectedAgentId || !selectedAgentLastFinishedAt) return;
+    if (selectedAgentLastViewedAt && selectedAgentLastViewedAt >= selectedAgentLastFinishedAt)
+      return;
+    void markAgentViewed(session.id, selectedAgentId);
+  }, [
+    isActive,
+    selectedAgentId,
+    selectedAgentLastFinishedAt,
+    selectedAgentLastViewedAt,
+    markAgentViewed,
+    session.id,
+  ]);
+
   const worktreePath = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const authResults = useAppStore((s) => s.authResults);
   const refreshProviders = useAppStore((s) => s.refreshProviders);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -518,6 +518,7 @@ export interface AppActions {
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
   loadPhaseRunsForSession(sessionId: SessionId): Promise<void>;
   selectAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
+  markAgentViewed(sessionId: SessionId, agentId: AgentId): Promise<void>;
   spawnAgent(
     sessionId: SessionId,
     args: {
@@ -3552,6 +3553,25 @@ export const useAppStore = create<AppStore>((set, get) => ({
       });
       throw err;
     }
+  },
+
+  markAgentViewed: async (sessionId, agentId) => {
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const agent = runs.find((r) => r.id === agentId);
+    if (!agent?.lastFinishedAt) return;
+    if (agent.lastViewedAt && agent.lastViewedAt >= agent.lastFinishedAt) return;
+
+    const stampedAt = new Date().toISOString() as IsoDateTime;
+    set((state) => ({
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((r) =>
+          r.id === agentId ? { ...r, lastViewedAt: stampedAt } : r,
+        ),
+      },
+    }));
+    void invokeSessionMarkViewed(agentId, stampedAt).catch(() => undefined);
+    void get().refreshUnreadWorkspaces();
   },
 
   spawnAgent: async (sessionId, args) => {

--- a/apps/desktop/src/store/store.viewed-stamping.test.ts
+++ b/apps/desktop/src/store/store.viewed-stamping.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import { agentHasUnread } from './selectors';
+
+const markViewedSpy = vi.fn();
+
+vi.mock('../features/chat/turn', () => ({
+  runTurn: vi.fn(),
+  cancelTurn: vi.fn(),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../features/permissions/permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(),
+  invokeAuditRetryEnqueue: vi.fn(async () => undefined),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(async () => undefined),
+  invokeAuditRetryDelete: vi.fn(async () => undefined),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+vi.mock('../shared/lib/db', () => ({
+  runDbMigrations: vi.fn(),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('@goodboy/db', () => ({
+  getSetting: vi.fn(),
+  insertMessage: vi.fn(),
+  insertProviderRun: vi.fn(),
+  insertSession: vi.fn(),
+  insertSessionWorktree: vi.fn(),
+  insertTelemetry: vi.fn(),
+  insertWorkspace: vi.fn(),
+  listContextSlotsForSession: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForTask: vi.fn(async () => []),
+  setSetting: vi.fn(),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(),
+  updateSessionState: vi.fn(),
+  upsertContextSlot: vi.fn(),
+  insertTurnEvent: vi.fn(async () => undefined),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForTask: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
+  insertNotification: vi.fn(async () => undefined),
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
+}));
+
+vi.mock('../features/providers/providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(),
+  getCursorStatus: vi.fn(),
+  getCodexStatus: vi.fn(),
+  getProviderStatus: vi.fn(),
+}));
+
+vi.mock('../features/providers/routing', () => ({
+  resolveProviderForTurn: vi.fn(),
+}));
+
+vi.mock('../features/budget/budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../features/skills/skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../features/phases/phases', () => ({
+  invokePhaseTemplateList: vi.fn(async () => []),
+  invokePhaseTemplateUpsert: vi.fn(),
+  invokePhaseTemplateDelete: vi.fn(),
+  invokePhaseRunList: vi.fn(async () => []),
+  invokePhaseRunInsert: vi.fn(),
+  invokePhaseRunUpdateStatus: vi.fn(),
+  invokeSessionMarkViewed: (...args: unknown[]) => Promise.resolve(markViewedSpy(...args)),
+  invokeWorkspacesWithUnread: vi.fn(async () => []),
+}));
+
+vi.mock('../features/worktree/worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../shared/lib/repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+vi.mock('../features/providers/provider-pricing', () => ({
+  parseProviderPricingConfig: vi.fn(() => null),
+  getCodexPriceOverride: vi.fn(() => null),
+  refreshPricingTable: vi.fn(() => Promise.resolve()),
+}));
+
+const SESSION_ID = 'session-vs-1' as SessionId;
+const AGENT_ID = 'agent-vs-1' as AgentId;
+const WORKSPACE_ID = 'workspace-vs-1' as WorkspaceId;
+const T1 = '2026-05-01T10:00:00.000Z' as IsoDateTime;
+const T2 = '2026-05-01T11:00:00.000Z' as IsoDateTime;
+const T3 = '2026-05-01T12:00:00.000Z' as IsoDateTime;
+
+function buildSession(): Session {
+  return {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'viewed stamping test',
+    state: { kind: 'idle', lastActivityAt: T1 },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+    permissionMode: 'bypassPermissions',
+    autoRun: false,
+    titleUserEdited: false,
+    userStatus: 'wip',
+    createdAt: T1,
+    updatedAt: T1,
+  };
+}
+
+function buildAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: AGENT_ID,
+    sessionId: SESSION_ID,
+    ordinal: 1,
+    name: 'Agent 1',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+async function importStore() {
+  const mod = await import('./store');
+  return mod.useAppStore;
+}
+
+describe('markAgentViewed', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stamps lastViewedAt when agent has lastFinishedAt and no lastViewedAt', async () => {
+    const useAppStore = await importStore();
+    const agent = buildAgent({ lastFinishedAt: T2 });
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    const updated = runs.find((r) => r.id === AGENT_ID);
+    expect(updated?.lastViewedAt).toBeDefined();
+    expect(updated?.lastViewedAt! >= T2).toBe(true);
+    expect(markViewedSpy).toHaveBeenCalledOnce();
+  });
+
+  it('stamps lastViewedAt when lastFinishedAt > lastViewedAt (stale viewed)', async () => {
+    const useAppStore = await importStore();
+    const agent = buildAgent({ lastFinishedAt: T3, lastViewedAt: T2 });
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    const updated = runs.find((r) => r.id === AGENT_ID);
+    expect(updated?.lastViewedAt! >= T3).toBe(true);
+    expect(markViewedSpy).toHaveBeenCalledOnce();
+  });
+
+  it('is a no-op when lastViewedAt >= lastFinishedAt', async () => {
+    const useAppStore = await importStore();
+    const agent = buildAgent({ lastFinishedAt: T2, lastViewedAt: T3 });
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    const updated = runs.find((r) => r.id === AGENT_ID);
+    expect(updated?.lastViewedAt).toBe(T3);
+    expect(markViewedSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when agent has no lastFinishedAt (not yet terminal)', async () => {
+    const useAppStore = await importStore();
+    const agent = buildAgent({ status: 'running' });
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    const updated = runs.find((r) => r.id === AGENT_ID);
+    expect(updated?.lastViewedAt).toBeUndefined();
+    expect(markViewedSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('agentHasUnread — after markAgentViewed', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false after markAgentViewed stamps lastViewedAt', async () => {
+    const useAppStore = await importStore();
+    const agent = buildAgent({ lastFinishedAt: T2 });
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    const updated = runs.find((r) => r.id === AGENT_ID)!;
+    expect(agentHasUnread(updated, false)).toBe(false);
+  });
+
+  it('returns true for a different session agent not yet marked viewed', async () => {
+    const OTHER_SESSION = 'session-other' as SessionId;
+    const OTHER_AGENT = 'agent-other' as AgentId;
+    const useAppStore = await importStore();
+
+    const currentAgent = buildAgent({ lastFinishedAt: T2 });
+    const otherAgent = buildAgent({
+      id: OTHER_AGENT,
+      sessionId: OTHER_SESSION,
+      lastFinishedAt: T3,
+    });
+
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: {
+        [SESSION_ID]: [currentAgent],
+        [OTHER_SESSION]: [otherAgent],
+      },
+    });
+
+    await useAppStore.getState().markAgentViewed(SESSION_ID, AGENT_ID);
+
+    const otherRuns = useAppStore.getState().sessionPhaseRuns[OTHER_SESSION] ?? [];
+    const otherUpdated = otherRuns.find((r) => r.id === OTHER_AGENT)!;
+    expect(agentHasUnread(otherUpdated, false)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

The yellow pulsing border on session tiles in the left rail stays lit even when the user has no open questions and no agents waiting to be reviewed. Two concrete failure paths:

1. **In-place watch** — user is on session A while its agent transitions to `completed`. `lastFinishedAt` is stamped, but `lastViewedAt` stays stale. While the user is on the tab `isCurrentlyViewed=true` masks the yellow. The moment they switch session → yellow lights up despite the user having literally just watched it finish.
2. **Revisit with cached transcript** — user re-enters session A; `ChatView`'s transcript effect short-circuits on `transcriptCached`; `selectAgent` is never called; `lastViewedAt` is never stamped for this visit; navigating away → yellow.

Root cause: `lastViewedAt` is only stamped inside `selectAgent`, which fires only on explicit agent-row click or transcript load. Passive viewing scenarios are missed.

## Fix

### `store.ts` — `markAgentViewed` action
New action that stamps `lastViewedAt` when `lastFinishedAt > lastViewedAt`. Guarded to be a no-op when already up-to-date (prevents double IPC on overlap with `selectAgent`). Fires `refreshUnreadWorkspaces` so the workspace dot clears in sync.

### `ChatView/index.tsx` — passive-viewed effect
New `useEffect` (sibling of the transcript-load effect) that calls `markAgentViewed` whenever the viewed agent's `lastFinishedAt` advances while the session is active. Dependencies include `lastFinishedAt`, so it re-fires the moment a terminal transition lands — covering both failure paths regardless of transcript cache state.

### `store.viewed-stamping.test.ts` — 6 unit tests
- stamps when `lastViewedAt` is absent
- stamps when `lastFinishedAt > lastViewedAt`
- no-op when already up-to-date
- no-op when agent not yet terminal
- `agentHasUnread` returns false after stamp
- other-session agent unaffected

## Files changed
- `apps/desktop/src/store/store.ts`
- `apps/desktop/src/features/chat/components/ChatView/index.tsx`
- `apps/desktop/src/store/store.viewed-stamping.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)