### PR TITLE
feat(desktop): provider connect modal + perf fix for refocus freeze

### DIFF
--- a/apps/desktop/src-tauri/src/external_terminal.rs
+++ b/apps/desktop/src-tauri/src/external_terminal.rs
@@ -1,0 +1,69 @@
+// Optional escape hatch: spawn an OS-native terminal window with a command
+// preloaded. The primary provider-lifecycle flow runs everything in-app via
+// an embedded PTY (see provider_lifecycle.rs). This module exists for the
+// "run this in my own terminal instead" button surfaced in the connect
+// modal, for power users who prefer their shell or who hit a corner case
+// (npm EACCES, slow sudo prompt, missing certs) the embedded PTY cannot
+// handle gracefully.
+//
+// macOS: AppleScript driving Terminal.app. Linux: probe gnome-terminal /
+// konsole / xterm in that order. Windows: cmd.exe via `start cmd /k`.
+
+use std::process::Command;
+
+#[cfg(target_os = "macos")]
+fn spawn_in_external_terminal(command: &str) -> Result<(), String> {
+    // `do script` opens a Terminal window but does not raise Terminal.app
+    // when Goodboy is frontmost; the explicit `activate` brings it forward.
+    let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
+    let script = format!(
+        "tell application \"Terminal\"\n  do script \"{}\"\n  activate\nend tell",
+        escaped
+    );
+    Command::new("osascript")
+        .args(["-e", &script])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_in_external_terminal(command: &str) -> Result<(), String> {
+    let terminals: &[(&str, &[&str])] = &[
+        ("gnome-terminal", &["--", "bash", "-c"]),
+        ("konsole", &["-e", "bash", "-c"]),
+        ("xterm", &["-e", "bash", "-c"]),
+    ];
+    for (term, base_args) in terminals {
+        let mut args: Vec<&str> = base_args.to_vec();
+        let cmd_with_pause = format!("{}; read -p 'press enter to close'", command);
+        args.push(&cmd_with_pause);
+        if Command::new(term).args(&args).spawn().is_ok() {
+            return Ok(());
+        }
+    }
+    Err("no supported terminal emulator found (tried gnome-terminal, konsole, xterm)".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn spawn_in_external_terminal(command: &str) -> Result<(), String> {
+    Command::new("cmd")
+        .args(["/c", "start", "cmd", "/k", command])
+        .spawn()
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn spawn_in_external_terminal(_command: &str) -> Result<(), String> {
+    Err("unsupported platform".to_string())
+}
+
+/// Open the user's system terminal with the given command preloaded. Used
+/// as the explicit "do it in my own shell" escape hatch in the provider
+/// connect modal. The embedded PTY remains the primary path; this returns
+/// to the user only when they ask for it.
+#[tauri::command]
+pub fn open_command_in_external_terminal(command: String) -> Result<(), String> {
+    spawn_in_external_terminal(&command)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod budget;
 mod config_export;
 mod db;
 mod editor;
+mod external_terminal;
 mod github;
 mod linear;
 mod parallel_groups;
@@ -99,6 +100,7 @@ pub fn run() {
       provider_lifecycle::provider_lifecycle_write,
       provider_lifecycle::provider_lifecycle_resize,
       provider_lifecycle::provider_lifecycle_cancel,
+      external_terminal::open_command_in_external_terminal,
       turn::turn_spawn,
       turn::turn_cancel,
       attachment::attachment_write,

--- a/apps/desktop/src-tauri/src/provider_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/provider_lifecycle.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
 use crate::providers::{
-    check_provider_auth, detect_claude, detect_codex, detect_cursor, detect_gemini, AuthState,
-    ProviderStatus,
+    check_provider_auth_blocking, detect_claude, detect_codex, detect_cursor, detect_gemini,
+    AuthState, ProviderStatus,
 };
 
 // ---------------------------------------------------------------------------
@@ -120,7 +120,7 @@ fn refresh_provider(provider_id: &str) -> (ProviderStatus, AuthState) {
             error: Some(format!("unknown provider: {}", provider_id)),
         },
     };
-    let auth = check_provider_auth(provider_id.to_string());
+    let auth = check_provider_auth_blocking(provider_id);
     (status, auth)
 }
 

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -7,8 +7,12 @@ use tauri::State;
 
 use crate::path_env;
 
-const DETECT_TIMEOUT: Duration = Duration::from_secs(5);
-const AUTH_TIMEOUT: Duration = Duration::from_secs(5);
+// Tight detection budgets: a CLI that doesn't respond to `--version` in 2s is
+// already broken from the user's POV, and worst-case sum across 4 providers
+// dominates the "refresh providers" UI latency. Auth was previously 5s × N
+// candidate subcommands × N providers, easily 20s+ wall time on cold runs.
+const DETECT_TIMEOUT: Duration = Duration::from_secs(2);
+const AUTH_TIMEOUT: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, Serialize)]
@@ -438,77 +442,20 @@ fn extract_gemini_identity_from_creds() -> Option<String> {
 }
 
 fn check_gemini_auth() -> AuthState {
-    // gemini-cli has no stable `auth status` subcommand at v0.x; probe a few
-    // candidates then fall back to the on-disk credentials file as ground truth.
-    let candidates: &[&[&str]] = &[
-        &["gemini", "auth", "status"],
-        &["gemini", "auth", "whoami"],
-        &["gemini", "whoami"],
-    ];
-    for cmd in candidates {
-        if let Ok(out) = run_auth_command(cmd) {
-            let text = out.primary_text();
-            if !text.trim().is_empty() {
-                let parsed = parse_gemini_auth_output(text);
-                if !matches!(parsed.state, AuthStateKind::Unknown) {
-                    return parsed;
-                }
-            }
-        }
-    }
+    // gemini-cli (v0.x) has no `auth status`-like subcommand. Past attempts to
+    // probe `gemini auth status`/`whoami` either hung interactively (no TTY)
+    // or printed help, costing 3 × AUTH_TIMEOUT per refresh. The credentials
+    // file is the actual ground truth — gemini writes it on every successful
+    // login and removes it on logout — so we read it directly. Fast, accurate,
+    // no subprocess.
     if let Some(identity) = extract_gemini_identity_from_creds() {
         return AuthState {
             state: AuthStateKind::Connected,
             identity: Some(identity),
         };
     }
-    // No subcommand worked and no creds file. Treat the absence as disconnected
-    // when the binary is present — install detection is handled separately, so
-    // reaching this point means `gemini --version` succeeded.
     AuthState {
         state: AuthStateKind::Disconnected,
-        identity: None,
-    }
-}
-
-fn parse_gemini_auth_output(output: &str) -> AuthState {
-    let stripped: String = strip_ansi(output);
-    let first_line = stripped
-        .lines()
-        .map(|l| l.trim())
-        .find(|l| !l.is_empty())
-        .unwrap_or("");
-    let lower = first_line.to_lowercase();
-
-    if lower.starts_with("not logged")
-        || lower.starts_with("not signed")
-        || lower.contains("not logged in")
-        || lower.contains("not signed in")
-        || lower.contains("unauthenticated")
-        || lower.contains("no credentials")
-    {
-        return AuthState {
-            state: AuthStateKind::Disconnected,
-            identity: None,
-        };
-    }
-    if lower.starts_with("logged in")
-        || lower.starts_with("signed in")
-        || lower.contains("authenticated as")
-        || extract_email(first_line).is_some()
-    {
-        let identity = extract_email(first_line)
-            .or_else(|| extract_json_string(output, "email"))
-            .or_else(|| extract_json_string(output, "username"))
-            .or_else(extract_gemini_identity_from_creds);
-        return AuthState {
-            state: AuthStateKind::Connected,
-            identity,
-        };
-    }
-
-    AuthState {
-        state: AuthStateKind::Unknown,
         identity: None,
     }
 }
@@ -641,9 +588,11 @@ pub fn refresh_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
     next
 }
 
-#[tauri::command]
-pub fn check_provider_auth(provider_id: String) -> AuthState {
-    match provider_id.as_str() {
+// Sync entry point for callers that already run on a blocking thread (e.g.
+// the lifecycle PTY exit handler in provider_lifecycle.rs). Kept private so
+// only the async Tauri command shape leaks into the JS surface.
+pub(crate) fn check_provider_auth_blocking(provider_id: &str) -> AuthState {
+    match provider_id {
         "anthropic" => check_claude_auth(),
         "cursor" => check_cursor_auth(),
         "codex" => check_codex_auth(),
@@ -653,6 +602,20 @@ pub fn check_provider_auth(provider_id: String) -> AuthState {
             identity: None,
         },
     }
+}
+
+// Async wrapper so Tauri schedules this on the async runtime and the
+// process-spawning work runs on a blocking thread instead of stalling the
+// main IPC thread. Without this, four parallel refreshProviders() auth
+// checks serialize on the main thread and freeze every other IPC call.
+#[tauri::command]
+pub async fn check_provider_auth(provider_id: String) -> AuthState {
+    tauri::async_runtime::spawn_blocking(move || check_provider_auth_blocking(&provider_id))
+        .await
+        .unwrap_or(AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        })
 }
 
 #[cfg(test)]
@@ -816,24 +779,10 @@ mod tests {
         assert!(out.primary_text().trim().is_empty());
     }
 
-    #[test]
-    fn gemini_parses_logged_in() {
-        let s = parse_gemini_auth_output("Logged in as alice@example.com\n");
-        assert_eq!(s.state, AuthStateKind::Connected);
-        assert_eq!(s.identity.as_deref(), Some("alice@example.com"));
-    }
-
-    #[test]
-    fn gemini_parses_not_logged_in() {
-        let s = parse_gemini_auth_output("Not logged in\n");
-        assert_eq!(s.state, AuthStateKind::Disconnected);
-    }
-
-    #[test]
-    fn gemini_unknown_on_unrecognized() {
-        let s = parse_gemini_auth_output("some unrelated output\n");
-        assert_eq!(s.state, AuthStateKind::Unknown);
-    }
+    // Gemini auth is now creds-file-based (no subprocess), so the cli-output
+    // parser is gone and unit-test coverage moved to the filesystem layer.
+    // See extract_email_from_id_token tests below for the JWT decode path
+    // that backs both gemini and codex on-disk identity recovery.
 
     #[test]
     #[ignore = "requires real codex binary + active login; opt in via GOODBOY_TEST_REAL_CODEX=1"]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -8,6 +8,7 @@ import { ContextPanel } from './features/context/components/ContextPanel';
 import { EndSessionDialog } from './features/session/components/EndSessionDialog';
 import { SettingsDialog } from './features/settings/components/SettingsDialog';
 import { ToastProvider } from './app/components/Toast';
+import { ProviderModalHost } from './features/providers/components/ProviderModalHost';
 import { WorkspacesSidebar } from './features/workspace/components/WorkspacesSidebar';
 import { WorkspaceLinkDialog } from './features/workspace/components/WorkspaceLinkDialog';
 import { DogMascot } from './shared/components/DogMascot';
@@ -384,6 +385,10 @@ export function App() {
       {currentSession && endOpen ? (
         <EndSessionDialog session={currentSession} open onClose={() => setEndOpen(false)} />
       ) : null}
+      {/* App-level modal host so the provider connect modal can be summoned
+          from any surface (providers panel, chat callout, future onboarding
+          cards) via a CustomEvent, without prop-drilling. */}
+      <ProviderModalHost />
     </ToastProvider>
   );
 }

--- a/apps/desktop/src/__tests__/regressions/no-unstable-zustand-selectors.test.ts
+++ b/apps/desktop/src/__tests__/regressions/no-unstable-zustand-selectors.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Static guard against the React #185 regression fixed in PR #648.
+ *
+ * The bug pattern:
+ *
+ *     useAppStore((s) => s.foo.filter(...).map(...))   // new array per call
+ *     useAppStore((s) => s.bar[id] ?? [])              // new array on miss
+ *     useAppStore((s) => [...s.baz])                   // new array via spread
+ *     useAppStore((s) => ({ a: s.x, b: s.y }))         // new object literal
+ *
+ * React 19's useSyncExternalStore compares the snapshot to the previous one
+ * via Object.is. A fresh non-primitive always fails that check and triggers
+ * an infinite re-render loop ("the result of getSnapshot should be cached").
+ *
+ * The fix is to wrap the offending selector in `useShallow` from
+ * `zustand/react/shallow`, which switches the comparison to a shallow value
+ * check so two arrays/objects with identical contents are treated as equal.
+ *
+ * This test scans every .ts / .tsx file in src/ for the antipattern and
+ * fails if any unwrapped occurrence is found. Better to break the build than
+ * ship another full-app crash on the user.
+ *
+ * Limitations:
+ *   - Regex-based, not AST-based. Catches the common shapes but a sufficiently
+ *     creative formatting could slip through. False positives can be silenced
+ *     with an explicit `// useShallow not needed: ...` comment on the line.
+ *   - Does not check that useShallow is actually imported. If you wrap an
+ *     unstable selector in a function called `useShallow` from somewhere
+ *     else, this test passes but TypeScript will catch it.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+import { describe, expect, it } from 'vitest';
+
+const SRC_ROOT = join(__dirname, '..', '..');
+const SKIP_SEGMENTS = new Set(['__tests__', 'node_modules', 'dist']);
+
+function listSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_SEGMENTS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      listSourceFiles(full, acc);
+    } else if (
+      (entry.endsWith('.ts') || entry.endsWith('.tsx')) &&
+      !entry.endsWith('.test.ts') &&
+      !entry.endsWith('.test.tsx') &&
+      !entry.endsWith('.d.ts')
+    ) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Heuristic for "this selector derives a fresh non-primitive each call".
+// We grab the body of every useAppStore() and look at the LAST evaluated
+// expression. If that expression is one of the array/object-producing forms
+// listed below we flag it; if it's a primitive coercion (.find(...), [0],
+// .some(...), .length, ?? null, etc) we let it pass even if the intermediate
+// shape used a fresh array. False positives can be silenced with a literal
+// `useShallow not needed:` comment inside the selector body.
+const USE_APP_STORE_CALL = /useAppStore\s*\(/g;
+const SAFE_OPT_OUT_COMMENT = /useShallow not needed/;
+
+// Extract the body of a `useAppStore(...)` call starting at `openParenIdx`
+// (the index of the `(` immediately after `useAppStore`). Returns the body
+// text (without the outer parens) and the index right after the matching
+// `)`. Returns null if the parens are unbalanced (truncated source).
+function extractCallBody(
+  source: string,
+  openParenIdx: number,
+): { body: string; endIdx: number } | null {
+  let depth = 0;
+  for (let i = openParenIdx; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) {
+        return { body: source.slice(openParenIdx + 1, i), endIdx: i + 1 };
+      }
+    }
+  }
+  return null;
+}
+
+// Trailing fresh-non-primitive expressions: anything matched here is the
+// last thing evaluated by the selector, so the result IS the freshly built
+// value. These are the actual bug shapes.
+const UNSTABLE_TAIL_PATTERNS: ReadonlyArray<RegExp> = [
+  // `.filter(...)`, `.map(...)`, etc as the final call
+  /\.\s*(?:filter|map|sort|concat|slice|flatMap|reduce|reverse)\s*\(([^()]|\([^()]*\))*\)\s*$/,
+  // `... ?? []` or `... ?? {}` as the final expression
+  /\?\?\s*[[{]\s*[\]}]\s*$/,
+  // Bare array spread literal `[...x]` at the end
+  /\[\s*\.\.\.[^\]]*\]\s*$/,
+  // Bare object spread literal `{ ...x }` at the end
+  /\{\s*\.\.\.[^}]*\}\s*$/,
+];
+
+interface BadCall {
+  readonly file: string;
+  readonly line: number;
+  readonly snippet: string;
+}
+
+function lineOf(content: string, idx: number): number {
+  return content.slice(0, idx).split('\n').length;
+}
+
+function selectorTail(body: string): string {
+  // Drop trailing whitespace and an optional `=> ` arrow prefix. We care
+  // about the rightmost expression of the lambda body.
+  const trimmed = body.trim();
+  // If the body is `(s) => expr`, lop off the `(s) => ` so we see the expr.
+  const arrowMatch = trimmed.match(/=>\s*([\s\S]*)$/);
+  const expr = arrowMatch?.[1] ?? trimmed;
+  // Drop a trailing optional semicolon or comma.
+  return expr.replace(/[;,]\s*$/, '').trim();
+}
+
+function checkFile(path: string): BadCall[] {
+  const content = readFileSync(path, 'utf-8');
+  const bad: BadCall[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = USE_APP_STORE_CALL.exec(content)) !== null) {
+    // `match.index + match[0].length - 1` points at the `(` after useAppStore
+    const openParen = match.index + match[0].length - 1;
+    const extracted = extractCallBody(content, openParen);
+    if (!extracted) continue;
+    const { body } = extracted;
+    if (body.includes('useShallow(')) continue;
+    if (SAFE_OPT_OUT_COMMENT.test(body)) continue;
+    const tail = selectorTail(body);
+    const isUnstable = UNSTABLE_TAIL_PATTERNS.some((re) => re.test(tail));
+    if (!isUnstable) continue;
+    bad.push({
+      file: relative(SRC_ROOT, path).split(sep).join('/'),
+      line: lineOf(content, match.index),
+      snippet: tail.replace(/\s+/g, ' ').slice(0, 140),
+    });
+  }
+  return bad;
+}
+
+describe('no unstable useAppStore selectors without useShallow', () => {
+  const files = listSourceFiles(SRC_ROOT);
+
+  it('every useAppStore call that derives a non-primitive uses useShallow', () => {
+    const bad = files.flatMap(checkFile);
+    if (bad.length > 0) {
+      const lines = bad.map((b) => `  - ${b.file}:${b.line}\n      ${b.snippet}`);
+      throw new Error(
+        `Found ${bad.length} useAppStore selector(s) that derive fresh references ` +
+          `without useShallow. React 19 useSyncExternalStore will detect a snapshot ` +
+          `mismatch and bail into an infinite render loop. Wrap each selector in ` +
+          `useShallow from zustand/react/shallow, or add a "useShallow not needed: ..." ` +
+          `comment if you have proof the selector is stable.\n\n${lines.join('\n')}`,
+      );
+    }
+    expect(bad).toEqual([]);
+  });
+});

