### PR TITLE
feat(desktop): client-side pr polling

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,7 @@ Major sprint bridging v0.7 → v1.0. Shipped in ~2 weeks.
 
 - GitHub panel with PR state, CI checks, comments, review decisions, linked issues (PR #539, #562)
 - Auto-refresh GitHub card when agent creates a PR (PR #547)
+- Periodic PR polling (5 min) plus on-open and on-workspace-switch refresh — interim until a GitHub webhook
 - Diff comment tracking consumed by reviewer agent (PR #557)
 - Git-aware diff view selector in files-touched modal (PR #556)
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -26,6 +26,7 @@ import {
   useWorkspaces,
 } from './store';
 import { refreshPricingTable } from './features/providers/provider-pricing';
+import { useGithubPolling } from './features/github/use-github-polling';
 import { STORAGE_PREFIXES } from './shared/lib/storage-keys';
 
 const CONTEXT_PANEL_KEY = (id: SessionId): string => `${STORAGE_PREFIXES.contextPanelOpen}${id}`;
@@ -85,6 +86,8 @@ export function App() {
     void hydrate();
     void refreshPricingTable();
   }, [hydrate]);
+
+  useGithubPolling();
 
   useEffect(() => {
     const handler = (event: Event) => {

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -99,20 +99,12 @@ export function ContextPanel({
   const filesTouched = useFilesTouched(session.id);
   const github = useAppStore((s) => s.sessionGithub[session.id as SessionId]);
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
-  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const loadDiffComments = useAppStore((s) => s.loadDiffComments);
 
   useEffect(() => {
     if (!isActive) return;
     void loadDiffComments(session.id);
   }, [isActive, session.id, loadDiffComments]);
-
-  useEffect(() => {
-    if (!isActive || !branch) return;
-    if (github && github.fetchedAt !== null) return;
-    if (github?.loading) return;
-    void refreshSessionPr(session.id as SessionId);
-  }, [isActive, session.id, branch, github, refreshSessionPr]);
 
   const summarizerTotals = useMemo(() => {
     let inputTokens = 0;

--- a/apps/desktop/src/features/github/use-github-polling.ts
+++ b/apps/desktop/src/features/github/use-github-polling.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import { useAppStore, useSessions } from '../../store';
+
+// Interim PR polling until a GitHub webhook lands. Five minutes is a
+// deliberate floor: the on-access and on-workspace-switch sweeps already
+// cover "I just looked at it", so the timer only refreshes cards the user is
+// watching passively.
+const POLL_INTERVAL_MS = 5 * 60_000;
+
+export function useGithubPolling(): void {
+  const sweepGithub = useAppStore((s) => s.sweepGithub);
+  const githubAvailable = useAppStore((s) => s.githubStatus?.available ?? false);
+  const sessions = useSessions();
+  const sessionBranches = useAppStore((s) => s.sessionBranches);
+
+  // Reactive sweep — boot, workspace switch, and session-list / branch
+  // changes: `sessions` and `sessionBranches` are replaced (fresh identity)
+  // on each, so this re-runs exactly when the set of PRs to poll changes.
+  // Full scope (no `skipUnknownPr`) so a session whose PR was created from
+  // outside the app — `gh pr create` in a terminal, web UI, etc. — gets
+  // discovered the first time we see it.
+  useEffect(() => {
+    sweepGithub();
+  }, [sweepGithub, githubAvailable, sessions, sessionBranches]);
+
+  // Steady-state poll. The tick no-ops while the window is hidden; returning
+  // to the foreground fires an immediate catch-up. Incremental scope: skip
+  // sessions we already learned have no PR — the app's PR-creation paths
+  // (createPrForSession, assistant-text URL detect, summarizer hook) refresh
+  // them explicitly, so the timer doesn't need to.
+  useEffect(() => {
+    const sweepIfVisible = (): void => {
+      if (document.visibilityState === 'visible') sweepGithub({ skipUnknownPr: true });
+    };
+    const intervalId = window.setInterval(sweepIfVisible, POLL_INTERVAL_MS);
+    document.addEventListener('visibilitychange', sweepIfVisible);
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', sweepIfVisible);
+    };
+  }, [sweepGithub]);
+}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -81,7 +81,10 @@ import {
 } from '../../../../features/session/components/AgentMetricsBlock';
 import { formatError } from '../../../../shared/lib/errors';
 import { useThemeStore } from '../../../../shared/lib/theme';
-import { STORAGE_KEYS } from '../../../../shared/lib/storage-keys';
+import {
+  readArchivedSessions,
+  writeArchivedSessions,
+} from '../../../../shared/lib/archived-sessions';
 import { WorkspaceSelect } from '../WorkspaceSelect';
 import { SessionActivityBar } from '../SessionActivityBar';
 import { SessionDetailPanel, SessionMetaFooter } from '../SessionDetailPanel';
@@ -117,19 +120,6 @@ export function WorkspacesSidebar({
     },
     [setCurrentSession],
   );
-  const sessionBranches = useAppStore((s) => s.sessionBranches);
-  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
-
-  const warmedRef = useRef(false);
-  useEffect(() => {
-    if (warmedRef.current || sessions.length === 0) return;
-    warmedRef.current = true;
-    for (const s of sessions) {
-      if (sessionBranches[s.id]) {
-        void refreshSessionPr(s.id as SessionId);
-      }
-    }
-  }, [sessions, sessionBranches, refreshSessionPr]);
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [newSessionOpen, setNewSessionOpen] = useState(false);
   const [guideOpen, setGuideOpen] = useState(false);
@@ -563,43 +553,17 @@ function NoWorkspaceEmpty({ onAddWorkspace }: { onAddWorkspace: () => void }) {
   );
 }
 
-const ARCHIVED_KEY = STORAGE_KEYS.archivedTasks;
-
-function readArchivedSet(): Record<string, true> {
-  try {
-    const raw = localStorage.getItem(ARCHIVED_KEY);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as unknown;
-    if (parsed && typeof parsed === 'object') {
-      const out: Record<string, true> = {};
-      for (const k of Object.keys(parsed as Record<string, unknown>)) out[k] = true;
-      return out;
-    }
-  } catch {
-    // ignore
-  }
-  return {};
-}
-
-function writeArchivedSet(map: Record<string, true>): void {
-  try {
-    localStorage.setItem(ARCHIVED_KEY, JSON.stringify(map));
-  } catch {
-    // ignore
-  }
-}
-
 function useArchivedSessions(): [
   Record<string, true>,
   (id: SessionId) => void,
   (id: SessionId) => void,
 ] {
-  const [map, setMap] = useState<Record<string, true>>(() => readArchivedSet());
+  const [map, setMap] = useState<Record<string, true>>(() => readArchivedSessions());
   // Stable refs so memoized SessionRow downstream doesn't invalidate.
   const archive = useCallback((id: SessionId) => {
     setMap((prev) => {
       const next = { ...prev, [id]: true as const };
-      writeArchivedSet(next);
+      writeArchivedSessions(next);
       return next;
     });
   }, []);
@@ -607,7 +571,7 @@ function useArchivedSessions(): [
     setMap((prev) => {
       const next = { ...prev };
       delete next[id];
-      writeArchivedSet(next);
+      writeArchivedSessions(next);
       return next;
     });
   }, []);

--- a/apps/desktop/src/shared/lib/archived-sessions.ts
+++ b/apps/desktop/src/shared/lib/archived-sessions.ts
@@ -1,0 +1,32 @@
+import { STORAGE_KEYS } from './storage-keys';
+
+const ARCHIVED_KEY = STORAGE_KEYS.archivedTasks;
+
+// Archive lives in localStorage because the column on `sessions` is on the
+// roadmap but not implemented yet; this util is the single source of truth.
+// Both the sidebar hook (`useArchivedSessions`) and the github polling sweep
+// read through here so a session archived in the UI is filtered out of the
+// very next poll tick.
+export function readArchivedSessions(): Record<string, true> {
+  try {
+    const raw = localStorage.getItem(ARCHIVED_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed && typeof parsed === 'object') {
+      const out: Record<string, true> = {};
+      for (const k of Object.keys(parsed as Record<string, unknown>)) out[k] = true;
+      return out;
+    }
+  } catch {
+    // localStorage unavailable / malformed payload — treat as empty.
+  }
+  return {};
+}
+
+export function writeArchivedSessions(map: Record<string, true>): void {
+  try {
+    localStorage.setItem(ARCHIVED_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage unavailable — ignore.
+  }
+}

--- a/apps/desktop/src/store/slices/github.slice.ts
+++ b/apps/desktop/src/store/slices/github.slice.ts
@@ -16,6 +16,7 @@ import {
 import type { GhTokenStatus, SessionId, IsoDateTime } from '@goodboy/types';
 import { tauriDatabase } from '../../shared/lib/db';
 import { formatError } from '../../shared/lib/errors';
+import { readArchivedSessions } from '../../shared/lib/archived-sessions';
 import type { AppStore } from '../store';
 
 type SetFn = (p: Partial<AppStore> | ((s: AppStore) => Partial<AppStore>)) => void;
@@ -84,7 +85,10 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
       await get().refreshGithubStatus();
     },
 
-    refreshSessionPr: async (sessionId: SessionId, opts?: { force?: boolean }) => {
+    refreshSessionPr: async (
+      sessionId: SessionId,
+      opts?: { force?: boolean; silent?: boolean; retries?: number },
+    ) => {
       // In-flight dedup: ContextPanel's effect can refire (StrictMode, fast
       // re-activation) before the first ~1s GitHub round-trip resolves. The
       // existing `loading` flag is the right signal, since this action sets it
@@ -112,72 +116,88 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
           },
         },
       }));
-      try {
-        const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath);
-        if (!slug) {
+      // Retry loop. Polling sweeps pass `retries: 1` so a transient gh
+      // failure gets a second chance; everything else defaults to a single
+      // attempt. The `slug === null` branch is a real success (no git repo
+      // for this workspace) and short-circuits without retrying.
+      const maxAttempts = (opts?.retries ?? 0) + 1;
+      let lastErr: unknown = null;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath);
+          if (!slug) {
+            set((state) => ({
+              sessionGithub: {
+                ...state.sessionGithub,
+                [sessionId]: {
+                  pr: null,
+                  linkedIssues: [],
+                  fetchedAt: new Date().toISOString() as IsoDateTime,
+                  loading: false,
+                  error: null,
+                  detail: null,
+                  detailFetchedAt: null,
+                  detailLoading: false,
+                  detailError: null,
+                },
+              },
+            }));
+            return;
+          }
+          const store = createTauriPrCacheStore(tauriDatabase);
+          const pr = await getPrForBranch(
+            { runner: tauriGhRunner, store },
+            { repoSlug: slug, branch, cwd: workspace.rootPath, force: opts?.force === true },
+          );
+          const linked = pr
+            ? await fetchLinkedIssues(tauriGhRunner, slug, pr, { cwd: workspace.rootPath })
+            : [];
           set((state) => ({
             sessionGithub: {
               ...state.sessionGithub,
               [sessionId]: {
-                pr: null,
-                linkedIssues: [],
+                pr,
+                linkedIssues: linked,
                 fetchedAt: new Date().toISOString() as IsoDateTime,
                 loading: false,
                 error: null,
-                detail: null,
-                detailFetchedAt: null,
-                detailLoading: false,
-                detailError: null,
+                detail: state.sessionGithub[sessionId]?.detail ?? null,
+                detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
+                detailLoading: state.sessionGithub[sessionId]?.detailLoading ?? false,
+                detailError: state.sessionGithub[sessionId]?.detailError ?? null,
               },
             },
           }));
           return;
+        } catch (err) {
+          lastErr = err;
         }
-        const store = createTauriPrCacheStore(tauriDatabase);
-        const pr = await getPrForBranch(
-          { runner: tauriGhRunner, store },
-          { repoSlug: slug, branch, cwd: workspace.rootPath, force: opts?.force === true },
-        );
-        const linked = pr
-          ? await fetchLinkedIssues(tauriGhRunner, slug, pr, { cwd: workspace.rootPath })
-          : [];
-        set((state) => ({
-          sessionGithub: {
-            ...state.sessionGithub,
-            [sessionId]: {
-              pr,
-              linkedIssues: linked,
-              fetchedAt: new Date().toISOString() as IsoDateTime,
-              loading: false,
-              error: null,
-              detail: state.sessionGithub[sessionId]?.detail ?? null,
-              detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
-              detailLoading: state.sessionGithub[sessionId]?.detailLoading ?? false,
-              detailError: state.sessionGithub[sessionId]?.detailError ?? null,
-            },
-          },
-        }));
-      } catch (err) {
-        set((state) => ({
-          sessionGithub: {
-            ...state.sessionGithub,
-            [sessionId]: {
-              pr: state.sessionGithub[sessionId]?.pr ?? null,
-              linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
-              fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
-              loading: false,
-              error: formatError(err),
-              detail: state.sessionGithub[sessionId]?.detail ?? null,
-              detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
-              detailLoading: state.sessionGithub[sessionId]?.detailLoading ?? false,
-              detailError: state.sessionGithub[sessionId]?.detailError ?? null,
-            },
-          },
-        }));
       }
+      // All attempts failed. `silent: true` (polling) suppresses the error
+      // chip — by design the timer-driven path shouldn't paint failures the
+      // user didn't ask for. Explicit refreshes keep the existing UI.
+      set((state) => ({
+        sessionGithub: {
+          ...state.sessionGithub,
+          [sessionId]: {
+            pr: state.sessionGithub[sessionId]?.pr ?? null,
+            linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
+            fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
+            loading: false,
+            error: opts?.silent ? null : formatError(lastErr),
+            detail: state.sessionGithub[sessionId]?.detail ?? null,
+            detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
+            detailLoading: state.sessionGithub[sessionId]?.detailLoading ?? false,
+            detailError: state.sessionGithub[sessionId]?.detailError ?? null,
+          },
+        },
+      }));
     },
 
-    refreshSessionPrDetail: async (sessionId: SessionId, opts?: { force?: boolean }) => {
+    refreshSessionPrDetail: async (
+      sessionId: SessionId,
+      opts?: { force?: boolean; silent?: boolean; retries?: number },
+    ) => {
       const existing = get().sessionGithub[sessionId];
       const pr = existing?.pr ?? null;
       if (!pr) return;
@@ -211,9 +231,35 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
           },
         },
       }));
