### PR TITLE
feat(repo): rework marketing site copy + github studio section

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary -->
-    <title>Goodboy: every AI agent, one shared brain</title>
+    <title>Goodboy</title>
     <meta name="description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
     <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
     <meta name="author" content="Amin Khayam" />
@@ -16,22 +16,22 @@
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
-    <meta property="og:title" content="Goodboy: every AI agent, one shared brain" />
+    <meta property="og:title" content="Goodboy: stop re-explaining yourself" />
     <meta property="og:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Goodboy: every AI agent, one shared brain" />
+    <meta property="og:image:alt" content="Goodboy: stop re-explaining yourself" />
     <meta property="og:locale" content="en_US" />
 
     <!-- Twitter / X card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
-    <meta name="twitter:title" content="Goodboy: every AI agent, one shared brain" />
+    <meta name="twitter:title" content="Goodboy: stop re-explaining yourself" />
     <meta name="twitter:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
-    <meta name="twitter:image:alt" content="Goodboy: every AI agent, one shared brain" />
+    <meta name="twitter:image:alt" content="Goodboy: stop re-explaining yourself" />
 
     <!-- Theme / PWA hints -->
     <meta name="theme-color" content="#1a1c26" />

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -4,18 +4,12 @@ import { Nav } from './sections/Nav';
 import { FloatingNav } from './sections/FloatingNav';
 import { Hero } from './sections/Hero';
 import { Letter } from './sections/Letter';
-import { LogoStrip } from './sections/LogoStrip';
 import { SessionsDeepDive } from './sections/SessionsDeepDive';
-import { AgentsDeepDive } from './sections/AgentsDeepDive';
 import { ContextDeepDive } from './sections/ContextDeepDive';
-import { PlansDeepDive } from './sections/PlansDeepDive';
 import { StudioDeepDive } from './sections/StudioDeepDive';
-import { LinearDeepDive } from './sections/LinearDeepDive';
-import { RoutingDeepDive } from './sections/RoutingDeepDive';
 import { GithubDeepDive } from './sections/GithubDeepDive';
-import { AlsoGrid } from './sections/AlsoGrid';
+import { MoreBriefly } from './sections/MoreBriefly';
 import { Comparison } from './sections/Comparison';
-import { Stack } from './sections/Stack';
 import { CTA } from './sections/CTA';
 import { Footer } from './sections/Footer';
 
