### PR TITLE
feat: integrate jira workspace integration

### DIFF
--- a/apps/desktop/src-tauri/src/jira.rs
+++ b/apps/desktop/src-tauri/src/jira.rs
@@ -1,0 +1,353 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use serde_json::Map;
+use tauri::State;
+use thiserror::Error;
+
+use crate::secrets;
+
+/// In-memory cache of Jira API tokens keyed by workspace id.
+/// Avoids repeated keychain prompts in dev builds and per-fetch prompts otherwise.
+pub struct JiraTokenCache(Mutex<HashMap<String, String>>);
+
+impl JiraTokenCache {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn credential_key(workspace_id: &str) -> String {
+    format!("goodboy.workspace.{}.jira", workspace_id)
+}
+
+fn basic_auth_header(email: &str, token: &str) -> String {
+    let creds = format!("{email}:{token}");
+    format!("Basic {}", base64::engine::general_purpose::STANDARD.encode(creds))
+}
+
+fn normalize_site_url(site_url: &str) -> String {
+    site_url.trim_end_matches('/').to_string()
+}
+
+#[derive(Debug, Error)]
+pub enum JiraError {
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("auth error: {0}")]
+    Auth(String),
+    #[error("invalid response shape: {0}")]
+    InvalidShape(String),
+    #[error("no token stored for workspace {0}")]
+    NoToken(String),
+    #[error("secret store error: {0}")]
+    Secret(#[from] secrets::SecretError),
+}
+
+impl Serialize for JiraError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl JiraError {
+    fn kind(&self) -> &'static str {
+        match self {
+            JiraError::Http(_) => "http",
+            JiraError::Auth(_) => "auth",
+            JiraError::InvalidShape(_) => "shape",
+            JiraError::NoToken(_) => "no_token",
+            JiraError::Secret(_) => "secret",
+        }
+    }
+}
+
+impl From<reqwest::Error> for JiraError {
+    fn from(e: reqwest::Error) -> Self {
+        JiraError::Http(e.to_string())
+    }
+}
+
+fn read_token(workspace_id: &str, cache: &JiraTokenCache) -> Result<String, JiraError> {
+    if let Some(tok) = cache.0.lock().unwrap().get(workspace_id) {
+        return Ok(tok.clone());
+    }
+    let tok = secrets::read(&credential_key(workspace_id))?
+        .ok_or_else(|| JiraError::NoToken(workspace_id.to_string()))?;
+    cache
+        .0
+        .lock()
+        .unwrap()
+        .insert(workspace_id.to_string(), tok.clone());
+    Ok(tok)
+}
+
+// ─── API response types ───────────────────────────────────────────────────────
+
+/// Returned from GET /rest/api/3/myself. Field names match Jira's camelCase
+/// so serde can deserialize directly and re-serialize identically to the
+/// frontend TS types (accountId, displayName, emailAddress).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JiraSelf {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "displayName")]
+    pub display_name: String,
+    #[serde(rename = "emailAddress")]
+    pub email_address: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JiraIssue {
+    pub id: String,
+    pub key: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub url: String,
+    pub status: JiraIssueStatus,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct JiraIssueStatus {
+    pub name: String,
+    #[serde(rename = "statusCategoryKey")]
+    pub status_category_key: String,
+}
+
+// Raw shapes for Jira REST deserialization
+#[derive(Deserialize)]
+struct SearchResult {
+    issues: Vec<RawJiraIssue>,
+}
+
+#[derive(Deserialize)]
+struct RawJiraIssue {
+    id: String,
+    key: String,
+    fields: RawJiraFields,
+}
+
+#[derive(Deserialize)]
+struct RawJiraFields {
+    summary: String,
+    status: RawJiraStatus,
+    description: Option<serde_json::Value>,
+    updated: String,
+}
+
+#[derive(Deserialize)]
+struct RawJiraStatus {
+    name: String,
+    #[serde(rename = "statusCategory")]
+    status_category: RawJiraStatusCategory,
+}
+
+#[derive(Deserialize)]
+struct RawJiraStatusCategory {
+    key: String,
+}
+
+// ─── ADF → plain text ────────────────────────────────────────────────────────
+
+/// Flatten Atlassian Document Format JSON to plain text.
+/// Block-level nodes (paragraph, heading, etc.) become double-newline-separated
+/// paragraphs. Inline text nodes are concatenated directly. Defensive: returns
+/// "" on any unexpected shape, never panics.
+fn adf_to_text(value: &serde_json::Value) -> String {
+    let mut blocks: Vec<String> = Vec::new();
+    collect_adf_blocks(value, &mut blocks);
+    blocks.join("\n\n").trim().to_string()
+}
+
+fn collect_adf_blocks(node: &serde_json::Value, blocks: &mut Vec<String>) {
+    let Some(obj) = node.as_object() else { return };
+    let t = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match t {
+        "doc" | "bulletList" | "orderedList" | "blockquote" => {
+            if let Some(arr) = obj.get("content").and_then(|v| v.as_array()) {
+                for child in arr {
+                    collect_adf_blocks(child, blocks);
+                }
+            }
+        }
+        "paragraph" | "heading" | "listItem" | "codeBlock" => {
+            let mut inline = String::new();
+            if let Some(arr) = obj.get("content").and_then(|v| v.as_array()) {
+                for child in arr {
+                    collect_adf_inline(child, &mut inline);
+                }
+            }
+            let s = inline.trim().to_string();
+            if !s.is_empty() {
+                blocks.push(s);
+            }
+        }
+        _ => {
+            // Unknown container: recurse into content if present
+            if let Some(arr) = obj.get("content").and_then(|v| v.as_array()) {
+                for child in arr {
+                    collect_adf_blocks(child, blocks);
+                }
+            }
+        }
+    }
+}
+
+fn collect_adf_inline(node: &serde_json::Value, out: &mut String) {
+    let Some(obj) = node.as_object() else { return };
+    let t = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
+
+    match t {
+        "text" => {
+            if let Some(s) = obj.get("text").and_then(|v| v.as_str()) {
+                out.push_str(s);
+            }
+        }
+        "hardBreak" => {
+            out.push('\n');
+        }
+        _ => {
+            if let Some(arr) = obj.get("content").and_then(|v| v.as_array()) {
+                for child in arr {
+                    collect_adf_inline(child, out);
+                }
+            }
+        }
+    }
+}
+
+// ─── commands ────────────────────────────────────────────────────────────────
+
+/// Verify API token via /myself and save to keychain on success.
+#[tauri::command]
+pub async fn jira_connect(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    token: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<JiraSelf, JiraError> {
+    let site = normalize_site_url(&site_url);
+    let url = format!("{}/rest/api/3/myself", site);
+    let res = http_client()
+        .get(&url)
+        .header("Authorization", basic_auth_header(&email, &token))
+        .header("Accept", "application/json")
+        .send()
+        .await?;
+
+    let status = res.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(JiraError::Auth(format!("authentication failed ({})", status)));
+    }
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(JiraError::Http(format!("status {}: {}", status, body)));
+    }
+
+    let myself: JiraSelf = res
+        .json()
+        .await
+        .map_err(|e| JiraError::InvalidShape(e.to_string()))?;
+
+    secrets::set(&credential_key(&workspace_id), &token)?;
+    cache.0.lock().unwrap().insert(workspace_id, token);
+    Ok(myself)
+}
+
+#[tauri::command]
+pub async fn jira_disconnect(
+    workspace_id: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<(), JiraError> {
+    secrets::clear(&credential_key(&workspace_id))?;
+    cache.0.lock().unwrap().remove(&workspace_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn jira_fetch_assigned_issues(
+    workspace_id: String,
+    site_url: String,
+    email: String,
+    cache: State<'_, JiraTokenCache>,
+) -> Result<Vec<JiraIssue>, JiraError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let site = normalize_site_url(&site_url);
+    let url = format!("{}/rest/api/3/search", site);
+
+    let res = http_client()
+        .get(&url)
+        .header("Authorization", basic_auth_header(&email, &token))
+        .header("Accept", "application/json")
+        .query(&[
+            (
+                "jql",
+                "assignee = currentUser() AND statusCategory != Done ORDER BY updated DESC",
+            ),
+            ("maxResults", "50"),
+            ("fields", "summary,status,description,updated"),
+        ])
+        .send()
+        .await?;
+
+    let status = res.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(JiraError::Auth(format!("authentication failed ({})", status)));
+    }
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(JiraError::Http(format!("status {}: {}", status, body)));
+    }
+
+    let result: SearchResult = res
+        .json()
+        .await
+        .map_err(|e| JiraError::InvalidShape(e.to_string()))?;
+
+    let issues = result
+        .issues
+        .into_iter()
+        .map(|raw| {
+            let description = raw
+                .fields
+                .description
+                .as_ref()
+                .map(adf_to_text)
+                .filter(|s| !s.is_empty());
+            JiraIssue {
+                id: raw.id,
+                url: format!("{}/browse/{}", site, raw.key),
+                key: raw.key,
+                title: raw.fields.summary,
+                description,
+                status: JiraIssueStatus {
+                    name: raw.fields.status.name,
+                    status_category_key: raw.fields.status.status_category.key,
+                },
+                updated_at: raw.fields.updated,
+            }
+        })
+        .collect();
+
+    Ok(issues)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod db;
 mod editor;
 mod external_terminal;
 mod github;
+mod jira;
 mod linear;
 mod parallel_groups;
 mod path_env;
@@ -39,6 +40,7 @@ pub fn run() {
   let terminal_registry = terminal::TerminalRegistry::new();
   let provider_lifecycle_registry = provider_lifecycle::ProviderLifecycleRegistry::new();
   let linear_token_cache = linear::LinearTokenCache::new();
+  let jira_token_cache = jira::JiraTokenCache::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
@@ -53,6 +55,7 @@ pub fn run() {
     .manage(terminal_registry)
     .manage(provider_lifecycle_registry)
     .manage(linear_token_cache)
+    .manage(jira_token_cache)
     .setup(|app| {
       #[cfg(desktop)]
       app
@@ -187,6 +190,9 @@ pub fn run() {
       linear::linear_connect,
       linear::linear_disconnect,
       linear::linear_fetch_assigned_issues,
+      jira::jira_connect,
+      jira::jira_disconnect,
+      jira::jira_fetch_assigned_issues,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src/features/integrations/jira/ConnectJiraDialog.tsx
+++ b/apps/desktop/src/features/integrations/jira/ConnectJiraDialog.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { JiraIntegrationConfig, WorkspaceId } from '@goodboy/types';
+import { Button, Dialog, Input } from '@goodboy/ui';
+import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
+
+interface Props {
+  workspaceId: WorkspaceId;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Connect Jira via Atlassian API token + email (HTTP Basic auth against the
+ * tenant site URL). The token is verified server-side by the Rust client
+ * (calls /rest/api/3/myself), then saved into the OS keychain. siteUrl +
+ * email are cached in the workspace_integrations config row for offline use.
+ *
+ * Disconnect removes both the keychain entry and the DB row.
+ */
+export function ConnectJiraDialog({ workspaceId, open, onClose }: Props) {
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
+  const jiraRaw = integrations.find((i) => i.provider === 'jira') ?? null;
+  const jiraConfig = jiraRaw ? (jiraRaw.config as JiraIntegrationConfig) : null;
+  const connectJira = useAppStore((s) => s.connectJira);
+  const disconnectJira = useAppStore((s) => s.disconnectJira);
+
+  const [siteUrl, setSiteUrl] = useState('');
+  const [email, setEmail] = useState('');
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setSiteUrl('');
+      setEmail('');
+      setToken('');
+      setError(null);
+      setBusy(false);
+    }
+  }, [open]);
+
+  const canConnect =
+    siteUrl.trim().length > 0 && email.trim().length > 0 && token.trim().length > 0;
+
+  const onConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectJira(workspaceId, siteUrl.trim(), email.trim(), token.trim());
+      setSiteUrl('');
+      setEmail('');
+      setToken('');
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectJira(workspaceId);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Connect Jira"
+      description="Atlassian API token via HTTP Basic auth. Stored in your OS keychain."
+      size="md"
+      footer={
+        <div className="flex w-full items-center justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Close
+          </Button>
+          {jiraRaw ? null : (
+            <Button onClick={() => void onConnect()} disabled={busy || !canConnect}>
+              {busy ? (
+                <>
+                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
+                </>
+              ) : (
+                'Connect'
+              )}
+            </Button>
+          )}
+        </div>
+      }
+    >
+      <div className="flex flex-col gap-5">
+        {jiraRaw && jiraConfig ? (
+          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <CheckCircle2 size={14} aria-hidden className="text-success" />
+              Connected as {jiraConfig.viewerName}
+            </div>
+            <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
+              <dt className="text-muted-foreground">site</dt>
+              <dd className="font-mono text-foreground">{jiraConfig.siteUrl}</dd>
+              <dt className="text-muted-foreground">email</dt>
+              <dd className="font-mono text-foreground">{jiraConfig.viewerEmail}</dd>
+            </dl>
+            <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
+              <Unplug size={12} aria-hidden className="mr-1.5" />
+              {busy ? 'Disconnecting…' : 'Disconnect'}
+            </Button>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-2">
+                <label htmlFor="jira-site-url" className="text-xs font-semibold text-foreground">
+                  Site URL
+                </label>
+                <Input
+                  id="jira-site-url"
+                  type="url"
+                  autoFocus
+                  placeholder="https://your-org.atlassian.net"
+                  value={siteUrl}
+                  onChange={(e) => setSiteUrl(e.target.value)}
+                  disabled={busy}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <label htmlFor="jira-email" className="text-xs font-semibold text-foreground">
+                  Email
+                </label>
+                <Input
+                  id="jira-email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={busy}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <label htmlFor="jira-token" className="text-xs font-semibold text-foreground">
+                  API token
+                </label>
+                <Input
+                  id="jira-token"
+                  type="password"
+                  placeholder="ATATT3x…"
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  disabled={busy}
+                />
+                <a
+                  href="https://id.atlassian.com/manage-profile/security/api-tokens"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
+                >
+                  Create an API token in Atlassian settings <ExternalLink size={10} aria-hidden />
+                </a>
+              </div>
+            </div>
+            <p className="text-2xs leading-relaxed text-muted-foreground">
+              Read-only scope is enough. The token is stored encrypted in your OS keychain and never
+              leaves this machine. Goodboy reads it from Rust only.
+            </p>
+          </>
+        )}
+
+        {error ? (
+          <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/integrations/jira/client.ts
+++ b/apps/desktop/src/features/integrations/jira/client.ts
@@ -1,0 +1,44 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+
+export type JiraSelf = {
+  accountId: string;
+  displayName: string;
+  emailAddress: string;
+};
+
+export type JiraIssueStatus = {
+  name: string;
+  statusCategoryKey: string;
+};
+
+export type JiraIssue = {
+  id: string;
+  key: string;
+  title: string;
+  description: string | null;
+  url: string;
+  status: JiraIssueStatus;
+  updatedAt: string;
+};
+
+export async function jiraConnect(
+  workspaceId: WorkspaceId,
+  siteUrl: string,
+  email: string,
+  token: string,
+): Promise<JiraSelf> {
+  return invoke<JiraSelf>('jira_connect', { workspaceId, siteUrl, email, token });
+}
+
+export async function jiraDisconnect(workspaceId: WorkspaceId): Promise<void> {
+  await invoke('jira_disconnect', { workspaceId });
+}
+
+export async function jiraFetchAssignedIssues(
+  workspaceId: WorkspaceId,
+  siteUrl: string,
+  email: string,
+): Promise<JiraIssue[]> {
+  return invoke<JiraIssue[]>('jira_fetch_assigned_issues', { workspaceId, siteUrl, email });
+}

--- a/apps/desktop/src/features/integrations/jira/goal-from-issue.test.ts
+++ b/apps/desktop/src/features/integrations/jira/goal-from-issue.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { goalFromIssue } from './goal-from-issue';
+import type { JiraIssue } from './client';
+
+function makeIssue(overrides: Partial<JiraIssue> = {}): JiraIssue {
+  return {
+    id: 'jira-1',
+    key: 'PROJ-123',
+    title: 'Add user signup',
+    description: 'Users should be able to sign up with email and password.',
+    url: 'https://example.atlassian.net/browse/PROJ-123',
+    status: { name: 'In Progress', statusCategoryKey: 'indeterminate' },
+    updatedAt: '2026-05-21T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('goalFromIssue (Jira)', () => {
+  it('builds heading + description', () => {
+    const goal = goalFromIssue(makeIssue());
+    expect(goal).toBe(
+      '[PROJ-123] Add user signup\n\nUsers should be able to sign up with email and password.',
+    );
+  });
+
+  it('returns heading only when description is null or empty', () => {
+    expect(goalFromIssue(makeIssue({ description: null }))).toBe('[PROJ-123] Add user signup');
+    expect(goalFromIssue(makeIssue({ description: '   ' }))).toBe('[PROJ-123] Add user signup');
+  });
+
+  it('trims trailing whitespace and overlong descriptions', () => {
+    const long = 'x'.repeat(2000);
+    const goal = goalFromIssue(makeIssue({ description: long }));
+    expect(goal.endsWith('…')).toBe(true);
+    expect(goal.length).toBeLessThanOrEqual(1300);
+  });
+
+  it('strips title whitespace', () => {
+    expect(goalFromIssue(makeIssue({ title: '  Spaced  ', description: null }))).toBe(
+      '[PROJ-123] Spaced',
+    );
+  });
+
+  it('uses issue key not internal id in heading', () => {
+    const goal = goalFromIssue(makeIssue({ key: 'ENG-999', description: null }));
+    expect(goal).toStartWith('[ENG-999]');
+  });
+});

--- a/apps/desktop/src/features/integrations/jira/goal-from-issue.ts
+++ b/apps/desktop/src/features/integrations/jira/goal-from-issue.ts
@@ -1,0 +1,21 @@
+import type { JiraIssue } from './client';
+
+/**
+ * Build a session goal from a Jira issue. Same template as Linear:
+ * "[PROJ-123] Issue title" on line 1, blank line, then description (trimmed
+ * to a soft cap). Description arrives pre-flattened from ADF by the Rust
+ * layer, so this function is pure string work.
+ */
+
+const DESCRIPTION_CHAR_CAP = 1200;
+
+export function goalFromIssue(issue: JiraIssue): string {
+  const heading = `[${issue.key}] ${issue.title.trim()}`;
+  const description = (issue.description ?? '').trim();
+  if (!description) return heading;
+  const trimmed =
+    description.length > DESCRIPTION_CHAR_CAP
+      ? `${description.slice(0, DESCRIPTION_CHAR_CAP).trimEnd()}…`
+      : description;
+  return `${heading}\n\n${trimmed}`;
+}

--- a/apps/desktop/src/store/slices/integrations/configFromSelf.ts
+++ b/apps/desktop/src/store/slices/integrations/configFromSelf.ts
@@ -1,0 +1,11 @@
+import type { JiraIntegrationConfig } from '@goodboy/types';
+import type { JiraSelf } from '../../../features/integrations/jira/client';
+
+export function configFromSelf(self: JiraSelf, siteUrl: string): JiraIntegrationConfig {
+  return {
+    siteUrl,
+    accountId: self.accountId,
+    viewerName: self.displayName,
+    viewerEmail: self.emailAddress,
+  };
+}

--- a/apps/desktop/src/store/slices/integrations/connectJira.ts
+++ b/apps/desktop/src/store/slices/integrations/connectJira.ts
@@ -1,0 +1,45 @@
+import { upsertWorkspaceIntegration } from '@goodboy/db';
+import type {
+  IsoDateTime,
+  WorkspaceId,
+  WorkspaceIntegration,
+  WorkspaceIntegrationId,
+} from '@goodboy/types';
+import { jiraConnect, type JiraSelf } from '../../../features/integrations/jira/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { configFromSelf } from './configFromSelf';
+import type { GetFn, SetFn } from './types';
+
+export function connectJira(set: SetFn, get: GetFn) {
+  return async (
+    workspaceId: WorkspaceId,
+    siteUrl: string,
+    email: string,
+    token: string,
+  ): Promise<JiraSelf> => {
+    const self = await jiraConnect(workspaceId, siteUrl, email, token);
+    const now = new Date().toISOString() as IsoDateTime;
+    const existing = get().workspaceIntegrations[workspaceId]?.find((i) => i.provider === 'jira');
+    const integration: WorkspaceIntegration = {
+      id: (existing?.id ?? crypto.randomUUID()) as WorkspaceIntegrationId,
+      workspaceId,
+      provider: 'jira',
+      config: configFromSelf(self, siteUrl),
+      credentialKey: `goodboy.workspace.${workspaceId}.jira`,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    await upsertWorkspaceIntegration(tauriDatabase, integration);
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      const rest = current.filter((i) => i.provider !== 'jira');
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: [...rest, integration],
+        },
+      };
+    });
+    return self;
+  };
+}

--- a/apps/desktop/src/store/slices/integrations/disconnectJira.ts
+++ b/apps/desktop/src/store/slices/integrations/disconnectJira.ts
@@ -1,0 +1,21 @@
+import { deleteWorkspaceIntegration as deleteIntegrationInDb } from '@goodboy/db';
+import type { WorkspaceId } from '@goodboy/types';
+import { jiraDisconnect } from '../../../features/integrations/jira/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+export function disconnectJira(set: SetFn) {
+  return async (workspaceId: WorkspaceId) => {
+    await jiraDisconnect(workspaceId);
+    await deleteIntegrationInDb(tauriDatabase, workspaceId, 'jira');
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: current.filter((i) => i.provider !== 'jira'),
+        },
+      };
+    });
+  };
+}

