### PR TITLE
feat: v0.1 release readiness (pipeline + signing + auto-updater)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,59 @@
+name: homebrew
+
+# Bump the cask in akhayam99/homebrew-tap when a release is published.
+# Requires the HOMEBREW_TAP_TOKEN secret (fine-grained PAT, contents:write on
+# the tap repo). See docs/release.md.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  bump:
+    name: bump cask
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: checkout (template)
+        uses: actions/checkout@v4
+
+      - name: resolve version and sha256
+        id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#v}"
+          asset="Goodboy_${version}_universal.dmg"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "$asset" --dir .
+          sha="$(shasum -a 256 "$asset" | cut -d' ' -f1)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: render cask
+        run: |
+          sed -e "s/:VERSION/\"${{ steps.meta.outputs.version }}\"/" \
+              -e "s/:SHA256/\"${{ steps.meta.outputs.sha256 }}\"/" \
+              packaging/goodboy.rb > goodboy.rb
+
+      - name: checkout tap
+        uses: actions/checkout@v4
+        with:
+          repository: akhayam99/homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap
+
+      - name: commit cask
+        working-directory: tap
+        run: |
+          mkdir -p Casks
+          cp ../goodboy.rb Casks/goodboy.rb
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "cask already up to date"
+            exit 0
+          fi
+          git add Casks/goodboy.rb
+          git commit -m "goodboy ${{ steps.meta.outputs.version }}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Build the macOS universal (.dmg) on tag push and publish it as a draft
+# GitHub Release. Signing + notarization run automatically when the APPLE_*
+# secrets are present; if they are unset the build still produces an unsigned
+# .dmg. See docs/release.md.
+
+permissions:
+  contents: write
+
+jobs:
+  macos:
+    name: build universal dmg
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.toml') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build workspace deps
+        run: pnpm turbo run build --filter=@goodboy/desktop^...
+
+      - name: build, release (universal)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          projectPath: apps/desktop
+          tagName: ${{ github.ref_name }}
+          releaseName: "Goodboy ${{ github.ref_name }}"
+          releaseDraft: true
+          prerelease: false
+          args: --target universal-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,11 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Updater signing: tauri-action signs the update artifacts and emits
+          # latest.json (attached to the release) so the in-app updater can
+          # verify and apply new versions.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 # Build the macOS universal (.dmg) on tag push and publish it as a draft
 # GitHub Release. Signing + notarization run automatically when the APPLE_*
@@ -17,7 +17,10 @@ jobs:
   macos:
     name: build universal dmg
     runs-on: macos-14
-    timeout-minutes: 45
+    # Apple notarization can be slow, especially the first submission from a new
+    # Developer ID account. Keep generous headroom so the runner does not get
+    # killed mid-notarization.
+    timeout-minutes: 90
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -66,7 +69,7 @@ jobs:
         with:
           projectPath: apps/desktop
           tagName: ${{ github.ref_name }}
-          releaseName: "Goodboy ${{ github.ref_name }}"
+          releaseName: 'Goodboy ${{ github.ref_name }}'
           releaseDraft: true
           prerelease: false
           args: --target universal-apple-darwin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,18 @@ Never bypass hooks (`--no-verify`, `--no-gpg-sign`, etc.).
 
 ---
 
+## Releasing
+
+When asked to cut a release ("do a release", "ship vX.Y.Z"), follow the runbook
+in [docs/release.md](./docs/release.md). Do not improvise the steps.
+
+In short: bump the version in all four manifests, validate with a throwaway
+`-rc.N` tag, then tag the real `vX.Y.Z`. A tag push builds a signed + notarized
+macOS universal `.dmg` and creates a draft GitHub Release; publishing it bumps
+the Homebrew cask. Signing runs under the personal Apple team (never Serenis).
+
+---
+
 ## Code rules
 
 - TypeScript strict mode.

--- a/README.md
+++ b/README.md
@@ -56,28 +56,22 @@ One connected CLI is enough to start. Full guide:
 
 ## Install
 
-macOS (Intel and Apple Silicon, one universal build).
+macOS (Intel and Apple Silicon, one universal build). Signed and notarized by
+Apple, so it opens with no security prompts.
 
-**Homebrew (recommended).** Installs cleanly, no security prompt:
+**Homebrew (recommended).**
 
 ```bash
 brew install --cask akhayam99/tap/goodboy
 ```
 
 **Direct download.** Grab the `.dmg` from the