-      try {
-        const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath);
-        if (!slug) {
+      // Retry loop — same shape as `refreshSessionPr`. Polling sweeps pass
+      // `retries: 1` so a transient gh failure gets a second chance.
+      const maxAttempts = (opts?.retries ?? 0) + 1;
+      let lastErr: unknown = null;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        try {
+          const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath);
+          if (!slug) {
+            set((state) => ({
+              sessionGithub: {
+                ...state.sessionGithub,
+                [sessionId]: {
+                  pr: state.sessionGithub[sessionId]?.pr ?? pr,
+                  linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
+                  fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
+                  loading: state.sessionGithub[sessionId]?.loading ?? false,
+                  error: state.sessionGithub[sessionId]?.error ?? null,
+                  detail: null,
+                  detailFetchedAt: new Date().toISOString() as IsoDateTime,
+                  detailLoading: false,
+                  detailError: null,
+                },
+              },
+            }));
+            return;
+          }
+          const detail = await fetchPrDetail(tauriGhRunner, slug, pr.number, {
+            cwd: workspace.rootPath,
+          });
           set((state) => ({
             sessionGithub: {
               ...state.sessionGithub,
@@ -223,7 +269,7 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
                 fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
                 loading: state.sessionGithub[sessionId]?.loading ?? false,
                 error: state.sessionGithub[sessionId]?.error ?? null,
-                detail: null,
+                detail,
                 detailFetchedAt: new Date().toISOString() as IsoDateTime,
                 detailLoading: false,
                 detailError: null,
@@ -231,44 +277,26 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
             },
           }));
           return;
+        } catch (err) {
+          lastErr = err;
         }
