### PR TITLE
Routing fallback on disconnect + opus-4-8 premium roles

### DIFF
--- a/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
+++ b/apps/desktop/src/features/chat/components/RoutingIndicator/index.tsx
@@ -52,15 +52,21 @@ export function RoutingIndicator({
   // Only render when there's actually something the user needs to know about
   //, fallbacks or budget warnings. The vanilla "claude / claude-opus-4-7"
   // routing label was redundant with the chips below the input.
-  if (decision.reason !== 'fallback-budget' || !decision.fallbackFrom) return null;
+  const isFallback =
+    decision.reason === 'fallback-budget' || decision.reason === 'fallback-disconnected';
+  if (!isFallback || !decision.fallbackFrom) return null;
 
   const label = decision.selectedProvider === 'anthropic' ? 'claude' : decision.selectedProvider;
+  const fromLabel = decision.fallbackFrom === 'anthropic' ? 'claude' : decision.fallbackFrom;
+  const cause =
+    decision.reason === 'fallback-budget'
+      ? `budget exceeded for ${fromLabel}`
+      : `${fromLabel} disconnected`;
 
   return (
     <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
       <span className="text-warning">
-        ⚠ fallback: {label} / {decision.selectedModel} (budget exceeded for{' '}
-        {decision.fallbackFrom === 'anthropic' ? 'claude' : decision.fallbackFrom})
+        ⚠ fallback: {label} / {decision.selectedModel} ({cause})
       </span>
     </div>
   );

--- a/packages/core/src/budget/__tests__/router.test.ts
+++ b/packages/core/src/budget/__tests__/router.test.ts
@@ -112,4 +112,46 @@ describe('resolveProvider', () => {
     expect(decision.fallbackUsed).toBe(false);
     expect(decision.fallbackFrom).toBeUndefined();
   });
+
+  it('preferred disconnected but a connected provider is within budget → fallback-disconnected', async () => {
+    const input = makeInput({
+      connectedProviders: ['cursor'],
+      budgetChecker: { checkProviderBudget: vi.fn().mockResolvedValue(notExceeded()) },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('cursor');
+    expect(decision.reason).toBe('fallback-disconnected');
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.fallbackFrom).toBe('anthropic');
+  });
+
+  it('preferred disconnected with no connected provider → returns preferred for the auth flow', async () => {
+    const input = makeInput({
+      connectedProviders: [],
+      budgetChecker: { checkProviderBudget: vi.fn().mockResolvedValue(notExceeded()) },
+    });
+    const decision = await resolveProvider(input);
+
+    // Handed back unchanged so the caller's auth-required flow can prompt a
+    // reconnect; not 'all-exceeded' (which would show a budget message).
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+    expect(decision.fallbackUsed).toBe(false);
+  });
+
+  it('preferred disconnected and the only fallback is over budget → returns preferred, not all-exceeded', async () => {
+    const checkMock = vi.fn(async (provider: string) =>
+      provider === 'cursor' ? exceeded() : notExceeded(),
+    );
+    const input = makeInput({
+      connectedProviders: ['cursor'],
+      budgetChecker: { checkProviderBudget: checkMock },
+    });
+    const decision = await resolveProvider(input);
+
+    expect(decision.selectedProvider).toBe('anthropic');
+    expect(decision.reason).toBe('preferred');
+    expect(decision.fallbackUsed).toBe(false);
+  });
 });

--- a/packages/core/src/budget/router.ts
+++ b/packages/core/src/budget/router.ts
@@ -44,9 +44,11 @@ export async function resolveProvider(input: ResolveProviderInput): Promise<Rout
       : (sessionPreference.defaultModel ?? getDefaultModel(preferredProvider));
 
   const preferredName = PROVIDER_ID_TO_NAME[preferredProvider];
+  const preferredConnected = connectedProviders.includes(preferredProvider);
   const preferredResult = await budgetChecker.checkProviderBudget(preferredName, 'monthly');
 
-  if (!preferredResult.exceeded) {
+  // Preferred is usable only when it's connected AND within budget.
+  if (preferredConnected && !preferredResult.exceeded) {
     return {
       selectedProvider: preferredProvider,
       selectedModel: preferredModel,
@@ -55,6 +57,10 @@ export async function resolveProvider(input: ResolveProviderInput): Promise<Rout
     };
   }
 
+  // Fall back to a connected provider within budget. Disconnection of the
+  // preferred provider triggers a fallback too, not just budget: a
+  // disconnected-but-under-budget preferred used to be selected anyway and the
+  // turn then failed downstream.
   for (const candidate of connectedProviders) {
     if (candidate === preferredProvider) continue;
 
@@ -65,11 +71,25 @@ export async function resolveProvider(input: ResolveProviderInput): Promise<Rout
       return {
         selectedProvider: candidate,
         selectedModel: getDefaultModel(candidate),
-        reason: 'fallback-budget',
+        // Disconnection takes precedence over budget as the labeled cause.
+        reason: preferredConnected ? 'fallback-budget' : 'fallback-disconnected',
         fallbackUsed: true,
         fallbackFrom: preferredProvider,
       };
     }
+  }
+
+  // No usable fallback. If the preferred is only disconnected (not over budget),
+  // hand it back unchanged so the caller's auth-required flow can prompt a
+  // reconnect; reporting 'all-exceeded' here would show a misleading budget
+  // message.
+  if (!preferredConnected) {
+    return {
+      selectedProvider: preferredProvider,
+      selectedModel: preferredModel,
+      reason: useOverride ? 'override' : 'preferred',
+      fallbackUsed: false,
+    };
   }
 
   return {

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -24,13 +24,13 @@ export const ROLE_DEFAULTS: Readonly<Record<AgentRole, RoleDefaults>> = {
   },
   planner: {
     provider: 'anthropic',
-    model: 'claude-opus-4-7',
+    model: 'claude-opus-4-8',
     effort: 'high',
     description: 'design the change; produce an ordered plan',
   },
   architect: {
     provider: 'anthropic',
-    model: 'claude-opus-4-7',
+    model: 'claude-opus-4-8',
     effort: 'high',
     description: 'propose technical approach, modules, data flow, migrations',
   },

--- a/packages/types/src/budget.ts
+++ b/packages/types/src/budget.ts
@@ -25,7 +25,12 @@ export type BudgetCheckResult = Readonly<{
   exceeded: boolean;
 }>;
 
-export type RoutingReason = 'preferred' | 'fallback-budget' | 'all-exceeded' | 'override';
+export type RoutingReason =
+  | 'preferred'
+  | 'fallback-budget'
+  | 'fallback-disconnected'
+  | 'all-exceeded'
+  | 'override';
 
 export type RoutingDecision = Readonly<{
   selectedProvider: ProviderId;


### PR DESCRIPTION
Follow-up to #649, closing the two deferred items.

## Summary

- **fix(types + core)** provider routing now falls back to a connected provider when the preferred one is **disconnected**, not only when it's over budget. A disconnected-but-under-budget preferred used to be selected anyway and the turn failed downstream. New `fallback-disconnected` routing reason. When there is no usable fallback, the disconnected preferred is returned unchanged so the existing auth-required callout can prompt a reconnect (instead of a misleading budget message).
- **fix(desktop)** the routing indicator renders the disconnect fallback with a clear cause ("<provider> disconnected") rather than a budget message.
- **feat(core)** the `planner` and `architect` roles default to `claude-opus-4-8` (the new default turn model). Other roles keep their sonnet/haiku tiers.

opus-4-8 default + standard Opus pricing (15/75/1.5) were shipped in #649 and confirmed as-is.

## Test plan

- [x] `pnpm turbo run test` — core 642 (+3 router disconnect tests), desktop 774
- [x] `pnpm typecheck` 5/5, `pnpm build`, `pnpm knip`, `pnpm audit --prod` — all clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)