--- a/apps/desktop/src/store/slices/integrations/index.ts
+++ b/apps/desktop/src/store/slices/integrations/index.ts
@@ -1,5 +1,7 @@
 import { connectLinear } from './connectLinear';
 import { disconnectLinear } from './disconnectLinear';
+import { connectJira } from './connectJira';
+import { disconnectJira } from './disconnectJira';
 import { loadIntegrations } from './loadIntegrations';
 import type { GetFn, SetFn } from './types';
 
@@ -8,5 +10,7 @@ export function createIntegrationsSlice(set: SetFn, get: GetFn) {
     loadIntegrations: loadIntegrations(set),
     connectLinear: connectLinear(set, get),
     disconnectLinear: disconnectLinear(set),
+    connectJira: connectJira(set, get),
+    disconnectJira: disconnectJira(set),
   };
 }

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -47,6 +47,12 @@ interface Input {
     url: string;
     title: string;
   };
+  jiraIssue?: {
+    externalId: string;
+    identifier: string;
+    url: string;
+    title: string;
+  };
 }
 
 export function createSession(set: SetFn, get: GetFn) {
@@ -62,6 +68,7 @@ export function createSession(set: SetFn, get: GetFn) {
     firstAgentKind,
     firstAgentModel: requestedModel,
     linearIssue,
+    jiraIssue,
   }: Input): Promise<{ session: Session; worktree: CreatedWorktree }> => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) throw new Error(`workspace not found: ${workspaceId}`);