-        const detail = await fetchPrDetail(tauriGhRunner, slug, pr.number, {
-          cwd: workspace.rootPath,
-        });
-        set((state) => ({
-          sessionGithub: {
-            ...state.sessionGithub,
-            [sessionId]: {
-              pr: state.sessionGithub[sessionId]?.pr ?? pr,
-              linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
-              fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
-              loading: state.sessionGithub[sessionId]?.loading ?? false,
-              error: state.sessionGithub[sessionId]?.error ?? null,
-              detail,
-              detailFetchedAt: new Date().toISOString() as IsoDateTime,
-              detailLoading: false,
-              detailError: null,
-            },
-          },
-        }));
-      } catch (err) {
-        set((state) => ({
-          sessionGithub: {
-            ...state.sessionGithub,
-            [sessionId]: {
-              pr: state.sessionGithub[sessionId]?.pr ?? pr,
-              linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
-              fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
-              loading: state.sessionGithub[sessionId]?.loading ?? false,
-              error: state.sessionGithub[sessionId]?.error ?? null,
-              detail: state.sessionGithub[sessionId]?.detail ?? null,
-              detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
-              detailLoading: false,
-              detailError: formatError(err),
-            },
-          },
-        }));
       }
+      set((state) => ({
+        sessionGithub: {
+          ...state.sessionGithub,
+          [sessionId]: {
+            pr: state.sessionGithub[sessionId]?.pr ?? pr,
+            linkedIssues: state.sessionGithub[sessionId]?.linkedIssues ?? [],
+            fetchedAt: state.sessionGithub[sessionId]?.fetchedAt ?? null,
+            loading: state.sessionGithub[sessionId]?.loading ?? false,
+            error: state.sessionGithub[sessionId]?.error ?? null,
+            detail: state.sessionGithub[sessionId]?.detail ?? null,
+            detailFetchedAt: state.sessionGithub[sessionId]?.detailFetchedAt ?? null,
+            detailLoading: false,
+            detailError: opts?.silent ? null : formatError(lastErr),
+          },
+        },
+      }));
     },
 
     // Closes a review thread on github with a contextual reply, then flips the