--- a/apps/desktop/src/__tests__/regressions/zustand-selector-stability.test.tsx
+++ b/apps/desktop/src/__tests__/regressions/zustand-selector-stability.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+/**
+ * Regression: opening WorkspaceSettingsDialog / SessionSettingsDialog /
+ * ConnectLinearDialog crashed with "Maximum update depth exceeded"
+ * (React #185) because they had useAppStore selectors that built a fresh
+ * non-primitive each call:
+ *
+ *     useAppStore((s) => s.providers.filter(...).map(...))
+ *     useAppStore((s) => s.workspaceIntegrations[id] ?? [])
+ *
+ * React 19's useSyncExternalStore compares snapshots via Object.is. A fresh
+ * array always fails that check, the snapshot mismatch retriggers the
+ * render, and the next render computes yet another fresh ref. Infinite loop,
+ * error boundary catches it as React #185, user sees "something went wrong".
+ *
+ * Fix: wrap the offending selector in `useShallow` from
+ * `zustand/react/shallow`. This file pins the contract: the wrapped pattern
+ * returns a stable ref across unrelated store updates, the raw pattern does
+ * not. If anyone removes useShallow from one of those dialogs the
+ * `no-unstable-zustand-selectors` source scan below catches it; if the
+ * underlying assumption about useShallow ever changes the hook tests here
+ * catch that too.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+interface TestState {
+  providers: ReadonlyArray<{ id: string; connection: string }>;
+  integrations: Readonly<Record<string, ReadonlyArray<string>>>;
+  filler: number;
+}
+
+afterEach(cleanup);
+
+function makeStore() {
+  return create<TestState>(() => ({
+    providers: [
+      { id: 'anthropic', connection: 'connected' },
+      { id: 'cursor', connection: 'missing' },
+    ],
+    integrations: {},
+    filler: 0,
+  }));
+}
+
+describe('useShallow keeps filter/map selectors stable', () => {
+  it('returns the same ref when an unrelated store key changes', () => {
+    const useStore = makeStore();
+    const { result, rerender } = renderHook(() =>
+      useStore(
+        useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
+      ),
+    );
+    const first = result.current;
+    expect(first).toEqual(['anthropic']);
+
+    act(() => useStore.setState({ filler: 1 }));
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('returns a new ref when the derived list actually changes', () => {
+    const useStore = makeStore();
+    const { result, rerender } = renderHook(() =>
+      useStore(
+        useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
+      ),
+    );
+    const first = result.current;
+
+    act(() =>
+      useStore.setState({
+        providers: [
+          { id: 'anthropic', connection: 'connected' },
+          { id: 'cursor', connection: 'connected' },
+        ],
+      }),
+    );
+    rerender();
+    expect(result.current).not.toBe(first);
+    expect(result.current).toEqual(['anthropic', 'cursor']);
+  });
+});
+
+describe('useShallow keeps `?? []` selectors stable', () => {
+  it('returns the same ref across unrelated store updates when the key is missing', () => {
+    const useStore = makeStore();
+    const { result, rerender } = renderHook(() =>
+      useStore(useShallow((s) => s.integrations['ws-1'] ?? [])),
+    );
+    const first = result.current;
+    expect(first).toEqual([]);
+
+    act(() => useStore.setState({ filler: 1 }));
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+
+describe('without useShallow these selectors are unstable', () => {
+  it('filter().map() returns a brand new array on every call (documents the bug)', () => {
+    const useStore = makeStore();
+    const select = (s: TestState) =>
+      s.providers.filter((p) => p.connection === 'connected').map((p) => p.id);
+    const a = select(useStore.getState());
+    const b = select(useStore.getState());
+    expect(a).toEqual(b);
+    expect(Object.is(a, b)).toBe(false);
+  });
+
+  it('`?? []` returns a brand new array on every missing-key lookup (documents the bug)', () => {
+    const useStore = makeStore();
+    const select = (s: TestState) => s.integrations['missing-key'] ?? [];
+    const a = select(useStore.getState());
+    const b = select(useStore.getState());
+    expect(Object.is(a, b)).toBe(false);
+  });
+});

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -421,7 +421,7 @@ exports[`snapshot, empty states > ProvidersPanel: no providers (store returns []
       />
     </svg>
     <span>
-      Install and sign in straight from the app. Each step runs in an embedded terminal so you never leave Goodboy.
+      Install and sign in straight from Goodboy. Every step runs in a roomy modal with the embedded terminal, the per-provider playbook, and an escape hatch to your own shell.
     </span>
   </div>
 </div>
@@ -1604,16 +1604,16 @@ exports[`snapshot, error states > ProvidersPanel: provider in error state 1`] = 
     </span>
   </div>
   <div
-    class="grid grid-cols-3 gap-2.5"
+    class="grid grid-cols-2 gap-2.5"
   >
     <div
       class="relative flex flex-col gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
     >
       <div
-        class="flex gap-3 flex-col items-center"
+        class="flex flex-col items-center gap-2"
       >
         <div
-          class="flex items-center flex-col gap-2"
+          class="flex flex-col items-center gap-2"
         >
           <div
             aria-hidden="true"
@@ -1713,7 +1713,7 @@ exports[`snapshot, error states > ProvidersPanel: provider in error state 1`] = 
       />
     </svg>
     <span>
-      Install and sign in straight from the app. Each step runs in an embedded terminal so you never leave Goodboy.
+      Install and sign in straight from Goodboy. Every step runs in a roomy modal with the embedded terminal, the per-provider playbook, and an escape hatch to your own shell.
     </span>
   </div>
 </div>

--- a/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.test.tsx
@@ -3,20 +3,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
-const { loginProviderMock } = vi.hoisted(() => ({
-  loginProviderMock: vi.fn(async () => undefined),
+const { openProviderModalMock } = vi.hoisted(() => ({
+  openProviderModalMock: vi.fn(),
 }));
 
-vi.mock('../../../../store', () => ({
-  useAppStore: <T,>(selector: (s: { loginProvider: typeof loginProviderMock }) => T) =>
-    selector({ loginProvider: loginProviderMock }),
+vi.mock('../../../providers/components/ProviderModalHost', () => ({
+  openProviderModal: openProviderModalMock,
 }));
 
 import { AuthRequiredCallout } from './index';
 
 afterEach(() => {
   cleanup();
-  loginProviderMock.mockClear();
+  openProviderModalMock.mockClear();
 });
 
 describe('AuthRequiredCallout', () => {
@@ -32,10 +31,10 @@ describe('AuthRequiredCallout', () => {
     expect(screen.getByText(/last known identity: amin@x\.io/i)).toBeDefined();
   });
 
-  it('invokes loginProvider when Connect is clicked', () => {
+  it('opens the provider modal in login mode when Connect is clicked', () => {
     render(<AuthRequiredCallout providerId="codex" onRefresh={() => undefined} />);
     fireEvent.click(screen.getByRole('button', { name: /connect now/i }));
-    expect(loginProviderMock).toHaveBeenCalledWith('codex');
+    expect(openProviderModalMock).toHaveBeenCalledWith({ providerId: 'codex', action: 'login' });
   });
 
   it('calls onRefresh when the Refresh status button is clicked', () => {

--- a/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.tsx
+++ b/apps/desktop/src/features/chat/components/AuthRequiredCallout/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@goodboy/ui';
 import type { ProviderId } from '@goodboy/types';
 import { PROVIDER_LABEL_LOWER } from '../../../../features/providers/providers';
-import { useAppStore } from '../../../../store';
+import { openProviderModal } from '../../../providers/components/ProviderModalHost';
 
 interface Props {
   readonly providerId: ProviderId;
@@ -11,10 +11,12 @@ interface Props {
 
 export function AuthRequiredCallout({ providerId, identity, onRefresh }: Props) {
   const label = PROVIDER_LABEL_LOWER[providerId];
-  const loginProvider = useAppStore((s) => s.loginProvider);
 
   const onConnect = () => {
-    void loginProvider(providerId);
+    // Route through the global provider modal so the user sees the guide +
+    // embedded terminal + escape hatch, instead of firing a background
+    // login that surfaces nothing in the chat view.
+    openProviderModal({ providerId, action: 'login' });
   };
 
   return (

--- a/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
+++ b/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import type { WorkspaceId } from '@goodboy/types';
 import { Button, Dialog, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
@@ -22,7 +23,10 @@ interface Props {
  * picker just stops appearing in new sessions.
  */
 export function ConnectLinearDialog({ workspaceId, open, onClose }: Props) {
-  const integrations = useAppStore((s) => s.workspaceIntegrations[workspaceId] ?? []);
+  // useShallow because `?? []` returns a fresh array on every missing-key
+  // lookup; without shallow comparison useSyncExternalStore loops on a
+  // snapshot mismatch in React 19.
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
   const linear = integrations.find((i) => i.provider === 'linear') ?? null;
   const connectLinear = useAppStore((s) => s.connectLinear);
   const disconnectLinear = useAppStore((s) => s.disconnectLinear);

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/EscapeHatch.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/EscapeHatch.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { Check, Copy, Terminal } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
+import { openCommandInExternalTerminal } from '../../external-terminal';
+import { formatError } from '../../../../shared/lib/errors';
+
+interface Props {
+  readonly command: string;
+}
+
+const RESET_AFTER_MS = 1500;
+
+// Power-user escape hatch: copy the command verbatim, or hand it off to the
+// OS native terminal. Both options stay out of the way visually (small
+// secondary buttons under the terminal) so they do not compete with the
+// primary embedded-PTY flow above. The OS-terminal handoff is best-effort:
+// Linux probes a few common emulators, Windows opens cmd.exe, macOS uses
+// Terminal.app; an exotic setup falls back to a copy-only toast.
+export function EscapeHatch({ command }: Props) {
+  const [copied, setCopied] = useState(false);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), RESET_AFTER_MS);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const onLaunch = async () => {
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      await openCommandInExternalTerminal(command);
+    } catch (err) {
+      setLaunchError(formatError(err));
+    } finally {
+      setLaunching(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <Tooltip content="Copy command" side="top">
+          <button
+            type="button"
+            onClick={() => void onCopy()}
+            aria-label="copy command"
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft px-2.5 py-1 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {copied ? (
+              <>
+                <Check size={11} aria-hidden />
+                <span>Copied</span>
+              </>
+            ) : (
+              <>
+                <Copy size={11} aria-hidden />
+                <span>Copy command</span>
+              </>
+            )}
+          </button>
+        </Tooltip>
+        <Tooltip content="Open in your system terminal" side="top">
+          <button
+            type="button"
+            disabled={launching}
+            onClick={() => void onLaunch()}
+            className="inline-flex items-center gap-1.5 rounded-md border border-border-soft px-2.5 py-1 text-2xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+          >
+            <Terminal size={11} aria-hidden />
+            <span>Run in my terminal</span>
+          </button>
+        </Tooltip>
+      </div>
+      {launchError ? (
+        <span className="text-2xs text-danger">
+          Could not open external terminal: {launchError}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/GuidePanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/GuidePanel.tsx
@@ -1,0 +1,52 @@
+import { ExternalLink } from 'lucide-react';
+import type { ProviderGuide } from './guides';
+
+interface Props {
+  readonly guide: ProviderGuide;
+}
+
+// Sidebar inside the modal: subscription line, numbered steps, docs link.
+// Scrollable independently of the terminal so a long guide does not push the
+// PTY off-screen on small viewports.
+export function GuidePanel({ guide }: Props) {
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-sm font-semibold text-foreground">{guide.headline}</h3>
+        {guide.subscription ? (
+          <p className="text-2xs text-muted-foreground">
+            <span className="font-medium text-foreground/70">Needs: </span>
+            {guide.subscription}
+          </p>
+        ) : null}
+      </div>
+
+      <ol className="flex flex-col gap-3">
+        {guide.steps.map((step, idx) => (
+          <li key={step.title} className="flex gap-2.5">
+            <span
+              aria-hidden
+              className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10 text-2xs font-semibold text-primary"
+            >
+              {idx + 1}
+            </span>
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="text-xs font-medium text-foreground">{step.title}</span>
+              <span className="text-2xs leading-relaxed text-muted-foreground">{step.body}</span>
+            </div>
+          </li>
+        ))}
+      </ol>
+
+      <a
+        href={guide.docsUrl}
+        target="_blank"
+        rel="noreferrer"
+        className="mt-auto inline-flex items-center gap-1.5 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <span>{guide.docsLabel}</span>
+        <ExternalLink size={10} aria-hidden />
+      </a>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
@@ -1,0 +1,230 @@
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+
+// Per-provider × action playbook surfaced in the modal sidebar. Three sections
+// (subscription, what happens, troubleshooting) keep every guide structured
+// identically so the user learns the pattern once. Logout is rare and brief,
+// so it shares a minimal template.
+interface GuideStep {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface ProviderGuide {
+  readonly headline: string;
+  readonly subscription: string;
+  readonly steps: ReadonlyArray<GuideStep>;
+  readonly docsUrl: string;
+  readonly docsLabel: string;
+}
+
+const ANTHROPIC_DOCS = 'https://docs.claude.com/en/docs/claude-code/overview';
+const CURSOR_DOCS = 'https://docs.cursor.com/en/cli/installation';
+const CODEX_DOCS = 'https://github.com/openai/codex#installation';
+const GEMINI_DOCS = 'https://github.com/google-gemini/gemini-cli#installation';
+
+const INSTALL_GUIDES: Record<ProviderId, ProviderGuide> = {
+  anthropic: {
+    headline: 'Install Claude Code',
+    subscription: 'Claude Pro or Max subscription on claude.ai.',
+    steps: [
+      {
+        title: 'Watch the install run',
+        body: 'npm fetches the Claude Code CLI and registers `claude` on your PATH. Takes 5 to 30 seconds depending on your network.',
+      },
+      {
+        title: 'If it asks for your password',
+        body: 'A global npm install can need sudo on macOS without nvm. Click in the terminal and type your password, the prompt accepts input directly.',
+      },
+      {
+        title: 'After install',
+        body: 'Goodboy automatically moves to the sign-in step. You stay in the same modal, no re-clicking.',
+      },
+    ],
+    docsUrl: ANTHROPIC_DOCS,
+    docsLabel: 'Claude Code docs',
+  },
+  cursor: {
+    headline: 'Install Cursor CLI',
+    subscription: 'Cursor Pro subscription on cursor.com.',
+    steps: [
+      {
+        title: 'Curl + bash installer',
+        body: 'Cursor is not on npm. The official script downloads the right binary for your OS and drops it into `~/.local/bin` (or equivalent).',
+      },
+      {
+        title: 'PATH check',
+        body: 'After install, restart Goodboy if `cursor-agent` does not show up. Some shells need a new session before the new PATH takes effect.',
+      },
+      {
+        title: 'Then sign in',
+        body: 'Sign-in opens Cursor in your browser. You authorize once and the CLI keeps a long-lived token.',
+      },
+    ],
+    docsUrl: CURSOR_DOCS,
+    docsLabel: 'Cursor CLI docs',
+  },
+  codex: {
+    headline: 'Install OpenAI Codex',
+    subscription: 'ChatGPT Plus, Pro, or Business plan on chat.openai.com.',
+    steps: [
+      {
+        title: 'npm global install',
+        body: 'Pulls `@openai/codex` and exposes the `codex` command. Same caveat as Claude: global npm may need sudo without nvm.',
+      },
+      {
+        title: 'Sign in with ChatGPT',
+        body: 'After install you sign in once. Codex stores an OAuth token under `~/.codex/auth.json` and reuses it across sessions.',
+      },
+      {
+        title: 'API-key alternative',
+        body: 'If you prefer, you can skip sign-in and set OPENAI_API_KEY in your shell instead. Goodboy will still detect Codex as connected.',
+      },
+    ],
+    docsUrl: CODEX_DOCS,
+    docsLabel: 'Codex install guide',
+  },
+  gemini: {
+    headline: 'Install Gemini CLI',
+    subscription: 'Google AI Pro plan, or any Google account on the free tier.',
+    steps: [
+      {
+        title: 'npm global install',
+        body: 'Fetches `@google/gemini-cli` and exposes the `gemini` command on your PATH. Node 20+ required.',
+      },
+      {
+        title: 'Sign-in is interactive',
+        body: 'Running `gemini` opens an interactive menu in the terminal where you pick the OAuth flow. Click in the terminal and use the arrow keys, the prompt accepts input directly.',
+      },
+      {
+        title: 'Auth lives in a file',
+        body: 'After login Gemini writes `~/.gemini/oauth_creds.json`. Goodboy reads that file to know you are connected, no subprocess polling needed.',
+      },
+    ],
+    docsUrl: GEMINI_DOCS,
+    docsLabel: 'Gemini CLI docs',
+  },
+};
+
+const LOGIN_GUIDES: Record<ProviderId, ProviderGuide> = {
+  anthropic: {
+    headline: 'Sign in to Claude',
+    subscription: 'Your Claude Pro or Max account.',
+    steps: [
+      {
+        title: 'Browser handoff',
+        body: 'The CLI opens your default browser. Sign in with your Anthropic account and approve the CLI prompt.',
+      },
+      {
+        title: 'You can close the browser',
+        body: 'Once the approval page says "you can close this window", come back here. Goodboy detects the new token automatically.',
+      },
+    ],
+    docsUrl: ANTHROPIC_DOCS,
+    docsLabel: 'Claude Code sign-in',
+  },
+  cursor: {
+    headline: 'Sign in to Cursor',
+    subscription: 'Your Cursor Pro account.',
+    steps: [
+      {
+        title: 'Browser handoff',
+        body: 'A browser tab opens to cursor.com. Sign in and approve the CLI request.',
+      },
+      {
+        title: 'Token is long-lived',
+        body: 'After this you should not need to sign in again unless you log out manually.',
+      },
+    ],
+    docsUrl: CURSOR_DOCS,
+    docsLabel: 'Cursor CLI docs',
+  },
+  codex: {
+    headline: 'Sign in to Codex',
+    subscription: 'Your ChatGPT plan.',
+    steps: [
+      {
+        title: 'Pick a method',
+        body: 'Codex offers ChatGPT login or API key in the terminal menu. Click in the terminal and use the arrow keys to pick one.',
+      },
+      {
+        title: 'ChatGPT flow opens the browser',
+        body: 'If you pick ChatGPT, the browser opens. Sign in and approve. The credentials land in `~/.codex/auth.json`.',
+      },
+    ],
+    docsUrl: CODEX_DOCS,
+    docsLabel: 'Codex sign-in',
+  },
+  gemini: {
+    headline: 'Sign in to Gemini',
+    subscription: 'Your Google account (free or AI Pro).',
+    steps: [
+      {
+        title: 'Pick the OAuth flow',
+        body: 'Gemini drops you into an interactive menu. Click in the terminal and use the arrow keys to choose "Login with Google".',
+      },
+      {
+        title: 'Browser handoff',
+        body: 'Google opens in the browser. Sign in, grant the requested scopes, and Gemini writes the token to `~/.gemini/oauth_creds.json`.',
+      },
+    ],
+    docsUrl: GEMINI_DOCS,
+    docsLabel: 'Gemini CLI auth',
+  },
+};
+
+const LOGOUT_GUIDES: Record<ProviderId, ProviderGuide> = {
+  anthropic: {
+    headline: 'Sign out of Claude',
+    subscription: '',
+    steps: [
+      {
+        title: 'Local-only',
+        body: '`claude /logout` clears the token from your machine. Your Anthropic account is untouched.',
+      },
+    ],
+    docsUrl: ANTHROPIC_DOCS,
+    docsLabel: 'Claude Code docs',
+  },
+  cursor: {
+    headline: 'Sign out of Cursor',
+    subscription: '',
+    steps: [
+      {
+        title: 'Local-only',
+        body: '`cursor-agent logout` removes the local token. Sign back in any time.',
+      },
+    ],
+    docsUrl: CURSOR_DOCS,
+    docsLabel: 'Cursor CLI docs',
+  },
+  codex: {
+    headline: 'Sign out of Codex',
+    subscription: '',
+    steps: [
+      {
+        title: 'Local-only',
+        body: '`codex logout` deletes `~/.codex/auth.json`. Your OpenAI plan stays intact.',
+      },
+    ],
+    docsUrl: CODEX_DOCS,
+    docsLabel: 'Codex docs',
+  },
+  gemini: {
+    headline: 'Sign out of Gemini',
+    subscription: '',
+    steps: [
+      {
+        title: 'File removal',
+        body: 'Gemini has no `logout` subcommand. Goodboy removes `~/.gemini/oauth_creds.json` directly, which is what gemini reads on startup.',
+      },
+    ],
+    docsUrl: GEMINI_DOCS,
+    docsLabel: 'Gemini CLI docs',
+  },
+};
+
+export function guideFor(providerId: ProviderId, action: ProviderLifecycleAction): ProviderGuide {
+  if (action === 'install') return INSTALL_GUIDES[providerId];
+  if (action === 'login') return LOGIN_GUIDES[providerId];
+  return LOGOUT_GUIDES[providerId];
+}

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/index.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Dialog, Button } from '@goodboy/ui';
+import { CheckCircle2, Info } from 'lucide-react';
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import type { ProviderLifecyclePhase } from '../../../../store/slices/providers';
+import { resolveLifecycleCommand } from '../../provider-lifecycle';
+import { brandColor, PROVIDER_BRAND } from '../provider-brand';
+import { CommandPreview } from '../ProviderLifecycleTile/CommandPreview';
+import { ErrorPanel } from '../ProviderLifecycleTile/ErrorPanel';
+import { InlineTerminal } from '../ProviderLifecycleTile/InlineTerminal';
+import { OpenInBrowserButton } from '../ProviderLifecycleTile/OpenInBrowserButton';
+import { StatusPill } from '../ProviderLifecycleTile/StatusPill';
+import { Stepper } from '../ProviderLifecycleTile/Stepper';
+import { EscapeHatch } from './EscapeHatch';
+import { GuidePanel } from './GuidePanel';
+import { guideFor } from './guides';
+
+interface Props {
+  /** Provider currently being configured. null means the modal is closed. */
+  readonly providerId: ProviderId | null;
+  /** Action to auto-dispatch when the modal opens on an idle lifecycle. */
+  readonly initialAction: ProviderLifecycleAction;
+  readonly onClose: () => void;
+}
+
+// One modal for the entire install + connect path. Stays mounted through
+// both phases so the user does not lose context when install finishes and
+// the flow advances to sign-in. Closing during an in-flight run is allowed:
+// the PTY keeps running, status returns to the tile, reopening replays
+// terminal output from the GenericTerminalPanel cache keyed by runId.
+export function ProviderConnectModal({ providerId, initialAction, onClose }: Props) {
+  const open = providerId !== null;
+  // Pin the active providerId across the close animation so the body keeps
+  // rendering its content for the duration of the dialog's exit transition.
+  const [pinned, setPinned] = useState<ProviderId | null>(null);
+  const [pinnedAction, setPinnedAction] = useState<ProviderLifecycleAction>(initialAction);
+
+  useEffect(() => {
+    if (providerId) {
+      setPinned(providerId);
+      setPinnedAction(initialAction);
+    }
+  }, [providerId, initialAction]);
+
+  const target = providerId ?? pinned;
+  if (!target) {
+    return (
+      <Dialog open={false} onClose={onClose} size="xl">
+        {null}
+      </Dialog>
+    );
+  }
+  return (
+    <ModalBody providerId={target} initialAction={pinnedAction} open={open} onClose={onClose} />
+  );
+}
+
+interface BodyProps {
+  readonly providerId: ProviderId;
+  readonly initialAction: ProviderLifecycleAction;
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+function ModalBody({ providerId, initialAction, open, onClose }: BodyProps) {
+  const lifecycle = useAppStore((s) => s.providerLifecycle[providerId]);
+  const provider = useAppStore((s) => s.providers.find((p) => p.id === providerId));
+  const installProvider = useAppStore((s) => s.installProvider);
+  const loginProvider = useAppStore((s) => s.loginProvider);
+  const cancelLifecycle = useAppStore((s) => s.cancelProviderLifecycle);
+
+  const [didAutoStart, setDidAutoStart] = useState(false);
+
+  // Auto-dispatch the initial action exactly once per open. Only if the
+  // lifecycle is resting and the provider is not already in the desired
+  // terminal state (e.g. opening the install modal on an already-installed
+  // provider should not reinstall it).
+  useEffect(() => {
+    if (!open) {
+      setDidAutoStart(false);
+      return;
+    }
+    if (didAutoStart) return;
+    const resting: ReadonlyArray<ProviderLifecyclePhase> = [
+      'idle',
+      'cancelled',
+      'error',
+      'installed',
+      'connected',
+    ];
+    if (!resting.includes(lifecycle.phase)) return;
+    if (initialAction === 'install' && provider?.connection !== 'missing') return;
+    if (initialAction === 'login' && provider?.connection === 'connected') return;
+    setDidAutoStart(true);
+    if (initialAction === 'install') void installProvider(providerId);
+    else if (initialAction === 'login') void loginProvider(providerId);
+  }, [
+    open,
+    didAutoStart,
+    initialAction,
+    lifecycle.phase,
+    provider?.connection,
+    providerId,
+    installProvider,
+    loginProvider,
+  ]);
+
+  const currentAction: ProviderLifecycleAction = lifecycle.action ?? initialAction;
+  const guide = useMemo(() => guideFor(providerId, currentAction), [providerId, currentAction]);
+  const command = lifecycle.command ?? resolveLifecycleCommand(providerId, currentAction);
+
+  const inFlight =
+    lifecycle.phase === 'installing' ||
+    lifecycle.phase === 'connecting' ||
+    lifecycle.phase === 'disconnecting';
+  const connected = provider?.connection === 'connected';
+  const installed = provider !== undefined && provider.connection !== 'missing';
+
+  const onPrimary = useCallback(() => {
+    if (inFlight) {
+      void cancelLifecycle(providerId);
+      return;
+    }
+    if (connected) {
+      onClose();
+      return;
+    }
+    if (!installed) void installProvider(providerId);
+    else void loginProvider(providerId);
+  }, [
+    inFlight,
+    connected,
+    installed,
+    providerId,
+    cancelLifecycle,
+    installProvider,
+    loginProvider,
+    onClose,
+  ]);
+
+  const primary = primaryButton(lifecycle.phase, connected, installed, inFlight);
+  const brand = PROVIDER_BRAND[providerId];
+  const Icon = brand.icon;
+  const color = brandColor(providerId);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      size="xl"
+      panel={<GuidePanel guide={guide} />}
+      panelWidthClass="w-72"
+      panelClassName="bg-subtle/30 px-5 py-5 overflow-y-auto"
+      title={
+        <span className="inline-flex items-center gap-2">
+          <span
+            aria-hidden
+            className="flex h-7 w-7 items-center justify-center rounded-full"
+            style={{
+              backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
+              color,
+            }}
+          >
+            <Icon size={14} strokeWidth={2} />
+          </span>
+          <span className="lowercase">{provider?.label ?? providerId}</span>
+          <StatusPill phase={lifecycle.phase} connection={provider?.connection ?? 'missing'} />
+        </span>
+      }
+      description={
+        lifecycle.action ? (
+          <Stepper action={lifecycle.action} />
+        ) : connected ? (
+          <span className="inline-flex items-center gap-1.5 text-success">
+            <CheckCircle2 size={12} aria-hidden />
+            <span>Connected as {provider?.identity ?? 'this account'}</span>
+          </span>
+        ) : (
+          'Step through install and sign-in without leaving Goodboy.'
+        )
+      }
+      footer={
+        <>
+          {!connected && !inFlight ? (
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Close
+            </Button>
+          ) : null}
+          <Button variant={primary.variant} size="sm" onClick={onPrimary}>
+            {primary.label}
+          </Button>
+        </>
+      }
+      bodyClassName="gap-4 px-6 py-5"
+    >
+      {command ? <CommandPreview command={command} /> : null}
+
+      {lifecycle.runId ? (
+        <InlineTerminal runId={lifecycle.runId} isActive={open} heightClass="h-72" />
+      ) : (
+        <EmptyTerminalPlaceholder connected={connected} />
+      )}
+
+      <HelperNote inFlight={inFlight} />
+
+      {lifecycle.detectedAuthUrl ? (
+        <div className="flex justify-center">
+          <OpenInBrowserButton url={lifecycle.detectedAuthUrl} />
+        </div>
+      ) : null}
+
+      {lifecycle.phase === 'error' && lifecycle.errorTail ? (
+        <ErrorPanel tail={lifecycle.errorTail} />
+      ) : null}
+
+      {command ? <EscapeHatch command={command} /> : null}
+    </Dialog>
+  );
+}
+
+interface PrimaryButton {
+  readonly label: string;
+  readonly variant: 'primary' | 'secondary' | 'ghost' | 'danger';
+}
+
+function primaryButton(
+  phase: ProviderLifecyclePhase,
+  connected: boolean,
+  installed: boolean,
+  inFlight: boolean,
+): PrimaryButton {
+  if (inFlight) return { label: 'Cancel', variant: 'secondary' };
+  if (connected) return { label: 'Done', variant: 'primary' };
+  if (phase === 'error') {
+    if (!installed) return { label: 'Retry install', variant: 'primary' };
+    return { label: 'Retry sign-in', variant: 'primary' };
+  }
+  if (!installed) return { label: 'Install', variant: 'primary' };
+  return { label: 'Sign in', variant: 'primary' };
+}
+
+function HelperNote({ inFlight }: { inFlight: boolean }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border-soft bg-subtle/30 px-3 py-2 text-2xs text-muted-foreground">
+      <Info size={12} aria-hidden className="mt-0.5 shrink-0" />
+      <span className="leading-relaxed">
+        {inFlight
+          ? 'If the install or sign-in pauses, click inside the terminal and type. It accepts keyboard input directly, exactly like your own shell.'
+          : 'The embedded terminal accepts keyboard input. Click in it and type if a step needs a password or a menu choice.'}
+      </span>
+    </div>
+  );
+}
+
+function EmptyTerminalPlaceholder({ connected }: { connected: boolean }) {
+  return (
+    <div className="flex h-72 items-center justify-center rounded-md border border-dashed border-border-soft bg-subtle/30 text-2xs text-muted-foreground">
+      {connected
+        ? 'You are already connected. The next sign-in or reinstall will run here.'
+        : 'Terminal will appear when the command starts running.'}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/InlineTerminal.tsx
@@ -31,13 +31,18 @@ function stringToBase64(s: string): string {
 interface Props {
   readonly runId: string;
   readonly isActive: boolean;
+  /** Tailwind height class for the terminal wrapper. Default `h-44`. */
+  readonly heightClass?: string;
 }
 
 // Wraps GenericTerminalPanel with a lifecycle-scoped driver. The driver
 // filters output/exit events by runId so concurrent lifecycle runs (e.g. user
 // installs claude then immediately starts codex install) never bleed into
 // each other's xterm view.
-export function InlineTerminal({ runId, isActive }: Props) {
+//
+// The same component is reused in the connect modal at a larger size by
+// overriding heightClass, see ProviderConnectModal.
+export function InlineTerminal({ runId, isActive, heightClass = 'h-44' }: Props) {
   const driver = useMemo<TerminalDriver>(
     () => ({
       write: (data) => {
@@ -61,7 +66,9 @@ export function InlineTerminal({ runId, isActive }: Props) {
   );
 
   return (
-    <div className="h-44 overflow-hidden rounded-md border border-border-soft bg-background">
+    <div
+      className={`${heightClass} overflow-hidden rounded-md border border-border-soft bg-background`}
+    >
       <GenericTerminalPanel terminalId={runId} driver={driver} isActive={isActive} exitMessage="" />
     </div>
   );

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/copy.ts
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/copy.ts
@@ -18,7 +18,8 @@ const COPY: Record<CopyKey, string> = {
   'codex.login': 'Opens your browser to sign in with your OpenAI account.',
   'codex.logout': 'Signs you out of Codex. You can sign back in any time.',
   'gemini.install': 'Installs the Google Gemini CLI globally via npm. Takes about 10 seconds.',
-  'gemini.login': 'Opens your browser to sign in with your Google account.',
+  'gemini.login':
+    'Opens an interactive menu in the terminal. Click in to pick Google sign-in with arrow keys.',
   'gemini.logout': 'Removes your Gemini credentials from this machine.',
 };
 

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/index.tsx
@@ -1,49 +1,28 @@
 import { useCallback, useState } from 'react';
-import { Code2, Gem, MousePointer2, Sparkles } from 'lucide-react';
-import type { LucideIcon } from 'lucide-react';
+import { ArrowRight, Loader2, Sparkles, type LucideIcon } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
-import { CommandPreview } from './CommandPreview';
+import { brandColor, PROVIDER_BRAND } from '../provider-brand';
+import { openProviderModal } from '../ProviderModalHost';
 import { CtaButton, intentForState } from './CtaButton';
 import { DisconnectControl } from './DisconnectControl';
-import { ErrorPanel } from './ErrorPanel';
 import { InfoBanner } from './InfoBanner';
-import { InlineTerminal } from './InlineTerminal';
-import { OpenInBrowserButton } from './OpenInBrowserButton';
 import { StatusPill } from './StatusPill';
-import { Stepper } from './Stepper';
 import { copyFor } from './copy';
-
-interface ProviderBrand {
-  readonly icon: LucideIcon;
-  readonly cssVar: string;
-}
-
-const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
-  anthropic: { icon: Sparkles, cssVar: '--color-provider-anthropic' },
-  cursor: { icon: MousePointer2, cssVar: '--color-provider-cursor' },
-  codex: { icon: Code2, cssVar: '--color-provider-codex' },
-  gemini: { icon: Gem, cssVar: '--color-provider-gemini' },
-};
 
 interface Props {
   readonly info: ProviderInfo;
 }
 
-// In-flight phases drive the wide layout (col-span-full with terminal).
-const WIDE_PHASES = new Set(['installing', 'connecting', 'disconnecting']);
-
 export function ProviderLifecycleTile({ info }: Props) {
   const providerId = info.id as ProviderId;
   const brand = PROVIDER_BRAND[providerId];
-  const Icon = brand?.icon ?? Sparkles;
-  const color = brand ? `var(${brand.cssVar})` : 'var(--color-primary)';
+  const Icon: LucideIcon = brand?.icon ?? Sparkles;
+  const color = brand ? brandColor(providerId) : 'var(--color-primary)';
 
   const lifecycle = useAppStore((s) => s.providerLifecycle[providerId]);
-  const installProvider = useAppStore((s) => s.installProvider);
-  const loginProvider = useAppStore((s) => s.loginProvider);
   const logoutProvider = useAppStore((s) => s.logoutProvider);
   const cancelLifecycle = useAppStore((s) => s.cancelProviderLifecycle);
   const refreshProviders = useAppStore((s) => s.refreshProviders);
@@ -58,82 +37,69 @@ export function ProviderLifecycleTile({ info }: Props) {
     }
   }, [refreshProviders]);
 
-  const fireAction = useCallback(
-    (action: ProviderLifecycleAction | 'cancel') => {
-      if (action === 'install') void installProvider(providerId);
-      else if (action === 'login') void loginProvider(providerId);
-      else if (action === 'logout') void logoutProvider(providerId);
-      else if (action === 'cancel') void cancelLifecycle(providerId);
-    },
-    [providerId, installProvider, loginProvider, logoutProvider, cancelLifecycle],
-  );
-
-  const isWide = WIDE_PHASES.has(lifecycle.phase);
   const intent = intentForState(lifecycle.phase, info.connection);
 
-  // The connected state with a stable connection gets its own composite
-  // (refresh + two-tap disconnect) rather than a single CTA button.
+  // Connected providers expose disconnect inline (two-tap confirm, no modal).
+  // Everything else routes through the modal.
   const showDisconnectComposite = lifecycle.phase === 'idle' && info.connection === 'connected';
+  const inFlight =
+    lifecycle.phase === 'installing' ||
+    lifecycle.phase === 'connecting' ||
+    lifecycle.phase === 'disconnecting';
+
+  const onCtaClick = useCallback(() => {
+    if (!intent) return;
+    if (intent.action === 'logout') {
+      void logoutProvider(providerId);
+      return;
+    }
+    if (intent.action === 'cancel') {
+      // Cancel directly from the tile so the user does not have to detour
+      // through the modal just to abort. "View progress" remains available
+      // as a separate inline button for the watching-only case.
+      void cancelLifecycle(providerId);
+      return;
+    }
+    openProviderModal({ providerId, action: intent.action });
+  }, [intent, providerId, cancelLifecycle, logoutProvider]);
 
   return (
     <div
       className="relative flex flex-col gap-2 rounded-lg border bg-subtle p-3 shadow-sm transition-colors"
       style={{
         borderColor: `color-mix(in oklch, ${color} 25%, var(--color-border-soft))`,
-        gridColumn: isWide ? '1 / -1' : undefined,
       }}
     >
-      <div
-        className={cn(
-          'flex items-start gap-3',
-          isWide ? 'justify-between' : 'flex-col items-center',
-        )}
-      >
-        <TileHeader
-          icon={Icon}
-          color={color}
-          info={info}
-          phase={lifecycle.phase}
-          stacked={!isWide}
-        />
-        {isWide ? (
-          <div className="flex flex-col items-end gap-1">
-            <StatusPill phase={lifecycle.phase} connection={info.connection} />
-            {lifecycle.action ? <Stepper action={lifecycle.action} /> : null}
-          </div>
-        ) : (
-          <StatusPill phase={lifecycle.phase} connection={info.connection} />
-        )}
+      <div className="flex flex-col items-center gap-2">
+        <TileHeader icon={Icon} color={color} info={info} phase={lifecycle.phase} />
+        <StatusPill phase={lifecycle.phase} connection={info.connection} />
       </div>
 
-      {isWide && lifecycle.command ? <CommandPreview command={lifecycle.command} /> : null}
-
-      {isWide && lifecycle.runId ? <InlineTerminal runId={lifecycle.runId} isActive /> : null}
-
-      {isWide && lifecycle.detectedAuthUrl ? (
-        <div className="flex justify-center">
-          <OpenInBrowserButton url={lifecycle.detectedAuthUrl} />
-        </div>
-      ) : null}
-
-      {lifecycle.phase === 'error' && lifecycle.errorTail ? (
-        <ErrorPanel tail={lifecycle.errorTail} />
-      ) : null}
-
-      {!isWide && lifecycle.phase === 'idle' && lifecycle.action !== 'logout' ? (
+      {lifecycle.phase === 'idle' && lifecycle.action !== 'logout' ? (
         <PreActionCopy providerId={providerId} info={info} />
+      ) : null}
+
+      {inFlight ? (
+        <InFlightPing
+          onClick={() =>
+            openProviderModal({
+              providerId,
+              action: lifecycle.action ?? 'install',
+            })
+          }
+        />
       ) : null}
 
       <div className="mt-1 w-full">
         {showDisconnectComposite ? (
           <DisconnectControl
-            onDisconnect={() => fireAction('logout')}
+            onDisconnect={() => void logoutProvider(providerId)}
             onRefresh={() => void onRefresh()}
             refreshing={refreshing}
             disconnecting={false}
           />
         ) : intent ? (
-          <CtaButton intent={intent} onClick={() => fireAction(intent.action)} />
+          <CtaButton intent={intent} onClick={onCtaClick} />
         ) : null}
       </div>
     </div>
@@ -145,13 +111,12 @@ interface HeaderProps {
   readonly color: string;
   readonly info: ProviderInfo;
   readonly phase: string;
-  readonly stacked: boolean;
 }
 
-function TileHeader({ icon: Icon, color, info, phase, stacked }: HeaderProps) {
+function TileHeader({ icon: Icon, color, info, phase }: HeaderProps) {
   const dim = info.connection !== 'connected' && info.connection !== 'error' && phase === 'idle';
   return (
-    <div className={cn('flex items-center gap-2.5', stacked && 'flex-col gap-2')}>
+    <div className="flex flex-col items-center gap-2">
       <div
         aria-hidden
         className={cn(
@@ -165,7 +130,7 @@ function TileHeader({ icon: Icon, color, info, phase, stacked }: HeaderProps) {
       >
         <Icon size={18} strokeWidth={2} />
       </div>
-      <div className={cn('flex flex-col', stacked ? 'items-center' : 'items-start')}>
+      <div className="flex flex-col items-center">
         <span className="text-sm font-semibold lowercase">{info.label}</span>
         <span
           className="max-w-[160px] truncate text-2xs text-muted-foreground"
@@ -189,4 +154,25 @@ function PreActionCopy({ providerId, info }: { providerId: ProviderId; info: Pro
         : null;
   if (!action) return null;
   return <InfoBanner text={copyFor(providerId, action)} />;
+}
+
+interface InFlightPingProps {
+  readonly onClick: () => void;
+}
+
+// Compact "in flight" hint when the lifecycle runs in the background and
+// the modal is closed. Clicking it reopens the modal as a viewer over the
+// existing PTY (the runId in the slice stays stable across remounts).
+function InFlightPing({ onClick }: InFlightPingProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2 py-1 text-2xs text-primary transition-colors hover:bg-primary/10"
+    >
+      <Loader2 size={11} aria-hidden className="animate-spin" />
+      <span>View progress</span>
+      <ArrowRight size={10} aria-hidden />
+    </button>
+  );
 }

--- a/apps/desktop/src/features/providers/components/ProviderModalHost/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderModalHost/index.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+import { ProviderConnectModal } from '../ProviderConnectModal';
+
+export interface OpenProviderModalDetail {
+  readonly providerId: ProviderId;
+  readonly action: ProviderLifecycleAction;
+}
+
+// Implementation detail of openProviderModal() below. Not exported because
+// callers should use the helper, not dispatch raw CustomEvents.
+const OPEN_PROVIDER_MODAL_EVENT = 'goodboy:open-provider-modal';
+
+/**
+ * App-level mount point for the provider connect modal. Listens for an
+ * `OPEN_PROVIDER_MODAL_EVENT` CustomEvent so any surface can request the
+ * modal (the tile in ProvidersPanel, the chat AuthRequiredCallout, future
+ * onboarding cards) without prop-drilling state through the tree.
+ *
+ * Event detail: `{ providerId, action }`. Dispatch with
+ * `window.dispatchEvent(new CustomEvent(OPEN_PROVIDER_MODAL_EVENT,
+ *   { detail: { providerId, action } }))`.
+ */
+export function ProviderModalHost() {
+  const [open, setOpen] = useState<OpenProviderModalDetail | null>(null);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<OpenProviderModalDetail>).detail;
+      if (!detail) return;
+      setOpen(detail);
+    };
+    window.addEventListener(OPEN_PROVIDER_MODAL_EVENT, handler);
+    return () => window.removeEventListener(OPEN_PROVIDER_MODAL_EVENT, handler);
+  }, []);
+
+  const onClose = useCallback(() => setOpen(null), []);
+
+  return (
+    <ProviderConnectModal
+      providerId={open?.providerId ?? null}
+      initialAction={open?.action ?? 'install'}
+      onClose={onClose}
+    />
+  );
+}
+
+// Convenience dispatcher so callers do not have to remember the event name
+// or detail shape. Imported by the tile, the chat callout, and any other
+// surface that wants to summon the modal.
+export function openProviderModal(detail: OpenProviderModalDetail): void {
+  window.dispatchEvent(
+    new CustomEvent<OpenProviderModalDetail>(OPEN_PROVIDER_MODAL_EVENT, { detail }),
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProvidersPanel/index.tsx
@@ -45,7 +45,7 @@ export function ProvidersPanel() {
       {ordered.length === 0 ? (
         <p className="text-2xs text-muted-foreground">No providers configured</p>
       ) : (
-        <div className="grid grid-cols-3 gap-2.5">
+        <div className="grid grid-cols-2 gap-2.5">
           {ordered.map((p) => (
             <ProviderLifecycleTile key={p.id} info={p} />
           ))}
@@ -54,8 +54,8 @@ export function ProvidersPanel() {
       <div className="flex items-start gap-1.5 text-2xs text-muted-foreground">
         <Info size={11} aria-hidden className="mt-0.5 shrink-0" />
         <span>
-          Install and sign in straight from the app. Each step runs in an embedded terminal so you
-          never leave Goodboy.
+          Install and sign in straight from Goodboy. Every step runs in a roomy modal with the
+          embedded terminal, the per-provider playbook, and an escape hatch to your own shell.
         </span>
       </div>
     </div>

--- a/apps/desktop/src/features/providers/components/provider-brand.ts
+++ b/apps/desktop/src/features/providers/components/provider-brand.ts
@@ -1,0 +1,21 @@
+import { Code2, Gem, MousePointer2, Sparkles, type LucideIcon } from 'lucide-react';
+import type { ProviderId } from '@goodboy/types';
+
+// Single source of truth for provider iconography and accent colors. Both
+// the compact tile and the connect modal pull from here, so a tweak to e.g.
+// the gemini hue cascades through every surface that names a provider.
+export interface ProviderBrand {
+  readonly icon: LucideIcon;
+  readonly cssVar: string;
+}
+
+export const PROVIDER_BRAND: Record<ProviderId, ProviderBrand> = {
+  anthropic: { icon: Sparkles, cssVar: '--color-provider-anthropic' },
+  cursor: { icon: MousePointer2, cssVar: '--color-provider-cursor' },
+  codex: { icon: Code2, cssVar: '--color-provider-codex' },
+  gemini: { icon: Gem, cssVar: '--color-provider-gemini' },
+};
+
+export function brandColor(providerId: ProviderId): string {
+  return `var(${PROVIDER_BRAND[providerId].cssVar})`;
+}

--- a/apps/desktop/src/features/providers/external-terminal.ts
+++ b/apps/desktop/src/features/providers/external-terminal.ts
@@ -1,0 +1,10 @@
+import { invoke } from '@tauri-apps/api/core';
+
+// Thin TS binding for the optional "open command in OS terminal" escape
+// hatch. Primary install/connect flow runs inside Goodboy via provider_
+// lifecycle; this is offered in the modal for users who prefer their own
+// shell or who hit something the embedded PTY cannot handle (sudo prompts
+// on systems without TouchID, etc).
+export async function openCommandInExternalTerminal(command: string): Promise<void> {
+  await invoke('open_command_in_external_terminal', { command });
+}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { Button, Dialog, Divider, Input, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
@@ -51,8 +52,11 @@ export function SessionSettingsDialog({
   const setSessionBudget = useAppStore((s) => s.setSessionBudget);
   const setSessionConfig = useAppStore((s) => s.setSessionConfig);
   const renameTask = useAppStore((s) => s.renameTask);
-  const connectedProviderIds = useAppStore((s) =>
-    s.providers.filter((p) => p.connection === 'connected').map((p) => p.id),
+  // useShallow because the selector derives a fresh array each call; without
+  // shallow comparison useSyncExternalStore detects a snapshot mismatch on
+  // every render and React 19 bails into an infinite render loop.
+  const connectedProviderIds = useAppStore(
+    useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
   const deleteTask = useAppStore((s) => s.deleteTask);
   const changeSessionBranch = useAppStore((s) => s.changeSessionBranch);

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import type { ProviderId, VerbosityLevel, WorkspaceId } from '@goodboy/types';
 import { Button, Dialog, cn } from '@goodboy/ui';
 import {
@@ -67,8 +68,11 @@ export function WorkspaceSettingsDialog({
   const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
   const storeSetWorkspaceOverrides = useAppStore((s) => s.setWorkspaceOverrides);
 
-  const connectedProviderIds = useAppStore((s) =>
-    s.providers.filter((p) => p.connection === 'connected').map((p) => p.id),
+  // useShallow because the selector derives a fresh array each call; without
+  // shallow comparison useSyncExternalStore detects a snapshot mismatch on
+  // every render and React 19 bails into an infinite render loop.
+  const connectedProviderIds = useAppStore(
+    useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
 
   const [active, setActive] = useState<Section>('general');
@@ -517,7 +521,10 @@ function DefaultProviderPicker({
 /* ──────────────────────────────────────────────────────────────────── */
 
 function IntegrationsPanel({ workspaceId }: { workspaceId: WorkspaceId }) {
-  const integrations = useAppStore((s) => s.workspaceIntegrations[workspaceId] ?? []);
+  // Same snapshot-stability fix as connectedProviderIds: `?? []` returns a
+  // fresh array on every missing-key lookup, which causes useSyncExternalStore
+  // to loop.
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
   const linear = integrations.find((i) => i.provider === 'linear') ?? null;
   const [linearOpen, setLinearOpen] = useState(false);
 

--- a/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
+++ b/apps/desktop/src/shared/hooks/useProviderRefreshOnFocus/index.ts
@@ -1,18 +1,30 @@
 import { useEffect } from 'react';
 import { useAppStore } from '../../../store/store';
 
+// Two layers of throttling. DEBOUNCE collapses a focus + visibilitychange
+// burst from the same window-restore into one call. TTL guards against the
+// real cost: a refresh re-runs detection + auth on all four providers, which
+// even after the Rust-side async + spawn_blocking rework still costs a few
+// hundred ms of subprocess wall time. No point repeating that every time the
+// user alt-tabs out and back in.
 const DEBOUNCE_MS = 500;
+const REFRESH_TTL_MS = 60_000;
 
 /**
  * Re-detects CLI presence + auth state when the app regains focus or its tab
  * becomes visible again. This is the coherence backstop for changes made
  * outside the app (e.g. user runs `npm i -g @anthropic-ai/claude-code` in
- * their own shell, or `claude /logout` in another terminal). On focus the
- * provider list resyncs with ground truth.
+ * their own shell, or `claude /logout` in another terminal).
  *
- * Lifecycle-driven refreshes (after the embedded install/login/logout flow)
- * already happen via the `provider-lifecycle-exit` event, this hook covers
- * the gap when state changes elsewhere on the machine.
+ * Three guards keep this from being a perf footgun:
+ *  - DEBOUNCE_MS: collapse focus + visibilitychange firing back-to-back.
+ *  - REFRESH_TTL_MS: skip if we refreshed recently. Manual refresh button +
+ *    lifecycle-exit event handle the in-app cases; this only catches
+ *    external machine changes, which are rare.
+ *  - Skip when any provider lifecycle is in flight: we already update on
+ *    PTY exit with fresh ground truth, and the running PTY itself holds
+ *    auth state in a transient form (entered codes, half-typed passwords).
+ *    A refresh mid-run could race against the exit handler's atomic update.
  */
 export function useProviderRefreshOnFocus(): void {
   const refreshProviders = useAppStore((s) => s.refreshProviders);
@@ -22,15 +34,22 @@ export function useProviderRefreshOnFocus(): void {
     let lastRunAt = 0;
 
     const schedule = (): void => {
-      const now = Date.now();
-      const elapsed = now - lastRunAt;
-      const wait = elapsed >= DEBOUNCE_MS ? 0 : DEBOUNCE_MS - elapsed;
       if (timer !== null) window.clearTimeout(timer);
       timer = window.setTimeout(() => {
-        lastRunAt = Date.now();
         timer = null;
+        const elapsed = Date.now() - lastRunAt;
+        if (elapsed < REFRESH_TTL_MS) return;
+
+        const lifecycle = useAppStore.getState().providerLifecycle;
+        const inFlight = Object.values(lifecycle).some(
+          (l) =>
+            l.phase === 'installing' || l.phase === 'connecting' || l.phase === 'disconnecting',
+        );
+        if (inFlight) return;
+
+        lastRunAt = Date.now();
         void refreshProviders();
-      }, wait);
+      }, DEBOUNCE_MS);
     };
 
     const onFocus = (): void => schedule();


### PR DESCRIPTION
## Summary

Four user-visible changes routed through the same refactor:

- **Refocus no longer freezes the app.** `check_provider_auth` was sync, running multi-second subprocess probes on the main IPC thread; converted to `async` with `spawn_blocking`, timeouts tightened 5s → 2s, gemini subcommand cascade dropped in favor of reading `~/.gemini/oauth_creds.json` directly (the actual ground truth). Focus-refresh hook gates on a 60s TTL + skips while any lifecycle is in flight.
- **Install / connect moved out of the cramped inline tile into a roomy modal** (Dialog `xl`, ~896px wide, embedded terminal at `h-72`). Tiles stay compact in every state. Closing the modal mid-run leaves the PTY running and surfaces a "View progress" chip so the user can reopen the same live terminal.
- **Per-provider playbook in the modal sidebar.** Three sections (needed subscription, what each step does, troubleshooting) for install and login per provider. Gemini entries call out the interactive menu and creds-file behavior explicitly so the flow stops looking "broken" when nothing happens after install.
- **Escape hatch buttons under the terminal:** "Copy command" + "Run in my terminal" (AppleScript on macOS, gnome-terminal/konsole/xterm probe on Linux, `cmd /k` on Windows). Restored as an explicit opt-in, not the primary flow.

Side moves: chat `AuthRequiredCallout` now opens the modal instead of firing a hidden login. Provider-brand registry extracted so tile + modal share icon and accent. Providers grid switched from `grid-cols-3` (4 providers leaving one orphan) to `grid-cols-2` (clean 2x2).

## Test plan

- [ ] **Perf**: cold start, switch to browser, switch back. UI responsive within 1s (was 20s+ before).
- [ ] **Modal open**: click Install on a missing provider tile, modal opens with guide + command preview + embedded terminal.
- [ ] **Auto-advance**: install completes, modal updates to sign-in step, primary CTA becomes "Sign in".
- [ ] **Close during run**: close modal mid-install, tile shows "View progress" chip, click → modal reopens with live terminal + replayed output.
- [ ] **Cancel from tile**: while install in flight, click tile's Cancel CTA, PTY killed.
- [ ] **Escape hatch — copy**: click Copy command, clipboard contains the exact command.
- [ ] **Escape hatch — external terminal**: click Run in my terminal, OS terminal opens with command preloaded (macOS / Linux / Windows).
- [ ] **Chat callout**: trigger AuthRequiredCallout in chat, click Connect now → modal opens with sign-in flow.
- [ ] **Disconnect**: connected tile shows two-tap confirm inline (unchanged behavior).
- [ ] **Gemini end-to-end**: install gemini, modal completes, sign-in opens interactive menu in embedded terminal, user picks Google flow, browser handoff, comes back to modal → connected.
- [ ] **All four providers**: smoke test install + login + logout for anthropic, cursor, codex, gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)