@@ -25,20 +19,18 @@ export function App() {
       <Nav />
       <FloatingNav />
       <main>
+        {/* above the fold: the reason + install/github + app overview */}
         <Hero />
+        {/* the human note, sets the voice before the features */}
         <Letter />
-        <LogoStrip />
+        {/* the key points */}
         <SessionsDeepDive />
-        <AgentsDeepDive />
-        <PlansDeepDive />
-        <StudioDeepDive />
         <ContextDeepDive />
-        <LinearDeepDive />
+        <StudioDeepDive />
         <GithubDeepDive />
-        <RoutingDeepDive />
-        <AlsoGrid />
+        <MoreBriefly />
+        {/* close */}
         <Comparison />
-        <Stack />
         <CTA />
       </main>
       <Footer />

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -34,7 +34,7 @@ export function Section({
           <div className="reveal min-w-0 max-w-lg">
             <Eyebrow>{eyebrow}</Eyebrow>
             <SectionTitle>{title}</SectionTitle>
-            <div className="mt-5 max-w-prose text-[16px] leading-[1.6] text-muted-foreground">
+            <div className="mt-5 max-w-prose text-pretty text-[16px] leading-[1.65] text-muted-foreground sm:text-[17px]">
               {body}
             </div>
           </div>

--- a/website/src/components/ui.tsx
+++ b/website/src/components/ui.tsx
@@ -70,7 +70,9 @@ export function SectionTitle({ children, className }: { children: ReactNode; cla
   return (
     <h2
       className={cn(
-        'mt-4 text-3xl sm:text-4xl tracking-[-0.025em] leading-[1.05] font-semibold text-foreground',
+        // h2 scale benchmarked against mantine.dev: larger than body for a
+        // clear step, slightly looser line-height so two-line titles breathe.
+        'mt-4 text-pretty text-[30px] sm:text-[40px] tracking-[-0.02em] leading-[1.12] font-semibold text-foreground',
         className,
       )}
     >

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -1107,144 +1107,176 @@ function SlotCard({
   );
 }
 
-/* ---------------------------- GitHub panel (unified) ---------------- */
+/* ---------------------------- GitHub Studio --------------------------- */
 
-/* Single coherent screen mirroring features/github/components/Panel: the PR
-   header for the session (state, branch, diff stats, CI), then the review
-   thread with line-anchored comments from human teammates, the locally-run
-   claude reviewer, and you. Each comment exposes a one-click resolve that
-   spawns a resolver agent in the worktree. Replaces the older two-snapshot
-   split (overview list + review list) which read as two different products. */
-const REVIEW_COMMENTS = [
+/* Mirrors features/github/components/GitHubStudio: a full-screen PR command
+   center. Left, the inbox: every session's PR bucketed by what it needs from
+   you (draft, in review, approved...). Right, the focused PR with its
+   lifecycle actions (mark ready, close, squash-merge) and a review comment
+   you can hand straight to an agent. Compacted to two panes for the page. */
+const INBOX_GROUPS: ReadonlyArray<{
+  readonly label: string;
+  readonly rows: ReadonlyArray<{
+    readonly goal: string;
+    readonly num: number;
+    readonly tone: 'open' | 'approved' | 'draft';
+    readonly attention?: boolean;
+    readonly active?: boolean;
+  }>;
+}> = [
   {
-    author: 'sara.h',
-    avatar: 'oklch(0.72 0.16 150)',
-    file: 'src/auth/reset/handler.ts',
-    line: 28,
-    body: 'Wrap the token insert + audit log in `transaction()` so a flaky mailer never leaves a token without a paired log row.',
-    status: 'open' as const,
+    label: 'In review',
+    rows: [
+      { goal: 'Add password reset', num: 214, tone: 'open', attention: true, active: true },
+      { goal: 'Rate limiter', num: 211, tone: 'open' },
+    ],
   },
   {
-    author: 'claude-reviewer',
-    avatar: 'oklch(0.74 0.15 55)',
-    file: 'src/auth/reset/token.ts',
-    line: 42,
-    body: 'Hash with `argon2id` instead of sha256. Tokens are short-lived but the table will still get scraped if the DB leaks.',
-    status: 'open' as const,
+    label: 'Approved',
+    rows: [{ goal: 'Webhook retry backoff', num: 208, tone: 'approved' }],
   },
   {
-    author: 'you',
-    avatar: 'oklch(0.78 0.13 200)',
-    file: 'src/mail/templates/reset.tsx',
-    line: 11,
-    body: 'Link text reads "Reset password" but the button below already says that. Make the body line a sentence.',
-    status: 'resolved' as const,
-    resolvedBy: 'resolver-c3b7',
+    label: 'Draft',
+    rows: [{ goal: 'Drop legacy cookies', num: 205, tone: 'draft' }],
   },
 ];
 
-export function GithubPanelSnapshot() {
-  const unresolved = REVIEW_COMMENTS.filter((c) => c.status === 'open').length;
+const PR_TONE: Record<'open' | 'approved' | 'draft', string> = {
+  open: 'text-success',
+  approved: 'text-success',
+  draft: 'text-muted-foreground/60',
+};
+
+export function GithubStudioSnapshot() {
   return (
-    <SnapshotFrame className="max-w-[540px]">
+    <SnapshotFrame className="max-w-[560px]">
       <FrameHeader
-        label="GitHub"
+        label="GitHub Studio"
         right={
-          <span className="font-mono text-[10px] text-muted-foreground/70">last sync 12s ago</span>
+          <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning">
+            beta
+          </span>
         }
       />
-
-      {/* PR header */}
-      <div className="border-b border-border-soft/60 px-3 py-3">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-[11px] text-muted-foreground">#214</span>
-          <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-foreground">
-            feat(auth): password reset via email link
-          </span>
-          <span className="chip chip-success">open</span>
+      <div className="flex">
+        {/* inbox: every session's PR, bucketed by what it needs from you */}
+        <div className="w-[176px] shrink-0 space-y-2.5 border-r border-border-soft p-2">
+          {INBOX_GROUPS.map((g) => (
+            <div key={g.label} className="flex flex-col gap-0.5">
+              <div className="flex items-center gap-1 px-1 pb-0.5">
+                <span className="text-[9px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                  {g.label}
+                </span>
+                <span className="text-[9px] tabular-nums text-muted-foreground/50">
+                  {g.rows.length}
+                </span>
+                <span aria-hidden className="ml-1 h-px flex-1 bg-border-soft" />
+              </div>
+              {g.rows.map((r) => (
+                <div
+                  key={r.num}
+                  className={[
+                    'flex items-center gap-1.5 rounded-md px-1.5 py-1',
+                    r.active ? 'bg-primary/10 ring-1 ring-primary/30' : '',
+                  ].join(' ')}
+                >
+                  <IconPullRequest size={11} className={['shrink-0', PR_TONE[r.tone]].join(' ')} />
+                  <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/85">
+                    {r.goal}
+                  </span>
+                  <span className="shrink-0 font-mono text-[9px] text-muted-foreground/50">
+                    #{r.num}
+                  </span>
+                  {r.attention ? (
+                    <span
+                      aria-hidden
+                      title="changes requested"
+                      className="size-1.5 shrink-0 rounded-full bg-danger"
+                    />
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ))}
         </div>
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-[10.5px] text-muted-foreground">
-          <span className="inline-flex items-center gap-1">
-            <IconBranch size={10} />
-            <span className="truncate">ak/password-reset</span>
-          </span>
-          <span className="inline-flex items-center gap-0.5 text-success">
-            <IconArrowUp size={9} />
-            180
-          </span>
-          <span className="inline-flex items-center gap-0.5 text-danger">
-            <IconArrowDown size={9} />2
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="size-1.5 rounded-full bg-success" />6 / 6 checks
-          </span>
-          <span className="inline-flex items-center gap-1">
-            <span className="size-1.5 rounded-full bg-warning" />
-            {unresolved} unresolved
-          </span>
+
+        {/* detail: the focused PR, full lifecycle + a comment you can hand off */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-2 px-3 pt-3 pb-2">
+            <span className="font-mono text-[10px] text-muted-foreground">#214</span>
+            <span className="min-w-0 flex-1 truncate text-[12px] font-semibold text-foreground">
+              feat(auth): password reset via email link
+            </span>
+            <span className="chip chip-success shrink-0">open</span>
+          </div>
+
+          {/* section nav */}
+          <div className="flex items-center gap-1 px-3 pb-2 text-[10px]">
+            <span className="rounded px-1.5 py-0.5 text-muted-foreground/70">Overview</span>
+            <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-medium text-foreground">
+              Conversation
+              <span className="rounded-full bg-warning/20 px-1 text-[8px] font-semibold text-warning">
+                2
+              </span>
+            </span>
+            <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-muted-foreground/70">
+              Checks
+              <span aria-hidden className="size-1.5 rounded-full bg-success" />
+            </span>
+          </div>
+
+          {/* lifecycle action bar */}
+          <div className="flex items-center gap-1.5 border-y border-border-soft/60 px-3 py-2">
+            <span className="inline-flex items-center gap-1 rounded-md border border-success bg-success px-2 py-1 text-[10px] font-semibold text-zinc-950">
+              <IconCheck size={10} /> Merge
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-1 text-[10px] font-medium text-muted-foreground">
+              Close
+            </span>
+            <span className="ml-auto inline-flex items-center gap-1 font-mono text-[9.5px] text-muted-foreground/60">
+              <IconBranch size={9} /> ak/password-reset → main
+            </span>
+          </div>
+
+          {/* one review comment, handed to an agent */}
+          <div className="flex flex-col gap-1.5 px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+              <span
+                aria-hidden
+                className="inline-flex size-4 items-center justify-center rounded-full font-mono text-[8.5px] font-semibold text-zinc-950"
+                style={{ background: 'oklch(0.74 0.15 55)' }}
+              >
+                C
+              </span>
+              <span className="font-medium text-foreground/80">claude-reviewer</span>
+              <span>on</span>
+              <code className="font-mono text-primary">token.ts:42</code>
+            </div>
+            <p className="text-[11px] leading-relaxed text-foreground/85">
+              Hash with <code className="font-mono text-foreground/70">argon2id</code> instead of
+              sha256, the table gets scraped if the DB ever leaks.
+            </p>
+            <div className="flex items-center gap-2">
+              <span className="inline-flex items-center gap-1 rounded-md border border-accent/40 bg-accent/5 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+                <IconSparkles size={10} /> resolve
+              </span>
+              <span className="text-[10px] text-muted-foreground/60">
+                hands the fix to an agent, replies on the thread
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-auto flex items-center justify-between gap-2 border-t border-border-soft bg-warning/5 px-3 py-2 text-[10.5px]">
+            <span className="inline-flex items-center gap-1.5 text-warning">
+              <IconSparkles size={11} /> Resolve all 2 with one agent
+            </span>
+            <span aria-hidden className="text-warning opacity-60">
+              →
+            </span>
+          </div>
         </div>
-      </div>
-
-      {/* Review thread */}
-      <ul className="flex flex-col divide-y divide-border-soft/40">
-        {REVIEW_COMMENTS.map((c, i) => (
-          <li key={i} className="px-3 py-2.5">
-            <ReviewCommentRow comment={c} />
-          </li>
-        ))}
-      </ul>
-
-      {/* Footer: batch resolve */}
-      <div className="flex items-center justify-between gap-2 border-t border-border-soft bg-warning/5 px-3 py-2 text-[11px]">
-        <span className="inline-flex items-center gap-1.5 text-warning">
-          <IconSparkles size={11} />
-          Resolve all {unresolved} with one agent batch
-        </span>
-        <span aria-hidden className="text-warning opacity-60">
-          →
-        </span>
       </div>
     </SnapshotFrame>
-  );
-}
-
-function ReviewCommentRow({ comment }: { comment: (typeof REVIEW_COMMENTS)[number] }) {
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-        <span
-          aria-hidden
-          className="inline-flex size-4 items-center justify-center rounded-full font-mono text-[8.5px] font-semibold text-zinc-950"
-          style={{ background: comment.avatar }}
-        >
-          {comment.author[0]!.toUpperCase()}
-        </span>
-        <span className="font-medium text-foreground/80">{comment.author}</span>
-        <span>on</span>
-        <code className="font-mono text-primary">
-          {comment.file.split('/').pop()}:{comment.line}
-        </code>
-      </div>
-      <p className="text-[11.5px] leading-relaxed text-foreground/85">{comment.body}</p>
-      <div className="flex items-center gap-2">
-        {comment.status === 'resolved' ? (
-          <span className="inline-flex items-center gap-1 rounded-md border border-success/30 bg-success/10 px-1.5 py-0.5 text-[10px] font-medium text-success">
-            <IconCheck size={10} />
-            resolved by {comment.resolvedBy}
-          </span>
-        ) : (
-          <>
-            <span className="inline-flex items-center gap-1 rounded-md border border-accent/40 bg-accent/5 px-1.5 py-0.5 text-[10px] font-medium text-accent">
-              <IconSparkles size={10} />
-              resolve
-            </span>
-            <span className="text-[10px] text-muted-foreground/60">
-              spawns a resolver agent on this comment
-            </span>
-          </>
-        )}
-      </div>
-    </div>
   );
 }
 
@@ -1975,14 +2007,14 @@ export function AppOverviewSnapshot() {
         <LayoutColumn
           eyebrow="Sessions"
           tag="rail + detail"
-          hint="Linked tickets, agents, scripts, PR state, branch and cost, collapsed into one rail."
+          hint="Every task you've got running, with its branch, agents and PR, in one rail."
           body={<SessionsAbstract />}
           tone="primary"
         />
         <LayoutColumn
           eyebrow="Conversation"
           tag="chat + composer"
-          hint="The transcript with the agent currently driving the turn. Switch role mid-flight."
+          hint="The chat, with whichever agent is talking right now. Hand the turn to another one without losing the thread."
           body={<ConversationAbstract />}
           tone="emerald"
           accent
@@ -1990,7 +2022,7 @@ export function AppOverviewSnapshot() {
         <LayoutColumn
           eyebrow="Context"
           tag="five tabs"
-          hint="Goal, plans, files, GitHub, terminal, one click each. Open questions pinned below."
+          hint="Goal, plans, files, the PR, a click each. Your open questions stay pinned so nothing slips."
           body={<ContextAbstract />}
           tone="info"
         />

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -65,11 +65,11 @@ export function CTA() {
           Open source &middot; MIT
         </p>
         <h2 className="mt-5 text-3xl sm:text-5xl leading-[1.02] tracking-[-0.03em] font-semibold text-foreground">
-          Install it, run it.
+          So, my friend: stop re-explaining yourself.
         </h2>
         <p className="mx-auto mt-5 max-w-md text-[15px] leading-[1.65] text-muted-foreground">
-          No waitlist. No email. Bring your own Claude, Cursor, Codex or Gemini subscription and
-          you&apos;re running locally.
+          No waitlist, no email, no sign-up. Plug in the Claude, Cursor, Codex or Gemini you already
+          pay for and you&apos;re running on your own machine in a minute.
         </p>
 
         <div className="mx-auto mt-11 max-w-lg">
@@ -112,7 +112,7 @@ export function CTA() {
               ))}
             </TerminalFrame>
             <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
-              Needs a Rust toolchain &middot; prebuilt binaries coming later
+              Needs a Rust toolchain &middot; prebuilt binaries coming soon
             </p>
           </div>
         </div>

--- a/website/src/sections/Comparison.tsx
+++ b/website/src/sections/Comparison.tsx
@@ -1,41 +1,56 @@
 import { useInView } from '../components/Reveal';
 
-interface Diff {
-  readonly title: string;
-  readonly hint: string;
+interface Row {
+  readonly stack: string;
+  readonly goodboy: string;
 }
 
-const diffs: ReadonlyArray<Diff> = [
+/* A real before/after. Left: life with a drawer full of separate tools.
+   Right: the same moment with Goodboy. Each row is one pain you actually
+   feel, answered. */
+const rows: ReadonlyArray<Row> = [
   {
-    title: 'Four providers, one session',
-    hint: 'Claude, Cursor, Codex and Gemini, routed per turn.',
+    stack: 'You paste the goal into every new chat',
+    goodboy: 'The next agent shows up already briefed',
   },
   {
-    title: 'Context every agent inherits',
-    hint: 'Goal, decisions, files and open questions persist outside the transcript.',
+    stack: 'Each tool is locked to its own model',
+    goodboy: 'Claude, Cursor, Codex and Gemini in one session',
   },
   {
-    title: 'Parallel multi-agent sessions',
-    hint: 'Spawn roles that work at once, each in its own git worktree.',
+    stack: 'You babysit which model gets which task',
+    goodboy: 'Goodboy taps your shoulder before you overpay',
   },
   {
-    title: 'Plans as first-class artifacts',
-    hint: 'Reusable workflows the implementer picks up, tracked end to end.',
+    stack: 'The PR lives in yet another browser tab',
+    goodboy: 'Every PR sits in one inbox, next to the work',
   },
   {
-    title: 'Per-session budget caps',
-    hint: 'A live cost meter ticking against an optional soft cap.',
-  },
-  {
-    title: 'Local-first, your keys',
-    hint: 'Runs on your machine, your subscriptions, your data. No cloud sync.',
+    stack: 'Your code and keys ride through someone’s cloud',
+    goodboy: 'Everything runs on your machine. Always',
   },
 ];
 
+function Cross() {
+  return (
+    <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-muted-foreground/10 text-muted-foreground/50">
+      <svg width="11" height="11" viewBox="0 0 12 12" aria-hidden>
+        <path
+          d="M3 3l6 6M9 3l-6 6"
+          stroke="currentColor"
+          strokeWidth="1.6"
+          fill="none"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  );
+}
+
 function Check() {
   return (
-    <span className="mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
-      <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden>
+    <span className="mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary">
+      <svg width="11" height="11" viewBox="0 0 12 12" aria-hidden>
         <path
           d="M2.5 6.5 5 9l4.5-5.5"
           stroke="currentColor"
@@ -58,35 +73,50 @@ export function Comparison() {
       className={`reveal-group relative py-24 sm:py-28 ${inView ? 'is-visible' : ''}`}
     >
       <div className="mx-auto max-w-5xl px-6">
-        <div className="reveal mb-10 max-w-2xl">
+        <div className="reveal mb-12 max-w-2xl">
           <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
-            Comparison
+            Why a layer, not another tool
           </p>
-          <h2 className="mt-4 text-3xl sm:text-4xl leading-[1.05] tracking-[-0.025em] font-semibold text-foreground">
-            Where Goodboy fits.
+          <h2 className="mt-4 text-pretty text-[30px] sm:text-[40px] leading-[1.12] tracking-[-0.02em] font-semibold text-foreground">
+            A step above the tools you already use.
           </h2>
-          <p className="mt-5 max-w-prose text-[15px] leading-[1.7] text-muted-foreground">
-            Not another IDE. The layer above. Keep your editor and your subscriptions, add the
-            coordination no single tool gives you.
+          <p className="mt-5 max-w-prose text-pretty text-[16px] leading-[1.65] text-muted-foreground sm:text-[17px]">
+            Keep your editor, keep your subscriptions. Goodboy doesn&apos;t replace any of it, it
+            just gets the whole stack pulling in the same direction.
           </p>
         </div>
-        <ul className="grid gap-2.5 sm:grid-cols-2 sm:gap-3">
-          {diffs.map((d, i) => (
-            <li
-              key={d.title}
-              className="reveal flex items-start gap-3 rounded-xl border border-border-soft bg-subtle px-4 py-3.5 transition-colors hover:border-border"
-              style={{ animationDelay: `${120 + i * 60}ms` }}
-            >
-              <Check />
-              <div className="min-w-0">
-                <p className="text-[14px] font-semibold tracking-[-0.005em] text-foreground">
-                  {d.title}
-                </p>
-                <p className="mt-0.5 text-[12.5px] leading-snug text-muted-foreground">{d.hint}</p>
-              </div>
-            </li>
-          ))}
-        </ul>
+
+        <div className="reveal grid gap-3 sm:grid-cols-2" style={{ animationDelay: '120ms' }}>
+          {/* the old way */}
+          <div className="rounded-2xl border border-border-soft bg-subtle/40 p-5 sm:p-6">
+            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.06em] text-muted-foreground/70">
+              A drawer of separate tools
+            </p>
+            <ul className="flex flex-col gap-3.5">
+              {rows.map((r) => (
+                <li key={r.stack} className="flex items-start gap-2.5">
+                  <Cross />
+                  <span className="text-[14px] leading-snug text-muted-foreground">{r.stack}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* the Goodboy way */}
+          <div className="rounded-2xl border border-primary/30 bg-primary/[0.04] p-5 sm:p-6">
+            <p className="mb-4 text-[13px] font-semibold uppercase tracking-[0.06em] text-primary/80">
+              With Goodboy
+            </p>
+            <ul className="flex flex-col gap-3.5">
+              {rows.map((r) => (
+                <li key={r.goodboy} className="flex items-start gap-2.5">
+                  <Check />
+                  <span className="text-[14px] leading-snug text-foreground">{r.goodboy}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/website/src/sections/ContextDeepDive.tsx
+++ b/website/src/sections/ContextDeepDive.tsx
@@ -5,13 +5,15 @@ export function ContextDeepDive() {
   return (
     <Section
       id="context"
-      eyebrow="Shared context"
+      eyebrow="02 · Shared context"
       reverse
-      title={<>A scratchpad that survives the next agent.</>}
+      title={<>Your next agent shows up already briefed.</>}
       body={
         <p>
-          Five slots (goal, decisions, files touched, open questions, last output) live outside the
-          transcript and persist across agents. No re-explaining, no copy-paste, no drift.
+          The goal, the calls you&apos;ve already made, the files in play, the questions still open:
+          it all lives next to the chat, not buried inside it. So when the next agent takes over, it
+          already knows the story, whatever provider or model it runs on. You stop explaining
+          yourself twice.
         </p>
       }
     >

--- a/website/src/sections/FloatingNav.tsx
+++ b/website/src/sections/FloatingNav.tsx
@@ -3,12 +3,9 @@ import { DogMascot } from '../components/DogMascot';
 
 const links = [
   { href: '#sessions', label: 'Sessions' },
-  { href: '#agents', label: 'Agents' },
-  { href: '#plans', label: 'Plans' },
-  { href: '#studio', label: 'Studio' },
   { href: '#context', label: 'Context' },
-  { href: '#linear', label: 'Linear' },
-  { href: '#github', label: 'GitHub' },
+  { href: '#studio', label: 'Workflow Studio' },
+  { href: '#github', label: 'GitHub Studio' },
   { href: '#compare', label: 'Compare' },
 ];
 

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -17,11 +17,11 @@ export function Footer() {
           >
             GitHub
           </a>
-          <a href="#features" className="transition-colors hover:text-foreground">
+          <a href="#sessions" className="transition-colors hover:text-foreground">
             Features
           </a>
-          <a href="#stack" className="transition-colors hover:text-foreground">
-            Stack
+          <a href="#compare" className="transition-colors hover:text-foreground">
+            Why Goodboy
           </a>
           <a href="#cta" className="transition-colors hover:text-foreground">
             Install

--- a/website/src/sections/GithubDeepDive.tsx
+++ b/website/src/sections/GithubDeepDive.tsx
@@ -1,22 +1,29 @@
 import { Section } from '../components/Section';
-import { GithubPanelSnapshot } from '../mockups/Snapshots';
+import { GithubStudioSnapshot } from '../mockups/Snapshots';
 
 export function GithubDeepDive() {
   return (
     <Section
       id="github"
-      eyebrow="GitHub"
+      eyebrow="04 · GitHub Studio"
       reverse
-      title={<>The PR is a panel, not another tab.</>}
+      title={<>Every pull request, in one inbox.</>}
       body={
-        <p>
-          State, CI, line counts and line-anchored comments, all beside the session. One click on a
-          comment spawns a resolver agent that makes the smallest fix, commits, and replies on the
-          thread.
-        </p>
+        <>
+          <p>
+            Every session&apos;s PR lands in one inbox, sorted by what it needs from you: draft, in
+            review, changes requested, ready to merge. No more digging through github.com to find
+            the one that&apos;s blocking you.
+          </p>
+          <p className="mt-4">
+            Open one and the conversation, the checks and the reviewers are right there, next to the
+            buttons that mark it ready or squash-merge it. A reviewer leaves a comment? Hand it to
+            an agent and it pushes the fix straight back to the thread.
+          </p>
+        </>
       }
     >
-      <GithubPanelSnapshot />
+      <GithubStudioSnapshot />
     </Section>
   );
 }

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -1,35 +1,46 @@
 import { DogMascot } from '../components/DogMascot';
-import { OrchestrationFlow } from '../components/OrchestrationFlow';
 import { LinkButton } from '../components/ui';
 import { AppOverviewSnapshot } from '../mockups/Snapshots';
 
+function GitHubGlyph() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+      <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+    </svg>
+  );
+}
+
 export function Hero() {
   return (
-    <section className="relative overflow-hidden pt-12 pb-24 sm:pt-16 sm:pb-28">
+    <section className="relative overflow-hidden pt-12 pb-20 sm:pt-16 sm:pb-24">
       <div className="relative z-10 mx-auto max-w-6xl px-6">
         <div className="mx-auto max-w-3xl text-center">
-          {/* brand lockup */}
-          <div className="rise inline-flex items-center gap-2 text-[26px] font-semibold tracking-tight text-foreground">
-            <DogMascot size={34} className="text-primary" />
+          <div className="rise inline-flex items-center gap-2 text-[22px] font-semibold tracking-tight text-foreground">
+            <DogMascot size={30} className="text-primary" />
             <span>Goodboy</span>
           </div>
 
-          {/* dominant tagline */}
           <h1
-            className="rise mt-6 text-balance text-[42px] font-semibold leading-[0.98] tracking-[-0.035em] sm:text-[64px] lg:text-[76px]"
+            className="rise mt-6 text-balance text-[42px] font-semibold leading-[1.02] tracking-[-0.035em] sm:text-[64px] lg:text-[72px]"
             style={{ animationDelay: '60ms' }}
           >
-            <span className="text-gradient">Every AI agent,</span>
+            <span className="text-gradient">Stop re-explaining</span>
             <br />
-            <span className="text-foreground">one shared brain.</span>
+            <span className="text-foreground">yourself.</span>
           </h1>
 
           <p
-            className="rise mx-auto mt-6 max-w-xl text-[15px] leading-[1.6] text-muted-foreground sm:text-[17px]"
+            className="rise mx-auto mt-6 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
             style={{ animationDelay: '120ms' }}
           >
-            One local session runs Claude, Cursor, Codex and Gemini. They share context, plans and a
-            live cost meter, so the next agent already knows the goal.
+            Run Claude, Cursor, Codex and Gemini in one local workspace.
+          </p>
+          <p
+            className="rise mx-auto mt-3 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
+            style={{ animationDelay: '160ms' }}
+          >
+            They share the same goal, plan and context, so the next agent picks up right where the
+            last left off.
           </p>
 
           <div
@@ -46,9 +57,7 @@ export function Hero() {
               size="lg"
               variant="secondary"
             >
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
-                <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
-              </svg>
+              <GitHubGlyph />
               GitHub
             </LinkButton>
           </div>
@@ -57,20 +66,14 @@ export function Hero() {
             className="rise mt-5 text-[12.5px] text-muted-foreground/75"
             style={{ animationDelay: '240ms' }}
           >
-            MIT licensed &middot; macOS prebuilt, Linux &amp; Windows from source &middot; Bring
-            your own subscription
+            Free &amp; open source &middot; macOS &middot; bring your own subscription
           </p>
         </div>
 
-        {/* animated routing diagram */}
-        <div className="rise mt-14 sm:mt-16" style={{ animationDelay: '320ms' }}>
-          <OrchestrationFlow />
-        </div>
-
-        {/* one comprehensive snapshot of the running app */}
+        {/* one honest snapshot of the running app */}
         <div
-          className="rise float relative mx-auto mt-12 max-w-5xl sm:mt-14"
-          style={{ animationDelay: '420ms' }}
+          className="rise float relative mx-auto mt-14 max-w-5xl sm:mt-16"
+          style={{ animationDelay: '320ms' }}
         >
           <AppOverviewSnapshot />
         </div>

--- a/website/src/sections/MoreBriefly.tsx
+++ b/website/src/sections/MoreBriefly.tsx
@@ -1,0 +1,63 @@
+import { Eyebrow } from '../components/ui';
+import { useInView } from '../components/Reveal';
+
+/* The fifth "point": everything else, kept deliberately dry. One line each,
+   no mockups. The four sections above carry the weight; this is the tail. */
+const ITEMS: ReadonlyArray<{ k: string; v: string }> = [
+  {
+    k: 'Routing & cost',
+    v: 'Each task goes to the model that fits it, and Goodboy nudges you before you burn Opus on a one-liner. Every session shows what it is costing you as it runs.',
+  },
+  {
+    k: 'Seven agent roles',
+    v: 'Scout, plan, implement, debug, test, review, docs. Each one sticks to its own job, so the reviewer never quietly rewrites your code.',
+  },
+  {
+    k: 'Plans',
+    v: 'Agents write the plan before they touch your code, and it stays put: something you can read and edit, not a message that scrolls away.',
+  },
+  {
+    k: 'Linear',
+    v: 'Pick a Linear issue and the goal and branch fill themselves in. A proper Linear Studio is on the way.',
+  },
+  {
+    k: 'Local-first',
+    v: 'Runs on your machine, with your keys and your data. Bring the subscription you already pay for.',
+  },
+  {
+    k: 'Open source',
+    v: 'MIT licensed, out in the open. Try it, break it, send feedback.',
+  },
+];
+
+export function MoreBriefly() {
+  const { ref, inView } = useInView<HTMLElement>();
+  return (
+    <section
+      ref={ref}
+      className={`reveal-group relative py-20 sm:py-24 ${inView ? 'is-visible' : ''}`}
+    >
+      <div className="mx-auto max-w-5xl px-6">
+        <div className="reveal max-w-2xl">
+          <Eyebrow>05 &middot; The rest, briefly</Eyebrow>
+          <p className="mt-4 text-pretty text-[16px] leading-[1.6] text-muted-foreground sm:text-[17px]">
+            The stuff that matters but doesn&apos;t need its own billboard.
+          </p>
+        </div>
+        <dl
+          className="reveal mt-8 grid gap-x-12 gap-y-7 sm:grid-cols-2 lg:grid-cols-3"
+          style={{ animationDelay: '120ms' }}
+        >
+          {ITEMS.map((it) => (
+            <div key={it.k} className="border-t border-border-soft pt-3.5">
+              <dt className="text-[15px] font-semibold text-foreground">{it.k}</dt>
+              <dd className="mt-1.5 text-pretty text-[13.5px] leading-[1.6] text-muted-foreground">
+                {it.v}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/website/src/sections/Nav.tsx
+++ b/website/src/sections/Nav.tsx
@@ -3,12 +3,9 @@ import { LinkButton } from '../components/ui';
 
 const links = [
   { href: '#sessions', label: 'Sessions' },
-  { href: '#agents', label: 'Agents' },
-  { href: '#plans', label: 'Plans' },
-  { href: '#studio', label: 'Studio' },
   { href: '#context', label: 'Context' },
-  { href: '#linear', label: 'Linear' },
-  { href: '#github', label: 'GitHub' },
+  { href: '#studio', label: 'Workflow Studio' },
+  { href: '#github', label: 'GitHub Studio' },
   { href: '#compare', label: 'Compare' },
 ];
 

--- a/website/src/sections/SessionsDeepDive.tsx
+++ b/website/src/sections/SessionsDeepDive.tsx
@@ -5,12 +5,13 @@ export function SessionsDeepDive() {
   return (
     <Section
       id="sessions"
-      eyebrow="Sessions"
-      title={<>One rail. Every thread you have running.</>}
+      eyebrow="01 · Sessions"
+      title={<>Everything you have running, in one rail.</>}
       body={
         <p>
-          Goal, branch, worktree, agents, PR state and live cost, all collapsed into one rail. Open
-          the worktree in Cursor, run a workspace script, jump between sessions with ⌘1-9.
+          Each task keeps its own goal, branch, agents and PR, all in one place. One glance and you
+          know what&apos;s working and what&apos;s waiting on you, instead of digging through ten
+          terminal tabs trying to remember where you left each one.
         </p>
       }
     >

--- a/website/src/sections/StudioDeepDive.tsx
+++ b/website/src/sections/StudioDeepDive.tsx
@@ -5,20 +5,18 @@ export function StudioDeepDive() {
   return (
     <Section
       id="studio"
-      eyebrow="Workflow Studio"
-      reverse
-      title={<>Compose your own pipelines from reusable steps.</>}
+      eyebrow="03 · Workflow Studio"
+      title={<>Build the flow once. Reuse it forever.</>}
       body={
         <>
           <p>
-            Workflow Studio is a full-screen composer. Drag steps from a shared library (scout,
-            plan, implement, review, test, debug) into a preset, in any order. Every step picks its
-            own provider, model and effort, so a cheap model scouts while Opus plans and Codex
-            implements.
+            Refactor incoming? Line up a sequence: a cheap model to scout the area, a smart one to
+            plan it, a mid one to implement, another to review, a cheap one to open the PR. Each
+            step picks its own provider and model, so you&apos;re never paying Opus prices to run a
+            grep.
           </p>
           <p className="mt-4">
-            Save it as a preset to reuse across every session, or run it once as a one-off. Broke
-            something? Reset to defaults restores the built-ins; your custom presets stay put.
+            Don&apos;t like that flow? Drag the steps around, swap the models, save it as your own.
           </p>
         </>
       }


### PR DESCRIPTION
## What

Full pass over the marketing site (`website/`): restructure around the reason to install, condense to five key points, and rewrite copy in a warmer, more human voice.

### Above the fold
- Headline -> **"Stop re-explaining yourself."**; dropped the "AI" framing and the "live cost meter" line.
- Subtitle split into two readable lines.
- **Install** button scrolls to the CTA; **Download for macOS** (CTA) still pulls the latest `.dmg`.
- Tab title -> **"Goodboy"**.

### Five key points
1. **Sessions** - "Everything you have running, in one rail."
2. **Shared context** - "Your next agent shows up already briefed."
3. **Workflow Studio** - "Build the flow once. Reuse it forever."
4. **GitHub Studio** - section + mock **rewritten from scratch** to match the shipped feature: PR inbox grouped by state, 3-pane detail, full lifecycle (mark ready / draft / close / reopen / squash-merge), resolve-a-comment-by-agent.
5. **The rest, briefly** - routing & cost, seven roles, plans, Linear, local-first, open source.

### Other
- Restored the founder note (Letter) right after the hero.
- **Comparison** reworked into a real two-column before/after instead of a feature grid.
- Synced top nav + floating nav labels (Workflow Studio / GitHub Studio).
- Fixed dead footer anchors (`#features`/`#stack` -> `#sessions`/`#compare`).
- Typography scale benchmarked against mantine.dev.
- Removed an invented "Sottovoce" voice mock.

## Verify
- `tsc -b && vite build` green (59 modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)