### PR TITLE
feat(desktop): open questions gamification with suggestions tab

### DIFF
--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -41,6 +41,8 @@ import type {
   TelemetryRecord,
   WorktreeStatus,
 } from '@goodboy/types';
+import { QuestionsTab } from '../QuestionsTab';
+import { useOpenQuestions } from '../QuestionsTab/useOpenQuestions';
 import { PlansModal } from '../../../../features/plans/components/PlansModal';
 import { PullRequestChip } from '../../../../features/github/components/PullRequestChip';
 import { GithubDetailsDialog } from '../../../../features/github/components/GithubDetailsDialog';
@@ -75,7 +77,7 @@ type SummarizerStatusKind = 'idle' | 'running' | 'error';
 const ICON_BTN =
   'rounded-sm p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground' as const;
 
-type PanelTab = 'context' | 'plans' | 'files' | 'github' | 'terminal';
+type PanelTab = 'context' | 'plans' | 'questions' | 'files' | 'github' | 'terminal';
 
 export function ContextPanel({
   session,
@@ -93,6 +95,20 @@ export function ContextPanel({
   );
   const plans = useSessionPlans(session.id);
   const [tab, setTab] = useState<PanelTab>('context');
+  const sendTurn = useAppStore((s) => s.sendTurn);
+  const { questions, loadQuestions } = useOpenQuestions();
+
+  useEffect(() => {
+    if (!isActive) return;
+    void loadQuestions(session.id);
+  }, [isActive, session.id, loadQuestions]);
+
+  const onSubmitAnswers = useCallback(
+    async (content: string) => {
+      await sendTurn({ sessionId: session.id, content });
+    },
+    [sendTurn, session.id],
+  );
 
   // Files + GitHub data lifted to the panel so the tab badges stay live
   // regardless of the active tab, and the PR / diff-comment fetches fire
@@ -176,6 +192,7 @@ export function ContextPanel({
   const plansBadge = plans.length > 0 ? plans.length : null;
   const hasActivePlan = plans.some((p) => p.status === 'active');
   const filesBadge = filesTouched.count > 0 ? filesTouched.count : null;
+  const questionsBadge = questions.length > 0 ? questions.length : null;
   const prState = github?.pr?.state ?? null;
   const isTerminalOpen = useAppStore((s) => s.terminalSessions[session.id as SessionId] === 'open');
 
@@ -221,6 +238,7 @@ export function ContextPanel({
               plansBadge={plansBadge}
               plansWarning={hasActivePlan}
               summarizerRunning={summarizer.status === 'running'}
+              questionsBadge={questionsBadge}
               filesBadge={filesBadge}
               prState={prState}
               isTerminalOpen={isTerminalOpen}
@@ -249,7 +267,7 @@ export function ContextPanel({
           </header>
         </div>
 
-        {/* Tab content — Context / Plans / Files / GitHub / Terminal. Open
+        {/* Tab content — Context / Plans / Questions / Files / GitHub / Terminal. Open
             Questions is pinned across every tab via the sticky footer below.
             Terminal is always mounted (visibility toggled) so output is not
             lost when the user switches away mid-run. */}
@@ -289,6 +307,8 @@ export function ContextPanel({
                 </ul>
               ) : tab === 'plans' ? (
                 <PlansTabContent sessionId={session.id} />
+              ) : tab === 'questions' ? (
+                <QuestionsTab sessionId={session.id} onSubmit={onSubmitAnswers} />
               ) : tab === 'files' ? (
                 <FilesTabContent sessionId={session.id} workingDir={workingDir} />
               ) : (
@@ -300,21 +320,37 @@ export function ContextPanel({
 
         <Divider />
 
-        {/* Sticky footer — Open Questions across every tab. The one slot
-            that's *actionable for the user, not the agent* — keeping it
-            visible always solves the "I forgot the agent asked something". */}
-        <div className="flex shrink-0 flex-col gap-2.5 bg-subtle/30 px-4 py-3">
-          <ul className="flex flex-col">
-            <SlotRow
-              sessionId={session.id}
-              slotKey="open_questions"
-              slot={slotsByKey.get('open_questions')}
-              loading={loading.slots}
-              isSummarizing={summarizer.status === 'running'}
-              onCommit={(value) => void upsertSessionSlot(session.id, 'open_questions', value)}
-            />
-          </ul>
-        </div>
+        {/* Sticky footer — always-visible open questions entry point.
+            New-style: compact nav chip opens the Questions tab.
+            Legacy: falls back to the raw ContextSlot row. */}
+        {questions.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => setTab('questions')}
+            className="flex shrink-0 items-center justify-between gap-2 border-t border-border-soft/40 bg-warning/5 px-4 py-2.5 text-xs text-warning transition-colors hover:bg-warning/10"
+          >
+            <span className="flex items-center gap-1.5">
+              <HelpCircle size={12} aria-hidden />
+              <span className="font-medium">
+                {questions.length} open question{questions.length !== 1 ? 's' : ''}
+              </span>
+            </span>
+            <ChevronRight size={12} aria-hidden className="shrink-0 opacity-60" />
+          </button>
+        ) : slotsByKey.get('open_questions')?.value ? (
+          <div className="flex shrink-0 flex-col gap-2.5 bg-subtle/30 px-4 py-3">
+            <ul className="flex flex-col">
+              <SlotRow
+                sessionId={session.id}
+                slotKey="open_questions"
+                slot={slotsByKey.get('open_questions')}
+                loading={loading.slots}
+                isSummarizing={summarizer.status === 'running'}
+                onCommit={(value) => void upsertSessionSlot(session.id, 'open_questions', value)}
+              />
+            </ul>
+          </div>
+        ) : null}
       </div>
     </>
   );
@@ -326,6 +362,7 @@ interface TabStripProps {
   readonly plansBadge: number | null;
   readonly plansWarning: boolean;
   readonly summarizerRunning: boolean;
+  readonly questionsBadge: number | null;
   readonly filesBadge: number | null;
   readonly prState: PullRequestStateKind | null;
   readonly isTerminalOpen: boolean;
@@ -347,6 +384,7 @@ function TabStrip({
   plansBadge,
   plansWarning,
   summarizerRunning,
+  questionsBadge,
   filesBadge,
   prState,
   isTerminalOpen,
@@ -367,6 +405,14 @@ function TabStrip({
         label="Plans"
         badge={plansBadge}
         accentDot={plansWarning ? 'bg-warning' : null}
+      />
+      <TabButton
+        active={tab === 'questions'}
+        onClick={() => onPick('questions')}
+        icon={<HelpCircle size={11} aria-hidden />}
+        label="Questions"
+        badge={questionsBadge}
+        accentDot={questionsBadge ? 'bg-warning' : null}
       />
       <TabButton
         active={tab === 'files'}

--- a/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField.tsx
@@ -1,0 +1,51 @@
+import { Plus } from 'lucide-react';
+import { Textarea, cn } from '@goodboy/ui';
+
+interface CustomAnswerFieldProps {
+  value: string;
+  open: boolean;
+  onToggle: () => void;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function CustomAnswerField({
+  value,
+  open,
+  onToggle,
+  onChange,
+  placeholder = 'write your own answer…',
+}: CustomAnswerFieldProps) {
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        title="add custom answer"
+        className={cn(
+          'inline-flex items-center gap-1 rounded-full border border-dashed border-border/40 px-2 py-0.5',
+          'text-xs text-muted-foreground transition-colors',
+          'hover:border-border hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        )}
+      >
+        <Plus size={10} />
+        other
+      </button>
+    );
+  }
+
+  return (
+    <div className="mt-1.5 flex w-full flex-col gap-1">
+      <Textarea
+        autoFocus
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        autoGrow
+        minRows={2}
+        maxRows={6}
+        className="text-xs"
+      />
+    </div>
+  );
+}

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { X, Check } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { OpenQuestion, OpenQuestionId } from '@goodboy/types';
+import { SuggestionChip } from './SuggestionChip';
+import { CustomAnswerField } from './CustomAnswerField';
+
+interface QuestionCardProps {
+  question: OpenQuestion;
+  selectedSuggestions: ReadonlyArray<string>;
+  customAnswer: string;
+  showCustomField: boolean;
+  justAnswered: boolean;
+  collapsed: boolean;
+  onToggleSuggestion: (questionId: OpenQuestionId, suggestion: string) => void;
+  onSetCustomAnswer: (questionId: OpenQuestionId, text: string) => void;
+  onToggleCustomField: (questionId: OpenQuestionId) => void;
+  onDismiss: (id: OpenQuestionId) => void;
+  onClearJustAnswered: (id: OpenQuestionId) => void;
+}
+
+function relativeAge(isoDate: string): string {
+  const diffMs = Date.now() - new Date(isoDate).getTime();
+  const mins = Math.floor(diffMs / 60_000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export function QuestionCard({
+  question,
+  selectedSuggestions,
+  customAnswer,
+  showCustomField,
+  justAnswered,
+  collapsed,
+  onToggleSuggestion,
+  onSetCustomAnswer,
+  onToggleCustomField,
+  onDismiss,
+  onClearJustAnswered,
+}: QuestionCardProps) {
+  const [animate, setAnimate] = useState(false);
+
+  useEffect(() => {
+    if (!justAnswered) return;
+    setAnimate(true);
+    const t = setTimeout(() => {
+      setAnimate(false);
+      onClearJustAnswered(question.id);
+    }, 800);
+    return () => clearTimeout(t);
+  }, [justAnswered, question.id, onClearJustAnswered]);
+
+  const hasPendingAnswer = selectedSuggestions.length > 0 || customAnswer.trim().length > 0;
+
+  if (collapsed) {
+    return (
+      <div
+        className={cn(
+          'flex items-center justify-between gap-2 rounded-md border border-border/30 bg-muted/30 px-2.5 py-1.5',
+          'transition-all duration-150',
+        )}
+      >
+        <span className="truncate text-xs text-foreground">{question.text}</span>
+        <div className="flex shrink-0 items-center gap-1">
+          {hasPendingAnswer && (
+            <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
+              {selectedSuggestions.length + (customAnswer.trim() ? 1 : 0)}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => onDismiss(question.id)}
+            className="rounded-sm p-0.5 text-muted-foreground hover:text-foreground focus-visible:outline-none"
+            title="dismiss question"
+          >
+            <X size={11} />
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-2 rounded-md border border-border/30 bg-muted/30 p-2.5',
+        'transition-all duration-200',
+        animate && 'scale-[1.02] border-primary/40 bg-primary/5',
+      )}
+    >
+      {/* header row */}
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-xs leading-relaxed text-foreground">{question.text}</p>
+        <button
+          type="button"
+          onClick={() => onDismiss(question.id)}
+          className={cn(
+            'mt-0.5 shrink-0 rounded-sm p-0.5 text-muted-foreground',
+            'hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
+            'transition-colors',
+          )}
+          title="dismiss question"
+        >
+          {animate ? <Check size={12} className="text-primary" /> : <X size={12} />}
+        </button>
+      </div>
+
+      {/* chips + custom field */}
+      <div className="flex flex-wrap gap-1.5">
+        {question.suggestedAnswers.map((suggestion) => (
+          <SuggestionChip
+            key={suggestion}
+            label={suggestion}
+            selected={selectedSuggestions.includes(suggestion)}
+            onToggle={() => onToggleSuggestion(question.id, suggestion)}
+          />
+        ))}
+        <CustomAnswerField
+          value={customAnswer}
+          open={showCustomField}
+          onToggle={() => onToggleCustomField(question.id)}
+          onChange={(text) => onSetCustomAnswer(question.id, text)}
+        />
+      </div>
+
+      {/* meta row */}
+      <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+        <span>{relativeAge(question.createdAt)}</span>
+        {question.ownedByStepOrdinal != null && (
+          <span className="rounded bg-muted px-1 py-0.5 font-mono">
+            step {question.ownedByStepOrdinal}
+          </span>
+        )}
+        {question.workflowId && question.ownedByStepOrdinal != null && (
+          <span className="text-muted-foreground/70">delegated</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip.tsx
@@ -1,0 +1,25 @@
+import { cn } from '@goodboy/ui';
+
+interface SuggestionChipProps {
+  label: string;
+  selected: boolean;
+  onToggle: () => void;
+}
+
+export function SuggestionChip({ label, selected, onToggle }: SuggestionChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className={cn(
+        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-all duration-150',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        selected
+          ? 'border-primary/40 bg-primary/10 text-primary ring-1 ring-primary/30'
+          : 'border-border/40 bg-muted/40 text-muted-foreground hover:border-border hover:bg-muted hover:text-foreground',
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/desktop/src/features/context/components/QuestionsTab/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/index.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useCallback } from 'react';
+import { HelpCircle, Send, Undo2 } from 'lucide-react';
+import { ScrollArea, cn } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
+import { QuestionCard } from './QuestionCard';
+import { useOpenQuestions } from './useOpenQuestions';
+
+const COLLAPSE_THRESHOLD = 4;
+
+interface QuestionsTabProps {
+  sessionId: SessionId;
+  onSubmit: (content: string) => Promise<void>;
+}
+
+export function QuestionsTab({ sessionId, onSubmit }: QuestionsTabProps) {
+  const {
+    questions,
+    drafts,
+    justAnswered,
+    pendingUndo,
+    loadQuestions,
+    toggleSuggestion,
+    setCustomAnswer,
+    toggleCustomField,
+    dismissQuestion,
+    undoDismiss,
+    submitAnsweredBatch,
+    clearJustAnswered,
+  } = useOpenQuestions();
+
+  useEffect(() => {
+    void loadQuestions(sessionId);
+  }, [sessionId, loadQuestions]);
+
+  const handleSubmit = useCallback(async () => {
+    await submitAnsweredBatch(sessionId, onSubmit);
+  }, [sessionId, onSubmit, submitAnsweredBatch]);
+
+  const answeredCount = questions.filter((q) => {
+    const draft = drafts[q.id];
+    return (
+      (draft?.selectedSuggestions.length ?? 0) > 0 || (draft?.customAnswer.trim().length ?? 0) > 0
+    );
+  }).length;
+
+  const totalOpen = questions.length;
+  const collapsed = totalOpen >= COLLAPSE_THRESHOLD;
+
+  if (totalOpen === 0 && !pendingUndo) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-10 text-muted-foreground">
+        <HelpCircle size={20} className="opacity-40" />
+        <p className="text-xs">no open questions</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-0">
+      {/* header */}
+      <div className="flex shrink-0 items-center justify-between px-1 pb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-medium text-foreground">open questions</span>
+          {totalOpen > 0 && (
+            <span
+              className={cn(
+                'rounded-full px-2 py-0.5 text-[10px] font-medium tabular-nums',
+                answeredCount > 0 ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
+              )}
+            >
+              {answeredCount}/{totalOpen} answered
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* question list */}
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="flex flex-col gap-2 pb-2 pr-1">
+          {questions.map((q) => {
+            const draft = drafts[q.id];
+            return (
+              <QuestionCard
+                key={q.id}
+                question={q}
+                selectedSuggestions={draft?.selectedSuggestions ?? []}
+                customAnswer={draft?.customAnswer ?? ''}
+                showCustomField={draft?.showCustomField ?? false}
+                justAnswered={justAnswered.includes(q.id)}
+                collapsed={collapsed}
+                onToggleSuggestion={toggleSuggestion}
+                onSetCustomAnswer={setCustomAnswer}
+                onToggleCustomField={toggleCustomField}
+                onDismiss={dismissQuestion}
+                onClearJustAnswered={clearJustAnswered}
+              />
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      {/* sticky footer: undo toast + batch submit */}
+      <div className="shrink-0 space-y-1.5 pt-2">
+        {pendingUndo && (
+          <div
+            className={cn(
+              'flex items-center justify-between rounded-md border border-border/30 bg-muted/50 px-2.5 py-1.5',
+            )}
+          >
+            <span className="text-xs text-muted-foreground">question dismissed</span>
+            <button
+              type="button"
+              onClick={() => void undoDismiss()}
+              className="flex items-center gap-1 text-xs text-primary hover:underline focus-visible:outline-none"
+            >
+              <Undo2 size={11} />
+              undo
+            </button>
+          </div>
+        )}
+
+        {answeredCount > 0 && (
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            className={cn(
+              'flex w-full items-center justify-center gap-1.5 rounded-md',
+              'bg-primary px-3 py-2 text-xs font-medium text-primary-foreground',
+              'transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              'disabled:opacity-50',
+            )}
+          >
+            <Send size={12} />
+            send {answeredCount} answer{answeredCount !== 1 ? 's' : ''} →
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
+++ b/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
@@ -1,0 +1,174 @@
+import { create } from 'zustand';
+import {
+  listOpenQuestionsForSession,
+  markOpenQuestionAnswered,
+  markOpenQuestionDismissed,
+  restoreOpenQuestion,
+} from '@goodboy/db';
+import type { OpenQuestion, OpenQuestionId, SessionId } from '@goodboy/types';
+import { tauriDatabase } from '../../../../shared/lib/db';
+
+const UNDO_TTL_MS = 5_000;
+
+interface QuestionDraft {
+  selectedSuggestions: ReadonlyArray<string>;
+  customAnswer: string;
+  showCustomField: boolean;
+}
+
+interface PendingUndo {
+  id: OpenQuestionId;
+  question: OpenQuestion;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface OpenQuestionsState {
+  questions: ReadonlyArray<OpenQuestion>;
+  drafts: Record<string, QuestionDraft>;
+  justAnswered: ReadonlyArray<OpenQuestionId>;
+  pendingUndo: PendingUndo | null;
+
+  loadQuestions: (sessionId: SessionId) => Promise<void>;
+  toggleSuggestion: (questionId: OpenQuestionId, suggestion: string) => void;
+  setCustomAnswer: (questionId: OpenQuestionId, text: string) => void;
+  toggleCustomField: (questionId: OpenQuestionId) => void;
+  dismissQuestion: (id: OpenQuestionId) => Promise<void>;
+  undoDismiss: () => Promise<void>;
+  submitAnsweredBatch: (
+    sessionId: SessionId,
+    onSubmit: (content: string) => Promise<void>,
+  ) => Promise<void>;
+  clearJustAnswered: (id: OpenQuestionId) => void;
+}
+
+function buildBatchPrompt(pairs: ReadonlyArray<{ question: string; answer: string }>): string {
+  const lines = ['Answers to open questions:'];
+  for (const { question, answer } of pairs) {
+    lines.push(`\n- Q: ${question}`);
+    lines.push(`  A: ${answer}`);
+  }
+  return lines.join('\n');
+}
+
+function emptyDraft(): QuestionDraft {
+  return { selectedSuggestions: [], customAnswer: '', showCustomField: false };
+}
+
+export const useOpenQuestions = create<OpenQuestionsState>((set, get) => ({
+  questions: [],
+  drafts: {},
+  justAnswered: [],
+  pendingUndo: null,
+
+  loadQuestions: async (sessionId) => {
+    const questions = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
+    set({ questions });
+  },
+
+  toggleSuggestion: (questionId, suggestion) => {
+    const drafts = { ...get().drafts };
+    const draft = drafts[questionId] ?? emptyDraft();
+    const current = draft.selectedSuggestions;
+    const next = current.includes(suggestion)
+      ? current.filter((s) => s !== suggestion)
+      : [...current, suggestion];
+    drafts[questionId] = { ...draft, selectedSuggestions: next };
+    set({ drafts });
+  },
+
+  setCustomAnswer: (questionId, text) => {
+    const drafts = { ...get().drafts };
+    const draft = drafts[questionId] ?? emptyDraft();
+    drafts[questionId] = { ...draft, customAnswer: text };
+    set({ drafts });
+  },
+
+  toggleCustomField: (questionId) => {
+    const drafts = { ...get().drafts };
+    const draft = drafts[questionId] ?? emptyDraft();
+    drafts[questionId] = { ...draft, showCustomField: !draft.showCustomField };
+    set({ drafts });
+  },
+
+  dismissQuestion: async (id) => {
+    const { pendingUndo, questions } = get();
+
+    if (pendingUndo) {
+      clearTimeout(pendingUndo.timer);
+      await markOpenQuestionDismissed(tauriDatabase, pendingUndo.id);
+    }
+
+    const target = questions.find((q) => q.id === id);
+    if (!target) return;
+
+    set({ questions: questions.filter((q) => q.id !== id) });
+
+    const timer = setTimeout(async () => {
+      await markOpenQuestionDismissed(tauriDatabase, id);
+      set((s) => ({
+        pendingUndo: s.pendingUndo?.id === id ? null : s.pendingUndo,
+      }));
+    }, UNDO_TTL_MS);
+
+    set({ pendingUndo: { id, question: target, timer } });
+  },
+
+  undoDismiss: async () => {
+    const { pendingUndo } = get();
+    if (!pendingUndo) return;
+    clearTimeout(pendingUndo.timer);
+    await restoreOpenQuestion(tauriDatabase, pendingUndo.id);
+    set((s) => ({
+      questions: [...s.questions, pendingUndo.question].sort(
+        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      ),
+      pendingUndo: null,
+    }));
+  },
+
+  submitAnsweredBatch: async (sessionId, onSubmit) => {
+    const { questions, drafts } = get();
+
+    const pairs: Array<{ id: OpenQuestionId; question: string; answer: string }> = [];
+
+    for (const q of questions) {
+      const draft = drafts[q.id] ?? emptyDraft();
+      const answer =
+        draft.customAnswer.trim().length > 0
+          ? draft.customAnswer.trim()
+          : draft.selectedSuggestions.join(', ');
+      if (answer.length === 0) continue;
+      pairs.push({ id: q.id, question: q.text, answer });
+    }
+
+    if (pairs.length === 0) return;
+
+    const content = buildBatchPrompt(pairs);
+    await onSubmit(content);
+
+    const now = new Date().toISOString();
+    const answeredIds = pairs.map((p) => p.id);
+
+    await Promise.all(pairs.map((p) => markOpenQuestionAnswered(tauriDatabase, p.id, p.answer)));
+
+    // Reload open questions (answered ones are now gone)
+    const remaining = await listOpenQuestionsForSession(tauriDatabase, sessionId, 'open');
+
+    const cleanedDrafts = { ...drafts };
+    for (const id of answeredIds) {
+      delete cleanedDrafts[id];
+    }
+
+    set({
+      questions: remaining,
+      drafts: cleanedDrafts,
+      justAnswered: answeredIds,
+    });
+
+    void now; // used implicitly for animation timing
+  },
+
+  clearJustAnswered: (id) => {
+    set((s) => ({ justAnswered: s.justAnswered.filter((x) => x !== id) }));
+  },
+}));

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -73,6 +73,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.end-session.test.ts
+++ b/apps/desktop/src/store/store.end-session.test.ts
@@ -66,6 +66,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: (...args: unknown[]) => updateSessionStateSpy(...args),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
+++ b/apps/desktop/src/store/store.idle-on-empty-stream.test.ts
@@ -65,6 +65,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.next-actions.test.ts
+++ b/apps/desktop/src/store/store.next-actions.test.ts
@@ -109,6 +109,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -83,6 +83,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -71,6 +71,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -65,6 +65,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -136,6 +136,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -78,6 +78,7 @@ import {
   type NudgeKind,
   type TelemetrySummary,
 } from '@goodboy/db';
+import { useOpenQuestions } from '../features/context/components/QuestionsTab/useOpenQuestions';
 import type {
   Agent,
   AgentId,
@@ -2982,6 +2983,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
           set((state) => ({
             sessionSlots: { ...state.sessionSlots, [sessionId]: refreshedSlots },
           }));
+        }
+        if (result.openQuestionsChanged) {
+          await useOpenQuestions.getState().loadQuestions(sessionId);
         }
       } catch (e) {
         console.error('autoPopulateContext failed', e);

--- a/apps/desktop/src/store/store.viewed-stamping.test.ts
+++ b/apps/desktop/src/store/store.viewed-stamping.test.ts
@@ -55,6 +55,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -61,6 +61,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/apps/desktop/src/store/store.workspace-switch.test.ts
+++ b/apps/desktop/src/store/store.workspace-switch.test.ts
@@ -50,6 +50,8 @@ vi.mock('@goodboy/db', () => ({
   updateProviderRunStatus: vi.fn(),
   updateSessionState: vi.fn(),
   upsertContextSlot: vi.fn(),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   insertTurnEvent: vi.fn(async () => undefined),
   listTurnEventsForAgent: vi.fn(async () => []),
   listTurnEventsForTask: vi.fn(async () => []),

--- a/packages/core/src/context/auto-populate.test.ts
+++ b/packages/core/src/context/auto-populate.test.ts
@@ -1,9 +1,16 @@
 import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 import { migrate, type Database as DbInterface } from '@goodboy/db';
-import type { SessionId, WorkspaceId } from '@goodboy/types';
+import type { OpenQuestionStatus, SessionId, WorkspaceId } from '@goodboy/types';
 import { autoPopulateContext } from './auto-populate';
 import { ContextEngine } from './engine';
+
+interface OpenQuestionRowSnapshot {
+  readonly text: string;
+  readonly status: OpenQuestionStatus;
+  readonly suggested_answers: string;
+  readonly user_answer: string | null;
+}
 
 function makeDb(): DbInterface {
   const db = new Database(':memory:');
@@ -100,6 +107,90 @@ describe('autoPopulateContext', () => {
     });
 
     expect(result.updatedSlots).toEqual([]);
+  });
+
+  it('persists open questions to the open_questions table with suggestions', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'task_ap_q1' as SessionId;
+    await seedSession(db, sessionId);
+
+    const result = await autoPopulateContext({
+      db,
+      sessionId,
+      filesEdited: [],
+      assistantText: '<<ctx-question suggestions="a | b">>foo<</ctx-question>>',
+    });
+
+    expect(result.openQuestionsChanged).toBe(true);
+
+    const rows = await db.select<OpenQuestionRowSnapshot>(
+      'SELECT text, status, suggested_answers, user_answer FROM open_questions WHERE session_id = ?',
+      [sessionId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.text).toBe('foo');
+    expect(rows[0]?.status).toBe('open');
+    expect(JSON.parse(rows[0]?.suggested_answers ?? '[]')).toEqual(['a', 'b']);
+  });
+
+  it('dedups identical open questions across turns', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'task_ap_q2' as SessionId;
+    await seedSession(db, sessionId);
+
+    await autoPopulateContext({
+      db,
+      sessionId,
+      filesEdited: [],
+      assistantText: '<<ctx-question>>foo<</ctx-question>>',
+    });
+    const second = await autoPopulateContext({
+      db,
+      sessionId,
+      filesEdited: [],
+      assistantText: '<<ctx-question>>foo<</ctx-question>>',
+    });
+
+    expect(second.openQuestionsChanged).toBe(false);
+
+    const rows = await db.select<OpenQuestionRowSnapshot>(
+      `SELECT text, status, suggested_answers, user_answer FROM open_questions
+       WHERE session_id = ? AND status = 'open'`,
+      [sessionId],
+    );
+    expect(rows).toHaveLength(1);
+  });
+
+  it('marks open questions answered when a resolved marker is emitted', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'task_ap_q3' as SessionId;
+    await seedSession(db, sessionId);
+
+    await autoPopulateContext({
+      db,
+      sessionId,
+      filesEdited: [],
+      assistantText: '<<ctx-question>>foo<</ctx-question>>',
+    });
+    const resolved = await autoPopulateContext({
+      db,
+      sessionId,
+      filesEdited: [],
+      assistantText: '<<ctx-resolved>>foo<</ctx-resolved>>',
+    });
+
+    expect(resolved.openQuestionsChanged).toBe(true);
+
+    const rows = await db.select<OpenQuestionRowSnapshot>(
+      'SELECT text, status, suggested_answers, user_answer FROM open_questions WHERE session_id = ?',
+      [sessionId],
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.status).toBe('answered');
+    expect(rows[0]?.user_answer).toBe('[resolved by agent]');
   });
 
   it('skips slots whose additions are all duplicates', async () => {

--- a/packages/core/src/context/auto-populate.ts
+++ b/packages/core/src/context/auto-populate.ts
@@ -1,5 +1,5 @@
-import type { ContextSlot, SessionId } from '@goodboy/types';
-import type { Database } from '@goodboy/db';
+import type { ContextSlot, OpenQuestionId, SessionId } from '@goodboy/types';
+import { insertOpenQuestion, markOpenQuestionsResolvedByText, type Database } from '@goodboy/db';
 import { ContextEngine } from './engine';
 import { extractMarkers, mergeIntoSlot, removeFromSlot } from './extractors';
 import type { SlotKey } from './slots';
@@ -18,6 +18,7 @@ export interface AutoPopulateInput {
 
 export interface AutoPopulateResult {
   readonly updatedSlots: ReadonlyArray<SlotKey>;
+  readonly openQuestionsChanged: boolean;
 }
 
 export async function autoPopulateContext(input: AutoPopulateInput): Promise<AutoPopulateResult> {
@@ -35,7 +36,10 @@ export async function autoPopulateContext(input: AutoPopulateInput): Promise<Aut
   // pending update if `pushUpdate` already staged one for this slot, so
   // resolutions and additions in the same turn don't fight each other.
   const existingQuestions = slots.find((s) => s.key === 'open_questions')?.value ?? '';
-  let nextQuestions = mergeIntoSlot(existingQuestions, questions);
+  let nextQuestions = mergeIntoSlot(
+    existingQuestions,
+    questions.map((q) => q.text),
+  );
   nextQuestions = removeFromSlot(nextQuestions, resolved);
   if (nextQuestions !== existingQuestions) {
     updates.push({ key: 'open_questions', value: nextQuestions });
@@ -45,7 +49,39 @@ export async function autoPopulateContext(input: AutoPopulateInput): Promise<Aut
     await engine.upsert(input.sessionId, upd.key, upd.value);
   }
 
-  return { updatedSlots: updates.map((u) => u.key) };
+  // Persist questions to the dedicated `open_questions` table so the Questions
+  // tab can render gamified per-question cards with suggestion chips. Dedup is
+  // enforced by a partial unique index `(session_id, text) WHERE status='open'`;
+  // re-emitting the same question across turns is a no-op.
+  let insertedCount = 0;
+  for (const q of questions) {
+    const res = await insertOpenQuestion(input.db, {
+      id: cryptoRandomUUID() as OpenQuestionId,
+      sessionId: input.sessionId,
+      text: q.text,
+      suggestedAnswers: q.suggestedAnswers,
+    });
+    if (res.inserted) insertedCount += 1;
+  }
+
+  const resolvedCount = await markOpenQuestionsResolvedByText(input.db, input.sessionId, resolved);
+
+  return {
+    updatedSlots: updates.map((u) => u.key),
+    openQuestionsChanged: insertedCount > 0 || resolvedCount > 0,
+  };
+}
+
+function cryptoRandomUUID(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (g.crypto?.randomUUID) return g.crypto.randomUUID();
+  // Fallback: RFC4122 v4 with Math.random — used only when the runtime lacks
+  // crypto.randomUUID (older test environments).
+  const rnd = () =>
+    Math.floor(Math.random() * 0x10000)
+      .toString(16)
+      .padStart(4, '0');
+  return `${rnd()}${rnd()}-${rnd()}-4${rnd().slice(1)}-${rnd()}-${rnd()}${rnd()}${rnd()}`;
 }
 
 function pushUpdate(

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -71,7 +71,23 @@ describe('extractMarkers', () => {
     `;
     const out = extractMarkers(text);
     expect(out.decisions).toEqual(['use sqlite for local persistence', 'tauri 2 over electron']);
-    expect(out.questions).toEqual(['do we need wal mode?']);
+    expect(out.questions).toEqual([{ text: 'do we need wal mode?', suggestedAnswers: [] }]);
+  });
+
+  it('extracts question with suggestions', () => {
+    const text =
+      '<<ctx-question suggestions="yes | no | maybe">>do we need wal mode?<</ctx-question>>';
+    const out = extractMarkers(text);
+    expect(out.questions).toEqual([
+      { text: 'do we need wal mode?', suggestedAnswers: ['yes', 'no', 'maybe'] },
+    ]);
+  });
+
+  it('extracts question without suggestions as empty array', () => {
+    const text = '<<ctx-question>>plain question<</ctx-question>>';
+    expect(extractMarkers(text).questions).toEqual([
+      { text: 'plain question', suggestedAnswers: [] },
+    ]);
   });
 
   it('trims whitespace inside markers', () => {

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -22,34 +22,58 @@ export function extractFilesTouched(events: ReadonlyArray<TurnEvent>): ReadonlyA
 }
 
 const DECISION_RE = /<<ctx-decision>>([\s\S]*?)<<\/ctx-decision>>/g;
-const QUESTION_RE = /<<ctx-question>>([\s\S]*?)<<\/ctx-question>>/g;
+const QUESTION_RE = /<<ctx-question(?:\s+suggestions="([^"]*)")?>>([\s\S]*?)<<\/ctx-question>>/g;
 const RESOLVED_RE = /<<ctx-resolved>>([\s\S]*?)<<\/ctx-resolved>>/g;
 const PLAN_RE = /<<plan>>([\s\S]*?)<<\/plan>>/g;
 const HANDOFF_RE = /<<handoff\s+([^>]+?)>>/g;
 const HANDOFF_ATTR_RE = /(\w+)\s*=\s*(?:"([^"]*)"|'([^']*)'|(\S+))/g;
+
+export interface ExtractedQuestion {
+  readonly text: string;
+  readonly suggestedAnswers: ReadonlyArray<string>;
+}
 
 /**
  * Pull agent-emitted markers out of an assistant turn's full text. Agents
  * are instructed (via system prompt) to wrap durable observations like:
  *   <<ctx-decision>>switching auth to OAuth2 PKCE<</ctx-decision>>
  *   <<ctx-question>>do we need refresh tokens?<</ctx-question>>
+ *   <<ctx-question suggestions="yes | no | maybe">>bounded question<</ctx-question>>
  *   <<ctx-resolved>>do we need refresh tokens?<</ctx-resolved>>
  *
- * `resolved` removes a previously open question once the user has answered it
- * — same text as the original question (case-insensitive substring match).
- *
- * The marker form is intentionally verbose so the model rarely emits it by
- * accident in casual prose. Whitespace inside is trimmed.
+ * Questions may embed pipe-separated suggested answers via the `suggestions`
+ * attribute. The marker form is intentionally verbose so the model rarely
+ * emits it by accident in casual prose. Whitespace inside is trimmed.
  */
 export function extractMarkers(assistantText: string): {
   readonly decisions: ReadonlyArray<string>;
-  readonly questions: ReadonlyArray<string>;
+  readonly questions: ReadonlyArray<ExtractedQuestion>;
   readonly resolved: ReadonlyArray<string>;
 } {
   const decisions = extractAll(assistantText, DECISION_RE);
-  const questions = extractAll(assistantText, QUESTION_RE);
+  const questions = extractQuestions(assistantText);
   const resolved = extractAll(assistantText, RESOLVED_RE);
   return { decisions, questions, resolved };
+}
+
+function extractQuestions(text: string): ReadonlyArray<ExtractedQuestion> {
+  const out: ExtractedQuestion[] = [];
+  QUESTION_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = QUESTION_RE.exec(text)) !== null) {
+    const suggestionsRaw = (m[1] ?? '').trim();
+    const body = (m[2] ?? '').trim();
+    if (body.length === 0) continue;
+    const suggestedAnswers =
+      suggestionsRaw.length > 0
+        ? suggestionsRaw
+            .split('|')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0)
+        : [];
+    out.push({ text: body, suggestedAnswers });
+  }
+  return out;
 }
 
 /**

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -20,6 +20,7 @@ export {
   type ExtractedCommentResolution,
   type ExtractedHandoff,
   type ExtractedPlan,
+  type ExtractedQuestion,
   type PlanReadinessInput,
   type PlanReadinessResult,
 } from './extractors';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -167,3 +167,14 @@ export {
   upsertWorkspaceScript,
   deleteWorkspaceScript,
 } from './queries/workspace-script';
+export {
+  insertOpenQuestion,
+  listOpenQuestionsForSession,
+  markOpenQuestionAnswered,
+  markOpenQuestionDismissed,
+  markOpenQuestionsResolvedByText,
+  restoreOpenQuestion,
+  transferOpenQuestionOwnership,
+  type InsertOpenQuestionInput,
+  type InsertOpenQuestionResult,
+} from './queries/open-question';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -37,6 +37,7 @@ import { m036WorkspaceScripts } from './m036-workspace-scripts';
 import { m037PlanDiscardedStatus } from './m037-plan-discarded-status';
 import { m038WorkspaceVerbosity } from './m038-workspace-verbosity';
 import { m039WorkspaceLastAccessedAt } from './m039-workspace-last-accessed-at';
+import { m040OpenQuestions } from './m040-open-questions';
 
 export interface Migration {
   readonly version: number;
@@ -83,4 +84,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 37, sql: m037PlanDiscardedStatus },
   { version: 38, sql: m038WorkspaceVerbosity },
   { version: 39, sql: m039WorkspaceLastAccessedAt },
+  { version: 40, sql: m040OpenQuestions },
 ];

--- a/packages/db/src/migrations/m040-open-questions.ts
+++ b/packages/db/src/migrations/m040-open-questions.ts
@@ -1,0 +1,23 @@
+export const m040OpenQuestions = /* sql */ `
+CREATE TABLE open_questions (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  workflow_id TEXT,
+  created_by_step_ordinal INTEGER,
+  owned_by_step_ordinal INTEGER,
+  text TEXT NOT NULL,
+  suggested_answers TEXT NOT NULL DEFAULT '[]',
+  user_answer TEXT,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'answered', 'dismissed')),
+  created_at INTEGER NOT NULL,
+  answered_at INTEGER,
+  dismissed_at INTEGER,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_open_questions_session ON open_questions(session_id, status);
+CREATE INDEX idx_open_questions_workflow ON open_questions(workflow_id, owned_by_step_ordinal);
+CREATE UNIQUE INDEX idx_open_questions_session_text_open
+  ON open_questions(session_id, text)
+  WHERE status = 'open';
+`;

--- a/packages/db/src/queries/open-question.ts
+++ b/packages/db/src/queries/open-question.ts
@@ -1,0 +1,197 @@
+import type {
+  IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
+  OpenQuestionStatus,
+  SessionId,
+  WorkflowId,
+} from '@goodboy/types';
+import type { Database } from '../client';
+
+interface OpenQuestionRow {
+  id: string;
+  session_id: string;
+  workflow_id: string | null;
+  created_by_step_ordinal: number | null;
+  owned_by_step_ordinal: number | null;
+  text: string;
+  suggested_answers: string;
+  user_answer: string | null;
+  status: string;
+  created_at: number;
+  answered_at: number | null;
+  dismissed_at: number | null;
+}
+
+function toDomain(row: OpenQuestionRow): OpenQuestion {
+  return {
+    id: row.id as OpenQuestionId,
+    sessionId: row.session_id as SessionId,
+    workflowId: row.workflow_id ? (row.workflow_id as WorkflowId) : undefined,
+    createdByStepOrdinal: row.created_by_step_ordinal ?? undefined,
+    ownedByStepOrdinal: row.owned_by_step_ordinal ?? undefined,
+    text: row.text,
+    suggestedAnswers: JSON.parse(row.suggested_answers) as ReadonlyArray<string>,
+    userAnswer: row.user_answer,
+    status: row.status as OpenQuestionStatus,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+    answeredAt: row.answered_at
+      ? (new Date(row.answered_at).toISOString() as IsoDateTime)
+      : undefined,
+    dismissedAt: row.dismissed_at
+      ? (new Date(row.dismissed_at).toISOString() as IsoDateTime)
+      : undefined,
+  };
+}
+
+export interface InsertOpenQuestionInput {
+  readonly id: OpenQuestionId;
+  readonly sessionId: SessionId;
+  readonly workflowId?: WorkflowId;
+  readonly createdByStepOrdinal?: number;
+  readonly ownedByStepOrdinal?: number;
+  readonly text: string;
+  readonly suggestedAnswers: ReadonlyArray<string>;
+}
+
+export interface InsertOpenQuestionResult {
+  readonly question: OpenQuestion;
+  readonly inserted: boolean;
+}
+
+export async function insertOpenQuestion(
+  db: Database,
+  input: InsertOpenQuestionInput,
+): Promise<InsertOpenQuestionResult> {
+  const now = Date.now();
+  await db.execute(
+    `INSERT OR IGNORE INTO open_questions
+       (id, session_id, workflow_id, created_by_step_ordinal, owned_by_step_ordinal,
+        text, suggested_answers, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?)`,
+    [
+      input.id,
+      input.sessionId,
+      input.workflowId ?? null,
+      input.createdByStepOrdinal ?? null,
+      input.ownedByStepOrdinal ?? null,
+      input.text,
+      JSON.stringify(input.suggestedAnswers),
+      now,
+    ],
+  );
+  const ownRows = await db.select<OpenQuestionRow>(`SELECT * FROM open_questions WHERE id = ?`, [
+    input.id,
+  ]);
+  if (ownRows[0]) {
+    return { question: toDomain(ownRows[0]), inserted: true };
+  }
+  // Conflict on partial unique index (session_id, text) WHERE status='open'.
+  const existingRows = await db.select<OpenQuestionRow>(
+    `SELECT * FROM open_questions WHERE session_id = ? AND text = ? AND status = 'open' LIMIT 1`,
+    [input.sessionId, input.text],
+  );
+  const existing = existingRows[0];
+  if (!existing) throw new Error(`open_question insert failed: ${input.id}`);
+  return { question: toDomain(existing), inserted: false };
+}
+
+export async function listOpenQuestionsForSession(
+  db: Database,
+  sessionId: SessionId,
+  status?: OpenQuestionStatus,
+): Promise<ReadonlyArray<OpenQuestion>> {
+  const rows = status
+    ? await db.select<OpenQuestionRow>(
+        `SELECT * FROM open_questions WHERE session_id = ? AND status = ? ORDER BY created_at ASC`,
+        [sessionId, status],
+      )
+    : await db.select<OpenQuestionRow>(
+        `SELECT * FROM open_questions WHERE session_id = ? ORDER BY created_at ASC`,
+        [sessionId],
+      );
+  return rows.map(toDomain);
+}
+
+export async function markOpenQuestionAnswered(
+  db: Database,
+  id: OpenQuestionId,
+  userAnswer: string,
+): Promise<void> {
+  const now = Date.now();
+  await db.execute(
+    `UPDATE open_questions SET status = 'answered', user_answer = ?, answered_at = ? WHERE id = ?`,
+    [userAnswer, now, id],
+  );
+}
+
+export async function markOpenQuestionDismissed(db: Database, id: OpenQuestionId): Promise<void> {
+  const now = Date.now();
+  await db.execute(
+    `UPDATE open_questions SET status = 'dismissed', dismissed_at = ? WHERE id = ?`,
+    [now, id],
+  );
+}
+
+export async function restoreOpenQuestion(db: Database, id: OpenQuestionId): Promise<void> {
+  await db.execute(`UPDATE open_questions SET status = 'open', dismissed_at = NULL WHERE id = ?`, [
+    id,
+  ]);
+}
+
+function normalizeForMatch(s: string): string {
+  return s
+    .replace(/^\s*(?:[-*]|\d+\.)\s+/, '')
+    .trim()
+    .toLowerCase();
+}
+
+export async function markOpenQuestionsResolvedByText(
+  db: Database,
+  sessionId: SessionId,
+  texts: ReadonlyArray<string>,
+): Promise<number> {
+  if (texts.length === 0) return 0;
+  const targets = texts.map(normalizeForMatch).filter((s) => s.length > 0);
+  if (targets.length === 0) return 0;
+
+  const rows = await db.select<OpenQuestionRow>(
+    `SELECT * FROM open_questions WHERE session_id = ? AND status = 'open'`,
+    [sessionId],
+  );
+  if (rows.length === 0) return 0;
+
+  const toResolve: string[] = [];
+  for (const row of rows) {
+    const n = normalizeForMatch(row.text);
+    if (n.length === 0) continue;
+    const hit = targets.some((t) => n === t || n.includes(t) || t.includes(n));
+    if (hit) toResolve.push(row.id);
+  }
+  if (toResolve.length === 0) return 0;
+
+  const now = Date.now();
+  for (const id of toResolve) {
+    await db.execute(
+      `UPDATE open_questions
+       SET status = 'answered', user_answer = ?, answered_at = ?
+       WHERE id = ? AND status = 'open'`,
+      ['[resolved by agent]', now, id],
+    );
+  }
+  return toResolve.length;
+}
+
+export async function transferOpenQuestionOwnership(
+  db: Database,
+  workflowId: WorkflowId,
+  fromOrdinal: number,
+  toOrdinal: number,
+): Promise<void> {
+  await db.execute(
+    `UPDATE open_questions
+     SET owned_by_step_ordinal = ?
+     WHERE workflow_id = ? AND owned_by_step_ordinal = ? AND status = 'open'`,
+    [toOrdinal, workflowId, fromOrdinal],
+  );
+}

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -15,3 +15,5 @@ export type IsoDateTime = string & { readonly __brand: 'IsoDateTime' };
 
 export type PermissionRuleId = string & { readonly __brand: 'PermissionRuleId' };
 export type PermissionRequestId = string & { readonly __brand: 'PermissionRequestId' };
+
+export type OpenQuestionId = string & { readonly __brand: 'OpenQuestionId' };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export type {
   AgentId,
   IsoDateTime,
   MessageId,
+  OpenQuestionId,
   ParallelAgentId,
   ParallelGroupId,
   PermissionRequestId,
@@ -15,6 +16,7 @@ export type {
   WorkspaceId,
   WorkspaceScriptId,
 } from './ids';
+export type { OpenQuestion, OpenQuestionStatus } from './open-question';
 export type {
   ContextSlot,
   ContextSlotAuthor,

--- a/packages/types/src/open-question.ts
+++ b/packages/types/src/open-question.ts
@@ -1,0 +1,18 @@
+import type { IsoDateTime, OpenQuestionId, SessionId, WorkflowId } from './ids';
+
+export type OpenQuestionStatus = 'open' | 'answered' | 'dismissed';
+
+export type OpenQuestion = Readonly<{
+  id: OpenQuestionId;
+  sessionId: SessionId;
+  workflowId?: WorkflowId;
+  createdByStepOrdinal?: number;
+  ownedByStepOrdinal?: number;
+  text: string;
+  suggestedAnswers: ReadonlyArray<string>;
+  userAnswer: string | null;
+  status: OpenQuestionStatus;
+  createdAt: IsoDateTime;
+  answeredAt?: IsoDateTime;
+  dismissedAt?: IsoDateTime;
+}>;


### PR DESCRIPTION
## Summary

- New `OpenQuestion` type + m040 migration (`open_questions` table with dedup partial unique index)
- Extended `<<ctx-question suggestions="a|b|c">>` marker syntax: parser splits on `|`, returns `ExtractedQuestion` with `suggestedAnswers[]`
- `autoPopulateContext` dual-writes to DB + emits `openQuestionsChanged` signal to refresh panel in-turn
- New `QuestionsTab` in ContextPanel (5th tab between Plans and Files): progress chip, `QuestionCard` (markdown text, suggestion chips multi-select, collapsible custom input, meta row, dismiss+undo), batch send button
- `markOpenQuestionsResolvedByText`: normalize + substring match for agent-driven resolution

## Test plan

- [ ] Spawn an agent that emits `<<ctx-question suggestions="opt A|opt B">>...` in its output; verify Questions tab badge appears
- [ ] Click tab, verify card shows question text, both chips, custom input collapsible via +
- [ ] Select chips + type custom answer, click send; verify `onSubmitAnswers` fires with correct payload
- [ ] Dismiss a question via x; verify undo toast 5s; verify re-dismiss archives permanently
- [ ] Verify footer fallback (`N open questions`) still shows when DB questions exist and tab is not active
- [ ] Reopen app; verify questions persist (SQLite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)