### PR TITLE
fix(ui,db): dialogs reopen + migrations self-heal after numbering bump

### DIFF
--- a/packages/db/src/migrations/runner.ts
+++ b/packages/db/src/migrations/runner.ts
@@ -32,7 +32,7 @@ export async function migrate(
       skipped.push(migration.version);
       continue;
     }
-    await db.exec(migration.sql);
+    await applyMigrationSql(db, migration);
     // OR IGNORE: under React StrictMode in dev, hydrate() runs twice and two
     // migrate() invocations race for the same version row. The SQL itself is
     // idempotent enough (table-rebuild recipe), but the version INSERT would
@@ -46,4 +46,41 @@ export async function migrate(
 
   const currentVersion = ordered.at(-1)?.version ?? 0;
   return { applied: newlyApplied, skipped, currentVersion };
+}
+
+// Self-healing apply: runs each statement individually so a benign "already
+// exists" error on an idempotent DDL (ALTER ADD COLUMN, CREATE INDEX, CREATE
+// TABLE) doesn't abort the rest of the migration. This unblocks users who
+// applied an older numbering of a migration before it was bumped to resolve
+// a version collision (the schema object is already there from the previous
+// run; re-applying it would otherwise throw and corrupt schema_version).
+async function applyMigrationSql(db: Database, migration: Migration): Promise<void> {
+  const statements = migration.sql
+    .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  for (const stmt of statements) {
+    try {
+      await db.exec(stmt);
+    } catch (err) {
+      if (isAlreadyExistsError(err)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[migrations] v${migration.version}: skipping idempotent statement (already applied): ${truncate(stmt)}`,
+        );
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+function isAlreadyExistsError(err: unknown): boolean {
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return msg.includes('duplicate column name') || msg.includes('already exists');
+}
+
+function truncate(s: string): string {
+  return s.length > 80 ? `${s.slice(0, 77)}...` : s;
 }

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -95,9 +95,34 @@ export function Dialog({
   const titleId = title ? `${uid}-title` : undefined;
   const descId = description ? `${uid}-desc` : undefined;
 
+  // Latest-onClose ref so the showModal effect can stay keyed on `open` alone
+  // instead of refiring whenever the parent re-renders with a fresh handler.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  // Suppress close-event-driven onClose when we ourselves called dialog.close()
+  // (cleanup or open→false transition). React 19 strict mode double-invokes
+  // effects, so a "mount when open" parent would otherwise: setup → showModal,
+  // cleanup → dialog.close() queues a close event, resetup → showModal again,
+  // then the deferred close event fires onClose against the new listener and
+  // the parent unmounts the dialog for real. The user sees nothing happen.
+  const programmaticCloseRef = useRef(false);
+
   useEffect(() => {
     const dialog = ref.current;
     if (!dialog) return;
+
+    const handleClose = () => {
+      if (programmaticCloseRef.current) {
+        programmaticCloseRef.current = false;
+        return;
+      }
+      onCloseRef.current();
+    };
+    dialog.addEventListener('close', handleClose);
+
     if (open) {
       if (!dialog.open) {
         dialog.showModal();
@@ -112,20 +137,18 @@ export function Dialog({
         }
       }
     } else if (dialog.open) {
+      programmaticCloseRef.current = true;
       dialog.close();
     }
+
     return () => {
-      if (dialog.open) dialog.close();
+      dialog.removeEventListener('close', handleClose);
+      if (dialog.open) {
+        programmaticCloseRef.current = true;
+        dialog.close();
+      }
     };
   }, [open, initialFocusRef]);
-
-  useEffect(() => {
-    const dialog = ref.current;
-    if (!dialog) return;
-    const handleClose = () => onClose();
-    dialog.addEventListener('close', handleClose);
-    return () => dialog.removeEventListener('close', handleClose);
-  }, [onClose]);
 
   const onBackdropClick = (event: MouseEvent<HTMLDialogElement>) => {
     if (!closeOnBackdrop) return;


### PR DESCRIPTION
## Summary

Two regressions surfaced after PR #633 + the m038→m039 migration bump (commit d80adeb):

- **Dialogs gated mount-on-open never opened** (+ workspace, settings ⚙, pricing \$, guide ?, session controls). React 19 strict mode synchronously cleans up then re-runs the Dialog effect; the cleanup's \`dialog.close()\` queues a close event that fires onClose *after* the re-setup, snapping the parent state back to false and unmounting for real. Fix in \`packages/ui/src/components/Dialog.tsx\`: merge the show/close + close-listener effects, route onClose via a ref, and guard the close handler with a \`programmaticCloseRef\` so our own cleanup-driven closes don't trigger onClose. ESC (via App.tsx), backdrop, and × still close as before.

- **\`sqlite error: no such column: last_accessed_at\`** when reopening the workspace link dialog. Users who applied the pre-bump m038 (last-accessed-at) ended up with v38 in \`schema_version\` and the column already present. The bumped m039 then re-ran the same ALTER, threw "duplicate column name", and the schema landed inconsistent with what \`schema_version\` claimed. Fix in \`packages/db/src/migrations/runner.ts\`: split each migration's SQL on \`;\`, run statements one at a time, and swallow "duplicate column name" / "already exists" — other errors still throw. Bumped migrations now replay cleanly.

Convention note in the commit body: prefer adding a reconciling migration over renumbering a released one.

## Test plan

- [ ] \`pnpm tauri:dev\`, click +, \$, ?, ⚙, session controls toggles → each dialog opens, ESC and × still close
- [ ] Reopen the workspace link dialog with a recent workspace → no sqlite error, recents populated
- [ ] Fresh DB: \`pnpm --filter @goodboy/db test\` still green (505/505)
- [ ] Simulate the bump: pre-create the \`last_accessed_at\` column manually, drop \`schema_version\` row 39, restart — runner logs warning and continues without throwing

🤖 Generated with [Claude Code](https://claude.com/claude-code)