### PR TITLE
perf(desktop): cache linear token to avoid repeated keychain prompts

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ pub fn run() {
   let turn_registry = turn::TurnRegistry::new();
   let script_registry = scripts::ScriptRegistry::new();
   let terminal_registry = terminal::TerminalRegistry::new();
+  let linear_token_cache = linear::LinearTokenCache::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
@@ -44,6 +45,7 @@ pub fn run() {
     .manage(turn_registry)
     .manage(script_registry)
     .manage(terminal_registry)
+    .manage(linear_token_cache)
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/apps/desktop/src-tauri/src/linear.rs
+++ b/apps/desktop/src-tauri/src/linear.rs
@@ -1,10 +1,24 @@
-use std::sync::OnceLock;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use tauri::State;
 use thiserror::Error;
 
 use crate::secrets;
+
+/// In-memory cache of Linear PATs keyed by workspace id.
+/// macOS Keychain prompts the user on every `get_password` unless the ACL is
+/// "Always Allow" + the app's code signature is stable. Caching avoids the
+/// repeated prompt in dev builds and the per-fetch prompt in any build.
+pub struct LinearTokenCache(Mutex<HashMap<String, String>>);
+
+impl LinearTokenCache {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
 
 const API_URL: &str = "https://api.linear.app/graphql";
 
@@ -100,9 +114,18 @@ async fn graphql<T: serde::de::DeserializeOwned>(
     serde_json::from_value(data).map_err(|e| LinearError::InvalidShape(e.to_string()))
 }
 
-fn read_token(workspace_id: &str) -> Result<String, LinearError> {
-    secrets::read(&credential_key(workspace_id))?
-        .ok_or_else(|| LinearError::NoToken(workspace_id.to_string()))
+fn read_token(workspace_id: &str, cache: &LinearTokenCache) -> Result<String, LinearError> {
+    if let Some(tok) = cache.0.lock().unwrap().get(workspace_id) {
+        return Ok(tok.clone());
+    }
+    let tok = secrets::read(&credential_key(workspace_id))?
+        .ok_or_else(|| LinearError::NoToken(workspace_id.to_string()))?;
+    cache
+        .0
+        .lock()
+        .unwrap()
+        .insert(workspace_id.to_string(), tok.clone());
+    Ok(tok)
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -178,15 +201,21 @@ query AssignedIssues($filter: IssueFilter!) {
 pub async fn linear_connect(
     workspace_id: String,
     token: String,
+    cache: State<'_, LinearTokenCache>,
 ) -> Result<LinearViewer, LinearError> {
     let viewer: ViewerResponse = graphql(&token, VIEWER_QUERY, None).await?;
     secrets::set(&credential_key(&workspace_id), &token)?;
+    cache.0.lock().unwrap().insert(workspace_id, token);
     Ok(viewer.viewer)
 }
 
 #[tauri::command]
-pub async fn linear_disconnect(workspace_id: String) -> Result<(), LinearError> {
+pub async fn linear_disconnect(
+    workspace_id: String,
+    cache: State<'_, LinearTokenCache>,
+) -> Result<(), LinearError> {
     secrets::clear(&credential_key(&workspace_id))?;
+    cache.0.lock().unwrap().remove(&workspace_id);
     Ok(())
 }
 
@@ -194,8 +223,9 @@ pub async fn linear_disconnect(workspace_id: String) -> Result<(), LinearError> 
 pub async fn linear_fetch_assigned_issues(
     workspace_id: String,
     team_id: Option<String>,
+    cache: State<'_, LinearTokenCache>,
 ) -> Result<Vec<LinearIssue>, LinearError> {
-    let token = read_token(&workspace_id)?;
+    let token = read_token(&workspace_id, &cache)?;
     let mut filter = serde_json::json!({
         "assignee": { "isMe": { "eq": true } },
         "state": { "type": { "nin": ["completed", "canceled"] } }


### PR DESCRIPTION
### Description

`read_token()` hit macOS Keychain on every `linear_fetch_assigned_issues` call, triggering a password prompt per fetch in dev builds (code signature unstable across rebuilds) and per session for users who picked "Consenti" instead of "Sempre" when first granting access.

Added an in-memory `LinearTokenCache(Mutex<HashMap<String, String>>)` keyed by workspace id, registered as Tauri managed state:

- populated on first cache miss in `read_token`
- populated on `linear_connect` (token already verified)
- cleared per-workspace on `linear_disconnect`

Per-workspace keys, no cross-contamination on multi-account setups. Cache empties on app restart (forces fresh keychain read once per session).
