### PR TITLE
feat(desktop): run multiple agents concurrently per session

### DIFF
--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from 'vitest';
-import { parseModelId } from '../features/chat/utils/chat-constants';
+import { parseModelId, suggestLighterModel } from '../features/chat/utils/chat-constants';
+
+const ANTHROPIC = [
+  'claude-haiku-4-5',
+  'claude-sonnet-4-5',
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
+  'claude-opus-4-7',
+  'claude-opus-4-8',
+];
+
+describe('suggestLighterModel', () => {
+  it('Opus 4.8 → Sonnet 4.6 (drops to cheapest non-floor tier, most capable in it)', () => {
+    expect(suggestLighterModel('claude-opus-4-8', ANTHROPIC)).toBe('claude-sonnet-4-6');
+  });
+
+  it('Opus 4.6 → Sonnet 4.6 (same target from a lighter Opus)', () => {
+    expect(suggestLighterModel('claude-opus-4-6', ANTHROPIC)).toBe('claude-sonnet-4-6');
+  });
+
+  it('never suggests below the Haiku floor', () => {
+    expect(suggestLighterModel('claude-opus-4-8', ANTHROPIC)).not.toMatch(/haiku/);
+  });
+
+  it('no nag when already mid-tier (gap below threshold)', () => {
+    expect(suggestLighterModel('claude-sonnet-4-6', ANTHROPIC)).toBeNull();
+  });
+
+  it('no suggestion when the only lighter options are floored out', () => {
+    expect(
+      suggestLighterModel('claude-sonnet-4-6', ['claude-sonnet-4-6', 'claude-haiku-4-5']),
+    ).toBeNull();
+  });
+});
 
 describe('parseModelId', () => {
   it('canonical anthropic ids: family/subfamily/variant', () => {

--- a/apps/desktop/src/__tests__/session-mutators.test.ts
+++ b/apps/desktop/src/__tests__/session-mutators.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId, TurnState } from '@goodboy/types';
+import { deriveSessionState } from '../store/session-mutators';
+
+const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
+const earlier = '2026-05-07T00:00:01.000Z' as IsoDateTime;
+const later = '2026-05-07T00:00:02.000Z' as IsoDateTime;
+
+const idle: TurnState = { kind: 'idle', lastActivityAt: now };
+const errored: TurnState = { kind: 'error', message: 'boom', failedAt: now };
+const starting: TurnState = { kind: 'starting', startedAt: now };
+const runA: TurnState = { kind: 'running', runId: 'run_a' as ProviderRunId, startedAt: earlier };
+const runB: TurnState = { kind: 'running', runId: 'run_b' as ProviderRunId, startedAt: later };
+
+describe('deriveSessionState', () => {
+  it('empty → idle', () => {
+    expect(deriveSessionState([], now)).toEqual({ kind: 'idle', lastActivityAt: now });
+  });
+
+  it('all idle → idle', () => {
+    expect(deriveSessionState([idle, idle], now)).toEqual({ kind: 'idle', lastActivityAt: now });
+  });
+
+  it('any running → running (precedence over error/idle)', () => {
+    expect(deriveSessionState([idle, errored, runA], now)).toMatchObject({ kind: 'running' });
+  });
+
+  it('multiple running → representative is the latest-started run', () => {
+    expect(deriveSessionState([runA, runB], now)).toMatchObject({
+      kind: 'running',
+      runId: 'run_b',
+    });
+    expect(deriveSessionState([runB, runA], now)).toMatchObject({
+      kind: 'running',
+      runId: 'run_b',
+    });
+  });
+
+  it('starting outranks error when nothing is running', () => {
+    expect(deriveSessionState([errored, starting], now)).toEqual(starting);
+  });
+
+  it('error only when no agent is running or starting', () => {
+    expect(deriveSessionState([idle, errored], now)).toEqual(errored);
+  });
+});

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -205,19 +205,27 @@ const SUGGESTION_FLOOR_PATTERN = /haiku|small|mini|nano|cursor-small/i;
 // for marginal savings like Sonnet 4.6 → 4.5).
 const MIN_WEIGHT_GAP = 20;
 
+const TIER_RANK: Record<CostTier, number> = { cheap: 0, mid: 1, expensive: 2 };
+
 export function suggestLighterModel(
   current: string,
   candidates: ReadonlyArray<string>,
 ): string | null {
   const currentWeight = modelWeight(current);
-  let best: { id: string; weight: number } | null = null;
-  for (const id of candidates) {
-    if (id === current) continue;
-    if (SUGGESTION_FLOOR_PATTERN.test(id)) continue;
+  const eligible = candidates.filter((id) => {
+    if (id === current) return false;
+    if (SUGGESTION_FLOOR_PATTERN.test(id)) return false;
     const w = modelWeight(id);
-    if (w >= currentWeight) continue;
-    if (currentWeight - w < MIN_WEIGHT_GAP) continue;
-    if (!best || w > best.weight) best = { id, weight: w };
+    return w < currentWeight && currentWeight - w >= MIN_WEIGHT_GAP;
+  });
+  if (eligible.length === 0) return null;
+  let best: { id: string; tierRank: number; weight: number } | null = null;
+  for (const id of eligible) {
+    const tierRank = TIER_RANK[modelTier(id)];
+    const weight = modelWeight(id);
+    if (!best || tierRank < best.tierRank || (tierRank === best.tierRank && weight > best.weight)) {
+      best = { id, tierRank, weight };
+    }
   }
   return best?.id ?? null;
 }

--- a/apps/desktop/src/store/session-mutators.ts
+++ b/apps/desktop/src/store/session-mutators.ts
@@ -33,6 +33,53 @@ export function applySessionUpdate(
   }));
 }
 
+export function deriveSessionState(
+  agentStates: ReadonlyArray<TurnState>,
+  now: IsoDateTime,
+): TurnState {
+  const running = agentStates.filter(
+    (s): s is Extract<TurnState, { kind: 'running' }> => s.kind === 'running',
+  );
+  if (running.length > 0) {
+    const rep = running.reduce((a, b) => (a.startedAt >= b.startedAt ? a : b));
+    return { kind: 'running', runId: rep.runId, startedAt: rep.startedAt };
+  }
+  const starting = agentStates.find((s) => s.kind === 'starting');
+  if (starting) return starting;
+  const errored = agentStates.find((s) => s.kind === 'error');
+  if (errored) return errored;
+  return { kind: 'idle', lastActivityAt: now };
+}
+
+export function applyAgentTurnState(
+  set: SetFn,
+  sessionId: SessionId,
+  agentId: AgentId,
+  agentState: TurnState,
+  now: IsoDateTime,
+): TurnState {
+  let derived: TurnState = agentState;
+  set((store) => {
+    const nextAgentTurn: Record<AgentId, TurnState> = {
+      ...store.agentTurnState,
+      [agentId]: agentState,
+    };
+    const sessionAgentIds = (store.sessionPhaseRuns[sessionId] ?? []).map((a) => a.id);
+    const ids = sessionAgentIds.includes(agentId) ? sessionAgentIds : [...sessionAgentIds, agentId];
+    const states = ids
+      .map((id) => nextAgentTurn[id])
+      .filter((s): s is TurnState => s !== undefined);
+    derived = deriveSessionState(states, now);
+    return {
+      sessions: store.sessions.map((s) =>
+        s.id === sessionId ? { ...s, state: derived, updatedAt: now } : s,
+      ),
+      agentTurnState: nextAgentTurn,
+    };
+  });
+  return derived;
+}
+
 /**
  * Module-scoped registry of run IDs cancelled by the user via
  * cancelCurrentTurn. The stream-end finalization in sendTurn checks this set

--- a/apps/desktop/src/store/slices/agents/deleteAgent.ts
+++ b/apps/desktop/src/store/slices/agents/deleteAgent.ts
@@ -1,44 +1,23 @@
-import type { AgentId, IsoDateTime, SessionId, TurnState } from '@goodboy/types';
+import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
 import { updateSessionState } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
 import { invokeAgentList } from '../../../features/workflows/workflows';
-import { applySessionUpdate, cancelledRunIds } from '../../session-mutators';
+import { cancelledRunIds, deriveSessionState } from '../../session-mutators';
 import type { GetFn, SetFn } from './types';
 
-// Deleting an agent has to do three things the original implementation
-// skipped, in this order:
-//   1. If the agent owns the active session run, cancel it. Otherwise the
-//      rust provider process keeps streaming, those events keep landing in
-//      applySessionUpdate, and `session.state.kind` stays `'running'`
-//      forever. ChatView falls back to that field whenever the fallback
-//      agent has no per-agent turn state, so a sibling chat starts showing
-//      a permanent "thinking…" indicator.
-//   2. Drop every per-agent map entry. Leaving `agentTurnState[agentId]`
-//      and friends behind is both a memory leak and a foot-gun: if the
-//      same id ever gets re-issued (or, more realistically, if a selector
-//      iterates all agent state) we surface ghosts of a deleted agent.
-//   3. Only then remove the DB row and re-pick the selected agent.
 export function deleteAgent(set: SetFn, get: GetFn) {
   return async (sessionId: SessionId, agentId: AgentId) => {
-    const session = get().sessions.find((s) => s.id === sessionId);
     const agentTurn = get().agentTurnState[agentId];
-    const sessionRunId = session?.state.kind === 'running' ? session.state.runId : null;
     const agentRunId = agentTurn?.kind === 'running' ? agentTurn.runId : null;
-    const ownsActiveRun =
-      sessionRunId !== null && agentRunId !== null && sessionRunId === agentRunId;
-
-    if (ownsActiveRun && sessionRunId !== null) {
-      cancelledRunIds.add(sessionRunId);
-      await cancelTurn(sessionRunId).catch(() => undefined);
-      const now = new Date().toISOString() as IsoDateTime;
-      const idleState: TurnState = { kind: 'idle', lastActivityAt: now };
-      await updateSessionState(tauriDatabase, sessionId, idleState, now).catch(() => undefined);
-      applySessionUpdate(set, sessionId, idleState);
+    if (agentRunId !== null) {
+      cancelledRunIds.add(agentRunId);
+      await cancelTurn(agentRunId).catch(() => undefined);
     }
 
     await tauriDatabase.execute('DELETE FROM agents WHERE id = ?', [agentId]);
     const refreshed = await invokeAgentList(sessionId);
+    let derived: ReturnType<typeof deriveSessionState> | null = null;
     set((s) => {
       // Clear selection, never auto-pick a sibling. Picking a 'fallback'
       // dumps the user into a chat they didn't ask for; the empty-state
@@ -61,6 +40,10 @@ export function deleteAgent(set: SetFn, get: GetFn) {
       delete nextModelOverride[agentId];
       const nextKindOverride = { ...s.agentKindOverride };
       delete nextKindOverride[agentId];
+      const survivorStates = refreshed
+        .map((a) => nextTurnState[a.id])
+        .filter((st): st is NonNullable<typeof st> => st !== undefined);
+      derived = deriveSessionState(survivorStates, new Date().toISOString() as IsoDateTime);
       return {
         sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed },
         selectedAgentId: nextSelected,
@@ -70,7 +53,18 @@ export function deleteAgent(set: SetFn, get: GetFn) {
         agentRunHistory: nextHistory,
         agentModelOverride: nextModelOverride,
         agentKindOverride: nextKindOverride,
+        sessions: s.sessions.map((sess) =>
+          sess.id === sessionId ? { ...sess, state: derived! } : sess,
+        ),
       };
     });
+    if (derived !== null) {
+      await updateSessionState(
+        tauriDatabase,
+        sessionId,
+        derived,
+        new Date().toISOString() as IsoDateTime,
+      ).catch(() => undefined);
+    }
   };
 }

--- a/apps/desktop/src/store/slices/sessions/endSession.ts
+++ b/apps/desktop/src/store/slices/sessions/endSession.ts
@@ -1,11 +1,11 @@
-import type { IsoDateTime, SessionId, TurnState } from '@goodboy/types';
+import type { IsoDateTime, ProviderRunId, SessionId, TurnState } from '@goodboy/types';
 import { turnReducer } from '@goodboy/core';
 import { deleteWorktreesForSession, updateSessionState } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
 import { removeWorktree } from '../../../features/worktree/worktree';
 import { formatError } from '../../../shared/lib/errors';
-import { applySessionUpdate } from '../../session-mutators';
+import { applySessionUpdate, cancelledRunIds } from '../../session-mutators';
 import type { GetFn, SetFn } from './types';
 
 export function endSession(set: SetFn, get: GetFn) {
@@ -13,12 +13,16 @@ export function endSession(set: SetFn, get: GetFn) {
     const session = get().sessions.find((s) => s.id === sessionId);
     if (!session) throw new Error(`session not found: ${sessionId}`);
     if (session.state.kind === 'ended') return;
-    if (session.state.kind === 'running') {
-      // Best-effort cancel, Rust TurnRegistry may have already removed the
-      // run (process exited, app restarted, etc). A "turn not found" error
-      // here must not block end-session: the session row is the source of
-      // truth, not the in-memory registry.
-      await cancelTurn(session.state.runId).catch(() => undefined);
+    const toCancel = new Set<ProviderRunId>();
+    if (session.state.kind === 'running') toCancel.add(session.state.runId);
+    const turnStates = get().agentTurnState;
+    for (const agent of get().sessionPhaseRuns[sessionId] ?? []) {
+      const st = turnStates[agent.id];
+      if (st?.kind === 'running') toCancel.add(st.runId);
+    }
+    for (const rid of toCancel) {
+      cancelledRunIds.add(rid);
+      await cancelTurn(rid).catch(() => undefined);
     }
 
     const worktreePaths = get().sessionWorktrees[sessionId] ?? [];

--- a/apps/desktop/src/store/slices/turn/cancelCurrentTurn.ts
+++ b/apps/desktop/src/store/slices/turn/cancelCurrentTurn.ts
@@ -2,19 +2,20 @@ import type { IsoDateTime, SessionId, TurnState } from '@goodboy/types';
 import { updateSessionState } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
-import { applySessionUpdate, cancelledRunIds } from '../../session-mutators';
+import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import type { GetFn, SetFn } from './types';
 
 export function cancelCurrentTurn(set: SetFn, get: GetFn) {
   return async (sessionId: SessionId) => {
-    const session = get().sessions.find((s) => s.id === sessionId);
-    if (!session || session.state.kind !== 'running') return;
-    const cancelAgentId = get().selectedAgentId[sessionId] ?? null;
-    cancelledRunIds.add(session.state.runId);
-    await cancelTurn(session.state.runId).catch(() => undefined);
+    const selectedAgentId = get().selectedAgentId[sessionId] ?? null;
+    if (!selectedAgentId) return;
+    const agentState = get().agentTurnState[selectedAgentId];
+    if (agentState?.kind !== 'running') return;
+    cancelledRunIds.add(agentState.runId);
+    await cancelTurn(agentState.runId).catch(() => undefined);
     const now = new Date().toISOString() as IsoDateTime;
     const idleState: TurnState = { kind: 'idle', lastActivityAt: now };
-    await updateSessionState(tauriDatabase, sessionId, idleState, now).catch(() => undefined);
-    applySessionUpdate(set, sessionId, idleState, cancelAgentId ?? undefined);
+    const derived = applyAgentTurnState(set, sessionId, selectedAgentId, idleState, now);
+    await updateSessionState(tauriDatabase, sessionId, derived, now).catch(() => undefined);
   };
 }

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -91,7 +91,7 @@ import {
   type ParallelBranchEffects,
 } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
-import { applySessionUpdate, cancelledRunIds } from '../../session-mutators';
+import { applyAgentTurnState, applySessionUpdate, cancelledRunIds } from '../../session-mutators';
 import { buildProviderSpendBreakdown } from '../budget';
 import {
   applyHeuristicTitle,
@@ -488,16 +488,19 @@ export function sendTurn(set: SetFn, get: GetFn) {
     }
 
     if (parallelDispatch === null) {
-      let nextState: TurnState = session.state;
-      if (nextState.kind === 'draft') {
-        nextState = turnReducer(nextState, { kind: 'start', at: now() });
+      let nextAgentState: TurnState = get().agentTurnState[activeAgentId] ?? {
+        kind: 'idle',
+        lastActivityAt: now(),
+      };
+      if (nextAgentState.kind === 'draft') {
+        nextAgentState = turnReducer(nextAgentState, { kind: 'start', at: now() });
       }
-      if (nextState.kind === 'error') {
-        nextState = turnReducer(nextState, { kind: 'retry', at: now() });
+      if (nextAgentState.kind === 'error') {
+        nextAgentState = turnReducer(nextAgentState, { kind: 'retry', at: now() });
       }
-      nextState = turnReducer(nextState, { kind: 'send', runId, at: now() });
-      await updateSessionState(tauriDatabase, sessionId, nextState, now());
-      applySessionUpdate(set, sessionId, nextState, activeAgentId);
+      nextAgentState = turnReducer(nextAgentState, { kind: 'send', runId, at: now() });
+      const derived = applyAgentTurnState(set, sessionId, activeAgentId, nextAgentState, now());
+      await updateSessionState(tauriDatabase, sessionId, derived, now());
     }
 
     const providerInfo = get().providers.find((p) => p.id === provider);
@@ -649,15 +652,15 @@ export function sendTurn(set: SetFn, get: GetFn) {
           await updateSessionState(tauriDatabase, sessionId, errorState, now());
           applySessionUpdate(set, sessionId, errorState, activeAgentId);
         } else {
-          await updateSessionState(
-            tauriDatabase,
-            sessionId,
-            turnReducer(get().sessions.find((s) => s.id === sessionId)?.state ?? nextStateP, {
+          const doneState = turnReducer(
+            get().sessions.find((s) => s.id === sessionId)?.state ?? nextStateP,
+            {
               kind: 'receive_event',
               event: { kind: 'done', runId: result.runIds[0]!, at: now() },
-            }),
-            now(),
+            },
           );
+          await updateSessionState(tauriDatabase, sessionId, doneState, now());
+          applySessionUpdate(set, sessionId, doneState, activeAgentId);
         }
       } catch (err) {
         const rawMessage = formatError(err);
@@ -902,23 +905,23 @@ export function sendTurn(set: SetFn, get: GetFn) {
           }
         }
 
-        const current = get().sessions.find((s) => s.id === sessionId);
-        if (current) {
-          const reduced = turnReducer(current.state, { kind: 'receive_event', event });
-          if (reduced !== current.state) {
-            await updateSessionState(tauriDatabase, sessionId, reduced, now());
-            applySessionUpdate(set, sessionId, reduced, activeAgentId);
+        const currentAgentState = get().agentTurnState[activeAgentId];
+        if (currentAgentState) {
+          const reduced = turnReducer(currentAgentState, { kind: 'receive_event', event });
+          if (reduced !== currentAgentState) {
+            const derived = applyAgentTurnState(set, sessionId, activeAgentId, reduced, now());
+            await updateSessionState(tauriDatabase, sessionId, derived, now());
           }
         }
       }
       // Stream ended without a 'done'/'error' event, provider CLI exited
       // cleanly but didn't emit a `result` line, so the reducer never left
       // 'running'. Force-idle so input re-enables.
-      const afterStream = get().sessions.find((s) => s.id === sessionId);
-      if (afterStream?.state.kind === 'running') {
+      const afterAgentState = get().agentTurnState[activeAgentId];
+      if (afterAgentState?.kind === 'running') {
         const idleState: TurnState = { kind: 'idle', lastActivityAt: now() };
-        await updateSessionState(tauriDatabase, sessionId, idleState, now());
-        applySessionUpdate(set, sessionId, idleState, activeAgentId);
+        const derived = applyAgentTurnState(set, sessionId, activeAgentId, idleState, now());
+        await updateSessionState(tauriDatabase, sessionId, derived, now());
         if (assistantText.length === 0) {
           get().appendTurnEvent(activeAgentId, sessionId, {
             kind: 'error',
@@ -1063,8 +1066,8 @@ export function sendTurn(set: SetFn, get: GetFn) {
         message: rawMessage,
         failedAt: now(),
       };
-      await updateSessionState(tauriDatabase, sessionId, errorState, now());
-      applySessionUpdate(set, sessionId, errorState, activeAgentId);
+      const derived = applyAgentTurnState(set, sessionId, activeAgentId, errorState, now());
+      await updateSessionState(tauriDatabase, sessionId, derived, now());
       await updateProviderRunStatus(tauriDatabase, runId, {
         kind: 'failed',
         finishedAt: now(),

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -247,6 +247,7 @@ function setupSession(
     sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
     sessionPhaseRuns: { [SESSION_ID]: [defaultAgent] },
     selectedAgentId: { [SESSION_ID]: defaultAgent.id },
+    agentTurnState: {},
     settings: {
       'experimental.enable_parallel_agents': 'true',
       'experimental.max_parallelism': '4',


### PR DESCRIPTION
## What

Two changes to the chat/turn layer:

1. **Per-agent turn concurrency.** The turn lifecycle now gates on the
   selected agent's state (`agentTurnState[agentId]`) instead of the single
   `session.state`. Two agents in one session (e.g. Claude + Gemini) can stream
   at the same time without the `illegal transition: cannot apply send in state
   running` crash. `session.state` becomes a derived aggregate
   (`running > starting > error > idle`); cancel/end/delete paths enumerate
   per-agent runIds rather than trusting the aggregate's representative runId.

2. **Right-sized model suggestion.** `suggestLighterModel` picked the
   heaviest-still-cheaper candidate, so a trivial first turn on Opus 4.8
   suggested Opus 4.6 (still expensive). It now drops to the cheapest tier above
   the Haiku floor and takes the most capable model there: Opus 4.8 -> Sonnet 4.6.

## Notes

- Backend already keyed runs per `run_id` (no per-session lock), so this is a
  frontend-only change.
- UI `isRunning` and the composer queue were already per-agent; untouched.
- Known limit: workspace teardown still cancels only the representative runId
  for background (non-hydrated) sessions. Pre-existing model limitation.

## Tests

- New: `deriveSessionState` precedence, `suggestLighterModel` right-sizing.
- typecheck green, full desktop suite green (782+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)