### PR TITLE
docs(repo): readme rewrite + website cta refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,93 +2,47 @@
 
 **AI workspace orchestrator. Local-first. Provider-agnostic.**
 
-Goodboy sits between you and your AI coding agents — it doesn't replace your
-editor or terminal, it commands them. Run agents against your repos, keep them
-aware of the work through a context they all share, route them across Claude,
-Cursor, Codex, and Gemini, and watch the cost as it accrues.
+You have a repo. You have a goal. You also have four CLIs open in four
+windows, each holding a slightly different version of the same task. This
+is the part that's missing in the middle.
 
-<img width="4036" height="2270" alt="CleanShot 2026-05-25 at 14 09 18@2x" src="https://github.com/user-attachments/assets/f669511b-c09d-472b-9f30-3dcc88b7ceae" />
+A desktop app that owns the context once and hands it to whichever agent
+you want to run next. Same goal, same memory, different model. Conversation,
+plans, decisions, PR state, all of it stays in a local SQLite on your
+machine. Your keys, your data, your bandwidth.
 
-## What it does
+<img width="4036" height="2270" alt="Goodboy screenshot" src="https://github.com/user-attachments/assets/f669511b-c09d-472b-9f30-3dcc88b7ceae" />
 
-You hand Goodboy a repo and a goal. It runs AI coding agents inside a git
-worktree, keeps a structured picture of the work in a context panel they all
-read, and lets you drive the whole thing — providers, plans, pull requests,
-repeatable scripts — from one window. The conversation and that context live
-in a local SQLite database, never on a server: your machine, your keys, your
-data.
+## The honest pitch
 
-## Main features
+Switching between `Claude`, `Codex`, `Cursor` and `Gemini` ten times a day
+was eating my afternoons. Every new tab meant rebuilding the same mental
+scratchpad from scratch. Eventually I got fed up and built this.
 
-### Shared context
+**Open source. Every feature included. No paywall, no telemetry, no account.**
 
-Every session carries a context panel — **Goal**, **Decisions**, **Last output
-summary**, **Open questions** — that a summarizer refreshes after each turn and
-that you can edit by hand at any time. It's the single source of truth for the
-work, kept separate from any one chat transcript.
+## What's actually inside
 