-[latest release](https://github.com/akhayam99/goodboy/releases/latest) and
-drag Goodboy to Applications.
+[latest release](https://github.com/akhayam99/goodboy/releases/latest) and drag
+Goodboy to Applications.
 
-> v0.1 is not yet notarized by Apple, so a direct-download `.dmg` triggers a
-> Gatekeeper prompt ("Apple could not verify..."). One-time fix after copying
-> the app to Applications:
->
-> ```bash
-> xattr -dr com.apple.quarantine /Applications/Goodboy.app
-> ```
->
-> Or: System Settings, Privacy and Security, then "Open Anyway". The Homebrew
-> install above avoids this entirely.
+**Updates are automatic.** When a new release ships, a "Restart to update"
+control appears in the status bar and next to the sidebar logo. One click
+downloads it and relaunches; Homebrew users can also `brew upgrade --cask goodboy`.
 
 ## Run it
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,31 @@ Bring your own subscription. The app drives the official CLIs locally, on
 One connected CLI is enough to start. Full guide:
 [docs/providers.md](./docs/providers.md).
 
+## Install
+
+macOS (Intel and Apple Silicon, one universal build).
+
+**Homebrew (recommended).** Installs cleanly, no security prompt:
+
+```bash
+brew install --cask akhayam99/tap/goodboy
+```
+
+**Direct download.** Grab the `.dmg` from the
+[latest release](https://github.com/akhayam99/goodboy/releases/latest) and
+drag Goodboy to Applications.
+
+> v0.1 is not yet notarized by Apple, so a direct-download `.dmg` triggers a
+> Gatekeeper prompt ("Apple could not verify..."). One-time fix after copying
+> the app to Applications:
+>
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/Goodboy.app
+> ```
+>
+> Or: System Settings, Privacy and Security, then "Open Anyway". The Homebrew
+> install above avoids this entirely.
+
 ## Run it
 
 ```bash

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,8 @@
     "@goodboy/ui": "workspace:*",
     "@tauri-apps/api": "^2.1.1",
     "@tauri-apps/plugin-dialog": "^2.2.0",
+    "@tauri-apps/plugin-process": "^2.2.0",
+    "@tauri-apps/plugin-updater": "^2.7.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.14.0",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,6 +29,8 @@ regex = "1"
 sha2 = "0.10"
 base64 = "0.22"
 tauri-plugin-dialog = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 libc = "0.2"
 portable-pty = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.0.0"
+version = "0.1.0"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": ["main"],
-  "permissions": ["core:default", "dialog:default"]
+  "permissions": ["core:default", "dialog:default", "updater:default", "process:default"]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ pub fn run() {
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
+    .plugin(tauri_plugin_process::init())
     .manage(database)
     .manage(provider_state)
     .manage(cursor_state)
@@ -53,6 +54,10 @@ pub fn run() {
     .manage(provider_lifecycle_registry)
     .manage(linear_token_cache)
     .setup(|app| {
+      #[cfg(desktop)]
+      app
+        .handle()
+        .plugin(tauri_plugin_updater::Builder::new().build())?;
       if cfg!(debug_assertions) {
         app.handle().plugin(
           tauri_plugin_log::Builder::default()

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -28,6 +28,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": "all",
     "icon": [
       "icons/32x32.png",
@@ -38,6 +39,12 @@
     ],
     "android": {
       "debugApplicationIdSuffix": ".debug"
+    }
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": ["https://github.com/akhayam99/goodboy/releases/latest/download/latest.json"],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDg1QkJCNTBFMjJFRTFBM0YKUldRL0d1NGlEclc3aFNOMTg4NGVHZTFWNXdzSi9aeHpQNi83aE91VGVNR0R6VEovTFMyNXdHQkUK"
     }
   }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -57,6 +57,7 @@ function writePersistedContextOpen(id: SessionId, open: boolean): void {
 
 export function App() {
   const hydrate = useAppStore((s) => s.hydrate);
+  const checkForUpdates = useAppStore((s) => s.checkForUpdates);
   const hydrated = useAppStore((s) => s.hydrated);
   const bootPhase = useAppStore((s) => s.bootPhase);
   const error = useAppStore((s) => s.error);
@@ -86,7 +87,9 @@ export function App() {
   useEffect(() => {
     void hydrate();
     void refreshPricingTable();
-  }, [hydrate]);
+    // Only meaningful in a packaged build; in dev there is no matching release.
+    if (import.meta.env.PROD) void checkForUpdates();
+  }, [hydrate, checkForUpdates]);
 
   useGithubPolling();
   useProviderRefreshOnFocus();

--- a/apps/desktop/src/app/components/StatusBar/index.tsx
+++ b/apps/desktop/src/app/components/StatusBar/index.tsx
@@ -1,6 +1,7 @@
 import { CircleHelp } from 'lucide-react';
 import { useCurrentSession, useCurrentWorkspace } from '../../../store';
 import { TelemetryPill } from '../../../features/providers/components/TelemetryPill';
+import { UpdateIndicator } from '../../../features/updater/components/UpdateIndicator';
 
 interface StatusBarProps {
   onFocusWorkspaces?: () => void;
@@ -27,6 +28,7 @@ export function StatusBar({ onFocusWorkspaces }: StatusBarProps) {
         <span className="text-muted-foreground">{sessionStateLabel}</span>
       </div>
       <div className="flex shrink-0 items-center gap-3">
+        <UpdateIndicator variant="bar" />
         <TelemetryPill />
         <span className="inline-flex items-center gap-1" title="open settings">
           <CircleHelp size={11} aria-hidden />

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
@@ -1,0 +1,55 @@
+import { useShallow } from 'zustand/react/shallow';
+import { ArrowUpCircle, Loader2 } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import { useAppStore } from '../../../../store';
+
+type Props = { variant: 'bar' | 'pip' };
+
+// Non-invasive "update ready" affordance, shown only when a newer release has
+// been found. Click downloads + installs + relaunches. Rendered both in the
+// status bar (bar) and next to the sidebar logo (pip), à la VS Code / Claude.
+export function UpdateIndicator({ variant }: Props) {
+  const { status, version, installUpdate } = useAppStore(
+    useShallow((s) => ({
+      status: s.updaterStatus,
+      version: s.updateVersion,
+      installUpdate: s.installUpdate,
+    })),
+  );
+
+  if (status !== 'available' && status !== 'downloading') return null;
+
+  const downloading = status === 'downloading';
+  const label = downloading
+    ? 'Downloading update, the app will restart'
+    : `Restart to update${version ? ` to ${version}` : ''}`;
+  const Icon = downloading ? Loader2 : ArrowUpCircle;
+
+  if (variant === 'pip') {
+    return (
+      <button
+        type="button"
+        onClick={() => void installUpdate()}
+        disabled={downloading}
+        title={label}
+        aria-label={label}
+        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-primary transition-colors hover:text-primary/70 disabled:opacity-60"
+      >
+        <Icon size={13} className={cn(downloading && 'animate-spin')} aria-hidden />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => void installUpdate()}
+      disabled={downloading}
+      title={label}
+      className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-primary transition-colors hover:bg-primary/10 disabled:opacity-60"
+    >
+      <Icon size={11} className={cn(downloading && 'animate-spin')} aria-hidden />
+      <span>{downloading ? 'Updating…' : 'Restart to update'}</span>
+    </button>
+  );
+}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -34,6 +34,7 @@ import { NotificationCenter } from '../../../../features/notifications/component
 import { PricingDialog } from '../../../providers/components/PricingDialog';
 import { MAX_WORKSPACES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { DogMascot } from '../../../../shared/components/DogMascot';
+import { UpdateIndicator } from '../../../updater/components/UpdateIndicator';
 import { OnboardingChip } from '../../../onboarding/OnboardingCard';
 import type {
   Agent,
@@ -538,6 +539,7 @@ function SidebarLogo() {
     <span className="flex items-center gap-1.5">
       <DogMascot size={16} className="shrink-0 text-foreground" />
       <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy</span>
+      <UpdateIndicator variant="pip" />
     </span>
   );
 }

--- a/apps/desktop/src/store/slices/updater/checkForUpdates.ts
+++ b/apps/desktop/src/store/slices/updater/checkForUpdates.ts
@@ -1,0 +1,26 @@
+import { check } from '@tauri-apps/plugin-updater';
+import { formatError } from '../../../shared/lib/errors';
+import { setPendingUpdate } from './pendingUpdate';
+import type { GetFn, SetFn } from './types';
+
+// Asks the configured endpoint whether a newer release exists. Stores the live
+// Update handle in module scope and reflects the outcome in the store so the
+// status bar and sidebar can surface it.
+export function checkForUpdates(set: SetFn, _get: GetFn) {
+  return async (): Promise<void> => {
+    set({ updaterStatus: 'checking', updateError: null });
+    try {
+      const update = await check();
+      if (update) {
+        setPendingUpdate(update);
+        set({ updaterStatus: 'available', updateVersion: update.version });
+      } else {
+        setPendingUpdate(null);
+        set({ updaterStatus: 'uptodate', updateVersion: null });
+      }
+    } catch (err) {
+      setPendingUpdate(null);
+      set({ updaterStatus: 'error', updateError: formatError(err) });
+    }
+  };
+}

--- a/apps/desktop/src/store/slices/updater/index.test.ts
+++ b/apps/desktop/src/store/slices/updater/index.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { checkMock, relaunchMock } = vi.hoisted(() => ({
+  checkMock: vi.fn(),
+  relaunchMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('@tauri-apps/plugin-updater', () => ({ check: checkMock }));
+vi.mock('@tauri-apps/plugin-process', () => ({ relaunch: relaunchMock }));
+
+import { createUpdaterSlice } from './index';
+import { initialUpdaterState, type UpdaterState } from './state';
+
+function harness() {
+  let state: UpdaterState = { ...initialUpdaterState };
+  const set = (p: Partial<UpdaterState> | ((s: UpdaterState) => Partial<UpdaterState>)) => {
+    state = { ...state, ...(typeof p === 'function' ? p(state) : p) };
+  };
+  const slice = createUpdaterSlice(set as never, (() => state) as never);
+  return { slice, getState: () => state };
+}
+
+describe('updater slice', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('marks uptodate when no update is available', async () => {
+    checkMock.mockResolvedValue(null);
+    const { slice, getState } = harness();
+    await slice.checkForUpdates();
+    expect(getState().updaterStatus).toBe('uptodate');
+    expect(getState().updateVersion).toBeNull();
+  });
+
+  it('marks available with the version when an update exists', async () => {
+    checkMock.mockResolvedValue({ version: '0.2.0', downloadAndInstall: vi.fn() });
+    const { slice, getState } = harness();
+    await slice.checkForUpdates();
+    expect(getState().updaterStatus).toBe('available');
+    expect(getState().updateVersion).toBe('0.2.0');
+  });
+
+  it('records an error when the check fails', async () => {
+    checkMock.mockRejectedValue(new Error('network down'));
+    const { slice, getState } = harness();
+    await slice.checkForUpdates();
+    expect(getState().updaterStatus).toBe('error');
+    expect(getState().updateError).toBe('network down');
+  });
+
+  it('installs and relaunches when an update is pending', async () => {
+    const downloadAndInstall = vi.fn(async () => undefined);
+    checkMock.mockResolvedValue({ version: '0.2.0', downloadAndInstall });
+    const { slice, getState } = harness();
+    await slice.checkForUpdates();
+    await slice.installUpdate();
+    expect(downloadAndInstall).toHaveBeenCalled();
+    expect(relaunchMock).toHaveBeenCalled();
+    expect(getState().updaterStatus).toBe('downloading');
+  });
+});

--- a/apps/desktop/src/store/slices/updater/index.ts
+++ b/apps/desktop/src/store/slices/updater/index.ts
@@ -1,0 +1,10 @@
+import { checkForUpdates } from './checkForUpdates';
+import { installUpdate } from './installUpdate';
+import type { GetFn, SetFn } from './types';
+
+export function createUpdaterSlice(set: SetFn, get: GetFn) {
+  return {
+    checkForUpdates: checkForUpdates(set, get),
+    installUpdate: installUpdate(set, get),
+  };
+}

--- a/apps/desktop/src/store/slices/updater/installUpdate.ts
+++ b/apps/desktop/src/store/slices/updater/installUpdate.ts
@@ -1,0 +1,20 @@
+import { relaunch } from '@tauri-apps/plugin-process';
+import { formatError } from '../../../shared/lib/errors';
+import { getPendingUpdate } from './pendingUpdate';
+import type { GetFn, SetFn } from './types';
+
+// Downloads + installs the pending update, then relaunches into the new
+// version. On success the process is replaced, so nothing runs after relaunch.
+export function installUpdate(set: SetFn, _get: GetFn) {
+  return async (): Promise<void> => {
+    const update = getPendingUpdate();
+    if (!update) return;
+    set({ updaterStatus: 'downloading', updateError: null });
+    try {
+      await update.downloadAndInstall();
+      await relaunch();
+    } catch (err) {
+      set({ updaterStatus: 'error', updateError: formatError(err) });
+    }
+  };
+}

--- a/apps/desktop/src/store/slices/updater/pendingUpdate.ts
+++ b/apps/desktop/src/store/slices/updater/pendingUpdate.ts
@@ -1,0 +1,14 @@
+import type { Update } from '@tauri-apps/plugin-updater';
+
+// The Update handle returned by `check()` carries the methods to download and
+// install. It is a live object, not serializable state, so it lives here in
+// module scope instead of in the store.
+let pending: Update | null = null;
+
+export function setPendingUpdate(update: Update | null): void {
+  pending = update;
+}
+
+export function getPendingUpdate(): Update | null {
+  return pending;
+}

--- a/apps/desktop/src/store/slices/updater/state.ts
+++ b/apps/desktop/src/store/slices/updater/state.ts
@@ -1,0 +1,19 @@
+export type UpdaterStatus =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'uptodate'
+  | 'error';
+
+export interface UpdaterState {
+  readonly updaterStatus: UpdaterStatus;
+  readonly updateVersion: string | null;
+  readonly updateError: string | null;
+}
+
+export const initialUpdaterState: UpdaterState = {
+  updaterStatus: 'idle',
+  updateVersion: null,
+  updateError: null,
+};

--- a/apps/desktop/src/store/slices/updater/types.ts
+++ b/apps/desktop/src/store/slices/updater/types.ts
@@ -1,0 +1,1 @@
+export type { SetFn, GetFn } from '../../slice-types';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -106,6 +106,8 @@ import { createWorkspacesSlice } from './slices/workspaces';
 import { createTurnSlice } from './slices/turn';
 import { createWorktreesSlice } from './slices/worktrees';
 import { createBootSlice } from './slices/boot';
+import { createUpdaterSlice } from './slices/updater';
+import { initialUpdaterState, type UpdaterState } from './slices/updater/state';
 import type { LinearViewer } from '../features/integrations/linear/client';
 
 export type BootPhase =
@@ -147,7 +149,7 @@ export type SessionNudge =
 import type { ProviderSpendEntry } from './slices/budget';
 export type { ProviderSpendEntry };
 
-export interface AppState {
+export interface AppState extends UpdaterState {
   readonly workspaces: ReadonlyArray<Workspace>;
   readonly workspaceIntegrations: Readonly<
     Record<WorkspaceId, ReadonlyArray<WorkspaceIntegration>>
@@ -303,6 +305,8 @@ export interface SummarizerSessionStatus {
 
 export interface AppActions {
   hydrate(): Promise<void>;
+  checkForUpdates(): Promise<void>;
+  installUpdate(): Promise<void>;
   setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
   setCurrentSession(id: SessionId | null): Promise<void>;
   refreshSessions(workspaceId: WorkspaceId): Promise<void>;
@@ -542,6 +546,7 @@ export interface AppActions {
 export type AppStore = AppState & AppActions;
 
 export const initialState: AppState = {
+  ...initialUpdaterState,
   workspaces: [],
   workspaceIntegrations: {},
   sessionExternalTasks: {},
@@ -645,6 +650,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createTurnSlice(set, get),
   ...createWorktreesSlice(set, get),
   ...createBootSlice(set, get),
+  ...createUpdaterSlice(set, get),
 }));
 
 export function useResolvedSettings(sessionId: SessionId | null): ResolvedSettings {

--- a/docs/release.md
+++ b/docs/release.md
@@ -93,6 +93,25 @@ Certificates", right-click the Developer ID cert, Export), then
 `base64 -i cert.p12 | gh secret set APPLE_CERTIFICATE --repo akhayam99/goodboy`
 and update `APPLE_CERTIFICATE_PASSWORD`.
 
+## Auto-update
+
+The app self-updates via `tauri-plugin-updater`. On launch (packaged builds
+only) it checks `releases/latest/download/latest.json`; when a newer version is
+found, a "Restart to update" control shows in the status bar and next to the
+sidebar logo, and clicking it downloads, installs, and relaunches.
+
+Update artifacts are signed with a dedicated **updater keypair** (separate from
+Apple code-signing). The public key lives in `tauri.conf.json`
+(`plugins.updater.pubkey`); the private key + password are repo secrets
+`TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`.
+`tauri-action` uses them to sign the `.app.tar.gz` and emit `latest.json`,
+which it attaches to the release.
+
+Because `latest.json` points at `releases/latest`, only a **published**
+(non-draft) release is visible to clients. The updater config must ship inside a
+release for older versions to update to it: never remove the pubkey or the
+plugin without a migration plan, or installed apps lose the ability to update.
+
 ## Homebrew tap
 
 Public install channel: `brew install --cask akhayam99/tap/goodboy`. For an

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,60 +1,130 @@
 # Release runbook
 
-How to cut a Goodboy release. Target: macOS universal `.dmg` (Intel + Apple
-Silicon), published to GitHub Releases and Homebrew.
+Canonical guide for cutting a Goodboy release. **If you are asked to "do a
+release", "ship vX.Y.Z", or "cut a release", follow this file end to end.**
 
-## Cut a release
+Target: macOS **universal** `.dmg` (Intel + Apple Silicon), signed + notarized,
+published to GitHub Releases and Homebrew.
 
-1. Land everything for the release on `main`.
-2. Bump the version in all four places (they must match):
-   - `package.json`
-   - `apps/desktop/package.json`
-   - `apps/desktop/src-tauri/tauri.conf.json` (`version`)
-   - `apps/desktop/src-tauri/Cargo.toml` (`package.version`)
-3. Tag and push:
-   ```bash
-   git tag v0.1.0
-   git push origin v0.1.0
-   ```
-4. The `release` workflow builds the universal `.dmg` and creates a **draft**
-   GitHub Release. Review it, write the notes, then publish.
-5. Publishing the release triggers the Homebrew cask bump (once the tap is
-   wired, see below).
+## How it works
 
-The tag is the source of truth for the release name. The version inside the
-build comes from `tauri.conf.json`, so keep step 2 in sync with the tag.
+- Pushing a tag `v*` triggers `.github/workflows/release.yml`, which builds the
+  universal `.dmg` via `tauri-action` and creates a **draft** GitHub Release.
+- Signing + notarization run automatically because the six `APPLE_*` secrets are
+  set on the repo (see "Signing" below). If those secrets were ever removed, the
+  build still succeeds but produces an unsigned `.dmg`.
+- Publishing the draft release triggers `.github/workflows/homebrew.yml`, which
+  bumps the cask in the Homebrew tap.
+
+The git tag is the source of truth for the release name. The version baked into
+the build comes from `tauri.conf.json`, so the two must match.
+
+## Step 1: bump the version
+
+Set the same version in all four places (they must match the tag, minus the `v`):
+
+- `package.json`
+- `apps/desktop/package.json`
+- `apps/desktop/src-tauri/tauri.conf.json` (`version`)
+- `apps/desktop/src-tauri/Cargo.toml` (`package.version`)
+
+Land the bump on `main` via PR.
+
+## Step 2: dry-run with a release candidate
+
+Never tag the real version first. Validate the pipeline with a throwaway rc, so
+a build failure does not burn the official tag.
+
+```bash
+git tag v0.1.0-rc.1
+git push origin v0.1.0-rc.1
+```
+
+This builds the universal `.dmg` and creates a draft pre-release. Then verify:
+
+```bash
+# after copying Goodboy.app out of the mounted dmg
+spctl -a -vv /Applications/Goodboy.app
+# expect: accepted, source=Notarized Developer ID
+codesign -dv --verbose=4 /Applications/Goodboy.app  # confirms the signing identity
+```
+
+Open the app from a normal double-click: no Gatekeeper warning means signing +
+notarization worked. When satisfied, delete the rc:
+
+```bash
+gh release delete v0.1.0-rc.1 --repo akhayam99/goodboy --yes
+git push origin :refs/tags/v0.1.0-rc.1
+git tag -d v0.1.0-rc.1
+```
+
+## Step 3: cut the real release
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Review the draft release the workflow creates, write the notes, then **publish**.
+Publishing fires the Homebrew cask bump.
+
+## Signing and notarization
+
+Goodboy is signed under n-bro's **personal Apple Developer Individual** team.
+
+- Team ID: **M3R9H4QX65** (personal). **Do not** use the Serenis org team
+  (`FC96QL5F9R`) for this project.
+- Signing identity: `Developer ID Application: Amin Khayam (M3R9H4QX65)`.
+
+Repo secrets on `akhayam99/goodboy` (already set):
+
+| Secret                       | What it is                                              |
+| ---------------------------- | ------------------------------------------------------- |
+| `APPLE_CERTIFICATE`          | Developer ID Application cert, exported `.p12`, base64  |
+| `APPLE_CERTIFICATE_PASSWORD` | password for the `.p12`                                 |
+| `APPLE_SIGNING_IDENTITY`     | `Developer ID Application: Amin Khayam (M3R9H4QX65)`    |
+| `APPLE_ID`                   | Apple ID email for notarytool                           |
+| `APPLE_PASSWORD`             | app-specific password for that Apple ID (not the login) |
+| `APPLE_TEAM_ID`              | `M3R9H4QX65`                                            |
+
+`tauri-action` reads these env vars and signs + notarizes with no extra workflow
+logic. To rotate the cert: re-export the `.p12` from Keychain Access ("My
+Certificates", right-click the Developer ID cert, Export), then
+`base64 -i cert.p12 | gh secret set APPLE_CERTIFICATE --repo akhayam99/goodboy`
+and update `APPLE_CERTIFICATE_PASSWORD`.
 
 ## Homebrew tap
 
 Public install channel: `brew install --cask akhayam99/tap/goodboy`. For an
-unsigned app this matters: Homebrew strips the quarantine attribute on cask
-install, so the app opens with no Gatekeeper prompt.
+unsigned build this would still matter (Homebrew strips the quarantine attribute
+on cask install); with notarization it is just the convenient path.
 
-One-time setup:
+One-time setup (not yet done):
 
 1. Create a public repo `akhayam99/homebrew-tap` (the `homebrew-` prefix is
    required; users type `akhayam99/tap`).
-2. Add `Casks/goodboy.rb` (template in this repo: `packaging/goodboy.rb`).
-3. Create a fine-grained PAT with `contents: write` on the tap repo, store it
-   as the `HOMEBREW_TAP_TOKEN` secret in `akhayam99/goodboy`.
+2. The `homebrew` workflow renders the cask from `packaging/goodboy.rb` and
+   pushes it to `Casks/goodboy.rb` in the tap.
+3. Create a fine-grained PAT with `contents: write` on the tap repo, store it as
+   the `HOMEBREW_TAP_TOKEN` secret on `akhayam99/goodboy`.
 
-The release workflow's `homebrew` job computes the `.dmg` sha256 and pushes the
-updated cask to the tap on each published release.
+Until the tap repo + token exist, the `homebrew` job fails (or is skipped);
+the GitHub Release itself is unaffected.
 
-## Signing and notarization (future)
+## Troubleshooting
 
-v0.1 ships unsigned. To remove the Gatekeeper friction on direct downloads,
-enroll an **Individual** Apple Developer Program membership (personal Apple ID,
-not the Serenis org team) and add these repo secrets:
-
-| Secret                          | What it is                                          |
-| ------------------------------- | --------------------------------------------------- |
-| `APPLE_CERTIFICATE`             | Developer ID Application cert, exported `.p12`, base64 |
-| `APPLE_CERTIFICATE_PASSWORD`    | password for the `.p12`                             |
-| `APPLE_SIGNING_IDENTITY`        | e.g. `Developer ID Application: Name (TEAMID)`      |
-| `APPLE_ID`                      | Apple ID email for notarytool                       |
-| `APPLE_PASSWORD`                | app-specific password for that Apple ID             |
-| `APPLE_TEAM_ID`                 | 10-char Team ID                                     |
-
-`tauri-action` reads these env vars and signs + notarizes automatically. No
-workflow logic changes beyond passing the secrets through `env:`.
+- **Build fails in the universal step**: most likely the monorepo workspace deps
+  were not built before `tauri build`. The workflow runs
+  `pnpm turbo run build --filter=@goodboy/desktop^...` first; if a new workspace
+  package was added, confirm it is a dependency of `@goodboy/desktop`.
+- **"The specified item could not be found in the keychain" / signing fails**:
+  `APPLE_SIGNING_IDENTITY` must match the cert in `APPLE_CERTIFICATE` exactly,
+  including the team ID in parentheses.
+- **Notarization fails with an auth error**: `APPLE_PASSWORD` must be an
+  app-specific password (appleid.apple.com), not the Apple ID login password,
+  and `APPLE_ID` / `APPLE_TEAM_ID` must belong to the same Individual team.
+- **macOS Keychain `.p12` uses legacy RC2-40**: reading it locally with OpenSSL 3
+  needs `openssl pkcs12 ... -legacy`. The CI runner uses `security import`, which
+  handles it natively, so this only affects local verification.
+- **Local manual build** to reproduce CI: `pnpm tauri:build`. For the universal
+  artifact: `pnpm --filter @goodboy/desktop tauri build --target universal-apple-darwin`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,60 @@
+# Release runbook
+
+How to cut a Goodboy release. Target: macOS universal `.dmg` (Intel + Apple
+Silicon), published to GitHub Releases and Homebrew.
+
+## Cut a release
+
+1. Land everything for the release on `main`.
+2. Bump the version in all four places (they must match):
+   - `package.json`
+   - `apps/desktop/package.json`
+   - `apps/desktop/src-tauri/tauri.conf.json` (`version`)
+   - `apps/desktop/src-tauri/Cargo.toml` (`package.version`)
+3. Tag and push:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+4. The `release` workflow builds the universal `.dmg` and creates a **draft**
+   GitHub Release. Review it, write the notes, then publish.
+5. Publishing the release triggers the Homebrew cask bump (once the tap is
+   wired, see below).
+
+The tag is the source of truth for the release name. The version inside the
+build comes from `tauri.conf.json`, so keep step 2 in sync with the tag.
+
+## Homebrew tap
+
+Public install channel: `brew install --cask akhayam99/tap/goodboy`. For an
+unsigned app this matters: Homebrew strips the quarantine attribute on cask
+install, so the app opens with no Gatekeeper prompt.
+
+One-time setup:
+
+1. Create a public repo `akhayam99/homebrew-tap` (the `homebrew-` prefix is
+   required; users type `akhayam99/tap`).
+2. Add `Casks/goodboy.rb` (template in this repo: `packaging/goodboy.rb`).
+3. Create a fine-grained PAT with `contents: write` on the tap repo, store it
+   as the `HOMEBREW_TAP_TOKEN` secret in `akhayam99/goodboy`.
+
+The release workflow's `homebrew` job computes the `.dmg` sha256 and pushes the
+updated cask to the tap on each published release.
+
+## Signing and notarization (future)
+
+v0.1 ships unsigned. To remove the Gatekeeper friction on direct downloads,
+enroll an **Individual** Apple Developer Program membership (personal Apple ID,
+not the Serenis org team) and add these repo secrets:
+
+| Secret                          | What it is                                          |
+| ------------------------------- | --------------------------------------------------- |
+| `APPLE_CERTIFICATE`             | Developer ID Application cert, exported `.p12`, base64 |
+| `APPLE_CERTIFICATE_PASSWORD`    | password for the `.p12`                             |
+| `APPLE_SIGNING_IDENTITY`        | e.g. `Developer ID Application: Name (TEAMID)`      |
+| `APPLE_ID`                      | Apple ID email for notarytool                       |
+| `APPLE_PASSWORD`                | app-specific password for that Apple ID             |
+| `APPLE_TEAM_ID`                 | 10-char Team ID                                     |
+
+`tauri-action` reads these env vars and signs + notarizes automatically. No
+workflow logic changes beyond passing the secrets through `env:`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/packaging/goodboy.rb
+++ b/packaging/goodboy.rb
@@ -1,0 +1,20 @@
+# Template for the Homebrew cask. The release workflow renders version + sha256
+# and pushes the result to akhayam99/homebrew-tap (Casks/goodboy.rb).
+cask "goodboy" do
+  version :VERSION
+  sha256 :SHA256
+
+  url "https://github.com/akhayam99/goodboy/releases/download/v#{version}/Goodboy_#{version}_universal.dmg"
+  name "Goodboy"
+  desc "AI workspace orchestrator, local-first and provider-agnostic"
+  homepage "https://github.com/akhayam99/goodboy"
+
+  app "Goodboy.app"
+
+  zap trash: [
+    "~/Library/Application Support/com.goodboy.desktop",
+    "~/Library/Caches/com.goodboy.desktop",
+    "~/Library/Preferences/com.goodboy.desktop.plist",
+    "~/Library/Saved Application State/com.goodboy.desktop.savedState",
+  ]
+end

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,12 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.2.0
         version: 2.7.1
+      '@tauri-apps/plugin-process':
+        specifier: ^2.2.0
+        version: 2.3.1
+      '@tauri-apps/plugin-updater':
+        specifier: ^2.7.0
+        version: 2.10.1
       '@xterm/addon-fit':
         specifier: ^0.10.0
         version: 0.10.0(@xterm/xterm@5.5.0)
@@ -1856,6 +1862,18 @@ packages:
     resolution:
       {
         integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==,
+      }
+
+  '@tauri-apps/plugin-process@2.3.1':
+    resolution:
+      {
+        integrity: sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==,
+      }
+
+  '@tauri-apps/plugin-updater@2.10.1':
+    resolution:
+      {
+        integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==,
       }
 
   '@testing-library/dom@10.4.1':
@@ -4449,6 +4467,14 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.1
 
   '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-process@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
       '@tauri-apps/api': 2.11.0
 


### PR DESCRIPTION
Everything needed for the first public v0.1.0 release, in one PR so it ships together.

## What's in here
- **Release pipeline** (`release.yml`): tag `v*` builds a signed + notarized universal `.dmg`, draft GitHub Release. Job timeout 90m (Apple notary can be slow on first submission).
- **Auto-updater**: `tauri-plugin-updater` + `process`; packaged builds self-update from `releases/latest/download/latest.json`. Updater store slice, reusable `UpdateIndicator` (status-bar button + sidebar-logo pip, VS Code / Claude style), auto-check on launch in prod. Signed with a dedicated updater key.
- **Homebrew** (`homebrew.yml` + `packaging/goodboy.rb`): cask bump on published release (tap repo `akhayam99/homebrew-tap` created; needs `HOMEBREW_TAP_TOKEN`).
- **Version** `0.0.0 -> 0.1.0`; README install section (signed, auto-update); `docs/release.md` runbook; AGENTS.md Releasing pointer.

## Secrets (set)
`APPLE_*` (6), `TAURI_SIGNING_PRIVATE_KEY(+_PASSWORD)`. Pending: `HOMEBREW_TAP_TOKEN` (n-bro).

## Verified
- rc.2 build green: signed + notarized universal `.dmg` opened cleanly on macOS.
- desktop typecheck, updater slice tests (4), knip: pass.
- Rust (`cargo check`) validated locally; CI here only covers TS.

## Go-live (gated)
1. `HOMEBREW_TAP_TOKEN` secret
2. merge this PR (branch protection -> needs admin/review)
3. tag `v0.1.0`, verify draft, publish
4. merge website PR #654

🤖 Generated with [Claude Code](https://claude.com/claude-code)