### PR TITLE
feat(desktop): add gemini as third-party provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Goodboy sits between you and your AI coding agents — it doesn't replace your
 editor or terminal, it commands them. Run agents against your repos, keep them
 aware of the work through a context they all share, route them across Claude,
-Cursor, and Codex, and watch the cost as it accrues.
+Cursor, Codex, and Gemini, and watch the cost as it accrues.
 
 <img width="4036" height="2270" alt="CleanShot 2026-05-25 at 14 09 18@2x" src="https://github.com/user-attachments/assets/f669511b-c09d-472b-9f30-3dcc88b7ceae" />
 
@@ -31,7 +31,7 @@ work, kept separate from any one chat transcript.
 
 Goodboy owns the conversation: every turn is rebuilt from the shared context,
 not resumed from a provider's session. So you can switch provider or model
-mid-task — Claude, Cursor, Codex; Haiku, Sonnet, Opus — and the agent still has
+mid-task — Claude, Cursor, Codex, Gemini; Haiku, Sonnet, Opus, Flash, Pro — and the agent still has
 the full picture. No re-explaining where things stand.
 
 ### First-class plans
@@ -95,6 +95,7 @@ Goodboy drives locally installed provider CLIs — each on your existing
 | **Anthropic (Claude)** | `npm i -g @anthropic-ai/claude-code` | Claude Max / Pro |
 | **Cursor**             | Cursor desktop app                   | Cursor Pro       |
 | **OpenAI (Codex)**     | `npm i -g @openai/codex`             | ChatGPT Pro      |
+| **Google (Gemini)**    | `npm i -g @google/gemini-cli`        | Google AI Pro    |
 
 At least one connected CLI is required. Full guide: [docs/providers.md](./docs/providers.md).
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -31,6 +31,7 @@ pub fn run() {
   let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
   let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
   let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
+  let gemini_state = providers::GeminiState(Mutex::new(providers::detect_gemini()));
   let turn_registry = turn::TurnRegistry::new();
   let script_registry = scripts::ScriptRegistry::new();
   let terminal_registry = terminal::TerminalRegistry::new();
@@ -42,6 +43,7 @@ pub fn run() {
     .manage(provider_state)
     .manage(cursor_state)
     .manage(codex_state)
+    .manage(gemini_state)
     .manage(turn_registry)
     .manage(script_registry)
     .manage(terminal_registry)
@@ -87,6 +89,8 @@ pub fn run() {
       providers::refresh_cursor_status,
       providers::get_codex_status,
       providers::refresh_codex_status,
+      providers::get_gemini_status,
+      providers::refresh_gemini_status,
       providers::check_provider_auth,
       providers::provider_action,
       turn::turn_spawn,

--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -104,6 +104,12 @@ fn build_cli_args(args: &PlannerArgs) -> Result<Vec<String>, PlannerError> {
             "--".to_string(),
             format!("{}\n\n{}", args.system_prompt, args.user_message),
         ]),
+        "gemini" => Ok(vec![
+            "-m".to_string(),
+            args.model.clone(),
+            "-p".to_string(),
+            format!("{}\n\n{}", args.system_prompt, args.user_message),
+        ]),
         other => Err(PlannerError::UnknownProvider(other.to_string())),
     }
 }

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -26,6 +26,8 @@ pub struct CursorState(pub Mutex<ProviderStatus>);
 
 pub struct CodexState(pub Mutex<ProviderStatus>);
 
+pub struct GeminiState(pub Mutex<ProviderStatus>);
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum AuthStateKind {
@@ -50,6 +52,10 @@ pub fn detect_cursor() -> ProviderStatus {
 
 pub fn detect_codex() -> ProviderStatus {
     detect_binary("codex", "codex")
+}
+
+pub fn detect_gemini() -> ProviderStatus {
+    detect_binary("gemini", "gemini")
 }
 
 fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
@@ -406,6 +412,107 @@ fn check_codex_auth() -> AuthState {
     }
 }
 
+fn extract_gemini_identity_from_creds() -> Option<String> {
+    // gemini-cli stores OAuth credentials at `~/.gemini/oauth_creds.json` after
+    // an interactive login; the `email` field carries the user's Google identity.
+    // Fallback paths covered: legacy `~/.config/gemini/auth.json`.
+    let home = dirs::home_dir()?;
+    for rel in ["./.gemini/oauth_creds.json", "./.config/gemini/auth.json"] {
+        let path = home.join(rel);
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
+            continue;
+        };
+        if let Some(email) = root.get("email").and_then(|v| v.as_str()) {
+            return Some(email.to_string());
+        }
+        if let Some(id_token) = root.get("id_token").and_then(|v| v.as_str()) {
+            if let Some(email) = extract_email_from_id_token(id_token) {
+                return Some(email);
+            }
+        }
+    }
+    None
+}
+
+fn check_gemini_auth() -> AuthState {
+    // gemini-cli has no stable `auth status` subcommand at v0.x; probe a few
+    // candidates then fall back to the on-disk credentials file as ground truth.
+    let candidates: &[&[&str]] = &[
+        &["gemini", "auth", "status"],
+        &["gemini", "auth", "whoami"],
+        &["gemini", "whoami"],
+    ];
+    for cmd in candidates {
+        if let Ok(out) = run_auth_command(cmd) {
+            let text = out.primary_text();
+            if !text.trim().is_empty() {
+                let parsed = parse_gemini_auth_output(text);
+                if !matches!(parsed.state, AuthStateKind::Unknown) {
+                    return parsed;
+                }
+            }
+        }
+    }
+    if let Some(identity) = extract_gemini_identity_from_creds() {
+        return AuthState {
+            state: AuthStateKind::Connected,
+            identity: Some(identity),
+        };
+    }
+    // No subcommand worked and no creds file. Treat the absence as disconnected
+    // when the binary is present — install detection is handled separately, so
+    // reaching this point means `gemini --version` succeeded.
+    AuthState {
+        state: AuthStateKind::Disconnected,
+        identity: None,
+    }
+}
+
+fn parse_gemini_auth_output(output: &str) -> AuthState {
+    let stripped: String = strip_ansi(output);
+    let first_line = stripped
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+    let lower = first_line.to_lowercase();
+
+    if lower.starts_with("not logged")
+        || lower.starts_with("not signed")
+        || lower.contains("not logged in")
+        || lower.contains("not signed in")
+        || lower.contains("unauthenticated")
+        || lower.contains("no credentials")
+    {
+        return AuthState {
+            state: AuthStateKind::Disconnected,
+            identity: None,
+        };
+    }
+    if lower.starts_with("logged in")
+        || lower.starts_with("signed in")
+        || lower.contains("authenticated as")
+        || extract_email(first_line).is_some()
+    {
+        let identity = extract_email(first_line)
+            .or_else(|| extract_json_string(output, "email"))
+            .or_else(|| extract_json_string(output, "username"))
+            .or_else(extract_gemini_identity_from_creds);
+        return AuthState {
+            state: AuthStateKind::Connected,
+            identity,
+        };
+    }
+
+    AuthState {
+        state: AuthStateKind::Unknown,
+        identity: None,
+    }
+}
+
 fn parse_codex_auth_output(output: &str) -> AuthState {
     let stripped: String = strip_ansi(output);
     let first_line = stripped
@@ -514,11 +621,34 @@ pub fn refresh_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
     next
 }
 
+#[tauri::command]
+pub fn get_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
+    state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
+        id: "gemini".to_string(),
+        binary: "gemini".to_string(),
+        available: false,
+        version: None,
+        error: Some("status mutex poisoned".to_string()),
+    })
+}
+
+#[tauri::command]
+pub fn refresh_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
+    let next = detect_gemini();
+    if let Ok(mut current) = state.0.lock() {
+        *current = next.clone();
+    }
+    next
+}
+
 fn provider_login_command(provider_id: &str) -> Option<String> {
     match provider_id {
         "anthropic" => Some("claude /login".to_string()),
         "cursor" => Some("cursor login".to_string()),
         "codex" => Some("codex login".to_string()),
+        // gemini-cli prompts for OAuth on first run when no creds file exists;
+        // launching the bare binary opens the browser flow.
+        "gemini" => Some("gemini".to_string()),
         _ => None,
     }
 }
@@ -528,6 +658,9 @@ fn provider_logout_command(provider_id: &str) -> Option<String> {
         "anthropic" => Some("claude /logout".to_string()),
         "cursor" => Some("cursor logout".to_string()),
         "codex" => Some("codex logout".to_string()),
+        // gemini-cli has no logout subcommand; deleting the creds file is the
+        // closest equivalent. Wrap with a confirmation message in the terminal.
+        "gemini" => Some("rm -f ~/.gemini/oauth_creds.json && echo 'gemini credentials removed'".to_string()),
         _ => None,
     }
 }
