### PR TITLE
fix(desktop): annotate sweep opts param to fix ci typecheck

### DIFF
--- a/apps/desktop/src/store/slices/github.slice.ts
+++ b/apps/desktop/src/store/slices/github.slice.ts
@@ -378,7 +378,7 @@ export function createGithubSlice(set: SetFn, get: GetFn) {
     //     them explicitly. The reactive sweep (boot / workspace switch /
     //     new session) still polls them once so PRs created from outside
     //     the app are discovered.
-    sweepGithub: (opts) => {
+    sweepGithub: (opts?: { skipUnknownPr?: boolean }) => {
       if (!get().githubStatus?.available) return;
       const archived = readArchivedSessions();
       const { sessions, sessionBranches, sessionGithub, currentSessionId } = get();


### PR DESCRIPTION
## Summary
- Fixes a TS7006 introduced by #615: the slice-level `sweepGithub` definition relied on inference from the `AppActions` interface, which TS doesn't propagate through the `create()` spread. Annotate the `opts` param explicitly to match.

## Why this is on main already
- #615 was the original polling PR. The repo has no required status checks on `main`, so `gh pr merge --auto --squash` queued the merge and GitHub immediately merged it before CI completed. The polling code landed; only this typecheck regression needs a follow-up fix. Worth toggling "Require status checks to pass" in branch protection to prevent this class of slip.

## Test plan
- [ ] `pnpm turbo run typecheck` green locally.
- [ ] CI "lint + typecheck + test + build" green on this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)