### PR TITLE
feat(repo): redesign marketing website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary -->
-    <title>Goodboy: AI workspace orchestrator</title>
+    <title>Goodboy: every AI agent, one shared brain</title>
     <meta name="description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
     <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
     <meta name="author" content="Amin Khayam" />
@@ -16,22 +16,22 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
-    <meta property="og:title" content="Goodboy: AI workspace orchestrator" />
+    <meta property="og:title" content="Goodboy: every AI agent, one shared brain" />
     <meta property="og:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Goodboy: AI workspace orchestrator" />
+    <meta property="og:image:alt" content="Goodboy: every AI agent, one shared brain" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter / X card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
-    <meta name="twitter:title" content="Goodboy: AI workspace orchestrator" />
+    <meta name="twitter:title" content="Goodboy: every AI agent, one shared brain" />
     <meta name="twitter:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
-    <meta name="twitter:image:alt" content="Goodboy: AI workspace orchestrator" />
+    <meta name="twitter:image:alt" content="Goodboy: every AI agent, one shared brain" />
 
     <!-- Theme / PWA hints -->
     <meta name="theme-color" content="#1a1c26" />

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -29,8 +29,8 @@ export function App() {
         <LogoStrip />
         <SessionsDeepDive />
         <AgentsDeepDive />
-        <ContextDeepDive />
         <PlansDeepDive />
+        <ContextDeepDive />
         <LinearDeepDive />
         <GithubDeepDive />
         <RoutingDeepDive />

--- a/website/src/components/OrchestrationFlow.tsx
+++ b/website/src/components/OrchestrationFlow.tsx
@@ -1,0 +1,118 @@
+import { DogMascot } from './DogMascot';
+
+/* The hero showpiece. A goal flows into the Goodboy router on the left, which
+   fans out to four providers on the right over live, flowing wires. Pure
+   CSS/SVG: the wires are dashed strokes scrolling along their paths
+   (vector-effect keeps them crisp at any scale), the router breathes, the
+   provider dots pulse in sequence. Collapses to a static diagram under
+   reduced motion. */
+
+const PROVIDERS = [
+  { name: 'Claude', color: 'oklch(0.74 0.15 55)', y: 40 },
+  { name: 'Cursor', color: 'oklch(0.70 0.16 290)', y: 100 },
+  { name: 'Codex', color: 'oklch(0.72 0.16 150)', y: 160 },
+  { name: 'Gemini', color: 'oklch(0.72 0.16 240)', y: 220 },
+] as const;
+
+function wirePath(y: number): string {
+  return `M390,130 C 470,130 492,${y} 560,${y}`;
+}
+
+export function OrchestrationFlow() {
+  return (
+    <div className="relative mx-auto h-[256px] w-full max-w-[680px] sm:h-[280px]">
+      {/* wire layer */}
+      <svg
+        className="absolute inset-0 h-full w-full"
+        viewBox="0 0 720 260"
+        preserveAspectRatio="none"
+        aria-hidden
+      >
+        {/* goal -> router */}
+        <path
+          d="M150,130 C 230,130 250,130 330,130"
+          fill="none"
+          stroke="oklch(0.74 0.11 200 / 0.25)"
+          strokeWidth="2"
+          vectorEffect="non-scaling-stroke"
+        />
+        <path
+          d="M150,130 C 230,130 250,130 330,130"
+          fill="none"
+          stroke="oklch(0.86 0.10 200)"
+          strokeWidth="2"
+          vectorEffect="non-scaling-stroke"
+          className="wire-flow"
+        />
+        {/* router -> each provider */}
+        {PROVIDERS.map((p, i) => (
+          <g key={p.name}>
+            <path
+              d={wirePath(p.y)}
+              fill="none"
+              stroke={p.color}
+              strokeOpacity={0.22}
+              strokeWidth="2"
+              vectorEffect="non-scaling-stroke"
+            />
+            <path
+              d={wirePath(p.y)}
+              fill="none"
+              stroke={p.color}
+              strokeWidth="2"
+              vectorEffect="non-scaling-stroke"
+              className="wire-flow"
+              style={{ animationDelay: `${i * 0.18}s` }}
+            />
+          </g>
+        ))}
+      </svg>
+
+      {/* goal node */}
+      <div
+        className="absolute -translate-y-1/2 rounded-lg border border-border-soft bg-subtle/90 px-3 py-2 shadow-sm backdrop-blur-sm"
+        style={{ left: '1%', top: '50%', width: '20%', minWidth: 116 }}
+      >
+        <div className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          <span className="size-1.5 rounded-full bg-primary" aria-hidden />
+          your goal
+        </div>
+        <p className="mt-1 line-clamp-2 text-[11px] leading-snug text-foreground/80">
+          “add password reset”
+        </p>
+      </div>
+
+      {/* router node: the box is centred on the wire line; the labels hang
+         below as an absolute element so they don't shift the box off-centre. */}
+      <div className="absolute left-1/2 top-1/2 size-14 -translate-x-1/2 -translate-y-1/2">
+        <span
+          aria-hidden
+          className="node-glow absolute left-1/2 top-1/2 size-20 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary/30 blur-xl"
+        />
+        <span className="relative flex size-14 items-center justify-center rounded-2xl border border-primary/40 bg-background shadow-md">
+          <DogMascot size={32} className="text-primary" />
+        </span>
+        <span className="absolute left-1/2 top-full mt-1.5 flex -translate-x-1/2 flex-col items-center whitespace-nowrap">
+          <span className="text-[11px] font-semibold text-foreground">Goodboy</span>
+          <span className="font-mono text-[9px] text-muted-foreground/70">router</span>
+        </span>
+      </div>
+
+      {/* provider nodes */}
+      {PROVIDERS.map((p, i) => (
+        <div
+          key={p.name}
+          className="absolute flex -translate-y-1/2 items-center gap-2 rounded-lg border border-border-soft bg-subtle/90 px-2.5 py-1.5 shadow-sm backdrop-blur-sm"
+          style={{ right: '1%', top: `${(p.y / 260) * 100}%`, minWidth: 112 }}
+        >
+          <span
+            className="node-glow size-2.5 shrink-0 rounded-full"
+            style={{ background: p.color, animationDelay: `${i * 0.18}s` }}
+            aria-hidden
+          />
+          <span className="text-[12px] font-medium text-foreground">{p.name}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/website/src/components/Reveal.tsx
+++ b/website/src/components/Reveal.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+
+/* Scroll-reveal primitive. `useInView` flips to true the first time the
+   element crosses into the viewport, then disconnects. Pairs with the
+   `.reveal-group` / `.reveal` CSS in styles.css. Falls back to visible when
+   IntersectionObserver is unavailable so content never gets stuck hidden. */
+export function useInView<T extends Element = HTMLDivElement>() {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setInView(true);
+            io.disconnect();
+            break;
+          }
+        }
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -8% 0px' },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  return { ref, inView };
+}
+
+/* Self-contained single-block reveal. Use for one-shot blocks; for multi-part
+   layouts drive `useInView` on the section and tag children `.reveal`. */
+export function Reveal({
+  children,
+  className,
+  delay = 0,
+}: {
+  children: ReactNode;
+  className?: string;
+  delay?: number;
+}) {
+  const { ref, inView } = useInView<HTMLDivElement>();
+  return (
+    <div
+      ref={ref}
+      className={['reveal-group', inView ? 'is-visible' : ''].filter(Boolean).join(' ')}
+    >
+      <div
+        className={['reveal', className].filter(Boolean).join(' ')}
+        style={{ animationDelay: `${delay}ms` }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react';
 import { Eyebrow, SectionTitle } from './ui';
+import { useInView } from './Reveal';
 
 /* Two-column editorial section: copy on one side, mockup on the other.
    Single-color title, eyebrow above. Reverse stacks the mockup to the left.
-*/
+   The whole section scroll-reveals: copy first, mockup a beat later. */
 export function Section({
   id,
   eyebrow,
@@ -19,20 +20,27 @@ export function Section({
   reverse?: boolean;
   children: ReactNode;
 }) {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section id={id} className="relative py-24 sm:py-28">
+    <section
+      id={id}
+      ref={ref}
+      className={`reveal-group relative py-24 sm:py-28 ${inView ? 'is-visible' : ''}`}
+    >
       <div className="mx-auto max-w-6xl px-6">
         <div
           className={`grid items-center gap-14 lg:grid-cols-2 lg:gap-20 ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
         >
-          <div className="min-w-0 max-w-lg">
+          <div className="reveal min-w-0 max-w-lg">
             <Eyebrow>{eyebrow}</Eyebrow>
             <SectionTitle>{title}</SectionTitle>
-            <div className="mt-6 max-w-prose space-y-4 text-[15px] leading-[1.7] text-muted-foreground">
+            <div className="mt-5 max-w-prose text-[16px] leading-[1.6] text-muted-foreground">
               {body}
             </div>
           </div>
-          <div className="min-w-0">{children}</div>
+          <div className="reveal min-w-0" style={{ animationDelay: '140ms' }}>
+            {children}
+          </div>
         </div>
       </div>
     </section>

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -1683,7 +1683,6 @@ const RunStepRow = forwardRef<
 >(function RunStepRow({ index, step, status }, ref) {
   const actionable = status === 'actionable';
   const running = status === 'running';
-  const done = status === 'done';
   const future = status === 'future';
   return (
     <div

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -7,18 +7,18 @@
    Source map:
    - SessionsSnapshot           <- features/workspace/components/SessionActivityBar
                                    + features/workspace/components/SessionDetailPanel
-   - WorkflowStackSnapshot      <- WorkspacesSidebar AgentsSection (multi-workflow)
+   - WorkflowRunSnapshot        <- WorkspacesSidebar AgentsSection (self-playing run)
    - WorkflowSnapshot           <- features/workflows/components/WorkflowsPanel +
                                    features/workflows/components/WorkflowNextStepCta
    - ContextSnapshot            <- features/context/components/ContextPanel
-   - ChatHeaderSnapshot         <- features/chat/components/ChatBreadcrumb
-   - AgentPickerSnapshot        <- features/quick-actions/QuickActionsPopover
+   - AgentRosterSnapshot        <- features/session/agent-kind.ts AGENT_KIND_META
    - NewSessionLinearSnapshot   <- features/session/components/NewSessionDialog
                                    with features/integrations/linear/IssuePicker
    - PRSnapshot                 <- features/github/components/* (PR row + diff comment)
 */
 
-import { useState, type ReactNode } from 'react';
+import { forwardRef, useEffect, useReducer, useRef, useState, type ReactNode } from 'react';
+import { useInView } from '../components/Reveal';
 import {
   IconArrowDown,
   IconArrowUp,
@@ -60,16 +60,20 @@ const KIND = {
 /* Apps/desktop AgentKindChip pattern: width-locked colored pill with a tiny
    silhouette of the role's dog on the left, label on the right. Mirrors the
    exact 60px width used in the product sidebar. */
-function KindBadge({ kind }: { kind: keyof typeof KIND }) {
+function KindBadge({ kind, muted }: { kind: keyof typeof KIND; muted?: boolean }) {
   const k = KIND[kind];
   return (
     <span
       className={[
-        'inline-flex w-[3.75rem] shrink-0 items-center justify-center gap-1 rounded py-0.5 pl-1 pr-1.5 text-[9px] font-semibold uppercase leading-none tracking-wide text-zinc-950',
-        k.bg,
+        'inline-flex w-[3.75rem] shrink-0 items-center justify-center gap-1 rounded py-0.5 pl-1 pr-1.5 text-[9px] font-semibold uppercase leading-none tracking-wide',
+        muted ? 'bg-muted-foreground/20 text-muted-foreground/60' : `${k.bg} text-zinc-950`,
       ].join(' ')}
     >
-      <AgentAvatar kind={k.kind} size={10} tint="bg-zinc-950/80" />
+      <AgentAvatar
+        kind={k.kind}
+        size={10}
+        tint={muted ? 'bg-muted-foreground/60' : 'bg-zinc-950/80'}
+      />
       <span>{k.label}</span>
     </span>
   );
@@ -175,8 +179,8 @@ const SESSION_DATA: ReadonlyArray<SessionMock> = [
    The detail panel shows the same things the real product shows: a status
    icon next to the title, a list of agent rows with kind chip + token/turn/
    cost line, and a footer that pairs the branch chip with the session cost
-   chip. No "ACTIVE SESSION / Status / Branch / PR / Spend" label-value list
-   — that's marketing UI, not product UI.
+   chip. No "ACTIVE SESSION / Status / Branch / PR / Spend" label-value list:
+   that's marketing UI, not product UI.
 */
 export function SessionsSnapshot() {
   return (
@@ -1234,117 +1238,63 @@ function TurnRow({ turn }: { turn: (typeof TURNS)[number] }) {
   );
 }
 
-/* ---------------------------- Chat header ---------------------------- */
+/* ---------------------------- Agent roster --------------------------- */
 
-/* Mirror of features/chat/components/ChatBreadcrumb. Path-on-the-left,
-   role-on-the-right. Labels are kept tight so the strip stays on a single
-   line at the snapshot's natural width: anything longer would wrap and the
-   composition stops reading as a header. */
-export function ChatHeaderSnapshot() {
-  return (
-    <SnapshotFrame className="max-w-[520px]">
-      <div className="flex h-9 items-center gap-1.5 whitespace-nowrap border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-3 text-[11px]">
-        <span className="font-medium text-muted-foreground">web</span>
-        <Chevron />
-        <span className="font-medium text-muted-foreground">Reset flow</span>
-        <Chevron />
-        <span className="inline-flex shrink-0 items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
-          <IconBranch size={9} />
-          <span>Rollout</span>
-          <span aria-hidden className="opacity-60">
-            ·
-          </span>
-          <span className="font-mono tabular-nums">3/4</span>
-        </span>
-        <Chevron />
-        <span className="font-medium text-foreground/90">build endpoint</span>
-        <div className="flex-1" />
-        <AgentAvatar kind="implementer" size={20} />
-      </div>
-      <div className="flex items-center justify-center px-6 py-12 text-center">
-        <p className="max-w-[26ch] text-[12px] leading-relaxed text-muted-foreground">
-          Where you are on the left.
-          <br />
-          Who is driving this turn on the right.
-        </p>
-      </div>
-    </SnapshotFrame>
-  );
-}
-
-function Chevron() {
-  return (
-    <svg
-      width="10"
-      height="10"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-      className="shrink-0 text-muted-foreground/40"
-    >
-      <path d="m9 18 6-6-6-6" />
-    </svg>
-  );
-}
-
-/* ---------------------------- Agent picker --------------------------- */
-
-/* Mirror of QuickActionsPopover with the agent action set. Each row carries
-   the agent name on the left and a role badge + dog avatar on the right, so
-   even custom-named agents stay legible. Triggered by typing @ in the
-   composer. */
-const PICKER_AGENTS: ReadonlyArray<{
-  readonly name: string;
-  readonly status: 'pending' | 'running' | 'completed';
-  readonly kind: AgentKind;
+/* The seven default roles, lifted verbatim from apps/desktop AGENT_KIND_META
+   (label + hint). Not a showcase of agents at work: a reference card you can
+   scan in one pass. Each row is the role icon, its name, and the one line that
+   says what it may (and may not) touch. Order follows the natural lifecycle of
+   a task: scout -> plan -> implement -> debug -> test -> review -> docs. */
+const ROSTER: ReadonlyArray<{
+  readonly kind: keyof typeof KIND;
+  readonly tile: string;
+  readonly hint: string;
 }> = [
-  { name: 'locate auth surface', status: 'completed', kind: 'scout' },
-  { name: 'one-off: check mailer', status: 'running', kind: 'generic' },
-  { name: 'design reset flow', status: 'completed', kind: 'planner' },
-  { name: 'build endpoint + email', status: 'running', kind: 'implementer' },
-  { name: 'review PR #214', status: 'pending', kind: 'reviewer' },
-  { name: 'document reset endpoint', status: 'pending', kind: 'docs' },
+  {
+    kind: 'scout',
+    tile: 'bg-sky-400/15',
+    hint: 'Reads and searches the codebase. Never edits files',
+  },
+  {
+    kind: 'plan',
+    tile: 'bg-violet-400/15',
+    hint: 'Turns a goal into an ordered plan. No code, no edits',
+  },
+  {
+    kind: 'imple',
+    tile: 'bg-emerald-400/15',
+    hint: 'Writes code against the active plan. No re-planning',
+  },
+  { kind: 'debug', tile: 'bg-amber-400/15', hint: 'Reproduces and fixes bugs. No refactoring' },
+  { kind: 'test', tile: 'bg-teal-400/15', hint: 'Writes tests. Never touches production code' },
+  { kind: 'review', tile: 'bg-cyan-400/15', hint: 'Reviews diffs read-only. Suggests fixes' },
+  { kind: 'docs', tile: 'bg-orange-400/15', hint: 'Writes documentation. Never touches logic' },
 ];
 
-export function AgentPickerSnapshot() {
+export function AgentRosterSnapshot() {
   return (
     <SnapshotFrame className="max-w-[520px]">
       <FrameHeader
-        label="@ agents"
+        label="default roles"
         right={
-          <span className="font-mono text-[10px] text-muted-foreground/70">
-            ↑↓ to nav · ↵ to pick
-          </span>
+          <span className="font-mono text-[10px] text-muted-foreground/70">7 ship by default</span>
         }
       />
       <ul className="divide-y divide-border-soft/40">
-        {PICKER_AGENTS.map((agent, i) => (
-          <li
-            key={agent.name}
-            className={[
-              'flex items-center gap-3 px-3 py-2',
-              i === 1 ? 'bg-muted/60' : 'hover:bg-muted/40',
-            ].join(' ')}
-          >
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-              <span className="truncate text-[12px] font-medium text-foreground">{agent.name}</span>
-              <span className="text-[10px] text-muted-foreground">{agent.status}</span>
-            </div>
-            <span className="flex shrink-0 items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-              <span>{KIND_LABEL[agent.kind]}</span>
-              <AgentAvatar kind={agent.kind} size={14} />
+        {ROSTER.map((r) => (
+          <li key={r.kind} className="flex items-center gap-3 px-3 py-2.5 hover:bg-muted/40">
+            <span className={`grid size-9 shrink-0 place-items-center rounded-lg ${r.tile}`}>
+              <AgentAvatar kind={KIND[r.kind].kind} size={18} />
             </span>
+            <div className="min-w-0 flex-1">
+              <span className="text-[13px] font-semibold text-foreground">
+                {KIND_LABEL[KIND[r.kind].kind]}
+              </span>
+              <p className="truncate text-[11.5px] leading-snug text-muted-foreground">{r.hint}</p>
+            </div>
           </li>
         ))}
       </ul>
-      <div className="flex items-center gap-2 border-t border-border-soft bg-[oklch(0.22_0.005_255)] px-3 py-2">
-        <span className="font-mono text-[12px] text-foreground">@</span>
-        <span className="text-[11px] text-muted-foreground/60">type to filter agents…</span>
-      </div>
     </SnapshotFrame>
   );
 }
@@ -1477,154 +1427,425 @@ function BranchMark() {
   return <IconBranch size={13} className="text-primary" />;
 }
 
-/* ---------------------------- Multi-workflow stack ------------------- */
+/* ---------------------------- Workflow run (animated) ---------------- */
 
-/* Mirror of WorkspacesSidebar AgentsSection when a session has two workflow
-   blocks attached. Each block lists its steps (with the per-step agent role
-   chip) and shows the "Attach another workflow" affordance below. The whole
-   stack lives in a single session: workflows are 1-to-many, not 1-to-1. */
-const STACK_WORKFLOWS = [
-  {
-    name: 'Password reset rollout',
-    progress: '2/4',
-    custom: false,
-    steps: [
-      {
-        kind: 'scout' as const,
-        name: 'Locate auth surface',
-        state: 'done' as const,
-        model: 'haiku-4-5',
-      },
-      {
-        kind: 'scout' as const,
-        name: 'Deep-scan token + mailer flow',
-        state: 'done' as const,
-        model: 'opus-4-7',
-      },
-      {
-        kind: 'imple' as const,
-        name: 'Build endpoint + email',
-        state: 'active' as const,
-        model: 'sonnet-4-5',
-      },
-      {
-        kind: 'review' as const,
-        name: 'Open PR for review',
-        state: 'pending' as const,
-        model: 'sonnet-4-5',
-      },
-    ],
-  },
-  {
-    name: 'Rate-limit follow-up',
-    progress: '0/3',
-    custom: true,
-    steps: [
-      {
-        kind: 'debug' as const,
-        name: 'Locate & analyze rate-limit gaps',
-        state: 'pending' as const,
-        model: 'haiku-4-5',
-      },
-      {
-        kind: 'plan' as const,
-        name: 'Pick a backoff strategy',
-        state: 'pending' as const,
-        model: 'opus-4-7',
-      },
-      {
-        kind: 'imple' as const,
-        name: 'Wrap mailer in limiter',
-        state: 'pending' as const,
-        model: 'sonnet-4-5',
-      },
-    ],
-  },
+/* Self-playing demo of the Plans & Workflows feature, mirroring the desktop
+   WorkspacesSidebar AgentsSection 1:1. There is no generic "run" button: the
+   next runnable step lights up (primary border + a pinging play dot) to invite
+   a click. A simulated cursor clicks that lit step; it runs (info spinner),
+   then settles done (green check) and the following step lights up. Partway
+   through, the cursor flips the Auto-run toggle in the header's top-right (the
+   real Zap control) and the remaining steps advance on their own. Loops while
+   in view; collapses to a static mid-run frame under reduced motion.
+   Illustrative only: the controls carry no handlers, the timeline drives all. */
+const RUN_STEPS = [
+  { kind: 'scout' as const, name: 'Locate auth surface', model: 'haiku-4-5' },
+  { kind: 'plan' as const, name: 'Draft reset flow + endpoints', model: 'opus-4-7' },
+  { kind: 'imple' as const, name: 'Build endpoint + email', model: 'sonnet-4-5' },
+  { kind: 'review' as const, name: 'Open PR for review', model: 'sonnet-4-5' },
 ];
 
-export function WorkflowStackSnapshot() {
-  return (
-    <SnapshotFrame className="max-w-[440px]">
-      <FrameHeader
-        label="Add password reset"
-        right={
-          <span className="font-mono text-[10px] text-muted-foreground/70">
-            {STACK_WORKFLOWS.length} workflows · 1 session
-          </span>
-        }
-      />
-      <div className="space-y-4 p-3">
-        {STACK_WORKFLOWS.map((wf) => (
-          <WorkflowBlock key={wf.name} workflow={wf} />
-        ))}
-        <button
-          type="button"
-          className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-[11px] text-muted-foreground transition-colors hover:border-border hover:bg-muted/40 hover:text-foreground"
-        >
-          <IconPlus size={11} />
-          Attach another workflow
-        </button>
-      </div>
-    </SnapshotFrame>
-  );
+/* Mirrors the desktop step statuses: a future step waits on its predecessors,
+   the next step is `actionable` (lit, clickable), then `running`, then `done`. */
+type StepStatus = 'future' | 'actionable' | 'running' | 'done';
+
+interface RunState {
+  steps: StepStatus[];
+  autoRun: boolean;
+  cursor: { x: number; y: number };
+  cursorVisible: boolean;
+  pressing: boolean;
 }
 
-function WorkflowBlock({ workflow }: { workflow: (typeof STACK_WORKFLOWS)[number] }) {
+type RunAction =
+  | { type: 'cursor'; pos: { x: number; y: number } | null }
+  | { type: 'hide' }
+  | { type: 'press' }
+  | { type: 'start'; i: number }
+  | { type: 'finish'; i: number }
+  | { type: 'auto' }
+  | { type: 'reset' }
+  | { type: 'static' };
+
+const RUN_INITIAL: RunState = {
+  steps: ['actionable', 'future', 'future', 'future'],
+  autoRun: false,
+  cursor: { x: 24, y: 24 },
+  cursorVisible: false,
+  pressing: false,
+};
+
+function runReducer(s: RunState, a: RunAction): RunState {
+  switch (a.type) {
+    case 'cursor':
+      return a.pos
+        ? { ...s, cursor: a.pos, cursorVisible: true, pressing: false }
+        : { ...s, cursorVisible: false, pressing: false };
+    case 'hide':
+      return { ...s, cursorVisible: false, pressing: false };
+    case 'press':
+      return { ...s, pressing: true };
+    case 'start':
+      return { ...s, pressing: false, steps: s.steps.map((v, i) => (i === a.i ? 'running' : v)) };
+    case 'finish':
+      // Completing a step unlocks the next one, exactly like the real stepper.
+      return {
+        ...s,
+        pressing: false,
+        steps: s.steps.map((v, i) =>
+          i === a.i ? 'done' : i === a.i + 1 && v === 'future' ? 'actionable' : v,
+        ),
+      };
+    case 'auto':
+      return { ...s, pressing: false, autoRun: true };
+    case 'reset':
+      return RUN_INITIAL;
+    case 'static':
+      return {
+        steps: ['done', 'running', 'actionable', 'future'],
+        autoRun: true,
+        cursor: { x: 24, y: 24 },
+        cursorVisible: false,
+        pressing: false,
+      };
+    default:
+      return s;
+  }
+}
+
+/* Playback timeline: each beat waits `d` ms, then applies its action; the
+   driver loops back to the top after the final reset. Cursor targets are a
+   step index (the lit row) or the auto-run toggle. */
+type Beat =
+  | { t: 'cursor'; to: number | 'toggle' }
+  | { t: 'hide' }
+  | { t: 'press' }
+  | { t: 'start'; i: number }
+  | { t: 'finish'; i: number }
+  | { t: 'auto' }
+  | { t: 'reset' };
+
+const RUN_SCRIPT: ReadonlyArray<{ d: number; a: Beat }> = [
+  { d: 800, a: { t: 'cursor', to: 0 } },
+  { d: 560, a: { t: 'press' } },
+  { d: 240, a: { t: 'start', i: 0 } },
+  { d: 1500, a: { t: 'finish', i: 0 } },
+  { d: 660, a: { t: 'cursor', to: 1 } },
+  { d: 520, a: { t: 'press' } },
+  { d: 240, a: { t: 'start', i: 1 } },
+  { d: 1500, a: { t: 'finish', i: 1 } },
+  { d: 680, a: { t: 'cursor', to: 'toggle' } },
+  { d: 520, a: { t: 'press' } },
+  { d: 240, a: { t: 'auto' } },
+  { d: 520, a: { t: 'hide' } },
+  { d: 460, a: { t: 'start', i: 2 } },
+  { d: 1400, a: { t: 'finish', i: 2 } },
+  { d: 540, a: { t: 'start', i: 3 } },
+  { d: 1400, a: { t: 'finish', i: 3 } },
+  { d: 2400, a: { t: 'reset' } },
+];
+
+export function WorkflowRunSnapshot() {
+  const [state, dispatch] = useReducer(runReducer, RUN_INITIAL);
+  const { ref: inViewRef, inView } = useInView<HTMLDivElement>();
+  const stageRef = useRef<HTMLDivElement>(null);
+  const stepRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!inView) return;
+    const reduced =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduced) {
+      dispatch({ type: 'static' });
+      return;
+    }
+
+    const pointTo = (el: HTMLElement | null) => {
+      const stage = stageRef.current;
+      if (!stage || !el) return null;
+      const sr = stage.getBoundingClientRect();
+      const er = el.getBoundingClientRect();
+      return { x: er.left - sr.left + er.width / 2, y: er.top - sr.top + er.height / 2 };
+    };
+
+    let timer: ReturnType<typeof setTimeout>;
+    const apply = (a: Beat) => {
+      switch (a.t) {
+        case 'cursor':
+          dispatch({
+            type: 'cursor',
+            pos: pointTo(a.to === 'toggle' ? toggleRef.current : stepRefs.current[a.to]),
+          });
+          break;
+        case 'hide':
+          dispatch({ type: 'hide' });
+          break;
+        case 'press':
+          dispatch({ type: 'press' });
+          break;
+        case 'start':
+          dispatch({ type: 'start', i: a.i });
+          break;
+        case 'finish':
+          dispatch({ type: 'finish', i: a.i });
+          break;
+        case 'auto':
+          dispatch({ type: 'auto' });
+          break;
+        case 'reset':
+          dispatch({ type: 'reset' });
+          break;
+      }
+    };
+    const run = (i: number) => {
+      timer = setTimeout(() => {
+        apply(RUN_SCRIPT[i].a);
+        run((i + 1) % RUN_SCRIPT.length);
+      }, RUN_SCRIPT[i].d);
+    };
+    run(0);
+    return () => clearTimeout(timer);
+  }, [inView]);
+
+  const done = state.steps.filter((s) => s === 'done').length;
+
   return (
-    <div>
-      <div className="flex items-center gap-2 pb-2">
-        <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
-          <IconBranch size={10} className="text-primary" />
-          Workflow
-        </span>
-        <span className="font-mono text-[10px] text-muted-foreground/60">
-          {workflow.custom ? 'custom' : 'preset'}
-        </span>
-        <span className="ml-auto inline-flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          <span className="font-mono tabular-nums">{workflow.progress}</span>
-        </span>
-      </div>
-      <div className="flex flex-col gap-1">
-        {workflow.steps.map((s, i) => (
-          <StackStepRow key={i} index={i + 1} step={s} />
-        ))}
-      </div>
+    <div ref={inViewRef}>
+      <SnapshotFrame className="max-w-[440px]">
+        <FrameHeader
+          label="Add password reset"
+          right={
+            <span className="font-mono text-[10px] text-muted-foreground/70">
+              <span className="tabular-nums text-foreground/80">{done}</span>/4 done
+            </span>
+          }
+        />
+        <div ref={stageRef} className="relative p-3">
+          {/* workflow header: label + preset, auto-run toggle in the top-right */}
+          <div className="flex items-center gap-2 pb-2">
+            <span className="inline-flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+              <IconBranch size={10} className="text-primary" />
+              Workflow
+            </span>
+            <span className="flex-1" />
+            <span className="max-w-[8rem] truncate font-mono text-[10px] text-muted-foreground/70">
+              preset
+            </span>
+            <AutoRunPill ref={toggleRef} on={state.autoRun} />
+          </div>
+
+          {/* steps: the next runnable one lights up to be clicked */}
+          <div className="flex flex-col gap-1">
+            {RUN_STEPS.map((s, i) => (
+              <RunStepRow
+                key={i}
+                ref={(el) => {
+                  stepRefs.current[i] = el;
+                }}
+                index={i + 1}
+                step={s}
+                status={state.steps[i]}
+              />
+            ))}
+          </div>
+
+          {/* simulated cursor + click ripple */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-0 top-0 z-20 transition-[transform,opacity] duration-[450ms] ease-[cubic-bezier(.4,0,.2,1)]"
+            style={{
+              transform: `translate(${state.cursor.x}px, ${state.cursor.y}px)`,
+              opacity: state.cursorVisible ? 1 : 0,
+            }}
+          >
+            {state.pressing && <span className="press-ring" />}
+            <svg width="16" height="22" viewBox="0 0 14 20" className="drop-shadow-md" aria-hidden>
+              <path
+                d="M1 1 L1 16 L4.8 12.4 L7.6 18.7 L10.1 17.5 L7.3 11.3 L12.6 11.1 Z"
+                fill="white"
+                stroke="oklch(0.2 0.01 255)"
+                strokeWidth="1"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </div>
+        </div>
+      </SnapshotFrame>
     </div>
   );
 }
 
-function StackStepRow({
-  index,
-  step,
-}: {
-  index: number;
-  step: (typeof STACK_WORKFLOWS)[number]['steps'][number];
-}) {
-  const done = step.state === 'done';
-  const active = step.state === 'active';
+const RunStepRow = forwardRef<
+  HTMLDivElement,
+  { index: number; step: (typeof RUN_STEPS)[number]; status: StepStatus }
+>(function RunStepRow({ index, step, status }, ref) {
+  const actionable = status === 'actionable';
+  const running = status === 'running';
+  const done = status === 'done';
+  const future = status === 'future';
   return (
     <div
+      ref={ref}
       className={[
-        'flex items-center gap-2 rounded px-2 py-1.5 text-[11px]',
-        active ? 'bg-muted/60 ring-1 ring-primary/30' : 'bg-subtle',
+        'relative flex items-center gap-2 overflow-hidden rounded border px-2.5 py-1.5 text-[11px] transition-colors duration-300',
+        running
+          ? 'border-info/60 bg-muted/40 text-foreground/80'
+          : actionable
+            ? 'border-primary/40 bg-primary/10 text-primary shadow-sm'
+            : future
+              ? 'border-transparent text-muted-foreground/40'
+              : 'border-border-soft/50 bg-muted/40 text-foreground/80',
       ].join(' ')}
     >
       <span
         className={[
-          'inline-flex size-4 shrink-0 items-center justify-center rounded-full text-[9px] font-semibold',
-          done
-            ? 'bg-success/20 text-success'
-            : active
-              ? 'bg-primary/20 text-primary'
-              : 'bg-muted text-muted-foreground/70',
+          'w-3 shrink-0 text-right font-mono text-[9px] tabular-nums',
+          future ? 'text-muted-foreground/40' : 'text-muted-foreground/60',
         ].join(' ')}
       >
-        {done ? <IconCheck size={9} /> : index}
+        {index}.
       </span>
-      <KindBadge kind={step.kind} />
-      <span className="min-w-0 flex-1 truncate font-medium text-foreground/90">{step.name}</span>
-      <span className="shrink-0 font-mono text-[10px] text-muted-foreground/70">{step.model}</span>
+      <StepStatusIcon status={status} />
+      <KindBadge kind={step.kind} muted={future} />
+      <span
+        className={[
+          'min-w-0 flex-1 truncate font-semibold transition-colors duration-300',
+          actionable ? 'text-primary' : future ? 'text-muted-foreground/45' : 'text-foreground/85',
+        ].join(' ')}
+      >
+        {step.name}
+      </span>
+      <span
+        className={[
+          'shrink-0 font-mono text-[10px]',
+          future ? 'text-muted-foreground/50' : 'text-muted-foreground/70',
+        ].join(' ')}
+      >
+        {step.model}
+      </span>
+      {running && <span className="run-bar" />}
     </div>
+  );
+});
+
+/* Per-status icon, mirroring the desktop WorkflowStepRow: a pinging play dot
+   when the step is the lit next action, an info spinner while running, a green
+   check when done, a clock while waiting on predecessors. */
+function StepStatusIcon({ status }: { status: StepStatus }) {
+  if (status === 'actionable') {
+    return (
+      <span className="relative inline-flex size-3.5 shrink-0">
+        <span
+          className="absolute inset-0 animate-ping rounded-full bg-primary/30 opacity-75"
+          aria-hidden
+        />
+        <span className="relative flex size-3.5 items-center justify-center rounded-full bg-primary/20">
+          <PlayIcon size={8} />
+        </span>
+      </span>
+    );
+  }
+  if (status === 'running') return <RunSpinner size={11} className="text-info" />;
+  if (status === 'done') {
+    return (
+      <span className="flex size-3.5 shrink-0 items-center justify-center rounded-full bg-success/20">
+        <IconCheck size={9} className="text-success" />
+      </span>
+    );
+  }
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="shrink-0 text-muted-foreground/50"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M12 7v5l3 2" />
+    </svg>
+  );
+}
+
+/* The real per-session auto-run control: a compact icon toggle that lives in
+   the workflow header's top-right. Off shows a slashed bolt in muted grey; on
+   shows a filled bolt with the "auto" label sliding in, tinted danger. */
+const AutoRunPill = forwardRef<HTMLButtonElement, { on: boolean }>(function AutoRunPill(
+  { on },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type="button"
+      tabIndex={-1}
+      role="switch"
+      aria-checked={on}
+      aria-label="Auto-run"
+      title={on ? 'autorun on' : 'autorun off'}
+      className={[
+        'inline-flex h-6 shrink-0 items-center justify-end rounded-md px-1 transition-colors',
+        on ? 'bg-danger/10 text-danger' : 'text-muted-foreground/60',
+      ].join(' ')}
+    >
+      <span
+        aria-hidden
+        className={[
+          'overflow-hidden whitespace-nowrap text-[10px] font-semibold uppercase tracking-wide',
+          'transition-[max-width,opacity,margin] duration-200 ease-out',
+          on ? 'mr-1 max-w-[2.5rem] opacity-100' : 'mr-0 max-w-0 opacity-0',
+        ].join(' ')}
+      >
+        auto
+      </span>
+      <svg
+        width="13"
+        height="13"
+        viewBox="0 0 24 24"
+        fill={on ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+        {!on && <line x1="3" y1="3" x2="21" y2="21" />}
+      </svg>
+    </button>
+  );
+});
+
+function RunSpinner({ size = 10, className }: { size?: number; className?: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      className={['shrink-0 animate-spin', className ?? ''].join(' ')}
+      aria-hidden
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}
+
+function PlayIcon({ size = 10 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+      <path d="M8 5v14l11-7z" />
+    </svg>
   );
 }
 
@@ -1648,7 +1869,7 @@ export function AppOverviewSnapshot() {
         <LayoutColumn
           eyebrow="Sessions"
           tag="rail + detail"
-          hint="Linked tickets, agents, scripts, PR state, branch + cost — collapsed into one rail."
+          hint="Linked tickets, agents, scripts, PR state, branch and cost, collapsed into one rail."
           body={<SessionsAbstract />}
           tone="primary"
         />
@@ -1663,7 +1884,7 @@ export function AppOverviewSnapshot() {
         <LayoutColumn
           eyebrow="Context"
           tag="five tabs"
-          hint="Goal, plans, files, GitHub, terminal — one click each. Open questions pinned below."
+          hint="Goal, plans, files, GitHub, terminal, one click each. Open questions pinned below."
           body={<ContextAbstract />}
           tone="info"
         />

--- a/website/src/sections/AgentsDeepDive.tsx
+++ b/website/src/sections/AgentsDeepDive.tsx
@@ -1,5 +1,5 @@
 import { Section } from '../components/Section';
-import { ChatHeaderSnapshot, AgentPickerSnapshot } from '../mockups/Snapshots';
+import { AgentRosterSnapshot } from '../mockups/Snapshots';
 
 export function AgentsDeepDive() {
   return (
@@ -9,30 +9,14 @@ export function AgentsDeepDive() {
       reverse
       title={<>Every agent has a role. Scoped, defaulted, swappable.</>}
       body={
-        <>
-          <p>
-            Seven roles ship out of the box: <strong>scout</strong> reads and searches without
-            editing, <strong>planner</strong> drafts steps and risks, <strong>implementer</strong>{' '}
-            writes code, <strong>debugger</strong> reproduces and fixes, <strong>tester</strong>{' '}
-            writes coverage, <strong>reviewer</strong> reads diffs, <strong>docs</strong> writes
-            documentation. A generic agent catches anything else.
-          </p>
-          <p>
-            Each role carries its own default model, default effort, and a system prompt that scopes
-            what it is allowed to do. A scout asked to refactor will hand off to an implementer
-            instead of editing the file.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            Spawn freely. Each new agent inherits the session brief on the right (goal, decisions,
-            open questions) so the next one starts already knowing what the last one was doing.
-          </p>
-        </>
+        <p>
+          Seven roles ship by default, each with its own model and a prompt that scopes what it may
+          touch. Spawn freely; every new agent inherits the session brief, so it arrives knowing the
+          goal.
+        </p>
       }
     >
-      <div className="flex flex-col gap-5">
-        <ChatHeaderSnapshot />
-        <AgentPickerSnapshot />
-      </div>
+      <AgentRosterSnapshot />
     </Section>
   );
 }

--- a/website/src/sections/AlsoGrid.tsx
+++ b/website/src/sections/AlsoGrid.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useInView } from '../components/Reveal';
 
 interface Item {
   readonly title: string;
@@ -98,17 +99,23 @@ const items: ReadonlyArray<Item> = [
    no per-card padding bloat: icon + label + one-line hint, period. Reads in a
    single mobile scroll. */
 export function AlsoGrid() {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section id="also" className="relative py-20 sm:py-24">
+    <section
+      id="also"
+      ref={ref}
+      className={`reveal-group relative py-20 sm:py-24 ${inView ? 'is-visible' : ''}`}
+    >
       <div className="mx-auto max-w-6xl px-6">
-        <p className="pb-7 text-center text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
+        <p className="reveal pb-7 text-center text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
           And also
         </p>
         <ul className="grid grid-cols-2 gap-2.5 sm:gap-3 lg:grid-cols-4">
-          {items.map((it) => (
+          {items.map((it, i) => (
             <li
               key={it.title}
-              className="flex items-start gap-3 rounded-lg border border-border-soft bg-subtle px-3.5 py-3 transition-colors hover:border-border"
+              className="reveal flex items-start gap-3 rounded-lg border border-border-soft bg-subtle px-3.5 py-3 transition-colors hover:border-border"
+              style={{ animationDelay: `${i * 70}ms` }}
             >
               <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border-soft bg-muted">
                 {it.icon}

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { LinkButton } from '../components/ui';
+import { useInView } from '../components/Reveal';
 
 const RELEASES_LATEST = 'https://github.com/akhayam99/goodboy/releases/latest';
 
@@ -28,9 +29,14 @@ function TerminalFrame({ label, children }: { label: string; children: ReactNode
 }
 
 export function CTA() {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section id="cta" className="relative py-28 sm:py-36">
-      <div className="mx-auto max-w-3xl px-6 text-center">
+    <section
+      id="cta"
+      ref={ref}
+      className={`reveal-group relative py-28 sm:py-36 ${inView ? 'is-visible' : ''}`}
+    >
+      <div className="reveal mx-auto max-w-3xl px-6 text-center">
         <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
           Open source &middot; MIT
         </p>

--- a/website/src/sections/Comparison.tsx
+++ b/website/src/sections/Comparison.tsx
@@ -1,154 +1,64 @@
-type Cell = boolean | 'partial' | string;
-type Row = {
-  label: string;
-  goodboy: Cell;
-  cursor: Cell;
-  claudeCode: Cell;
-  gemini: Cell;
-  chatgpt: Cell;
-};
+import { useInView } from '../components/Reveal';
 
-const rows: Row[] = [
+interface Diff {
+  readonly title: string;
+  readonly hint: string;
+}
+
+const diffs: ReadonlyArray<Diff> = [
   {
-    label: 'Multiple AI providers',
-    goodboy: true,
-    cursor: false,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
+    title: 'Four providers, one session',
+    hint: 'Claude, Cursor, Codex and Gemini, routed per turn.',
   },
   {
-    label: 'Shared context across agents',
-    goodboy: true,
-    cursor: false,
-    claudeCode: 'partial',
-    gemini: false,
-    chatgpt: false,
+    title: 'Context every agent inherits',
+    hint: 'Goal, decisions, files and open questions persist outside the transcript.',
   },
   {
-    label: 'Multi-agent parallel sessions',
-    goodboy: true,
-    cursor: false,
-    claudeCode: 'partial',
-    gemini: false,
-    chatgpt: false,
+    title: 'Parallel multi-agent sessions',
+    hint: 'Spawn roles that work at once, each in its own git worktree.',
   },
   {
-    label: 'Multi-workflow per session',
-    goodboy: true,
-    cursor: false,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
+    title: 'Plans as first-class artifacts',
+    hint: 'Reusable workflows the implementer picks up, tracked end to end.',
   },
   {
-    label: 'Linear issue → session goal',
-    goodboy: true,
-    cursor: false,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
+    title: 'Per-session budget caps',
+    hint: 'A live cost meter ticking against an optional soft cap.',
   },
   {
-    label: 'Per-session budget caps',
-    goodboy: true,
-    cursor: false,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
-  },
-  {
-    label: 'Structured plans as artifacts',
-    goodboy: true,
-    cursor: false,
-    claudeCode: 'partial',
-    gemini: false,
-    chatgpt: false,
-  },
-  {
-    label: 'Git worktrees per session',
-    goodboy: true,
-    cursor: false,
-    claudeCode: 'partial',
-    gemini: false,
-    chatgpt: false,
-  },
-  {
-    label: 'GitHub PR panel built-in',
-    goodboy: true,
-    cursor: false,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
-  },
-  {
-    label: 'Local-first (no cloud sync)',
-    goodboy: true,
-    cursor: false,
-    claudeCode: true,
-    gemini: true,
-    chatgpt: false,
-  },
-  {
-    label: 'Uses your subscription',
-    goodboy: 'all three',
-    cursor: 'own',
-    claudeCode: 'own',
-    gemini: 'own',
-    chatgpt: 'own',
-  },
-  {
-    label: 'Replaces your IDE',
-    goodboy: false,
-    cursor: true,
-    claudeCode: false,
-    gemini: false,
-    chatgpt: false,
+    title: 'Local-first, your keys',
+    hint: 'Runs on your machine, your subscriptions, your data. No cloud sync.',
   },
 ];
 
-function CellView({ v }: { v: Cell }) {
-  if (v === true) {
-    return (
-      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-success/15 text-success">
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <path
-            d="M2.5 6.5 5 9l4.5-5.5"
-            stroke="currentColor"
-            strokeWidth="1.8"
-            fill="none"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
-      </span>
-    );
-  }
-  if (v === false) {
-    return (
-      <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-muted text-muted-foreground/70">
-        <svg width="10" height="10" viewBox="0 0 12 12">
-          <path
-            d="M3 3l6 6M9 3l-6 6"
-            stroke="currentColor"
-            strokeWidth="1.6"
-            strokeLinecap="round"
-          />
-        </svg>
-      </span>
-    );
-  }
-  if (v === 'partial') {
-    return <span className="chip chip-warning">partial</span>;
-  }
-  return <span className="chip chip-primary">{v}</span>;
+function Check() {
+  return (
+    <span className="mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+      <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+        <path
+          d="M2.5 6.5 5 9l4.5-5.5"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </span>
+  );
 }
 
 export function Comparison() {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section id="compare" className="relative py-24 sm:py-28">
-      <div className="mx-auto max-w-6xl px-6">
-        <div className="mb-12 max-w-2xl">
+    <section
+      id="compare"
+      ref={ref}
+      className={`reveal-group relative py-24 sm:py-28 ${inView ? 'is-visible' : ''}`}
+    >
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="reveal mb-10 max-w-2xl">
           <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
             Comparison
           </p>
@@ -156,66 +66,28 @@ export function Comparison() {
             Where Goodboy fits.
           </h2>
           <p className="mt-5 max-w-prose text-[15px] leading-[1.7] text-muted-foreground">
-            Not another IDE. The layer above. Keep what you have, add coordination.
+            Not another IDE. The layer above. Keep your editor and your subscriptions, add the
+            coordination no single tool gives you.
           </p>
         </div>
-        <div className="overflow-x-auto rounded-xl border border-border-soft bg-subtle">
-          <div className="grid min-w-[780px] grid-cols-[1.4fr_1fr_1fr_1fr_1fr_1fr] text-[11.5px]">
-            <div className="bg-[oklch(0.27_0.008_255)] px-4 py-3 text-[10.5px] uppercase tracking-wider text-muted-foreground">
-              Capability
-            </div>
-            <Header label="Goodboy" highlight />
-            <Header label="Cursor" />
-            <Header label="Claude Code" />
-            <Header label="Gemini" />
-            <Header label="ChatGPT" />
-            {rows.map((r, i) => (
-              <ComparisonRow key={r.label} row={r} odd={i % 2 === 1} />
-            ))}
-          </div>
-        </div>
+        <ul className="grid gap-2.5 sm:grid-cols-2 sm:gap-3">
+          {diffs.map((d, i) => (
+            <li
+              key={d.title}
+              className="reveal flex items-start gap-3 rounded-xl border border-border-soft bg-subtle px-4 py-3.5 transition-colors hover:border-border"
+              style={{ animationDelay: `${120 + i * 60}ms` }}
+            >
+              <Check />
+              <div className="min-w-0">
+                <p className="text-[14px] font-semibold tracking-[-0.005em] text-foreground">
+                  {d.title}
+                </p>
+                <p className="mt-0.5 text-[12.5px] leading-snug text-muted-foreground">{d.hint}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </section>
-  );
-}
-
-function Header({ label, highlight }: { label: string; highlight?: boolean }) {
-  return (
-    <div
-      className={[
-        'bg-[oklch(0.27_0.008_255)] px-4 py-3 text-center text-[12.5px] font-semibold',
-        highlight
-          ? 'border-l border-r border-primary/25 bg-primary/[0.06] text-primary'
-          : 'text-foreground',
-      ].join(' ')}
-    >
-      {label}
-    </div>
-  );
-}
-
-function ComparisonRow({ row, odd }: { row: Row; odd: boolean }) {
-  const bg = odd ? 'bg-[oklch(0.27_0.008_255)]' : 'bg-subtle';
-  return (
-    <>
-      <div className={`px-4 py-3 text-foreground ${bg}`}>{row.label}</div>
-      <div
-        className={`flex items-center justify-center border-l border-r border-primary/15 px-4 py-3 ${bg}`}
-      >
-        <CellView v={row.goodboy} />
-      </div>
-      <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
-        <CellView v={row.cursor} />
-      </div>
-      <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
-        <CellView v={row.claudeCode} />
-      </div>
-      <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
-        <CellView v={row.gemini} />
-      </div>
-      <div className={`flex items-center justify-center px-4 py-3 ${bg}`}>
-        <CellView v={row.chatgpt} />
-      </div>
-    </>
   );
 }

--- a/website/src/sections/ContextDeepDive.tsx
+++ b/website/src/sections/ContextDeepDive.tsx
@@ -6,24 +6,13 @@ export function ContextDeepDive() {
     <Section
       id="context"
       eyebrow="Shared context"
+      reverse
       title={<>A scratchpad that survives the next agent.</>}
       body={
-        <>
-          <p>
-            Every new chat starts from scratch. Goodboy doesn&apos;t. Five context slots (goal,
-            decisions, files touched, open questions, last output) sit outside the transcript and
-            persist across agents.
-          </p>
-          <p>
-            A cheap summarizer updates them after each turn. You can edit them by hand at any time.
-            Open questions get their own clustered tab so the next agent always knows what is still
-            unresolved before it spawns.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            No re-explaining. No copy-paste between windows. No drift between agents on the same
-            goal.
-          </p>
-        </>
+        <p>
+          Five slots (goal, decisions, files touched, open questions, last output) live outside the
+          transcript and persist across agents. No re-explaining, no copy-paste, no drift.
+        </p>
       }
     >
       <ContextSnapshot />

--- a/website/src/sections/FloatingNav.tsx
+++ b/website/src/sections/FloatingNav.tsx
@@ -4,8 +4,8 @@ import { DogMascot } from '../components/DogMascot';
 const links = [
   { href: '#sessions', label: 'Sessions' },
   { href: '#agents', label: 'Agents' },
-  { href: '#context', label: 'Context' },
   { href: '#plans', label: 'Plans' },
+  { href: '#context', label: 'Context' },
   { href: '#linear', label: 'Linear' },
   { href: '#github', label: 'GitHub' },
   { href: '#compare', label: 'Compare' },

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -2,7 +2,7 @@ import { Logo } from '../components/Logo';
 
 export function Footer() {
   return (
-    <footer className="mt-8 border-t border-border-soft/60 py-10">
+    <footer className="mt-8 border-t border-border-soft/60 bg-background py-10">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-5 px-6 sm:flex-row">
         <div className="flex items-center gap-4">
           <Logo size={22} />

--- a/website/src/sections/GithubDeepDive.tsx
+++ b/website/src/sections/GithubDeepDive.tsx
@@ -9,24 +9,11 @@ export function GithubDeepDive() {
       reverse
       title={<>The PR is a panel, not another tab.</>}
       body={
-        <>
-          <p>
-            Pull requests live next to the session that opened them. State, CI checks, line counts,
-            reviews — refreshed by client-side polling and immediately when an agent opens or
-            updates a PR.
-          </p>
-          <p>
-            Diff comments are line-anchored, from any reviewer: a teammate on GitHub, a Claude
-            review agent run locally, or you writing one in the desktop. Each comment gets a
-            one-click <em>resolve</em>. Click it and a resolver agent spawns in the session
-            worktree, addresses the comment with the smallest reasonable change, commits locally,
-            and posts back on the thread.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            No webhooks to configure. No browser tab to alt-tab. The conversation comes to where the
-            code is.
-          </p>
-        </>
+        <p>
+          State, CI, line counts and line-anchored comments, all beside the session. One click on a
+          comment spawns a resolver agent that makes the smallest fix, commits, and replies on the
+          thread.
+        </p>
       }
     >
       <GithubPanelSnapshot />

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -1,33 +1,35 @@
 import { DogMascot } from '../components/DogMascot';
+import { OrchestrationFlow } from '../components/OrchestrationFlow';
 import { LinkButton } from '../components/ui';
 import { AppOverviewSnapshot } from '../mockups/Snapshots';
 
 export function Hero() {
   return (
-    <section className="relative pt-16 pb-24 sm:pt-24 sm:pb-28">
-      <div className="relative mx-auto max-w-6xl px-6">
+    <section className="relative overflow-hidden pt-12 pb-24 sm:pt-16 sm:pb-28">
+      <div className="relative z-10 mx-auto max-w-6xl px-6">
         <div className="mx-auto max-w-3xl text-center">
-          <div className="rise relative mx-auto inline-flex flex-col pb-7">
-            <h1 className="flex items-center gap-2 sm:gap-3 text-[48px] sm:text-[68px] lg:text-[80px] leading-[0.95] tracking-[-0.035em] font-semibold text-foreground">
-              <DogMascot size={96} className="shrink-0 text-primary" />
-              <span>Goodboy</span>
-            </h1>
-
-            <p
-              className="rise absolute inset-x-0 top-full -mt-1 text-center text-[15px] sm:text-[17px] font-medium leading-[1.2] tracking-[-0.005em] text-primary"
-              style={{ animationDelay: '80ms' }}
-            >
-              AI workspace orchestrator.
-            </p>
+          {/* brand lockup */}
+          <div className="rise inline-flex items-center gap-2 text-[26px] font-semibold tracking-tight text-foreground">
+            <DogMascot size={34} className="text-primary" />
+            <span>Goodboy</span>
           </div>
 
+          {/* dominant tagline */}
+          <h1
+            className="rise mt-6 text-balance text-[42px] font-semibold leading-[0.98] tracking-[-0.035em] sm:text-[64px] lg:text-[76px]"
+            style={{ animationDelay: '60ms' }}
+          >
+            <span className="text-gradient">Every AI agent,</span>
+            <br />
+            <span className="text-foreground">one shared brain.</span>
+          </h1>
+
           <p
-            className="rise mx-auto mt-7 max-w-xl text-[15px] sm:text-[16px] leading-[1.6] text-muted-foreground"
+            className="rise mx-auto mt-6 max-w-xl text-[15px] leading-[1.6] text-muted-foreground sm:text-[17px]"
             style={{ animationDelay: '120ms' }}
           >
-            Stack workflows on one session. Route agents across Claude, Cursor, Codex, and Gemini
-            without re-explaining the goal. Shared context, structured plans, real-time cost.
-            Local-first. Your keys, your machine.
+            One local session runs Claude, Cursor, Codex and Gemini. They share context, plans and a
+            live cost meter, so the next agent already knows the goal.
           </p>
 
           <div
@@ -52,18 +54,24 @@ export function Hero() {
           </div>
 
           <p
-            className="rise mt-6 text-[12.5px] text-muted-foreground/75"
+            className="rise mt-5 text-[12.5px] text-muted-foreground/75"
             style={{ animationDelay: '240ms' }}
           >
-            MIT licensed &middot; Prebuilt for macOS, source on Linux &amp; Windows &middot; Bring
+            MIT licensed &middot; macOS prebuilt, Linux &amp; Windows from source &middot; Bring
             your own subscription
           </p>
         </div>
 
-        {/* One comprehensive snapshot of the running app: sidebar, chat,
-            context panel, all visible together. The deep-dives below zoom in
-            on each piece. */}
-        <div className="rise relative mx-auto mt-16 max-w-5xl" style={{ animationDelay: '320ms' }}>
+        {/* animated routing diagram */}
+        <div className="rise mt-14 sm:mt-16" style={{ animationDelay: '320ms' }}>
+          <OrchestrationFlow />
+        </div>
+
+        {/* one comprehensive snapshot of the running app */}
+        <div
+          className="rise float relative mx-auto mt-12 max-w-5xl sm:mt-14"
+          style={{ animationDelay: '420ms' }}
+        >
           <AppOverviewSnapshot />
         </div>
       </div>

--- a/website/src/sections/LinearDeepDive.tsx
+++ b/website/src/sections/LinearDeepDive.tsx
@@ -8,23 +8,10 @@ export function LinearDeepDive() {
       eyebrow="Linear (optional)"
       title={<>Start sessions from a ticket. Or just write your goal.</>}
       body={
-        <>
-          <p>
-            Sessions always start the same way: open the dialog, write what you want to do, pick a
-            branch. If you connect a Linear workspace, the dialog grows an issue picker so you can
-            skip the goal field entirely: pick a ticket assigned to you and the title, description,
-            and identifier auto-fill the session.
-          </p>
-          <p>
-            The Linear chip then rides with the session everywhere: in the rail, in the detail
-            header, in the session footer. One click jumps back to the original ticket. If you never
-            connect Linear, the dialog stays exactly as before. No nag, no fallback prompt.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            Your OAuth token, stored locally. Issues fetched on demand, never synced. No webhooks to
-            configure on the Linear side.
-          </p>
-        </>
+        <p>
+          Connect Linear and the new-session dialog grows an issue picker that auto-fills the goal
+          and tags the session. Skip it and nothing changes. Token stored locally, no webhooks.
+        </p>
       }
     >
       <NewSessionLinearSnapshot />

--- a/website/src/sections/LogoStrip.tsx
+++ b/website/src/sections/LogoStrip.tsx
@@ -1,3 +1,6 @@
+import type { CSSProperties } from 'react';
+import { useInView } from '../components/Reveal';
+
 type Card = {
   name: string;
   color: string;
@@ -6,98 +9,84 @@ type Card = {
 };
 
 const subscriptions: Card[] = [
-  {
-    name: 'Claude',
-    color: 'oklch(0.74 0.15 55)',
-    desc: 'Planning, refactors, reviews',
-  },
-  {
-    name: 'Cursor',
-    color: 'oklch(0.70 0.16 290)',
-    desc: 'Inline edits, autocomplete',
-  },
-  {
-    name: 'Codex',
-    color: 'oklch(0.72 0.16 150)',
-    desc: 'Scaffolds, one-shots',
-  },
-  {
-    name: 'Gemini',
-    color: 'oklch(0.72 0.16 240)',
-    desc: 'Long context, multimodal',
-  },
+  { name: 'Claude', color: 'oklch(0.74 0.15 55)', desc: 'Planning, refactors, reviews' },
+  { name: 'Cursor', color: 'oklch(0.70 0.16 290)', desc: 'Inline edits, autocomplete' },
+  { name: 'Codex', color: 'oklch(0.72 0.16 150)', desc: 'Scaffolds, one-shots' },
+  { name: 'Gemini', color: 'oklch(0.72 0.16 240)', desc: 'Long context, multimodal' },
 ];
 
 const integrations: Card[] = [
-  {
-    name: 'GitHub',
-    color: 'oklch(0.86 0.005 250)',
-    desc: 'PRs, checks, diff comments, resolver agents',
-  },
-  {
-    name: 'Linear',
-    color: 'oklch(0.62 0.18 275)',
-    desc: 'Issue picker, goal auto-fill, identifier badge',
-  },
-  {
-    name: 'GitLab',
-    color: 'oklch(0.74 0.15 55)',
-    desc: 'MRs, pipelines, threads',
-    soon: true,
-  },
-  {
-    name: 'Slack',
-    color: 'oklch(0.76 0.13 78)',
-    desc: 'Notify on PR ready, budget alerts',
-    soon: true,
-  },
+  { name: 'GitHub', color: 'oklch(0.86 0.005 250)', desc: 'PRs, checks, diff comments, resolvers' },
+  { name: 'Linear', color: 'oklch(0.62 0.18 275)', desc: 'Issue picker, goal auto-fill' },
+  { name: 'GitLab', color: 'oklch(0.74 0.15 55)', desc: 'MRs, pipelines, threads', soon: true },
+  { name: 'Slack', color: 'oklch(0.76 0.13 78)', desc: 'PR-ready and budget alerts', soon: true },
 ];
 
+const MASK: CSSProperties = {
+  WebkitMaskImage: 'linear-gradient(90deg, transparent, black 8%, black 92%, transparent)',
+  maskImage: 'linear-gradient(90deg, transparent, black 8%, black 92%, transparent)',
+};
+
 export function LogoStrip() {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section className="relative border-y border-border-soft/60 py-20">
-      <div className="mx-auto max-w-6xl space-y-14 px-6">
+    <section
+      ref={ref}
+      className={`reveal-group relative border-y border-border-soft/60 py-20 ${inView ? 'is-visible' : ''}`}
+    >
+      <div className="mx-auto max-w-6xl space-y-12 px-6">
         <Row eyebrow="Bring your own subscription" cards={subscriptions} />
-        <Row eyebrow="Integrations" cards={integrations} />
+        <Row eyebrow="Integrations" cards={integrations} reverse />
       </div>
     </section>
   );
 }
 
-function Row({ eyebrow, cards }: { eyebrow: string; cards: Card[] }) {
+function Row({ eyebrow, cards, reverse }: { eyebrow: string; cards: Card[]; reverse?: boolean }) {
   return (
-    <div>
+    <div className="reveal">
       <p className="pb-7 text-center text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
         {eyebrow}
       </p>
-      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
-        {cards.map((p) => (
-          <div
-            key={p.name}
-            className={[
-              'rounded-lg border border-border-soft bg-subtle p-4',
-              p.soon ? 'opacity-65' : '',
-            ].join(' ')}
-          >
-            <div className="flex items-center gap-2.5">
-              <span
-                className="h-2 w-2 shrink-0 rounded-full"
-                style={{ background: p.color }}
-                aria-hidden
-              />
-              <span className="text-[14px] font-semibold tracking-[-0.005em] text-foreground">
-                {p.name}
-              </span>
-              {p.soon ? (
-                <span className="ml-auto rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                  soon
-                </span>
-              ) : null}
-            </div>
-            <p className="mt-2 text-[12.5px] leading-snug text-muted-foreground">{p.desc}</p>
-          </div>
-        ))}
+      <div className="marquee-mask overflow-hidden" style={MASK}>
+        <div
+          className="marquee gap-3"
+          style={reverse ? { animationDirection: 'reverse' } : undefined}
+        >
+          {[...cards, ...cards].map((p, i) => (
+            <CardItem key={`${p.name}-${i}`} card={p} aria-hidden={i >= cards.length} />
+          ))}
+        </div>
       </div>
+    </div>
+  );
+}
+
+function CardItem({ card, ...rest }: { card: Card } & { 'aria-hidden'?: boolean }) {
+  return (
+    <div
+      {...rest}
+      className={[
+        'w-[230px] shrink-0 rounded-lg border border-border-soft bg-subtle p-4',
+        card.soon ? 'opacity-65' : '',
+      ].join(' ')}
+    >
+      <div className="flex items-center gap-2.5">
+        <span
+          className="h-2 w-2 shrink-0 rounded-full"
+          style={{ background: card.color }}
+          aria-hidden
+        />
+        <span className="text-[14px] font-semibold tracking-[-0.005em] text-foreground">
+          {card.name}
+        </span>
+        {card.soon ? (
+          <span className="ml-auto rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+            soon
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-2 text-[12.5px] leading-snug text-muted-foreground">{card.desc}</p>
     </div>
   );
 }

--- a/website/src/sections/Nav.tsx
+++ b/website/src/sections/Nav.tsx
@@ -4,8 +4,8 @@ import { LinkButton } from '../components/ui';
 const links = [
   { href: '#sessions', label: 'Sessions' },
   { href: '#agents', label: 'Agents' },
-  { href: '#context', label: 'Context' },
   { href: '#plans', label: 'Plans' },
+  { href: '#context', label: 'Context' },
   { href: '#linear', label: 'Linear' },
   { href: '#github', label: 'GitHub' },
   { href: '#compare', label: 'Compare' },
@@ -17,7 +17,7 @@ const links = [
 */
 export function Nav() {
   return (
-    <header className="relative z-30 border-b border-border-soft/40">
+    <header className="relative z-30 border-b border-border-soft/40 bg-background">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
         <a href="#" className="flex items-center">
           <Logo />

--- a/website/src/sections/PlansDeepDive.tsx
+++ b/website/src/sections/PlansDeepDive.tsx
@@ -1,34 +1,21 @@
 import { Section } from '../components/Section';
-import { WorkflowStackSnapshot } from '../mockups/Snapshots';
+import { WorkflowRunSnapshot } from '../mockups/Snapshots';
 
 export function PlansDeepDive() {
   return (
     <Section
       id="plans"
       eyebrow="Plans & workflows"
-      reverse
-      title={<>Stack workflows on one session. Plans land as artifacts.</>}
+      title={<>Save a workflow once. Replay it on every goal.</>}
       body={
-        <>
-          <p>
-            A workflow is a reusable sequence of typed steps (scout, plan, implement, review, debug,
-            test, docs). Attach one to start a session, then stack another on top when the work
-            forks. One session can carry many workflows in flight, each tracked end to end.
-          </p>
-          <p>
-            Pick a preset or design a fresh one from a theme. The planner agent emits structured
-            output wrapped in <code className="font-mono text-warning">&lt;&lt;plan&gt;&gt;</code>{' '}
-            markers; Goodboy lifts them out of the chat and stores them as first-class plan
-            artifacts the implementer can consume.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            Workflows live at the workspace. Plans live at the session. The boundary is explicit so
-            templates stay reusable and artifacts stay specific to the work that produced them.
-          </p>
-        </>
+        <p>
+          A workflow is a saved sequence of agent roles: scout, implement, review. Run it a step at
+          a time, or flip on auto-run and let it carry the goal to a PR on its own. Plans land as
+          first-class artifacts the implementer picks up, tracked end to end.
+        </p>
       }
     >
-      <WorkflowStackSnapshot />
+      <WorkflowRunSnapshot />
     </Section>
   );
 }

--- a/website/src/sections/RoutingDeepDive.tsx
+++ b/website/src/sections/RoutingDeepDive.tsx
@@ -6,25 +6,13 @@ export function RoutingDeepDive() {
     <Section
       id="routing"
       eyebrow="Routing & cost"
-      title={<>Three providers. One ledger.</>}
+      title={<>Four providers. One ledger.</>}
       body={
-        <>
-          <p>
-            Pick the right provider for the work. Long-context refactor? Claude or Gemini. Inline
-            edit? Cursor. Codegen scaffold? Codex. Switch the session default at any time, or
-            override just the next turn from the composer chip. Either way the next agent rebuilds
-            from shared context, never the provider thread.
-          </p>
-          <p>
-            Each turn carries an estimated cost. The session keeps a running total. Set an optional
-            soft cap and Goodboy warns you before it overshoots. The cost chip ticks live next to
-            the composer so the bill never lives in a different tab.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            Subscription-based. Uses your Claude, Cursor, ChatGPT, and Google AI subscriptions. No
-            metered API tokens.
-          </p>
-        </>
+        <p>
+          Pick the right provider per turn; the next agent rebuilds from shared context, never the
+          thread. Every turn&apos;s cost ticks live against an optional soft cap, on your own
+          subscriptions.
+        </p>
       }
     >
       <BudgetSnapshot />

--- a/website/src/sections/SessionsDeepDive.tsx
+++ b/website/src/sections/SessionsDeepDive.tsx
@@ -8,24 +8,10 @@ export function SessionsDeepDive() {
       eyebrow="Sessions"
       title={<>One rail. Every thread you have running.</>}
       body={
-        <>
-          <p>
-            A session is a unit of work: a goal, a branch, a worktree, a transcript, a ledger. The
-            left rail keeps every active session a click away. The detail panel collapses agents,
-            editor launchers, workspace scripts, PR state, and session settings behind a single
-            action menu so the title gets the space it deserves.
-          </p>
-          <p>
-            One click opens the worktree in Cursor or VS Code. Another runs a saved workspace script
-            (deploy a preview, copy env, anything you script). The branch chip and the PR status
-            ride alongside the running cost so you always know where the work is, what it cost, and
-            whether CI is green.
-          </p>
-          <p className="text-[14px] text-muted-foreground/80">
-            Jump between workspaces with ⌘1-9. Cycle sessions inside one with ⌘[ and ⌘]. Archive
-            when finished, reopen when you change your mind, nothing is lost.
-          </p>
-        </>
+        <p>
+          Goal, branch, worktree, agents, PR state and live cost, all collapsed into one rail. Open
+          the worktree in Cursor, run a workspace script, jump between sessions with ⌘1-9.
+        </p>
       }
     >
       <SessionsSnapshot />

--- a/website/src/sections/Stack.tsx
+++ b/website/src/sections/Stack.tsx
@@ -1,48 +1,37 @@
-const items = [
-  { label: 'Tauri 2', sub: 'native shell', glyph: 'T' },
-  { label: 'React 19', sub: 'UI', glyph: 'R' },
-  { label: 'TypeScript', sub: 'strict mode', glyph: 'TS' },
-  { label: 'Tailwind 4', sub: 'design system', glyph: 'tw' },
-  { label: 'Zustand', sub: 'state', glyph: 'Z' },
-  { label: 'SQLite', sub: 'local DB', glyph: 'SQ' },
-  { label: 'Vite', sub: 'build', glyph: 'V' },
-  { label: 'Turborepo', sub: 'monorepo', glyph: 'TR' },
-];
+import { useInView } from '../components/Reveal';
+
+const tech = ['Tauri 2', 'React 19', 'TypeScript', 'SQLite'] as const;
 
 export function Stack() {
+  const { ref, inView } = useInView<HTMLElement>();
   return (
-    <section id="stack" className="relative py-24 sm:py-28">
-      <div className="mx-auto max-w-6xl px-6">
-        <div className="grid items-start gap-16 lg:grid-cols-[1.1fr_1fr]">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
-              Architecture
-            </p>
-            <h2 className="mt-4 text-3xl sm:text-4xl leading-[1.05] tracking-[-0.025em] font-semibold text-foreground">
-              Native shell. Modern web underneath.
-            </h2>
-            <p className="mt-6 max-w-prose text-[15px] leading-[1.7] text-muted-foreground">
-              Tauri shell wrapping a React + TypeScript surface. SQLite stores everything locally.
-              API keys live in your OS credential store. Nothing leaves the machine unless an agent
-              calls a provider you authorized.
-            </p>
-          </div>
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-            {items.map((i) => (
-              <div
-                key={i.label}
-                className="flex aspect-square flex-col justify-between rounded-xl border border-border-soft bg-subtle p-4"
+    <section
+      id="stack"
+      ref={ref}
+      className={`reveal-group relative py-16 sm:py-20 ${inView ? 'is-visible' : ''}`}
+    >
+      <div className="mx-auto max-w-3xl px-6">
+        <div className="reveal rounded-2xl border border-border-soft bg-subtle px-6 py-8 sm:px-10 sm:py-10">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
+            Local-first
+          </p>
+          <h2 className="mt-3 text-2xl sm:text-3xl leading-[1.1] tracking-[-0.02em] font-semibold text-foreground">
+            Native shell. Your data stays home.
+          </h2>
+          <p className="mt-4 max-w-prose text-[15px] leading-[1.7] text-muted-foreground">
+            Keys live in your OS keychain, SQLite on disk. Nothing leaves the machine unless an
+            agent calls a provider you authorized.
+          </p>
+          <ul className="mt-6 flex flex-wrap gap-2">
+            {tech.map((t) => (
+              <li
+                key={t}
+                className="rounded-full border border-border-soft bg-muted px-3 py-1 font-mono text-[11.5px] text-muted-foreground"
               >
-                <div className="flex h-8 w-8 items-center justify-center rounded-md border border-border-soft bg-muted font-mono text-[12px] font-semibold text-primary">
-                  {i.glyph}
-                </div>
-                <div>
-                  <div className="text-[13px] font-medium text-foreground">{i.label}</div>
-                  <div className="text-[11px] text-muted-foreground">{i.sub}</div>
-                </div>
-              </div>
+                {t}
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       </div>
     </section>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -78,14 +78,11 @@ body,
   -webkit-font-smoothing: antialiased;
 }
 
-body {
-  /* a single, very faint wash across the top of the page. nothing else. */
-  background-image: radial-gradient(
-    ellipse 80% 40% at 50% -10%,
-    oklch(0.74 0.11 200 / 0.05),
-    transparent 60%
-  );
-  background-attachment: fixed;
+#root {
+  /* a fine dot grid across the whole page. #root carries the opaque base
+     colour, so the dots must live here (a pattern on body is hidden behind it). */
+  background-image: radial-gradient(oklch(0.78 0.02 255 / 0.08) 1px, transparent 1.5px);
+  background-size: 20px 20px;
 }
 
 ::selection {
@@ -184,6 +181,191 @@ body {
   line-height: 1.62;
 }
 
+/* ------------------------------------------------------------------ *
+ *  Motion layer. Demolish-and-rebuild pass: the page is allowed to be
+ *  alive now. Scroll-reveal, a drifting aurora, flowing wires, a marquee.
+ *  Everything below collapses to a static end-state under reduced motion.
+ * ------------------------------------------------------------------ */
+
+/* Scroll reveal. A parent `.reveal-group` flips to `.is-visible` when it
+   enters the viewport (IntersectionObserver). Children tagged `.reveal`
+   animate in, staggered by an inline animation-delay. */
+@keyframes reveal-up {
+  from { opacity: 0; transform: translateY(26px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.reveal-group .reveal {
+  opacity: 0;
+  will-change: opacity, transform;
+}
+.reveal-group.is-visible .reveal {
+  animation: reveal-up 760ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+/* Aurora: two oversized, blurred colour fields that drift behind the hero.
+   Pure transform animation, GPU-cheap, sits at -z under the content. */
+@keyframes aurora-a {
+  0%, 100% { transform: translate3d(-8%, -6%, 0) scale(1); }
+  50% { transform: translate3d(6%, 8%, 0) scale(1.18); }
+}
+@keyframes aurora-b {
+  0%, 100% { transform: translate3d(8%, 6%, 0) scale(1.1); }
+  50% { transform: translate3d(-6%, -8%, 0) scale(0.92); }
+}
+.aurora {
+  position: absolute;
+  inset: -20% -10% auto -10%;
+  height: 760px;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  /* Feather the bottom so the clipped, blurred blobs dissolve into the page
+     instead of cutting off in a hard horizontal seam. */
+  -webkit-mask-image: linear-gradient(to bottom, #000 45%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 45%, transparent 100%);
+}
+.aurora::before,
+.aurora::after {
+  content: '';
+  position: absolute;
+  width: 60vw;
+  height: 60vw;
+  max-width: 760px;
+  max-height: 760px;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.5;
+}
+.aurora::before {
+  top: -18%;
+  left: 8%;
+  background: radial-gradient(circle at 50% 50%, oklch(0.74 0.11 200 / 0.55), transparent 70%);
+  animation: aurora-a 16s ease-in-out infinite;
+}
+.aurora::after {
+  top: -8%;
+  right: 6%;
+  background: radial-gradient(circle at 50% 50%, oklch(0.70 0.16 290 / 0.4), transparent 70%);
+  animation: aurora-b 19s ease-in-out infinite;
+}
+
+/* Animated gradient text. Used on the hero tagline. */
+@keyframes gradient-pan {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+.text-gradient {
+  background-image: linear-gradient(
+    100deg,
+    oklch(0.95 0.02 90),
+    oklch(0.82 0.12 200),
+    oklch(0.80 0.13 290),
+    oklch(0.95 0.02 90)
+  );
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradient-pan 7s linear infinite;
+}
+
+/* Floating element (hero snapshot). Tiny vertical drift. */
+@keyframes float-y {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-10px); }
+}
+.float {
+  animation: float-y 7s ease-in-out infinite;
+}
+
+/* Flowing wires: dashed strokes that scroll along their path so the
+   connectors read as live data moving between nodes. */
+@keyframes dash-flow {
+  to { stroke-dashoffset: -28; }
+}
+.wire-flow {
+  stroke-dasharray: 4 8;
+  animation: dash-flow 1s linear infinite;
+}
+
+/* Node breathing glow for the orchestration diagram. */
+@keyframes node-glow {
+  0%, 100% { opacity: 0.35; transform: scale(1); }
+  50% { opacity: 0.75; transform: scale(1.08); }
+}
+.node-glow {
+  animation: node-glow 3s ease-in-out infinite;
+}
+
+/* Self-playing workflow demo: a per-step progress bar that fills while a step
+   runs, and a one-shot ripple where the simulated cursor presses. */
+@keyframes run-progress {
+  from { transform: scaleX(0); }
+  to { transform: scaleX(1); }
+}
+.run-bar {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  width: 100%;
+  background: var(--color-primary);
+  transform-origin: left;
+  transform: scaleX(0);
+  animation: run-progress 1.4s ease-in-out forwards;
+}
+@keyframes press-ring {
+  from { opacity: 0.5; transform: translate(-50%, -50%) scale(0.4); }
+  to { opacity: 0; transform: translate(-50%, -50%) scale(1.7); }
+}
+.press-ring {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 9999px;
+  border: 2px solid var(--color-primary);
+  animation: press-ring 420ms ease-out forwards;
+}
+
+/* Marquee: a track duplicated twice, translated -50% on loop, so the row
+   scrolls forever with no seam. Always animating, no hover pause. */
+@keyframes marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.marquee {
+  display: flex;
+  width: max-content;
+  animation: marquee 34s linear infinite;
+}
+
+/* Shimmer sweep for the eyebrow pill. */
+@keyframes shimmer {
+  0% { background-position: -150% 0; }
+  100% { background-position: 250% 0; }
+}
+.shimmer {
+  background-image: linear-gradient(
+    100deg,
+    transparent 20%,
+    oklch(1 0 0 / 0.07) 50%,
+    transparent 80%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 3.4s ease-in-out infinite;
+}
+
+/* Snapshot hover-tilt. Lifts toward the cursor on hover. */
+.tilt {
+  transition: transform 400ms cubic-bezier(0.16, 1, 0.3, 1), box-shadow 400ms ease;
+}
+.tilt:hover {
+  transform: perspective(1400px) rotateX(2deg) translateY(-4px);
+  box-shadow: var(--shadow-lg);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
@@ -191,4 +373,7 @@ body {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+  /* Never leave reveal content stuck at opacity 0 if motion is disabled. */
+  .reveal-group .reveal { opacity: 1 !important; transform: none !important; }
+  .aurora { display: none; }
 }


### PR DESCRIPTION
## Summary
- Rework the landing page into a guided tour of one coherent product story (shipping a password-reset flow), with scroll-reveal motion and snapshots that mirror real desktop UI at full fidelity.
- New motion system (`Reveal` + `styles.css` keyframes) and `OrchestrationFlow` hero.
- Plans section: self-playing workflow run (lit step, simulated click, auto-run toggle) faithful to the desktop `WorkflowStepRow` / `AutoRunToggle`.
- Agents section: role roster (icon, name, scope) replacing the busy showcase; copy lifted verbatim from `agent-kind.ts` `AGENT_KIND_META`.
- Reorder sections, floating nav, trimmed copy across the page.

## Test plan
- [ ] `pnpm dev` in `website/`, review at localhost:1499
- [ ] Plans `#plans`: lit step → click → running → done → next lit; auto-run toggle flips top-right; remaining steps auto-advance; loops
- [ ] Agents `#agents`: 7 default roles render with icon + name + one-line scope
- [ ] Desktop + mobile layouts
- [ ] `prefers-reduced-motion`: animations fall back to a static frame