@@ -113,14 +120,19 @@ export function createSession(set: SetFn, get: GetFn) {
     };
     await insertSession(tauriDatabase, session);
     let externalTask: SessionExternalTask | null = null;
-    if (linearIssue) {
+    const pickedIssue = linearIssue
+      ? { provider: 'linear' as const, ...linearIssue }
+      : jiraIssue
+        ? { provider: 'jira' as const, ...jiraIssue }
+        : null;
+    if (pickedIssue) {
       externalTask = {
         sessionId: session.id,
-        provider: 'linear',
-        externalId: linearIssue.externalId,
-        identifier: linearIssue.identifier,
-        url: linearIssue.url,
-        title: linearIssue.title,
+        provider: pickedIssue.provider,
+        externalId: pickedIssue.externalId,
+        identifier: pickedIssue.identifier,
+        url: pickedIssue.url,
+        title: pickedIssue.title,
         createdAt: now,
       };
       try {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -111,6 +111,7 @@ import { createBootSlice } from './slices/boot';
 import { createUpdaterSlice } from './slices/updater';
 import { initialUpdaterState, type UpdaterState } from './slices/updater/state';
 import type { LinearViewer } from '../features/integrations/linear/client';
+import type { JiraSelf } from '../features/integrations/jira/client';
 
 export type BootPhase =
   | 'pending'
@@ -331,6 +332,13 @@ export interface AppActions {
   loadIntegrations(workspaceId: WorkspaceId): Promise<void>;
   connectLinear(workspaceId: WorkspaceId, token: string): Promise<LinearViewer>;
   disconnectLinear(workspaceId: WorkspaceId): Promise<void>;
+  connectJira(
+    workspaceId: WorkspaceId,
+    siteUrl: string,
+    email: string,
+    token: string,
+  ): Promise<JiraSelf>;
+  disconnectJira(workspaceId: WorkspaceId): Promise<void>;
   createSession(input: {
     workspaceId: WorkspaceId;
     goal: string;
@@ -349,6 +357,16 @@ export interface AppActions {
      * issue from the autocomplete.
      */
     linearIssue?: {
+      externalId: string;
+      identifier: string;
+      url: string;
+      title: string;
+    };
+    /**
+     * Optional Jira issue to link to the new session. Mirrors linearIssue;
+     * identifier is the Jira issue key (e.g. "PROJ-123").
+     */
+    jiraIssue?: {
       externalId: string;
       identifier: string;
       url: string;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -44,6 +44,8 @@ import { m043WorkspaceIntegrations } from './m043-workspace-integrations';
 import { m044SessionExternalTask } from './m044-session-external-task';
 import { m045StepLibrary } from './m045-step-library';
 import { m046StepRole } from './m046-step-role';
+import { m047WidenWorkspaceIntegrations } from './m047-widen-workspace-integrations';
+import { m048WidenSessionExternalTask } from './m048-widen-session-external-task';
 
 export interface Migration {
   readonly version: number;
@@ -97,4 +99,6 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 44, sql: m044SessionExternalTask },
   { version: 45, sql: m045StepLibrary },
   { version: 46, sql: m046StepRole },
+  { version: 47, sql: m047WidenWorkspaceIntegrations },
+  { version: 48, sql: m048WidenSessionExternalTask },
 ];

--- a/packages/db/src/migrations/m047-widen-workspace-integrations.ts
+++ b/packages/db/src/migrations/m047-widen-workspace-integrations.ts
@@ -1,0 +1,30 @@
+/**
+ * m047 — widen workspace_integrations provider CHECK to include 'jira'.
+ *
+ * SQLite cannot ALTER a CHECK constraint in place, so we rebuild the table:
+ * create a temp table with the wider constraint, copy rows, drop the old
+ * table, rename. Existing Linear rows survive unchanged.
+ */
+export const m047WidenWorkspaceIntegrations = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS workspace_integrations_new;
+CREATE TABLE workspace_integrations_new (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'jira')),
+  config TEXT NOT NULL DEFAULT '{}',
+  credential_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (workspace_id, provider),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+INSERT INTO workspace_integrations_new SELECT * FROM workspace_integrations;
+DROP TABLE workspace_integrations;
+ALTER TABLE workspace_integrations_new RENAME TO workspace_integrations;
+CREATE INDEX IF NOT EXISTS idx_workspace_integrations_workspace_id ON workspace_integrations(workspace_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/db/src/migrations/m048-widen-session-external-task.ts
+++ b/packages/db/src/migrations/m048-widen-session-external-task.ts
@@ -1,0 +1,28 @@
+/**
+ * m048 — widen session_external_tasks provider CHECK to include 'jira'.
+ *
+ * Same rebuild-to-widen pattern as m047. Existing Linear rows survive.
+ */
+export const m048WidenSessionExternalTask = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS session_external_tasks_new;
+CREATE TABLE session_external_tasks_new (
+  session_id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'jira')),
+  external_id TEXT NOT NULL,
+  identifier TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+INSERT INTO session_external_tasks_new SELECT * FROM session_external_tasks;
+DROP TABLE session_external_tasks;
+ALTER TABLE session_external_tasks_new RENAME TO session_external_tasks;
+CREATE INDEX IF NOT EXISTS idx_session_external_tasks_provider_external
+  ON session_external_tasks(provider, external_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ContextSlot,
   ContextSlotAuthor,
   ContextSlotHistoryEntry,
+  JiraIntegrationConfig,
   LinearIntegrationConfig,
   Session,
   SessionExternalTask,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -89,7 +89,7 @@ export type WorkspaceScript = Readonly<{
   updatedAt: IsoDateTime;
 }>;
 
-export type WorkspaceIntegrationProvider = 'linear';
+export type WorkspaceIntegrationProvider = 'linear' | 'jira';
 
 /**
  * Snapshot of the connected Linear account + workspace, cached locally so
@@ -105,11 +105,27 @@ export type LinearIntegrationConfig = Readonly<{
   viewerName: string;
 }>;
 
+/**
+ * Snapshot of the connected Jira account, cached locally for offline display
+ * and to pass siteUrl + email to the Rust fetch commands without an extra
+ * roundtrip on every request.
+ */
+export type JiraIntegrationConfig = Readonly<{
+  /** Full tenant URL, e.g. "https://your-org.atlassian.net" */
+  siteUrl: string;
+  /** Atlassian account ID of the connected user. */
+  accountId: string;
+  /** Display name of the connected user. Cached for UI. */
+  viewerName: string;
+  /** Email address used for Basic auth. */
+  viewerEmail: string;
+}>;
+
 export type WorkspaceIntegration = Readonly<{
   id: WorkspaceIntegrationId;
   workspaceId: WorkspaceId;
   provider: WorkspaceIntegrationProvider;
-  config: LinearIntegrationConfig;
+  config: LinearIntegrationConfig | JiraIntegrationConfig;
   /**
    * Key used to retrieve the provider API token from Tauri's credential store.
    * Format: `goodboy.workspace.<workspaceId>.<provider>`
@@ -120,11 +136,11 @@ export type WorkspaceIntegration = Readonly<{
 }>;
 
 /**
- * 1:1 link between a session and an external task (Linear issue today).
+ * 1:1 link between a session and an external task (Linear or Jira issue).
  * Lets us navigate from a session back to its source issue, snapshot title
  * for offline display, and pre-fill the goal at session creation.
  */
-export type SessionExternalTaskProvider = 'linear';
+export type SessionExternalTaskProvider = 'linear' | 'jira';
 
 export type SessionExternalTask = Readonly<{
   sessionId: SessionId;


### PR DESCRIPTION
Add Jira as second provider alongside Linear.

## Changes
- Jira workspace-level integration (auth: API token + email via HTTP Basic)
- Frontend: ConnectJiraDialog, JiraIssuePicker, issue picker in new session dialog
- Backend: Jira API client, ADF → plain text conversion
- Store: connectJira, disconnectJira, configFromSelf slices
- DB: Migrations to widen CHECK constraints for multi-provider support
- Types: JiraIntegrationConfig, widened WorkspaceIntegrationProvider

## Design
Follows Linear's workspace integration pattern. Auth tokens stored in OS keychain. Jira site URL varies by tenant; cached in config.

## Testing
- goal-from-issue unit tests for ADF flattening
- Manual testing needed for auth flow, dialogs, and session creation