### PR TITLE
feat(desktop): flat app shell + studio open/close transitions

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -5,6 +5,7 @@ import type { SessionId } from '@goodboy/types';
 import { InboxList } from './InboxList';
 import { PrDetailPanel } from './PrDetailPanel';
 import { useGithubInbox } from './useGithubInbox';
+import { useStudioOverlay } from '../../../../shared/hooks/useStudioOverlay';
 
 interface Props {
   readonly workspaceName: string;
@@ -15,14 +16,7 @@ interface Props {
 export function GitHubStudio({ workspaceName, initialSessionId, onClose }: Props) {
   const groups = useGithubInbox();
   const [focused, setFocused] = useState<SessionId | null>(initialSessionId);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  const { closing, requestClose } = useStudioOverlay(onClose);
 
   useEffect(() => {
     if (focused !== null) return;
@@ -31,7 +25,12 @@ export function GitHubStudio({ workspaceName, initialSessionId, onClose }: Props
   }, [focused, groups]);
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-background">
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col bg-background',
+        closing ? 'motion-safe:animate-studio-out' : 'motion-safe:animate-studio-in',
+      )}
+    >
       <header className="flex shrink-0 items-center gap-3 px-6 py-3">
         <span className="flex size-8 items-center justify-center rounded-lg bg-primary/10">
           <GitPullRequest size={16} className="text-primary" aria-hidden />
@@ -48,11 +47,11 @@ export function GitHubStudio({ workspaceName, initialSessionId, onClose }: Props
         <div className="flex-1" />
         <button
           type="button"
-          onClick={onClose}
+          onClick={requestClose}
           className={cn(
-            'inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5',
-            'text-xs font-medium text-muted-foreground transition-colors',
-            'hover:border-border hover:bg-muted/50 hover:text-foreground',
+            'inline-flex items-center gap-1.5 rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5',
+            'text-xs font-semibold text-danger transition-colors',
+            'hover:border-danger/60 hover:bg-danger/15',
           )}
           aria-label="close github studio"
         >
@@ -67,7 +66,7 @@ export function GitHubStudio({ workspaceName, initialSessionId, onClose }: Props
         </div>
         <Divider orientation="vertical" />
         <div className="min-h-0 flex-1">
-          <PrDetailPanel sessionId={focused} onClose={onClose} />
+          <PrDetailPanel sessionId={focused} onClose={requestClose} />
         </div>
       </div>
     </div>

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/index.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
 import { cn, Divider } from '@goodboy/ui';
 import { Layers, X } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { WorkflowsPanel } from '../WorkflowsPanel';
+import { useStudioOverlay } from '../../../../shared/hooks/useStudioOverlay';
 
 interface Props {
   readonly workspaceId: WorkspaceId;
@@ -10,20 +10,16 @@ interface Props {
   readonly onClose: () => void;
 }
 
-// Full-screen takeover for authoring multi-agent workflows. Replaces chat +
-// context entirely so the user focuses only on the blueprint. Opened from the
-// sidebar footer; Esc closes.
 export function WorkflowStudio({ workspaceId, workspaceName, onClose }: Props) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
+  const { closing, requestClose } = useStudioOverlay(onClose);
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-background">
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col bg-background',
+        closing ? 'motion-safe:animate-studio-out' : 'motion-safe:animate-studio-in',
+      )}
+    >
       <header className="flex shrink-0 items-center gap-3 px-6 py-3">
         <span className="flex size-8 items-center justify-center rounded-lg bg-primary/10">
           <Layers size={16} className="text-primary" aria-hidden />
@@ -40,11 +36,11 @@ export function WorkflowStudio({ workspaceId, workspaceName, onClose }: Props) {
         <div className="flex-1" />
         <button
           type="button"
-          onClick={onClose}
+          onClick={requestClose}
           className={cn(
-            'inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5',
-            'text-xs font-medium text-muted-foreground transition-colors',
-            'hover:border-border hover:bg-muted/50 hover:text-foreground',
+            'inline-flex items-center gap-1.5 rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5',
+            'text-xs font-semibold text-danger transition-colors',
+            'hover:border-danger/60 hover:bg-danger/15',
           )}
           aria-label="close workflow studio"
         >

--- a/apps/desktop/src/shared/hooks/useStudioOverlay.ts
+++ b/apps/desktop/src/shared/hooks/useStudioOverlay.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
+
+const EXIT_MS = 200;
+
+interface StudioOverlay {
+  readonly closing: boolean;
+  readonly requestClose: () => void;
+}
+
+export function useStudioOverlay(onClose: () => void): StudioOverlay {
+  const [closing, setClosing] = useState(false);
+
+  const requestClose = useCallback(() => setClosing(true), []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') requestClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [requestClose]);
+
+  useEffect(() => {
+    if (!closing) return;
+    const t = setTimeout(onClose, EXIT_MS);
+    return () => clearTimeout(t);
+  }, [closing, onClose]);
+
+  return { closing, requestClose };
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -103,6 +103,32 @@
     }
   }
 
+  --animate-studio-in: studio-in 280ms cubic-bezier(0.2, 0, 0, 1);
+
+  @keyframes studio-in {
+    from {
+      opacity: 0;
+      transform: scale(0.985);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  --animate-studio-out: studio-out 200ms cubic-bezier(0.4, 0, 1, 1) forwards;
+
+  @keyframes studio-out {
+    from {
+      opacity: 1;
+      transform: scale(1);
+    }
+    to {
+      opacity: 0;
+      transform: scale(0.985);
+    }
+  }
+
   /* Dark shadows, subtle drop + faint inner highlight to lift cards on dark bg. */
   --shadow-sm:
     0 1px 2px 0 oklch(0 0 0 / 0.28),

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -206,7 +206,7 @@ export function AppShell({
       >
         {hasLeftSidebar ? (
           <aside
-            className="m-3 flex min-h-0 min-w-0 flex-col overflow-hidden rounded-[6px] bg-subtle shadow-md"
+            className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background"
             style={{ gridArea: 'left' }}
           >
             {leftSidebar}
@@ -223,7 +223,7 @@ export function AppShell({
             className="group relative cursor-col-resize select-none"
             style={{ gridArea: 'lhandle' }}
           >
-            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border group-focus-visible:bg-primary" />
+            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-gradient-to-b from-transparent via-border-soft to-transparent transition-colors group-hover:via-border group-focus-visible:via-primary" />
           </div>
         ) : null}
         <main
@@ -246,17 +246,12 @@ export function AppShell({
             )}
             style={{ gridArea: 'rhandle' }}
           >
-            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-border group-focus-visible:bg-primary" />
+            <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-gradient-to-b from-transparent via-border-soft to-transparent transition-colors group-hover:via-border group-focus-visible:via-primary" />
           </div>
         ) : null}
         {hasRightSidebar ? (
           <aside
-            className={cn(
-              'flex min-h-0 min-w-0 flex-col overflow-hidden transition-[margin,background-color,border-radius,box-shadow] duration-200 ease-out',
-              rightSidebarCollapsed
-                ? 'mr-3 mt-3 bg-background'
-                : 'm-3 rounded-[6px] bg-subtle shadow-md',
-            )}
+            className="flex min-h-0 min-w-0 flex-col overflow-hidden bg-background"
             style={{ gridArea: 'right' }}
           >
             {rightSidebar}


### PR DESCRIPTION
## What

Bring the main view in line with the studios' flat, table-like look, and give the studio takeovers a legible enter/exit transition.

### Flat app shell
- `AppShell`: drop the floating-card treatment (margins, rounded corners, `bg-subtle`, shadows) on the left/right panels. Panels are now full-bleed `bg-background` separated only by gradient hairline dividers, matching Workflow Studio and GitHub Studio.
- Resize handles use the same fading divider gradient (hover → `border`, focus → `primary`) instead of a hard line.

### Studio transitions
- `styles.css`: new `studio-in` / `studio-out` keyframes (fade + subtle scale) so a takeover reads as "a mode opening over the app" rather than a hard cut. `studio-out` is faster than the enter — the reveal deserves more weight than the dismissal.
- `useStudioOverlay`: shared hook owning Esc-to-close and a deferred unmount, so the exit animation can play before `App.tsx` drops the overlay. `EXIT_MS` is kept in sync with the keyframe duration.
- `WorkflowStudio` / `GitHubStudio`: wire the hook, animate enter/exit symmetrically, and recolor the **Done** button to `danger` so the way out is obvious (previously a muted grey that was easy to miss).

## Notes
- Reduced-motion: keyframes are neutralized by the global `prefers-reduced-motion` block; the overlay simply holds for `EXIT_MS` then unmounts (imperceptible).
- Removed the now-duplicated Esc bindings from both studios (centralized in the hook).

## Test plan
- [ ] Main view reads flat (no card edges/shadows), panels separated by dividers only
- [ ] Sidebar resize handles still drag; divider fades in on hover
- [ ] Opening Workflow / GitHub Studio fades + scales in
- [ ] Closing via Done or Esc plays the exit transition before unmount
- [ ] Done button is clearly visible (red) top-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)