### PR TITLE
chore(repo): renumber versions to 0.0.x line

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Goodboy — Roadmap
 
-Local-first AI workspace orchestrator. This roadmap tracks the path from bootstrap to v1.0. Each version is a GitHub milestone; issues live there.
+Local-first AI workspace orchestrator. This roadmap tracks the path from bootstrap to v0.1.0 (first public release). Each version is a GitHub milestone; issues live there.
 
-> **Status**: post-v0.7 sprint complete (PRs #501–#569). Domain rename shipped. GitHub panel, plans, agent kinds, next-actions, diff viewer, notifications, session status all live. **v1.0 next.**
+> **Status**: post-v0.0.7 sprint complete (PRs #501–#569). Domain rename shipped. GitHub panel, plans, agent kinds, next-actions, diff viewer, notifications, session status all live. **v0.1.0 next.**
 
 ## Architectural decisions (locked)
 
@@ -12,8 +12,8 @@ Non-negotiable choices that frame the product. Numbers preserved for cross-refer
 2. **Goodboy owns the conversation** — history lives in our SQLite, not in `~/.claude/projects/`. Every turn is reconstructed from the synthetic context plus the new user message; we never rely on `--resume`. This is what makes context portable across providers.
 3. **Synthetic context = hybrid structured slots** — fixed slots (`goal`, `files_touched`, `decisions`, `open_questions`, `last_output_summary`), editable by hand at any time, auto-updated post-turn by a cheap summarizer (active provider's cheap-tier model via CLI — no separate API key required, runs against the user's existing subscription).
 4. **Isolation = git worktree per session** — branch prefix configurable per workspace (default `kay`). Worktree is the sandbox in which agents operate.
-5. **Provider scope, phased** — v0.1 shipped with Claude only behind a stable adapter interface; v0.2 added Cursor + Codex together to stress-test the contract on two new adapters at once.
-6. **Permission proxy** — landed in v0.6 for Claude (intercept tool-calls → UI approve/deny). Cursor + Codex coverage tracked for v1.0.
+5. **Provider scope, phased** — v0.0.1 shipped with Claude only behind a stable adapter interface; v0.0.2 added Cursor + Codex together to stress-test the contract on two new adapters at once.
+6. **Permission proxy** — landed in v0.0.6 for Claude (intercept tool-calls → UI approve/deny). Cursor + Codex coverage tracked for v0.1.0.
 7. **Stack** — Tauri 2 + React 19 + TypeScript 5 strict + Vite 6 + Tailwind v4 + Zustand 5 + SQLite. Monorepo via pnpm 10 workspaces + Turborepo. See [CLAUDE.md](./CLAUDE.md) and [CONVENTIONS.md](./CONVENTIONS.md).
 8. **Domain model = workspace > session > agent (n)** — sessions own a goal, a worktree, and a shared context panel. Agents are independent chat threads inside a session, spawned at will from the sidebar; they share the session's context but each owns its own message history. DB tables match the domain: `sessions`, `agents`. Types: `Session`/`SessionId`, `Agent`/`AgentId`. Full rename completed in m031 (PR #564).
 
@@ -21,57 +21,57 @@ Non-negotiable choices that frame the product. Numbers preserved for cross-refer
 
 ## Completed milestones
 
-### v0.1 — MVP
+### v0.0.1 — MVP
 
 Single-provider session with synthetic context and live telemetry. End-to-end Claude session inside a Goodboy-managed worktree.
 
-[v0.1 milestone](https://github.com/akhayam99/goodboy/milestone/1)
+[v0.0.1 milestone](https://github.com/akhayam99/goodboy/milestone/1)
 
-### v0.2 — Multi-provider
+### v0.0.2 — Multi-provider
 
 Cursor + Codex adapters, capability matrix, provider connection UX, summarizer migrated to active-provider CLI.
 
-[v0.2 milestone](https://github.com/akhayam99/goodboy/milestone/2)
+[v0.0.2 milestone](https://github.com/akhayam99/goodboy/milestone/2)
 
-### v0.3 — Budget & routing
+### v0.0.3 — Budget & routing
 
 Per-provider monthly cap, per-session soft cap, automatic fallback when cap hit, threshold alerts, routing engine wired into turn flow.
 
-[v0.3 milestone](https://github.com/akhayam99/goodboy/milestone/3)
+[v0.0.3 milestone](https://github.com/akhayam99/goodboy/milestone/3)
 
-### v0.4 — Multi-agent sequential
+### v0.0.4 — Multi-agent sequential
 
 Declared phases inside a session. Each phase spawns its own agent; synthetic context flows between phases.
 
-[v0.4 milestone](https://github.com/akhayam99/goodboy/milestone/4)
+[v0.0.4 milestone](https://github.com/akhayam99/goodboy/milestone/4)
 
-### v0.5 — Skills
+### v0.0.5 — Skills
 
 Local skill registry (markdown + scripts), slash-command invocation from chat, executable across providers.
 
-[v0.5 milestone](https://github.com/akhayam99/goodboy/milestone/5)
+[v0.0.5 milestone](https://github.com/akhayam99/goodboy/milestone/5)
 
-### v0.6 — Permission proxy
+### v0.0.6 — Permission proxy
 
 Tool-call interception via static rules + audit for Claude. `--dangerously-skip-permissions` removed.
 
-[v0.6 milestone](https://github.com/akhayam99/goodboy/milestone/6)
+[v0.0.6 milestone](https://github.com/akhayam99/goodboy/milestone/6)
 
-### v0.7 — Multi-agent parallel
+### v0.0.7 — Multi-agent parallel
 
 Multiple agents inside a single session on throwaway worktrees, coordinating via shared context. Fan-out / fan-in with merge conflict UI.
 
-[v0.7 milestone](https://github.com/akhayam99/goodboy/milestone/7)
+[v0.0.7 milestone](https://github.com/akhayam99/goodboy/milestone/7)
 
-### pre-1.0 — UX polish
+### pre-0.1.0 — UX polish
 
 Design tokens, typography scale, motion language, empty/loading/error states, sidebar mega, settings IA split, a11y baseline, config export/import, settings inheritance resolver.
 
 ---
 
-## Post-v0.7 sprint (PRs #501–#569)
+## Post-v0.0.7 sprint (PRs #501–#569)
 
-Major sprint bridging v0.7 → v1.0. Shipped in ~2 weeks.
+Major sprint bridging v0.0.7 → v0.1.0. Shipped in ~2 weeks.
 
 ### Domain & DB
 
@@ -125,7 +125,7 @@ Major sprint bridging v0.7 → v1.0. Shipped in ~2 weeks.
 
 ---
 
-## v1.0 — Stable release
+## v0.1.0 — First public release
 
 Signed binary distribution and everything needed for a public launch.
 
@@ -148,7 +148,7 @@ Signed binary distribution and everything needed for a public launch.
 - Cursor + Codex permission proxy parity (currently Claude-only)
 - Command palette (⌘K) polish
 
-[v1.0 milestone](https://github.com/akhayam99/goodboy/milestone/8)
+[v0.1.0 milestone](https://github.com/akhayam99/goodboy/milestone/8)
 
 ---
 

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 // Snapshot baseline for empty + error states.
-// Purpose: catch unintentional regressions during pre-1.0 IA refactor.
+// Purpose: catch unintentional regressions during pre-0.1.0 IA refactor.
 // Update snapshots intentionally with: vitest run --update-snapshots
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));

--- a/docs/parallel-agents.md
+++ b/docs/parallel-agents.md
@@ -1,6 +1,6 @@
 # Parallel Agents (Experimental)
 
-Parallel agents let you fan out a goal across multiple independent agent threads, then merge results back into your main session. Experimental as of v0.7.
+Parallel agents let you fan out a goal across multiple independent agent threads, then merge results back into your main session. Experimental as of v0.0.7.
 
 ## What it is
 
@@ -53,7 +53,7 @@ Each phase runs on a new worktree. On completion, Goodboy merges back into main 
 - **Context sharing**: Agents copy parent context once at launch. Real-time parent updates don't propagate to running agents.
 - **Provider quota**: Parallel agents count against your provider subscription cap. Running 3 agents uses 3x the quota.
 
-See [#214](https://github.com/akhayam99/goodboy/issues/214) for v0.7 integration tests (fan-out/fan-in verified).
+See [#214](https://github.com/akhayam99/goodboy/issues/214) for v0.0.7 integration tests (fan-out/fan-in verified).
 
 ## Rollback
 

--- a/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md
+++ b/docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-The pre-1.0 workflow model treats a Task as an automatic chain of single-turn steps. The orchestrator advances on every user message: 1 message → 1 assistant turn → step marked complete → next message routed to next step. The user reported (verbatim, 2026-05-09):
+The pre-0.1.0 workflow model treats a Task as an automatic chain of single-turn steps. The orchestrator advances on every user message: 1 message → 1 assistant turn → step marked complete → next message routed to next step. The user reported (verbatim, 2026-05-09):
 
 - "ogni input crea nuovo agent" — cannot iterate within a step
 - "step 4 chat fresca, contesto perso" — only `outputSummary` (≤2000 char) of the immediately previous step propagates
@@ -102,7 +102,7 @@ Each PR: green CI required before merge. No squashed mega-PR.
 
 ## Out of scope (deferred)
 
-- Cross-Task ContextPanel inheritance (e.g. seeding new Task from previous Task's panel). Future v1.x.
+- Cross-Task ContextPanel inheritance (e.g. seeding new Task from previous Task's panel). Future v0.1.x.
 - Multi-agent parallel execution within one Task. Existing parallel mode unchanged for now.
 - Agent handoff protocols beyond ContextPanel reads (e.g. structured tool-call passing). Out of scope.
 - LLM-driven role inference (auto-detecting "this prompt feels like planning"). Always user-explicit chip.

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -176,7 +176,7 @@ async function* spawnClaude(
   });
 
   child.stderr?.on('data', () => {
-    // captured but not surfaced as TurnEvent for v0.1
+    // captured but not surfaced as TurnEvent for v0.0.1
   });
 
   try {

--- a/packages/core/src/providers/codex/adapter.ts
+++ b/packages/core/src/providers/codex/adapter.ts
@@ -170,7 +170,7 @@ async function* spawnCodex(
   });
 
   child.stderr?.on('data', () => {
-    // captured but not surfaced as TurnEvent for v0.1
+    // captured but not surfaced as TurnEvent for v0.0.1
   });
 
   try {

--- a/packages/core/src/providers/cursor/adapter.ts
+++ b/packages/core/src/providers/cursor/adapter.ts
@@ -165,7 +165,7 @@ async function* spawnCursor(
   });
 
   child.stderr?.on('data', () => {
-    // captured but not surfaced as TurnEvent for v0.1
+    // captured but not surfaced as TurnEvent for v0.0.1
   });
 
   try {

--- a/website/SEO.md
+++ b/website/SEO.md
@@ -70,7 +70,7 @@ Opzione C . sito live: usa `mcp__Claude_Preview__preview_screenshot` sulla pagin
 
 - Cambio tagline
 - Nuovo logo
-- Nuovo major version (es. v1.0)
+- Nuovo major version (es. v0.1.0)
 - Cambio palette
 
 ---
@@ -105,7 +105,7 @@ Definito inline in `index.html`. Campi da tenere aggiornati:
 
 | Campo             | Dove aggiornare                                      |
 | ----------------- | ---------------------------------------------------- |
-| `softwareVersion` | Ad ogni release (v0.7 → v0.8 → v1.0)                 |
+| `softwareVersion` | Ad ogni release (v0.0.7 → v0.0.8 → v0.1.0)           |
 | `featureList`     | Quando si aggiungono/rimuovono features dal prodotto |
 | `offers.price`    | Quando arriva il pricing                             |
 | `operatingSystem` | Se si aggiunge mobile/web                            |

--- a/website/public/og-image.svg
+++ b/website/public/og-image.svg
@@ -83,5 +83,5 @@
   <!-- Badge -->
   <rect x="88" y="550" width="200" height="32" rx="16" fill="#1a2830" stroke="#2a4855"/>
   <circle cx="112" cy="566" r="5" fill="#4fbcd4"/>
-  <text x="125" y="571" font-family="-apple-system, sans-serif" font-size="15" fill="#7dcfe0">v0.7 · private beta</text>
+  <text x="125" y="571" font-family="-apple-system, sans-serif" font-size="15" fill="#7dcfe0">v0.0.7 · private beta</text>
 </svg>

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -544,7 +544,7 @@ export function ContextSnapshot() {
         </p>
         <p className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-foreground/85">
           <IconHelp size={11} className="mt-0.5 shrink-0 text-warning" />
-          Should reverts be reachable from the UI in v0.8, or wait for the audit page in v0.9?
+          Should reverts be reachable from the UI in v0.0.8, or wait for the audit page in v0.0.9?
         </p>
       </div>
     </SnapshotFrame>


### PR DESCRIPTION
## Summary

- Shift planned versions down one tier: `v0.1`–`v0.8` → `v0.0.1`–`v0.0.8`, `v1.0` → `v0.1.0`, `pre-1.0` → `pre-0.1.0`. First public release now targets `v0.1.0` instead of `v1.0`.
- Updates ROADMAP, docs, website assets (SEO.md, og-image.svg, Snapshots.tsx mockup), and historical code/test comments referencing prior version labels.
- GitHub milestones renamed in lockstep (m1–m10); issue→milestone links preserved.

## Files touched

- `ROADMAP.md` — full version rewrite + status banner
- `website/SEO.md`, `website/public/og-image.svg`, `website/src/mockups/Snapshots.tsx`
- `docs/parallel-agents.md`, `docs/superpowers/specs/2026-05-09-task-as-shared-memory-design.md`
- `packages/core/src/providers/{claude,codex,cursor}/adapter.ts` (3 comment-only refs)
- `apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx` (comment-only)

## Out of scope

- README, VISION, DESIGN — no version refs to update
- `engine.test.ts` fixture string `ship v0.1` — test data, not a version label
- External CLI versions (codex v0.130, etc.) and dependency versions
- Issue body contents (per spec, milestone linkage is what matters)

## Test plan

- [ ] CI green (lint, typecheck, tests, commitlint, knip)
- [ ] Confirm milestone link in ROADMAP `[v0.1.0 milestone](.../milestone/8)` resolves to renamed milestone