@@ -330,6 +358,43 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
         undefined,
         { sessionId, workspaceId: workspace.id },
       );
+    },
+
+    // Interim PR auto-refresh until a GitHub webhook lands. Sweeps every
+    // session held in `state.sessions` (the active workspace's): head for all,
+    // detail for the one whose card is open. Each refresh is silent with one
+    // retry — polling errors don't deserve UI, transient gh failures get a
+    // second chance. No `force` — the 60s/30s caches absorb overlapping
+    // sweep / on-access / manual refreshes.
+    //
+    // Filters:
+    //   - archived sessions → hidden in the sidebar, polling them is waste.
+    //   - terminal PRs (merged/closed) → no new commits, CI, or reviews can
+    //     land. On-access still refreshes them so reopening shows current.
+    //   - `skipUnknownPr` → set by the steady-state interval. Sessions where
+    //     we already learned there's no PR (`pr === null` post-fetch) get
+    //     skipped, since the in-app PR-creation paths (`createPrForSession`
+    //     + the assistant-text URL detector + the summarizer hook) refresh
+    //     them explicitly. The reactive sweep (boot / workspace switch /
+    //     new session) still polls them once so PRs created from outside
+    //     the app are discovered.
+    sweepGithub: (opts) => {
+      if (!get().githubStatus?.available) return;
+      const archived = readArchivedSessions();
+      const { sessions, sessionBranches, sessionGithub, currentSessionId } = get();
+      const subOpts = { silent: true, retries: 1 } as const;
+      for (const session of sessions) {
+        if (archived[session.id]) continue;
+        if (!sessionBranches[session.id]) continue;
+        const cached = sessionGithub[session.id];
+        const pr = cached?.pr;
+        if (pr && (pr.state === 'merged' || pr.state === 'closed')) continue;
+        if (opts?.skipUnknownPr && cached?.fetchedAt && pr === null) continue;
+        const head = get().refreshSessionPr(session.id, subOpts);
+        if (session.id === currentSessionId) {
+          void head.then(() => get().refreshSessionPrDetail(session.id, subOpts));
+        }
+      }
     },
   };
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -546,8 +546,15 @@ export interface AppActions {
   refreshGithubStatus(): Promise<void>;
   setGithubPat(token: string): Promise<GhTokenStatus>;
   clearGithubToken(): Promise<void>;
-  refreshSessionPr(sessionId: SessionId, opts?: { force?: boolean }): Promise<void>;
-  refreshSessionPrDetail(sessionId: SessionId, opts?: { force?: boolean }): Promise<void>;
+  refreshSessionPr(
+    sessionId: SessionId,
+    opts?: { force?: boolean; silent?: boolean; retries?: number },
+  ): Promise<void>;
+  refreshSessionPrDetail(
+    sessionId: SessionId,
+    opts?: { force?: boolean; silent?: boolean; retries?: number },
+  ): Promise<void>;
+  sweepGithub(opts?: { skipUnknownPr?: boolean }): void;
   resolveGithubThread(
     sessionId: SessionId,
     threadId: string,
@@ -836,6 +843,20 @@ async function runSummarizer(
         await upsertContextSlot(tauriDatabase, sessionId, next);
       }),
     );
