### PR TITLE
fix(desktop): stub open-questions hook in context-panel-rail test

### DIFF
--- a/apps/desktop/src/__tests__/context-panel-rail.test.tsx
+++ b/apps/desktop/src/__tests__/context-panel-rail.test.tsx
@@ -9,6 +9,23 @@ vi.mock('@tauri-apps/plugin-sql', () => ({
   default: { load: vi.fn().mockResolvedValue({}) },
 }));
 
+vi.mock('../features/context/components/QuestionsTab/useOpenQuestions', () => ({
+  useOpenQuestions: () => ({
+    questions: [],
+    drafts: {},
+    justAnswered: [],
+    pendingUndo: null,
+    loadQuestions: vi.fn().mockResolvedValue(undefined),
+    toggleSuggestion: vi.fn(),
+    setCustomAnswer: vi.fn(),
+    toggleCustomField: vi.fn(),
+    dismissQuestion: vi.fn().mockResolvedValue(undefined),
+    undoDismiss: vi.fn().mockResolvedValue(undefined),
+    submitAnsweredBatch: vi.fn().mockResolvedValue(undefined),
+    clearJustAnswered: vi.fn(),
+  }),
+}));
+
 vi.mock('../store', () => ({
   EMPTY_ARRAY: [],
   useAppStore: vi.fn((selector: (s: unknown) => unknown) => {


### PR DESCRIPTION
## Summary

- ci on main went red after #623 merged: `context-panel-rail.test.tsx` triggers an unhandled rejection at mount time
- `useOpenQuestions.loadQuestions` calls `listOpenQuestionsForSession` which does `rows.map(...)`. the test's `@tauri-apps/plugin-sql` mock returns `{}`, so `db.select()` resolves `undefined` → typeerror
- fix scopes the test to context-panel rail behavior by stubbing the `useOpenQuestions` hook with a noop loader and safe defaults
- prod code untouched

## Test plan

- [x] `pnpm vitest run src/__tests__/context-panel-rail.test.tsx` → 10/10 pass, 0 unhandled rejections
- [x] `pnpm turbo run lint typecheck test --filter=@goodboy/desktop` → all green (505 tests)
- [ ] ci on this pr passes