### PR TITLE
fix(repo): move vercel.json to website dir

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": null,
-  "installCommand": "cd website && pnpm install --ignore-workspace --frozen-lockfile",
-  "buildCommand": "cd website && pnpm build",
-  "outputDirectory": "website/dist"
-}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "pnpm install --ignore-workspace --frozen-lockfile",
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- vercel project has Root Directory = website, so build cwd is website/
- previous root vercel.json with `cd website &&` failed: "No such file or directory"
- move vercel.json into website/ and drop the cd

## Test plan
- [ ] vercel deploy succeeds