### PR TITLE
feat(desktop): in-app provider lifecycle ui + kill external terminal

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -95,7 +95,6 @@ pub fn run() {
       providers::get_gemini_status,
       providers::refresh_gemini_status,
       providers::check_provider_auth,
-      providers::provider_action,
       provider_lifecycle::provider_lifecycle_run,
       provider_lifecycle::provider_lifecycle_write,
       provider_lifecycle::provider_lifecycle_resize,

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -1,4 +1,4 @@
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -639,90 +639,6 @@ pub fn refresh_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
         *current = next.clone();
     }
     next
-}
-
-fn provider_login_command(provider_id: &str) -> Option<String> {
-    match provider_id {
-        "anthropic" => Some("claude /login".to_string()),
-        "cursor" => Some("cursor login".to_string()),
-        "codex" => Some("codex login".to_string()),
-        // gemini-cli prompts for OAuth on first run when no creds file exists;
-        // launching the bare binary opens the browser flow.
-        "gemini" => Some("gemini".to_string()),
-        _ => None,
-    }
-}
-
-fn provider_logout_command(provider_id: &str) -> Option<String> {
-    match provider_id {
-        "anthropic" => Some("claude /logout".to_string()),
-        "cursor" => Some("cursor logout".to_string()),
-        "codex" => Some("codex logout".to_string()),
-        // gemini-cli has no logout subcommand; deleting the creds file is the
-        // closest equivalent. Wrap with a confirmation message in the terminal.
-        "gemini" => Some("rm -f ~/.gemini/oauth_creds.json && echo 'gemini credentials removed'".to_string()),
-        _ => None,
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn spawn_in_terminal(command: &str) -> Result<(), String> {
-    // `do script` opens a Terminal window but does not raise Terminal.app when
-    // Goodboy is frontmost; the explicit `activate` brings it to the foreground.
-    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
-    let script = format!(
-        "tell application \"Terminal\"\n  do script \"{}\"\n  activate\nend tell",
-        escaped
-    );
-    Command::new("osascript")
-        .args(["-e", &script])
-        .spawn()
-        .map_err(|e| e.to_string())?;
-    Ok(())
-}
-
-#[cfg(target_os = "linux")]
-fn spawn_in_terminal(command: &str) -> Result<(), String> {
-    let terminals: &[(&str, &[&str])] = &[
-        ("gnome-terminal", &["--", "bash", "-c"]),
-        ("konsole", &["-e", "bash", "-c"]),
-        ("xterm", &["-e", "bash", "-c"]),
-    ];
-    for (term, base_args) in terminals {
-        let mut args: Vec<&str> = base_args.to_vec();
-        let cmd_with_pause = format!("{}; read -p 'press enter to close'", command);
-        args.push(&cmd_with_pause);
-        if Command::new(term).args(&args).spawn().is_ok() {
-            return Ok(());
-        }
-    }
-    Err("no supported terminal emulator found (tried gnome-terminal, konsole, xterm)".to_string())
-}
-
-#[cfg(target_os = "windows")]
-fn spawn_in_terminal(command: &str) -> Result<(), String> {
-    Command::new("cmd")
-        .args(["/c", "start", "cmd", "/k", command])
-        .spawn()
-        .map_err(|e| e.to_string())?;
-    Ok(())
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn spawn_in_terminal(_command: &str) -> Result<(), String> {
-    Err("unsupported platform".to_string())
-}
-
-#[tauri::command]
-pub fn provider_action(provider_id: String, action: String) -> Result<(), String> {
-    let command = match action.as_str() {
-        "login" => provider_login_command(&provider_id),
-        "logout" => provider_logout_command(&provider_id),
-        _ => return Err(format!("unknown action: {}", action)),
-    }
-    .ok_or_else(|| format!("unknown provider: {}", provider_id))?;
-
-    spawn_in_terminal(&command)
 }
 
 #[tauri::command]

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -421,14 +421,7 @@ exports[`snapshot, empty states > ProvidersPanel: no providers (store returns []
       />
     </svg>
     <span>
-      Sign in once via each provider's CLI (e.g. run
-       
-      <code
-        class="rounded bg-muted px-1"
-      >
-        claude
-      </code>
-       in a terminal). Goodboy picks up the credentials.
+      Install and sign in straight from the app. Each step runs in an embedded terminal so you never leave Goodboy.
     </span>
   </div>
 </div>
@@ -1614,80 +1607,81 @@ exports[`snapshot, error states > ProvidersPanel: provider in error state 1`] = 
     class="grid grid-cols-3 gap-2.5"
   >
     <div
-      class="relative flex flex-col items-center gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
+      class="relative flex flex-col gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
     >
-      <span
-        class="relative inline-flex"
-      >
-        <span
-          aria-hidden="true"
-          class="absolute left-2.5 top-2.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-danger"
-        />
-      </span>
       <div
-        aria-hidden="true"
-        class="mt-1 flex h-10 w-10 items-center justify-center rounded-full transition-opacity"
-        style="color: var(--color-provider-anthropic);"
+        class="flex gap-3 flex-col items-center"
       >
-        <svg
-          aria-hidden="true"
-          class="lucide lucide-sparkles"
-          fill="none"
-          height="18"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          viewBox="0 0 24 24"
-          width="18"
-          xmlns="http://www.w3.org/2000/svg"
+        <div
+          class="flex items-center flex-col gap-2"
         >
-          <path
-            d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
-          />
-          <path
-            d="M20 2v4"
-          />
-          <path
-            d="M22 4h-4"
-          />
-          <circle
-            cx="4"
-            cy="20"
-            r="2"
-          />
-        </svg>
-      </div>
-      <div
-        class="flex flex-col items-center gap-0.5"
-      >
+          <div
+            aria-hidden="true"
+            class="flex h-10 w-10 items-center justify-center rounded-full transition-opacity"
+            style="color: var(--color-provider-anthropic);"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-sparkles"
+              fill="none"
+              height="18"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+              />
+              <path
+                d="M20 2v4"
+              />
+              <path
+                d="M22 4h-4"
+              />
+              <circle
+                cx="4"
+                cy="20"
+                r="2"
+              />
+            </svg>
+          </div>
+          <div
+            class="flex flex-col items-center"
+          >
+            <span
+              class="text-sm font-semibold lowercase"
+            >
+              claude
+            </span>
+            <span
+              class="max-w-[160px] truncate text-2xs text-muted-foreground"
+              title="1.0.0"
+            >
+              1.0.0
+            </span>
+          </div>
+        </div>
         <span
-          class="text-sm font-semibold lowercase"
+          class="inline-flex items-center gap-1.5 text-2xs font-medium"
         >
-          claude
+          <span
+            aria-hidden="true"
+            class="inline-block h-1.5 w-1.5 rounded-full bg-danger"
+          />
+          <span
+            class="text-danger"
+          >
+            Error
+          </span>
         </span>
-        <span
-          class="text-2xs text-muted-foreground"
-        >
-          1.0.0
-        </span>
-      </div>
-      <div
-        class="line-clamp-2 text-center text-2xs text-danger"
-        title="unknown error"
-      >
-        unknown error
       </div>
       <div
         class="mt-1 w-full"
-      >
-        <button
-          class="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
-          type="button"
-        >
-          Retry
-        </button>
-      </div>
+      />
     </div>
   </div>
   <div
@@ -1719,14 +1713,7 @@ exports[`snapshot, error states > ProvidersPanel: provider in error state 1`] = 
       />
     </svg>
     <span>
-      Sign in once via each provider's CLI (e.g. run
-       
-      <code
-        class="rounded bg-muted px-1"
-      >
-        claude
-      </code>
-       in a terminal). Goodboy picks up the credentials.
+      Install and sign in straight from the app. Each step runs in an embedded terminal so you never leave Goodboy.
     </span>
   </div>
 </div>

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -17,6 +17,48 @@ vi.mock('../../store', () => ({
       budgetAlerts: [],
       notifications: [],
       providers: [],
+      providerLifecycle: {
+        anthropic: {
+          phase: 'idle' as const,
+          runId: null,
+          action: null,
+          command: null,
+          exitCode: null,
+          startedAt: null,
+          errorTail: null,
+          detectedAuthUrl: null,
+        },
+        cursor: {
+          phase: 'idle' as const,
+          runId: null,
+          action: null,
+          command: null,
+          exitCode: null,
+          startedAt: null,
+          errorTail: null,
+          detectedAuthUrl: null,
+        },
+        codex: {
+          phase: 'idle' as const,
+          runId: null,
+          action: null,
+          command: null,
+          exitCode: null,
+          startedAt: null,
+          errorTail: null,
+          detectedAuthUrl: null,
+        },
+        gemini: {
+          phase: 'idle' as const,
+          runId: null,
+          action: null,
+          command: null,
+          exitCode: null,
+          startedAt: null,
+          errorTail: null,
+          detectedAuthUrl: null,
+        },
+      },
       skills: {},
       settings: {},
       phaseTemplates: {},
@@ -34,6 +76,10 @@ vi.mock('../../store', () => ({
       markNotificationsRead: vi.fn(),
       clearNotifications: vi.fn(),
       refreshProviders: vi.fn(),
+      installProvider: vi.fn(),
+      loginProvider: vi.fn(),
+      logoutProvider: vi.fn(),
+      cancelProviderLifecycle: vi.fn(),
       loadSkills: vi.fn(),
       saveSkill: vi.fn(),
       deleteSkill: vi.fn(),
@@ -91,9 +137,27 @@ import type { AppStore } from '../../store/store';
 import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../store';
 
+const IDLE_LIFECYCLE = {
+  phase: 'idle' as const,
+  runId: null,
+  action: null,
+  command: null,
+  exitCode: null,
+  startedAt: null,
+  errorTail: null,
+  detectedAuthUrl: null,
+};
+
+const DEFAULT_LIFECYCLE_MAP = {
+  anthropic: IDLE_LIFECYCLE,
+  cursor: IDLE_LIFECYCLE,
+  codex: IDLE_LIFECYCLE,
+  gemini: IDLE_LIFECYCLE,
+};
+
 function mockStore(partial: Partial<AppStore>): void {
   vi.mocked(useAppStore).mockImplementation((selector: (state: AppStore) => unknown) =>
-    selector(partial as AppStore),
+    selector({ providerLifecycle: DEFAULT_LIFECYCLE_MAP, ...partial } as AppStore),
   );
 }
 import { NotificationCenter } from '../../features/notifications/components/NotificationCenter';

--- a/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.test.tsx
@@ -3,15 +3,20 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
-const { invokeMock } = vi.hoisted(() => ({ invokeMock: vi.fn(async () => undefined) }));
+const { loginProviderMock } = vi.hoisted(() => ({
+  loginProviderMock: vi.fn(async () => undefined),
+}));
 
-vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: { loginProvider: typeof loginProviderMock }) => T) =>
+    selector({ loginProvider: loginProviderMock }),
+}));
 
 import { AuthRequiredCallout } from './index';
 
 afterEach(() => {
   cleanup();
-  invokeMock.mockClear();
+  loginProviderMock.mockClear();
 });
 
 describe('AuthRequiredCallout', () => {
@@ -27,10 +32,10 @@ describe('AuthRequiredCallout', () => {
     expect(screen.getByText(/last known identity: amin@x\.io/i)).toBeDefined();
   });
 
-  it('invokes provider_action login when Connect is clicked', () => {
+  it('invokes loginProvider when Connect is clicked', () => {
     render(<AuthRequiredCallout providerId="codex" onRefresh={() => undefined} />);
     fireEvent.click(screen.getByRole('button', { name: /connect now/i }));
-    expect(invokeMock).toHaveBeenCalledWith('provider_action', { id: 'codex', action: 'login' });
+    expect(loginProviderMock).toHaveBeenCalledWith('codex');
   });
 
   it('calls onRefresh when the Refresh status button is clicked', () => {

--- a/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.tsx
+++ b/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.tsx
@@ -1,11 +1,7 @@
-import { invoke } from '@tauri-apps/api/core';
 import { Button } from '@goodboy/ui';
 import type { ProviderId } from '@goodboy/types';
 import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
-
-async function providerAction(id: ProviderId, action: 'login' | 'logout'): Promise<void> {
-  return invoke('provider_action', { id, action });
-}
+import { useAppStore } from '../../../../store';
 
 interface Props {
   readonly providerId: ProviderId;
@@ -15,9 +11,10 @@ interface Props {
 
 export function AuthRequiredCallout({ providerId, identity, onRefresh }: Props) {
   const label = PROVIDER_LABEL_LOWER[providerId];
+  const loginProvider = useAppStore((s) => s.loginProvider);
 
   const onConnect = () => {
-    void providerAction(providerId, 'login');
+    void loginProvider(providerId);
   };
 
   return (

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/CommandPreview.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/CommandPreview.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  readonly command: string;
+}
+
+// Reassures power users by showing exactly what shell command runs. Mirrors
+// the conventional `$ ` prompt prefix so it reads as runnable text.
+export function CommandPreview({ command }: Props) {
+  return (
+    <div className="overflow-x-auto rounded-md bg-muted/40 px-2.5 py-1.5 font-mono text-2xs text-muted-foreground">
+      <span aria-hidden className="text-muted-foreground/50">
+        ${' '}
+      </span>
+      <span className="text-foreground">{command}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/CtaButton.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/CtaButton.tsx
@@ -1,0 +1,74 @@
+import { cn } from '@goodboy/ui';
+import type { ProviderLifecycleAction } from '@goodboy/types';
+import type { ProviderLifecyclePhase } from '../../../../store/slices/providers';
+import type { ProviderConnectionState } from '../../../../features/providers/providers';
+
+// CTA descriptor: derived once per render so the tile can ask "what should
+// the primary button do right now" without duplicating the phase-to-action
+// mapping. Returning null means the tile renders its own composite controls
+// (e.g. the disconnect confirm chip).
+export interface CtaIntent {
+  readonly label: string;
+  readonly action: ProviderLifecycleAction | 'cancel';
+  readonly variant: 'primary' | 'secondary' | 'danger';
+}
+
+export function intentForState(
+  phase: ProviderLifecyclePhase,
+  connection: ProviderConnectionState,
+): CtaIntent | null {
+  if (phase === 'installing' || phase === 'connecting' || phase === 'disconnecting') {
+    return { label: 'Cancel', action: 'cancel', variant: 'secondary' };
+  }
+  if (phase === 'installed') {
+    return { label: 'Connect', action: 'login', variant: 'primary' };
+  }
+  if (phase === 'cancelled' || phase === 'error') {
+    if (connection === 'connected') {
+      return { label: 'Disconnect', action: 'logout', variant: 'secondary' };
+    }
+    if (connection === 'installed_disconnected') {
+      return { label: 'Connect', action: 'login', variant: 'primary' };
+    }
+    return { label: 'Retry install', action: 'install', variant: 'primary' };
+  }
+  // idle / connected / fresh, fall through to connection-driven CTA.
+  if (connection === 'connected') {
+    return null; // tile renders disconnect-with-confirm composite
+  }
+  if (connection === 'installed_disconnected') {
+    return { label: 'Connect', action: 'login', variant: 'primary' };
+  }
+  if (connection === 'missing') {
+    return { label: 'Install', action: 'install', variant: 'primary' };
+  }
+  return null;
+}
+
+interface Props {
+  readonly intent: CtaIntent;
+  readonly disabled?: boolean;
+  readonly onClick: () => void;
+}
+
+const VARIANT_CLASS: Record<CtaIntent['variant'], string> = {
+  primary: 'border-primary/30 text-primary hover:bg-primary/10',
+  secondary: 'border-border-soft text-muted-foreground hover:bg-muted hover:text-foreground',
+  danger: 'border-danger/30 text-danger hover:bg-danger/10',
+};
+
+export function CtaButton({ intent, disabled, onClick }: Props) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={cn(
+        'block w-full rounded-md border py-1.5 text-center text-xs transition-colors disabled:opacity-50',
+        VARIANT_CLASS[intent.variant],
+      )}
+    >
+      {intent.label}
+    </button>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/DisconnectControl.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/DisconnectControl.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Tooltip } from '@goodboy/ui';
+import { RotateCw } from 'lucide-react';
+
+interface Props {
+  readonly onDisconnect: () => void;
+  readonly onRefresh: () => void;
+  readonly refreshing: boolean;
+  readonly disconnecting: boolean;
+}
+
+const CONFIRM_WINDOW_MS = 3_000;
+
+// Two-tap disconnect to avoid a modal while still preventing a fat-finger
+// signout. First tap arms a 3s confirmation window, second tap commits.
+// Refresh button kept alongside so the user can manually re-check identity.
+export function DisconnectControl({ onDisconnect, onRefresh, refreshing, disconnecting }: Props) {
+  const [armed, setArmed] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const onClick = useCallback(() => {
+    if (!armed) {
+      setArmed(true);
+      timerRef.current = window.setTimeout(() => setArmed(false), CONFIRM_WINDOW_MS);
+      return;
+    }
+    clearTimer();
+    setArmed(false);
+    onDisconnect();
+  }, [armed, clearTimer, onDisconnect]);
+
+  return (
+    <div className="flex w-full items-stretch gap-1.5">
+      <Tooltip content="Re-check identity" side="top">
+        <button
+          type="button"
+          aria-label="Re-check identity"
+          disabled={refreshing}
+          className="rounded-md border border-border-soft px-2 text-xs hover:bg-muted disabled:opacity-50"
+          onClick={onRefresh}
+        >
+          <RotateCw size={12} className={refreshing ? 'animate-spin' : undefined} aria-hidden />
+        </button>
+      </Tooltip>
+      <button
+        type="button"
+        disabled={disconnecting}
+        className={
+          armed
+            ? 'flex-1 rounded-md border border-danger/40 bg-danger/5 py-1.5 text-center text-xs font-medium text-danger transition-colors hover:bg-danger/10 disabled:opacity-50'
+            : 'flex-1 rounded-md border border-border-soft py-1.5 text-center text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50'
+        }
+        onClick={onClick}
+      >
+        {disconnecting ? 'Signing out…' : armed ? 'Click again to confirm' : 'Disconnect'}
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/ErrorPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/ErrorPanel.tsx
@@ -1,0 +1,22 @@
+import { AlertTriangle } from 'lucide-react';
+
+interface Props {
+  readonly tail: string;
+}
+
+// Compact error surface: short header + last few lines of output (ANSI
+// already stripped by runLifecycle). Kept lightweight, the full transcript
+// stays in the inline terminal when the user expands again.
+export function ErrorPanel({ tail }: Props) {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-danger/30 bg-danger/5 px-2.5 py-2 text-2xs text-danger">
+      <div className="flex items-center gap-1.5 font-semibold">
+        <AlertTriangle size={11} aria-hidden />
+        <span>Something went wrong</span>
+      </div>
+      <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-foreground/80">
+        {tail.trim() || 'No output captured.'}
+      </pre>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InfoBanner.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InfoBanner.tsx
@@ -1,0 +1,16 @@
+import { Info } from 'lucide-react';
+
+interface Props {
+  readonly text: string;
+}
+
+// Renders a single-line explainer above the CTA. Goal: never surprise the
+// user with what they are about to run.
+export function InfoBanner({ text }: Props) {
+  return (
+    <div className="flex items-start gap-1.5 text-2xs text-muted-foreground">
+      <Info size={11} aria-hidden className="mt-0.5 shrink-0" />
+      <span>{text}</span>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react';
+import {
+  GenericTerminalPanel,
+  type TerminalDriver,
+} from '../../../../shared/components/GenericTerminalPanel';
+import {
+  invokeProviderLifecycleResize,
+  invokeProviderLifecycleWrite,
+  listenLifecycleExit,
+  listenLifecycleOutput,
+} from '../../provider-lifecycle';
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function stringToBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+}
+
+interface Props {
+  readonly runId: string;
+  readonly isActive: boolean;
+}
+
+// Wraps GenericTerminalPanel with a lifecycle-scoped driver. The driver
+// filters output/exit events by runId so concurrent lifecycle runs (e.g. user
+// installs claude then immediately starts codex install) never bleed into
+// each other's xterm view.
+export function InlineTerminal({ runId, isActive }: Props) {
+  const driver = useMemo<TerminalDriver>(
+    () => ({
+      write: (data) => {
+        void invokeProviderLifecycleWrite(runId, stringToBase64(data));
+      },
+      resize: (cols, rows) => {
+        void invokeProviderLifecycleResize(runId, cols, rows);
+      },
+      onOutput: (handler) =>
+        listenLifecycleOutput((payload) => {
+          if (payload.runId !== runId) return;
+          handler(base64ToBytes(payload.data));
+        }),
+      onExit: (handler) =>
+        listenLifecycleExit((payload) => {
+          if (payload.runId !== runId) return;
+          handler(payload.exitCode);
+        }),
+    }),
+    [runId],
+  );
+
+  return (
+    <div className="h-44 overflow-hidden rounded-md border border-border-soft bg-background">
+      <GenericTerminalPanel terminalId={runId} driver={driver} isActive={isActive} exitMessage="" />
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/OpenInBrowserButton.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/OpenInBrowserButton.tsx
@@ -1,0 +1,22 @@
+import { ExternalLink } from 'lucide-react';
+import { openUrl } from '../../../../shared/lib/editor';
+
+interface Props {
+  readonly url: string;
+}
+
+// Surfaces a detected OAuth URL with click-through to the system browser.
+// Never auto-opens, the user owns the navigation decision.
+export function OpenInBrowserButton({ url }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={() => void openUrl(url)}
+      title={url}
+      className="inline-flex items-center justify-center gap-1.5 rounded-md border border-primary/30 px-3 py-1.5 text-xs text-primary transition-colors hover:bg-primary/10"
+    >
+      <ExternalLink size={12} aria-hidden />
+      <span>Open in browser</span>
+    </button>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/StatusPill.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/StatusPill.tsx
@@ -1,0 +1,81 @@
+import { cn } from '@goodboy/ui';
+import type { ProviderLifecyclePhase } from '../../../../store/slices/providers';
+import type { ProviderConnectionState } from '../../../../features/providers/providers';
+
+interface Props {
+  readonly phase: ProviderLifecyclePhase;
+  readonly connection: ProviderConnectionState;
+}
+
+interface PillSpec {
+  readonly label: string;
+  readonly dotClass: string;
+  readonly labelClass: string;
+}
+
+// Phase wins when an in-flight action is happening, otherwise we fall back to
+// the connection state (idle providers show their detection truth).
+function specFor(phase: ProviderLifecyclePhase, connection: ProviderConnectionState): PillSpec {
+  switch (phase) {
+    case 'installing':
+      return {
+        label: 'Installing',
+        dotClass: 'bg-primary animate-pulse',
+        labelClass: 'text-primary',
+      };
+    case 'connecting':
+      return {
+        label: 'Signing in',
+        dotClass: 'bg-primary animate-pulse',
+        labelClass: 'text-primary',
+      };
+    case 'disconnecting':
+      return {
+        label: 'Signing out',
+        dotClass: 'bg-muted-foreground animate-pulse',
+        labelClass: 'text-muted-foreground',
+      };
+    case 'installed':
+      return { label: 'Ready to connect', dotClass: 'bg-warning', labelClass: 'text-warning' };
+    case 'cancelled':
+      return {
+        label: 'Cancelled',
+        dotClass: 'bg-muted-foreground/60',
+        labelClass: 'text-muted-foreground',
+      };
+    case 'error':
+      return { label: 'Error', dotClass: 'bg-danger', labelClass: 'text-danger' };
+    case 'connected':
+      return { label: 'Connected', dotClass: 'bg-primary', labelClass: 'text-primary' };
+    case 'idle':
+    default:
+      return connectionSpec(connection);
+  }
+}
+
+function connectionSpec(connection: ProviderConnectionState): PillSpec {
+  switch (connection) {
+    case 'connected':
+      return { label: 'Connected', dotClass: 'bg-primary', labelClass: 'text-primary' };
+    case 'installed_disconnected':
+      return { label: 'Not signed in', dotClass: 'bg-warning', labelClass: 'text-warning' };
+    case 'missing':
+      return {
+        label: 'Not installed',
+        dotClass: 'bg-muted-foreground/40',
+        labelClass: 'text-muted-foreground',
+      };
+    case 'error':
+      return { label: 'Error', dotClass: 'bg-danger', labelClass: 'text-danger' };
+  }
+}
+
+export function StatusPill({ phase, connection }: Props) {
+  const spec = specFor(phase, connection);
+  return (
+    <span className="inline-flex items-center gap-1.5 text-2xs font-medium">
+      <span aria-hidden className={cn('inline-block h-1.5 w-1.5 rounded-full', spec.dotClass)} />
+      <span className={spec.labelClass}>{spec.label}</span>
+    </span>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/Stepper.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/Stepper.tsx
@@ -1,0 +1,26 @@
+import type { ProviderLifecycleAction } from '@goodboy/types';
+
+interface Props {
+  readonly action: ProviderLifecycleAction;
+}
+
+// Two-step ladder rendered only during install or connect. Install is step 1,
+// the implicit follow-on connect is step 2. Logout has no stepper.
+export function Stepper({ action }: Props) {
+  if (action === 'logout') return null;
+  const current = action === 'install' ? 1 : 2;
+  return (
+    <div
+      className="flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground"
+      aria-label={`Step ${current} of 2`}
+    >
+      <span>Step {current} of 2</span>
+      <span aria-hidden className="text-muted-foreground/40">
+        ·
+      </span>
+      <span className="text-foreground">
+        {action === 'install' ? 'Installing CLI' : 'Signing in'}
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/copy.ts
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/copy.ts
@@ -1,0 +1,27 @@
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+
+// Pre-action copy shown above the CTA so the user knows what they are about
+// to trigger. Kept short, ~1 sentence, no em-dashes. Per provider × action so
+// the OAuth quirks (claude in browser, gemini bare-command, codex device flow)
+// can be flagged honestly.
+
+type CopyKey = `${ProviderId}.${ProviderLifecycleAction}`;
+
+const COPY: Record<CopyKey, string> = {
+  'anthropic.install': 'Installs the Claude Code CLI globally via npm. Takes about 10 seconds.',
+  'anthropic.login': 'Opens your browser to sign in with your Anthropic account.',
+  'anthropic.logout': 'Signs you out of Claude. You can sign back in any time.',
+  'cursor.install': 'Installs the Cursor agent CLI. Runs the official installer script.',
+  'cursor.login': 'Opens your browser to sign in with your Cursor account.',
+  'cursor.logout': 'Signs you out of Cursor. You can sign back in any time.',
+  'codex.install': 'Installs the OpenAI Codex CLI globally via npm. Takes about 10 seconds.',
+  'codex.login': 'Opens your browser to sign in with your OpenAI account.',
+  'codex.logout': 'Signs you out of Codex. You can sign back in any time.',
+  'gemini.install': 'Installs the Google Gemini CLI globally via npm. Takes about 10 seconds.',
+  'gemini.login': 'Opens your browser to sign in with your Google account.',
+  'gemini.logout': 'Removes your Gemini credentials from this machine.',
+};
+
+export function copyFor(providerId: ProviderId, action: ProviderLifecycleAction): string {
+  return COPY[`${providerId}.${action}`];
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/index.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useState } from 'react';
+import { Code2, Gem, MousePointer2, Sparkles } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+import type { ProviderInfo } from '../../../../features/providers/providers';
+import { useAppStore } from '../../../../store';
+import { CommandPreview } from './CommandPreview';
+import { CtaButton, intentForState } from './CtaButton';
+import { DisconnectControl } from './DisconnectControl';
+import { ErrorPanel } from './ErrorPanel';
+import { InfoBanner } from './InfoBanner';
+import { InlineTerminal } from './InlineTerminal';
+import { OpenInBrowserButton } from './OpenInBrowserButton';
+import { StatusPill } from './StatusPill';
+import { Stepper } from './Stepper';
+import { copyFor } from './copy';
+
+interface ProviderBrand {
+  readonly icon: LucideIcon;
+  readonly cssVar: string;
+}
+
+const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
+  anthropic: { icon: Sparkles, cssVar: '--color-provider-anthropic' },
+  cursor: { icon: MousePointer2, cssVar: '--color-provider-cursor' },
+  codex: { icon: Code2, cssVar: '--color-provider-codex' },
+  gemini: { icon: Gem, cssVar: '--color-provider-gemini' },
+};
+
+interface Props {
+  readonly info: ProviderInfo;
+}
+
+// In-flight phases drive the wide layout (col-span-full with terminal).
+const WIDE_PHASES = new Set(['installing', 'connecting', 'disconnecting']);
+
+export function ProviderLifecycleTile({ info }: Props) {
+  const providerId = info.id as ProviderId;
+  const brand = PROVIDER_BRAND[providerId];
+  const Icon = brand?.icon ?? Sparkles;
+  const color = brand ? `var(${brand.cssVar})` : 'var(--color-primary)';
+
+  const lifecycle = useAppStore((s) => s.providerLifecycle[providerId]);
+  const installProvider = useAppStore((s) => s.installProvider);
+  const loginProvider = useAppStore((s) => s.loginProvider);
+  const logoutProvider = useAppStore((s) => s.logoutProvider);
+  const cancelLifecycle = useAppStore((s) => s.cancelProviderLifecycle);
+  const refreshProviders = useAppStore((s) => s.refreshProviders);
+
+  const [refreshing, setRefreshing] = useState(false);
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await refreshProviders();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refreshProviders]);
+
+  const fireAction = useCallback(
+    (action: ProviderLifecycleAction | 'cancel') => {
+      if (action === 'install') void installProvider(providerId);
+      else if (action === 'login') void loginProvider(providerId);
+      else if (action === 'logout') void logoutProvider(providerId);
+      else if (action === 'cancel') void cancelLifecycle(providerId);
+    },
+    [providerId, installProvider, loginProvider, logoutProvider, cancelLifecycle],
+  );
+
+  const isWide = WIDE_PHASES.has(lifecycle.phase);
+  const intent = intentForState(lifecycle.phase, info.connection);
+
+  // The connected state with a stable connection gets its own composite
+  // (refresh + two-tap disconnect) rather than a single CTA button.
+  const showDisconnectComposite = lifecycle.phase === 'idle' && info.connection === 'connected';
+
+  return (
+    <div
+      className="relative flex flex-col gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
+      style={{
+        borderColor: `color-mix(in oklch, ${color} 25%, var(--color-border-soft))`,
+        gridColumn: isWide ? '1 / -1' : undefined,
+      }}
+    >
+      <div
+        className={cn(
+          'flex items-start gap-3',
+          isWide ? 'justify-between' : 'flex-col items-center',
+        )}
+      >
+        <TileHeader
+          icon={Icon}
+          color={color}
+          info={info}
+          phase={lifecycle.phase}
+          stacked={!isWide}
+        />
+        {isWide ? (
+          <div className="flex flex-col items-end gap-1">
+            <StatusPill phase={lifecycle.phase} connection={info.connection} />
+            {lifecycle.action ? <Stepper action={lifecycle.action} /> : null}
+          </div>
+        ) : (
+          <StatusPill phase={lifecycle.phase} connection={info.connection} />
+        )}
+      </div>
+
+      {isWide && lifecycle.command ? <CommandPreview command={lifecycle.command} /> : null}
+
+      {isWide && lifecycle.runId ? <InlineTerminal runId={lifecycle.runId} isActive /> : null}
+
+      {isWide && lifecycle.detectedAuthUrl ? (
+        <div className="flex justify-center">
+          <OpenInBrowserButton url={lifecycle.detectedAuthUrl} />
+        </div>
+      ) : null}
+
+      {lifecycle.phase === 'error' && lifecycle.errorTail ? (
+        <ErrorPanel tail={lifecycle.errorTail} />
+      ) : null}
+
+      {!isWide && lifecycle.phase === 'idle' && lifecycle.action !== 'logout' ? (
+        <PreActionCopy providerId={providerId} info={info} />
+      ) : null}
+
+      <div className="mt-1 w-full">
+        {showDisconnectComposite ? (
+          <DisconnectControl
+            onDisconnect={() => fireAction('logout')}
+            onRefresh={() => void onRefresh()}
+            refreshing={refreshing}
+            disconnecting={false}
+          />
+        ) : intent ? (
+          <CtaButton intent={intent} onClick={() => fireAction(intent.action)} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface HeaderProps {
+  readonly icon: LucideIcon;
+  readonly color: string;
+  readonly info: ProviderInfo;
+  readonly phase: string;
+  readonly stacked: boolean;
+}
+
+function TileHeader({ icon: Icon, color, info, phase, stacked }: HeaderProps) {
+  const dim = info.connection !== 'connected' && info.connection !== 'error' && phase === 'idle';
+  return (
+    <div className={cn('flex items-center gap-2.5', stacked && 'flex-col gap-2')}>
+      <div
+        aria-hidden
+        className={cn(
+          'flex h-10 w-10 items-center justify-center rounded-full transition-opacity',
+          dim && 'opacity-50',
+        )}
+        style={{
+          backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
+          color,
+        }}
+      >
+        <Icon size={18} strokeWidth={2} />
+      </div>
+      <div className={cn('flex flex-col', stacked ? 'items-center' : 'items-start')}>
+        <span className="text-sm font-semibold lowercase">{info.label}</span>
+        <span
+          className="max-w-[160px] truncate text-2xs text-muted-foreground"
+          title={info.identity ?? info.version ?? ''}
+        >
+          {info.connection === 'connected'
+            ? (info.identity ?? 'connected')
+            : (info.version ?? info.binary)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PreActionCopy({ providerId, info }: { providerId: ProviderId; info: ProviderInfo }) {
+  const action: ProviderLifecycleAction | null =
+    info.connection === 'missing'
+      ? 'install'
+      : info.connection === 'installed_disconnected'
+        ? 'login'
+        : null;
+  if (!action) return null;
+  return <InfoBanner text={copyFor(providerId, action)} />;
+}

--- a/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
@@ -1,65 +1,12 @@
 import { useState } from 'react';
-import { Code2, Gem, Info, MousePointer2, RotateCw, Sparkles } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
-import { Tooltip, cn } from '@goodboy/ui';
-import type {
-  ProviderConnectionState,
-  ProviderInfo,
-} from '../../../../features/providers/providers';
-import { providerAction } from '../../../../features/providers/providers';
-import type { ProviderId } from '../../../../features/providers/providers';
+import { Info, RotateCw } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
+import type { ProviderId } from '@goodboy/types';
+import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
-import { openUrl } from '../../../../shared/lib/editor';
-
-const STATE_LABEL: Record<ProviderConnectionState, string> = {
-  connected: 'Connected',
-  installed_disconnected: 'Not logged in',
-  missing: 'Not installed',
-  error: 'Error',
-};
-
-const STATE_DOT: Record<ProviderConnectionState, string> = {
-  connected: 'bg-primary',
-  installed_disconnected: 'bg-warning',
-  missing: 'bg-muted-foreground/40',
-  error: 'bg-danger',
-};
+import { ProviderLifecycleTile } from '../ProviderLifecycleTile';
 
 const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
-
-interface ProviderBrand {
-  readonly name: string;
-  readonly description: string;
-  readonly icon: LucideIcon;
-  readonly cssVar: string;
-}
-
-const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
-  anthropic: {
-    name: 'claude',
-    description: 'anthropic claude code cli',
-    icon: Sparkles,
-    cssVar: '--color-provider-anthropic',
-  },
-  cursor: {
-    name: 'cursor',
-    description: 'cursor agent cli',
-    icon: MousePointer2,
-    cssVar: '--color-provider-cursor',
-  },
-  codex: {
-    name: 'codex',
-    description: 'openai codex cli',
-    icon: Code2,
-    cssVar: '--color-provider-codex',
-  },
-  gemini: {
-    name: 'gemini',
-    description: 'google gemini cli',
-    icon: Gem,
-    cssVar: '--color-provider-gemini',
-  },
-};
 
 export function ProvidersPanel() {
   const providers = useAppStore((s) => s.providers);
@@ -100,197 +47,17 @@ export function ProvidersPanel() {
       ) : (
         <div className="grid grid-cols-3 gap-2.5">
           {ordered.map((p) => (
-            <ProviderTile key={p.id} info={p} onRefresh={onRefresh} />
+            <ProviderLifecycleTile key={p.id} info={p} />
           ))}
         </div>
       )}
       <div className="flex items-start gap-1.5 text-2xs text-muted-foreground">
         <Info size={11} aria-hidden className="mt-0.5 shrink-0" />
         <span>
-          Sign in once via each provider's CLI (e.g. run{' '}
-          <code className="rounded bg-muted px-1">claude</code> in a terminal). Goodboy picks up the
-          credentials.
+          Install and sign in straight from the app. Each step runs in an embedded terminal so you
+          never leave Goodboy.
         </span>
       </div>
-    </div>
-  );
-}
-
-function ProviderTile({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
-  const brand = PROVIDER_BRAND[info.id as ProviderId];
-  const Icon = brand?.icon ?? Sparkles;
-  const connected = info.connection === 'connected';
-  const errored = info.connection === 'error';
-  const dim = !connected && !errored;
-  const color = brand ? `var(${brand.cssVar})` : 'var(--color-primary)';
-
-  return (
-    <div
-      className="relative flex flex-col items-center gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
-      style={{
-        borderColor: `color-mix(in oklch, ${color} 25%, var(--color-border-soft))`,
-      }}
-    >
-      {info.connection !== 'connected' ? (
-        <Tooltip content={STATE_LABEL[info.connection]} side="top">
-          <span
-            aria-hidden
-            className={cn(
-              'absolute left-2.5 top-2.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full',
-              STATE_DOT[info.connection],
-            )}
-          />
-        </Tooltip>
-      ) : null}
-
-      <div
-        aria-hidden
-        className={cn(
-          'mt-1 flex h-10 w-10 items-center justify-center rounded-full transition-opacity',
-          dim && 'opacity-50',
-        )}
-        style={{
-          backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
-          color,
-        }}
-      >
-        <Icon size={18} strokeWidth={2} />
-      </div>
-
-      <div className="flex flex-col items-center gap-0.5">
-        <span className="text-sm font-semibold lowercase">{brand?.name ?? info.label}</span>
-        <span className="text-2xs text-muted-foreground">
-          {info.version ?? brand?.description ?? info.binary}
-        </span>
-      </div>
-
-      <TileStatus info={info} />
-
-      <div className="mt-1 w-full">
-        <TileAction info={info} onRefresh={onRefresh} />
-      </div>
-    </div>
-  );
-}
-
-function TileStatus({ info }: { info: ProviderInfo }) {
-  if (info.connection === 'connected') {
-    return (
-      <div
-        className="max-w-full truncate text-2xs text-muted-foreground"
-        title={info.identity ?? ''}
-      >
-        {info.identity ?? 'No identity found'}
-      </div>
-    );
-  }
-  if (info.connection === 'error') {
-    return (
-      <div className="line-clamp-2 text-center text-2xs text-danger" title={info.error ?? ''}>
-        {info.error ?? 'unknown error'}
-      </div>
-    );
-  }
-  return <div className="text-2xs text-muted-foreground">{STATE_LABEL[info.connection]}</div>;
-}
-
-function TileAction({ info, onRefresh }: { info: ProviderInfo; onRefresh: () => Promise<void> }) {
-  const [pending, setPending] = useState<'login' | 'logout' | null>(null);
-
-  const onAction = async (action: 'login' | 'logout') => {
-    setPending(action);
-    try {
-      await providerAction(info.id as ProviderId, action);
-    } catch {
-      // terminal launch failed, surface as no-op; user can retry
-    }
-  };
-
-  if (info.connection === 'missing') {
-    return (
-      <button
-        type="button"
-        className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs text-primary hover:bg-muted"
-        onClick={() => void openUrl(info.docsUrl)}
-      >
-        Install ↗
-      </button>
-    );
-  }
-
-  if (info.connection === 'error') {
-    return (
-      <button
-        type="button"
-        className="block w-full rounded-md border border-border-soft py-1.5 text-center text-xs hover:bg-muted"
-        onClick={() => void onRefresh()}
-      >
-        Retry
-      </button>
-    );
-  }
-
-  if (info.connection === 'installed_disconnected') {
-    return (
-      <div className="flex flex-col items-center gap-1">
-        <button
-          type="button"
-          className="w-full rounded-md border border-border-soft py-1.5 text-center text-xs text-primary hover:bg-muted disabled:opacity-50"
-          disabled={pending === 'login'}
-          onClick={() => void onAction('login')}
-        >
-          Connect ↗
-        </button>
-        {pending === 'login' ? (
-          <span className="text-center text-2xs text-muted-foreground">
-            Complete in terminal, then{' '}
-            <button
-              type="button"
-              className="underline hover:text-foreground"
-              onClick={() => void onRefresh()}
-            >
-              Refresh ↻
-            </button>
-          </span>
-        ) : null}
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex flex-col items-center gap-1">
-      <div className="flex w-full items-stretch gap-1.5">
-        <Tooltip content="Re-check identity" side="top">
-          <button
-            type="button"
-            aria-label="Re-check identity"
-            className="rounded-md border border-border-soft px-2 text-xs hover:bg-muted"
-            onClick={() => void onRefresh()}
-          >
-            ↻
-          </button>
-        </Tooltip>
-        <button
-          type="button"
-          className="flex-1 rounded-md border border-border-soft py-1.5 text-center text-xs text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
-          disabled={pending === 'logout'}
-          onClick={() => void onAction('logout')}
-        >
-          Disconnect ↗
-        </button>
-      </div>
-      {pending === 'logout' ? (
-        <span className="text-center text-2xs text-muted-foreground">
-          Complete in terminal, then{' '}
-          <button
-            type="button"
-            className="underline hover:text-foreground"
-            onClick={() => void onRefresh()}
-          >
-            Refresh ↻
-          </button>
-        </span>
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/providers/providers.ts
+++ b/apps/desktop/src/features/providers/providers.ts
@@ -76,15 +76,6 @@ export async function checkProviderAuth(providerId: ProviderId): Promise<AuthSta
   return invoke<AuthState>('check_provider_auth', { providerId });
 }
 
-export type ProviderAction = 'login' | 'logout';
-
-export async function providerAction(
-  providerId: ProviderId,
-  action: ProviderAction,
-): Promise<void> {
-  return invoke<void>('provider_action', { providerId, action });
-}
-
 export type ProviderAuthResults = Readonly<Record<ProviderId, AuthState | null>>;
 
 function connectionFromDetectionAndAuth(

--- a/apps/desktop/src/features/scripts/components/TerminalPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/TerminalPanel/index.tsx
@@ -1,67 +1,17 @@
-import { useCallback, useEffect, useRef } from 'react';
-import { Terminal, type ITheme } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import '@xterm/xterm/css/xterm.css';
-import { RotateCcw } from 'lucide-react';
+import { useCallback, useEffect, useMemo } from 'react';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
-import { useThemeStore } from '../../../../shared/lib/theme';
 import {
-  invokeTerminalWrite,
+  clearTerminalCache,
+  GenericTerminalPanel,
+  type TerminalDriver,
+} from '../../../../shared/components/GenericTerminalPanel';
+import {
   invokeTerminalResize,
-  listenTerminalOutput,
+  invokeTerminalWrite,
   listenTerminalExit,
+  listenTerminalOutput,
 } from '../../../terminal/terminal';
-
-// Persists terminal output across tab switches and remounts, keyed by sessionId.
-const outputCache = new Map<SessionId, Uint8Array[]>();
-const MAX_CACHE_CHUNKS = 500;
-
-const LIGHT_THEME: ITheme = {
-  background: '#f8f8f8',
-  foreground: '#1a1a2e',
-  cursor: '#4078f2',
-  selectionBackground: '#4078f230',
-  black: '#383a42',
-  red: '#e45649',
-  green: '#50a14f',
-  yellow: '#c18401',
-  blue: '#4078f2',
-  magenta: '#a626a4',
-  cyan: '#0184bc',
-  white: '#fafafa',
-  brightBlack: '#696c77',
-  brightRed: '#e45649',
-  brightGreen: '#50a14f',
-  brightYellow: '#986801',
-  brightBlue: '#4078f2',
-  brightMagenta: '#a626a4',
-  brightCyan: '#0184bc',
-  brightWhite: '#ffffff',
-};
-
-const DARK_THEME: ITheme = {
-  background: '#1a1a1f',
-  foreground: '#e6e6e6',
-  cursor: '#8ab4f8',
-  selectionBackground: '#8ab4f840',
-  black: '#3c3c3c',
-  red: '#ff7b72',
-  green: '#7ee787',
-  yellow: '#f0c674',
-  blue: '#8ab4f8',
-  magenta: '#d2a8ff',
-  cyan: '#79c0ff',
-  white: '#d0d0d0',
-  brightBlack: '#6e7681',
-  brightRed: '#ffa198',
-  brightGreen: '#7ee787',
-  brightYellow: '#ffd66e',
-  brightBlue: '#8ab4f8',
-  brightMagenta: '#d2a8ff',
-  brightCyan: '#79c0ff',
-  brightWhite: '#ffffff',
-};
 
 function base64ToBytes(b64: string): Uint8Array {
   const binary = atob(b64);
@@ -88,137 +38,59 @@ interface Props {
 }
 
 export function TerminalPanel({ sessionId, isActive, cwd }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-
   const openTerminal = useAppStore((s) => s.openTerminal);
   const closeTerminal = useAppStore((s) => s.closeTerminal);
-  const theme = useThemeStore((s) => s.theme);
 
-  // Restart: kill the shell, clear cached output + xterm buffer, spawn a fresh shell.
-  const handleRestart = useCallback(async () => {
-    const term = termRef.current;
-    try {
-      await closeTerminal(sessionId);
-    } catch {
-      // best-effort
-    }
-    outputCache.delete(sessionId);
-    if (term) {
-      term.reset();
-      const cols = term.cols;
-      const rows = term.rows;
-      await openTerminal(sessionId, cwd, cols, rows);
-    }
+  // Session driver: routes write/resize through invokeTerminal* and filters
+  // global output/exit events by sessionId before forwarding to the panel.
+  const driver = useMemo<TerminalDriver>(
+    () => ({
+      write: (data: string) => {
+        void invokeTerminalWrite(sessionId, stringToBase64(data));
+      },
+      resize: (cols: number, rows: number) => {
+        void invokeTerminalResize(sessionId, cols, rows);
+      },
+      onOutput: (handler) =>
+        listenTerminalOutput((payload) => {
+          if (payload.sessionId !== sessionId) return;
+          handler(base64ToBytes(payload.data));
+        }),
+      onExit: (handler) =>
+        listenTerminalExit((payload) => {
+          if (payload.sessionId !== sessionId) return;
+          handler(payload.exitCode);
+        }),
+    }),
+    [sessionId],
+  );
+
+  // Lazy-spawn bash on first mount per session. Idempotent on the backend.
+  useEffect(() => {
+    void openTerminal(sessionId, cwd, 100, 24);
+  }, [sessionId, cwd, openTerminal]);
+
+  // Restart: close, clear cache, reopen. The xterm reset is handled by
+  // GenericTerminalPanel remount via the cache clear plus exit message.
+  const handleRestart = useCallback(() => {
+    void (async () => {
+      try {
+        await closeTerminal(sessionId);
+      } catch {
+        // best-effort
+      }
+      clearTerminalCache(sessionId);
+      await openTerminal(sessionId, cwd, 100, 24);
+    })();
   }, [sessionId, cwd, closeTerminal, openTerminal]);
 
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return;
-
-    const term = new Terminal({
-      convertEol: true,
-      scrollback: 5000,
-      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
-      fontSize: 12,
-      lineHeight: 1.4,
-      theme: theme === 'dark' ? DARK_THEME : LIGHT_THEME,
-    });
-
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(container);
-    if (isActive) fitAddon.fit();
-
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
-
-    // Replay cached output so switching tabs doesn't lose history.
-    const cached = outputCache.get(sessionId) ?? [];
-    for (const chunk of cached) {
-      term.write(chunk);
-    }
-
-    const dataDisposable = term.onData((data) => {
-      void invokeTerminalWrite(sessionId, stringToBase64(data));
-    });
-
-    let unlistenOutput: (() => void) | null = null;
-    let unlistenExit: (() => void) | null = null;
-    let mounted = true;
-
-    listenTerminalOutput((payload) => {
-      if (payload.sessionId !== sessionId) return;
-      const bytes = base64ToBytes(payload.data);
-      const cache = outputCache.get(sessionId) ?? [];
-      if (cache.length < MAX_CACHE_CHUNKS) {
-        cache.push(bytes);
-        outputCache.set(sessionId, cache);
-      }
-      if (mounted) term.write(bytes);
-    }).then((fn) => {
-      if (mounted) unlistenOutput = fn;
-      else fn();
-    });
-
-    listenTerminalExit((payload) => {
-      if (payload.sessionId !== sessionId) return;
-      if (mounted) term.writeln('\r\n\x1B[90m[shell exited, click ↻ to restart]\x1B[0m');
-    }).then((fn) => {
-      if (mounted) unlistenExit = fn;
-      else fn();
-    });
-
-    const ro = new ResizeObserver(() => {
-      fitAddon.fit();
-      void invokeTerminalResize(sessionId, term.cols, term.rows);
-    });
-    ro.observe(container);
-
-    // Open the bash shell on first tab visit (lazy).
-    void openTerminal(sessionId, cwd, term.cols, term.rows);
-
-    return () => {
-      mounted = false;
-      dataDisposable.dispose();
-      unlistenOutput?.();
-      unlistenExit?.();
-      ro.disconnect();
-      term.dispose();
-      termRef.current = null;
-      fitAddonRef.current = null;
-    };
-  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // React to global light/dark toggle without remounting the terminal.
-  useEffect(() => {
-    const term = termRef.current;
-    if (!term) return;
-    term.options.theme = theme === 'dark' ? DARK_THEME : LIGHT_THEME;
-  }, [theme]);
-
-  useEffect(() => {
-    if (isActive) {
-      const id = requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
-      });
-      return () => cancelAnimationFrame(id);
-    }
-  }, [isActive]);
-
   return (
-    <div className="relative size-full overflow-hidden">
-      <div ref={containerRef} className="size-full overflow-hidden" />
-      <button
-        type="button"
-        onClick={() => void handleRestart()}
-        title="restart shell"
-        aria-label="restart shell"
-        className="absolute right-2 top-2 z-10 rounded-sm bg-background/80 p-1 text-muted-foreground backdrop-blur hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-      >
-        <RotateCcw size={12} aria-hidden />
-      </button>
-    </div>
+    <GenericTerminalPanel
+      terminalId={sessionId}
+      driver={driver}
+      isActive={isActive}
+      exitMessage="\r\n\x1B[90m[shell exited, click ↻ to restart]\x1B[0m"
+      onRestart={handleRestart}
+    />
   );
 }

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useRef } from 'react';
+import { Terminal, type ITheme } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import '@xterm/xterm/css/xterm.css';
+import { RotateCcw } from 'lucide-react';
+import { useThemeStore } from '../../lib/theme';
+
+// Driver abstraction so the same xterm renderer can be wired to either a
+// long-lived session shell (TerminalPanel) or a transient lifecycle PTY
+// (LifecycleTerminalPanel) without duplicating ~150 lines of setup.
+export interface TerminalDriver {
+  /** Send keyboard input (raw UTF-8 string) into the underlying PTY. */
+  write(data: string): void;
+  /** Notify PTY about a window resize. */
+  resize(cols: number, rows: number): void;
+  /**
+   * Subscribe to output chunks. The driver is responsible for any filtering
+   * (e.g. by sessionId or runId) before invoking the handler.
+   */
+  onOutput(handler: (bytes: Uint8Array) => void): Promise<() => void>;
+  /** Subscribe to the PTY exit event. */
+  onExit(handler: (exitCode: number) => void): Promise<() => void>;
+}
+
+const MAX_CACHE_CHUNKS = 500;
+
+// Output cache keyed by terminalId so tab switches and remounts don't lose
+// history. Module-level because each terminalId has its own buffer regardless
+// of which component instance mounted last.
+const outputCache = new Map<string, Uint8Array[]>();
+
+export function clearTerminalCache(terminalId: string): void {
+  outputCache.delete(terminalId);
+}
+
+const LIGHT_THEME: ITheme = {
+  background: '#f8f8f8',
+  foreground: '#1a1a2e',
+  cursor: '#4078f2',
+  selectionBackground: '#4078f230',
+  black: '#383a42',
+  red: '#e45649',
+  green: '#50a14f',
+  yellow: '#c18401',
+  blue: '#4078f2',
+  magenta: '#a626a4',
+  cyan: '#0184bc',
+  white: '#fafafa',
+  brightBlack: '#696c77',
+  brightRed: '#e45649',
+  brightGreen: '#50a14f',
+  brightYellow: '#986801',
+  brightBlue: '#4078f2',
+  brightMagenta: '#a626a4',
+  brightCyan: '#0184bc',
+  brightWhite: '#ffffff',
+};
+
+const DARK_THEME: ITheme = {
+  background: '#1a1a1f',
+  foreground: '#e6e6e6',
+  cursor: '#8ab4f8',
+  selectionBackground: '#8ab4f840',
+  black: '#3c3c3c',
+  red: '#ff7b72',
+  green: '#7ee787',
+  yellow: '#f0c674',
+  blue: '#8ab4f8',
+  magenta: '#d2a8ff',
+  cyan: '#79c0ff',
+  white: '#d0d0d0',
+  brightBlack: '#6e7681',
+  brightRed: '#ffa198',
+  brightGreen: '#7ee787',
+  brightYellow: '#ffd66e',
+  brightBlue: '#8ab4f8',
+  brightMagenta: '#d2a8ff',
+  brightCyan: '#79c0ff',
+  brightWhite: '#ffffff',
+};
+
+interface Props {
+  /** Stable id used to scope the output cache across remounts. */
+  readonly terminalId: string;
+  readonly driver: TerminalDriver;
+  readonly isActive: boolean;
+  /** When true, keyboard input is dropped (still subscribes to output). */
+  readonly readOnly?: boolean;
+  /** Optional message appended on exit. Empty string suppresses it. */
+  readonly exitMessage?: string;
+  /** Optional restart action. Renders the ↻ button when provided. */
+  readonly onRestart?: () => void;
+  /** Optional notification when the PTY exits. */
+  readonly onExit?: (exitCode: number) => void;
+}
+
+const DEFAULT_EXIT_MESSAGE = '\r\n\x1B[90m[process exited]\x1B[0m';
+
+export function GenericTerminalPanel({
+  terminalId,
+  driver,
+  isActive,
+  readOnly = false,
+  exitMessage = DEFAULT_EXIT_MESSAGE,
+  onRestart,
+  onExit,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+
+  const theme = useThemeStore((s) => s.theme);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const term = new Terminal({
+      convertEol: true,
+      scrollback: 5000,
+      fontFamily: "'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace",
+      fontSize: 12,
+      lineHeight: 1.4,
+      theme: theme === 'dark' ? DARK_THEME : LIGHT_THEME,
+      disableStdin: readOnly,
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(container);
+    if (isActive) fitAddon.fit();
+
+    termRef.current = term;
+    fitAddonRef.current = fitAddon;
+
+    // Replay cached output so switching tabs/remounts don't lose history.
+    const cached = outputCache.get(terminalId) ?? [];
+    for (const chunk of cached) {
+      term.write(chunk);
+    }
+
+    const dataDisposable = readOnly
+      ? null
+      : term.onData((data) => {
+          driver.write(data);
+        });
+
+    let unlistenOutput: (() => void) | null = null;
+    let unlistenExit: (() => void) | null = null;
+    let mounted = true;
+
+    driver
+      .onOutput((bytes) => {
+        const cache = outputCache.get(terminalId) ?? [];
+        if (cache.length < MAX_CACHE_CHUNKS) {
+          cache.push(bytes);
+          outputCache.set(terminalId, cache);
+        }
+        if (mounted) term.write(bytes);
+      })
+      .then((fn) => {
+        if (mounted) unlistenOutput = fn;
+        else fn();
+      });
+
+    driver
+      .onExit((exitCode) => {
+        if (!mounted) return;
+        if (exitMessage) term.writeln(exitMessage);
+        onExit?.(exitCode);
+      })
+      .then((fn) => {
+        if (mounted) unlistenExit = fn;
+        else fn();
+      });
+
+    const ro = new ResizeObserver(() => {
+      fitAddon.fit();
+      driver.resize(term.cols, term.rows);
+    });
+    ro.observe(container);
+
+    return () => {
+      mounted = false;
+      dataDisposable?.dispose();
+      unlistenOutput?.();
+      unlistenExit?.();
+      ro.disconnect();
+      term.dispose();
+      termRef.current = null;
+      fitAddonRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [terminalId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = theme === 'dark' ? DARK_THEME : LIGHT_THEME;
+  }, [theme]);
+
+  useEffect(() => {
+    if (isActive) {
+      const id = requestAnimationFrame(() => {
+        fitAddonRef.current?.fit();
+      });
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isActive]);
+
+  return (
+    <div className="relative size-full overflow-hidden">
+      <div ref={containerRef} className="size-full overflow-hidden" />
+      {onRestart ? (
+        <button
+          type="button"
+          onClick={onRestart}
+          title="restart shell"
+          aria-label="restart shell"
+          className="absolute right-2 top-2 z-10 rounded-sm bg-background/80 p-1 text-muted-foreground backdrop-blur hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        >
+          <RotateCcw size={12} aria-hidden />
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/store/slices/providers/index.ts
+++ b/apps/desktop/src/store/slices/providers/index.ts
@@ -6,7 +6,7 @@ import { refreshProviderStatus } from './refreshProviderStatus';
 import { refreshProviders } from './refreshProviders';
 import type { GetFn, SetFn } from './types';
 
-export type { ProviderLifecycleMap, ProviderLifecycleState } from './types';
+export type { ProviderLifecycleMap, ProviderLifecyclePhase, ProviderLifecycleState } from './types';
 export { INITIAL_LIFECYCLE_MAP } from './types';
 
 export function createProvidersSlice(set: SetFn, get: GetFn) {

--- a/apps/desktop/src/store/slices/providers/runLifecycle.ts
+++ b/apps/desktop/src/store/slices/providers/runLifecycle.ts
@@ -19,6 +19,21 @@ import { IDLE_LIFECYCLE, type ProviderLifecyclePhase } from './types';
 const OUTPUT_TAIL_CAP = 4 * 1024;
 // eslint-disable-next-line no-control-regex
 const ANSI_RE = /\x1B\[[0-?]*[ -/]*[@-~]/g;
+const URL_RE = /https?:\/\/[^\s<>"'\x00-\x1F]+/g;
+const AUTH_HINT_RE =
+  /oauth|authoriz|sign[-_]?in|\/login|cli-auth|claude\.|anthropic\.|cursor\.|openai\.|accounts\.google\./i;
+
+// First plausible OAuth URL in the chunk, or null. Stays conservative: only
+// surfaces URLs whose path or host looks auth-related so we don't offer to
+// "open in browser" on a random npm changelog link.
+function findAuthUrl(text: string): string | null {
+  const matches = text.match(URL_RE);
+  if (!matches) return null;
+  for (const url of matches) {
+    if (AUTH_HINT_RE.test(url)) return url;
+  }
+  return null;
+}
 
 // Map an action to the in-flight phase that drives the UI while the PTY runs.
 function pendingPhase(action: ProviderLifecycleAction): ProviderLifecyclePhase {
@@ -99,11 +114,13 @@ export async function runLifecycle(
         exitCode: null,
         startedAt,
         errorTail: null,
+        detectedAuthUrl: null,
       },
     },
   }));
 
   let outputTail = '';
+  let foundAuthUrl = false;
   let unlistenOutput: () => void = () => undefined;
   let unlistenExit: () => void = () => undefined;
 
@@ -111,6 +128,22 @@ export async function runLifecycle(
     if (payload.runId !== runId) return;
     const chunk = atob(payload.data);
     outputTail = (outputTail + chunk).slice(-OUTPUT_TAIL_CAP);
+    if (!foundAuthUrl) {
+      const url = findAuthUrl(chunk.replace(ANSI_RE, ''));
+      if (url) {
+        foundAuthUrl = true;
+        set((state) => {
+          const curr = state.providerLifecycle[providerId];
+          if (curr.runId !== runId) return {};
+          return {
+            providerLifecycle: {
+              ...state.providerLifecycle,
+              [providerId]: { ...curr, detectedAuthUrl: url },
+            },
+          };
+        });
+      }
+    }
   });
 
   unlistenExit = await listenLifecycleExit((payload) => {

--- a/apps/desktop/src/store/slices/providers/types.ts
+++ b/apps/desktop/src/store/slices/providers/types.ts
@@ -20,6 +20,9 @@ export interface ProviderLifecycleState {
   readonly exitCode: number | null;
   readonly startedAt: number | null;
   readonly errorTail: string | null;
+  // First OAuth URL spotted in the lifecycle PTY stream, surfaced so the UI
+  // can offer "Open in browser" without auto-opening (link safety).
+  readonly detectedAuthUrl: string | null;
 }
 
 export const IDLE_LIFECYCLE: ProviderLifecycleState = {
@@ -30,6 +33,7 @@ export const IDLE_LIFECYCLE: ProviderLifecycleState = {
   exitCode: null,
   startedAt: null,
   errorTail: null,
+  detectedAuthUrl: null,
 };
 
 export type ProviderLifecycleMap = Readonly<Record<ProviderId, ProviderLifecycleState>>;


### PR DESCRIPTION
## Summary

Phase 2 + 3 + 4 of the in-app provider lifecycle refactor. The flow is now fully self-contained: clicking Install or Connect on a provider tile expands an inline drawer with a live terminal, status pill, stepper, command preview, and optional Open in browser when the CLI prints an OAuth URL. The external-terminal handoff (`provider_action` + per-OS shell spawners) is deleted.

## What ships

**Phase 2 (GenericTerminalPanel)**
- `apps/desktop/src/shared/components/GenericTerminalPanel`: xterm renderer behind a small `TerminalDriver` interface (`write` / `resize` / `onOutput` / `onExit`). Driver does any filtering (sessionId, runId).
- `TerminalPanel` refactored into a thin wrapper that builds a session driver via the existing terminal.ts invokers. No xterm code duplication.

**Phase 3 (ProviderLifecycleTile)**
- New `ProviderLifecycleTile/` folder with 10 sub-components, one export per file per AGENTS.md.
- Collapsed tile: icon, name, status pill, single CTA, pre-action explainer copy.
- Expanded tile (in-flight): col-span-full, stepper (1 of 2 / 2 of 2), `$ command` preview, embedded xterm, Cancel.
- Connected tile: refresh button + two-tap disconnect confirm chip (no modal).
- Resting error tile: short ANSI-stripped error tail, single Retry CTA.

**Phase 4 (polish + dead code)**
- OAuth URL detection in the lifecycle stream surfaces an Open in browser button (never auto-opens, per link safety rule).
- Removed: `provider_action` Tauri command, `provider_login_command` / `provider_logout_command`, four per-platform `spawn_in_terminal` helpers, `providerAction` TS binding, unused `Command` import in `providers.rs`.
- `AuthRequiredCallout` now calls `loginProvider` from the store instead of dispatching to an external terminal.
- Snapshot baseline regenerated for `empty-error-states.test.tsx`.

## Coherence (from phase 1, preserved)

Every lifecycle exit still ships a fresh `ProviderStatus` + `AuthState` so the UI can never desync from on-disk truth. Resting phase is computed from that payload, not from exit code alone: a half-installed CLI lands on `error` even if `npm install` exited 0.

## Verification

- typecheck green across packages
- knip clean
- 767/767 tests pass (snapshot updated intentionally)
- desktop build green
- `cargo check` clean (pre-existing unrelated warning only)

## Test plan

- [ ] Install Claude from a fresh machine. Tile expands, npm runs, exits 0, detection refresh, tile lands on Ready to connect with Connect CTA.
- [ ] Connect Claude. OAuth URL detected, Open in browser button appears, complete flow in browser, tile lands on Connected as <email>.
- [ ] Disconnect Claude. Two-tap confirm, claude /logout runs in pty, tile lands on Not signed in.
- [ ] Cancel mid-install. PTY killed, detection still runs, tile lands on Cancelled with refreshed connection state.
- [ ] Repeat for Cursor, Codex, Gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)