+
+    // If the summarizer carried a GitHub PR URL into any slot value and we
+    // still have no PR cached for this session, pull the PR state now so the
+    // polling sweep picks it up on its next tick. Complements the same regex
+    // run on raw assistant text post-turn — covers cases where the URL only
+    // surfaces in the summarized context, not in the verbatim turn output.
+    if (
+      !get().sessionGithub[sessionId]?.pr &&
+      result.delta.upserts.some((u) => /github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/.test(u.value))
+    ) {
+      void get()
+        .refreshSessionPr(sessionId, { force: true })
+        .then(() => void get().refreshSessionPrDetail(sessionId, { force: true }));
+    }
 
     const summarizerRunId = crypto.randomUUID() as ProviderRunId;
     const startedAt = now();
@@ -1557,6 +1578,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
         endSummary();
         markDone('summary');
       });
+
+    // GitHub PR: refresh head + detail for the opened session so its context
+    // panel shows fresh CI / review state on every visit. No `force` — the
+    // 60s/30s caches dedupe rapid back-and-forth between sessions.
+    if (get().sessionBranches[id]) {
+      void get()
+        .refreshSessionPr(id)
+        .then(() => get().refreshSessionPrDetail(id));
+    }
 
     // Telemetry
     if (!cached?.telemetry) {


### PR DESCRIPTION
## Summary
- New `sweepGithub` store action centralizes PR refresh across the active workspace's sessions. Triggered on boot, workspace switch, session-list/branch change, session open, and every 5 min while `document.visibilityState === 'visible'`. A visibility transition back to the foreground fires an immediate catch-up.
- The 5-min interval passes `{ skipUnknownPr: true }` and the sweep skips:
  - archived sessions (read via the new shared `readArchivedSessions` util),
  - terminal PRs (`merged` / `closed`),
  - sessions confirmed to have no PR after a successful fetch.
- PR creation inside the app is caught explicitly by three triggers, so `skipUnknownPr` is safe: `createPrForSession`, the existing post-turn assistant-text URL regex, and a new summarizer hook that scans slot upserts for PR URLs.
- Polling refreshes pass `{ silent: true, retries: 1 }` — one retry on transient gh failures, then swallow silently (no error chip from the timer). On-access (`setCurrentSession`) and manual refresh paths keep the existing error UI.
- Cleanup: removed the superseded `warmedRef` boot sweep from `WorkspacesSidebar` and the now-redundant first-visit PR-fetch effect from `ContextPanel`. All PR fetching now flows through `sweepGithub` (list-level) or the on-access path in `setCurrentSession` (session-level).

Interim stopgap until a GitHub webhook exists.

## Test plan
- [ ] Open the app cold with multiple workspaces; verify PR chips populate for the active workspace's sessions without a manual refresh.
- [ ] Switch workspace; verify sessions in the new workspace get fresh PR state.
- [ ] Open a session whose PR was created outside the app (`gh pr create` in a terminal) — verify it's picked up on the next reactive sweep (boot / workspace switch / session-list change) or at most within 5 min of being created (via the assistant-text or summarizer hook if mentioned in chat).
- [ ] Archive a session; verify it stops being polled (no PR chip refresh) without restarting the app.
- [ ] Merge / close a PR on github.com; verify the next reactive sweep updates the chip, then no further polling against that session.
- [ ] Background the app for >5 min; verify polling pauses (no gh activity in dev tools / process monitor) and returning to the foreground fires an immediate catch-up.
- [ ] Disconnect network briefly to force a gh failure; verify no error chip surfaces from polling, and that on-access / manual refresh still surface errors normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)