-### One agent, aware on any provider
-
-Goodboy owns the conversation: every turn is rebuilt from the shared context,
-not resumed from a provider's session. So you can switch provider or model
-mid-task — Claude, Cursor, Codex, Gemini; Haiku, Sonnet, Opus, Flash, Pro — and the agent still has
-the full picture. No re-explaining where things stand.
-
-### First-class plans
-
-Planner agents emit structured plans. They land in the context panel's
-**Plans** tab as artifacts with a status — listed and ordered, ready to hand to
-the agent that implements them — instead of being lost in a transcript.
-
-### GitHub integration
-
-The context panel's **GitHub** tab shows the session's pull request right where
-you work: state, CI checks, and unresolved review comments, one click from the
-full detail.
-
-### Linear integration
-
-Connect a Linear workspace to pull issues assigned to you straight into the
-new-session dialog. Pick an issue, the goal autofills from its title and
-description, and the session header carries a chip that opens the issue back
-in Linear.
-
-Integration scope is **per workspace** (not global): each workspace holds its
-own Linear account, so a single repo can be wired to its own Linear org without
-leaking issues across repos. The personal access token is verified against
-Linear's `/viewer` endpoint and stored in the OS keychain
-(`goodboy.workspace.<id>.linear`). It never leaves your machine.
-
-To enable:
-
-1. Generate a Linear PAT at
-   [linear.app/settings/account/security](https://linear.app/settings/account/security)
-   (read-only scope is enough).
-2. Open **Workspace settings → Integrations → Linear**, paste the token, click
-   **Connect**.
-3. New sessions in that workspace now show a Linear issue picker above the
-   goal field.
-
-Disconnect from the same panel: removes both the keychain entry and the DB
-row. Sessions already linked keep their chip — history is preserved.
-
-### Workflows
-
-Run a whole multi-step flow as a single session. Each step is a role-typed
-agent — scout, plan, implement, verify — that runs in order and carries the
-shared context forward. Start from a saved preset or build a custom workflow
-that matches how your repo actually works.
-
-### One-click scripts
-
-Register the shell commands you keep running by hand — install deps, copy an
-env file, build — as workspace scripts, then run them in one click with the
-output inline. No agent, no tokens spent.
+- **A context the agents share.** Goal, decisions, last summary, open
+  questions. A summarizer keeps it fresh after every turn, you can edit any
+  field by hand when the agents get it wrong.
+- **Provider swap mid-task, without amnesia.** Each turn is rebuilt from
+  the shared context, never resumed from a vendor session. Drop Claude
+  halfway, hand the same task to Cursor or Codex, watch it pick up clean.
+- **Plans as artifacts, not transcript scrollback.** They show up in a Plans
+  tab with a status, ready to hand off to the agent that implements them.
+- **GitHub and Linear in the side panel.** Pull request state, CI, review
+  threads still owed answers, the issues assigned to you back at the office.
+  One click from where you're typing.
+- **Workflows for the multi-step stuff.** Scout, plan, implement, verify.
+  Each step a typed agent, all of them sharing one context.
+- **One-click scripts** for the four commands you keep retyping in the
+  terminal. No agent, no tokens, just a button.
 
 ## Providers
 
-Goodboy drives locally installed provider CLIs — each on your existing
-**subscription**, not metered API tokens.
+Bring your own subscription. The app drives the official CLIs locally, on
+**your existing plan**, never on a metered API key.
 
 | Provider               | CLI                                  | Subscription     |
 | ---------------------- | ------------------------------------ | ---------------- |
@@ -97,29 +51,42 @@ Goodboy drives locally installed provider CLIs — each on your existing
 | **OpenAI (Codex)**     | `npm i -g @openai/codex`             | ChatGPT Pro      |
 | **Google (Gemini)**    | `npm i -g @google/gemini-cli`        | Google AI Pro    |
 
-At least one connected CLI is required. Full guide: [docs/providers.md](./docs/providers.md).
+One connected CLI is enough to start. Full guide:
+[docs/providers.md](./docs/providers.md).
 
-## Quickstart
+## Run it
 
 ```bash
 pnpm install
-pnpm tauri:dev          # launch the desktop app in dev
+
+pnpm tauri:dev      # hot reload, fastest to iterate
+pnpm tauri:build    # produces an installable binary in apps/desktop/src-tauri/target/release/bundle/
 ```
 
-Needs **Node ≥ 20**, **pnpm ≥ 10**, and the **Rust** toolchain (Tauri shells out
-to `cargo`). Platform prerequisites: <https://v2.tauri.app/start/prerequisites/>.
+Needs **Node ≥ 20**, **pnpm ≥ 10**, and a working **Rust** toolchain (Tauri
+shells out to `cargo`). Platform prereqs:
+<https://v2.tauri.app/start/prerequisites/>.
+
+Hacking on the app itself? The dev-loop notes live in
+[apps/desktop/README.md](./apps/desktop/README.md).
+
+## Help out
+
+Try it. If something breaks, feels weird, or is missing, open an issue.
+Half-formed thoughts welcome. Screenshots welcome. "This feels off" is a
+perfectly valid bug report.
 
 ## Stack
 
 **Tauri 2 · React 19 · TypeScript · Tailwind v4 · Zustand · SQLite**, in a
-pnpm + Turborepo monorepo — `apps/desktop` plus `packages/{ui,core,db,types}`.
+pnpm + Turborepo monorepo: `apps/desktop` plus `packages/{ui,core,db,types}`.
 
 ## More
 
-- [VISION.md](./VISION.md) — what Goodboy is and why
-- [DESIGN.md](./DESIGN.md) — how it looks and behaves
-- [ROADMAP.md](./ROADMAP.md) — milestones and what shipped
-- [CONVENTIONS.md](./CONVENTIONS.md) · [CLAUDE.md](./CLAUDE.md) — contributor rules
+- [VISION.md](./VISION.md): the why
+- [DESIGN.md](./DESIGN.md): how it looks and behaves
+- [ROADMAP.md](./ROADMAP.md): milestones and what shipped
+- [CONVENTIONS.md](./CONVENTIONS.md) · [CLAUDE.md](./CLAUDE.md): contributor rules
 
 ## License
 

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -3,7 +3,7 @@ import { LinkButton } from '../components/ui';
 const lines = [
   { prompt: '$', command: 'git clone https://github.com/akhayam99/goodboy.git', muted: false },
   { prompt: '$', command: 'cd goodboy && pnpm install', muted: false },
-  { prompt: '$', command: 'pnpm tauri:dev', muted: true },
+  { prompt: '$', command: 'pnpm tauri:build', muted: true },
 ];
 
 export function CTA() {
@@ -17,8 +17,8 @@ export function CTA() {
           Clone, install, run it.
         </h2>
         <p className="mx-auto mt-5 max-w-md text-[15px] leading-[1.65] text-muted-foreground">
-          No waitlist. No email. The repo is public. Bring your own Claude, Cursor or Codex
-          subscription and you&apos;re running locally in a couple of minutes.
+          No waitlist. No email. The repo is public. Bring your own Claude, Cursor, Codex or Gemini
+          subscription and you&apos;re running locally.
         </p>
 
         <div className="mx-auto mt-10 max-w-xl overflow-hidden rounded-xl border border-border-soft bg-[oklch(0.22_0.007_255)] text-left">


### PR DESCRIPTION
## Summary

Tone-of-voice pass on the README plus the matching CTA fix on the website.

## README

- Drops the marketing-page feature list and third-person product copy.
- New personal opener (you have a repo, you have a goal, four CLI windows in the way).
- Honest origin paragraph, no copy-paste from the GitHub Sponsors page.
- "What's actually inside" block: bullets that lead with value, not feature names.
- Quickstart now shows both `pnpm tauri:dev` (hot reload, fastest to iterate) and `pnpm tauri:build` (installable binary). No more fake build-time promises.
- Linear setup details migrated out of the README to keep the landing short. Will land in `docs/providers.md` separately.
- Zero in-body repetitions of the product name (was 7 before). Em-dashes scrubbed.

## Website (CTA section)

- `pnpm tauri:dev` swapped for `pnpm tauri:build` to match the README.
- Gemini added to the BYO-subscription list (was missing since #644 even though Hero and LogoStrip already list it).
- "in a couple of minutes" tagline removed: a cold release build is closer to five.

## Test plan

- [ ] Render the README on GitHub, check the screenshot, links, and spacing.
- [ ] Preview the website locally, scroll to the CTA section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)