### PR TITLE
feat(desktop): visible update affordance + confirm-before-restart (v0.1.2)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.1"
+version = "0.1.2"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
@@ -1,13 +1,15 @@
+import { useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { ArrowUpCircle, Loader2 } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { Button, Dialog, cn } from '@goodboy/ui';
 import { useAppStore } from '../../../../store';
 
 type Props = { variant: 'bar' | 'pip' };
 
 // Non-invasive "update ready" affordance, shown only when a newer release has
-// been found. Click downloads + installs + relaunches. Rendered both in the
-// status bar (bar) and next to the sidebar logo (pip), à la VS Code / Claude.
+// been found. Click opens a confirm dialog (the app relaunches on install, so
+// we warn before interrupting running sessions). Rendered both in the status
+// bar (bar) and next to the sidebar logo (pip), à la VS Code / Claude.
 export function UpdateIndicator({ variant }: Props) {
   const { status, version, installUpdate } = useAppStore(
     useShallow((s) => ({
@@ -16,40 +18,72 @@ export function UpdateIndicator({ variant }: Props) {
       installUpdate: s.installUpdate,
     })),
   );
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   if (status !== 'available' && status !== 'downloading') return null;
 
   const downloading = status === 'downloading';
-  const label = downloading
+  const title = downloading
     ? 'Downloading update, the app will restart'
-    : `Restart to update${version ? ` to ${version}` : ''}`;
+    : `Update available${version ? ` (${version})` : ''}`;
   const Icon = downloading ? Loader2 : ArrowUpCircle;
 
-  if (variant === 'pip') {
-    return (
+  const confirm = () => {
+    setConfirmOpen(false);
+    void installUpdate();
+  };
+
+  // Both placements share the same confirm flow; only the trigger chrome differs.
+  const trigger =
+    variant === 'pip' ? (
       <button
         type="button"
-        onClick={() => void installUpdate()}
+        onClick={() => setConfirmOpen(true)}
         disabled={downloading}
-        title={label}
-        aria-label={label}
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-primary transition-colors hover:text-primary/70 disabled:opacity-60"
+        title={title}
+        className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-1.5 py-0.5 text-2xs font-medium text-primary transition-colors hover:bg-primary/20 disabled:opacity-60"
       >
-        <Icon size={13} className={cn(downloading && 'animate-spin')} aria-hidden />
+        <Icon size={11} className={cn(downloading && 'animate-spin')} aria-hidden />
+        <span>{downloading ? 'updating…' : 'update'}</span>
+      </button>
+    ) : (
+      <button
+        type="button"
+        onClick={() => setConfirmOpen(true)}
+        disabled={downloading}
+        title={title}
+        className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-primary transition-colors hover:bg-primary/10 disabled:opacity-60"
+      >
+        <Icon size={11} className={cn(downloading && 'animate-spin')} aria-hidden />
+        <span>{downloading ? 'Updating…' : 'Update'}</span>
       </button>
     );
-  }
 
   return (
-    <button
-      type="button"
-      onClick={() => void installUpdate()}
-      disabled={downloading}
-      title={label}
-      className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-primary transition-colors hover:bg-primary/10 disabled:opacity-60"
-    >
-      <Icon size={11} className={cn(downloading && 'animate-spin')} aria-hidden />
-      <span>{downloading ? 'Updating…' : 'Restart to update'}</span>
-    </button>
+    <>
+      {trigger}
+      <Dialog
+        open={confirmOpen}
+        onClose={() => setConfirmOpen(false)}
+        size="sm"
+        title="Install update?"
+        description={version ? `A new version (${version}) is ready.` : 'A new version is ready.'}
+        footer={
+          <>
+            <Button variant="ghost" size="sm" onClick={() => setConfirmOpen(false)}>
+              Not now
+            </Button>
+            <Button variant="primary" size="sm" onClick={confirm}>
+              Update and restart
+            </Button>
+          </>
+        }
+      >
+        <p className="leading-relaxed text-muted-foreground">
+          Goodboy will restart to finish installing. Any running sessions are interrupted, so save
+          your work before continuing.
+        </p>
+      </Dialog>
+    </>
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## what

- update affordance next to the sidebar logo is now a labeled pill (`↑ update`) instead of a bare arrow, so it reads as actionable
- clicking the update control (pill or status bar) no longer installs immediately; it opens a confirm dialog warning that Goodboy restarts and running sessions are interrupted
- bumps version to 0.1.2

verified via `v0.1.2-rc.1` draft build (signed + notarized dmg launches clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)