### PR TITLE
feat(desktop): workspace-level verbosity default with per-chat override

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() {
       workflows::agent_update_status,
       workflows::agent_set_provider_session_id,
       workflows::agent_set_kind,
+      workflows::agent_set_verbosity,
       workflows::agent_mark_viewed,
       workflows::workspaces_with_unread,
       parallel_groups::parallel_group_create,

--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -13,6 +13,8 @@ pub struct SettingsOverrides {
     pub default_branch_prefix: Option<String>,
     #[serde(rename = "parallelEnabled")]
     pub parallel_enabled: Option<bool>,
+    #[serde(rename = "defaultVerbosity")]
+    pub default_verbosity: Option<String>,
 }
 
 #[tauri::command]
@@ -22,7 +24,7 @@ pub fn get_workspace_overrides(
 ) -> Result<Option<SettingsOverrides>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
-        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
+        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity
          FROM workspaces WHERE id = ?1",
     )?;
     let mut rows = stmt.query_map(rusqlite::params![workspace_id], |row| {
@@ -32,6 +34,7 @@ pub fn get_workspace_overrides(
             default_workflow_id: row.get(1)?,
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
+            default_verbosity: row.get(4)?,
         })
     })?;
     match rows.next() {
@@ -55,13 +58,15 @@ pub fn set_workspace_overrides(
              default_workflow_id = ?2,
              default_branch_prefix = ?3,
              parallel_enabled = ?4,
-             updated_at = ?5
-         WHERE id = ?6",
+             default_verbosity = ?5,
+             updated_at = ?6
+         WHERE id = ?7",
         rusqlite::params![
             overrides.default_provider_id,
             overrides.default_workflow_id,
             overrides.default_branch_prefix,
             parallel_val,
+            overrides.default_verbosity,
             now,
             workspace_id,
         ],
@@ -86,6 +91,7 @@ pub fn get_session_overrides(
             default_workflow_id: row.get(1)?,
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
+            default_verbosity: None,
         })
     })?;
     match rows.next() {

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -84,6 +84,7 @@ pub struct SessionRow {
     #[serde(rename = "lastViewedAt")]
     pub last_viewed_at: Option<String>,
     pub kind: Option<String>,
+    pub verbosity: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -105,6 +106,7 @@ pub struct PhaseRunInsertInput {
     #[serde(rename = "completedAt")]
     pub completed_at: Option<String>,
     pub kind: Option<String>,
+    pub verbosity: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -433,7 +435,7 @@ pub fn agent_list_for_session(
     let mut stmt = conn.prepare(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, kind
+                provider_session_id, last_finished_at, last_viewed_at, kind, verbosity
          FROM agents
          WHERE session_id = ?1
          ORDER BY ordinal ASC",
@@ -454,6 +456,7 @@ pub fn agent_list_for_session(
             last_finished_at: row.get(11)?,
             last_viewed_at: row.get(12)?,
             kind: row.get(13)?,
+            verbosity: row.get(14)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -470,8 +473,8 @@ pub fn agent_insert(
     conn.execute(
         "INSERT INTO agents
            (id, session_id, step_id, ordinal, name, status,
-            provider_run_id, output_summary, started_at, completed_at, kind)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            provider_run_id, output_summary, started_at, completed_at, kind, verbosity)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         rusqlite::params![
             id,
             input.session_id,
@@ -484,6 +487,7 @@ pub fn agent_insert(
             input.started_at,
             input.completed_at,
             input.kind,
+            input.verbosity,
         ],
     )?;
 
@@ -502,6 +506,7 @@ pub fn agent_insert(
         last_finished_at: None,
         last_viewed_at: None,
         kind: input.kind,
+        verbosity: input.verbosity,
     })
 }
 
@@ -542,7 +547,7 @@ pub fn agent_update_status(
     let mut stmt = conn.prepare(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, kind
+                provider_session_id, last_finished_at, last_viewed_at, kind, verbosity
          FROM agents
          WHERE id = ?1
          LIMIT 1",
@@ -563,6 +568,7 @@ pub fn agent_update_status(
             last_finished_at: row.get(11)?,
             last_viewed_at: row.get(12)?,
             kind: row.get(13)?,
+            verbosity: row.get(14)?,
         })
     })?;
     match rows.next() {
@@ -584,6 +590,24 @@ pub fn agent_set_kind(
     let affected = conn.execute(
         "UPDATE agents SET kind = ?2 WHERE id = ?1",
         rusqlite::params![id, kind],
+    )?;
+    if affected == 0 {
+        return Err(PhaseError::RunNotFound(id));
+    }
+    Ok(())
+}
+
+// Persists the agent-level verbosity override. NULL = inherit from workspace.
+#[tauri::command]
+pub fn agent_set_verbosity(
+    state: State<'_, Db>,
+    id: String,
+    verbosity: Option<String>,
+) -> Result<(), PhaseError> {
+    let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
+    let affected = conn.execute(
+        "UPDATE agents SET verbosity = ?2 WHERE id = ?1",
+        rusqlite::params![id, verbosity],
     )?;
     if affected == 0 {
         return Err(PhaseError::RunNotFound(id));

--- a/apps/desktop/src/__tests__/ChatInput.test.tsx
+++ b/apps/desktop/src/__tests__/ChatInput.test.tsx
@@ -13,6 +13,8 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
   interface S {
     sendTurn: typeof send;
     cancelCurrentTurn: typeof cancel;
+    setAgentVerbosity: (sessionId: string, agentId: string, level: string) => Promise<void>;
+    workspaceOverrides: Record<string, never>;
     providers: ReadonlyArray<{ id: string; connection: string }>;
     skills: Record<string, never>;
     workspaceScripts: Record<string, never>;
@@ -42,6 +44,8 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
   const store = create<S>((set) => ({
     sendTurn: send,
     cancelCurrentTurn: cancel,
+    setAgentVerbosity: async () => undefined,
+    workspaceOverrides: {},
     providers: [
       { id: 'anthropic', connection: 'connected' },
       { id: 'cursor', connection: 'connected' },

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -425,6 +425,18 @@ exports[`snapshot — empty states > ProvidersPanel: no providers (store returns
 </div>
 `;
 
+exports[`snapshot — empty states > QuickActionsPopover: no skills / empty items 1`] = `
+<div
+  class="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md"
+>
+  <p
+    class="px-3 py-2 text-xs text-muted-foreground"
+  >
+    no skills. create one in settings
+  </p>
+</div>
+`;
+
 exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
 <div
   class="flex flex-col gap-3"
@@ -458,18 +470,6 @@ exports[`snapshot — empty states > SkillsPanel: no skills 1`] = `
     class="text-2xs text-muted-foreground"
   >
     No skills for this workspace. Create one or rescan the workspace directory.
-  </p>
-</div>
-`;
-
-exports[`snapshot — empty states > QuickActionsPopover: no skills / empty items 1`] = `
-<div
-  class="absolute bottom-full left-0 right-0 z-50 mb-1 overflow-hidden rounded-md border border-border bg-subtle shadow-md"
->
-  <p
-    class="px-3 py-2 text-xs text-muted-foreground"
-  >
-    no skills. create one in settings
   </p>
 </div>
 `;

--- a/apps/desktop/src/__tests__/verbosity.test.ts
+++ b/apps/desktop/src/__tests__/verbosity.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  readWorkspaceVerbosity,
+  writeWorkspaceVerbosity,
+  verbosityDirective,
+  VERBOSITY_LEVELS,
+} from '../features/settings/verbosity';
+import type { WorkspaceId } from '@goodboy/types';
+
+const WORKSPACE = 'ws-1' as WorkspaceId;
+const WORKSPACE_KEY = `goodboy:workspace-verbosity:${WORKSPACE}`;
+
+beforeEach(() => localStorage.clear());
+
+describe('readWorkspaceVerbosity', () => {
+  it('returns null when absent', () => {
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBeNull();
+  });
+
+  it.each(VERBOSITY_LEVELS)('returns stored %s', (level) => {
+    localStorage.setItem(WORKSPACE_KEY, level);
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe(level);
+  });
+
+  it('returns null for unrecognized value', () => {
+    localStorage.setItem(WORKSPACE_KEY, '???');
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBeNull();
+  });
+
+  it('normalizes legacy "minimal" → brief', () => {
+    localStorage.setItem(WORKSPACE_KEY, 'minimal');
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe('brief');
+  });
+
+  it('normalizes legacy "essential" → brief', () => {
+    localStorage.setItem(WORKSPACE_KEY, 'essential');
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe('brief');
+  });
+
+  it('normalizes legacy "detailed" → verbose', () => {
+    localStorage.setItem(WORKSPACE_KEY, 'detailed');
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe('verbose');
+  });
+});
+
+describe('writeWorkspaceVerbosity', () => {
+  it.each(VERBOSITY_LEVELS)('persists %s', (level) => {
+    writeWorkspaceVerbosity(WORKSPACE, level);
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe(level);
+  });
+
+  it('overwrite: last write wins', () => {
+    writeWorkspaceVerbosity(WORKSPACE, 'brief');
+    writeWorkspaceVerbosity(WORKSPACE, 'normal');
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe('normal');
+  });
+
+  it('different workspace IDs are isolated', () => {
+    const WS2 = 'ws-2' as WorkspaceId;
+    writeWorkspaceVerbosity(WORKSPACE, 'brief');
+    writeWorkspaceVerbosity(WS2, 'verbose');
+
+    expect(readWorkspaceVerbosity(WORKSPACE)).toBe('brief');
+    expect(readWorkspaceVerbosity(WS2)).toBe('verbose');
+  });
+});
+
+describe('verbosityDirective', () => {
+  it('brief directive contains BRIEF', () => {
+    expect(verbosityDirective('brief')).toContain('BRIEF');
+  });
+
+  it('normal directive contains NORMAL', () => {
+    expect(verbosityDirective('normal')).toContain('NORMAL');
+  });
+
+  it('verbose directive contains VERBOSE', () => {
+    expect(verbosityDirective('verbose')).toContain('VERBOSE');
+  });
+
+  it('each level returns a non-empty string', () => {
+    for (const level of VERBOSITY_LEVELS) {
+      expect(verbosityDirective(level).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('directives are distinct across levels', () => {
+    const directives = VERBOSITY_LEVELS.map(verbosityDirective);
+    const unique = new Set(directives);
+    expect(unique.size).toBe(VERBOSITY_LEVELS.length);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -44,10 +44,7 @@ import {
 } from '../../../quick-actions';
 import {
   type VerbosityLevel,
-  readVerbosity,
-  writeVerbosity,
-  readAgentVerbosity,
-  writeAgentVerbosity,
+  readWorkspaceVerbosity,
 } from '../../../../features/settings/verbosity';
 import { EFFORT_LEVELS, type EffortLevel, suggestLighterModel } from '../../utils/chat-constants';
 import { ProviderUsagePill } from '../ProviderUsagePill';
@@ -231,6 +228,10 @@ function toastMessageForAlert(alert: BudgetAlert): string {
 export function ChatInput({ session, providerDisconnected = false }: ChatInputProps) {
   const sendTurn = useAppStore((s) => s.sendTurn);
   const cancelCurrentTurn = useAppStore((s) => s.cancelCurrentTurn);
+  const storeSetAgentVerbosity = useAppStore((s) => s.setAgentVerbosity);
+  const workspaceDefaultVerbosity = useAppStore(
+    (s) => s.workspaceOverrides[session.workspaceId]?.defaultVerbosity ?? null,
+  );
   const sessionNudge = useAppStore((s) => s.sessionNudges[session.id] ?? null);
   const dismissSessionNudge = useAppStore((s) => s.dismissSessionNudge);
   const acceptSessionNudgeHandoff = useAppStore((s) => s.acceptSessionNudgeHandoff);
@@ -295,7 +296,19 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
     readModel(session.id),
   );
   const [effort, setEffortState] = useState<EffortLevel>(() => readEffort(session.id));
-  const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => readVerbosity(session.id));
+  const [verbosity, setVerbosityState] = useState<VerbosityLevel>(() => {
+    const initialAgentId = useAppStore.getState().selectedAgentId[session.id] ?? null;
+    const initialRuns = useAppStore.getState().sessionPhaseRuns[session.id] ?? [];
+    const agentRow = initialAgentId
+      ? (initialRuns.find((r) => r.id === initialAgentId) ?? null)
+      : null;
+    return (
+      (agentRow?.verbosity as VerbosityLevel | undefined) ??
+      workspaceDefaultVerbosity ??
+      readWorkspaceVerbosity(session.workspaceId) ??
+      'normal'
+    );
+  });
   const [showPopover, setShowPopover] = useState(false);
   const [scriptResult, setScriptResult] = useState<ScriptResultState | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -503,8 +516,7 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
 
   const setVerbosity = (level: VerbosityLevel) => {
     setVerbosityState(level);
-    writeVerbosity(session.id, level);
-    if (selectedAgentId) writeAgentVerbosity(selectedAgentId, level);
+    if (selectedAgentId) void storeSetAgentVerbosity(session.id, selectedAgentId, level);
   };
 
   const setSelectedProvider = (id: ProviderId | null) => {
@@ -707,13 +719,22 @@ export function ChatInput({ session, providerDisconnected = false }: ChatInputPr
       writeAgentProvider(outgoingAgentId, currentProviderRef.current);
       writeAgentModel(outgoingAgentId, currentModelRef.current);
       writeAgentEffort(outgoingAgentId, currentEffortRef.current);
-      writeAgentVerbosity(outgoingAgentId, currentVerbosityRef.current);
     }
 
     const restoredProvider = selectedAgentId !== null ? readAgentProvider(selectedAgentId) : null;
     const restoredModel = selectedAgentId !== null ? readAgentModel(selectedAgentId) : null;
     const restoredEffort = selectedAgentId !== null ? readAgentEffort(selectedAgentId) : null;
-    const restoredVerbosity = selectedAgentId !== null ? readAgentVerbosity(selectedAgentId) : null;
+    const restoredAgent =
+      selectedAgentId !== null
+        ? (useAppStore.getState().sessionPhaseRuns[session.id] ?? []).find(
+            (r) => r.id === selectedAgentId,
+          )
+        : null;
+    const restoredVerbosity =
+      (restoredAgent?.verbosity as VerbosityLevel | undefined) ??
+      workspaceDefaultVerbosity ??
+      readWorkspaceVerbosity(session.workspaceId) ??
+      null;
 
     setSelectedProviderState(restoredProvider);
     setSelectedModelState(restoredModel);

--- a/apps/desktop/src/features/phases/phases.ts
+++ b/apps/desktop/src/features/phases/phases.ts
@@ -9,6 +9,7 @@ import type {
   Agent,
   AgentId,
   AgentStatus,
+  VerbosityLevel,
   Workflow,
   WorkflowId,
   ProviderRunId,
@@ -52,6 +53,7 @@ interface RawPhaseRunRow {
   readonly lastFinishedAt: string | null;
   readonly lastViewedAt: string | null;
   readonly kind: string | null;
+  readonly verbosity: string | null;
 }
 
 function rowToDefinition(row: RawPhaseDefinitionRow): Step {
@@ -94,6 +96,7 @@ function rowToPhaseRun(row: RawPhaseRunRow): Agent {
     ...(row.lastFinishedAt != null && { lastFinishedAt: row.lastFinishedAt as IsoDateTime }),
     ...(row.lastViewedAt != null && { lastViewedAt: row.lastViewedAt as IsoDateTime }),
     ...(row.kind != null && { kind: row.kind }),
+    ...(row.verbosity != null && { verbosity: row.verbosity as VerbosityLevel }),
   };
 }
 
@@ -162,6 +165,7 @@ export interface PhaseRunInsertArgs {
   readonly startedAt?: IsoDateTime;
   readonly completedAt?: IsoDateTime;
   readonly kind?: string;
+  readonly verbosity?: VerbosityLevel;
 }
 
 export async function invokePhaseRunInsert(run: PhaseRunInsertArgs): Promise<Agent> {
@@ -178,6 +182,7 @@ export async function invokePhaseRunInsert(run: PhaseRunInsertArgs): Promise<Age
       startedAt: run.startedAt ?? null,
       completedAt: run.completedAt ?? null,
       kind: run.kind ?? null,
+      verbosity: run.verbosity ?? null,
     },
   });
   return rowToPhaseRun(row);
@@ -185,6 +190,13 @@ export async function invokePhaseRunInsert(run: PhaseRunInsertArgs): Promise<Age
 
 export async function invokeAgentSetKind(id: AgentId, kind: string | null): Promise<void> {
   return invoke<void>('agent_set_kind', { id, kind });
+}
+
+export async function invokeAgentSetVerbosity(
+  id: AgentId,
+  verbosity: VerbosityLevel | null,
+): Promise<void> {
+  return invoke<void>('agent_set_verbosity', { id, verbosity });
 }
 
 export interface PhaseRunUpdateFields {

--- a/apps/desktop/src/features/settings/verbosity.ts
+++ b/apps/desktop/src/features/settings/verbosity.ts
@@ -1,4 +1,4 @@
-import type { AgentId, SessionId } from '@goodboy/types';
+import type { WorkspaceId } from '@goodboy/types';
 import { STORAGE_PREFIXES } from '../../shared/lib/storage-keys';
 
 export const VERBOSITY_LEVELS = ['brief', 'normal', 'verbose'] as const;
@@ -10,8 +10,7 @@ export const VERBOSITY_LABEL: Record<VerbosityLevel, string> = {
   verbose: 'Verbose',
 };
 
-const STORAGE_PREFIX = STORAGE_PREFIXES.verbosity;
-const DEFAULT_LEVEL: VerbosityLevel = 'normal';
+const WORKSPACE_STORAGE_PREFIX = STORAGE_PREFIXES.workspaceVerbosity;
 
 const LEGACY_MAP: Record<string, VerbosityLevel> = {
   essential: 'brief',
@@ -19,43 +18,24 @@ const LEGACY_MAP: Record<string, VerbosityLevel> = {
   detailed: 'verbose',
 };
 
-export function readVerbosity(sessionId: SessionId): VerbosityLevel {
-  try {
-    const raw = localStorage.getItem(`${STORAGE_PREFIX}${sessionId}`);
-    if (!raw) return DEFAULT_LEVEL;
-    if ((VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) return raw as VerbosityLevel;
-    if (raw in LEGACY_MAP) return LEGACY_MAP[raw]!;
-  } catch {
-    // ignore
-  }
-  return DEFAULT_LEVEL;
-}
-
-export function writeVerbosity(sessionId: SessionId, level: VerbosityLevel): void {
-  try {
-    localStorage.setItem(`${STORAGE_PREFIX}${sessionId}`, level);
-  } catch {
-    // ignore
-  }
-}
-
-const AGENT_STORAGE_PREFIX = STORAGE_PREFIXES.agentVerbosity;
-
-export function readAgentVerbosity(agentId: AgentId): VerbosityLevel | null {
-  try {
-    const raw = localStorage.getItem(`${AGENT_STORAGE_PREFIX}${agentId}`);
-    if (!raw) return null;
-    if ((VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) return raw as VerbosityLevel;
-    if (raw in LEGACY_MAP) return LEGACY_MAP[raw]!;
-  } catch {
-    // ignore
-  }
+function normalizeVerbosity(raw: string | null): VerbosityLevel | null {
+  if (!raw) return null;
+  if ((VERBOSITY_LEVELS as ReadonlyArray<string>).includes(raw)) return raw as VerbosityLevel;
+  if (raw in LEGACY_MAP) return LEGACY_MAP[raw]!;
   return null;
 }
 
-export function writeAgentVerbosity(agentId: AgentId, level: VerbosityLevel): void {
+export function readWorkspaceVerbosity(workspaceId: WorkspaceId): VerbosityLevel | null {
   try {
-    localStorage.setItem(`${AGENT_STORAGE_PREFIX}${agentId}`, level);
+    return normalizeVerbosity(localStorage.getItem(`${WORKSPACE_STORAGE_PREFIX}${workspaceId}`));
+  } catch {
+    return null;
+  }
+}
+
+export function writeWorkspaceVerbosity(workspaceId: WorkspaceId, level: VerbosityLevel): void {
+  try {
+    localStorage.setItem(`${WORKSPACE_STORAGE_PREFIX}${workspaceId}`, level);
   } catch {
     // ignore
   }

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { VerbosityLevel, WorkspaceId } from '@goodboy/types';
 import { Button, Dialog, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
@@ -14,6 +14,11 @@ import {
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
 import { PhasesPanel } from '../../../../features/phases/components/PhasesPanel';
 import { ScriptsPanel } from '../../../../features/scripts';
+import { VerbositySelect } from '../../../../features/session/components/config-selects';
+import {
+  readWorkspaceVerbosity,
+  writeWorkspaceVerbosity,
+} from '../../../../features/settings/verbosity';
 import { formatError } from '../../../../shared/lib/errors';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../../features/settings/settings';
 import { WORKSPACE_FEATURES } from '../../../../shared/lib/features';
@@ -58,10 +63,14 @@ export function WorkspaceSettingsDialog({
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
   const disconnect = useAppStore((s) => s.deleteWorkspace);
+  const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
+  const storeSetWorkspaceOverrides = useAppStore((s) => s.setWorkspaceOverrides);
 
   const [active, setActive] = useState<Section>('general');
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [savedBranchPrefix, setSavedBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [verbosity, setVerbosity] = useState<VerbosityLevel>('normal');
+  const [savedVerbosity, setSavedVerbosity] = useState<VerbosityLevel>('normal');
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
@@ -79,7 +88,11 @@ export function WorkspaceSettingsDialog({
       setBranchPrefix(value);
       setSavedBranchPrefix(value);
     });
-  }, [open, workspaceId, loadSetting, initialSection]);
+    const savedVerbosityValue =
+      wsOverrides?.defaultVerbosity ?? readWorkspaceVerbosity(workspaceId) ?? 'normal';
+    setVerbosity(savedVerbosityValue);
+    setSavedVerbosity(savedVerbosityValue);
+  }, [open, workspaceId, loadSetting, initialSection, wsOverrides]);
 
   const onDisconnect = async () => {
     setDisconnecting(true);
@@ -101,6 +114,16 @@ export function WorkspaceSettingsDialog({
       await saveSetting(settingBranchPrefix(workspaceId), next);
       setSavedBranchPrefix(next);
       setBranchPrefix(next);
+      const mergedOverrides = {
+        defaultProviderId: wsOverrides?.defaultProviderId ?? null,
+        defaultWorkflowId: wsOverrides?.defaultWorkflowId ?? null,
+        defaultBranchPrefix: wsOverrides?.defaultBranchPrefix ?? null,
+        parallelEnabled: wsOverrides?.parallelEnabled ?? null,
+        defaultVerbosity: verbosity,
+      };
+      await storeSetWorkspaceOverrides(workspaceId, mergedOverrides);
+      writeWorkspaceVerbosity(workspaceId, verbosity);
+      setSavedVerbosity(verbosity);
       setSaveState('saved');
     } catch (err) {
       setSaveState('error');
@@ -109,6 +132,8 @@ export function WorkspaceSettingsDialog({
   };
 
   const branchPrefixDirty = branchPrefix.trim() !== savedBranchPrefix.trim();
+  const verbosityDirty = verbosity !== savedVerbosity;
+  const settingsDirty = branchPrefixDirty || verbosityDirty;
 
   const navItems: ReadonlyArray<NavItem> = [
     { id: 'general', label: 'General', icon: <FolderCode size={13} aria-hidden /> },
@@ -171,7 +196,7 @@ export function WorkspaceSettingsDialog({
               <span className="inline-flex items-center gap-1 text-xs text-success">
                 <Check size={12} aria-hidden /> Saved
               </span>
-            ) : branchPrefixDirty && active === 'general' ? (
+            ) : settingsDirty && active === 'general' ? (
               <span className="text-xs text-muted-foreground">Unsaved changes</span>
             ) : null}
           </div>
@@ -181,7 +206,7 @@ export function WorkspaceSettingsDialog({
           {active === 'general' ? (
             <Button
               onClick={() => void onSave()}
-              disabled={saveState === 'saving' || !branchPrefixDirty}
+              disabled={saveState === 'saving' || !settingsDirty}
             >
               {saveState === 'saving' ? (
                 <>
@@ -201,6 +226,8 @@ export function WorkspaceSettingsDialog({
           <GeneralSection
             branchPrefix={branchPrefix}
             setBranchPrefix={setBranchPrefix}
+            verbosity={verbosity}
+            setVerbosity={setVerbosity}
             busy={saveState === 'saving'}
           />
         ) : null}
@@ -296,10 +323,14 @@ function NavButton({
 function GeneralSection({
   branchPrefix,
   setBranchPrefix,
+  verbosity,
+  setVerbosity,
   busy,
 }: {
   branchPrefix: string;
   setBranchPrefix: (v: string) => void;
+  verbosity: VerbosityLevel;
+  setVerbosity: (v: VerbosityLevel) => void;
   busy: boolean;
 }) {
   const sanitized = (input: string): string =>
@@ -356,6 +387,19 @@ function GeneralSection({
             {branchPrefix.trim() || DEFAULT_BRANCH_PREFIX}/refactor-auth-domain
           </span>
         </p>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
+        <div className="flex items-center gap-2">
+          <Zap size={13} aria-hidden className="text-muted-foreground" />
+          <span className="text-xs font-semibold text-foreground">Output verbosity</span>
+        </div>
+        <p className="text-2xs leading-relaxed text-muted-foreground">
+          Default response style for agents in this workspace. Each agent can override per-session.
+        </p>
+        <div className="max-w-xs">
+          <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -8,14 +8,13 @@ export const STORAGE_KEYS = {
 } as const;
 
 export const STORAGE_PREFIXES = {
-  verbosity: `${PREFIX}verbosity:`,
   effort: `${PREFIX}effort:`,
   model: `${PREFIX}model:`,
   provider: `${PREFIX}provider:`,
   contextPanelOpen: `${PREFIX}context-panel-open:`,
-  agentVerbosity: `${PREFIX}agent-verbosity:`,
   agentEffort: `${PREFIX}agent-effort:`,
   agentModel: `${PREFIX}agent-model:`,
   agentProvider: `${PREFIX}agent-provider:`,
+  workspaceVerbosity: `${PREFIX}workspace-verbosity:`,
   diffView: `${PREFIX}diff-view:`,
 } as const;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -109,6 +109,7 @@ import type {
   ProviderRun,
   ProviderRunId,
   ResolvedSettings,
+  VerbosityLevel,
   TurnState,
   Skill,
   SkillId,
@@ -164,7 +165,11 @@ import {
   encodeAuthRequiredMessage,
   isAuthErrorMessage,
 } from '../features/chat/turn';
-import { readVerbosity, verbosityDirective } from '../features/settings/verbosity';
+import {
+  readWorkspaceVerbosity,
+  verbosityDirective,
+  writeWorkspaceVerbosity,
+} from '../features/settings/verbosity';
 import {
   createWorktree,
   removeWorktree,
@@ -206,6 +211,7 @@ import {
   invokeSessionSetProviderSessionId,
   invokeSessionMarkViewed,
   invokeAgentSetKind,
+  invokeAgentSetVerbosity,
   type PhaseTemplateUpsertArgs,
 } from '../features/phases/phases';
 import {
@@ -547,6 +553,7 @@ export interface AppActions {
   setWorkspaceOverrides(workspaceId: WorkspaceId, overrides: OverrideSettings): Promise<void>;
   loadSessionOverrides(sessionId: SessionId): Promise<void>;
   setTaskOverrides(sessionId: SessionId, overrides: OverrideSettings): Promise<void>;
+  setAgentVerbosity(sessionId: SessionId, agentId: AgentId, level: VerbosityLevel): Promise<void>;
   renameTask(sessionId: SessionId, goal: string): Promise<void>;
   autoTitleSession(sessionId: SessionId, title: string): Promise<void>;
   deleteTask(sessionId: SessionId): Promise<void>;
@@ -1468,6 +1475,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         phaseTemplates: { ...state.phaseTemplates, [id]: phaseTemplates },
         agentKindOverride: { ...state.agentKindOverride, ...kindOverridesFromDb },
       }));
+      void get().loadWorkspaceOverrides(id);
     } else {
       set({ providerSpendBreakdown: [] });
     }
@@ -1541,6 +1549,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // downstream parallel fetch by the IPC round-trip (~5-50ms of dead time).
     void dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, id ?? '');
     if (!id) return;
+    void get().loadSessionOverrides(id);
     const perf = (op: string) => {
       const t0 = performance.now();
       return () => {
@@ -1867,6 +1876,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
     const agentModelOverrides: Record<string, string> = {};
     const agentKindOverrides: Record<string, string> = {};
 
+    // Seed L2 (per-agent) verbosity from the workspace default at insert time
+    // so each new chat starts with the user's workspace setting baked in.
+    const workspaceVerbositySeed =
+      get().workspaceOverrides[workspaceId]?.defaultVerbosity ??
+      readWorkspaceVerbosity(workspaceId) ??
+      undefined;
+
     if (workflowId) {
       const templates = get().phaseTemplates[workspaceId] ?? [];
       const template = templates.find((t) => t.id === workflowId) ?? null;
@@ -1883,6 +1899,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
             name: step.name,
             status: 'pending',
             kind,
+            ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
           });
           agentModelOverrides[agent.id] = step.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model;
           agentKindOverrides[agent.id] = kind;
@@ -1896,6 +1913,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
           ordinal: 0,
           name: 'agent 1',
           status: 'pending',
+          ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
         });
         prespawnedRuns = [fallback];
       }
@@ -1908,6 +1926,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
         name: agentName,
         status: 'pending',
         kind: firstAgentKind,
+        ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
       });
       if (model !== null) agentModelOverrides[singleAgent.id] = model;
       agentKindOverrides[singleAgent.id] = firstAgentKind;
@@ -2627,9 +2646,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
       }
     }
 
-    const verbosityHint = verbosityDirective(
-      phaseDefinition?.verbosity ?? readVerbosity(sessionId),
-    );
+    const agentRowForVerbosity =
+      (get().sessionPhaseRuns[sessionId] ?? []).find((r) => r.id === activeAgentId) ?? null;
+    const effectiveVerbosity =
+      phaseDefinition?.verbosity ??
+      agentRowForVerbosity?.verbosity ??
+      get().workspaceOverrides[session.workspaceId]?.defaultVerbosity ??
+      readWorkspaceVerbosity(session.workspaceId) ??
+      'normal';
+    const verbosityHint = verbosityDirective(effectiveVerbosity);
     resolvedPrompt = `${verbosityHint}\n\n${resolvedPrompt}`;
 
     // M4: soft-cap warning. heuristic only — exact tokenization requires wasm.
@@ -3577,6 +3602,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }
     const currentRuns = state.sessionPhaseRuns[sessionId] ?? [];
     const nextOrdinal = currentRuns.reduce((max, r) => Math.max(max, r.ordinal), -1) + 1;
+    const workspaceVerbositySeed =
+      state.workspaceOverrides[session.workspaceId]?.defaultVerbosity ??
+      readWorkspaceVerbosity(session.workspaceId) ??
+      undefined;
     const inserted = await invokePhaseRunInsert({
       sessionId,
       ...(args.stepId !== undefined && { stepId: args.stepId }),
@@ -3584,6 +3613,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
       name: resolvedName,
       status: 'pending',
       ...(args.kindOverride !== undefined && { kind: args.kindOverride }),
+      ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
     });
     const refreshed = await invokePhaseRunList(sessionId);
     set((s) => ({
@@ -3803,6 +3833,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
       set((state) => ({
         workspaceOverrides: { ...state.workspaceOverrides, [workspaceId]: overrides },
       }));
+      if (overrides.defaultVerbosity !== null) {
+        writeWorkspaceVerbosity(workspaceId, overrides.defaultVerbosity);
+      }
     }
   },
 
@@ -3827,6 +3860,19 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set((state) => ({
       sessionOverrides: { ...state.sessionOverrides, [sessionId]: overrides },
     }));
+  },
+
+  setAgentVerbosity: async (sessionId, agentId, level) => {
+    await invokeAgentSetVerbosity(agentId, level);
+    set((state) => {
+      const runs = state.sessionPhaseRuns[sessionId] ?? [];
+      return {
+        sessionPhaseRuns: {
+          ...state.sessionPhaseRuns,
+          [sessionId]: runs.map((r) => (r.id === agentId ? { ...r, verbosity: level } : r)),
+        },
+      };
+    });
   },
 
   renameTask: async (sessionId, goal) => {
@@ -4155,6 +4201,7 @@ export function useResolvedSettings(sessionId: SessionId | null): ResolvedSettin
       defaultWorkflowId: null,
       defaultBranchPrefix: DEFAULT_BRANCH_PREFIX,
       parallelEnabled: AGENT_FEATURES.parallelAgents,
+      defaultVerbosity: 'normal',
     };
 
     const workspaceOverride = workspaceId ? (state.workspaceOverrides[workspaceId] ?? null) : null;

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -9,6 +9,7 @@ const GLOBAL: GlobalSettings = {
   defaultWorkflowId: null,
   defaultBranchPrefix: 'kay',
   parallelEnabled: false,
+  defaultVerbosity: 'normal',
 };
 
 const NULL_OVERRIDE: OverrideSettings = {
@@ -16,6 +17,7 @@ const NULL_OVERRIDE: OverrideSettings = {
   defaultWorkflowId: null,
   defaultBranchPrefix: null,
   parallelEnabled: null,
+  defaultVerbosity: null,
 };
 
 describe('resolveSettings', () => {
@@ -33,40 +35,46 @@ describe('resolveSettings', () => {
       defaultWorkflowId: 'tpl-1' as WorkflowId,
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: true,
+      defaultVerbosity: 'verbose',
     };
     const result = resolveSettings({ global: GLOBAL, workspaceOverride: wsOverride });
     expect(result.defaultProviderId).toBe('cursor');
     expect(result.defaultWorkflowId).toBe('tpl-1');
     expect(result.defaultBranchPrefix).toBe('ws-prefix');
     expect(result.parallelEnabled).toBe(true);
+    expect(result.defaultVerbosity).toBe('verbose');
   });
 
-  it('null/null/value → session wins', () => {
+  it('null/null/value (session) → session wins for provider/workflow/prefix/parallel; session.defaultVerbosity always null in production', () => {
     const sessOverride: OverrideSettings = {
       defaultProviderId: 'codex' as ProviderId,
       defaultWorkflowId: 'tpl-2' as WorkflowId,
       defaultBranchPrefix: 'sess-prefix',
       parallelEnabled: true,
+      defaultVerbosity: null,
     };
     const result = resolveSettings({ global: GLOBAL, sessionOverride: sessOverride });
     expect(result.defaultProviderId).toBe('codex');
     expect(result.defaultWorkflowId).toBe('tpl-2');
     expect(result.defaultBranchPrefix).toBe('sess-prefix');
     expect(result.parallelEnabled).toBe(true);
+    expect(result.defaultVerbosity).toBe('normal');
   });
 
-  it('null/value/value → session wins over workspace', () => {
+  it('session overrides win over workspace for non-verbosity fields', () => {
     const wsOverride: OverrideSettings = {
       defaultProviderId: 'cursor' as ProviderId,
       defaultWorkflowId: 'tpl-ws' as WorkflowId,
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: false,
+      defaultVerbosity: 'verbose',
     };
     const sessOverride: OverrideSettings = {
       defaultProviderId: 'codex' as ProviderId,
       defaultWorkflowId: 'tpl-sess' as WorkflowId,
       defaultBranchPrefix: 'sess-prefix',
       parallelEnabled: true,
+      defaultVerbosity: null,
     };
     const result = resolveSettings({
       global: GLOBAL,
@@ -77,20 +85,23 @@ describe('resolveSettings', () => {
     expect(result.defaultWorkflowId).toBe('tpl-sess');
     expect(result.defaultBranchPrefix).toBe('sess-prefix');
     expect(result.parallelEnabled).toBe(true);
+    expect(result.defaultVerbosity).toBe('verbose');
   });
 
-  it('null/value/null-fields → session null fields fall back to workspace', () => {
+  it('null-fields session falls back to workspace', () => {
     const wsOverride: OverrideSettings = {
       defaultProviderId: 'cursor' as ProviderId,
       defaultWorkflowId: null,
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: true,
+      defaultVerbosity: 'verbose',
     };
     const sessOverride: OverrideSettings = {
       defaultProviderId: null,
       defaultWorkflowId: null,
       defaultBranchPrefix: null,
       parallelEnabled: null,
+      defaultVerbosity: null,
     };
     const result = resolveSettings({
       global: GLOBAL,
@@ -100,6 +111,7 @@ describe('resolveSettings', () => {
     expect(result.defaultProviderId).toBe('cursor');
     expect(result.defaultBranchPrefix).toBe('ws-prefix');
     expect(result.parallelEnabled).toBe(true);
+    expect(result.defaultVerbosity).toBe('verbose');
   });
 
   it('all-null overrides → global used everywhere', () => {
@@ -111,6 +123,7 @@ describe('resolveSettings', () => {
     expect(result.defaultProviderId).toBe('anthropic');
     expect(result.defaultBranchPrefix).toBe('kay');
     expect(result.parallelEnabled).toBe(false);
+    expect(result.defaultVerbosity).toBe('normal');
   });
 
   it('undefined overrides treated same as null overrides', () => {
@@ -130,5 +143,61 @@ describe('resolveSettings', () => {
     };
     const result = resolveSettings({ global: globalWithTemplate });
     expect(result.defaultWorkflowId).toBe('global-tpl');
+  });
+
+  // ─── verbosity-specific resolution ─────────────────────────────────────────
+  //
+  // After m038, session.defaultVerbosity is always null in production
+  // (per-chat verbosity moved to agents.verbosity). Workspace remains L1,
+  // global is the final fallback.
+
+  it('verbosity: global normal when no overrides', () => {
+    const result = resolveSettings({ global: GLOBAL });
+    expect(result.defaultVerbosity).toBe('normal');
+  });
+
+  it('verbosity: workspace brief overrides global normal', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: { ...NULL_OVERRIDE, defaultVerbosity: 'brief' },
+    });
+    expect(result.defaultVerbosity).toBe('brief');
+  });
+
+  it('verbosity: workspace verbose overrides global normal', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: { ...NULL_OVERRIDE, defaultVerbosity: 'verbose' },
+    });
+    expect(result.defaultVerbosity).toBe('verbose');
+  });
+
+  it('verbosity: session.defaultVerbosity always null → workspace wins', () => {
+    const result = resolveSettings({
+      global: GLOBAL,
+      workspaceOverride: { ...NULL_OVERRIDE, defaultVerbosity: 'verbose' },
+      sessionOverride: { ...NULL_OVERRIDE, defaultVerbosity: null },
+    });
+    expect(result.defaultVerbosity).toBe('verbose');
+  });
+
+  it('verbosity: session null + workspace null → global', () => {
+    const globalVerbose: GlobalSettings = { ...GLOBAL, defaultVerbosity: 'verbose' };
+    const result = resolveSettings({
+      global: globalVerbose,
+      workspaceOverride: NULL_OVERRIDE,
+      sessionOverride: NULL_OVERRIDE,
+    });
+    expect(result.defaultVerbosity).toBe('verbose');
+  });
+
+  it('verbosity: workspace null falls back to global brief', () => {
+    const globalBrief: GlobalSettings = { ...GLOBAL, defaultVerbosity: 'brief' };
+    const result = resolveSettings({
+      global: globalBrief,
+      workspaceOverride: NULL_OVERRIDE,
+      sessionOverride: NULL_OVERRIDE,
+    });
+    expect(result.defaultVerbosity).toBe('brief');
   });
 });

--- a/packages/core/src/settings/resolver.ts
+++ b/packages/core/src/settings/resolver.ts
@@ -27,5 +27,6 @@ export function resolveSettings(input: ResolveSettingsInput): ResolvedSettings {
     defaultBranchPrefix:
       sess?.defaultBranchPrefix ?? ws?.defaultBranchPrefix ?? g.defaultBranchPrefix,
     parallelEnabled: sess?.parallelEnabled ?? ws?.parallelEnabled ?? g.parallelEnabled,
+    defaultVerbosity: sess?.defaultVerbosity ?? ws?.defaultVerbosity ?? g.defaultVerbosity,
   };
 }

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -35,6 +35,7 @@ import { m034WorkspaceDisconnectedAt } from './m034-workspace-disconnected-at';
 import { m035NudgeEvents } from './m035-nudge-events';
 import { m036WorkspaceScripts } from './m036-workspace-scripts';
 import { m037PlanDiscardedStatus } from './m037-plan-discarded-status';
+import { m038WorkspaceVerbosity } from './m038-workspace-verbosity';
 
 export interface Migration {
   readonly version: number;
@@ -79,4 +80,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 35, sql: m035NudgeEvents },
   { version: 36, sql: m036WorkspaceScripts },
   { version: 37, sql: m037PlanDiscardedStatus },
+  { version: 38, sql: m038WorkspaceVerbosity },
 ];

--- a/packages/db/src/migrations/m038-workspace-verbosity.ts
+++ b/packages/db/src/migrations/m038-workspace-verbosity.ts
@@ -1,0 +1,5 @@
+export const m038WorkspaceVerbosity = /* sql */ `
+ALTER TABLE workspaces ADD COLUMN default_verbosity TEXT CHECK (default_verbosity IN ('brief', 'normal', 'verbose'));
+
+UPDATE agents SET verbosity = 'normal' WHERE verbosity IS NULL OR verbosity NOT IN ('brief', 'normal', 'verbose');
+`;

--- a/packages/db/src/queries/settings-overrides.ts
+++ b/packages/db/src/queries/settings-overrides.ts
@@ -1,20 +1,45 @@
-import type { OverrideSettings, SessionId, WorkflowId, WorkspaceId } from '@goodboy/types';
+import type {
+  OverrideSettings,
+  SessionId,
+  VerbosityLevel,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
 import type { ProviderId } from '@goodboy/types';
 import type { Database } from '../client';
 
-interface OverrideRow {
+interface WorkspaceOverrideRow {
+  default_provider_id: string | null;
+  default_workflow_id: string | null;
+  default_branch_prefix: string | null;
+  parallel_enabled: number | null;
+  default_verbosity: string | null;
+}
+
+interface SessionOverrideRow {
   default_provider_id: string | null;
   default_workflow_id: string | null;
   default_branch_prefix: string | null;
   parallel_enabled: number | null;
 }
 
-function rowToOverride(row: OverrideRow): OverrideSettings {
+function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
   return {
     defaultProviderId: row.default_provider_id as ProviderId | null,
     defaultWorkflowId: row.default_workflow_id as WorkflowId | null,
     defaultBranchPrefix: row.default_branch_prefix,
     parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
+    defaultVerbosity: row.default_verbosity as VerbosityLevel | null,
+  };
+}
+
+function sessionRowToOverride(row: SessionOverrideRow): OverrideSettings {
+  return {
+    defaultProviderId: row.default_provider_id as ProviderId | null,
+    defaultWorkflowId: row.default_workflow_id as WorkflowId | null,
+    defaultBranchPrefix: row.default_branch_prefix,
+    parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
+    defaultVerbosity: null,
   };
 }
 
@@ -22,13 +47,13 @@ export async function getWorkspaceOverrides(
   db: Database,
   workspaceId: WorkspaceId,
 ): Promise<OverrideSettings | null> {
-  const rows = await db.select<OverrideRow>(
-    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
+  const rows = await db.select<WorkspaceOverrideRow>(
+    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity
      FROM workspaces WHERE id = ?`,
     [workspaceId],
   );
   const row = rows[0];
-  return row ? rowToOverride(row) : null;
+  return row ? workspaceRowToOverride(row) : null;
 }
 
 export async function setWorkspaceOverrides(
@@ -42,6 +67,7 @@ export async function setWorkspaceOverrides(
          default_workflow_id = ?,
          default_branch_prefix = ?,
          parallel_enabled = ?,
+         default_verbosity = ?,
          updated_at = ?
      WHERE id = ?`,
     [
@@ -49,6 +75,7 @@ export async function setWorkspaceOverrides(
       overrides.defaultWorkflowId,
       overrides.defaultBranchPrefix,
       overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
+      overrides.defaultVerbosity,
       Date.now(),
       workspaceId,
     ],
@@ -59,13 +86,13 @@ export async function getSessionOverrides(
   db: Database,
   sessionId: SessionId,
 ): Promise<OverrideSettings | null> {
-  const rows = await db.select<OverrideRow>(
+  const rows = await db.select<SessionOverrideRow>(
     `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
      FROM sessions WHERE id = ?`,
     [sessionId],
   );
   const row = rows[0];
-  return row ? rowToOverride(row) : null;
+  return row ? sessionRowToOverride(row) : null;
 }
 
 export async function setSessionOverrides(

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -71,7 +71,13 @@ export type {
   StepTransition,
   Workflow,
 } from './workflow';
-export type { GlobalSettings, OverrideSettings, ResolvedSettings, SettingsScope } from './settings';
+export type {
+  GlobalSettings,
+  OverrideSettings,
+  ResolvedSettings,
+  SettingsScope,
+  VerbosityLevel,
+} from './settings';
 export type { BranchCommit, DiffView, WorktreeDiffScope, WorktreeStatus } from './worktree';
 export type {
   ConfigBundle,

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,12 +1,15 @@
 import type { SessionId, WorkflowId, WorkspaceId } from './ids';
 import type { ProviderId } from './provider-registry';
 
+export type VerbosityLevel = 'brief' | 'normal' | 'verbose';
+
 /** Fields that can be overridden at workspace or session scope. Null = inherit from parent. */
 export type OverrideSettings = Readonly<{
   defaultProviderId: ProviderId | null;
   defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string | null;
   parallelEnabled: boolean | null;
+  defaultVerbosity: VerbosityLevel | null;
 }>;
 
 /** Fully-resolved settings after applying global → workspace → session cascade. */
@@ -15,6 +18,7 @@ export type ResolvedSettings = Readonly<{
   defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string;
   parallelEnabled: boolean;
+  defaultVerbosity: VerbosityLevel;
 }>;
 
 /** Global settings (non-nullable — always has a value). */
@@ -23,6 +27,7 @@ export type GlobalSettings = Readonly<{
   defaultWorkflowId: WorkflowId | null;
   defaultBranchPrefix: string;
   parallelEnabled: boolean;
+  defaultVerbosity: VerbosityLevel;
 }>;
 
 export type SettingsScope =


### PR DESCRIPTION
## Summary

- Adds `default_verbosity` to `workspaces` table (migration m038)
- WorkspaceSettingsDialog exposes a verbosity selector, persisted to DB
- `spawnAgent` seeds `agents.verbosity` from workspace default at insert time
- Chat toolbar updates `agents.verbosity` via new `agent_set_verbosity` Rust command
- Send-time resolver chains all three tiers: `step.verbosity → agent.verbosity → workspace.defaultVerbosity → 'normal'`
- Removed dead localStorage verbosity API

## Test plan

- [ ] Set workspace verbosity to `verbose` → new chat inherits it
- [ ] Override per-chat via toolbar → DB-persisted, survives agent switch
- [ ] Workflow step verbosity still wins over both
- [ ] 405 unit tests pass, typecheck clean, cargo check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)