### PR TITLE
feat(repo): website install CTA by platform (v0.1)

### DIFF
--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -20,7 +20,9 @@ function TerminalFrame({ label, children }: { label: string; children: ReactNode
         <span className="h-2.5 w-2.5 rounded-full bg-success" aria-hidden />
         <span className="ml-3 font-mono text-[10.5px] text-muted-foreground">{label}</span>
       </div>
-      <div className="px-5 py-4 font-mono text-[12.5px] leading-[1.9]">{children}</div>
+      <div className="overflow-x-auto px-5 py-4 font-mono text-[12.5px] leading-[1.9]">
+        {children}
+      </div>
     </div>
   );
 }
@@ -40,40 +42,39 @@ export function CTA() {
           you&apos;re running locally.
         </p>
 
-        <div className="mx-auto mt-10 grid max-w-xl gap-6 text-left sm:grid-cols-2">
-          <div>
-            <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              macOS
-            </p>
-            <TerminalFrame label="Homebrew">
-              <div className="flex items-start gap-2">
-                <span className="shrink-0 select-none text-muted-foreground">$</span>
-                <span className="text-foreground break-all">{brewLine}</span>
-              </div>
-            </TerminalFrame>
-            <div className="mt-4">
-              <LinkButton
-                href={RELEASES_LATEST}
-                target="_blank"
-                rel="noreferrer"
-                size="lg"
-                variant="primary"
-              >
-                Download for macOS
-              </LinkButton>
-            </div>
-            <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
-              Universal build &middot; Intel &amp; Apple Silicon
-            </p>
+        <div className="mx-auto mt-11 max-w-lg">
+          {/* macOS: the primary path */}
+          <LinkButton
+            href={RELEASES_LATEST}
+            target="_blank"
+            rel="noreferrer"
+            size="lg"
+            variant="primary"
+            className="w-full sm:w-auto"
+          >
+            Download for macOS
+          </LinkButton>
+          <p className="mt-3 text-[12px] text-muted-foreground/70">
+            Universal build &middot; Intel &amp; Apple Silicon
+          </p>
+
+          <div className="mt-5 flex items-center gap-3 text-left">
+            <span className="shrink-0 font-mono text-[11px] uppercase tracking-[0.08em] text-muted-foreground/60">
+              or brew
+            </span>
+            <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded-lg border border-border-soft bg-[oklch(0.22_0.007_255)] px-4 py-2.5 font-mono text-[12.5px] text-foreground">
+              {brewLine}
+            </code>
           </div>
 
-          <div>
+          {/* Linux & Windows: build from source */}
+          <div className="mt-9 text-left">
             <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-              Linux &amp; Windows
+              Linux &amp; Windows &middot; from source
             </p>
-            <TerminalFrame label="build from source">
+            <TerminalFrame label="~/work">
               {sourceLines.map((l) => (
-                <div key={l.command} className="flex items-start gap-2">
+                <div key={l.command} className="flex items-start gap-2 whitespace-nowrap">
                   <span className="shrink-0 select-none text-muted-foreground">{l.prompt}</span>
                   <span className={l.muted ? 'text-primary' : 'text-foreground'}>{l.command}</span>
                 </div>
@@ -85,7 +86,7 @@ export function CTA() {
           </div>
         </div>
 
-        <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
+        <div className="mt-11 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <LinkButton
             href="https://github.com/akhayam99/goodboy"
             target="_blank"
@@ -108,11 +109,6 @@ export function CTA() {
             Read the docs
           </LinkButton>
         </div>
-
-        <p className="mt-6 text-[12px] text-muted-foreground/70">
-          Prebuilt for macOS &middot; build from source on Linux &amp; Windows &middot; Node 20+
-          &middot; pnpm 9+
-        </p>
       </div>
     </section>
   );

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -1,10 +1,29 @@
+import type { ReactNode } from 'react';
 import { LinkButton } from '../components/ui';
 
-const lines = [
+const RELEASES_LATEST = 'https://github.com/akhayam99/goodboy/releases/latest';
+
+const brewLine = 'brew install --cask akhayam99/tap/goodboy';
+
+const sourceLines = [
   { prompt: '$', command: 'git clone https://github.com/akhayam99/goodboy.git', muted: false },
   { prompt: '$', command: 'cd goodboy && pnpm install', muted: false },
   { prompt: '$', command: 'pnpm tauri:build', muted: true },
 ];
+
+function TerminalFrame({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-border-soft bg-[oklch(0.22_0.007_255)] text-left">
+      <div className="flex items-center gap-2 border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-4 py-2.5">
+        <span className="h-2.5 w-2.5 rounded-full bg-danger" aria-hidden />
+        <span className="h-2.5 w-2.5 rounded-full bg-warning" aria-hidden />
+        <span className="h-2.5 w-2.5 rounded-full bg-success" aria-hidden />
+        <span className="ml-3 font-mono text-[10.5px] text-muted-foreground">{label}</span>
+      </div>
+      <div className="px-5 py-4 font-mono text-[12.5px] leading-[1.9]">{children}</div>
+    </div>
+  );
+}
 
 export function CTA() {
   return (
@@ -14,37 +33,65 @@ export function CTA() {
           Open source &middot; MIT
         </p>
         <h2 className="mt-5 text-3xl sm:text-5xl leading-[1.02] tracking-[-0.03em] font-semibold text-foreground">
-          Clone, install, run it.
+          Install it, run it.
         </h2>
         <p className="mx-auto mt-5 max-w-md text-[15px] leading-[1.65] text-muted-foreground">
-          No waitlist. No email. The repo is public. Bring your own Claude, Cursor, Codex or Gemini
-          subscription and you&apos;re running locally.
+          No waitlist. No email. Bring your own Claude, Cursor, Codex or Gemini subscription and
+          you&apos;re running locally.
         </p>
 
-        <div className="mx-auto mt-10 max-w-xl overflow-hidden rounded-xl border border-border-soft bg-[oklch(0.22_0.007_255)] text-left">
-          <div className="flex items-center gap-2 border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-4 py-2.5">
-            <span className="h-2.5 w-2.5 rounded-full bg-danger" aria-hidden />
-            <span className="h-2.5 w-2.5 rounded-full bg-warning" aria-hidden />
-            <span className="h-2.5 w-2.5 rounded-full bg-success" aria-hidden />
-            <span className="ml-3 font-mono text-[10.5px] text-muted-foreground">~/work</span>
-          </div>
-          <div className="px-5 py-4 font-mono text-[12.5px] leading-[1.9]">
-            {lines.map((l) => (
-              <div key={l.command} className="flex items-start gap-2">
-                <span className="shrink-0 select-none text-muted-foreground">{l.prompt}</span>
-                <span className={l.muted ? 'text-primary' : 'text-foreground'}>{l.command}</span>
+        <div className="mx-auto mt-10 grid max-w-xl gap-6 text-left sm:grid-cols-2">
+          <div>
+            <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              macOS
+            </p>
+            <TerminalFrame label="Homebrew">
+              <div className="flex items-start gap-2">
+                <span className="shrink-0 select-none text-muted-foreground">$</span>
+                <span className="text-foreground break-all">{brewLine}</span>
               </div>
-            ))}
+            </TerminalFrame>
+            <div className="mt-4">
+              <LinkButton
+                href={RELEASES_LATEST}
+                target="_blank"
+                rel="noreferrer"
+                size="lg"
+                variant="primary"
+              >
+                Download for macOS
+              </LinkButton>
+            </div>
+            <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
+              Universal build &middot; Intel &amp; Apple Silicon
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2.5 text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              Linux &amp; Windows
+            </p>
+            <TerminalFrame label="build from source">
+              {sourceLines.map((l) => (
+                <div key={l.command} className="flex items-start gap-2">
+                  <span className="shrink-0 select-none text-muted-foreground">{l.prompt}</span>
+                  <span className={l.muted ? 'text-primary' : 'text-foreground'}>{l.command}</span>
+                </div>
+              ))}
+            </TerminalFrame>
+            <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
+              Needs a Rust toolchain &middot; prebuilt binaries coming later
+            </p>
           </div>
         </div>
 
-        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+        <div className="mt-10 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <LinkButton
             href="https://github.com/akhayam99/goodboy"
             target="_blank"
             rel="noreferrer"
             size="lg"
-            variant="primary"
+            variant="secondary"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
               <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
@@ -63,8 +110,8 @@ export function CTA() {
         </div>
 
         <p className="mt-6 text-[12px] text-muted-foreground/70">
-          macOS, Windows, Linux &middot; Node 20+ &middot; pnpm 9+ &middot; Bring your own
-          subscription
+          Prebuilt for macOS &middot; build from source on Linux &amp; Windows &middot; Node 20+
+          &middot; pnpm 9+
         </p>
       </div>
     </section>

--- a/website/src/sections/Comparison.tsx
+++ b/website/src/sections/Comparison.tsx
@@ -1,5 +1,12 @@
 type Cell = boolean | 'partial' | string;
-type Row = { label: string; goodboy: Cell; cursor: Cell; claudeCode: Cell; chatgpt: Cell };
+type Row = {
+  label: string;
+  goodboy: Cell;
+  cursor: Cell;
+  claudeCode: Cell;
+  gemini: Cell;
+  chatgpt: Cell;
+};
 
 const rows: Row[] = [
   {
@@ -7,6 +14,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: false,
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -14,6 +22,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: 'partial',
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -21,6 +30,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: 'partial',
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -28,6 +38,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: false,
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -35,6 +46,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: false,
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -42,6 +54,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: false,
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -49,6 +62,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: 'partial',
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -56,6 +70,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: 'partial',
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -63,6 +78,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: false,
+    gemini: false,
     chatgpt: false,
   },
   {
@@ -70,6 +86,7 @@ const rows: Row[] = [
     goodboy: true,
     cursor: false,
     claudeCode: true,
+    gemini: true,
     chatgpt: false,
   },
   {
@@ -77,9 +94,17 @@ const rows: Row[] = [
     goodboy: 'all three',
     cursor: 'own',
     claudeCode: 'own',
+    gemini: 'own',
     chatgpt: 'own',
   },
-  { label: 'Replaces your IDE', goodboy: false, cursor: true, claudeCode: false, chatgpt: false },
+  {
+    label: 'Replaces your IDE',
+    goodboy: false,
+    cursor: true,
+    claudeCode: false,
+    gemini: false,
+    chatgpt: false,
+  },
 ];
 
 function CellView({ v }: { v: Cell }) {
@@ -135,13 +160,14 @@ export function Comparison() {
           </p>
         </div>
         <div className="overflow-x-auto rounded-xl border border-border-soft bg-subtle">
-          <div className="grid min-w-[640px] grid-cols-[1.4fr_1fr_1fr_1fr_1fr] text-[11.5px]">
+          <div className="grid min-w-[780px] grid-cols-[1.4fr_1fr_1fr_1fr_1fr_1fr] text-[11.5px]">
             <div className="bg-[oklch(0.27_0.008_255)] px-4 py-3 text-[10.5px] uppercase tracking-wider text-muted-foreground">
               Capability
             </div>
             <Header label="Goodboy" highlight />
             <Header label="Cursor" />
             <Header label="Claude Code" />
+            <Header label="Gemini" />
             <Header label="ChatGPT" />
             {rows.map((r, i) => (
               <ComparisonRow key={r.label} row={r} odd={i % 2 === 1} />
@@ -183,6 +209,9 @@ function ComparisonRow({ row, odd }: { row: Row; odd: boolean }) {
       </div>
       <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
         <CellView v={row.claudeCode} />
+      </div>
+      <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
+        <CellView v={row.gemini} />
       </div>
       <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
         <CellView v={row.chatgpt} />

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -35,7 +35,7 @@ export function Hero() {
             style={{ animationDelay: '180ms' }}
           >
             <LinkButton href="#cta" size="lg" variant="primary">
-              Clone &amp; run
+              Install
             </LinkButton>
             <LinkButton
               href="https://github.com/akhayam99/goodboy"
@@ -55,7 +55,8 @@ export function Hero() {
             className="rise mt-6 text-[12.5px] text-muted-foreground/75"
             style={{ animationDelay: '240ms' }}
           >
-            MIT licensed &middot; macOS, Windows, Linux &middot; Bring your own subscription
+            MIT licensed &middot; Prebuilt for macOS, source on Linux &amp; Windows &middot; Bring
+            your own subscription
           </p>
         </div>
 


### PR DESCRIPTION
**Draft until v0.1.0 is published + the Homebrew tap exists** (the brew command and Download button 404 otherwise, and merging deploys via Vercel).

## Summary
- macOS: Homebrew one-liner (`brew install --cask akhayam99/tap/goodboy`) + "Download for macOS" button to `releases/latest`. Universal build note (Intel + Apple Silicon), single download.
- Linux / Windows: build-from-source path (`git clone`, `pnpm install`, `pnpm tauri:build`).
- Reworded the platform line (prebuilt macOS only for now; source on Linux/Windows). Homebrew casks are macOS-only, so brew is not offered for Linux/Windows.

## Merge checklist
- [ ] v0.1.0 release published (so `releases/latest` resolves)
- [ ] `akhayam99/homebrew-tap` exists with the goodboy cask (so the brew command works)
- [ ] visual check of the CTA section

🤖 Generated with [Claude Code](https://claude.com/claude-code)