### PR TITLE
feat(desktop,core,types): in-app provider lifecycle infra (phase 1)

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod path_env;
 mod permissions;
 mod planner;
 mod workflows;
+mod provider_lifecycle;
 mod providers;
 mod repo;
 mod scripts;
@@ -35,6 +36,7 @@ pub fn run() {
   let turn_registry = turn::TurnRegistry::new();
   let script_registry = scripts::ScriptRegistry::new();
   let terminal_registry = terminal::TerminalRegistry::new();
+  let provider_lifecycle_registry = provider_lifecycle::ProviderLifecycleRegistry::new();
   let linear_token_cache = linear::LinearTokenCache::new();
 
   tauri::Builder::default()
@@ -47,6 +49,7 @@ pub fn run() {
     .manage(turn_registry)
     .manage(script_registry)
     .manage(terminal_registry)
+    .manage(provider_lifecycle_registry)
     .manage(linear_token_cache)
     .setup(|app| {
       if cfg!(debug_assertions) {
@@ -93,6 +96,10 @@ pub fn run() {
       providers::refresh_gemini_status,
       providers::check_provider_auth,
       providers::provider_action,
+      provider_lifecycle::provider_lifecycle_run,
+      provider_lifecycle::provider_lifecycle_write,
+      provider_lifecycle::provider_lifecycle_resize,
+      provider_lifecycle::provider_lifecycle_cancel,
       turn::turn_spawn,
       turn::turn_cancel,
       attachment::attachment_write,

--- a/apps/desktop/src-tauri/src/provider_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/provider_lifecycle.rs
@@ -1,0 +1,355 @@
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use serde::Serialize;
+use tauri::{AppHandle, Emitter, State};
+
+use crate::providers::{
+    check_provider_auth, detect_claude, detect_codex, detect_cursor, detect_gemini, AuthState,
+    ProviderStatus,
+};
+
+// ---------------------------------------------------------------------------
+// PTY run slot
+// ---------------------------------------------------------------------------
+
+struct PtyRun {
+    writer: Box<dyn Write + Send>,
+    master: Box<dyn portable_pty::MasterPty + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+#[derive(Serialize, Clone)]
+struct LifecycleOutputPayload {
+    #[serde(rename = "runId")]
+    run_id: String,
+    #[serde(rename = "providerId")]
+    provider_id: String,
+    action: String,
+    data: String,
+}
+
+#[derive(Serialize, Clone)]
+struct LifecycleExitPayload {
+    #[serde(rename = "runId")]
+    run_id: String,
+    #[serde(rename = "providerId")]
+    provider_id: String,
+    action: String,
+    #[serde(rename = "exitCode")]
+    exit_code: i32,
+    // Coherence guarantee: ship the fresh detection + auth result alongside the
+    // exit code so the UI cannot stay desynced from the actual on-disk state.
+    status: ProviderStatus,
+    auth: AuthState,
+}
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+type PtySlot = Arc<Mutex<Option<PtyRun>>>;
+
+#[derive(Default)]
+pub struct ProviderLifecycleRegistry(Arc<Mutex<HashMap<String, PtySlot>>>);
+
+impl ProviderLifecycleRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error)]
+pub enum LifecycleError {
+    #[error("registry mutex poisoned")]
+    Poisoned,
+    #[error("io error: {0}")]
+    Io(String),
+}
+
+impl Serialize for LifecycleError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serde_json::Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl LifecycleError {
+    fn kind(&self) -> &'static str {
+        match self {
+            LifecycleError::Poisoned => "poisoned",
+            LifecycleError::Io(_) => "io",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection refresh helper
+// ---------------------------------------------------------------------------
+
+// Re-detect both binary presence and auth status for the affected provider.
+// Called on PTY exit so the lifecycle-exit event ships ground-truth state.
+fn refresh_provider(provider_id: &str) -> (ProviderStatus, AuthState) {
+    let status = match provider_id {
+        "anthropic" => detect_claude(),
+        "cursor" => detect_cursor(),
+        "codex" => detect_codex(),
+        "gemini" => detect_gemini(),
+        _ => ProviderStatus {
+            id: provider_id.to_string(),
+            binary: provider_id.to_string(),
+            available: false,
+            version: None,
+            error: Some(format!("unknown provider: {}", provider_id)),
+        },
+    };
+    let auth = check_provider_auth(provider_id.to_string());
+    (status, auth)
+}
+
+// ---------------------------------------------------------------------------
+// Command: spawn a provider lifecycle command in a pty
+// ---------------------------------------------------------------------------
+
+/// Spawns `bash -c <command>` in a pty for an install/login/logout flow.
+/// Output streams as `provider-lifecycle-output` events. On exit, the backend
+/// re-runs detection + auth check for the provider and emits the fresh state
+/// alongside the exit code in `provider-lifecycle-exit`. This is the coherence
+/// contract: the UI never has to guess what changed.
+#[tauri::command]
+pub async fn provider_lifecycle_run(
+    app: AppHandle,
+    registry: State<'_, ProviderLifecycleRegistry>,
+    provider_id: String,
+    action: String,
+    command: String,
+    run_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), LifecycleError> {
+    let registry_arc = Arc::clone(&registry.0);
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let pty_system = native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| LifecycleError::Io(e.to_string()))?;
+
+        let mut cmd = CommandBuilder::new("bash");
+        cmd.arg("-c");
+        cmd.arg(&command);
+        let cwd = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
+        cmd.cwd(&cwd);
+        cmd.env("PATH", crate::path_env::resolved_path());
+        cmd.env("TERM", "xterm-256color");
+        if let Ok(home) = std::env::var("HOME") {
+            cmd.env("HOME", home);
+        }
+        if let Ok(user) = std::env::var("USER") {
+            cmd.env("USER", user);
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| LifecycleError::Io(e.to_string()))?;
+        drop(pair.slave);
+
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| LifecycleError::Io(e.to_string()))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| LifecycleError::Io(e.to_string()))?;
+
+        let slot: PtySlot = Arc::new(Mutex::new(Some(PtyRun {
+            writer,
+            master: pair.master,
+            child,
+        })));
+
+        registry_arc
+            .lock()
+            .map_err(|_| LifecycleError::Poisoned)?
+            .insert(run_id.clone(), Arc::clone(&slot));
+
+        let run_id_r = run_id.clone();
+        let provider_id_r = provider_id.clone();
+        let action_r = action.clone();
+        let app_r = app.clone();
+        let registry_r = Arc::clone(&registry_arc);
+
+        thread::spawn(move || {
+            let mut reader = reader;
+            let mut buf = [0u8; 4096];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(n) => {
+                        let encoded = STANDARD.encode(&buf[..n]);
+                        let _ = app_r.emit(
+                            "provider-lifecycle-output",
+                            LifecycleOutputPayload {
+                                run_id: run_id_r.clone(),
+                                provider_id: provider_id_r.clone(),
+                                action: action_r.clone(),
+                                data: encoded,
+                            },
+                        );
+                    }
+                }
+            }
+
+            let exit_code = {
+                let slot = {
+                    let guard = registry_r.lock().ok();
+                    guard.as_ref().and_then(|m| m.get(&run_id_r).cloned())
+                };
+                if let Some(slot) = slot {
+                    let mut g = slot.lock().unwrap_or_else(|e| e.into_inner());
+                    g.as_mut()
+                        .and_then(|r| r.child.wait().ok())
+                        .map(|s| if s.success() { 0_i32 } else { 1_i32 })
+                        .unwrap_or(-1)
+                } else {
+                    -1
+                }
+            };
+
+            // Refresh detection + auth before announcing exit. Always run, even
+            // on non-zero exit, because a half-installed CLI or partial logout
+            // still changes ground truth.
+            let (status, auth) = refresh_provider(&provider_id_r);
+
+            let _ = app_r.emit(
+                "provider-lifecycle-exit",
+                LifecycleExitPayload {
+                    run_id: run_id_r.clone(),
+                    provider_id: provider_id_r.clone(),
+                    action: action_r.clone(),
+                    exit_code,
+                    status,
+                    auth,
+                },
+            );
+
+            if let Ok(mut map) = registry_r.lock() {
+                map.remove(&run_id_r);
+            }
+        });
+
+        Ok(())
+    })
+    .await
+    .map_err(|e| LifecycleError::Io(e.to_string()))?
+}
+
+// ---------------------------------------------------------------------------
+// Command: send keyboard input to a running lifecycle pty
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn provider_lifecycle_write(
+    registry: State<'_, ProviderLifecycleRegistry>,
+    run_id: String,
+    data: String,
+) -> Result<(), LifecycleError> {
+    let bytes = STANDARD
+        .decode(&data)
+        .map_err(|e| LifecycleError::Io(e.to_string()))?;
+
+    let slot = {
+        let map = registry.0.lock().map_err(|_| LifecycleError::Poisoned)?;
+        map.get(&run_id).cloned()
+    };
+
+    if let Some(slot) = slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(run) = guard.as_mut() {
+                let _ = run.writer.write_all(&bytes);
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Command: resize the pty window
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub fn provider_lifecycle_resize(
+    registry: State<'_, ProviderLifecycleRegistry>,
+    run_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<(), LifecycleError> {
+    let slot = {
+        let map = registry.0.lock().map_err(|_| LifecycleError::Poisoned)?;
+        map.get(&run_id).cloned()
+    };
+
+    if let Some(slot) = slot {
+        if let Ok(guard) = slot.lock() {
+            if let Some(run) = guard.as_ref() {
+                let _ = run.master.resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Command: cancel an in-flight lifecycle run
+// ---------------------------------------------------------------------------
+
+/// Kills the pty child. Dropping the master sends SIGHUP to the entire process
+/// group. Exit handler still runs and refreshes detection, so UI reflects the
+/// real (possibly half-installed) state.
+#[tauri::command]
+pub fn provider_lifecycle_cancel(
+    registry: State<'_, ProviderLifecycleRegistry>,
+    run_id: String,
+) -> Result<(), LifecycleError> {
+    let slot = {
+        let map = registry.0.lock().map_err(|_| LifecycleError::Poisoned)?;
+        map.get(&run_id).cloned()
+    };
+    if let Some(slot) = slot {
+        if let Ok(mut guard) = slot.lock() {
+            if let Some(run) = guard.as_mut() {
+                let _ = run.child.kill();
+            }
+        }
+    }
+    Ok(())
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -15,6 +15,7 @@ import { OnboardingCard } from './features/onboarding/OnboardingCard';
 import { markStepComplete } from './features/onboarding/onboarding-store';
 import { BookOpen, MessageSquare, MessagesSquare } from 'lucide-react';
 import { useKeyboardShortcut } from './shared/hooks/useKeyboardShortcut';
+import { useProviderRefreshOnFocus } from './shared/hooks/useProviderRefreshOnFocus';
 import {
   useAppStore,
   useCurrentSession,
@@ -87,6 +88,7 @@ export function App() {
   }, [hydrate]);
 
   useGithubPolling();
+  useProviderRefreshOnFocus();
 
   useEffect(() => {
     const handler = (event: Event) => {

--- a/apps/desktop/src/features/providers/provider-lifecycle.ts
+++ b/apps/desktop/src/features/providers/provider-lifecycle.ts
@@ -1,0 +1,84 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  PROVIDER_LIFECYCLE_COMMANDS,
+  type ProviderId,
+  type ProviderLifecycleAction,
+  type ProviderPlatform,
+} from '@goodboy/types';
+import type { AuthState, ProviderStatus } from './providers';
+
+export interface LifecycleOutputPayload {
+  readonly runId: string;
+  readonly providerId: ProviderId;
+  readonly action: ProviderLifecycleAction;
+  readonly data: string;
+}
+
+export interface LifecycleExitPayload {
+  readonly runId: string;
+  readonly providerId: ProviderId;
+  readonly action: ProviderLifecycleAction;
+  readonly exitCode: number;
+  readonly status: ProviderStatus;
+  readonly auth: AuthState;
+}
+
+// Resolve the platform once per process. Tauri runs on darwin/linux/win32 only;
+// anything else falls back to linux because the npm commands are identical.
+export function currentPlatform(): ProviderPlatform {
+  if (typeof navigator === 'undefined') return 'linux';
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes('mac')) return 'darwin';
+  if (ua.includes('win')) return 'win32';
+  return 'linux';
+}
+
+export function resolveLifecycleCommand(
+  providerId: ProviderId,
+  action: ProviderLifecycleAction,
+  platform: ProviderPlatform = currentPlatform(),
+): string {
+  const entry = PROVIDER_LIFECYCLE_COMMANDS[providerId];
+  if (action === 'install') return entry.install[platform];
+  return entry[action];
+}
+
+export function invokeProviderLifecycleRun(args: {
+  providerId: ProviderId;
+  action: ProviderLifecycleAction;
+  command: string;
+  runId: string;
+  cols: number;
+  rows: number;
+}): Promise<void> {
+  return invoke<void>('provider_lifecycle_run', args);
+}
+
+export function invokeProviderLifecycleWrite(runId: string, data: string): Promise<void> {
+  return invoke<void>('provider_lifecycle_write', { runId, data });
+}
+
+export function invokeProviderLifecycleResize(
+  runId: string,
+  cols: number,
+  rows: number,
+): Promise<void> {
+  return invoke<void>('provider_lifecycle_resize', { runId, cols, rows });
+}
+
+export function invokeProviderLifecycleCancel(runId: string): Promise<void> {
+  return invoke<void>('provider_lifecycle_cancel', { runId });
+}
+
+export function listenLifecycleOutput(
+  handler: (payload: LifecycleOutputPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<LifecycleOutputPayload>('provider-lifecycle-output', (e) => handler(e.payload));
+}
+
+export function listenLifecycleExit(
+  handler: (payload: LifecycleExitPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<LifecycleExitPayload>('provider-lifecycle-exit', (e) => handler(e.payload));
+}

--- a/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
+++ b/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../../../store/store';
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * Re-detects CLI presence + auth state when the app regains focus or its tab
+ * becomes visible again. This is the coherence backstop for changes made
+ * outside the app (e.g. user runs `npm i -g @anthropic-ai/claude-code` in
+ * their own shell, or `claude /logout` in another terminal). On focus the
+ * provider list resyncs with ground truth.
+ *
+ * Lifecycle-driven refreshes (after the embedded install/login/logout flow)
+ * already happen via the `provider-lifecycle-exit` event, this hook covers
+ * the gap when state changes elsewhere on the machine.
+ */
+export function useProviderRefreshOnFocus(): void {
+  const refreshProviders = useAppStore((s) => s.refreshProviders);
+
+  useEffect(() => {
+    let timer: number | null = null;
+    let lastRunAt = 0;
+
+    const schedule = (): void => {
+      const now = Date.now();
+      const elapsed = now - lastRunAt;
+      const wait = elapsed >= DEBOUNCE_MS ? 0 : DEBOUNCE_MS - elapsed;
+      if (timer !== null) window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        lastRunAt = Date.now();
+        timer = null;
+        void refreshProviders();
+      }, wait);
+    };
+
+    const onFocus = (): void => schedule();
+    const onVisibility = (): void => {
+      if (document.visibilityState === 'visible') schedule();
+    };
+
+    window.addEventListener('focus', onFocus);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('focus', onFocus);
+      document.removeEventListener('visibilitychange', onVisibility);
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [refreshProviders]);
+}

--- a/apps/desktop/src/store/slices/providers/cancelProviderLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/cancelProviderLifecycle.ts
@@ -1,0 +1,26 @@
+import type { ProviderId } from '@goodboy/types';
+import { invokeProviderLifecycleCancel } from '../../../features/providers/provider-lifecycle';
+import type { GetFn, SetFn } from './types';
+
+export function cancelProviderLifecycle(set: SetFn, get: GetFn) {
+  return async (providerId: ProviderId): Promise<void> => {
+    const curr = get().providerLifecycle[providerId];
+    if (!curr.runId) return;
+    if (
+      curr.phase !== 'installing' &&
+      curr.phase !== 'connecting' &&
+      curr.phase !== 'disconnecting'
+    ) {
+      return;
+    }
+    // Optimistic mark; the exit handler will land on the resting phase based on
+    // refreshed detection but preserves 'cancelled' if it sees it.
+    set((state) => ({
+      providerLifecycle: {
+        ...state.providerLifecycle,
+        [providerId]: { ...curr, phase: 'cancelled' },
+      },
+    }));
+    await invokeProviderLifecycleCancel(curr.runId);
+  };
+}

--- a/apps/desktop/src/store/slices/providers/index.ts
+++ b/apps/desktop/src/store/slices/providers/index.ts
@@ -1,10 +1,21 @@
+import { cancelProviderLifecycle } from './cancelProviderLifecycle';
+import { installProvider } from './installProvider';
+import { loginProvider } from './loginProvider';
+import { logoutProvider } from './logoutProvider';
 import { refreshProviderStatus } from './refreshProviderStatus';
 import { refreshProviders } from './refreshProviders';
 import type { GetFn, SetFn } from './types';
 
-export function createProvidersSlice(set: SetFn, _get: GetFn) {
+export type { ProviderLifecycleMap, ProviderLifecycleState } from './types';
+export { INITIAL_LIFECYCLE_MAP } from './types';
+
+export function createProvidersSlice(set: SetFn, get: GetFn) {
   return {
     refreshProviderStatus: refreshProviderStatus(set),
     refreshProviders: refreshProviders(set),
+    installProvider: installProvider(set, get),
+    loginProvider: loginProvider(set, get),
+    logoutProvider: logoutProvider(set, get),
+    cancelProviderLifecycle: cancelProviderLifecycle(set, get),
   };
 }

--- a/apps/desktop/src/store/slices/providers/installProvider.ts
+++ b/apps/desktop/src/store/slices/providers/installProvider.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from '@goodboy/types';
+import { runLifecycle } from './runLifecycle';
+import type { GetFn, SetFn } from './types';
+
+export function installProvider(set: SetFn, get: GetFn) {
+  return (providerId: ProviderId): Promise<void> =>
+    runLifecycle(set, get, { providerId, action: 'install' });
+}

--- a/apps/desktop/src/store/slices/providers/loginProvider.ts
+++ b/apps/desktop/src/store/slices/providers/loginProvider.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from '@goodboy/types';
+import { runLifecycle } from './runLifecycle';
+import type { GetFn, SetFn } from './types';
+
+export function loginProvider(set: SetFn, get: GetFn) {
+  return (providerId: ProviderId): Promise<void> =>
+    runLifecycle(set, get, { providerId, action: 'login' });
+}

--- a/apps/desktop/src/store/slices/providers/logoutProvider.ts
+++ b/apps/desktop/src/store/slices/providers/logoutProvider.ts
@@ -1,0 +1,8 @@
+import type { ProviderId } from '@goodboy/types';
+import { runLifecycle } from './runLifecycle';
+import type { GetFn, SetFn } from './types';
+
+export function logoutProvider(set: SetFn, get: GetFn) {
+  return (providerId: ProviderId): Promise<void> =>
+    runLifecycle(set, get, { providerId, action: 'logout' });
+}

--- a/apps/desktop/src/store/slices/providers/runLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.ts
@@ -1,0 +1,186 @@
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+import {
+  buildProviderList,
+  type ProviderAuthResults,
+  type ProviderStatus,
+  type ProviderStatuses,
+} from '../../../features/providers/providers';
+import {
+  invokeProviderLifecycleRun,
+  listenLifecycleExit,
+  listenLifecycleOutput,
+  resolveLifecycleCommand,
+  type LifecycleExitPayload,
+} from '../../../features/providers/provider-lifecycle';
+import { formatError } from '../../../shared/lib/errors';
+import type { GetFn, SetFn } from './types';
+import { IDLE_LIFECYCLE, type ProviderLifecyclePhase } from './types';
+
+const OUTPUT_TAIL_CAP = 4 * 1024;
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+
+// Map an action to the in-flight phase that drives the UI while the PTY runs.
+function pendingPhase(action: ProviderLifecycleAction): ProviderLifecyclePhase {
+  if (action === 'install') return 'installing';
+  if (action === 'login') return 'connecting';
+  return 'disconnecting';
+}
+
+// Map exit payload to the resting phase the UI lands on after exit. Coherence
+// guard: ground truth comes from the fresh detection in the payload, not from
+// our optimistic guess. If detection says "missing" after an install attempt,
+// we land on 'error' regardless of exit code (half-installed).
+function restingPhase(
+  action: ProviderLifecycleAction,
+  payload: LifecycleExitPayload,
+): ProviderLifecyclePhase {
+  const installed = payload.status.available;
+  const connected = payload.auth.state === 'connected';
+  if (payload.exitCode !== 0) {
+    if (action === 'install') return installed ? 'installed' : 'error';
+    if (action === 'login') return connected ? 'connected' : 'error';
+    return connected ? 'error' : 'installed';
+  }
+  if (action === 'install') return installed ? 'installed' : 'error';
+  if (action === 'login') return connected ? 'connected' : 'error';
+  return connected ? 'error' : 'installed';
+}
+
+function statusSlotPatch(
+  providerId: ProviderId,
+  status: ProviderStatus,
+): {
+  providerStatus?: ProviderStatus;
+  cursorStatus?: ProviderStatus;
+  codexStatus?: ProviderStatus;
+  geminiStatus?: ProviderStatus;
+} {
+  if (providerId === 'anthropic') return { providerStatus: status };
+  if (providerId === 'cursor') return { cursorStatus: status };
+  if (providerId === 'codex') return { codexStatus: status };
+  return { geminiStatus: status };
+}
+
+export interface RunLifecycleArgs {
+  readonly providerId: ProviderId;
+  readonly action: ProviderLifecycleAction;
+  readonly cols?: number;
+  readonly rows?: number;
+}
+
+export async function runLifecycle(
+  set: SetFn,
+  get: GetFn,
+  { providerId, action, cols = 100, rows = 24 }: RunLifecycleArgs,
+): Promise<void> {
+  const existing = get().providerLifecycle[providerId];
+  if (
+    existing.phase === 'installing' ||
+    existing.phase === 'connecting' ||
+    existing.phase === 'disconnecting'
+  ) {
+    // Idempotent: another run is already in flight for this provider.
+    return;
+  }
+
+  const runId = crypto.randomUUID();
+  const command = resolveLifecycleCommand(providerId, action);
+  const startedAt = Date.now();
+
+  set((state) => ({
+    providerLifecycle: {
+      ...state.providerLifecycle,
+      [providerId]: {
+        phase: pendingPhase(action),
+        runId,
+        action,
+        command,
+        exitCode: null,
+        startedAt,
+        errorTail: null,
+      },
+    },
+  }));
+
+  let outputTail = '';
+  let unlistenOutput: () => void = () => undefined;
+  let unlistenExit: () => void = () => undefined;
+
+  unlistenOutput = await listenLifecycleOutput((payload) => {
+    if (payload.runId !== runId) return;
+    const chunk = atob(payload.data);
+    outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_CAP);
+  });
+
+  unlistenExit = await listenLifecycleExit((payload) => {
+    if (payload.runId !== runId) return;
+    unlistenExit();
+    unlistenOutput();
+
+    const curr = get().providerLifecycle[providerId];
+    // If user cancelled, the slice already wrote phase='cancelled'. Preserve it
+    // but still refresh provider state from the payload.
+    const finalPhase: ProviderLifecyclePhase =
+      curr.phase === 'cancelled' ? 'cancelled' : restingPhase(action, payload);
+    const errorTail = finalPhase === 'error' ? outputTail.replace(ANSI_RE, '').slice(-500) : null;
+
+    set((state) => {
+      const statuses: ProviderStatuses = {
+        anthropic: providerId === 'anthropic' ? payload.status : state.providerStatus,
+        cursor: providerId === 'cursor' ? payload.status : state.cursorStatus,
+        codex: providerId === 'codex' ? payload.status : state.codexStatus,
+        gemini: providerId === 'gemini' ? payload.status : state.geminiStatus,
+      };
+      const authResults: ProviderAuthResults = {
+        ...(state.authResults ?? {
+          anthropic: null,
+          cursor: null,
+          codex: null,
+          gemini: null,
+        }),
+        [providerId]: payload.auth,
+      };
+      return {
+        ...statusSlotPatch(providerId, payload.status),
+        authResults,
+        providers: buildProviderList(statuses, authResults),
+        providerLifecycle: {
+          ...state.providerLifecycle,
+          [providerId]: {
+            ...curr,
+            phase: finalPhase,
+            exitCode: payload.exitCode,
+            errorTail,
+          },
+        },
+      };
+    });
+  });
+
+  try {
+    await invokeProviderLifecycleRun({
+      providerId,
+      action,
+      command,
+      runId,
+      cols,
+      rows,
+    });
+  } catch (err) {
+    unlistenExit();
+    unlistenOutput();
+    set((state) => ({
+      providerLifecycle: {
+        ...state.providerLifecycle,
+        [providerId]: {
+          ...IDLE_LIFECYCLE,
+          phase: 'error',
+          action,
+          command,
+          errorTail: formatError(err),
+        },
+      },
+    }));
+  }
+}

--- a/apps/desktop/src/store/slices/providers/types.ts
+++ b/apps/desktop/src/store/slices/providers/types.ts
@@ -1,1 +1,42 @@
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+
 export type { SetFn, GetFn } from '../../slice-types';
+
+export type ProviderLifecyclePhase =
+  | 'idle'
+  | 'installing'
+  | 'installed'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'error'
+  | 'cancelled';
+
+export interface ProviderLifecycleState {
+  readonly phase: ProviderLifecyclePhase;
+  readonly runId: string | null;
+  readonly action: ProviderLifecycleAction | null;
+  readonly command: string | null;
+  readonly exitCode: number | null;
+  readonly startedAt: number | null;
+  readonly errorTail: string | null;
+}
+
+export const IDLE_LIFECYCLE: ProviderLifecycleState = {
+  phase: 'idle',
+  runId: null,
+  action: null,
+  command: null,
+  exitCode: null,
+  startedAt: null,
+  errorTail: null,
+};
+
+export type ProviderLifecycleMap = Readonly<Record<ProviderId, ProviderLifecycleState>>;
+
+export const INITIAL_LIFECYCLE_MAP: ProviderLifecycleMap = {
+  anthropic: IDLE_LIFECYCLE,
+  cursor: IDLE_LIFECYCLE,
+  codex: IDLE_LIFECYCLE,
+  gemini: IDLE_LIFECYCLE,
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -88,7 +88,11 @@ import { createSessionViewSlice } from './slices/session-view';
 import { createTerminalSlice } from './slices/terminal';
 import { createScriptsSlice } from './slices/scripts';
 import { createPermissionsSlice } from './slices/permissions';
-import { createProvidersSlice } from './slices/providers';
+import {
+  createProvidersSlice,
+  INITIAL_LIFECYCLE_MAP,
+  type ProviderLifecycleMap,
+} from './slices/providers';
 import { createAgentsSlice } from './slices/agents';
 import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
@@ -170,6 +174,7 @@ export interface AppState {
   readonly geminiStatus: ProviderStatus | null;
   readonly authResults: ProviderAuthResults | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
+  readonly providerLifecycle: ProviderLifecycleMap;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
   readonly error: string | null;
@@ -310,6 +315,10 @@ export interface AppActions {
   saveSetting(key: string, value: string): Promise<void>;
   refreshProviderStatus(status: ProviderStatus): void;
   refreshProviders(): Promise<void>;
+  installProvider(providerId: ProviderId): Promise<void>;
+  loginProvider(providerId: ProviderId): Promise<void>;
+  logoutProvider(providerId: ProviderId): Promise<void>;
+  cancelProviderLifecycle(providerId: ProviderId): Promise<void>;
   addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
   deleteWorkspace(id: WorkspaceId): Promise<void>;
   loadIntegrations(workspaceId: WorkspaceId): Promise<void>;
@@ -548,6 +557,7 @@ export const initialState: AppState = {
   geminiStatus: null,
   authResults: null,
   providers: buildProviderList({ anthropic: null, cursor: null, codex: null, gemini: null }),
+  providerLifecycle: INITIAL_LIFECYCLE_MAP,
   hydrated: false,
   bootPhase: 'pending',
   error: null,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -53,6 +53,13 @@ export type {
   ProviderId,
   ProviderRegistryCapabilities,
 } from './provider-registry';
+export type {
+  ProviderLifecycleAction,
+  ProviderLifecycleCommands,
+  ProviderPlatform,
+  ProviderPlatformCommands,
+} from './provider-commands';
+export { PROVIDER_LIFECYCLE_COMMANDS } from './provider-commands';
 export type { SessionProviderPreference, TurnProviderOverride } from './provider-preference';
 export { DEFAULT_SESSION_PROVIDER_PREFERENCE } from './provider-preference';
 export type { Skill, SkillFrontmatter, SkillInvocation, SlashCommand } from './skill';

--- a/packages/types/src/provider-commands.ts
+++ b/packages/types/src/provider-commands.ts
@@ -1,0 +1,59 @@
+import type { ProviderId } from './provider-registry';
+
+export type ProviderLifecycleAction = 'install' | 'login' | 'logout';
+
+export type ProviderPlatform = 'darwin' | 'linux' | 'win32';
+
+export interface ProviderPlatformCommands {
+  readonly darwin: string;
+  readonly linux: string;
+  readonly win32: string;
+}
+
+export interface ProviderLifecycleCommands {
+  readonly install: ProviderPlatformCommands;
+  readonly login: string;
+  readonly logout: string;
+}
+
+// Cross-platform, npm-first. Cursor is the only non-npm exception because
+// cursor-agent is not published on npm. Gemini logout has no subcommand so we
+// remove the OAuth creds file directly (matches detect fallback in providers.rs).
+export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCommands> = {
+  anthropic: {
+    install: {
+      darwin: 'npm install -g @anthropic-ai/claude-code',
+      linux: 'npm install -g @anthropic-ai/claude-code',
+      win32: 'npm install -g @anthropic-ai/claude-code',
+    },
+    login: 'claude /login',
+    logout: 'claude /logout',
+  },
+  cursor: {
+    install: {
+      darwin: 'curl https://cursor.com/install -fsS | bash',
+      linux: 'curl https://cursor.com/install -fsS | bash',
+      win32: 'powershell -Command "irm https://cursor.com/install.ps1 | iex"',
+    },
+    login: 'cursor-agent login',
+    logout: 'cursor-agent logout',
+  },
+  codex: {
+    install: {
+      darwin: 'npm install -g @openai/codex',
+      linux: 'npm install -g @openai/codex',
+      win32: 'npm install -g @openai/codex',
+    },
+    login: 'codex login',
+    logout: 'codex logout',
+  },
+  gemini: {
+    install: {
+      darwin: 'npm install -g @google/gemini-cli',
+      linux: 'npm install -g @google/gemini-cli',
+      win32: 'npm install -g @google/gemini-cli',
+    },
+    login: 'gemini',
+    logout: 'rm -f ~/.gemini/oauth_creds.json && echo "gemini credentials removed"',
+  },
+};


### PR DESCRIPTION
## Summary

Phase 1 of the in-app provider lifecycle refactor: backend + state machine for install / connect / disconnect that run inside the embedded PTY instead of spawning an external terminal. No UI yet.

The headline feature is the **coherence contract**: every lifecycle run ends with a fresh detection + auth check, shipped in the exit event payload. The UI cannot drift from on-disk truth.

## What's in this PR

- **`packages/types/src/provider-commands.ts`**: cross-platform command registry. `npm install` for anthropic/codex/gemini, `curl | bash` for cursor (not on npm). Login/logout strings per provider.
- **`src-tauri/src/provider_lifecycle.rs`**: dedicated Tauri command set (`provider_lifecycle_run` / `_write` / `_resize` / `_cancel`) mirroring the `scripts.rs` PTY pattern. On exit it re-runs `detect_<provider>` + `check_<provider>_auth` and ships the fresh `ProviderStatus` + `AuthState` alongside the exit code.
- **`store/slices/providers/`**: new actions `installProvider`, `loginProvider`, `logoutProvider`, `cancelProviderLifecycle`. Shared `runLifecycle` helper drives a phase machine `idle -> installing/connecting/disconnecting -> resting (installed/connected/error/cancelled)`. Resting phase comes from the exit payload, not optimistic guesses: if detection says "missing" after a successful install, the UI lands on `error`.
- **`shared/hooks/useProviderRefreshOnFocus`**: window focus + visibilitychange listener (500ms debounce) that calls `refreshProviders`. Catches changes made outside the app (manual install in a separate shell, `claude /logout` elsewhere).
- **Mounted in App.tsx** so coherence holds across the whole session.

## Coherence guards layered in this PR

1. Backend re-detects after every PTY exit. Authoritative.
2. Exit event ships `ProviderStatus` + `AuthState` so the store transition is atomic (phase, providers list, authResults all update from the same payload).
3. Focus / visibilitychange refresh covers external changes.
4. Resting phase ignores exit code when detection contradicts (half-installed CLI lands on `error` even if `npm install` exited 0).
5. Cancel preserves the `cancelled` phase but still updates the provider list with refreshed detection, so the user sees what real state survived the cancel.

## Out of scope (next phases)

- Phase 2: extract `GenericTerminalPanel` from the session-scoped `TerminalPanel` (decouple from `SessionId`, accept `terminalId` + optional `command`).
- Phase 3: `ProviderLifecycleTile` UI (expandable inline drawer with stepper, command preview, embedded xterm, success / error states).
- Phase 4+: cancel UX polish, npm prefix preflight, OAuth URL detection, kill `provider_action` external-terminal code.

## Test plan

- [ ] CI: lint + typecheck + knip + test + build (already verified locally: typecheck green across all packages, 767 tests pass, build green, `cargo check` clean)
- [ ] Smoke once UI lands (phase 3): install -> auto detect -> Connect prompt -> login -> Connected pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)