### PR TITLE
feat(repo): add presentation website

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -23,6 +23,9 @@
     "packages/ui": {
       "entry": ["src/**/*.test.{ts,tsx}"],
       "project": ["src/**/*.{ts,tsx}"]
+    },
+    "website": {
+      "project": ["src/**/*.{ts,tsx}"]
     }
   }
 }

--- a/website/.claude/launch.json
+++ b/website/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "goodboy-website",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 1499
+    }
+  ]
+}

--- a/website/SEO.md
+++ b/website/SEO.md
@@ -1,0 +1,217 @@
+# SEO . Goodboy website
+
+Questo file descrive tutto ciò che serve a un agente (o a te) per mantenere, aggiornare ed estendere la SEO del sito senza doverla riscoprire da zero.
+
+---
+
+## Stato attuale
+
+| Layer                       | File                  | Status        |
+| --------------------------- | --------------------- | ------------- |
+| Robots                      | `public/robots.txt`   | ✓ presente    |
+| Sitemap                     | `public/sitemap.xml`  | ✓ presente    |
+| OG image (SVG placeholder)  | `public/og-image.svg` | ✓ presente    |
+| OG image (PNG produzione)   | `public/og-image.png` | ⚠ da generare |
+| Meta tags completi          | `index.html`          | ✓ completo    |
+| JSON-LD SoftwareApplication | `index.html`          | ✓ presente    |
+| Twitter/X card              | `index.html`          | ✓ presente    |
+| Canonical                   | `index.html`          | ✓ presente    |
+
+---
+
+## Dominio di produzione
+
+Placeholder attuale: `https://goodboy.dev/`
+
+Quando il dominio cambia, cerca e sostituisci `goodboy.dev` in:
+
+- `public/robots.txt` (Sitemap:)
+- `public/sitemap.xml` (<loc>)
+- `index.html` (canonical, og:url, og:image, twitter:image)
+
+```bash
+# find & replace rapido
+grep -rn "goodboy.dev" website/public/ website/index.html
+```
+
+---
+
+## OG image
+
+### Problema attuale
+
+`og:image` punta a `https://goodboy.dev/og-image.png`. Il file PNG non esiste ancora . c'è solo `og-image.svg` (placeholder usabile in sviluppo, non valido per crawler che richiedono PNG/JPG).
+
+### Come generare il PNG
+
+Opzione A . Puppeteer one-liner (headless Chrome):
+
+```bash
+cd website
+node -e "
+const puppeteer = require('puppeteer');
+(async () => {
+  const b = await puppeteer.launch();
+  const p = await b.newPage();
+  await p.setViewport({ width: 1200, height: 630 });
+  await p.goto('file://' + process.cwd() + '/public/og-image.svg');
+  await p.screenshot({ path: 'public/og-image.png', type: 'png' });
+  await b.close();
+  console.log('done');
+})();
+"
+```
+
+Opzione B . tool online: carica `public/og-image.svg` su [Squoosh](https://squoosh.app/) → esporta PNG 1200×630.
+
+Opzione C . sito live: usa `mcp__Claude_Preview__preview_screenshot` sulla pagina `/og-image.svg` a 1200×630 e salva come PNG.
+
+### Quando aggiornare l'OG image
+
+- Cambio tagline
+- Nuovo logo
+- Nuovo major version (es. v1.0)
+- Cambio palette
+
+---
+
+## Meta tags . posizione e logica
+
+Tutti i meta risiedono in `website/index.html` (app SPA . unico HTML). Non ci sono route secondarie da gestire.
+
+### Gerarchia consigliata (già presente)
+
+```
+1. <title>           . testo puro, max 60 char
+2. meta description  . 120–160 char, include differenziator principale
+3. og:title/desc     . può essere leggermente più lungo del <title>
+4. twitter:*         . stessa copia di OG (summary_large_image)
+5. canonical         . https://goodboy.dev/ sempre con trailing slash
+6. JSON-LD           . SoftwareApplication schema
+```
+
+### Regole di copy SEO
+
+- keyword primaria nella prima frase: "AI workspace orchestrator"
+- keyword secondarie: "local-first", "multi-agent", "Claude Cursor Codex", "developer tools"
+- niente keyword stuffing: le parole chiave vanno nei testi del sito, non solo nei meta
+- `<title>` format: `[Product] . [tagline corta]` (es. "Goodboy . AI workspace orchestrator")
+
+---
+
+## JSON-LD . SoftwareApplication
+
+Definito inline in `index.html`. Campi da tenere aggiornati:
+
+| Campo             | Dove aggiornare                                      |
+| ----------------- | ---------------------------------------------------- |
+| `softwareVersion` | Ad ogni release (v0.7 → v0.8 → v1.0)                 |
+| `featureList`     | Quando si aggiungono/rimuovono features dal prodotto |
+| `offers.price`    | Quando arriva il pricing                             |
+| `operatingSystem` | Se si aggiunge mobile/web                            |
+
+Schema reference: [schema.org/SoftwareApplication](https://schema.org/SoftwareApplication)
+
+Validare con: [Google Rich Results Test](https://search.google.com/test/rich-results) o [Schema.org Validator](https://validator.schema.org/).
+
+---
+
+## Sitemap
+
+`public/sitemap.xml` . SPA con un solo URL, quindi una sola `<url>`.
+
+### Quando aggiornare
+
+- Cambio URL del sito
+- Aggiunta di pagine separate (es. `/docs`, `/blog`)
+- Cambio significativo al contenuto del sito → aggiorna `<lastmod>`
+
+### Se diventa multi-page
+
+Aggiungi ogni URL come `<url>` separato. `<priority>` consigliata:
+
+- `/` → 1.0
+- `/docs` → 0.8
+- `/blog/[post]` → 0.6
+
+---
+
+## Robots.txt
+
+`public/robots.txt` . attuale configurazione: tutto crawlabile.
+
+Modificare solo se:
+
+- Si aggiunge un admin panel o route privata → `Disallow: /admin`
+- Si aggiungono route parametriche di debug → `Disallow: /?*`
+
+Non bloccare mai `/` o le risorse statiche (CSS/JS/immagini) . penalizza il rendering Google.
+
+---
+
+## Checklist pre-deploy
+
+- [ ] Sostituire `goodboy.dev` con il dominio reale
+- [ ] Generare `public/og-image.png` (1200×630 px, < 8 MB)
+- [ ] Verificare JSON-LD con Google Rich Results Test
+- [ ] Aggiornare `<lastmod>` in `sitemap.xml` con la data di deploy
+- [ ] Aggiornare `twitter:site` in `index.html` con l'handle Twitter reale
+- [ ] Submit sitemap su Google Search Console: `https://search.google.com/search-console`
+- [ ] Submit sitemap su Bing Webmaster Tools (opzionale ma gratuito)
+- [ ] Verificare che `og:image` risponda 200 con content-type corretto
+
+---
+
+## Checklist post-deploy
+
+- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) sull'URL di produzione
+- [ ] [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) . verifica unfurl OG
+- [ ] [Twitter Card Validator](https://cards-dev.twitter.com/validator) . verifica card
+- [ ] [PageSpeed Insights](https://pagespeed.web.dev/) . target LCP < 2.5s, CLS < 0.1
+- [ ] Controlla che `robots.txt` risponda su `https://[domain]/robots.txt`
+- [ ] Controlla che `sitemap.xml` risponda su `https://[domain]/sitemap.xml`
+
+---
+
+## Performance SEO
+
+Il sito già ottimizzato per Core Web Vitals:
+
+- bundle JS: 248kB raw / 73kB gzip (Vite tree-shaking)
+- CSS: 31kB raw / 7kB gzip
+- no layout shift: altezze definite, niente skeleton dinamici
+- font: system font stack (nessuna Google Fonts request)
+- immagini: solo SVG inline . nessun LCP da bitmap
+
+Se si aggiungono immagini reali (screenshots dell'app):
+
+- formato WebP con fallback JPG
+- attributi `width` e `height` sempre presenti
+- `loading="lazy"` per immagini sotto the fold
+- `loading="eager"` + `fetchpriority="high"` per l'hero image
+
+---
+
+## Internazionalizzazione (non attiva)
+
+Il sito è English-only. Se si aggiunge l'italiano:
+
+- aggiungere `<link rel="alternate" hreflang="it" href="https://goodboy.dev/it/" />`
+- aggiungere `<link rel="alternate" hreflang="en" href="https://goodboy.dev/" />`
+- aggiungere `<link rel="alternate" hreflang="x-default" href="https://goodboy.dev/" />`
+
+---
+
+## File map
+
+```
+website/
+├── index.html              ← tutti i meta tags, JSON-LD
+├── public/
+│   ├── robots.txt          ← crawl policy + sitemap pointer
+│   ├── sitemap.xml         ← URL index
+│   ├── favicon.svg         ← browser tab icon
+│   ├── og-image.svg        ← og image placeholder (dev)
+│   └── og-image.png        ← og image produzione (da generare)
+└── SEO.md                  ← questo file
+```

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+    <!-- Primary -->
+    <title>Goodboy: AI workspace orchestrator</title>
+    <meta name="description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
+    <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
+    <meta name="author" content="Amin Khayam" />
+    <link rel="canonical" href="https://goodboy.dev/" />
+
+    <!-- Open Graph (Facebook, LinkedIn, Slack unfurls) -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Goodboy" />
+    <meta property="og:url" content="https://goodboy.dev/" />
+    <meta property="og:title" content="Goodboy: AI workspace orchestrator" />
+    <meta property="og:description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta property="og:image" content="https://goodboy.dev/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Goodboy: AI workspace orchestrator" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter / X card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@akhayam99" />
+    <meta name="twitter:creator" content="@akhayam99" />
+    <meta name="twitter:title" content="Goodboy: AI workspace orchestrator" />
+    <meta name="twitter:description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
+    <meta name="twitter:image:alt" content="Goodboy: AI workspace orchestrator" />
+
+    <!-- Theme / PWA hints -->
+    <meta name="theme-color" content="#1a1c26" />
+    <meta name="color-scheme" content="dark" />
+
+    <!-- JSON-LD: SoftwareApplication -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      "name": "Goodboy",
+      "description": "AI workspace orchestrator. Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first desktop app.",
+      "url": "https://goodboy.dev/",
+      "applicationCategory": "DeveloperApplication",
+      "operatingSystem": "macOS, Windows, Linux",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD",
+        "description": "Open source under MIT license"
+      },
+      "author": {
+        "@type": "Person",
+        "name": "Amin Khayam",
+        "url": "https://github.com/akhayam99"
+      },
+      "license": "https://opensource.org/licenses/MIT",
+      "codeRepository": "https://github.com/akhayam99/goodboy",
+      "keywords": ["AI orchestrator", "Claude", "Cursor", "Codex", "multi-agent", "local-first", "developer tools"],
+      "featureList": [
+        "Multi-provider routing (Claude, Cursor, Codex)",
+        "Shared context panel across agents",
+        "Multi-agent sessions with role assignment",
+        "Plans as first-class artifacts",
+        "Workflow presets (scout → planner → implementer → reviewer)",
+        "GitHub PR integration",
+        "Per-session budget control",
+        "Permission proxy and audit trail",
+        "Workspace skills and slash-commands",
+        "Git worktree per session",
+        "VS Code and Cursor editor integration"
+      ]
+    }
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/website/package.json
+++ b/website/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "goodboy-website",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 1499 --host",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --port 1499"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "@tailwindcss/vite": "^4.0.0",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.6.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -1,0 +1,1924 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.0.0
+        version: 4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.15)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.3.0
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+packages:
+  '@babel/code-frame@7.29.0':
+    resolution:
+      {
+        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/compat-data@7.29.3':
+    resolution:
+      {
+        integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/core@7.29.0':
+    resolution:
+      {
+        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/generator@7.29.1':
+    resolution:
+      {
+        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution:
+      {
+        integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-globals@7.28.0':
+    resolution:
+      {
+        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution:
+      {
+        integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution:
+      {
+        integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
+      }
+    engines: { node: '>=6.9.0' }
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution:
+      {
+        integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution:
+      {
+        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution:
+      {
+        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution:
+      {
+        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/helpers@7.29.2':
+    resolution:
+      {
+        integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/parser@7.29.3':
+    resolution:
+      {
+        integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution:
+      {
+        integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==,
+      }
+    engines: { node: '>=6.9.0' }
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution:
+      {
+        integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==,
+      }
+    engines: { node: '>=6.9.0' }
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution:
+      {
+        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/traverse@7.29.0':
+    resolution:
+      {
+        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@babel/types@7.29.0':
+    resolution:
+      {
+        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution:
+      {
+        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution:
+      {
+        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution:
+      {
+        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+      }
+    engines: { node: '>=18' }
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution:
+      {
+        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+      }
+    engines: { node: '>=18' }
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution:
+      {
+        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+      }
+    engines: { node: '>=18' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution:
+      {
+        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+      }
+    engines: { node: '>=18' }
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution:
+      {
+        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
+      }
+    engines: { node: '>=18' }
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
+
+  '@jridgewell/remapping@2.3.5':
+    resolution:
+      {
+        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+      }
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: '>=6.0.0' }
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution:
+      {
+        integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==,
+      }
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution:
+      {
+        integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==,
+      }
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==,
+      }
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==,
+      }
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==,
+      }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution:
+      {
+        integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution:
+      {
+        integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution:
+      {
+        integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution:
+      {
+        integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==,
+      }
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution:
+      {
+        integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution:
+      {
+        integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution:
+      {
+        integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==,
+      }
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution:
+      {
+        integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==,
+      }
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution:
+      {
+        integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==,
+      }
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution:
+      {
+        integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==,
+      }
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution:
+      {
+        integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution:
+      {
+        integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==,
+      }
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.3.0':
+    resolution:
+      {
+        integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==,
+      }
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    resolution:
+      {
+        integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution:
+      {
+        integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    resolution:
+      {
+        integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    resolution:
+      {
+        integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    resolution:
+      {
+        integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution:
+      {
+        integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution:
+      {
+        integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution:
+      {
+        integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution:
+      {
+        integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    resolution:
+      {
+        integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==,
+      }
+    engines: { node: '>=14.0.0' }
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution:
+      {
+        integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution:
+      {
+        integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==,
+      }
+    engines: { node: '>= 20' }
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.0':
+    resolution:
+      {
+        integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==,
+      }
+    engines: { node: '>= 20' }
+
+  '@tailwindcss/vite@4.3.0':
+    resolution:
+      {
+        integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==,
+      }
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/babel__core@7.20.5':
+    resolution:
+      {
+        integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==,
+      }
+
+  '@types/babel__generator@7.27.0':
+    resolution:
+      {
+        integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==,
+      }
+
+  '@types/babel__template@7.4.4':
+    resolution:
+      {
+        integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==,
+      }
+
+  '@types/babel__traverse@7.28.0':
+    resolution:
+      {
+        integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
+      }
+
+  '@types/estree@1.0.8':
+    resolution:
+      {
+        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
+      }
+
+  '@types/react-dom@19.2.3':
+    resolution:
+      {
+        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
+      }
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution:
+      {
+        integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==,
+      }
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution:
+      {
+        integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.32:
+    resolution:
+      {
+        integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==,
+      }
+    engines: { node: '>=6.0.0' }
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution:
+      {
+        integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
+
+  caniuse-lite@1.0.30001793:
+    resolution:
+      {
+        integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==,
+      }
+
+  convert-source-map@2.0.0:
+    resolution:
+      {
+        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
+      }
+
+  csstype@3.2.3:
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
+
+  debug@4.4.3:
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: '>=6.0' }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: '>=8' }
+
+  electron-to-chromium@1.5.361:
+    resolution:
+      {
+        integrity: sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==,
+      }
+
+  enhanced-resolve@5.22.0:
+    resolution:
+      {
+        integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==,
+      }
+    engines: { node: '>=10.13.0' }
+
+  esbuild@0.25.12:
+    resolution:
+      {
+        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
+      }
+    engines: { node: '>=18' }
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution:
+      {
+        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
+      }
+    engines: { node: '>=6' }
+
+  fdir@6.5.0:
+    resolution:
+      {
+        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
+      }
+    engines: { node: '>=12.0.0' }
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution:
+      {
+        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution:
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: '>=6.9.0' }
+
+  graceful-fs@4.2.11:
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
+
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution:
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
+
+  jsesc@3.1.0:
+    resolution:
+      {
+        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
+      }
+    engines: { node: '>=6' }
+    hasBin: true
+
+  json5@2.2.3:
+    resolution:
+      {
+        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
+      }
+    engines: { node: '>=6' }
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: '>= 12.0.0' }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+
+  lru-cache@5.1.1:
+    resolution:
+      {
+        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
+      }
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  nanoid@3.3.12:
+    resolution:
+      {
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  node-releases@2.0.46:
+    resolution:
+      {
+        integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==,
+      }
+    engines: { node: '>=18' }
+
+  picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+
+  picomatch@4.0.4:
+    resolution:
+      {
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+      }
+    engines: { node: '>=12' }
+
+  postcss@8.5.15:
+    resolution:
+      {
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  react-dom@19.2.6:
+    resolution:
+      {
+        integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==,
+      }
+    peerDependencies:
+      react: ^19.2.6
+
+  react-refresh@0.17.0:
+    resolution:
+      {
+        integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  react@19.2.6:
+    resolution:
+      {
+        integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  rollup@4.60.4:
+    resolution:
+      {
+        integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==,
+      }
+    engines: { node: '>=18.0.0', npm: '>=8.0.0' }
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution:
+      {
+        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
+      }
+
+  semver@6.3.1:
+    resolution:
+      {
+        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
+      }
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: '>=0.10.0' }
+
+  tailwindcss@4.3.0:
+    resolution:
+      {
+        integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==,
+      }
+
+  tapable@2.3.3:
+    resolution:
+      {
+        integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
+      }
+    engines: { node: '>=6' }
+
+  tinyglobby@0.2.16:
+    resolution:
+      {
+        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
+      }
+    engines: { node: '>=12.0.0' }
+
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: '>=14.17' }
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution:
+      {
+        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+      }
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@6.4.2:
+    resolution:
+      {
+        integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==,
+      }
+    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution:
+      {
+        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
+      }
+
+snapshots:
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.22.0
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.0
+
+  '@tailwindcss/oxide-android-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.0':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-darwin-x64': 4.3.0
+      '@tailwindcss/oxide-freebsd-x64': 4.3.0
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/vite@4.3.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.2(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.32: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.32
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.361
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001793: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  electron-to-chromium@1.5.361: {}
+
+  enhanced-resolve@5.22.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.46: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.6: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  tailwindcss@4.3.0: {}
+
+  tapable@2.3.3: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@6.4.2(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.60.4
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  yallist@3.1.1: {}

--- a/website/public/favicon.svg
+++ b/website/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="oklch(0.25 0.006 255)"/>
+  <!-- DogMascot scaled to fit 32x32 (original 24x24 viewBox, centered with padding) -->
+  <g transform="translate(4,4) scale(1)">
+    <!-- left ear -->
+    <path d="M9 8.5Q4.3 7.7 3 11.5Q2.5 15.5 4.8 17.3Q6.8 18.2 7.2 15.3Q6.7 12.5 6.3 10.3Q6 8.9 9 8.5Z" fill="oklch(0.78 0.13 200)"/>
+    <!-- right ear -->
+    <path d="M15 8.5Q19.7 7.7 21 11.5Q21.5 15.5 19.2 17.3Q17.2 18.2 16.8 15.3Q17.3 12.5 17.7 10.3Q18 8.9 15 8.5Z" fill="oklch(0.78 0.13 200)"/>
+    <!-- head + eyes + nose (evenodd) -->
+    <path fill-rule="evenodd" d="M7.5 13a4.5 5.1 0 1 0 9 0a4.5 5.1 0 1 0-9 0ZM9.3 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM12.5 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM10.7 14.4Q12 16.2 13.3 14.4Q12 13.7 10.7 14.4Z" fill="oklch(0.78 0.13 200)"/>
+  </g>
+</svg>

--- a/website/public/og-image.svg
+++ b/website/public/og-image.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1a1c26"/>
+      <stop offset="100%" stop-color="#141520"/>
+    </linearGradient>
+    <linearGradient id="title" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e8eef5"/>
+      <stop offset="50%" stop-color="#9dcfdd"/>
+      <stop offset="100%" stop-color="#5a9bb5"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9dcfdd"/>
+      <stop offset="100%" stop-color="#7b6fcc"/>
+    </linearGradient>
+    <linearGradient id="logo-g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#9dcfdd"/>
+      <stop offset="100%" stop-color="#4e88a6"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+
+  <!-- Grid lines -->
+  <g stroke="#2a2d3e" stroke-width="1" opacity="0.6">
+    <line x1="0" y1="90" x2="1200" y2="90"/>
+    <line x1="0" y1="180" x2="1200" y2="180"/>
+    <line x1="0" y1="270" x2="1200" y2="270"/>
+    <line x1="0" y1="360" x2="1200" y2="360"/>
+    <line x1="0" y1="450" x2="1200" y2="450"/>
+    <line x1="0" y1="540" x2="1200" y2="540"/>
+    <line x1="90" y1="0" x2="90" y2="630"/>
+    <line x1="180" y1="0" x2="180" y2="630"/>
+    <line x1="270" y1="0" x2="270" y2="630"/>
+    <line x1="360" y1="0" x2="360" y2="630"/>
+    <line x1="450" y1="0" x2="450" y2="630"/>
+    <line x1="540" y1="0" x2="540" y2="630"/>
+    <line x1="630" y1="0" x2="630" y2="630"/>
+    <line x1="720" y1="0" x2="720" y2="630"/>
+    <line x1="810" y1="0" x2="810" y2="630"/>
+    <line x1="900" y1="0" x2="900" y2="630"/>
+    <line x1="990" y1="0" x2="990" y2="630"/>
+    <line x1="1080" y1="0" x2="1080" y2="630"/>
+    <line x1="1170" y1="0" x2="1170" y2="630"/>
+  </g>
+
+  <!-- Glow -->
+  <ellipse cx="600" cy="200" rx="500" ry="200" fill="#4fbcd4" opacity="0.06"/>
+
+  <!-- Logo . DogMascot @ 44px, then wordmark -->
+  <g transform="translate(88,64) scale(1.83)">
+    <path d="M9 8.5Q4.3 7.7 3 11.5Q2.5 15.5 4.8 17.3Q6.8 18.2 7.2 15.3Q6.7 12.5 6.3 10.3Q6 8.9 9 8.5Z" fill="url(#logo-g)"/>
+    <path d="M15 8.5Q19.7 7.7 21 11.5Q21.5 15.5 19.2 17.3Q17.2 18.2 16.8 15.3Q17.3 12.5 17.7 10.3Q18 8.9 15 8.5Z" fill="url(#logo-g)"/>
+    <path fill-rule="evenodd" d="M7.5 13a4.5 5.1 0 1 0 9 0a4.5 5.1 0 1 0-9 0ZM9.3 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM12.5 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM10.7 14.4Q12 16.2 13.3 14.4Q12 13.7 10.7 14.4Z" fill="url(#logo-g)"/>
+  </g>
+  <text x="144" y="94" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="24" font-weight="600" fill="#e8eef5" letter-spacing="-0.3">Goodboy</text>
+
+  <!-- Main headline -->
+  <text x="88" y="230" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="80" font-weight="700" fill="url(#title)" letter-spacing="-2">AI workspace</text>
+  <text x="88" y="320" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="80" font-weight="700" fill="url(#accent)" letter-spacing="-2">orchestrator.</text>
+
+  <!-- Sub -->
+  <text x="88" y="400" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-size="26" fill="#8899aa" letter-spacing="-0.2">Local-first · Provider-agnostic · Your machine, your keys, your data</text>
+
+  <!-- Pills -->
+  <rect x="88" y="456" width="148" height="36" rx="18" fill="#1e2733" stroke="#3a4455"/>
+  <circle cx="112" cy="474" r="5" fill="#d4a059"/>
+  <text x="125" y="479" font-family="monospace" font-size="16" fill="#c8a870">Anthropic</text>
+
+  <rect x="248" y="456" width="120" height="36" rx="18" fill="#1e2733" stroke="#3a4455"/>
+  <circle cx="272" cy="474" r="5" fill="#9580cc"/>
+  <text x="285" y="479" font-family="monospace" font-size="16" fill="#b09cd4">Cursor</text>
+
+  <rect x="380" y="456" width="110" height="36" rx="18" fill="#1e2733" stroke="#3a4455"/>
+  <circle cx="404" cy="474" r="5" fill="#66c490"/>
+  <text x="417" y="479" font-family="monospace" font-size="16" fill="#8ed4aa">Codex</text>
+
+  <rect x="502" y="456" width="124" height="36" rx="18" fill="#1e2733" stroke="#3a4455"/>
+  <circle cx="526" cy="474" r="5" fill="#4fbcd4"/>
+  <text x="539" y="479" font-family="monospace" font-size="16" fill="#7dcfe0">SQLite</text>
+
+  <!-- Badge -->
+  <rect x="88" y="550" width="200" height="32" rx="16" fill="#1a2830" stroke="#2a4855"/>
+  <circle cx="112" cy="566" r="5" fill="#4fbcd4"/>
+  <text x="125" y="571" font-family="-apple-system, sans-serif" font-size="15" fill="#7dcfe0">v0.7 · private beta</text>
+</svg>

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://goodboy.dev/sitemap.xml

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://goodboy.dev/</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,0 +1,33 @@
+import { Nav } from './sections/Nav';
+import { Hero } from './sections/Hero';
+import { LogoStrip } from './sections/LogoStrip';
+import { FeatureGrid } from './sections/FeatureGrid';
+import { ContextDeepDive } from './sections/ContextDeepDive';
+import { RoutingDeepDive } from './sections/RoutingDeepDive';
+import { PlansDeepDive } from './sections/PlansDeepDive';
+import { GithubDeepDive } from './sections/GithubDeepDive';
+import { Comparison } from './sections/Comparison';
+import { Stack } from './sections/Stack';
+import { CTA } from './sections/CTA';
+import { Footer } from './sections/Footer';
+
+export function App() {
+  return (
+    <div className="relative min-h-screen overflow-x-hidden">
+      <Nav />
+      <main>
+        <Hero />
+        <LogoStrip />
+        <FeatureGrid />
+        <ContextDeepDive />
+        <RoutingDeepDive />
+        <PlansDeepDive />
+        <GithubDeepDive />
+        <Comparison />
+        <Stack />
+        <CTA />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/website/src/components/DogMascot.tsx
+++ b/website/src/components/DogMascot.tsx
@@ -1,0 +1,27 @@
+interface DogMascotProps {
+  size?: number;
+  className?: string;
+}
+
+// Goodboy mascot. Solid dog face ("musetto"). Single-color (currentColor):
+// two floppy ears + a rounded head; eyes and nose are knocked out (evenodd)
+// so the background shows through. Reads as a dog from 16px up to hero sizes.
+export function DogMascot({ size = 16, className }: DogMascotProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+      className={className}
+    >
+      <path d="M9 8.5Q4.3 7.7 3 11.5Q2.5 15.5 4.8 17.3Q6.8 18.2 7.2 15.3Q6.7 12.5 6.3 10.3Q6 8.9 9 8.5Z" />
+      <path d="M15 8.5Q19.7 7.7 21 11.5Q21.5 15.5 19.2 17.3Q17.2 18.2 16.8 15.3Q17.3 12.5 17.7 10.3Q18 8.9 15 8.5Z" />
+      <path
+        fillRule="evenodd"
+        d="M7.5 13a4.5 5.1 0 1 0 9 0a4.5 5.1 0 1 0-9 0ZM9.3 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM12.5 12a1.1 1.1 0 1 0 2.2 0a1.1 1.1 0 1 0-2.2 0ZM10.7 14.4Q12 16.2 13.3 14.4Q12 13.7 10.7 14.4Z"
+      />
+    </svg>
+  );
+}

--- a/website/src/components/Icons.tsx
+++ b/website/src/components/Icons.tsx
@@ -1,0 +1,197 @@
+// Minimal inline SVGs that match the lucide-react icons used in the real
+// Goodboy app. Pure presentational. No deps, no runtime overhead.
+
+type P = { size?: number; className?: string };
+
+function S({ size = 14, className, children }: P & { children: React.ReactNode }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const IconChevronRight = (p: P) => (
+  <S {...p}>
+    <path d="m9 18 6-6-6-6" />
+  </S>
+);
+export const IconChevronDown = (p: P) => (
+  <S {...p}>
+    <path d="m6 9 6 6 6-6" />
+  </S>
+);
+export const IconPlus = (p: P) => (
+  <S {...p}>
+    <path d="M5 12h14M12 5v14" />
+  </S>
+);
+export const IconMore = (p: P) => (
+  <S {...p}>
+    <circle cx="12" cy="12" r="1" />
+    <circle cx="19" cy="12" r="1" />
+    <circle cx="5" cy="12" r="1" />
+  </S>
+);
+export const IconSettings = (p: P) => (
+  <S {...p}>
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+    <circle cx="12" cy="12" r="3" />
+  </S>
+);
+export const IconList = (p: P) => (
+  <S {...p}>
+    <path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01" />
+  </S>
+);
+export const IconTarget = (p: P) => (
+  <S {...p}>
+    <circle cx="12" cy="12" r="10" />
+    <circle cx="12" cy="12" r="6" />
+    <circle cx="12" cy="12" r="2" />
+  </S>
+);
+export const IconSparkles = (p: P) => (
+  <S {...p}>
+    <path d="M9.5 3 11 7l4 1.5L11 10l-1.5 4L8 10l-4-1.5L8 7zM18 4l1 2 2 1-2 1-1 2-1-2-2-1 2-1zM18 15l1 2 2 1-2 1-1 2-1-2-2-1 2-1z" />
+  </S>
+);
+export const IconWand = (p: P) => (
+  <S {...p}>
+    <path d="M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8 19 13M15 9h.01M17.8 6.2 19 5M3 21l9-9M12.2 6.2 11 5" />
+  </S>
+);
+export const IconHelp = (p: P) => (
+  <S {...p}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
+  </S>
+);
+export const IconClipboard = (p: P) => (
+  <S {...p}>
+    <rect width="8" height="4" x="8" y="2" rx="1" ry="1" />
+    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+  </S>
+);
+export const IconBook = (p: P) => (
+  <S {...p}>
+    <path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H20v20H6.5a2.5 2.5 0 0 1 0-5H20" />
+  </S>
+);
+export const IconEdit = (p: P) => (
+  <S {...p}>
+    <path d="M21 13.5V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5.5M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </S>
+);
+export const IconPullRequest = (p: P) => (
+  <S {...p}>
+    <circle cx="6" cy="6" r="3" />
+    <circle cx="6" cy="18" r="3" />
+    <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+    <circle cx="18" cy="18" r="3" />
+  </S>
+);
+export const IconWorkflow = (p: P) => (
+  <S {...p}>
+    <rect width="8" height="8" x="3" y="3" rx="2" />
+    <path d="M7 11v4a2 2 0 0 0 2 2h4" />
+    <rect width="8" height="8" x="13" y="13" rx="2" />
+  </S>
+);
+export const IconPlay = (p: P) => (
+  <S {...p}>
+    <polygon points="6 3 20 12 6 21 6 3" />
+  </S>
+);
+export const IconSearch = (p: P) => (
+  <S {...p}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </S>
+);
+export const IconSend = (p: P) => (
+  <S {...p}>
+    <path d="m22 2-7 20-4-9-9-4z" />
+    <path d="M22 2 11 13" />
+  </S>
+);
+export const IconPanelLeft = (p: P) => (
+  <S {...p}>
+    <rect width="18" height="18" x="3" y="3" rx="2" />
+    <path d="M9 3v18" />
+  </S>
+);
+export const IconDollar = (p: P) => (
+  <S {...p}>
+    <line x1="12" y1="2" x2="12" y2="22" />
+    <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+  </S>
+);
+export const IconSun = (p: P) => (
+  <S {...p}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+  </S>
+);
+export const IconFolder = (p: P) => (
+  <S {...p}>
+    <path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.93a2 2 0 0 1-1.66-.9l-.82-1.2A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z" />
+  </S>
+);
+export const IconTerminal = (p: P) => (
+  <S {...p}>
+    <path d="m4 17 6-6-6-6M12 19h8" />
+  </S>
+);
+export const IconLock = (p: P) => (
+  <S {...p}>
+    <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </S>
+);
+export const IconArrowDown = (p: P) => (
+  <S {...p}>
+    <path d="M12 5v14M19 12l-7 7-7-7" />
+  </S>
+);
+export const IconArrowUp = (p: P) => (
+  <S {...p}>
+    <path d="M12 19V5M5 12l7-7 7 7" />
+  </S>
+);
+export const IconClock = (p: P) => (
+  <S {...p}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M12 6v6l4 2" />
+  </S>
+);
+export const IconBranch = (p: P) => (
+  <S {...p}>
+    <line x1="6" y1="3" x2="6" y2="15" />
+    <circle cx="18" cy="6" r="3" />
+    <circle cx="6" cy="18" r="3" />
+    <path d="M18 9a9 9 0 0 1-9 9" />
+  </S>
+);
+export const IconArchive = (p: P) => (
+  <S {...p}>
+    <rect width="20" height="5" x="2" y="3" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8M10 12h4" />
+  </S>
+);
+export const IconCheck = (p: P) => (
+  <S {...p}>
+    <path d="M20 6 9 17l-5-5" />
+  </S>
+);

--- a/website/src/components/Logo.tsx
+++ b/website/src/components/Logo.tsx
@@ -1,0 +1,10 @@
+import { DogMascot } from './DogMascot';
+
+export function Logo({ size = 28 }: { size?: number }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <DogMascot size={size} className="text-[oklch(0.78_0.13_200)]" />
+      <span className="text-[17px] font-semibold tracking-tight">Goodboy</span>
+    </div>
+  );
+}

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+export function Section({
+  id,
+  eyebrow,
+  title,
+  body,
+  reverse,
+  children,
+}: {
+  id?: string;
+  eyebrow: string;
+  title: ReactNode;
+  body: ReactNode;
+  reverse?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} className="py-28 relative">
+      <div className="mx-auto max-w-7xl px-6">
+        <div
+          className={`grid lg:grid-cols-2 gap-14 lg:gap-24 items-center ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
+        >
+          <div className="max-w-lg">
+            <div className="text-[11px] uppercase tracking-[0.2em] text-[oklch(0.82_0.12_200)] pb-4">
+              {eyebrow}
+            </div>
+            <h2 className="text-[36px] sm:text-[48px] tracking-[-0.025em] font-bold leading-[1.02]">
+              {title}
+            </h2>
+            <div className="mt-6 text-[16px] text-[oklch(0.72_0.012_255)] leading-[1.65] space-y-4">
+              {body}
+            </div>
+          </div>
+          <div>{children}</div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/main.tsx
+++ b/website/src/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './App';
+import './styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/website/src/mockups/AppMockup.tsx
+++ b/website/src/mockups/AppMockup.tsx
@@ -1,0 +1,720 @@
+/* eslint-disable react-refresh/only-export-components */
+/**
+ * Hero app mockup. Faithful pseudo-data reproduction of the Goodboy desktop
+ * UI. Mirrors layout, palette, density, and iconography from
+ * apps/desktop/src/. Colors track the app's @theme tokens:
+ *   bg          oklch(0.25 0.006 255)
+ *   subtle      oklch(0.29 0.008 255)
+ *   muted       oklch(0.33 0.010 255)
+ *   elevated    oklch(0.37 0.011 255)
+ *   border      oklch(0.40 0.012 255)
+ *   border-soft oklch(0.32 0.010 255)
+ *   primary     oklch(0.74 0.11 200)  (teal/cyan accent)
+ *   foreground  oklch(0.91 0.006 90)
+ *   muted-fg    oklch(0.68 0.015 255)
+ */
+
+import {
+  IconArchive,
+  IconArrowDown,
+  IconArrowUp,
+  IconBook,
+  IconBranch,
+  IconChevronDown,
+  IconChevronRight,
+  IconClipboard,
+  IconClock,
+  IconDollar,
+  IconEdit,
+  IconFolder,
+  IconHelp,
+  IconList,
+  IconLock,
+  IconPanelLeft,
+  IconPlus,
+  IconPullRequest,
+  IconSearch,
+  IconSend,
+  IconSettings,
+  IconSparkles,
+  IconSun,
+  IconTarget,
+  IconTerminal,
+  IconWand,
+  IconWorkflow,
+} from '../components/Icons';
+import { DogMascot } from '../components/DogMascot';
+
+const C = {
+  bg: 'bg-[oklch(0.25_0.006_255)]',
+  subtle: 'bg-[oklch(0.29_0.008_255)]',
+  muted40: 'bg-[oklch(0.33_0.010_255_/_0.4)]',
+  muted60: 'bg-[oklch(0.33_0.010_255_/_0.6)]',
+  elevated: 'bg-[oklch(0.37_0.011_255)]',
+  border: 'border-[oklch(0.40_0.012_255)]',
+  borderSoft: 'border-[oklch(0.32_0.010_255)]',
+  fg: 'text-[oklch(0.91_0.006_90)]',
+  mutedFg: 'text-[oklch(0.68_0.015_255)]',
+  dimFg: 'text-[oklch(0.55_0.015_255)]',
+  faintFg: 'text-[oklch(0.50_0.015_255)]',
+  primary: 'text-[oklch(0.78_0.13_200)]',
+  primaryRing: 'ring-[oklch(0.74_0.11_200_/_0.45)]',
+  primaryBg: 'bg-[oklch(0.74_0.11_200_/_0.10)]',
+};
+
+function WindowChrome() {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2.5 bg-[oklch(0.27_0.008_255)] border-b border-[oklch(0.32_0.010_255)]">
+      <span className="h-3 w-3 rounded-full bg-[oklch(0.63_0.17_22)]" />
+      <span className="h-3 w-3 rounded-full bg-[oklch(0.76_0.13_78)]" />
+      <span className="h-3 w-3 rounded-full bg-[oklch(0.69_0.13_148)]" />
+    </div>
+  );
+}
+
+// chip colors mirror AGENT_KIND_PALETTE in apps/desktop/src/features/session/agent-kind.ts
+const KIND_BG = {
+  agent: 'bg-[oklch(0.84_0.16_82)]', // amber-400
+  plan: 'bg-[oklch(0.74_0.16_295)]', // violet-400
+  imple: 'bg-[oklch(0.77_0.15_162)]', // emerald-400
+  review: 'bg-[oklch(0.79_0.13_213)]', // cyan-400
+  scout: 'bg-[oklch(0.76_0.13_232)]', // sky-400
+  debug: 'bg-[oklch(0.84_0.16_82)]', // amber-400
+} as const;
+
+function KindChip({ kind }: { kind: keyof typeof KIND_BG }) {
+  return (
+    <span
+      className={[
+        'inline-flex shrink-0 items-center justify-center rounded px-1.5 py-px text-[9px] font-semibold uppercase tracking-wide leading-none text-zinc-950',
+        KIND_BG[kind],
+      ].join(' ')}
+    >
+      {kind}
+    </span>
+  );
+}
+
+/**
+ * Workspace selector row at the very top of the sidebar.
+ * Mirrors WorkspaceSelect: outline pills, current one filled.
+ */
+function WorkspaceSelectorRow() {
+  return (
+    <div className={`flex items-center gap-1 px-2.5 pt-2.5 pb-1.5 border-b ${C.borderSoft}`}>
+      <button className="flex items-center gap-1 rounded border border-[oklch(0.40_0.012_255_/_0.6)] bg-transparent px-1.5 py-0.5 text-[10px] text-[oklch(0.72_0.012_255)]">
+        app-web
+        <IconSettings size={9} className="opacity-50" />
+      </button>
+      <button
+        className={`flex items-center gap-1 rounded border ${C.border} ${C.elevated} px-1.5 py-0.5 text-[10px] ${C.fg}`}
+      >
+        goodboy
+        <IconSettings size={9} className="opacity-60" />
+      </button>
+      <button className={`rounded border border-[oklch(0.40_0.012_255_/_0.6)] p-1 ${C.mutedFg}`}>
+        <IconPlus size={9} />
+      </button>
+      <span className={`ml-auto text-[9px] font-mono ${C.dimFg}`}>2/3</span>
+    </div>
+  );
+}
+
+/**
+ * Sessions rail: w-28 narrow column with vertical-stacked session cards.
+ * Each card is centered, icon top, 2-line title, cost bottom.
+ * Matches SessionActivityBar at apps/desktop/src/features/workspace/components/SessionActivityBar.
+ */
+function SessionsRail() {
+  return (
+    <div className={`w-[112px] shrink-0 flex flex-col border-r ${C.borderSoft}`}>
+      <div className="flex items-center justify-between px-2 pt-2 pb-1">
+        <span className={`text-[9px] uppercase tracking-[0.10em] font-semibold ${C.dimFg}`}>
+          Sessions
+        </span>
+        <button className={`${C.dimFg}`}>
+          <IconList size={9} />
+        </button>
+      </div>
+      <button
+        className={`mx-1.5 mb-1.5 flex items-center justify-center gap-1 rounded border ${C.borderSoft} ${C.muted40} py-1 text-[9.5px] ${C.mutedFg}`}
+      >
+        <IconPlus size={9} /> New session
+      </button>
+
+      <div className="flex-1 overflow-hidden flex flex-col px-1.5 gap-1">
+        <GroupRow label="No PR" count={1} />
+        <RailItem
+          icon={<IconHelp size={10} className="text-[oklch(0.86_0.13_78)]" />}
+          title="openquestions as a gamification"
+          cost="$12.36"
+        />
+
+        <GroupRow label="Draft" count={1} />
+        <RailItem
+          icon={<IconWorkflow size={10} className={C.primary} />}
+          prChip="draft"
+          title="Multi-workflow"
+          cost="$4.36"
+          active
+        />
+
+        <GroupRow label="In review" count={1} />
+        <RailItem
+          icon={<IconClock size={10} className="text-[oklch(0.86_0.13_78)]" />}
+          prChip="review"
+          title="euristic agent title"
+          cost="$10.36"
+        />
+      </div>
+
+      <div className="p-1.5">
+        <button
+          className={`flex w-full items-center justify-center gap-1 rounded py-1 text-[9.5px] ${C.mutedFg}`}
+        >
+          <IconArchive size={10} /> Archived
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function GroupRow({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="mt-1.5 first:mt-0 flex items-center gap-1 px-0.5">
+      <span className={`text-[8.5px] font-semibold uppercase tracking-[0.10em] ${C.dimFg}`}>
+        {label}
+      </span>
+      <span className={`text-[8.5px] font-mono ${C.faintFg}`}>{count}</span>
+      <span className={`ml-0.5 h-px flex-1 ${C.muted60}`} />
+    </div>
+  );
+}
+
+function RailItem({
+  icon,
+  title,
+  cost,
+  active,
+  prChip,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  cost: string;
+  active?: boolean;
+  prChip?: 'draft' | 'review';
+}) {
+  const prColor =
+    prChip === 'draft'
+      ? 'text-[oklch(0.68_0.015_255)]'
+      : prChip === 'review'
+        ? 'text-[oklch(0.86_0.13_78)]'
+        : '';
+  return (
+    <button
+      className={[
+        'flex w-full flex-col items-center gap-1 rounded border px-1 py-2 text-center transition-colors',
+        active
+          ? `${C.elevated} ${C.fg} border-[oklch(0.40_0.012_255)] shadow-sm`
+          : `${C.muted40} text-[oklch(0.78_0.01_255_/_0.85)] border-transparent`,
+      ].join(' ')}
+    >
+      <span className="flex items-center gap-1">
+        {icon}
+        {prChip ? (
+          <span className={`text-[8px] font-semibold uppercase ${prColor}`}>
+            <IconPullRequest size={9} />
+          </span>
+        ) : null}
+      </span>
+      <span
+        className={`line-clamp-2 w-full text-[9.5px] leading-tight ${active ? C.fg : C.mutedFg}`}
+      >
+        {title}
+      </span>
+      <span className={`text-[8.5px] font-mono ${C.faintFg}`}>{cost}</span>
+    </button>
+  );
+}
+
+/**
+ * Session detail panel: title bar at top, agents/workflow scroll body,
+ * meta footer at bottom. Mirrors SessionDetailPanel + AgentsSection.
+ */
+function SessionDetail() {
+  return (
+    <div className="flex-1 min-w-[260px] flex flex-col overflow-hidden">
+      {/* detail header: status + title + icons */}
+      <div className="flex items-center gap-2 px-3 pt-2.5 pb-1.5">
+        <span className="h-3.5 w-3.5 rounded-full bg-[oklch(0.69_0.13_148_/_0.18)] inline-flex items-center justify-center ring-1 ring-[oklch(0.69_0.13_148_/_0.4)]">
+          <span className="h-1.5 w-1.5 rounded-full bg-[oklch(0.82_0.13_148)]" />
+        </span>
+        <span className={`flex-1 line-clamp-1 text-[11.5px] font-semibold ${C.fg}`}>
+          Multi-workflow
+        </span>
+        <IconFolder size={11} className={C.dimFg} />
+        <IconTerminal size={11} className={C.dimFg} />
+        <IconSettings size={11} className={C.dimFg} />
+      </div>
+
+      <div className="px-3 flex items-center justify-between pt-2 pb-1.5">
+        <span
+          className={`inline-flex items-center gap-1 text-[9px] uppercase tracking-[0.10em] font-semibold ${C.dimFg}`}
+        >
+          <IconWorkflow size={9} className={C.primary} />
+          Workflow
+        </span>
+        <span className={`inline-flex items-center gap-1 text-[9px] ${C.faintFg}`}>
+          custom
+          <IconLock size={9} />
+        </span>
+      </div>
+
+      <div className="px-2 space-y-px">
+        <Step n={1} kind="agent" title="Analyze Branch State" model="haiku-4" />
+        <Step n={2} kind="plan" title="Plan Completion" model="opus-4" />
+        <Step n={3} kind="imple" title="Implement Restructuring" model="sonnet-4" />
+        <Step n={4} kind="review" title="Review, Cleanup, Create PR" model="sonnet-4" active />
+      </div>
+
+      <div
+        className={`px-3 pt-3 pb-1.5 flex items-center gap-1 text-[9px] uppercase tracking-[0.10em] font-semibold ${C.dimFg}`}
+      >
+        <IconSparkles size={9} className={C.primary} />
+        Agents
+      </div>
+      <div className="px-2 space-y-px">
+        <AgentRowMock n={1} kind="imple" name="agent 5" age="12m" />
+        <button
+          className={`w-full flex items-center justify-center gap-1 mt-1 rounded py-1 text-[9.5px] ${C.mutedFg} border border-dashed ${C.borderSoft}`}
+        >
+          <IconPlus size={9} /> Spawn agent
+        </button>
+      </div>
+
+      <div className="flex-1" />
+
+      {/* meta footer */}
+      <div className={`border-t ${C.borderSoft} px-2.5 py-2 flex items-center gap-1.5`}>
+        <IconBranch size={10} className={C.mutedFg} />
+        <span className={`text-[9.5px] font-mono truncate ${C.mutedFg} flex-1`}>
+          kay/multi-workflow-for-session
+        </span>
+        <span className="inline-flex items-center rounded bg-[oklch(0.69_0.13_148_/_0.15)] text-[oklch(0.82_0.13_148)] px-1.5 py-px font-mono text-[9px] ring-1 ring-[oklch(0.69_0.13_148_/_0.3)]">
+          $4.36
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function Step({
+  n,
+  kind,
+  title,
+  model,
+  active,
+}: {
+  n: number;
+  kind: keyof typeof KIND_BG;
+  title: string;
+  model: string;
+  active?: boolean;
+}) {
+  return (
+    <div
+      className={['rounded px-1.5 py-1', active ? `${C.muted40} ring-1 ${C.primaryRing}` : ''].join(
+        ' ',
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className={`w-3 shrink-0 text-center text-[9px] font-mono ${C.faintFg}`}>{n}.</span>
+        <span className="inline-flex h-2.5 w-2.5 shrink-0 items-center justify-center rounded-full bg-[oklch(0.69_0.13_148_/_0.18)] ring-1 ring-[oklch(0.69_0.13_148_/_0.4)]">
+          <span className="h-1 w-1 rounded-full bg-[oklch(0.82_0.13_148)]" />
+        </span>
+        <KindChip kind={kind} />
+        <span className={`text-[10.5px] ${C.fg} truncate flex-1`}>{title}</span>
+        <span
+          className={`shrink-0 rounded px-1 py-px text-[8.5px] font-mono ${C.mutedFg} ${C.muted40} ring-1 ${C.borderSoft}`}
+        >
+          {model}
+        </span>
+      </div>
+      {active ? (
+        <div className={`mt-1 ml-7 flex items-center gap-2 text-[9px] font-mono ${C.dimFg}`}>
+          <span className="inline-flex items-center gap-0.5">
+            <IconArrowDown size={8} />
+            13
+          </span>
+          <span className="inline-flex items-center gap-0.5">
+            <IconArrowUp size={8} />
+            7.2k
+          </span>
+          <span>1t</span>
+          <span className="text-[oklch(0.82_0.13_148)]">$0.220</span>
+          <span className="inline-flex items-center gap-0.5">
+            <IconClock size={8} />
+            2m
+          </span>
+          <span className="ml-auto inline-flex items-center gap-1">
+            <span className={C.primary}>CTX</span>
+            <span className="inline-block h-1 w-10 rounded-full bg-[oklch(0.33_0.010_255)] overflow-hidden">
+              <span className="block h-full w-[4%] bg-[oklch(0.74_0.11_200)]" />
+            </span>
+            <span>4%</span>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function AgentRowMock({
+  n,
+  kind,
+  name,
+  age,
+}: {
+  n: number;
+  kind: keyof typeof KIND_BG;
+  name: string;
+  age: string;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 px-1.5 py-1 rounded">
+      <span className={`w-3 shrink-0 text-center text-[9px] font-mono ${C.faintFg}`}>{n}.</span>
+      <KindChip kind={kind} />
+      <span className={`text-[10.5px] ${C.fg} flex-1 truncate`}>{name}</span>
+      <span className={`text-[9px] font-mono ${C.dimFg}`}>{age}</span>
+    </div>
+  );
+}
+
+/**
+ * Sidebar shell: workspace selector + sessions rail + session detail,
+ * with footer logo/icons row. Width tuned so 3 rail items + ~260px detail fit.
+ */
+function Sidebar() {
+  return (
+    <aside
+      className={`w-[400px] shrink-0 flex flex-col ${C.bg} border-r ${C.borderSoft}`}
+      style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif' }}
+    >
+      <WorkspaceSelectorRow />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <SessionsRail />
+        <SessionDetail />
+      </div>
+      {/* sidebar footer */}
+      <div className={`flex items-center gap-1.5 px-2.5 py-2 border-t ${C.borderSoft}`}>
+        <DogMascot size={14} className={`${C.fg} shrink-0`} />
+        <span className={`text-[10.5px] font-semibold ${C.fg}`}>Goodboy</span>
+        <span className="ml-auto flex items-center gap-1">
+          <IconPanelLeft size={11} className={C.mutedFg} />
+          <IconDollar size={11} className={C.mutedFg} />
+          <IconSun size={11} className={C.mutedFg} />
+          <span className="relative inline-flex">
+            <IconHelp size={11} className={C.mutedFg} />
+            <span className="absolute -top-1.5 -right-2 bg-[oklch(0.76_0.13_78)] text-zinc-950 text-[7px] font-mono px-0.5 rounded leading-none py-px">
+              99+
+            </span>
+          </span>
+          <IconSettings size={11} className={C.mutedFg} />
+        </span>
+      </div>
+    </aside>
+  );
+}
+
+function Transcript() {
+  return (
+    <div
+      className={`flex-1 flex flex-col min-w-0 ${C.bg}`}
+      style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif' }}
+    >
+      {/* Breadcrumb */}
+      <div className={`flex items-center gap-1.5 border-b ${C.borderSoft} px-4 py-2.5 text-[11px]`}>
+        <span className={C.mutedFg}>goodboy</span>
+        <IconChevronRight size={9} className={C.faintFg} />
+        <span className={C.mutedFg}>Multi-workflow</span>
+        <IconChevronRight size={9} className={C.faintFg} />
+        <span className="inline-flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-[oklch(0.82_0.13_148)]" />
+          <span className={C.fg}>Review, Cleanup, Create PR</span>
+        </span>
+        <KindChip kind="review" />
+      </div>
+
+      {/* Markdown content */}
+      <div className={`flex-1 overflow-hidden px-5 py-4 text-[12.5px] leading-[1.65] ${C.fg}`}>
+        <p className={`font-mono text-[11px] ${C.dimFg}`}>
+          <code className="text-[oklch(0.88_0.12_200)]">BEGIN</code> /{' '}
+          <code className="text-[oklch(0.88_0.12_200)]">COMMIT</code> or equivalent.
+        </p>
+
+        <p className="mt-3">
+          <span className={`font-semibold ${C.fg}`}>3.</span>{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">insertSession</code> silently
+          drops <code className="font-mono text-[oklch(0.88_0.12_200)]">workflowIds</code>{' '}
+          <span className={`font-mono text-[10.5px] ${C.dimFg}`}>(session.ts:175.194)</span>
+        </p>
+        <p className={`mt-1 text-[12px] ${C.mutedFg}`}>
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">insertSession</code> no longer
+          writes <code className="font-mono text-[oklch(0.88_0.12_200)]">workflow_id</code> to{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">sessions</code> (correct), but
+          also never writes to{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">session_workflows</code>. a
+          Session with{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">workflowIds: ['wf1']</code> passed
+          to <code className="font-mono text-[oklch(0.88_0.12_200)]">insertSession</code> loses
+          those associations silently.
+        </p>
+
+        <h4 className={`mt-3 text-[12px] font-semibold ${C.fg}`}>design issues</h4>
+
+        <p className="mt-2">
+          <span className={`font-semibold ${C.fg}`}>4.</span>{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">updateSessionWorkflow</code>{' '}
+          legacy compat is inconsistent
+        </p>
+        <ul className={`mt-1 space-y-1 text-[12px] ${C.mutedFg}`}>
+          <li className="flex gap-2">
+            <span className={`${C.faintFg} shrink-0`}>·</span>
+            <span>
+              writes back to{' '}
+              <code className="font-mono text-[oklch(0.88_0.12_200)]">sessions.workflow_id</code>{' '}
+              (scalar). correct for first attachment, but when a second workflow is attached via{' '}
+              <code className="font-mono text-[oklch(0.88_0.12_200)]">attachWorkflowToSession</code>
+              , the scalar column goes stale.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <span className={`${C.faintFg} shrink-0`}>·</span>
+            <span>
+              signature changed from{' '}
+              <code className="font-mono text-[oklch(0.88_0.12_200)]">WorkflowId | null</code> to{' '}
+              <code className="font-mono text-[oklch(0.88_0.12_200)]">WorkflowId</code>{' '}
+              (non-nullable). any caller passing null to detach would break at compile time.
+            </span>
+          </li>
+        </ul>
+
+        <p className="mt-3">
+          <span className={`font-semibold ${C.fg}`}>5.</span>{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">SessionRow</code> interface
+          removed <code className="font-mono text-[oklch(0.88_0.12_200)]">workflow_id</code> but{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">SELECT *</code> still fetches it
+        </p>
+
+        <h4 className={`mt-3 text-[12px] font-semibold ${C.fg}`}>minor</h4>
+        <p className={`mt-2 ${C.mutedFg}`}>
+          <span className={`font-semibold ${C.fg}`}>6.</span> duplicate row to domain mapping.{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">loadWorkflowsForSession</code> and{' '}
+          <code className="font-mono text-[oklch(0.88_0.12_200)]">listSessionsForWorkspace</code>{' '}
+          both independently build the same 5 lines.
+        </p>
+
+        <div className={`mt-4 text-[10px] font-mono ${C.faintFg}`}>
+          13 in / 7.2k out · 373k cached
+        </div>
+      </div>
+
+      {/* Composer */}
+      <div className={`border-t ${C.borderSoft} px-4 pt-3 pb-3`}>
+        <div className={`rounded-lg border ${C.borderSoft} ${C.subtle} px-3 py-2.5`}>
+          <div className={`text-[12px] ${C.dimFg}`}>
+            Message Claude. <span className="font-mono">$ scripts</span> ·{' '}
+            <span className="font-mono">~ workflows</span> ·{' '}
+            <span className="font-mono">@ agents</span>
+          </div>
+          <div className="mt-2.5 flex items-center gap-2 text-[10.5px]">
+            <button className="inline-flex items-center gap-1 rounded bg-[oklch(0.63_0.17_22_/_0.15)] text-[oklch(0.82_0.13_22)] ring-1 ring-[oklch(0.63_0.17_22_/_0.3)] px-2 py-0.5">
+              <span className="h-1 w-1 rounded-full bg-current" /> Bypass
+              <IconChevronDown size={9} />
+            </button>
+            <div className={`ml-auto flex items-center gap-2 ${C.mutedFg}`}>
+              <span className="font-mono text-[oklch(0.86_0.13_55)]">Claude</span>
+              <span className={C.faintFg}>·</span>
+              <span className="font-mono">Opus 4.7</span>
+              <span className={C.faintFg}>·</span>
+              <span className="text-[oklch(0.86_0.13_78)]">High</span>
+              <span className={C.faintFg}>·</span>
+              <span>Brief</span>
+              <button className={`rounded ${C.elevated} p-1 ${C.fg} ring-1 ${C.borderSoft}`}>
+                <IconSend size={10} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ContextPanel() {
+  return (
+    <aside
+      className={`w-[300px] shrink-0 flex flex-col ${C.bg} border-l ${C.borderSoft} text-[11px]`}
+      style={{ fontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif' }}
+    >
+      <div className="px-3 pt-3 pb-2 flex items-center gap-1">
+        <span
+          className={`inline-flex items-center gap-1 rounded ${C.subtle} px-2 py-1 text-[9.5px] uppercase tracking-[0.08em] ${C.fg} font-semibold ring-1 ${C.borderSoft}`}
+        >
+          <IconBook size={9} />
+          Context
+        </span>
+        <button className={`rounded p-1 ${C.dimFg} inline-flex items-center gap-0.5`}>
+          <IconClipboard size={10} />
+          <span className="text-[8.5px] font-mono">1</span>
+        </button>
+        <button className={`rounded p-1 ${C.dimFg} inline-flex items-center gap-0.5`}>
+          <IconEdit size={10} />
+          <span className="text-[8.5px] font-mono">29</span>
+        </button>
+        <button className={`rounded p-1 ${C.dimFg}`}>
+          <IconPullRequest size={10} />
+        </button>
+        <span
+          className={`ml-auto rounded-full ${C.muted40} px-1.5 py-0.5 text-[9px] ${C.mutedFg} font-mono`}
+        >
+          Σ $0.2472
+        </span>
+        <button className={`rounded p-1 ${C.dimFg}`}>
+          <IconSearch size={10} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-hidden px-2.5 py-2 space-y-2">
+        <Slot
+          icon={<IconTarget size={11} className="text-[oklch(0.85_0.12_200)]" />}
+          iconBg="bg-[oklch(0.74_0.11_200_/_0.10)] ring-[oklch(0.74_0.11_200_/_0.25)]"
+          label="Goal"
+          sub="What this session is set out to achieve"
+        >
+          <p className={`text-[10.5px] ${C.fg} leading-snug`}>
+            ristrutturazione 1:n session/workflow su{' '}
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">
+              kay/multi-workflow-for-session
+            </code>
+            . type:{' '}
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">Session.workflowId</code>{' '}
+            diventa <code className="font-mono text-[oklch(0.88_0.12_200)]">workflowIds[]</code>.
+            DB: <code className="font-mono text-[oklch(0.88_0.12_200)]">session_workflows</code>{' '}
+            (session_id, workflow_id, ordinal). queries:{' '}
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">listWorkflowsForSession</code>,{' '}
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">attachWorkflowToSession</code>.
+            store: <code className="font-mono text-[oklch(0.88_0.12_200)]">sessionWorkflows</code>.
+            UI: <code className="font-mono text-[oklch(0.88_0.12_200)]">SessionDetailPanel</code>{' '}
+            multi-workflow.
+          </p>
+        </Slot>
+
+        <Slot
+          icon={<IconSparkles size={11} className="text-[oklch(0.82_0.13_148)]" />}
+          iconBg="bg-[oklch(0.69_0.13_148_/_0.10)] ring-[oklch(0.69_0.13_148_/_0.25)]"
+          label="Decisions"
+          sub="Choices already locked in for this session"
+          rightMeta="7 items"
+          collapsed
+        >
+          <p className={`text-[10.5px] truncate ${C.mutedFg}`}>
+            branch:{' '}
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">
+              kay/multi-workflow-for-session
+            </code>{' '}
+            (confermato utente)
+          </p>
+        </Slot>
+
+        <Slot
+          icon={<IconWand size={11} className="text-[oklch(0.82_0.11_238)]" />}
+          iconBg="bg-[oklch(0.69_0.11_238_/_0.10)] ring-[oklch(0.69_0.11_238_/_0.25)]"
+          label="Last output summary"
+          sub="Summary of the assistant's most recent reply"
+          collapsed
+        >
+          <p className={`text-[10.5px] truncate ${C.mutedFg}`}>phase 1 latency analysis:</p>
+        </Slot>
+      </div>
+
+      <div className={`bg-[oklch(0.27_0.008_255_/_0.6)] border-t ${C.borderSoft} px-3 py-3`}>
+        <div className="flex items-center gap-1.5 mb-1">
+          <span className="flex h-4 w-4 items-center justify-center rounded bg-[oklch(0.76_0.13_78_/_0.12)] ring-1 ring-[oklch(0.76_0.13_78_/_0.3)]">
+            <IconHelp size={9} className="text-[oklch(0.86_0.13_78)]" />
+          </span>
+          <span className={`text-[9.5px] uppercase tracking-[0.08em] font-semibold ${C.fg}`}>
+            Open questions
+          </span>
+        </div>
+        <p className={`text-[9.5px] leading-tight ${C.faintFg} pl-6`}>
+          Things the agent still needs clarified
+        </p>
+        <p className="mt-1.5 text-[10.5px] text-[oklch(0.86_0.13_78)] leading-snug pl-6">
+          fix 5 latent bugs now in phase 1 patch commit, or review{' '}
+          <code className="font-mono">m038/queries</code> schema first?
+        </p>
+      </div>
+    </aside>
+  );
+}
+
+function Slot({
+  icon,
+  iconBg,
+  label,
+  sub,
+  rightMeta,
+  collapsed,
+  children,
+}: {
+  icon: React.ReactNode;
+  iconBg: string;
+  label: string;
+  sub: string;
+  rightMeta?: string;
+  collapsed?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`rounded-md ${C.subtle} ring-1 ${C.borderSoft} p-2`}>
+      <div className="flex items-center gap-1.5">
+        <span className={`flex h-4 w-4 items-center justify-center rounded ring-1 ${iconBg}`}>
+          {icon}
+        </span>
+        <div className="flex flex-col min-w-0 flex-1">
+          <span
+            className={`text-[9px] uppercase tracking-[0.08em] font-semibold ${C.fg} flex items-baseline gap-1`}
+          >
+            {label}
+            {rightMeta ? (
+              <span className={`text-[8.5px] font-normal normal-case tracking-normal ${C.dimFg}`}>
+                · {rightMeta}
+              </span>
+            ) : null}
+          </span>
+          <span className={`text-[9px] leading-tight ${C.faintFg} truncate`}>{sub}</span>
+        </div>
+        {collapsed ? (
+          <IconChevronRight size={10} className={C.faintFg} />
+        ) : (
+          <IconChevronDown size={10} className={C.faintFg} />
+        )}
+      </div>
+      <div className="mt-1.5 pl-1">{children}</div>
+    </div>
+  );
+}
+
+export function AppMockup() {
+  return (
+    <div className="card-glow overflow-hidden">
+      <WindowChrome />
+      <div className={`flex h-[600px] ${C.bg} ${C.fg}`}>
+        <Sidebar />
+        <Transcript />
+        <ContextPanel />
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -1,0 +1,88 @@
+const lines = [
+  {
+    prompt: '$',
+    command: 'git clone https://github.com/akhayam99/goodboy.git',
+    cls: 'text-[oklch(0.92_0.006_90)]',
+  },
+  { prompt: '$', command: 'cd goodboy && pnpm install', cls: 'text-[oklch(0.92_0.006_90)]' },
+  { prompt: '$', command: 'pnpm tauri:dev', cls: 'text-[oklch(0.88_0.12_200)]' },
+];
+
+export function CTA() {
+  return (
+    <section id="cta" className="py-24 relative">
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="card-glow relative overflow-hidden p-10 sm:p-14 text-center">
+          <div className="absolute inset-0 grid-bg pointer-events-none opacity-60" />
+          <div className="absolute -top-20 left-1/2 -translate-x-1/2 h-40 w-[600px] bg-[oklch(0.78_0.13_200_/_0.25)] blur-3xl rounded-full pointer-events-none" />
+          <div className="relative">
+            <div className="inline-flex items-center gap-2 rounded-full border border-[oklch(0.69_0.13_148_/_0.3)] bg-[oklch(0.69_0.13_148_/_0.08)] px-3 py-1 text-[11.5px] text-[oklch(0.82_0.13_148)] mb-6">
+              <span className="h-1.5 w-1.5 rounded-full bg-[oklch(0.69_0.13_148)]" />
+              Open source · MIT
+            </div>
+            <h2 className="text-[40px] sm:text-[60px] tracking-[-0.03em] font-bold leading-[0.98]">
+              <span className="gradient-text">Clone, install,</span>
+              <br />
+              <span className="gradient-text-accent">run it.</span>
+            </h2>
+            <p className="mt-5 text-[15.5px] text-[oklch(0.82_0.01_255)] leading-[1.6] max-w-xl mx-auto">
+              No waitlist. No email. The repo is public. Bring your own Claude / Cursor / Codex
+              subscription and you&apos;re running locally in a couple of minutes.
+            </p>
+
+            <div className="mt-9 mx-auto max-w-2xl rounded-xl border border-[oklch(0.36_0.012_255)] bg-[oklch(0.18_0.006_255)] overflow-hidden text-left">
+              <div className="flex items-center gap-2 px-4 py-2.5 border-b border-[oklch(0.36_0.012_255)] bg-[oklch(0.23_0.007_255)]">
+                <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.63_0.17_22)]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.76_0.13_78)]" />
+                <span className="h-2.5 w-2.5 rounded-full bg-[oklch(0.69_0.13_148)]" />
+                <span className="ml-3 text-[10.5px] font-mono text-[oklch(0.58_0.015_255)]">
+                  ~/work
+                </span>
+              </div>
+              <div className="px-5 py-4 font-mono text-[12.5px] leading-[1.9]">
+                {lines.map((l) => (
+                  <div key={l.command} className="flex items-start gap-2">
+                    <span className="text-[oklch(0.58_0.015_255)] select-none shrink-0">
+                      {l.prompt}
+                    </span>
+                    <span className={l.cls}>{l.command}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <a
+                href="https://github.com/akhayam99/goodboy"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg bg-[oklch(0.78_0.13_200)] px-5 py-2.5 text-[14px] font-semibold text-[oklch(0.13_0.02_200)] hover:bg-[oklch(0.82_0.13_200)] transition-colors shadow-[0_0_40px_-10px_oklch(0.78_0.13_200_/_0.7)]"
+              >
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                  <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+                </svg>
+                View on GitHub
+              </a>
+              <a
+                href="https://github.com/akhayam99/goodboy/blob/main/README.md"
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 rounded-lg border border-[oklch(0.42_0.012_255)] bg-[oklch(0.26_0.008_255_/_0.8)] px-5 py-2.5 text-[14px] font-medium text-[oklch(0.88_0.008_90)] hover:bg-[oklch(0.32_0.010_255)] transition-colors"
+              >
+                Read the docs
+              </a>
+            </div>
+
+            <div className="mt-6 flex items-center justify-center gap-5 text-[11.5px] text-[oklch(0.68_0.015_255)]">
+              <span>macOS · Windows · Linux</span>
+              <span>·</span>
+              <span>Node 20+ · pnpm 9+</span>
+              <span>·</span>
+              <span>Bring your own subscription</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/sections/Comparison.tsx
+++ b/website/src/sections/Comparison.tsx
@@ -1,0 +1,186 @@
+type Cell = boolean | 'partial' | string;
+type Row = { label: string; goodboy: Cell; cursor: Cell; claudeCode: Cell; chatgpt: Cell };
+
+const rows: Row[] = [
+  {
+    label: 'Multiple AI providers',
+    goodboy: true,
+    cursor: false,
+    claudeCode: false,
+    chatgpt: false,
+  },
+  {
+    label: 'Shared context across agents',
+    goodboy: true,
+    cursor: false,
+    claudeCode: 'partial',
+    chatgpt: false,
+  },
+  {
+    label: 'Multi-agent parallel sessions',
+    goodboy: true,
+    cursor: false,
+    claudeCode: 'partial',
+    chatgpt: false,
+  },
+  {
+    label: 'Per-session budget caps',
+    goodboy: true,
+    cursor: false,
+    claudeCode: false,
+    chatgpt: false,
+  },
+  {
+    label: 'Structured plans as artifacts',
+    goodboy: true,
+    cursor: false,
+    claudeCode: 'partial',
+    chatgpt: false,
+  },
+  {
+    label: 'Git worktrees per session',
+    goodboy: true,
+    cursor: false,
+    claudeCode: 'partial',
+    chatgpt: false,
+  },
+  {
+    label: 'GitHub PR panel built-in',
+    goodboy: true,
+    cursor: false,
+    claudeCode: false,
+    chatgpt: false,
+  },
+  {
+    label: 'Local-first (no cloud sync)',
+    goodboy: true,
+    cursor: false,
+    claudeCode: true,
+    chatgpt: false,
+  },
+  {
+    label: 'Uses your subscription',
+    goodboy: 'all three',
+    cursor: 'own',
+    claudeCode: 'own',
+    chatgpt: 'own',
+  },
+  { label: 'Replaces your IDE', goodboy: false, cursor: true, claudeCode: false, chatgpt: false },
+];
+
+function CellView({ v }: { v: Cell }) {
+  if (v === true) {
+    return (
+      <span className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-[oklch(0.69_0.13_148_/_0.15)] text-[oklch(0.82_0.13_148)]">
+        <svg width="12" height="12" viewBox="0 0 12 12">
+          <path
+            d="M2.5 6.5 5 9l4.5-5.5"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            fill="none"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (v === false) {
+    return (
+      <span className="inline-flex items-center justify-center h-6 w-6 rounded-full bg-[oklch(0.30_0.010_255)] text-[oklch(0.55_0.015_255)]">
+        <svg width="10" height="10" viewBox="0 0 12 12">
+          <path
+            d="M3 3l6 6M9 3l-6 6"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+          />
+        </svg>
+      </span>
+    );
+  }
+  if (v === 'partial') {
+    return (
+      <span className="inline-flex items-center justify-center h-6 px-2 rounded chip-warning text-[10.5px] font-medium">
+        partial
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center justify-center h-6 px-2 rounded chip-primary text-[10.5px] font-medium">
+      {v}
+    </span>
+  );
+}
+
+export function Comparison() {
+  return (
+    <section id="compare" className="py-24 relative">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="max-w-2xl mb-14">
+          <div className="text-[11px] uppercase tracking-[0.2em] text-[oklch(0.82_0.12_200)] pb-4">
+            Comparison
+          </div>
+          <h2 className="text-[38px] sm:text-[50px] tracking-[-0.025em] font-bold leading-[1.02]">
+            <span className="gradient-text">Where Goodboy fits.</span>
+          </h2>
+          <p className="mt-5 text-[16px] text-[oklch(0.70_0.012_255)] leading-relaxed">
+            Not another IDE. The layer above. Keep what you have, add coordination.
+          </p>
+        </div>
+        <div className="card-glow overflow-hidden">
+          <div className="grid grid-cols-[1.4fr_1fr_1fr_1fr_1fr] text-[11.5px]">
+            <div className="px-4 py-3 text-[oklch(0.58_0.015_255)] uppercase tracking-wider text-[10.5px] bg-[oklch(0.25_0.008_255)]">
+              Capability
+            </div>
+            <Header label="Goodboy" highlight />
+            <Header label="Cursor" />
+            <Header label="Claude Code" />
+            <Header label="ChatGPT" />
+            {rows.map((r, i) => (
+              <ComparisonRow key={r.label} row={r} odd={i % 2 === 1} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Header({ label, highlight }: { label: string; highlight?: boolean }) {
+  return (
+    <div
+      className={[
+        'px-4 py-3 text-center text-[12.5px] font-semibold bg-[oklch(0.25_0.008_255)]',
+        highlight
+          ? 'text-[oklch(0.88_0.12_200)] border-l border-r border-[oklch(0.78_0.13_200_/_0.25)] bg-[oklch(0.78_0.13_200_/_0.06)]'
+          : 'text-[oklch(0.92_0.006_90)]',
+      ].join(' ')}
+    >
+      {label}
+    </div>
+  );
+}
+
+function ComparisonRow({ row, odd }: { row: Row; odd: boolean }) {
+  const bg = odd ? 'bg-[oklch(0.22_0.007_255)]' : 'bg-[oklch(0.24_0.008_255)]';
+  return (
+    <>
+      <div className={`px-4 py-3 text-[oklch(0.86_0.008_90)] ${bg}`}>{row.label}</div>
+      <div
+        className={`px-4 py-3 flex items-center justify-center ${bg} border-l border-r border-[oklch(0.78_0.13_200_/_0.15)]`}
+      >
+        <CellView v={row.goodboy} />
+      </div>
+      <div className={`px-4 py-3 flex items-center justify-center ${bg}`}>
+        <CellView v={row.cursor} />
+      </div>
+      <div className={`px-4 py-3 flex items-center justify-center ${bg}`}>
+        <CellView v={row.claudeCode} />
+      </div>
+      <div className={`px-4 py-3 flex items-center justify-center ${bg}`}>
+        <CellView v={row.chatgpt} />
+      </div>
+    </>
+  );
+}

--- a/website/src/sections/ContextDeepDive.tsx
+++ b/website/src/sections/ContextDeepDive.tsx
@@ -1,0 +1,132 @@
+import { Section } from '../components/Section';
+
+export function ContextDeepDive() {
+  return (
+    <Section
+      id="context"
+      eyebrow="Shared context"
+      title={
+        <>
+          <span className="gradient-text">A scratchpad that survives</span>{' '}
+          <span className="gradient-text-accent">the next agent.</span>
+        </>
+      }
+      body={
+        <>
+          <p>
+            Every new chat starts from scratch. Goodboy doesn&apos;t. Five context slots (goal,
+            decisions, files touched, open questions, last output) sit outside the transcript and
+            persist across agents.
+          </p>
+          <p>
+            A cheap summarizer updates them after each turn. You can edit them by hand at any time.
+            When you spawn a reviewer agent in a new provider, it reads the same notes the
+            implementer wrote.
+          </p>
+          <p className="text-[oklch(0.78_0.01_255)] text-[14px]">
+            No re-explaining. No copy-paste between windows. No drift between agents on the same
+            goal.
+          </p>
+        </>
+      }
+    >
+      <ContextMockup />
+    </Section>
+  );
+}
+
+function ContextMockup() {
+  return (
+    <div className="card-glow p-5">
+      <div className="flex items-center justify-between pb-4 border-b border-[oklch(0.36_0.012_255)]">
+        <div>
+          <div className="text-[11px] uppercase tracking-wider text-[oklch(0.58_0.015_255)]">
+            Session context
+          </div>
+          <div className="text-[13px] font-mono text-[oklch(0.92_0.006_90)]">
+            context-slot-history
+          </div>
+        </div>
+        <div className="text-[10.5px] text-[oklch(0.68_0.015_255)] flex items-center gap-1.5">
+          <span className="h-1.5 w-1.5 rounded-full bg-[oklch(0.69_0.13_148)]" />5 of 5 slots
+          written
+        </div>
+      </div>
+      <div className="mt-4 space-y-2.5">
+        <Slot label="Goal" tone="primary">
+          Add history table for{' '}
+          <code className="font-mono text-[oklch(0.86_0.13_55)]">context_slots</code> so reversions
+          are auditable. Preserve current write path.
+        </Slot>
+        <Slot label="Decisions" tone="anthropic">
+          <ul className="space-y-1">
+            <li className="flex gap-2">
+              <span className="text-[oklch(0.86_0.13_55)] mt-px">·</span>history table mirrors slot
+              schema with <code className="font-mono">snapshot_at</code>
+            </li>
+            <li className="flex gap-2">
+              <span className="text-[oklch(0.86_0.13_55)] mt-px">·</span>trigger on UPDATE, not
+              application code
+            </li>
+            <li className="flex gap-2">
+              <span className="text-[oklch(0.86_0.13_55)] mt-px">·</span>retain 90 days, prune via
+              nightly cron
+            </li>
+          </ul>
+        </Slot>
+        <Slot label="Files touched" tone="info">
+          <ul className="font-mono text-[11.5px] space-y-0.5 text-[oklch(0.86_0.008_90)]">
+            <li>packages/db/migrations/038_context_slot_history.sql</li>
+            <li>packages/core/context/history.ts</li>
+            <li>packages/core/context/__tests__/history.test.ts</li>
+          </ul>
+        </Slot>
+        <Slot label="Open questions" tone="warning">
+          Should reverts be reachable from the UI in v0.8, or wait for the audit page in v0.9?
+        </Slot>
+        <Slot label="Last output" tone="success">
+          Migration applied. Trigger fires on update. Tests green. Ready for review.
+        </Slot>
+      </div>
+      <div className="mt-4 flex items-center justify-between text-[10.5px] text-[oklch(0.68_0.015_255)]">
+        <span>Auto-summarized after each turn · 412 tokens · $0.0021</span>
+        <button className="rounded border border-[oklch(0.40_0.012_255)] px-2 py-0.5 hover:bg-[oklch(0.30_0.010_255)]">
+          Edit
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const toneMap: Record<string, string> = {
+  primary: 'oklch(0.78 0.13 200)',
+  anthropic: 'oklch(0.74 0.15 55)',
+  info: 'oklch(0.69 0.11 238)',
+  warning: 'oklch(0.76 0.13 78)',
+  success: 'oklch(0.69 0.13 148)',
+};
+
+function Slot({
+  label,
+  tone,
+  children,
+}: {
+  label: string;
+  tone: keyof typeof toneMap;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-[oklch(0.36_0.012_255)] bg-[oklch(0.22_0.007_255)] p-3 relative overflow-hidden">
+      <span
+        className="absolute left-0 top-3 bottom-3 w-[3px] rounded-r"
+        style={{ background: toneMap[tone] }}
+      />
+      <div className="pl-3">
+        <div className="text-[10px] uppercase tracking-[0.12em] text-[oklch(0.58_0.015_255)] mb-1.5">
+          {label}
+        </div>
+        <div className="text-[12.5px] leading-relaxed text-[oklch(0.88_0.008_90)]">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/FeatureGrid.tsx
+++ b/website/src/sections/FeatureGrid.tsx
@@ -1,0 +1,324 @@
+import type { ReactNode } from 'react';
+
+type Feature = {
+  title: string;
+  body: string;
+  span: string;
+  icon: ReactNode;
+  visual?: ReactNode;
+};
+
+const Icon = {
+  context: (
+    <path
+      d="M3 5h10M3 9h10M3 13h7"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      fill="none"
+    />
+  ),
+  routing: (
+    <>
+      <circle cx="4" cy="4" r="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="12" cy="8" r="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="4" cy="12" r="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M6 4h4M6 12h4" stroke="currentColor" strokeWidth="1.5" />
+    </>
+  ),
+  agents: (
+    <>
+      <circle cx="5" cy="6" r="2.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="11" cy="6" r="2.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path
+        d="M2 14c0-1.5 1-3 3-3s3 1.5 3 3M8 14c0-1.5 1-3 3-3s3 1.5 3 3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+      />
+    </>
+  ),
+  plan: (
+    <>
+      <path d="M3 3h10v10H3z" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path
+        d="M5.5 6h5M5.5 8.5h5M5.5 11h3"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </>
+  ),
+  workflow: (
+    <>
+      <circle cx="3" cy="3" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="13" cy="3" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="3" cy="13" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="13" cy="13" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M4.5 3h7M4.5 13h7M3 4.5v7M13 4.5v7" stroke="currentColor" strokeWidth="1.5" />
+    </>
+  ),
+  github: (
+    <path
+      d="M8 2C4.7 2 2 4.7 2 8c0 2.6 1.7 4.9 4.1 5.7.3.1.4-.1.4-.3v-1.2c-1.7.4-2-.8-2-.8-.3-.7-.7-.9-.7-.9-.6-.4 0-.4 0-.4.6 0 .9.6.9.6.6 1 1.5.7 1.9.6 0-.4.2-.7.4-.9-1.3-.2-2.7-.7-2.7-3 0-.7.2-1.2.6-1.6 0-.2-.3-.8.1-1.6 0 0 .5-.2 1.6.6.5-.1.9-.2 1.4-.2s.9.1 1.4.2c1.1-.7 1.6-.6 1.6-.6.3.8.1 1.4.1 1.6.4.4.6.9.6 1.6 0 2.3-1.4 2.8-2.7 3 .2.2.4.5.4 1.1v1.7c0 .2.1.4.4.3C12.3 12.9 14 10.6 14 8c0-3.3-2.7-6-6-6z"
+      stroke="currentColor"
+      strokeWidth="1"
+      fill="none"
+    />
+  ),
+  budget: (
+    <>
+      <rect
+        x="2"
+        y="6"
+        width="12"
+        height="7"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <path d="M2 9h12" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M5 4l3-2 3 2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </>
+  ),
+  permission: (
+    <>
+      <path
+        d="M8 2L3 4v4c0 3 2.5 5.5 5 6 2.5-.5 5-3 5-6V4l-5-2z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 8l1.5 1.5L10 7"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </>
+  ),
+  skill: (
+    <>
+      <path
+        d="M8 2v3M8 11v3M2 8h3M11 8h3M3.5 3.5l2 2M10.5 10.5l2 2M3.5 12.5l2-2M10.5 5.5l2-2"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <circle cx="8" cy="8" r="2" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </>
+  ),
+  worktree: (
+    <>
+      <circle cx="4" cy="3" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="4" cy="13" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <circle cx="12" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path d="M4 4.5v7M5.5 13c2.5 0 5-2 5-5" stroke="currentColor" strokeWidth="1.5" fill="none" />
+    </>
+  ),
+  notif: (
+    <>
+      <path
+        d="M4 7a4 4 0 1 1 8 0v3l1 2H3l1-2V7z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6.5 13.5a1.5 1.5 0 0 0 3 0"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+      />
+    </>
+  ),
+  editor: (
+    <>
+      <rect
+        x="2"
+        y="3"
+        width="12"
+        height="10"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+      />
+      <path d="M2 6h12" stroke="currentColor" strokeWidth="1.5" />
+      <circle cx="3.5" cy="4.5" r="0.5" fill="currentColor" />
+      <circle cx="5.5" cy="4.5" r="0.5" fill="currentColor" />
+    </>
+  ),
+};
+
+function IconWrap({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[oklch(0.78_0.13_200_/_0.12)] text-[oklch(0.85_0.12_200)] border border-[oklch(0.78_0.13_200_/_0.2)]">
+      <svg width="16" height="16" viewBox="0 0 16 16">
+        {children}
+      </svg>
+    </div>
+  );
+}
+
+const features: Feature[] = [
+  {
+    title: 'Shared context panel',
+    body: 'Five synthetic slots (goal, decisions, files touched, open questions, last output) live outside the chat. Auto-populated, hand-editable. Every agent reads the same notes.',
+    span: 'lg:col-span-2 lg:row-span-2',
+    icon: <IconWrap>{Icon.context}</IconWrap>,
+    visual: <ContextVisual />,
+  },
+  {
+    title: 'Multi-provider routing',
+    body: 'Claude. Cursor. Codex. Route by task, by budget, by latency. Switch mid-session without re-explaining.',
+    span: 'lg:col-span-2',
+    icon: <IconWrap>{Icon.routing}</IconWrap>,
+  },
+  {
+    title: 'Multi-agent sessions',
+    body: 'Spawn scouts, planners, implementers, reviewers in parallel. Each has its own thread, model, and effort. Independent work, shared notes.',
+    span: '',
+    icon: <IconWrap>{Icon.agents}</IconWrap>,
+  },
+  {
+    title: 'Plans as artifacts',
+    body: 'Planner output gets captured as a structured plan, not buried in transcripts. Consumed by downstream agents, tracked to completion.',
+    span: '',
+    icon: <IconWrap>{Icon.plan}</IconWrap>,
+  },
+  {
+    title: 'Workflow presets',
+    body: 'Pre-built or custom flows fan out agents at session start: scout → planner → implementer → reviewer. Sequential or parallel.',
+    span: 'lg:col-span-2',
+    icon: <IconWrap>{Icon.workflow}</IconWrap>,
+  },
+  {
+    title: 'GitHub integration',
+    body: 'PR state, CI checks, review decisions, linked issues, line-level diff comments. Refreshed in real time.',
+    span: '',
+    icon: <IconWrap>{Icon.github}</IconWrap>,
+  },
+  {
+    title: 'Budget control',
+    body: 'Per-provider monthly caps. Per-session soft caps. Configurable threshold alerts. Real-time USD next to every turn.',
+    span: '',
+    icon: <IconWrap>{Icon.budget}</IconWrap>,
+  },
+  {
+    title: 'Permission proxy',
+    body: 'Tool-call interception, static rule matching, audit trail. Run agents autonomously without losing the kill switch.',
+    span: 'lg:col-span-2',
+    icon: <IconWrap>{Icon.permission}</IconWrap>,
+  },
+  {
+    title: 'Skills & slash-commands',
+    body: 'Workspace-scoped automation (.kay/skills/). Markdown + scripts. Invoke /skill in chat across any provider.',
+    span: '',
+    icon: <IconWrap>{Icon.skill}</IconWrap>,
+  },
+  {
+    title: 'Git worktrees',
+    body: 'Each session lives on its own branch + worktree. Auto-created, auto-cleaned. Agents never collide on the working tree.',
+    span: '',
+    icon: <IconWrap>{Icon.worktree}</IconWrap>,
+  },
+  {
+    title: 'Editor integration',
+    body: "Open VS Code or Cursor on the right worktree, on the right branch, when it's time to write code. Then hand control back.",
+    span: '',
+    icon: <IconWrap>{Icon.editor}</IconWrap>,
+  },
+  {
+    title: 'Notifications & nudges',
+    body: 'Budget alerts, PR state changes, session events. Toast for transient, feed for full history. No spam.',
+    span: '',
+    icon: <IconWrap>{Icon.notif}</IconWrap>,
+  },
+];
+
+function ContextVisual() {
+  const slots = [
+    { label: 'Goal', value: 'Audit reversions on context slots.', tone: 'oklch(0.78 0.13 200)' },
+    { label: 'Decisions', value: '3 entries · last edit 2m ago', tone: 'oklch(0.86 0.13 55)' },
+    {
+      label: 'Files touched',
+      value: '3 paths in packages/db, packages/core',
+      tone: 'oklch(0.69 0.11 238)',
+    },
+    { label: 'Open questions', value: '1 · awaiting answer', tone: 'oklch(0.76 0.13 78)' },
+    {
+      label: 'Last output',
+      value: 'Migration applied · tests green',
+      tone: 'oklch(0.69 0.13 148)',
+    },
+  ];
+  return (
+    <div className="mt-5 space-y-1.5">
+      {slots.map((s) => (
+        <div
+          key={s.label}
+          className="rounded-md border border-[oklch(0.36_0.012_255)] bg-[oklch(0.22_0.007_255)] px-3 py-2 flex items-center gap-3"
+        >
+          <span className="h-1.5 w-1.5 rounded-full shrink-0" style={{ background: s.tone }} />
+          <span className="text-[10.5px] uppercase tracking-wider text-[oklch(0.58_0.015_255)] w-20 shrink-0">
+            {s.label}
+          </span>
+          <span className="text-[12px] text-[oklch(0.86_0.008_90)] truncate">{s.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function FeatureGrid() {
+  return (
+    <section id="features" className="py-24 relative">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="max-w-2xl mb-16">
+          <div className="text-[11px] uppercase tracking-[0.2em] text-[oklch(0.82_0.12_200)] pb-3">
+            Features
+          </div>
+          <h2 className="text-[38px] sm:text-[50px] tracking-[-0.025em] font-bold leading-[1.02]">
+            <span className="gradient-text">Everything an agent needs</span>
+            <br />
+            <span className="gradient-text-accent">to work alongside you.</span>
+          </h2>
+          <p className="mt-5 text-[16px] text-[oklch(0.70_0.012_255)] leading-relaxed">
+            Twelve building blocks. They compose. They stay out of your way until you need them.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 lg:auto-rows-[230px]">
+          {features.map((f) => (
+            <article
+              key={f.title}
+              className={[
+                'card-glow p-6 group hover:border-[oklch(0.50_0.06_200)] transition-colors',
+                f.span,
+              ].join(' ')}
+            >
+              <div className="flex items-start justify-between">{f.icon}</div>
+              <h3 className="mt-4 text-[16px] font-semibold tracking-[-0.01em]">{f.title}</h3>
+              <p className="mt-1.5 text-[13px] leading-relaxed text-[oklch(0.78_0.01_255)]">
+                {f.body}
+              </p>
+              {f.visual}
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -1,0 +1,42 @@
+import { Logo } from '../components/Logo';
+
+export function Footer() {
+  return (
+    <footer className="border-t border-[oklch(0.36_0.012_255_/_0.5)] py-10 mt-8">
+      <div className="mx-auto max-w-7xl px-6 flex flex-col sm:flex-row items-center justify-between gap-5">
+        <div className="flex items-center gap-4">
+          <Logo size={22} />
+          <span className="text-[11.5px] text-[oklch(0.58_0.015_255)]">© 2026 · MIT licensed</span>
+        </div>
+        <nav className="flex items-center gap-5 text-[12px] text-[oklch(0.78_0.01_255)]">
+          <a
+            href="https://github.com/akhayam99/goodboy"
+            target="_blank"
+            rel="noreferrer"
+            className="hover:text-[oklch(0.95_0.005_90)]"
+          >
+            GitHub
+          </a>
+          <a href="#features" className="hover:text-[oklch(0.95_0.005_90)]">
+            Features
+          </a>
+          <a href="#stack" className="hover:text-[oklch(0.95_0.005_90)]">
+            Stack
+          </a>
+          <a href="#cta" className="hover:text-[oklch(0.95_0.005_90)]">
+            Install
+          </a>
+          <span className="text-[oklch(0.45_0.015_255)]">·</span>
+          <a
+            href="https://github.com/akhayam99/goodboy/blob/main/README.md"
+            target="_blank"
+            rel="noreferrer"
+            className="font-mono text-[oklch(0.78_0.01_255)] hover:text-[oklch(0.95_0.005_90)]"
+          >
+            Docs
+          </a>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/website/src/sections/GithubDeepDive.tsx
+++ b/website/src/sections/GithubDeepDive.tsx
@@ -1,0 +1,167 @@
+import { Section } from '../components/Section';
+
+export function GithubDeepDive() {
+  return (
+    <Section
+      id="github"
+      eyebrow="GitHub"
+      reverse
+      title={
+        <>
+          <span className="gradient-text">PRs live</span>{' '}
+          <span className="gradient-text-accent">where you work.</span>
+        </>
+      }
+      body={
+        <>
+          <p>
+            Open the GitHub panel next to your session. PR state, CI checks, reviews, linked issues.
+            Refreshed by client-side polling every five minutes, and immediately when an agent
+            creates a PR.
+          </p>
+          <p>
+            Diff comments are line-anchored. Spawn a resolver agent on one with a click. It
+            addresses the comment in the worktree, commits locally, and posts back. Approvals show
+            up in the session feed so you never miss a green light.
+          </p>
+          <p className="text-[oklch(0.78_0.01_255)] text-[14px]">
+            No webhooks to configure. No browser tab to alt-tab. The PR comes to you.
+          </p>
+        </>
+      }
+    >
+      <GithubMockup />
+    </Section>
+  );
+}
+
+function GithubMockup() {
+  return (
+    <div className="card-glow p-5">
+      <div className="flex items-center justify-between pb-3 border-b border-[oklch(0.36_0.012_255)]">
+        <div className="flex items-center gap-2.5">
+          <svg width="18" height="18" viewBox="0 0 16 16" className="text-[oklch(0.86_0.008_90)]">
+            <path
+              d="M8 2C4.7 2 2 4.7 2 8c0 2.6 1.7 4.9 4.1 5.7.3.1.4-.1.4-.3v-1.2c-1.7.4-2-.8-2-.8-.3-.7-.7-.9-.7-.9-.6-.4 0-.4 0-.4.6 0 .9.6.9.6.6 1 1.5.7 1.9.6 0-.4.2-.7.4-.9-1.3-.2-2.7-.7-2.7-3 0-.7.2-1.2.6-1.6 0-.2-.3-.8.1-1.6 0 0 .5-.2 1.6.6.5-.1.9-.2 1.4-.2s.9.1 1.4.2c1.1-.7 1.6-.6 1.6-.6.3.8.1 1.4.1 1.6.4.4.6.9.6 1.6 0 2.3-1.4 2.8-2.7 3 .2.2.4.5.4 1.1v1.7c0 .2.1.4.4.3C12.3 12.9 14 10.6 14 8c0-3.3-2.7-6-6-6z"
+              fill="currentColor"
+            />
+          </svg>
+          <div>
+            <div className="text-[13.5px] font-medium text-[oklch(0.92_0.006_90)]">
+              akhayam99/goodboy
+            </div>
+            <div className="text-[10.5px] text-[oklch(0.68_0.015_255)] font-mono">
+              3 open PRs · last sync 12s ago
+            </div>
+          </div>
+        </div>
+        <button className="text-[10.5px] rounded border border-[oklch(0.40_0.012_255)] px-2 py-0.5 text-[oklch(0.78_0.01_255)] hover:bg-[oklch(0.30_0.010_255)]">
+          refresh
+        </button>
+      </div>
+      <div className="mt-3 space-y-2">
+        <PR
+          num={617}
+          title="feat(core): context_slot_history with rollback"
+          branch="ak/context-slot-history"
+          state="open"
+          checksPass={5}
+          checksFail={0}
+          reviews={['claude-reviewer ✓', 'human pending']}
+        />
+        <PR
+          num={616}
+          title="fix(desktop): annotate sweep opts param"
+          branch="ak/typecheck-fix"
+          state="merged"
+          checksPass={6}
+          checksFail={0}
+          reviews={['merged via squash']}
+        />
+        <PR
+          num={615}
+          title="feat(desktop): client-side pr polling"
+          branch="ak/pr-polling"
+          state="draft"
+          checksPass={3}
+          checksFail={1}
+          reviews={['ci red']}
+        />
+      </div>
+      <div className="mt-4 pt-3 border-t border-[oklch(0.36_0.012_255)]">
+        <div className="text-[10.5px] uppercase tracking-wider text-[oklch(0.58_0.015_255)] pb-2">
+          Latest diff comment · PR #617
+        </div>
+        <div className="rounded-lg border border-[oklch(0.36_0.012_255)] bg-[oklch(0.22_0.007_255)] p-3">
+          <div className="flex items-center gap-2 text-[10.5px] text-[oklch(0.68_0.015_255)]">
+            <span className="inline-flex items-center gap-1 rounded chip-anthropic px-1.5 py-0.5">
+              claude-reviewer
+            </span>
+            <span>on</span>
+            <code className="font-mono text-[oklch(0.88_0.12_200)]">
+              packages/db/migrations/038…sql:14
+            </code>
+          </div>
+          <div className="mt-2 text-[12px] text-[oklch(0.86_0.008_90)] leading-relaxed">
+            <code className="font-mono text-[10.5px] text-[oklch(0.86_0.13_78)] block bg-[oklch(0.76_0.13_78_/_0.08)] px-2 py-1 rounded mb-2">
+              CREATE INDEX idx_history_slot_id ON context_slot_history(slot_id);
+            </code>
+            Add a composite index on <code className="font-mono">(slot_id, snapshot_at DESC)</code>{' '}
+            if reverts need to scan history quickly.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PR({
+  num,
+  title,
+  branch,
+  state,
+  checksPass,
+  checksFail,
+  reviews,
+}: {
+  num: number;
+  title: string;
+  branch: string;
+  state: 'open' | 'merged' | 'draft';
+  checksPass: number;
+  checksFail: number;
+  reviews: string[];
+}) {
+  const stateChip =
+    state === 'merged' ? 'chip-merged' : state === 'draft' ? 'chip-warning' : 'chip-success';
+  return (
+    <div className="rounded-lg border border-[oklch(0.36_0.012_255)] bg-[oklch(0.22_0.007_255)] p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-[11px] font-mono text-[oklch(0.58_0.015_255)]">#{num}</span>
+          <span className="text-[12.5px] text-[oklch(0.92_0.006_90)] truncate">{title}</span>
+        </div>
+        <span
+          className={`shrink-0 inline-flex items-center gap-1 rounded ${stateChip} px-1.5 py-0.5 text-[10px] uppercase tracking-wider`}
+        >
+          <span className="h-1 w-1 rounded-full bg-current" />
+          {state}
+        </span>
+      </div>
+      <div className="mt-1.5 flex items-center gap-3 text-[10.5px] text-[oklch(0.68_0.015_255)] font-mono">
+        <span className="truncate">{branch}</span>
+        <span>·</span>
+        <span className="inline-flex items-center gap-1">
+          <span className="h-1 w-1 rounded-full bg-[oklch(0.69_0.13_148)]" /> {checksPass} pass
+        </span>
+        {checksFail > 0 && (
+          <span className="inline-flex items-center gap-1 text-[oklch(0.86_0.13_22)]">
+            <span className="h-1 w-1 rounded-full bg-[oklch(0.63_0.17_22)]" /> {checksFail} fail
+          </span>
+        )}
+        <span>·</span>
+        <span className="truncate">{reviews.join(' · ')}</span>
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -1,0 +1,113 @@
+import { AppMockup } from '../mockups/AppMockup';
+
+export function Hero() {
+  return (
+    <section className="relative pt-20 pb-28">
+      <div className="absolute inset-0 grid-bg pointer-events-none" />
+      {/* large ambient glow behind headline */}
+      <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[900px] h-[500px] bg-[oklch(0.78_0.13_200_/_0.07)] blur-[120px] pointer-events-none rounded-full" />
+
+      <div className="relative mx-auto max-w-7xl px-6">
+        <div className="mx-auto max-w-4xl text-center">
+          {/* badge */}
+          <div className="inline-flex items-center gap-2 rounded-full border border-[oklch(0.69_0.13_148_/_0.3)] bg-[oklch(0.69_0.13_148_/_0.07)] px-4 py-1.5 text-[12px] text-[oklch(0.82_0.13_148)] mb-8 fade-up">
+            <span className="h-1.5 w-1.5 rounded-full bg-[oklch(0.69_0.13_148)]" />
+            Open source · MIT
+            <span className="text-[oklch(0.50_0.015_255)]">·</span>
+            <span className="text-[oklch(0.65_0.012_255)]">macOS · Windows · Linux</span>
+          </div>
+
+          {/* headline */}
+          <h1
+            className="text-[56px] sm:text-[72px] lg:text-[88px] leading-[0.92] tracking-[-0.03em] font-bold fade-up"
+            style={{ animationDelay: '60ms' }}
+          >
+            <span className="gradient-text">AI workspace</span>
+            <br />
+            <span className="gradient-text-accent">orchestrator.</span>
+          </h1>
+
+          {/* sub */}
+          <p
+            className="mt-7 text-[17px] sm:text-[19px] leading-[1.6] text-[oklch(0.72_0.012_255)] max-w-2xl mx-auto fade-up"
+            style={{ animationDelay: '120ms' }}
+          >
+            Route agents across Claude, Cursor, and Codex without re-explaining the goal. Shared
+            context, structured plans, real-time cost. Local-first. Your keys, your machine.
+          </p>
+
+          {/* CTAs */}
+          <div
+            className="mt-9 flex flex-col sm:flex-row items-center justify-center gap-3 fade-up"
+            style={{ animationDelay: '180ms' }}
+          >
+            <a
+              href="#cta"
+              className="inline-flex items-center gap-2 rounded-lg bg-[oklch(0.78_0.13_200)] px-6 py-3 text-[15px] font-semibold text-[oklch(0.12_0.02_200)] hover:bg-[oklch(0.83_0.13_200)] transition-all shadow-[0_0_80px_-12px_oklch(0.78_0.13_200_/_0.7)]"
+            >
+              Clone &amp; run
+              <svg width="13" height="13" viewBox="0 0 12 12" aria-hidden>
+                <path
+                  d="M3 6h6m-2-2 2 2-2 2"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </a>
+            <a
+              href="https://github.com/akhayam99/goodboy"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-lg border border-[oklch(0.42_0.012_255)] bg-[oklch(0.26_0.008_255_/_0.8)] px-6 py-3 text-[15px] font-medium text-[oklch(0.88_0.008_90)] hover:bg-[oklch(0.32_0.010_255)] transition-colors"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+              </svg>
+              View on GitHub
+            </a>
+          </div>
+
+          {/* trust bullets */}
+          <div
+            className="mt-8 flex flex-wrap items-center justify-center gap-x-7 gap-y-2 text-[12px] text-[oklch(0.56_0.015_255)] fade-up"
+            style={{ animationDelay: '240ms' }}
+          >
+            <Bullet>No cloud sync</Bullet>
+            <Bullet>No metered tokens</Bullet>
+            <Bullet>MIT licensed</Bullet>
+            <Bullet>Bring your own keys</Bullet>
+          </div>
+        </div>
+
+        {/* app mockup */}
+        <div className="relative mt-20 fade-up" style={{ animationDelay: '200ms' }}>
+          <div className="absolute -inset-x-20 top-12 bottom-0 bg-[oklch(0.78_0.13_200_/_0.10)] blur-[80px] pointer-events-none rounded-full" />
+          <div className="relative max-w-7xl mx-auto">
+            <AppMockup />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Bullet({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <svg width="11" height="11" viewBox="0 0 12 12" aria-hidden>
+        <path
+          d="M2.5 6.5 5 9l4.5-5.5"
+          stroke="oklch(0.69 0.13 148)"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      {children}
+    </span>
+  );
+}

--- a/website/src/sections/LogoStrip.tsx
+++ b/website/src/sections/LogoStrip.tsx
@@ -1,0 +1,134 @@
+type Card = {
+  name: string;
+  org: string;
+  color: string;
+  desc: string;
+  accent: string;
+  border: string;
+  soon?: boolean;
+};
+
+const subscriptions: Card[] = [
+  {
+    name: 'Claude',
+    org: 'Anthropic Max',
+    color: 'oklch(0.74 0.15 55)',
+    desc: 'Planning, refactors, reviews',
+    accent: 'oklch(0.74 0.15 55 / 0.12)',
+    border: 'oklch(0.74 0.15 55 / 0.25)',
+  },
+  {
+    name: 'Cursor',
+    org: 'Cursor Pro',
+    color: 'oklch(0.70 0.16 290)',
+    desc: 'Inline edits, autocomplete',
+    accent: 'oklch(0.70 0.16 290 / 0.12)',
+    border: 'oklch(0.70 0.16 290 / 0.25)',
+  },
+  {
+    name: 'Codex',
+    org: 'ChatGPT Pro',
+    color: 'oklch(0.72 0.16 150)',
+    desc: 'Scaffolds, one-shots',
+    accent: 'oklch(0.72 0.16 150 / 0.12)',
+    border: 'oklch(0.72 0.16 150 / 0.25)',
+  },
+  {
+    name: 'More',
+    org: 'soon',
+    color: 'oklch(0.55 0.012 255)',
+    desc: 'Gemini, local LLMs, OSS adapters',
+    accent: 'oklch(0.30 0.010 255 / 0.6)',
+    border: 'oklch(0.36 0.012 255 / 0.7)',
+    soon: true,
+  },
+];
+
+const integrations: Card[] = [
+  {
+    name: 'GitHub',
+    org: 'PRs + CI',
+    color: 'oklch(0.86 0.005 250)',
+    desc: 'PRs, checks, diff comments',
+    accent: 'oklch(0.86 0.005 250 / 0.08)',
+    border: 'oklch(0.86 0.005 250 / 0.20)',
+  },
+  {
+    name: 'VS Code',
+    org: 'soon',
+    color: 'oklch(0.69 0.11 238)',
+    desc: 'Open worktree in editor, jump-to-file',
+    accent: 'oklch(0.30 0.010 255 / 0.6)',
+    border: 'oklch(0.36 0.012 255 / 0.7)',
+    soon: true,
+  },
+  {
+    name: 'Linear',
+    org: 'soon',
+    color: 'oklch(0.70 0.16 290)',
+    desc: 'Link issues to sessions, sync status',
+    accent: 'oklch(0.30 0.010 255 / 0.6)',
+    border: 'oklch(0.36 0.012 255 / 0.7)',
+    soon: true,
+  },
+  {
+    name: 'Slack',
+    org: 'soon',
+    color: 'oklch(0.76 0.13 78)',
+    desc: 'Notify on PR ready, budget alerts',
+    accent: 'oklch(0.30 0.010 255 / 0.6)',
+    border: 'oklch(0.36 0.012 255 / 0.7)',
+    soon: true,
+  },
+];
+
+export function LogoStrip() {
+  return (
+    <section className="py-20 border-y border-[oklch(0.36_0.012_255_/_0.4)]">
+      <div className="mx-auto max-w-7xl px-6 space-y-12">
+        <Row eyebrow="Subscriptions you already have" cards={subscriptions} />
+        <Row eyebrow="Integrations" cards={integrations} />
+      </div>
+    </section>
+  );
+}
+
+function Row({ eyebrow, cards }: { eyebrow: string; cards: Card[] }) {
+  return (
+    <div>
+      <p className="text-center text-[11px] uppercase tracking-[0.2em] text-[oklch(0.55_0.015_255)] pb-6">
+        {eyebrow}
+      </p>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+        {cards.map((p) => (
+          <div
+            key={p.name + p.org}
+            className="rounded-xl p-4 flex flex-col gap-3"
+            style={{
+              background: p.accent,
+              border: `1px solid ${p.border}`,
+              opacity: p.soon ? 0.7 : 1,
+            }}
+          >
+            <div className="flex items-center gap-2.5">
+              <span className="h-2.5 w-2.5 rounded-full shrink-0" style={{ background: p.color }} />
+              <span className="text-[15px] font-semibold text-[oklch(0.94_0.006_90)]">
+                {p.name}
+              </span>
+              <span
+                className="ml-auto text-[10px] font-mono px-1.5 py-0.5 rounded"
+                style={{
+                  color: p.soon ? 'oklch(0.65 0.015 255)' : p.color,
+                  background: p.soon ? 'oklch(0.30 0.010 255)' : p.accent,
+                }}
+              >
+                {p.org}
+              </span>
+            </div>
+            <p className="text-[12.5px] text-[oklch(0.72_0.012_255)] leading-snug">{p.desc}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/Nav.tsx
+++ b/website/src/sections/Nav.tsx
@@ -1,0 +1,50 @@
+import { Logo } from '../components/Logo';
+
+const links = [
+  { href: '#features', label: 'Features' },
+  { href: '#routing', label: 'Routing' },
+  { href: '#plans', label: 'Plans' },
+  { href: '#stack', label: 'Stack' },
+];
+
+export function Nav() {
+  return (
+    <header className="sticky top-0 z-50 backdrop-blur-xl bg-[oklch(0.20_0.006_255_/_0.7)] border-b border-[oklch(0.36_0.012_255_/_0.5)]">
+      <div className="mx-auto flex h-14 max-w-7xl items-center justify-between px-6">
+        <a href="#" className="flex items-center">
+          <Logo />
+        </a>
+        <nav className="hidden md:flex items-center gap-8">
+          {links.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              className="text-[13px] text-[oklch(0.78_0.01_255)] hover:text-[oklch(0.95_0.005_90)] transition-colors"
+            >
+              {l.label}
+            </a>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <a
+            href="#cta"
+            className="hidden sm:inline-flex text-[13px] text-[oklch(0.78_0.01_255)] hover:text-[oklch(0.95_0.005_90)] transition-colors"
+          >
+            Install
+          </a>
+          <a
+            href="https://github.com/akhayam99/goodboy"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md bg-[oklch(0.78_0.13_200)] px-3.5 py-1.5 text-[13px] font-medium text-[oklch(0.13_0.02_200)] hover:bg-[oklch(0.82_0.13_200)] transition-colors"
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+              <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+            </svg>
+            GitHub
+          </a>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/website/src/sections/PlansDeepDive.tsx
+++ b/website/src/sections/PlansDeepDive.tsx
@@ -1,0 +1,116 @@
+import { Section } from '../components/Section';
+
+export function PlansDeepDive() {
+  return (
+    <Section
+      id="plans"
+      eyebrow="Plans"
+      title={
+        <>
+          <span className="gradient-text">Plans are artifacts,</span>{' '}
+          <span className="gradient-text-accent">not transcripts.</span>
+        </>
+      }
+      body={
+        <>
+          <p>
+            Planner agents emit structured plans wrapped in{' '}
+            <code className="font-mono text-[oklch(0.86_0.13_55)]">&lt;&lt;plan&gt;&gt;</code>{' '}
+            markers. Goodboy lifts them out of the chat and stores them as first-class objects.
+          </p>
+          <p>
+            Trees, statuses, references. A plan shows you what&apos;s active, what&apos;s consumed,
+            what&apos;s been superseded. Downstream agents pick them up and execute. You see
+            progress as it lands.
+          </p>
+          <p className="text-[oklch(0.78_0.01_255)] text-[14px]">
+            No more scrolling through a 4,000-line conversation to find what was decided.
+          </p>
+        </>
+      }
+    >
+      <PlanMockup />
+    </Section>
+  );
+}
+
+const tree = [
+  { id: '1', text: 'Add history table & trigger', status: 'done', depth: 0 },
+  { id: '1.1', text: 'Write migration 038_context_slot_history.sql', status: 'done', depth: 1 },
+  { id: '1.2', text: 'Apply migration locally', status: 'done', depth: 1 },
+  { id: '1.3', text: 'Add ON UPDATE trigger', status: 'done', depth: 1 },
+  { id: '2', text: 'Write unit tests', status: 'active', depth: 0 },
+  { id: '2.1', text: 'Fixture-backed history insert path', status: 'done', depth: 1 },
+  { id: '2.2', text: 'Rollback test for trigger', status: 'active', depth: 1 },
+  { id: '2.3', text: 'Pruning cron test', status: 'pending', depth: 1 },
+  { id: '3', text: 'Wire UI revert affordance', status: 'pending', depth: 0 },
+  { id: '3.1', text: 'Open question: v0.8 or v0.9?', status: 'blocked', depth: 1 },
+];
+
+const statusColors: Record<string, { dot: string; text: string }> = {
+  done: {
+    dot: 'bg-[oklch(0.69_0.13_148)]',
+    text: 'text-[oklch(0.62_0.015_255)] line-through decoration-[oklch(0.50_0.015_255)]',
+  },
+  active: { dot: 'bg-[oklch(0.69_0.11_238)]', text: 'text-[oklch(0.92_0.006_90)]' },
+  pending: { dot: 'bg-[oklch(0.45_0.015_255)]', text: 'text-[oklch(0.78_0.01_255)]' },
+  blocked: { dot: 'bg-[oklch(0.76_0.13_78)]', text: 'text-[oklch(0.86_0.13_78)]' },
+};
+
+function PlanMockup() {
+  return (
+    <div className="card-glow p-5">
+      <div className="flex items-center justify-between pb-4 border-b border-[oklch(0.36_0.012_255)]">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 items-center justify-center rounded-md chip-merged">
+            <svg width="14" height="14" viewBox="0 0 16 16">
+              <path d="M3 3h10v10H3z" stroke="currentColor" strokeWidth="1.5" fill="none" />
+              <path
+                d="M5.5 6h5M5.5 8.5h5M5.5 11h3"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              />
+            </svg>
+          </div>
+          <div>
+            <div className="text-[13.5px] font-medium text-[oklch(0.92_0.006_90)]">
+              Add history table for context_slots
+            </div>
+            <div className="text-[10.5px] text-[oklch(0.68_0.015_255)] font-mono">
+              plan · drafted by planner · picked up by implementer
+            </div>
+          </div>
+        </div>
+        <span className="inline-flex items-center gap-1.5 rounded chip-info px-2 py-0.5 text-[10px]">
+          <span className="h-1 w-1 rounded-full bg-current" />
+          active
+        </span>
+      </div>
+      <ul className="mt-4 space-y-1.5">
+        {tree.map((n) => {
+          const c = statusColors[n.status];
+          return (
+            <li
+              key={n.id}
+              className="flex items-start gap-2.5 text-[12.5px]"
+              style={{ paddingLeft: `${n.depth * 18}px` }}
+            >
+              <span
+                className={`mt-1.5 h-1.5 w-1.5 rounded-full shrink-0 ${c.dot} ${n.status === 'active' ? 'pulse' : ''}`}
+              />
+              <span className="font-mono text-[10px] text-[oklch(0.58_0.015_255)] mt-0.5 w-7 shrink-0">
+                {n.id}
+              </span>
+              <span className={c.text}>{n.text}</span>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="mt-4 pt-3 border-t border-[oklch(0.36_0.012_255)] flex items-center justify-between text-[10.5px] text-[oklch(0.68_0.015_255)]">
+        <span>Referenced by 3 sessions · 1 PR linked</span>
+        <span className="font-mono">v2 · edited 4m ago</span>
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/RoutingDeepDive.tsx
+++ b/website/src/sections/RoutingDeepDive.tsx
@@ -1,0 +1,164 @@
+import { Section } from '../components/Section';
+
+export function RoutingDeepDive() {
+  return (
+    <Section
+      id="routing"
+      eyebrow="Routing & budget"
+      reverse
+      title={
+        <>
+          <span className="gradient-text">Three providers.</span>{' '}
+          <span className="gradient-text-accent">One ledger.</span>
+        </>
+      }
+      body={
+        <>
+          <p>
+            Pick the right provider for the work. Long-context refactor? Claude. Inline edit?
+            Cursor. Codegen scaffold? Codex. Switch mid-session without re-explaining the goal:
+            every turn is rebuilt from the shared context, not resumed from the provider&apos;s
+            thread.
+          </p>
+          <p>
+            Per-provider monthly caps. Per-session soft caps. Configurable threshold alerts. The
+            cost chip ticks live next to every turn. No surprise invoice.
+          </p>
+          <p className="text-[oklch(0.78_0.01_255)] text-[14px]">
+            Subscription-based. Uses your Claude Max, Cursor Pro, ChatGPT Pro. No metered API
+            tokens.
+          </p>
+        </>
+      }
+    >
+      <RoutingMockup />
+    </Section>
+  );
+}
+
+function RoutingMockup() {
+  return (
+    <div className="card-glow p-5">
+      <div className="flex items-center justify-between pb-4 border-b border-[oklch(0.36_0.012_255)]">
+        <div>
+          <div className="text-[11px] uppercase tracking-wider text-[oklch(0.58_0.015_255)]">
+            Budget · May 2026
+          </div>
+          <div className="text-[13px] font-mono text-[oklch(0.92_0.006_90)]">all providers</div>
+        </div>
+        <div className="inline-flex items-center gap-1.5 rounded chip-success px-2 py-0.5 text-[10px]">
+          <span className="h-1 w-1 rounded-full bg-current" />
+          on track
+        </div>
+      </div>
+      <div className="mt-5 space-y-4">
+        <BudgetCard
+          provider="Anthropic"
+          model="Claude Sonnet 4.6"
+          spent={144}
+          cap={250}
+          color="oklch(0.74 0.15 55)"
+          tasks={['planning', 'refactors', 'reviews']}
+        />
+        <BudgetCard
+          provider="Cursor"
+          model="cursor-default"
+          spent={48}
+          cap={150}
+          color="oklch(0.70 0.16 290)"
+          tasks={['inline edits', 'autocomplete']}
+        />
+        <BudgetCard
+          provider="Codex"
+          model="gpt-5-codex"
+          spent={21}
+          cap={150}
+          color="oklch(0.72 0.16 150)"
+          tasks={['scaffolds', 'one-shots']}
+        />
+      </div>
+      <div className="mt-5 rounded-lg border border-[oklch(0.76_0.13_78_/_0.3)] bg-[oklch(0.76_0.13_78_/_0.06)] p-3 flex items-start gap-3">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 16 16"
+          className="mt-0.5 text-[oklch(0.86_0.13_78)] shrink-0"
+        >
+          <path
+            d="M8 2l6 11H2L8 2z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            fill="none"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M8 7v3M8 11.5v.1"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+        <div className="text-[12px] leading-relaxed">
+          <div className="text-[oklch(0.92_0.006_90)] font-medium">Threshold alert</div>
+          <div className="text-[oklch(0.78_0.01_255)]">
+            Anthropic at 58% of the monthly cap with 13 days remaining. Heads-up before you hit it.
+            Switch to Cursor or Codex from the model picker.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BudgetCard({
+  provider,
+  model,
+  spent,
+  cap,
+  color,
+  tasks,
+}: {
+  provider: string;
+  model: string;
+  spent: number;
+  cap: number;
+  color: string;
+  tasks: string[];
+}) {
+  const pct = Math.round((spent / cap) * 100);
+  return (
+    <div className="rounded-lg border border-[oklch(0.36_0.012_255)] bg-[oklch(0.22_0.007_255)] p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <span className="h-2.5 w-2.5 rounded-full" style={{ background: color }} />
+          <div>
+            <div className="text-[13px] font-medium text-[oklch(0.92_0.006_90)]">{provider}</div>
+            <div className="text-[10.5px] font-mono text-[oklch(0.68_0.015_255)]">{model}</div>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[14px] font-mono font-semibold" style={{ color }}>
+            ${spent}
+          </div>
+          <div className="text-[10px] text-[oklch(0.58_0.015_255)]">of ${cap} cap</div>
+        </div>
+      </div>
+      <div className="mt-2.5 h-1.5 rounded-full bg-[oklch(0.30_0.010_255)] overflow-hidden">
+        <div
+          className="h-full rounded-full bar-grow"
+          style={{ width: `${pct}%`, background: color }}
+        />
+      </div>
+      <div className="mt-2.5 flex items-center gap-1.5 flex-wrap">
+        {tasks.map((t) => (
+          <span
+            key={t}
+            className="text-[10px] rounded px-1.5 py-0.5 bg-[oklch(0.28_0.010_255)] text-[oklch(0.78_0.01_255)] font-mono"
+          >
+            {t}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/website/src/sections/Stack.tsx
+++ b/website/src/sections/Stack.tsx
@@ -1,0 +1,54 @@
+const items = [
+  { label: 'Tauri 2', sub: 'native shell', glyph: 'T' },
+  { label: 'React 19', sub: 'UI', glyph: 'R' },
+  { label: 'TypeScript', sub: 'strict mode', glyph: 'TS' },
+  { label: 'Tailwind 4', sub: 'design system', glyph: 'tw' },
+  { label: 'Zustand', sub: 'state', glyph: 'Z' },
+  { label: 'SQLite', sub: 'local DB', glyph: 'SQ' },
+  { label: 'Vite', sub: 'build', glyph: 'V' },
+  { label: 'Turborepo', sub: 'monorepo', glyph: 'TR' },
+];
+
+export function Stack() {
+  return (
+    <section id="stack" className="py-24 relative">
+      <div className="mx-auto max-w-7xl px-6">
+        <div className="grid lg:grid-cols-[1.1fr_1fr] gap-16 items-start">
+          <div>
+            <div className="text-[11px] uppercase tracking-[0.2em] text-[oklch(0.82_0.12_200)] pb-4">
+              Architecture
+            </div>
+            <h2 className="text-[38px] sm:text-[50px] tracking-[-0.025em] font-bold leading-[1.02]">
+              <span className="gradient-text">Native shell.</span>
+              <br />
+              <span className="gradient-text-accent">Modern web underneath.</span>
+            </h2>
+            <p className="mt-6 text-[16px] text-[oklch(0.70_0.012_255)] leading-[1.65]">
+              Tauri shell wrapping a React + TypeScript surface. SQLite stores everything locally.
+              API keys live in your OS credential store. Nothing leaves the machine unless an agent
+              calls a provider you authorized.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            {items.map((i) => (
+              <div
+                key={i.label}
+                className="card-glow p-4 aspect-square flex flex-col justify-between"
+              >
+                <div className="flex h-8 w-8 items-center justify-center rounded-md bg-[oklch(0.78_0.13_200_/_0.12)] text-[oklch(0.85_0.12_200)] border border-[oklch(0.78_0.13_200_/_0.2)] text-[12px] font-mono font-semibold">
+                  {i.glyph}
+                </div>
+                <div>
+                  <div className="text-[13px] font-medium text-[oklch(0.92_0.006_90)]">
+                    {i.label}
+                  </div>
+                  <div className="text-[10.5px] text-[oklch(0.68_0.015_255)]">{i.sub}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -1,0 +1,265 @@
+@import 'tailwindcss';
+
+@theme {
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', monospace;
+  --font-display: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+
+  --color-background: oklch(0.20 0.006 255);
+  --color-foreground: oklch(0.94 0.006 90);
+  --color-subtle: oklch(0.25 0.008 255);
+  --color-muted: oklch(0.30 0.010 255);
+  --color-elevated: oklch(0.35 0.011 255);
+  --color-muted-foreground: oklch(0.68 0.015 255);
+  --color-border: oklch(0.36 0.012 255);
+  --color-border-soft: oklch(0.30 0.010 255);
+
+  --color-primary: oklch(0.78 0.13 200);
+  --color-primary-foreground: oklch(0.13 0.02 200);
+
+  --color-danger: oklch(0.63 0.17 22);
+  --color-warning: oklch(0.76 0.13 78);
+  --color-success: oklch(0.69 0.13 148);
+  --color-info: oklch(0.69 0.11 238);
+  --color-merged: oklch(0.70 0.15 305);
+
+  --color-anthropic: oklch(0.74 0.15 55);
+  --color-cursor: oklch(0.70 0.16 290);
+  --color-codex: oklch(0.72 0.16 150);
+
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 15px;
+  --text-lg: 17px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 32px;
+  --text-4xl: 44px;
+  --text-5xl: 64px;
+  --text-6xl: 88px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-2xl: 20px;
+
+  --shadow-sm:
+    0 1px 2px 0 oklch(0 0 0 / 0.28),
+    inset 0 1px 0 0 oklch(1 0 0 / 0.03);
+  --shadow-md:
+    0 6px 16px -4px oklch(0 0 0 / 0.44),
+    0 2px 4px -1px oklch(0 0 0 / 0.30),
+    inset 0 1px 0 0 oklch(1 0 0 / 0.04);
+  --shadow-lg:
+    0 18px 40px -10px oklch(0 0 0 / 0.52),
+    0 6px 12px -4px oklch(0 0 0 / 0.38),
+    inset 0 1px 0 0 oklch(1 0 0 / 0.05);
+  --shadow-glow:
+    0 0 80px -10px oklch(0.78 0.13 200 / 0.35),
+    0 0 30px -5px oklch(0.78 0.13 200 / 0.25);
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+html,
+body,
+#root {
+  background: var(--color-background);
+  color: var(--color-foreground);
+  color-scheme: dark;
+  font-family: var(--font-sans);
+  font-feature-settings: 'cv11', 'ss01';
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  background-image:
+    radial-gradient(circle at 20% 0%, oklch(0.78 0.13 200 / 0.08) 0%, transparent 50%),
+    radial-gradient(circle at 80% 30%, oklch(0.70 0.16 290 / 0.06) 0%, transparent 50%);
+  background-attachment: fixed;
+}
+
+/* Grid noise overlay for tactile feel */
+.noise::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.04;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* Gradient text utility */
+.gradient-text {
+  background: linear-gradient(
+    125deg,
+    oklch(0.97 0.01 90) 0%,
+    oklch(0.90 0.06 200) 45%,
+    oklch(0.80 0.13 210) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.gradient-text-accent {
+  background: linear-gradient(
+    125deg,
+    oklch(0.88 0.13 200) 0%,
+    oklch(0.75 0.17 215) 50%,
+    oklch(0.65 0.18 280) 100%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Card glow */
+.card-glow {
+  position: relative;
+  background: linear-gradient(180deg, oklch(0.27 0.008 255) 0%, oklch(0.23 0.006 255) 100%);
+  border: 1px solid oklch(0.36 0.012 255);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+}
+
+.card-glow::before {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(
+    180deg,
+    oklch(0.55 0.04 200 / 0.4),
+    oklch(0.30 0.01 255 / 0)
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+}
+
+/* Scrollbar, subtle */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.36 0.012 255) transparent;
+}
+*::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+*::-webkit-scrollbar-thumb {
+  background: oklch(0.36 0.012 255 / 0.6);
+  border-radius: 999px;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.45 0.015 255);
+}
+
+/* Animated grid background */
+.grid-bg {
+  background-image:
+    linear-gradient(oklch(0.36 0.012 255 / 0.15) 1px, transparent 1px),
+    linear-gradient(90deg, oklch(0.36 0.012 255 / 0.15) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, #000 30%, transparent 80%);
+}
+
+/* Fade-in on scroll */
+@keyframes fade-up {
+  from { opacity: 0; transform: translateY(16px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.fade-up {
+  animation: fade-up 600ms cubic-bezier(0.2, 0, 0, 1) backwards;
+}
+
+@keyframes soft-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+.pulse { animation: soft-pulse 2.4s ease-in-out infinite; }
+
+@keyframes bar-grow {
+  from { transform: scaleY(0); }
+  to   { transform: scaleY(1); }
+}
+
+.bar-grow {
+  transform-origin: bottom;
+  animation: bar-grow 800ms cubic-bezier(0.2, 0, 0, 1) backwards;
+}
+
+@keyframes shimmer {
+  0% { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+.shimmer {
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    oklch(0.78 0.13 200 / 0.15) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 3s linear infinite;
+}
+
+@keyframes orbit {
+  from { transform: rotate(0deg) translateX(120px) rotate(0deg); }
+  to   { transform: rotate(360deg) translateX(120px) rotate(-360deg); }
+}
+
+@keyframes orbit-rev {
+  from { transform: rotate(0deg) translateX(80px) rotate(0deg); }
+  to   { transform: rotate(-360deg) translateX(80px) rotate(360deg); }
+}
+
+.orbit-a { animation: orbit 14s linear infinite; }
+.orbit-b { animation: orbit-rev 10s linear infinite; animation-delay: -3s; }
+
+/* Mockup window chrome */
+.window-chrome {
+  background: oklch(0.27 0.008 255);
+  border: 1px solid oklch(0.36 0.012 255);
+  border-radius: 12px 12px 0 0;
+  padding: 10px 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+/* Provider chips */
+.chip-anthropic { background: oklch(0.74 0.15 55 / 0.15); color: oklch(0.86 0.13 55); border: 1px solid oklch(0.74 0.15 55 / 0.3); }
+.chip-cursor    { background: oklch(0.70 0.16 290 / 0.15); color: oklch(0.82 0.13 290); border: 1px solid oklch(0.70 0.16 290 / 0.3); }
+.chip-codex     { background: oklch(0.72 0.16 150 / 0.15); color: oklch(0.86 0.13 150); border: 1px solid oklch(0.72 0.16 150 / 0.3); }
+.chip-primary   { background: oklch(0.78 0.13 200 / 0.15); color: oklch(0.88 0.12 200); border: 1px solid oklch(0.78 0.13 200 / 0.3); }
+.chip-warning   { background: oklch(0.76 0.13 78 / 0.15); color: oklch(0.86 0.13 78); border: 1px solid oklch(0.76 0.13 78 / 0.3); }
+.chip-success   { background: oklch(0.69 0.13 148 / 0.15); color: oklch(0.82 0.13 148); border: 1px solid oklch(0.69 0.13 148 / 0.3); }
+.chip-info      { background: oklch(0.69 0.11 238 / 0.15); color: oklch(0.82 0.11 238); border: 1px solid oklch(0.69 0.11 238 / 0.3); }
+.chip-merged    { background: oklch(0.70 0.15 305 / 0.15); color: oklch(0.82 0.13 305); border: 1px solid oklch(0.70 0.15 305 / 0.3); }
+
+/* Marquee for logo strip */
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(-50%); }
+}
+.marquee { animation: marquee 28s linear infinite; }

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src"]
+}

--- a/website/vite.config.ts
+++ b/website/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    port: 1499,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## Summary

- New `/website` package: marketing/presentation site for Goodboy.
- React 19 + Vite 6 + Tailwind v4. Zero extra runtime deps.
- Hero with a faithful 3-column mockup of the desktop UI (sessions rail, workflow detail, transcript, context panel) rendered with pseudo data.
- Sections: features bento, routing/plans/github/context deep-dives, comparison, stack, install CTA.
- Local-first messaging. Open-source-first CTAs: `Clone & run`, `View on GitHub`. No email collection, no waitlist.
- SEO: OG image, `robots.txt`, `sitemap.xml`, JSON-LD `SoftwareApplication`.

## Test plan

- [x] `pnpm --dir website build` clean (46 modules, ~270 KB JS / 37 KB CSS).
- [ ] `pnpm --dir website dev` on :1499 renders hero, mockup, all sections without console errors.
- [ ] Hero mockup visually tracks the real desktop UI (workspace pills, sessions rail w-28 vertical cards, workflow steps with kind chips + model badges, active step stats + CTX bar, agents, breadcrumb, markdown transcript, composer, context slots, open-questions footer).
- [ ] Responsive: hero stacks under `lg`, no horizontal overflow on mobile.
- [ ] All copy free of em-dashes (verified by `grep -rn "—" website/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)