@@ -598,6 +731,7 @@ pub fn check_provider_auth(provider_id: String) -> AuthState {
         "anthropic" => check_claude_auth(),
         "cursor" => check_cursor_auth(),
         "codex" => check_codex_auth(),
+        "gemini" => check_gemini_auth(),
         _ => AuthState {
             state: AuthStateKind::Unknown,
             identity: None,
@@ -764,6 +898,25 @@ mod tests {
             stderr: String::new(),
         };
         assert!(out.primary_text().trim().is_empty());
+    }
+
+    #[test]
+    fn gemini_parses_logged_in() {
+        let s = parse_gemini_auth_output("Logged in as alice@example.com\n");
+        assert_eq!(s.state, AuthStateKind::Connected);
+        assert_eq!(s.identity.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn gemini_parses_not_logged_in() {
+        let s = parse_gemini_auth_output("Not logged in\n");
+        assert_eq!(s.state, AuthStateKind::Disconnected);
+    }
+
+    #[test]
+    fn gemini_unknown_on_unrecognized() {
+        let s = parse_gemini_auth_output("some unrelated output\n");
+        assert_eq!(s.state, AuthStateKind::Unknown);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -133,6 +133,27 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
             v.shrink_to_fit();
             v
         }
+        "gemini" => {
+            // gemini-cli v0.x headless mode: `-m <model> -p <prompt>`. Working
+            // directory is set on the spawned child via current_dir(), the CLI
+            // has no --cwd/--workspace flag yet. No resume/system_prompt/tool
+            // gates are honoured by the binary today.
+            let _ = (
+                args.permission_mode,
+                args.allowed_tools,
+                args.disallowed_tools,
+                args.resume_session_id,
+                args.system_prompt,
+            );
+            let mut v = vec![
+                "-m".to_string(),
+                args.model.to_string(),
+                "-p".to_string(),
+                args.prompt.to_string(),
+            ];
+            v.shrink_to_fit();
+            v
+        }
         "codex" => {
             // codex exec v0.130 gotchas:
             //   --cd, NOT --cwd (codex exits 1 with "unexpected argument").

--- a/apps/desktop/src/features/budget/components/BudgetRulesPanel/index.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetRulesPanel/index.tsx
@@ -4,7 +4,7 @@ import type { BudgetRule, ProviderName } from '@goodboy/types';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore } from '../../../../store';
 
-const PROVIDER_OPTIONS: ProviderName[] = ['anthropic', 'cursor', 'codex'];
+const PROVIDER_OPTIONS: ProviderName[] = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 const DEFAULT_THRESHOLD = 80;
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -75,7 +75,7 @@ const CHAT_PREFIX_RE = /^\s*[$/~@][^\s]*$/;
 // so the user is taught every quick-action up front, not over time.
 const CHAT_PLACEHOLDER = 'Message Claude · $ scripts · ~ workflows · @ agents';
 
-const VALID_PROVIDERS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+const VALID_PROVIDERS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 const MAX_ATTACHMENT_BYTES = 15 * 1024 * 1024;
 const ATTACHMENT_LIMIT = 10;
@@ -926,7 +926,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
     ? 'override disabled in session settings'
     : undefined;
 
-  const providerCandidates: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+  const providerCandidates: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
   const modelCandidates = useMemo<ReadonlyArray<string>>(() => {
     const ids = new Set(providerModels.map((m) => m.id));

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -4,6 +4,7 @@ import {
   parseStreamJsonLine,
   parseCursorStreamLine,
   parseCodexJsonLine,
+  parseGeminiJsonLine,
   type ParseContext,
 } from '@goodboy/core';
 import type { IsoDateTime, ProviderId, ProviderRunId, TurnEvent } from '@goodboy/types';
@@ -22,6 +23,8 @@ function parseForProvider(
       return parseCursorStreamLine(line, ctx);
     case 'codex':
       return parseCodexJsonLine(line, ctx);
+    case 'gemini':
+      return parseGeminiJsonLine(line, ctx);
     default: {
       const _exhaustive: never = provider;
       void _exhaustive;

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -5,12 +5,14 @@ export const PROVIDER_LABEL: Record<ProviderId, string> = {
   anthropic: 'Claude',
   cursor: 'Cursor',
   codex: 'Codex',
+  gemini: 'Gemini',
 };
 
 export const PROVIDER_TEXT: Record<ProviderId, string> = {
   anthropic: 'text-[var(--color-provider-anthropic)]',
   cursor: 'text-[var(--color-provider-cursor)]',
   codex: 'text-[var(--color-provider-codex)]',
+  gemini: 'text-[var(--color-provider-gemini)]',
 };
 
 export const EFFORT_LEVELS = ['low', 'medium', 'high', 'extra-high', 'max'] as const;

--- a/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Code2, Info, MousePointer2, RotateCw, Sparkles } from 'lucide-react';
+import { Code2, Gem, Info, MousePointer2, RotateCw, Sparkles } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { Tooltip, cn } from '@goodboy/ui';
 import type {
@@ -25,7 +25,7 @@ const STATE_DOT: Record<ProviderConnectionState, string> = {
   error: 'bg-danger',
 };
 
-const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex'];
+const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 interface ProviderBrand {
   readonly name: string;
@@ -52,6 +52,12 @@ const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
     description: 'openai codex cli',
     icon: Code2,
     cssVar: '--color-provider-codex',
+  },
+  gemini: {
+    name: 'gemini',
+    description: 'google gemini cli',
+    icon: Gem,
+    cssVar: '--color-provider-gemini',
   },
 };
 

--- a/apps/desktop/src/features/providers/components/TelemetryPill/index.tsx
+++ b/apps/desktop/src/features/providers/components/TelemetryPill/index.tsx
@@ -9,6 +9,7 @@ const PROVIDER_DOT: Record<string, string> = {
   anthropic: 'bg-[var(--color-provider-anthropic)]',
   cursor: 'bg-[var(--color-provider-cursor)]',
   codex: 'bg-[var(--color-provider-codex)]',
+  gemini: 'bg-[var(--color-provider-gemini)]',
 };
 
 export function TelemetryPill() {

--- a/apps/desktop/src/features/providers/pricing.json
+++ b/apps/desktop/src/features/providers/pricing.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026-05-08",
+  "version": "2026-05-28",
   "anthropic": {
     "claude-opus-4-7": { "inputPerMtok": 15, "outputPerMtok": 75, "cachedInputPerMtok": 1.5 },
     "claude-sonnet-4-6": { "inputPerMtok": 3, "outputPerMtok": 15, "cachedInputPerMtok": 0.3 },
@@ -9,5 +9,14 @@
   "codex": {
     "codex-latest": { "inputPerMtok": 2.5, "outputPerMtok": 10, "cachedInputPerMtok": 1.25 },
     "codex-mini-latest": { "inputPerMtok": 1.5, "outputPerMtok": 6, "cachedInputPerMtok": 0.75 }
+  },
+  "gemini": {
+    "gemini-2.5-pro": { "inputPerMtok": 1.25, "outputPerMtok": 10, "cachedInputPerMtok": 0.31 },
+    "gemini-2.5-flash": { "inputPerMtok": 0.3, "outputPerMtok": 2.5, "cachedInputPerMtok": 0.075 },
+    "gemini-2.5-flash-lite": {
+      "inputPerMtok": 0.1,
+      "outputPerMtok": 0.4,
+      "cachedInputPerMtok": 0.025
+    }
   }
 }

--- a/apps/desktop/src/features/providers/provider-pricing.test.ts
+++ b/apps/desktop/src/features/providers/provider-pricing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   getCodexPriceOverride,
+  getGeminiPriceOverride,
   getActivePricingTable,
   refreshPricingTable,
 } from './provider-pricing';
@@ -11,6 +12,7 @@ describe('getActivePricingTable', () => {
     expect(table.anthropic).toBeDefined();
     expect(table.codex).toBeDefined();
     expect(table.cursor).toBeDefined();
+    expect(table.gemini).toBeDefined();
     expect(typeof table.version).toBe('string');
   });
 
@@ -32,6 +34,23 @@ describe('getCodexPriceOverride', () => {
     const knownModel = Object.keys(table.codex)[0];
     if (knownModel) {
       const result = getCodexPriceOverride(null, knownModel);
+      expect(result).not.toBeNull();
+      expect(result?.inputPerMtok).toBeGreaterThan(0);
+      expect(result?.outputPerMtok).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getGeminiPriceOverride', () => {
+  it('returns null for unknown model', () => {
+    expect(getGeminiPriceOverride(null, 'unknown-model-xyz')).toBeNull();
+  });
+
+  it('returns price for known gemini model', () => {
+    const table = getActivePricingTable();
+    const knownModel = Object.keys(table.gemini)[0];
+    if (knownModel) {
+      const result = getGeminiPriceOverride(null, knownModel);
       expect(result).not.toBeNull();
       expect(result?.inputPerMtok).toBeGreaterThan(0);
       expect(result?.outputPerMtok).toBeGreaterThan(0);

--- a/apps/desktop/src/features/providers/provider-pricing.ts
+++ b/apps/desktop/src/features/providers/provider-pricing.ts
@@ -1,4 +1,4 @@
-import type { CodexModelPriceOverride } from '@goodboy/core';
+import type { CodexModelPriceOverride, GeminiModelPriceOverride } from '@goodboy/core';
 import shippedPricing from './pricing.json';
 
 interface ModelPrice {
@@ -12,6 +12,7 @@ export interface PricingTable {
   readonly anthropic: Record<string, ModelPrice>;
   readonly cursor: Record<string, ModelPrice>;
   readonly codex: Record<string, ModelPrice>;
+  readonly gemini: Record<string, ModelPrice>;
 }
 
 const activeTable: PricingTable = shippedPricing as PricingTable;
@@ -39,7 +40,7 @@ declare global {
 const IS_DEV = import.meta.env.DEV === true;
 
 function priceForModel(
-  provider: 'anthropic' | 'cursor' | 'codex',
+  provider: 'anthropic' | 'cursor' | 'codex' | 'gemini',
   model: string,
 ): ModelPrice | null {
   const table: PricingTable =
@@ -56,6 +57,21 @@ export function getCodexPriceOverride(
   model: string,
 ): CodexModelPriceOverride | null {
   const price = priceForModel('codex', model);
+  if (price === null) return null;
+  return {
+    inputPerMtok: price.inputPerMtok,
+    outputPerMtok: price.outputPerMtok,
+    ...(price.cachedInputPerMtok !== undefined
+      ? { cachedInputPerMtok: price.cachedInputPerMtok }
+      : {}),
+  };
+}
+
+export function getGeminiPriceOverride(
+  _config: unknown,
+  model: string,
+): GeminiModelPriceOverride | null {
+  const price = priceForModel('gemini', model);
   if (price === null) return null;
   return {
     inputPerMtok: price.inputPerMtok,

--- a/apps/desktop/src/features/providers/providers.ts
+++ b/apps/desktop/src/features/providers/providers.ts
@@ -32,6 +32,7 @@ export const PROVIDER_LABEL_LOWER: Record<ProviderId, string> = {
   anthropic: 'claude',
   cursor: 'cursor',
   codex: 'codex',
+  gemini: 'gemini',
 };
 
 const PROVIDER_DOCS: Record<ProviderId, string> = {
@@ -39,18 +40,21 @@ const PROVIDER_DOCS: Record<ProviderId, string> = {
   // cursor-agent (CLI), NOT cursor IDE, point at the agent CLI install docs.
   cursor: 'https://docs.cursor.com/en/cli/installation',
   codex: 'https://github.com/openai/codex#installation',
+  gemini: 'https://github.com/google-gemini/gemini-cli#installation',
 };
 
 const PROVIDER_DEFAULT_BINARY: Record<ProviderId, string> = {
   anthropic: 'claude',
   cursor: 'cursor-agent',
   codex: 'codex',
+  gemini: 'gemini',
 };
 
 const TAURI_GET_CMD: Record<ProviderId, string> = {
   anthropic: 'get_provider_status',
   cursor: 'get_cursor_status',
   codex: 'get_codex_status',
+  gemini: 'get_gemini_status',
 };
 
 const EMPTY_CAPABILITIES: ProviderInfoBase['capabilities'] = {
@@ -66,6 +70,7 @@ export async function getProviderStatus(id: ProviderId): Promise<ProviderStatus>
 
 export const getCursorStatus = (): Promise<ProviderStatus> => getProviderStatus('cursor');
 export const getCodexStatus = (): Promise<ProviderStatus> => getProviderStatus('codex');
+export const getGeminiStatus = (): Promise<ProviderStatus> => getProviderStatus('gemini');
 
 export async function checkProviderAuth(providerId: ProviderId): Promise<AuthState> {
   return invoke<AuthState>('check_provider_auth', { providerId });
@@ -131,12 +136,13 @@ export interface ProviderStatuses {
   readonly anthropic: ProviderStatus | null;
   readonly cursor: ProviderStatus | null;
   readonly codex: ProviderStatus | null;
+  readonly gemini: ProviderStatus | null;
 }
 
 export function buildProviderList(
   statuses: ProviderStatuses,
   auth?: ProviderAuthResults,
 ): ReadonlyArray<ProviderInfo> {
-  const ids: ProviderId[] = ['anthropic', 'cursor', 'codex'];
+  const ids: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
   return ids.map((id) => providerInfoFromStatus(id, statuses[id], auth?.[id] ?? null));
 }

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -23,6 +23,7 @@ const PROVIDER_LABELS: Record<ProviderId, string> = {
   anthropic: 'Claude Code',
   cursor: 'cursor-agent',
   codex: 'OpenAI Codex',
+  gemini: 'Google Gemini',
 };
 
 function formatError(err: unknown): string {
@@ -40,7 +41,7 @@ function formatError(err: unknown): string {
   return String(err);
 }
 
-const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 function pickDefaultProvider(connectedIds: ReadonlySet<ProviderId>): ProviderId {
   for (const id of PROVIDER_ORDER) {
@@ -63,6 +64,8 @@ function getCheapModel(providerId: ProviderId): string {
       return 'composer-2-fast';
     case 'codex':
       return 'gpt-5.4-mini';
+    case 'gemini':
+      return 'gemini-2.5-flash';
     default: {
       const _exhaustive: never = providerId;
       void _exhaustive;
@@ -79,6 +82,8 @@ function getDefaultBinary(providerId: ProviderId): string {
       return 'cursor-agent';
     case 'codex':
       return 'codex';
+    case 'gemini':
+      return 'gemini';
     default: {
       const _exhaustive: never = providerId;
       void _exhaustive;

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.test.tsx
@@ -16,9 +16,11 @@ const { state, toastMock } = vi.hoisted(() => ({
     sessionSummary: null as null | { estimatedCostUsd: number },
     loadSessionBudget: vi.fn(async () => undefined),
     setSessionBudget: vi.fn(async () => undefined),
+    setSessionConfig: vi.fn(async () => undefined),
     renameTask: vi.fn(async () => undefined),
     deleteTask: vi.fn(async () => undefined),
     changeSessionBranch: vi.fn(async () => undefined),
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
     workspaces: [{ id: 'ws-1', rootPath: '/repo' }] as ReadonlyArray<{
       id: string;
       rootPath: string;

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -13,7 +13,7 @@ import {
   Trash2,
   Zap,
 } from 'lucide-react';
-import type { SessionId } from '@goodboy/types';
+import type { ProviderId, SessionId } from '@goodboy/types';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore, useSessionById } from '../../../../store';
 import { SESSION_FEATURES } from '../../../../shared/lib/features';
@@ -21,7 +21,7 @@ import { parseCap } from '../../../../shared/lib/parse-cap';
 import { listLocalBranches, type LocalBranchInfo } from '../../../../features/worktree/worktree';
 import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
 import { useToast } from '../../../../app/components/Toast';
-import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
+import { PROVIDER_LABEL } from '../../../../features/chat/utils/chat-constants';
 
 interface SessionSettingsDialogProps {
   sessionId: SessionId;
@@ -49,7 +49,11 @@ export function SessionSettingsDialog({
   const sessionSummary = useAppStore((s) => s.sessionSummary);
   const loadSessionBudget = useAppStore((s) => s.loadSessionBudget);
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
+  const setSessionConfig = useAppStore((s) => s.setSessionConfig);
   const renameTask = useAppStore((s) => s.renameTask);
+  const connectedProviderIds = useAppStore((s) =>
+    s.providers.filter((p) => p.connection === 'connected').map((p) => p.id),
+  );
   const deleteTask = useAppStore((s) => s.deleteTask);
   const changeSessionBranch = useAppStore((s) => s.changeSessionBranch);
   const workspace = useAppStore((s) =>
@@ -220,6 +224,20 @@ export function SessionSettingsDialog({
     onClose();
   };
 
+  const onChangeProvider = async (next: ProviderId) => {
+    if (next === session?.providerPreference.defaultProvider) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await setSessionConfig(sessionId, { defaultProvider: next });
+      showToast('success', `default provider set to ${PROVIDER_LABEL[next] ?? next}`);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
   const onDelete = async () => {
     setBusy(true);
     setError(null);
@@ -314,6 +332,8 @@ export function SessionSettingsDialog({
           branch={branch}
           workspaceReady={!!workspace}
           busy={busy}
+          connectedProviderIds={connectedProviderIds}
+          onChangeProvider={(p) => void onChangeProvider(p)}
           branchEditOpen={branchEditOpen}
           setBranchEditOpen={setBranchEditOpen}
           branchMode={branchMode}
@@ -361,13 +381,15 @@ export function SessionSettingsDialog({
 /* ──────────────────────────────────────────────────────────────────── */
 
 interface GeneralSectionProps {
-  readonly session: { goal: string; providerPreference: { defaultProvider: string } };
+  readonly session: { goal: string; providerPreference: { defaultProvider: ProviderId } };
   readonly goalDraft: string;
   readonly setGoalDraft: (v: string) => void;
   readonly onSaveGoal: () => void;
   readonly branch: string | null;
   readonly workspaceReady: boolean;
   readonly busy: boolean;
+  readonly connectedProviderIds: ReadonlyArray<ProviderId>;
+  readonly onChangeProvider: (p: ProviderId) => void;
   readonly branchEditOpen: boolean;
   readonly setBranchEditOpen: (v: boolean) => void;
   readonly branchMode: 'existing' | 'new';
@@ -393,6 +415,8 @@ function GeneralSection(props: GeneralSectionProps) {
     branch,
     workspaceReady,
     busy,
+    connectedProviderIds,
+    onChangeProvider,
     branchEditOpen,
     setBranchEditOpen,
     branchMode,
@@ -409,10 +433,7 @@ function GeneralSection(props: GeneralSectionProps) {
     onChangeBranch,
   } = props;
 
-  const providerLabel =
-    PROVIDER_LABEL_LOWER[
-      session.providerPreference.defaultProvider as keyof typeof PROVIDER_LABEL_LOWER
-    ] ?? session.providerPreference.defaultProvider;
+  const currentProvider = session.providerPreference.defaultProvider;
 
   return (
     <div className="flex flex-col gap-7">
@@ -567,16 +588,68 @@ function GeneralSection(props: GeneralSectionProps) {
         </div>
       </Field>
 
-      {/* Provider, read-only */}
       <Field
         label="Provider"
-        hint="Set at creation time. Per-turn overrides happen in the chat composer."
+        hint="Default provider for new agents and workflows spawned in this session. Inherited from the workspace at creation; per-turn overrides still happen in the chat composer."
       >
-        <span className="inline-flex w-fit items-center gap-1.5 rounded-md border border-border-soft bg-background px-2.5 py-1.5 text-xs">
-          <Zap size={11} aria-hidden className="text-muted-foreground" />
-          <span className="font-medium text-foreground">{providerLabel}</span>
-        </span>
+        <SessionProviderPicker
+          value={currentProvider}
+          onChange={onChangeProvider}
+          connected={connectedProviderIds}
+          disabled={busy}
+        />
       </Field>
+    </div>
+  );
+}
+
+const SESSION_PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = [
+  'anthropic',
+  'cursor',
+  'codex',
+  'gemini',
+];
+
+function SessionProviderPicker({
+  value,
+  onChange,
+  connected,
+  disabled,
+}: {
+  value: ProviderId;
+  onChange: (p: ProviderId) => void;
+  connected: ReadonlyArray<ProviderId>;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {SESSION_PROVIDER_OPTIONS.map((id) => {
+        const active = value === id;
+        const isConnected = connected.includes(id);
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onChange(id)}
+            disabled={disabled}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs motion-safe:transition-colors',
+              active
+                ? 'border-primary/40 bg-primary/10 font-medium text-primary'
+                : 'border-border-soft bg-background text-muted-foreground hover:border-border hover:text-foreground',
+              !isConnected && 'opacity-60',
+              disabled && 'cursor-not-allowed opacity-50',
+            )}
+            title={isConnected ? undefined : 'CLI not connected'}
+          >
+            <Zap size={11} aria-hidden />
+            {PROVIDER_LABEL[id]}
+            {!isConnected ? (
+              <span className="text-[9px] uppercase tracking-wide text-warning">offline</span>
+            ) : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -57,7 +57,7 @@ function templateToForm(t: Workflow): TemplateForm {
   };
 }
 
-const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex'];
+const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 export function WorkflowsPanel({ workspaceId }: Props) {
   const templates = useAppStore((s) => s.phaseTemplates[workspaceId] ?? EMPTY_ARRAY);

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.test.tsx
@@ -11,6 +11,7 @@ const { state } = vi.hoisted(() => ({
     workspaceOverrides: {} as Record<string, unknown>,
     setWorkspaceOverrides: vi.fn(async () => undefined),
     workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
   },
 }));
 

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import type { VerbosityLevel, WorkspaceId } from '@goodboy/types';
+import type { ProviderId, VerbosityLevel, WorkspaceId } from '@goodboy/types';
 import { Button, Dialog, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
@@ -8,10 +8,12 @@ import {
   GitBranch,
   Link2,
   Loader2,
+  Sparkles,
   Terminal,
   Unplug,
   Zap,
 } from 'lucide-react';
+import { PROVIDER_LABEL } from '../../../../features/chat/utils/chat-constants';
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
 import { WorkflowsPanel } from '../../../../features/workflows/components/WorkflowsPanel';
 import { ScriptsPanel } from '../../../../features/scripts';
@@ -65,11 +67,17 @@ export function WorkspaceSettingsDialog({
   const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
   const storeSetWorkspaceOverrides = useAppStore((s) => s.setWorkspaceOverrides);
 
+  const connectedProviderIds = useAppStore((s) =>
+    s.providers.filter((p) => p.connection === 'connected').map((p) => p.id),
+  );
+
   const [active, setActive] = useState<Section>('general');
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [savedBranchPrefix, setSavedBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
   const [verbosity, setVerbosity] = useState<VerbosityLevel>('normal');
   const [savedVerbosity, setSavedVerbosity] = useState<VerbosityLevel>('normal');
+  const [defaultProvider, setDefaultProvider] = useState<ProviderId | null>(null);
+  const [savedDefaultProvider, setSavedDefaultProvider] = useState<ProviderId | null>(null);
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [confirmDisconnect, setConfirmDisconnect] = useState(false);
@@ -90,6 +98,9 @@ export function WorkspaceSettingsDialog({
     const savedVerbosityValue = wsOverrides?.defaultVerbosity ?? 'normal';
     setVerbosity(savedVerbosityValue);
     setSavedVerbosity(savedVerbosityValue);
+    const savedProvider = wsOverrides?.defaultProviderId ?? null;
+    setDefaultProvider(savedProvider);
+    setSavedDefaultProvider(savedProvider);
   }, [open, workspaceId, loadSetting, initialSection, wsOverrides]);
 
   const onDisconnect = async () => {
@@ -113,7 +124,7 @@ export function WorkspaceSettingsDialog({
       setSavedBranchPrefix(next);
       setBranchPrefix(next);
       const mergedOverrides = {
-        defaultProviderId: wsOverrides?.defaultProviderId ?? null,
+        defaultProviderId: defaultProvider,
         defaultWorkflowId: wsOverrides?.defaultWorkflowId ?? null,
         defaultBranchPrefix: wsOverrides?.defaultBranchPrefix ?? null,
         parallelEnabled: wsOverrides?.parallelEnabled ?? null,
@@ -121,6 +132,7 @@ export function WorkspaceSettingsDialog({
       };
       await storeSetWorkspaceOverrides(workspaceId, mergedOverrides);
       setSavedVerbosity(verbosity);
+      setSavedDefaultProvider(defaultProvider);
       setSaveState('saved');
     } catch (err) {
       setSaveState('error');
@@ -130,7 +142,8 @@ export function WorkspaceSettingsDialog({
 
   const branchPrefixDirty = branchPrefix.trim() !== savedBranchPrefix.trim();
   const verbosityDirty = verbosity !== savedVerbosity;
-  const settingsDirty = branchPrefixDirty || verbosityDirty;
+  const providerDirty = defaultProvider !== savedDefaultProvider;
+  const settingsDirty = branchPrefixDirty || verbosityDirty || providerDirty;
 
   const navItems: ReadonlyArray<NavItem> = [
     { id: 'general', label: 'General', icon: <FolderCode size={13} aria-hidden /> },
@@ -226,6 +239,9 @@ export function WorkspaceSettingsDialog({
             setBranchPrefix={setBranchPrefix}
             verbosity={verbosity}
             setVerbosity={setVerbosity}
+            defaultProvider={defaultProvider}
+            setDefaultProvider={setDefaultProvider}
+            connectedProviderIds={connectedProviderIds}
             busy={saveState === 'saving'}
           />
         ) : null}
@@ -333,12 +349,18 @@ function GeneralSection({
   setBranchPrefix,
   verbosity,
   setVerbosity,
+  defaultProvider,
+  setDefaultProvider,
+  connectedProviderIds,
   busy,
 }: {
   branchPrefix: string;
   setBranchPrefix: (v: string) => void;
   verbosity: VerbosityLevel;
   setVerbosity: (v: VerbosityLevel) => void;
+  defaultProvider: ProviderId | null;
+  setDefaultProvider: (v: ProviderId | null) => void;
+  connectedProviderIds: ReadonlyArray<ProviderId>;
   busy: boolean;
 }) {
   const sanitized = (input: string): string =>
@@ -399,6 +421,23 @@ function GeneralSection({
 
       <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
         <div className="flex items-center gap-2">
+          <Sparkles size={13} aria-hidden className="text-muted-foreground" />
+          <span className="text-xs font-semibold text-foreground">Default provider</span>
+        </div>
+        <p className="text-2xs leading-relaxed text-muted-foreground">
+          New sessions in this workspace start with this provider. Each session can override it from
+          its own settings without affecting siblings.
+        </p>
+        <DefaultProviderPicker
+          value={defaultProvider}
+          onChange={setDefaultProvider}
+          connected={connectedProviderIds}
+          disabled={busy}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/50 p-4">
+        <div className="flex items-center gap-2">
           <Zap size={13} aria-hidden className="text-muted-foreground" />
           <span className="text-xs font-semibold text-foreground">Output verbosity</span>
         </div>
@@ -409,6 +448,66 @@ function GeneralSection({
           <VerbositySelect value={verbosity} onChange={setVerbosity} disabled={busy} />
         </div>
       </div>
+    </div>
+  );
+}
+
+const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
+
+function DefaultProviderPicker({
+  value,
+  onChange,
+  connected,
+  disabled,
+}: {
+  value: ProviderId | null;
+  onChange: (v: ProviderId | null) => void;
+  connected: ReadonlyArray<ProviderId>;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        disabled={disabled}
+        className={cn(
+          'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs motion-safe:transition-colors',
+          value === null
+            ? 'border-primary/40 bg-primary/10 font-medium text-primary'
+            : 'border-border-soft bg-background text-muted-foreground hover:border-border hover:text-foreground',
+          disabled && 'cursor-not-allowed opacity-50',
+        )}
+        title="Use global default"
+      >
+        Inherit global
+      </button>
+      {PROVIDER_OPTIONS.map((id) => {
+        const active = value === id;
+        const isConnected = connected.includes(id);
+        return (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onChange(id)}
+            disabled={disabled}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs motion-safe:transition-colors',
+              active
+                ? 'border-primary/40 bg-primary/10 font-medium text-primary'
+                : 'border-border-soft bg-background text-muted-foreground hover:border-border hover:text-foreground',
+              !isConnected && 'opacity-60',
+              disabled && 'cursor-not-allowed opacity-50',
+            )}
+            title={isConnected ? undefined : 'CLI not connected'}
+          >
+            {PROVIDER_LABEL[id]}
+            {!isConnected ? (
+              <span className="text-[9px] uppercase tracking-wide text-warning">offline</span>
+            ) : null}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/shared/lib/ls-to-db-migration.ts
+++ b/apps/desktop/src/shared/lib/ls-to-db-migration.ts
@@ -46,7 +46,7 @@ const PREFIX_AGENT_PROVIDER = 'goodboy:agent-provider:';
 
 const VERBOSITY_VALUES = ['brief', 'normal', 'verbose'] as const;
 const EFFORT_VALUES = ['low', 'medium', 'high', 'extra-high', 'max'] as const;
-const PROVIDER_VALUES = ['anthropic', 'cursor', 'codex'] as const;
+const PROVIDER_VALUES = ['anthropic', 'cursor', 'codex', 'gemini'] as const;
 const LEGACY_VERBOSITY_MAP: Record<string, 'brief' | 'normal' | 'verbose'> = {
   essential: 'brief',
   minimal: 'brief',

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -8,6 +8,7 @@ import {
   checkProviderAuth,
   getCodexStatus,
   getCursorStatus,
+  getGeminiStatus,
   getProviderStatus,
   type ProviderAuthResults,
   type ProviderStatuses,
@@ -54,34 +55,40 @@ export function hydrate(set: SetFn, get: GetFn) {
         });
 
         set({ bootPhase: 'detecting-cli' });
-        const [providerStatus, cursorStatus, codexStatus, detectedEditors] = await Promise.all([
-          getProviderStatus('anthropic'),
-          getCursorStatus(),
-          getCodexStatus(),
-          detectEditors(),
-        ]);
+        const [providerStatus, cursorStatus, codexStatus, geminiStatus, detectedEditors] =
+          await Promise.all([
+            getProviderStatus('anthropic'),
+            getCursorStatus(),
+            getCodexStatus(),
+            getGeminiStatus(),
+            detectEditors(),
+          ]);
         set({ detectedEditors });
         const statuses: ProviderStatuses = {
           anthropic: providerStatus,
           cursor: cursorStatus,
           codex: codexStatus,
+          gemini: geminiStatus,
         };
         set({
           providerStatus,
           cursorStatus,
           codexStatus,
+          geminiStatus,
           providers: buildProviderList(statuses),
         });
 
-        const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
+        const [anthropicAuth, cursorAuth, codexAuth, geminiAuth] = await Promise.all([
           checkProviderAuth('anthropic'),
           checkProviderAuth('cursor'),
           checkProviderAuth('codex'),
+          checkProviderAuth('gemini'),
         ]);
         const authResults: ProviderAuthResults = {
           anthropic: anthropicAuth,
           cursor: cursorAuth,
           codex: codexAuth,
+          gemini: geminiAuth,
         };
         set({ authResults, providers: buildProviderList(statuses, authResults) });
 

--- a/apps/desktop/src/store/slices/providers/refreshProviderStatus.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviderStatus.ts
@@ -12,6 +12,7 @@ export function refreshProviderStatus(set: SetFn) {
         anthropic: status,
         cursor: state.cursorStatus,
         codex: state.codexStatus,
+        gemini: state.geminiStatus,
       };
       return {
         providerStatus: status,

--- a/apps/desktop/src/store/slices/providers/refreshProviders.ts
+++ b/apps/desktop/src/store/slices/providers/refreshProviders.ts
@@ -3,6 +3,7 @@ import {
   checkProviderAuth,
   getCodexStatus,
   getCursorStatus,
+  getGeminiStatus,
   getProviderStatus,
   type ProviderAuthResults,
   type ProviderStatuses,
@@ -11,30 +12,35 @@ import type { SetFn } from './types';
 
 export function refreshProviders(set: SetFn) {
   return async () => {
-    const [providerStatus, cursorStatus, codexStatus] = await Promise.all([
+    const [providerStatus, cursorStatus, codexStatus, geminiStatus] = await Promise.all([
       getProviderStatus('anthropic'),
       getCursorStatus(),
       getCodexStatus(),
+      getGeminiStatus(),
     ]);
     const statuses: ProviderStatuses = {
       anthropic: providerStatus,
       cursor: cursorStatus,
       codex: codexStatus,
+      gemini: geminiStatus,
     };
-    const [anthropicAuth, cursorAuth, codexAuth] = await Promise.all([
+    const [anthropicAuth, cursorAuth, codexAuth, geminiAuth] = await Promise.all([
       checkProviderAuth('anthropic'),
       checkProviderAuth('cursor'),
       checkProviderAuth('codex'),
+      checkProviderAuth('gemini'),
     ]);
     const authResults: ProviderAuthResults = {
       anthropic: anthropicAuth,
       cursor: cursorAuth,
       codex: codexAuth,
+      gemini: geminiAuth,
     };
     set({
       providerStatus,
       cursorStatus,
       codexStatus,
+      geminiStatus,
       authResults,
       providers: buildProviderList(statuses, authResults),
     });

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -77,6 +77,22 @@ export function createSession(set: SetFn, get: GetFn) {
       ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
     });
 
+    // Make sure workspace overrides are cached before reading defaultProviderId,
+    // otherwise a fresh boot would silently fall back to anthropic for the
+    // first session created against a workspace.
+    if (!get().workspaceOverrides[workspaceId]) {
+      try {
+        await get().loadWorkspaceOverrides(workspaceId);
+      } catch {
+        // best-effort: missing overrides just means we fall back to global default
+      }
+    }
+    const workspaceDefaultProvider =
+      get().workspaceOverrides[workspaceId]?.defaultProviderId ?? null;
+    const inheritedPreference: SessionProviderPreference = workspaceDefaultProvider
+      ? { ...DEFAULT_SESSION_PROVIDER_PREFERENCE, defaultProvider: workspaceDefaultProvider }
+      : DEFAULT_SESSION_PROVIDER_PREFERENCE;
+
     const now = new Date().toISOString() as IsoDateTime;
     const initialState: TurnState = { kind: 'draft' };
     const session: Session = {
@@ -85,7 +101,7 @@ export function createSession(set: SetFn, get: GetFn) {
       goal: goal.trim() || worktree.slug,
       state: initialState,
       contextSlots: [],
-      providerPreference: providerPreference ?? DEFAULT_SESSION_PROVIDER_PREFERENCE,
+      providerPreference: providerPreference ?? inheritedPreference,
       permissionMode: 'bypassPermissions',
       workflowIds: workflowId !== undefined ? [workflowId] : [],
       currentStepByWorkflow: {},

--- a/apps/desktop/src/store/slices/sessions/setSessionConfig.ts
+++ b/apps/desktop/src/store/slices/sessions/setSessionConfig.ts
@@ -15,12 +15,21 @@ export function setSessionConfig(set: SetFn, get: GetFn) {
       const nextEffort = fields.effort !== undefined ? fields.effort : (effort ?? null);
       const nextModel =
         fields.modelOverride !== undefined ? fields.modelOverride : (modelOverride ?? null);
+      // Changing the session-level default in db clears provider_override; mirror
+      // that here so the ChatInput pill drops back to "session default" too.
       const nextProvider =
-        fields.providerOverride !== undefined
-          ? fields.providerOverride
-          : (providerOverride ?? null);
+        fields.defaultProvider !== undefined && fields.defaultProvider !== null
+          ? null
+          : fields.providerOverride !== undefined
+            ? fields.providerOverride
+            : (providerOverride ?? null);
+      const nextPreference =
+        fields.defaultProvider !== undefined && fields.defaultProvider !== null
+          ? { ...s.providerPreference, defaultProvider: fields.defaultProvider }
+          : s.providerPreference;
       return {
         ...next,
+        providerPreference: nextPreference,
         ...(nextVerbosity != null && { verbosity: nextVerbosity }),
         ...(nextEffort != null && { effort: nextEffort }),
         ...(nextModel != null && { modelOverride: nextModel }),

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -11,6 +11,7 @@ import {
   computeCostUsd,
   computeCodexCostUsd,
   computeCursorCostUsd,
+  computeGeminiCostUsd,
 } from '@goodboy/core';
 import {
   insertMessage,
@@ -78,6 +79,7 @@ import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../../../features/s
 import { slotsForKind } from '../../../features/providers/slot-routing';
 import {
   getCodexPriceOverride,
+  getGeminiPriceOverride,
   refreshPricingTable,
 } from '../../../features/providers/provider-pricing';
 import { AGENT_FEATURES } from '../../../shared/lib/features';
@@ -697,7 +699,7 @@ export function sendTurn(set: SetFn, get: GetFn) {
 
     // M5: codex/cursor have no native --resume. inject recent turn text so
     // they keep working memory. claude skips, duplicating context wastes tokens.
-    const needsTextHistory = provider === 'cursor' || provider === 'codex';
+    const needsTextHistory = provider === 'cursor' || provider === 'codex' || provider === 'gemini';
     if (needsTextHistory) {
       const priorTranscripts = get().transcripts[activeAgentId] ?? [];
       const priorTurns = buildPriorTurnsBlock(priorTranscripts, 8000);
@@ -853,6 +855,9 @@ export function sendTurn(set: SetFn, get: GetFn) {
               return computeCodexCostUsd(event.usage, model, getCodexPriceOverride(null, model));
             }
             if (provider === 'cursor') return computeCursorCostUsd(event.usage, model);
+            if (provider === 'gemini') {
+              return computeGeminiCostUsd(event.usage, model, getGeminiPriceOverride(null, model));
+            }
             return computeCostUsd(event.usage, model);
           })();
           const record: TelemetryRecord = {

--- a/apps/desktop/src/store/store.audit-retry.test.ts
+++ b/apps/desktop/src/store/store.audit-retry.test.ts
@@ -97,6 +97,7 @@ vi.mock('../features/providers/providers', () => ({
   checkProviderAuth: vi.fn(),
   getCursorStatus: vi.fn(),
   getCodexStatus: vi.fn(),
+  getGeminiStatus: vi.fn(),
   getProviderStatus: vi.fn(),
 }));
 
@@ -340,8 +341,13 @@ describe('audit retry queue, drain worker (happy path)', () => {
     const { getSetting } = await import('@goodboy/db');
     (getSetting as ReturnType<typeof vi.fn>).mockResolvedValue(null);
 
-    const { getProviderStatus, getCursorStatus, getCodexStatus, checkProviderAuth } =
-      await import('../features/providers/providers');
+    const {
+      getProviderStatus,
+      getCursorStatus,
+      getCodexStatus,
+      getGeminiStatus,
+      checkProviderAuth,
+    } = await import('../features/providers/providers');
     (getProviderStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       state: 'connected',
       identity: 'test',
@@ -351,6 +357,10 @@ describe('audit retry queue, drain worker (happy path)', () => {
       identity: 'test',
     });
     (getCodexStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      state: 'connected',
+      identity: 'test',
+    });
+    (getGeminiStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
       state: 'connected',
       identity: 'test',
     });

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -167,6 +167,7 @@ export interface AppState {
   readonly providerStatus: ProviderStatus | null;
   readonly cursorStatus: ProviderStatus | null;
   readonly codexStatus: ProviderStatus | null;
+  readonly geminiStatus: ProviderStatus | null;
   readonly authResults: ProviderAuthResults | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly hydrated: boolean;
@@ -544,8 +545,9 @@ export const initialState: AppState = {
   providerStatus: null,
   cursorStatus: null,
   codexStatus: null,
+  geminiStatus: null,
   authResults: null,
-  providers: buildProviderList({ anthropic: null, cursor: null, codex: null }),
+  providers: buildProviderList({ anthropic: null, cursor: null, codex: null, gemini: null }),
   hydrated: false,
   bootPhase: 'pending',
   error: null,

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -39,6 +39,7 @@
   --color-provider-anthropic: oklch(0.74 0.15 55);
   --color-provider-cursor: oklch(0.70 0.16 290);
   --color-provider-codex: oklch(0.72 0.16 150);
+  --color-provider-gemini: oklch(0.72 0.16 240);
 
   --text-2xs: 11px;
   --text-xs: 12px;
@@ -157,6 +158,7 @@ html[data-theme="light"] {
   --color-provider-anthropic: oklch(0.54 0.16 55);
   --color-provider-cursor: oklch(0.50 0.17 290);
   --color-provider-codex: oklch(0.48 0.15 148);
+  --color-provider-gemini: oklch(0.50 0.16 240);
   --color-focus-ring: oklch(0.50 0.13 200 / 0.45);
   /* Light shadows, softer, multi-layered for depth without harshness. */
   --shadow-sm:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -152,6 +152,63 @@ Skipped by default; opt in when you want to verify a fresh install.
 
 ---
 
+## Google (Gemini)
+
+### Install
+
+```bash
+npm install -g @google/gemini-cli
+```
+
+Docs: <https://github.com/google-gemini/gemini-cli>
+
+Verify: `gemini --version`
+
+### Connect
+
+```bash
+gemini
+```
+
+Launching the bare binary triggers the OAuth flow on first run — Goodboy spawns it in an external terminal. Complete the Google sign-in in the browser that opens; credentials land in `~/.gemini/oauth_creds.json`.
+
+### Disconnect
+
+```bash
+rm -f ~/.gemini/oauth_creds.json
+```
+
+gemini-cli v0.x has no `logout` subcommand. Goodboy wires the disconnect button to remove the credentials file directly.
+
+### Subscription tier
+
+Requires **Google AI Pro** (or the free tier with rate caps). Goodboy uses the local CLI's authenticated Google account; no API key is needed when signed in via OAuth.
+
+### Default models
+
+Per Google's Gemini 2.5 lineup:
+
+- **Turn**: `gemini-2.5-pro` (default).
+- **Cheap**: `gemini-2.5-flash` (default), `gemini-2.5-flash-lite`.
+
+All three support a 1M-token context window.
+
+### Turn spawn args
+
+Goodboy spawns gemini non-interactively:
+
+```
+gemini -m <MODEL> -p <PROMPT>
+```
+
+The working directory is set on the spawned process; gemini-cli has no `--cwd` flag yet. There is no stable structured JSON output today, so the parser treats each stdout line as an `assistant_text` delta and is forward-compatible with a future `--output-format json` mode.
+
+### Auth detection
+
+gemini-cli does not ship a stable `auth status` subcommand. Goodboy probes a few candidates (`gemini auth status`, `gemini whoami`) and falls back to reading the email claim from `~/.gemini/oauth_creds.json` as ground truth. If the providers panel shows "not logged in" after a successful browser flow, click **refresh** so the file check runs again.
+
+---
+
 ## Multi-account
 
 A common setup: Claude Pro on `personal@example.com` and Claude Team on `work@example.com`. Each session in Goodboy targets one active identity per provider.

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -25,6 +25,7 @@ const PROVIDER_ID_TO_NAME: Readonly<Record<ProviderId, ProviderName>> = {
   anthropic: 'anthropic',
   cursor: 'cursor',
   codex: 'openai',
+  gemini: 'gemini',
 };
 
 export async function resolveProvider(input: ResolveProviderInput): Promise<RoutingDecision> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,19 @@ export {
   type ParseContext as CodexParseContext,
 } from './providers/codex/parser';
 
+// GeminiAdapter (node:child_process) is intentionally excluded from this browser-safe barrel.
+// Import directly from packages/core/src/providers/gemini/adapter in Node contexts.
+export {
+  GEMINI_CHEAP_MODEL,
+  GEMINI_DEFAULT_MODEL,
+  GEMINI_MODELS,
+} from './providers/gemini/constants';
+export { computeGeminiCostUsd, type GeminiModelPriceOverride } from './providers/gemini/cost';
+export {
+  parseJsonLine as parseGeminiJsonLine,
+  type ParseContext as GeminiParseContext,
+} from './providers/gemini/parser';
+
 // SummarizerCli (node:child_process) is intentionally excluded from this browser-safe barrel.
 // Import directly from packages/core/src/summarizer/cli in Node/test contexts.
 export {

--- a/packages/core/src/planner/cli.ts
+++ b/packages/core/src/planner/cli.ts
@@ -114,6 +114,8 @@ function defaultBinary(providerId: ProviderId): string {
       return 'cursor-agent';
     case 'codex':
       return 'codex';
+    case 'gemini':
+      return 'gemini';
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);
@@ -161,6 +163,8 @@ function buildCliArgs(
         '--skip-git-repo-check',
         `${systemPrompt}\n\n${userMessage}`,
       ];
+    case 'gemini':
+      return ['-m', model, '-p', `${systemPrompt}\n\n${userMessage}`];
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/core/src/planner/client.ts
+++ b/packages/core/src/planner/client.ts
@@ -106,6 +106,8 @@ function defaultBinary(providerId: ProviderId): string {
       return 'cursor-agent';
     case 'codex':
       return 'codex';
+    case 'gemini':
+      return 'gemini';
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,6 +1,7 @@
 import type { ProviderId, ProviderRegistryCapabilities } from '@goodboy/types';
 import { CURSOR_MODELS } from './cursor/models';
 import { CODEX_MODELS } from './codex/constants';
+import { GEMINI_MODELS } from './gemini/constants';
 
 export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistryCapabilities>> = {
   anthropic: {
@@ -23,6 +24,12 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
   },
   codex: {
     models: CODEX_MODELS,
+    supportsTools: true,
+    supportsStream: true,
+    supportsCheapModel: true,
+  },
+  gemini: {
+    models: GEMINI_MODELS,
     supportsTools: true,
     supportsStream: true,
     supportsCheapModel: true,

--- a/packages/core/src/providers/gemini/adapter.ts
+++ b/packages/core/src/providers/gemini/adapter.ts
@@ -1,0 +1,189 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type {
+  DetectResult,
+  IsoDateTime,
+  ProviderAdapter,
+  ProviderCapabilities,
+  ProviderUsage,
+  TurnEvent,
+  TurnRequest,
+} from '@goodboy/types';
+import { GEMINI_DEFAULT_MODEL, GEMINI_MODELS } from './constants';
+import { computeGeminiCostUsd, type GeminiModelPriceOverride } from './cost';
+import { parseJsonLine } from './parser';
+
+const CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  toolUse: true,
+  fileEdits: true,
+  contextWindow: 1_000_000,
+  defaultModel: GEMINI_DEFAULT_MODEL,
+  availableModels: GEMINI_MODELS.map((m) => m.id),
+};
+
+export interface GeminiAdapterDeps {
+  readonly binary?: string;
+  readonly now?: () => IsoDateTime;
+  readonly spawnFn?: typeof spawn;
+  readonly onUnknown?: (type: string, payload: unknown) => void;
+  readonly priceOverride?: GeminiModelPriceOverride | null;
+}
+
+export class GeminiAdapter implements ProviderAdapter {
+  readonly id = 'gemini' as const;
+  readonly capabilities = CAPABILITIES;
+
+  private readonly binary: string;
+  private readonly now: () => IsoDateTime;
+  private readonly spawnFn: typeof spawn;
+  private readonly onUnknown: (type: string, payload: unknown) => void;
+  private readonly priceOverride: GeminiModelPriceOverride | null;
+
+  constructor(deps: GeminiAdapterDeps = {}) {
+    this.binary = deps.binary ?? 'gemini';
+    this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
+    this.spawnFn = deps.spawnFn ?? spawn;
+    this.onUnknown = deps.onUnknown ?? (() => undefined);
+    this.priceOverride = deps.priceOverride ?? null;
+  }
+
+  async detect(): Promise<DetectResult> {
+    return new Promise((resolve) => {
+      const child = this.spawnFn(this.binary, ['--version'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf8');
+      });
+      child.on('error', (err) => {
+        resolve({ kind: 'missing', binary: this.binary, reason: err.message });
+      });
+      child.on('close', (code) => {
+        if (code === 0) {
+          resolve({ kind: 'available', binary: this.binary, version: stdout.trim() });
+        } else {
+          resolve({
+            kind: 'missing',
+            binary: this.binary,
+            reason: `exited with code ${code}`,
+          });
+        }
+      });
+    });
+  }
+
+  // Free-tier Google AI users are unmetered; paid users can wire a per-model
+  // price via GeminiAdapterDeps.priceOverride to surface estimated USD.
+  cost(usage: ProviderUsage, model: string): number {
+    return computeGeminiCostUsd(usage, model, this.priceOverride);
+  }
+
+  spawn(request: TurnRequest): AsyncIterable<TurnEvent> {
+    return spawnGemini(this.binary, this.spawnFn, this.now, this.onUnknown, request);
+  }
+}
+
+async function* spawnGemini(
+  binary: string,
+  spawnFn: typeof spawn,
+  now: () => IsoDateTime,
+  onUnknown: (type: string, payload: unknown) => void,
+  request: TurnRequest,
+): AsyncIterable<TurnEvent> {
+  // gemini-cli headless flags (v0.x, May 2026):
+  //   gemini -m <model> -p <prompt>
+  // -p forces non-interactive mode and writes the model response to stdout.
+  // Working directory is taken from process cwd; we set it via spawn options.
+  // systemPrompt is prepended to userMessage since the CLI has no
+  // `--system-prompt` flag yet.
+  const prompt = request.systemPrompt
+    ? `${request.systemPrompt}\n\n${request.userMessage}`
+    : request.userMessage;
+  const args = ['-m', request.model, '-p', prompt];
+
+  const child: ChildProcess = spawnFn(binary, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: request.workingDir,
+  });
+
+  if (!child.stdout) {
+    throw new Error('gemini CLI started without stdout');
+  }
+
+  const queue: TurnEvent[] = [];
+  let resolver: ((value: IteratorResult<TurnEvent>) => void) | null = null;
+  let rejector: ((err: unknown) => void) | null = null;
+  let ended = false;
+  let error: unknown = null;
+
+  const ctx = { runId: request.runId, now, onUnknown };
+
+  const flush = () => {
+    if (resolver && queue.length > 0) {
+      const value = queue.shift()!;
+      const r = resolver;
+      resolver = null;
+      r({ value, done: false });
+    } else if (resolver && ended) {
+      const r = resolver;
+      resolver = null;
+      if (error) {
+        const rej = rejector;
+        rejector = null;
+        rej?.(error);
+      } else {
+        r({ value: undefined, done: true });
+      }
+    }
+  };
+
+  const lineReader = createInterface({ input: child.stdout });
+
+  lineReader.on('line', (line) => {
+    const events = parseJsonLine(line, ctx);
+    for (const event of events) queue.push(event);
+    flush();
+  });
+
+  lineReader.on('close', () => {
+    queue.push({ kind: 'done', runId: request.runId, at: now() });
+    ended = true;
+    flush();
+  });
+
+  child.on('error', (err) => {
+    error = err;
+    ended = true;
+    flush();
+  });
+
+  child.stderr?.on('data', () => {
+    // captured but not surfaced as TurnEvent for v0.0.1
+  });
+
+  try {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (ended) {
+        if (error) throw error;
+        return;
+      }
+      const value = await new Promise<IteratorResult<TurnEvent>>((resolve, reject) => {
+        resolver = resolve;
+        rejector = reject;
+      });
+      if (value.done) return;
+      yield value.value;
+    }
+  } finally {
+    if (!child.killed && child.exitCode === null) {
+      child.kill('SIGTERM');
+    }
+    lineReader.close();
+  }
+}

--- a/packages/core/src/providers/gemini/constants.ts
+++ b/packages/core/src/providers/gemini/constants.ts
@@ -1,0 +1,13 @@
+import type { ModelTier } from '@goodboy/types';
+
+// gemini-cli v0.x accepts any model ID the user's Google account has access to.
+// Curated set mirrors Google's published Gemini 2.5 family (May 2026).
+// `pro` = premium turn, `flash` = fast cheap, `flash-lite` = cheapest.
+export const GEMINI_DEFAULT_MODEL = 'gemini-2.5-pro';
+export const GEMINI_CHEAP_MODEL = 'gemini-2.5-flash';
+
+export const GEMINI_MODELS: ReadonlyArray<ModelTier> = [
+  { id: 'gemini-2.5-pro', tier: 'turn', contextWindow: 1_000_000 },
+  { id: 'gemini-2.5-flash', tier: 'cheap', contextWindow: 1_000_000 },
+  { id: 'gemini-2.5-flash-lite', tier: 'cheap', contextWindow: 1_000_000 },
+];

--- a/packages/core/src/providers/gemini/cost.ts
+++ b/packages/core/src/providers/gemini/cost.ts
@@ -1,0 +1,26 @@
+import type { ProviderUsage } from '@goodboy/types';
+
+// gemini-cli does not surface token counts in its current output stream. Cost
+// is therefore not computable from usage data alone. Users on a paid Google AI
+// tier can wire a per-model override via providerPricingConfig in app settings;
+// overrides are applied in the desktop layer before recording telemetry.
+// Default: 0 (free tier / cost unknown).
+export function computeGeminiCostUsd(
+  usage: ProviderUsage,
+  _model: string,
+  override: GeminiModelPriceOverride | null,
+): number {
+  if (override === null) return 0;
+  const billableInput = Math.max(0, usage.inputTokens - usage.cachedInputTokens);
+  return (
+    (billableInput * override.inputPerMtok) / 1_000_000 +
+    (usage.cachedInputTokens * (override.cachedInputPerMtok ?? override.inputPerMtok)) / 1_000_000 +
+    (usage.outputTokens * override.outputPerMtok) / 1_000_000
+  );
+}
+
+export interface GeminiModelPriceOverride {
+  readonly inputPerMtok: number;
+  readonly outputPerMtok: number;
+  readonly cachedInputPerMtok?: number;
+}

--- a/packages/core/src/providers/gemini/parser.test.ts
+++ b/packages/core/src/providers/gemini/parser.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId } from '@goodboy/types';
+import { parseJsonLine, type ParseContext } from './parser';
+
+const at = '2026-05-28T00:00:00.000Z' as IsoDateTime;
+const ctx: ParseContext = {
+  runId: 'run_1' as ProviderRunId,
+  now: () => at,
+};
+
+function parse(line: string) {
+  return parseJsonLine(line, ctx);
+}
+
+describe('parseJsonLine (gemini v0.x)', () => {
+  it('returns [] for empty / blank lines', () => {
+    expect(parse('')).toEqual([]);
+    expect(parse('   ')).toEqual([]);
+  });
+
+  it('treats plain text as an assistant_text delta with trailing newline', () => {
+    const events = parse('Hello, world!');
+    expect(events).toEqual([
+      {
+        kind: 'assistant_text',
+        runId: ctx.runId,
+        delta: 'Hello, world!\n',
+        at,
+      },
+    ]);
+  });
+
+  it('parses response.delta when CLI emits structured json', () => {
+    const events = parse(JSON.stringify({ type: 'response.delta', text: 'hi' }));
+    expect(events).toEqual([{ kind: 'assistant_text', runId: ctx.runId, delta: 'hi', at }]);
+  });
+
+  it('skips response.completed (no event needed before done)', () => {
+    expect(parse(JSON.stringify({ type: 'response.completed' }))).toEqual([]);
+  });
+
+  it('extracts usage when emitted', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'usage',
+        usage: { input_tokens: 100, output_tokens: 50, cached_input_tokens: 10 },
+      }),
+    );
+    expect(events).toEqual([
+      {
+        kind: 'usage',
+        runId: ctx.runId,
+        usage: {
+          inputTokens: 100,
+          outputTokens: 50,
+          cachedInputTokens: 10,
+          estimatedCostUsd: 0,
+        },
+        at,
+      },
+    ]);
+  });
+
+  it('surfaces error payloads', () => {
+    const events = parse(JSON.stringify({ type: 'error', message: 'oops' }));
+    expect(events).toEqual([{ kind: 'error', runId: ctx.runId, message: 'oops', at }]);
+  });
+});

--- a/packages/core/src/providers/gemini/parser.ts
+++ b/packages/core/src/providers/gemini/parser.ts
@@ -1,0 +1,96 @@
+import type { IsoDateTime, ProviderRunId, ProviderUsage, TurnEvent } from '@goodboy/types';
+import { devWarn } from '../../dev-log';
+
+export interface ParseContext {
+  readonly runId: ProviderRunId;
+  readonly now: () => IsoDateTime;
+  readonly onUnknown?: (type: string, payload: unknown) => void;
+}
+
+// gemini-cli v0.x emits plain text on stdout in headless mode (`-p <prompt>`).
+// No stable structured streaming schema is documented today; we fall back to
+// treating each non-empty line as an assistant_text delta. When future versions
+// gain a JSON output flag, the JSON branch below already handles a small set
+// of expected types (mirrors codex.parser conventions) so we can opt in by
+// passing `--output-format json` from turn.rs without rewriting this file.
+const KNOWN_TYPES = new Set(['response.delta', 'response.completed', 'usage', 'error']);
+
+interface UsagePayload {
+  readonly input_tokens?: number;
+  readonly cached_input_tokens?: number;
+  readonly output_tokens?: number;
+}
+
+function buildUsage(raw: UsagePayload | undefined): ProviderUsage {
+  return {
+    inputTokens: raw?.input_tokens ?? 0,
+    outputTokens: raw?.output_tokens ?? 0,
+    cachedInputTokens: raw?.cached_input_tokens ?? 0,
+    estimatedCostUsd: 0,
+  };
+}
+
+function tryParseJson(line: string): ({ type?: string } & Record<string, unknown>) | null {
+  if (!line.startsWith('{') && !line.startsWith('[')) return null;
+  try {
+    return JSON.parse(line) as { type?: string } & Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function parseJsonLine(line: string, ctx: ParseContext): ReadonlyArray<TurnEvent> {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return [];
+
+  const at = ctx.now();
+  const payload = tryParseJson(trimmed);
+
+  if (payload === null) {
+    // Plain-text mode: every line is text the model produced. Preserve newline
+    // so multi-line output renders correctly in the transcript.
+    return [{ kind: 'assistant_text', runId: ctx.runId, delta: `${trimmed}\n`, at }];
+  }
+
+  const type = payload.type;
+  switch (type) {
+    case 'response.delta': {
+      const delta = typeof payload['text'] === 'string' ? (payload['text'] as string) : '';
+      if (delta.length === 0) return [];
+      return [{ kind: 'assistant_text', runId: ctx.runId, delta, at }];
+    }
+
+    case 'response.completed':
+      return [];
+
+    case 'usage': {
+      const usage = buildUsage(payload['usage'] as UsagePayload | undefined);
+      return [{ kind: 'usage', runId: ctx.runId, usage, at }];
+    }
+
+    case 'error': {
+      const msg =
+        typeof payload['message'] === 'string'
+          ? (payload['message'] as string)
+          : JSON.stringify(payload);
+      return [{ kind: 'error', runId: ctx.runId, message: msg, at }];
+    }
+
+    default:
+      if (typeof type === 'string' && !KNOWN_TYPES.has(type)) {
+        devWarn(`[gemini-adapter] unknown json payload type: ${type}`);
+        ctx.onUnknown?.(type, payload);
+        return [
+          {
+            kind: 'unknown_payload',
+            runId: ctx.runId,
+            adapter: 'gemini',
+            payloadType: type,
+            raw: payload,
+            at,
+          },
+        ];
+      }
+      return [];
+  }
+}

--- a/packages/core/src/providers/registry.test.ts
+++ b/packages/core/src/providers/registry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { ClaudeAdapter } from './claude/adapter';
 import { CursorAdapter } from './cursor/adapter';
 import { CodexAdapter } from './codex/adapter';
+import { GeminiAdapter } from './gemini/adapter';
 import {
   UnknownProviderError,
   createProvider,
@@ -10,8 +11,8 @@ import {
 } from './registry';
 
 describe('listSupportedProviders', () => {
-  it('returns all three provider ids', () => {
-    expect(listSupportedProviders()).toEqual(['anthropic', 'cursor', 'codex']);
+  it('returns all four provider ids', () => {
+    expect(listSupportedProviders()).toEqual(['anthropic', 'cursor', 'codex', 'gemini']);
   });
 
   it('result is readonly array', () => {
@@ -37,6 +38,12 @@ describe('createProvider', () => {
     const adapter = createProvider('codex');
     expect(adapter).toBeInstanceOf(CodexAdapter);
     expect(adapter.id).toBe('codex');
+  });
+
+  it('returns GeminiAdapter for gemini', () => {
+    const adapter = createProvider('gemini');
+    expect(adapter).toBeInstanceOf(GeminiAdapter);
+    expect(adapter.id).toBe('gemini');
   });
 
   it('passes deps through to adapter', () => {
@@ -73,6 +80,12 @@ describe('getCapabilities', () => {
 
   it('codex capabilities have models', () => {
     const caps = getCapabilities('codex');
+    expect(caps.models.length).toBeGreaterThan(0);
+    expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
+  });
+
+  it('gemini capabilities have models', () => {
+    const caps = getCapabilities('gemini');
     expect(caps.models.length).toBeGreaterThan(0);
     expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
   });

--- a/packages/core/src/providers/registry.ts
+++ b/packages/core/src/providers/registry.ts
@@ -8,6 +8,7 @@ import type {
 import { ClaudeAdapter } from './claude/adapter';
 import { CursorAdapter } from './cursor/adapter';
 import { CodexAdapter } from './codex/adapter';
+import { GeminiAdapter } from './gemini/adapter';
 import { PROVIDER_CAPABILITIES } from './capabilities';
 
 export type { ProviderRegistryCapabilities };
@@ -34,6 +35,8 @@ export function createProvider(id: ProviderId, deps: ProviderDeps = {}): Provide
       return new CursorAdapter(deps);
     case 'codex':
       return new CodexAdapter(deps);
+    case 'gemini':
+      return new GeminiAdapter(deps);
     default: {
       const _exhaustive: never = id;
       throw new UnknownProviderError(_exhaustive);
@@ -42,7 +45,7 @@ export function createProvider(id: ProviderId, deps: ProviderDeps = {}): Provide
 }
 
 export function listSupportedProviders(): ReadonlyArray<ProviderId> {
-  return ['anthropic', 'cursor', 'codex'];
+  return ['anthropic', 'cursor', 'codex', 'gemini'];
 }
 
 export function getCapabilities(id: ProviderId): ProviderRegistryCapabilities {

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -109,6 +109,8 @@ function getDefaultBinary(providerId: ProviderId): string {
       return 'cursor-agent';
     case 'codex':
       return 'codex';
+    case 'gemini':
+      return 'gemini';
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);
@@ -233,6 +235,8 @@ function buildCliArgs(
         '--skip-git-repo-check',
         `${systemPrompt}\n\n${userMessage}`,
       ];
+    case 'gemini':
+      return ['-m', model, '-p', `${systemPrompt}\n\n${userMessage}`];
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -17,6 +17,8 @@ function getDefaultBinary(providerId: ProviderId): string {
       return 'cursor-agent';
     case 'codex':
       return 'codex';
+    case 'gemini':
+      return 'gemini';
     default: {
       const _exhaustive: never = providerId;
       throw new Error(`unknown provider: ${_exhaustive}`);

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -136,6 +136,10 @@ export interface SessionConfigUpdate {
   effort?: 'low' | 'medium' | 'high' | 'extra-high' | 'max' | null;
   modelOverride?: string | null;
   providerOverride?: string | null;
+  /** Session-level default provider. New agents/workflows spawned in this
+   *  session inherit it. Distinct from `providerOverride`, which is the
+   *  ephemeral per-turn pick from the chat composer. */
+  defaultProvider?: ProviderId | null;
 }
 
 export async function updateSessionConfig(
@@ -160,6 +164,14 @@ export async function updateSessionConfig(
   if (fields.providerOverride !== undefined) {
     updates.push('provider_override = ?');
     values.push(fields.providerOverride);
+  }
+  if (fields.defaultProvider !== undefined && fields.defaultProvider !== null) {
+    updates.push('provider_default = ?');
+    values.push(fields.defaultProvider);
+    // Changing the session-level default clears any stale per-turn override so
+    // future agents inherit the new default instead of the old override.
+    updates.push('provider_override = ?');
+    values.push(null);
   }
   if (updates.length === 0) return;
   values.push(id);

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -1,4 +1,4 @@
-export type ProviderId = 'anthropic' | 'cursor' | 'codex';
+export type ProviderId = 'anthropic' | 'cursor' | 'codex' | 'gemini';
 
 export type ProviderConnectionState = 'connected' | 'installed_disconnected' | 'missing' | 'error';
 

--- a/packages/types/src/provider.ts
+++ b/packages/types/src/provider.ts
@@ -1,7 +1,7 @@
 import type { IsoDateTime, ProviderRunId, SessionId } from './ids';
 import type { RoutingDecision } from './budget';
 
-export type ProviderName = 'anthropic' | 'openai' | 'cursor' | 'codex';
+export type ProviderName = 'anthropic' | 'openai' | 'cursor' | 'codex' | 'gemini';
 
 export type ProviderRunStatus =
   | { kind: 'pending' }

--- a/website/SEO.md
+++ b/website/SEO.md
@@ -93,7 +93,7 @@ Tutti i meta risiedono in `website/index.html` (app SPA . unico HTML). Non ci so
 ### Regole di copy SEO
 
 - keyword primaria nella prima frase: "AI workspace orchestrator"
-- keyword secondarie: "local-first", "multi-agent", "Claude Cursor Codex", "developer tools"
+- keyword secondarie: "local-first", "multi-agent", "Claude Cursor Codex Gemini", "developer tools"
 - niente keyword stuffing: le parole chiave vanno nei testi del sito, non solo nei meta
 - `<title>` format: `[Product] . [tagline corta]` (es. "Goodboy . AI workspace orchestrator")
 

--- a/website/index.html
+++ b/website/index.html
@@ -7,8 +7,8 @@
 
     <!-- Primary -->
     <title>Goodboy: AI workspace orchestrator</title>
-    <meta name="description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
-    <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
+    <meta name="description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
+    <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
     <meta name="author" content="Amin Khayam" />
     <link rel="canonical" href="https://goodboy.dev/" />
 
@@ -17,7 +17,7 @@
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
     <meta property="og:title" content="Goodboy: AI workspace orchestrator" />
-    <meta property="og:description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta property="og:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -29,7 +29,7 @@
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
     <meta name="twitter:title" content="Goodboy: AI workspace orchestrator" />
-    <meta name="twitter:description" content="Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta name="twitter:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
     <meta name="twitter:image:alt" content="Goodboy: AI workspace orchestrator" />
 
@@ -43,7 +43,7 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Goodboy",
-      "description": "AI workspace orchestrator. Route agents across Claude, Cursor, and Codex. Share context, structure plans, track budgets in real time. Local-first desktop app.",
+      "description": "AI workspace orchestrator. Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app.",
       "url": "https://goodboy.dev/",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Windows, Linux",
@@ -60,9 +60,9 @@
       },
       "license": "https://opensource.org/licenses/MIT",
       "codeRepository": "https://github.com/akhayam99/goodboy",
-      "keywords": ["AI orchestrator", "Claude", "Cursor", "Codex", "multi-agent", "local-first", "developer tools"],
+      "keywords": ["AI orchestrator", "Claude", "Cursor", "Codex", "Gemini", "multi-agent", "local-first", "developer tools"],
       "featureList": [
-        "Multi-provider routing (Claude, Cursor, Codex)",
+        "Multi-provider routing (Claude, Cursor, Codex, Gemini)",
         "Shared context panel across agents",
         "Multi-agent sessions with role assignment",
         "Plans as first-class artifacts",

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -25,9 +25,9 @@ export function Hero() {
             className="rise mx-auto mt-7 max-w-xl text-[15px] sm:text-[16px] leading-[1.6] text-muted-foreground"
             style={{ animationDelay: '120ms' }}
           >
-            Stack workflows on one session. Route agents across Claude, Cursor, and Codex without
-            re-explaining the goal. Shared context, structured plans, real-time cost. Local-first.
-            Your keys, your machine.
+            Stack workflows on one session. Route agents across Claude, Cursor, Codex, and Gemini
+            without re-explaining the goal. Shared context, structured plans, real-time cost.
+            Local-first. Your keys, your machine.
           </p>
 
           <div

--- a/website/src/sections/LogoStrip.tsx
+++ b/website/src/sections/LogoStrip.tsx
@@ -22,10 +22,9 @@ const subscriptions: Card[] = [
     desc: 'Scaffolds, one-shots',
   },
   {
-    name: 'More',
-    color: 'oklch(0.55 0.012 255)',
-    desc: 'Gemini, local LLMs, OSS adapters',
-    soon: true,
+    name: 'Gemini',
+    color: 'oklch(0.72 0.16 240)',
+    desc: 'Long context, multimodal',
   },
 ];
 

--- a/website/src/sections/RoutingDeepDive.tsx
+++ b/website/src/sections/RoutingDeepDive.tsx
@@ -10,10 +10,10 @@ export function RoutingDeepDive() {
       body={
         <>
           <p>
-            Pick the right provider for the work. Long-context refactor? Claude. Inline edit?
-            Cursor. Codegen scaffold? Codex. Switch the session default at any time, or override
-            just the next turn from the composer chip. Either way the next agent rebuilds from
-            shared context, never the provider thread.
+            Pick the right provider for the work. Long-context refactor? Claude or Gemini. Inline
+            edit? Cursor. Codegen scaffold? Codex. Switch the session default at any time, or
+            override just the next turn from the composer chip. Either way the next agent rebuilds
+            from shared context, never the provider thread.
           </p>
           <p>
             Each turn carries an estimated cost. The session keeps a running total. Set an optional
@@ -21,8 +21,8 @@ export function RoutingDeepDive() {
             the composer so the bill never lives in a different tab.
           </p>
           <p className="text-[14px] text-muted-foreground/80">
-            Subscription-based. Uses your Claude, Cursor, ChatGPT subscriptions. No metered API
-            tokens.
+            Subscription-based. Uses your Claude, Cursor, ChatGPT, and Google AI subscriptions. No
+            metered API tokens.
           </p>
         </>
       }


### PR DESCRIPTION
## Summary

- Adds Google Gemini as a first-class provider alongside Claude, Cursor, and Codex.
- User installs the `gemini` CLI, logs in via OAuth on first run, and the desktop app detects + surfaces it with the same status, model list, theming, and pricing flow as the others.
- Curated model set: `gemini-2.5-pro` (turn), `gemini-2.5-flash` and `gemini-2.5-flash-lite` (cheap). 1M-token context window per model.

## What's wired up

- **Types**: `'gemini'` added to `ProviderId` and `ProviderName`.
- **Core**: `GeminiAdapter` (spawns `gemini -m <model> -p <prompt>`), models, cost helper with optional price overrides, parser that falls back to plain-text streaming and is forward-compatible with structured JSON output. Adapter registered in `createProvider`, `PROVIDER_CAPABILITIES`, planner CLI, summarizer CLI and budget router.
- **Tauri**: `detect_gemini`, `check_gemini_auth` (probes `gemini auth status/whoami`, falls back to `~/.gemini/oauth_creds.json`), `GeminiState`, `get_gemini_status` / `refresh_gemini_status`, login (opens `gemini` in terminal for OAuth flow) / logout (deletes creds file), CLI-arg branch in `turn.rs`, planner case in `planner.rs`.
- **React**: provider records (label / docs / binary / Tauri cmd), `getGeminiStatus`, `buildProviderList`, chat-side parser dispatch, `VALID_PROVIDERS`, colour tokens + theming in `TelemetryPill` / `ProvidersPanel` / `NewSessionDialog` / `WorkflowsPanel` / `BudgetRulesPanel`, `pricing.json` + `getGeminiPriceOverride`, zustand `geminiStatus` slot + cost dispatch.
- **Tests**: gemini parser unit test, registry test, pricing test, Rust auth parse tests, and updates to existing store/audit-retry mocks.

## Test plan

- [ ] Install gemini-cli, log in, confirm the Providers panel shows gemini as connected with email identity.
- [ ] Start a session against gemini-2.5-pro and gemini-2.5-flash, confirm streaming output renders.
- [ ] Confirm cost rolls into TelemetryPill correctly (pro vs flash should differ).
- [ ] Confirm login/logout from the Providers panel opens a terminal and updates state on refresh.
- [ ] Confirm the chat composer accepts gemini as provider override via the prefix syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)