### PR TITLE
docs(repo): rewrite readme in new tov + tone-of-voice doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,62 @@
 # Goodboy
 
-**AI workspace orchestrator. Local-first. Provider-agnostic.**
+**Stop re-explaining yourself.**
 
 You have a repo. You have a goal. You also have four CLIs open in four
-windows, each holding a slightly different version of the same task. This
-is the part that's missing in the middle.
+windows, each holding a slightly different version of the same task. By
+evening you've spent more time pasting the goal back into the next chat
+than actually building.
 
-A desktop app that owns the context once and hands it to whichever agent
-you want to run next. Same goal, same memory, different model. Conversation,
-plans, decisions, PR state, all of it stays in a local SQLite on your
-machine. Your keys, your data, your bandwidth.
+Goodboy is a desktop app that holds the goal, the plan and the context once,
+then hands them to whichever agent you want to run next. Same brief, same
+memory, different model. Conversation, plans, decisions and PR state stay in
+a local SQLite on your machine. Your keys, your data, your bandwidth.
 
-<img width="3972" height="2234" alt="CleanShot 2026-05-31 at 05 31 42@2x" src="https://github.com/user-attachments/assets/1d6a4259-e205-4d9a-9fe8-eaf4c486d98d" />
+<img width="3972" height="2234" alt="Goodboy desktop app" src="https://github.com/user-attachments/assets/1d6a4259-e205-4d9a-9fe8-eaf4c486d98d" />
 
-## The honest pitch
+## Why it exists
 
-Switching between `Claude`, `Codex`, `Cursor` and `Gemini` ten times a day
-was eating my afternoons. Every new tab meant rebuilding the same mental
-scratchpad from scratch. Eventually I got fed up and built this.
+Switching between `Claude`, `Codex`, `Cursor` and `Gemini` ten times a day was
+eating my afternoons. Every new tab meant rebuilding the same mental
+scratchpad from scratch, then watching the next model run off in a slightly
+different direction. Eventually I got fed up and built this.
 
-**Open source. Every feature included. No paywall, no telemetry, no account.**
+Open source. Every feature included. No paywall, no telemetry, no account.
 
-## What's actually inside
+## What's inside
 
-- **A context the agents share.** Goal, decisions, last summary, open
-  questions. A summarizer keeps it fresh after every turn, you can edit any
-  field by hand when the agents get it wrong.
-- **Provider swap mid-task, without amnesia.** Each turn is rebuilt from
-  the shared context, never resumed from a vendor session. Drop Claude
-  halfway, hand the same task to Cursor or Codex, watch it pick up clean.
-- **Plans as artifacts, not transcript scrollback.** They show up in a Plans
-  tab with a status, ready to hand off to the agent that implements them.
-- **GitHub and Linear in the side panel.** Pull request state, CI, review
-  threads still owed answers, the issues assigned to you back at the office.
-  One click from where you're typing.
-- **Workflows for the multi-step stuff.** Scout, plan, implement, verify.
-  Each step a typed agent, all of them sharing one context.
-- **One-click scripts** for the four commands you keep retyping in the
-  terminal. No agent, no tokens, just a button.
+**Shared context, not vendor sessions.** Goal, decisions, last summary, open
+questions. A summarizer keeps it fresh after every turn. Edit any field by
+hand when the agents get it wrong. The next agent shows up already briefed.
+
+**Provider swap mid-task, without amnesia.** Each turn is rebuilt from the
+shared context, never resumed from a vendor's session blob. Drop Claude
+halfway, hand the same task to Cursor or Codex, watch it pick up clean.
+
+**Workflows for the multi-step stuff.** Refactor incoming? Line up a sequence:
+a cheap model to scout the area, a smart one to plan it, a mid one to
+implement, another to review, a cheap one to open the PR. Each step picks its
+own provider and model, so you're never paying Opus prices to run a grep.
+
+**Plans as artifacts, not transcript scrollback.** Agents write the plan
+before they touch your code, and it stays put: something you can read, edit
+and hand to whichever model implements it. Not a message that scrolls away.
+
+**GitHub Studio.** Every pull request you're involved in, in one inbox,
+bucketed by state (draft, in review, approved, merged). Open one and you've
+got the body, the lifecycle controls and the unresolved comments in a single
+view. Reply yourself, or hand a comment to an agent to resolve.
+
+**Linear in the side panel.** Pick an issue and the goal and branch fill
+themselves in. A proper Linear Studio is on the way.
+
+**Cost meter that taps your shoulder.** Every session shows what it's costing
+as it runs. Goodboy nudges you before you burn Opus on a one-liner.
 
 ## Providers
 
-Bring your own subscription. The app drives the official CLIs locally, on
-**your existing plan**, never on a metered API key.
+Bring the subscription you already pay for. Goodboy drives the official CLIs
+locally, on your existing plan, never on a metered API key.
 
 | Provider               | CLI                                  | Subscription     |
 | ---------------------- | ------------------------------------ | ---------------- |
@@ -56,8 +70,8 @@ One connected CLI is enough to start. Full guide:
 
 ## Install
 
-macOS (Intel and Apple Silicon, one universal build). Signed and notarized by
-Apple, so it opens with no security prompts.
+macOS, Intel and Apple Silicon, one universal build. Signed and notarized
+by Apple, so it opens with no security prompts.
 
 **Homebrew (recommended).**
 
@@ -66,12 +80,13 @@ brew install --cask akhayam99/tap/goodboy
 ```
 
 **Direct download.** Grab the `.dmg` from the
-[latest release](https://github.com/akhayam99/goodboy/releases/latest) and drag
-Goodboy to Applications.
+[latest release](https://github.com/akhayam99/goodboy/releases/latest) and
+drag Goodboy to Applications.
 
 **Updates are automatic.** When a new release ships, a "Restart to update"
 control appears in the status bar and next to the sidebar logo. One click
-downloads it and relaunches; Homebrew users can also `brew upgrade --cask goodboy`.
+downloads it and relaunches; Homebrew users can also
+`brew upgrade --cask goodboy`.
 
 ## Run it
 
@@ -82,7 +97,7 @@ pnpm tauri:dev      # hot reload, fastest to iterate
 pnpm tauri:build    # produces an installable binary in apps/desktop/src-tauri/target/release/bundle/
 ```
 
-Needs **Node ≥ 20**, **pnpm ≥ 10**, and a working **Rust** toolchain (Tauri
+Needs **Node ≥ 20**, **pnpm ≥ 10** and a working **Rust** toolchain (Tauri
 shells out to `cargo`). Platform prereqs:
 <https://v2.tauri.app/start/prerequisites/>.
 
@@ -91,7 +106,7 @@ Hacking on the app itself? The dev-loop notes live in
 
 ## Help out
 
-Try it. If something breaks, feels weird, or is missing, open an issue.
+Try it. If something breaks, feels weird or is missing, open an issue.
 Half-formed thoughts welcome. Screenshots welcome. "This feels off" is a
 perfectly valid bug report.
 
@@ -102,7 +117,8 @@ pnpm + Turborepo monorepo: `apps/desktop` plus `packages/{ui,core,db,types}`.
 
 ## More
 
-- [VISION.md](./VISION.md): the why
+- [docs/tone-of-voice.md](./docs/tone-of-voice.md): how Goodboy talks
+- [VISION.md](./VISION.md): the why, at length
 - [DESIGN.md](./DESIGN.md): how it looks and behaves
 - [ROADMAP.md](./ROADMAP.md): milestones and what shipped
 - [CONVENTIONS.md](./CONVENTIONS.md) · [CLAUDE.md](./CLAUDE.md): contributor rules

--- a/docs/tone-of-voice.md
+++ b/docs/tone-of-voice.md
@@ -22,21 +22,21 @@ Two voices in the codebase:
 
 ### Words to avoid
 
-- **"AI"** — say `agent`, `model`, `Claude`, `Codex`, `Cursor`, `Gemini`, or
+- **"AI"**. Say `agent`, `model`, `Claude`, `Codex`, `Cursor`, `Gemini`, or
   the specific behavior. "AI" is a marketing word; we don't need it.
 - **"powered by"**, **"intelligent"**, **"smart"**, **"seamless"**,
-  **"revolutionary"**, **"blazing fast"**, **"next-gen"** — fluff. Cut.
-- **"simply"**, **"just"**, **"obviously"**, **"basically"** — minimizers. If
+  **"revolutionary"**, **"blazing fast"**, **"next-gen"**. Fluff. Cut.
+- **"simply"**, **"just"**, **"obviously"**, **"basically"**. Minimizers. If
   the thing is simple, the reader can decide that. If it isn't, you're lying.
-- **"unlock"**, **"empower"**, **"leverage"**, **"streamline"** — sales-deck
+- **"unlock"**, **"empower"**, **"leverage"**, **"streamline"**. Sales-deck
   verbs. Use the actual verb.
-- **"enterprise-grade"**, **"world-class"**, **"best-in-class"** — empty
+- **"enterprise-grade"**, **"world-class"**, **"best-in-class"**. Empty
   superlatives. Be specific or stay quiet.
 
 ### Punctuation
 
-- **No em-dashes** (`—`). Use a period, comma, colon, or parens instead. Em-
-  dashes read as ChatGPT.
+- **No em-dashes** (`—`). Use a period, comma, colon, or parens instead.
+  Em-dashes read as ChatGPT.
 - **One sentence per idea.** Don't chain three clauses with semicolons.
 - **Sentence case** for headings. Not Title Case. Not ALL CAPS.
 - **Code identifiers in backticks**: `pnpm tauri:dev`, not "the pnpm tauri:dev

--- a/docs/tone-of-voice.md
+++ b/docs/tone-of-voice.md
@@ -1,0 +1,139 @@
+# Tone of voice
+
+This is how Goodboy talks to people. README, website, release notes, in-app
+copy, error messages. If a string is going to be read by a human, it lives by
+these rules.
+
+## The shape
+
+Write like a person who's been in the trenches with the reader, not a brand
+addressing a market. The user has four CLIs open and an unfinished refactor.
+They don't want to be sold to. They want to be understood, then helped.
+
+Two voices in the codebase:
+
+- **Product voice** ("Goodboy does X"): direct, second person, concrete. README,
+  feature sections, in-app copy.
+- **Author voice** ("I built this because…"): first person, conversational,
+  reserved for the founder note and release blog posts. Never bleeds into
+  product copy.
+
+## Rules
+
+### Words to avoid
+
+- **"AI"** — say `agent`, `model`, `Claude`, `Codex`, `Cursor`, `Gemini`, or
+  the specific behavior. "AI" is a marketing word; we don't need it.
+- **"powered by"**, **"intelligent"**, **"smart"**, **"seamless"**,
+  **"revolutionary"**, **"blazing fast"**, **"next-gen"** — fluff. Cut.
+- **"simply"**, **"just"**, **"obviously"**, **"basically"** — minimizers. If
+  the thing is simple, the reader can decide that. If it isn't, you're lying.
+- **"unlock"**, **"empower"**, **"leverage"**, **"streamline"** — sales-deck
+  verbs. Use the actual verb.
+- **"enterprise-grade"**, **"world-class"**, **"best-in-class"** — empty
+  superlatives. Be specific or stay quiet.
+
+### Punctuation
+
+- **No em-dashes** (`—`). Use a period, comma, colon, or parens instead. Em-
+  dashes read as ChatGPT.
+- **One sentence per idea.** Don't chain three clauses with semicolons.
+- **Sentence case** for headings. Not Title Case. Not ALL CAPS.
+- **Code identifiers in backticks**: `pnpm tauri:dev`, not "the pnpm tauri:dev
+  command".
+
+### Structure
+
+- **Show the problem, then the fix.** "You have four CLIs open, each holding a
+  different version of the same task. Goodboy holds the context once and hands
+  it to whichever one you run next." Not "Goodboy is an AI orchestration
+  platform."
+- **Concrete over abstract.** "A cheap model to scout, a smart one to plan,
+  a mid one to implement" beats "intelligent multi-model routing".
+- **Specific friction the reader has felt.** "Re-pasting the goal into a new
+  window." "Burning Opus on a one-liner." If the reader nods, you've earned
+  the next paragraph.
+- **No feature inventory dumps.** Pick the few that matter, write them as
+  scenarios, leave the rest in a short list with one line each.
+
+### Honesty
+
+- **Don't oversell the roadmap.** "A proper Linear Studio is on the way" not
+  "Full Linear integration".
+- **Name the limits.** "Needs a Rust toolchain. Prebuilt binaries for Linux
+  and Windows coming." Not silence.
+- **Admit when something is rough.** "Try it, break it, send feedback" >
+  "Production-ready since day one".
+
+## Examples
+
+### Headlines
+
+Bad:
+
+> Revolutionize Your AI Workflow with Unified Multi-Provider Orchestration
+
+Good:
+
+> Stop re-explaining yourself.
+
+Bad:
+
+> AI-Powered Workspace for the Modern Developer
+
+Good:
+
+> Every pull request, in one inbox.
+
+### Feature copy
+
+Bad:
+
+> Goodboy leverages advanced AI routing to seamlessly orchestrate your agents
+> across providers, unlocking unprecedented productivity gains.
+
+Good:
+
+> Each task goes to the model that fits it, and Goodboy nudges you before you
+> burn Opus on a one-liner. Every session shows what it is costing you as it
+> runs.
+
+### Workflow description
+
+Bad:
+
+> Create powerful multi-step automations with our intuitive workflow builder.
+
+Good:
+
+> Refactor incoming? Line up a sequence: a cheap model to scout the area, a
+> smart one to plan it, a mid one to implement, another to review, a cheap one
+> to open the PR. Each step picks its own provider and model, so you're never
+> paying Opus prices to run a grep.
+
+### Install instructions
+
+Bad:
+
+> Get started instantly with our blazing-fast installer.
+
+Good:
+
+> No waitlist, no email, no sign-up. Plug in the Claude, Cursor, Codex or
+> Gemini you already pay for and you're running on your own machine in a
+> minute.
+
+### In-app micro-copy
+
+| Place          | Bad                                       | Good                                              |
+| -------------- | ----------------------------------------- | ------------------------------------------------- |
+| Empty state    | "No agents available. Configure one now." | "No CLIs connected yet. Pick one to start."       |
+| Error          | "An unexpected error occurred."           | "Couldn't reach the Claude CLI. Is it installed?" |
+| Confirm dialog | "Are you sure you want to proceed?"       | "Delete this session and all of its turns?"       |
+| Loading        | "Please wait…"                            | "Building the context."                           |
+| Success        | "Operation successful!"                   | "Session saved."                                  |
+
+## When in doubt
+
+Read it out loud. If it sounds like a press release, rewrite. If it sounds like
+something you'd say to a friend after the third coffee of the day, ship it.

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -3,12 +3,12 @@ import { SpeedInsights } from '@vercel/speed-insights/react';
 import { Nav } from './sections/Nav';
 import { FloatingNav } from './sections/FloatingNav';
 import { Hero } from './sections/Hero';
-import { Letter } from './sections/Letter';
 import { SessionsDeepDive } from './sections/SessionsDeepDive';
 import { ContextDeepDive } from './sections/ContextDeepDive';
 import { StudioDeepDive } from './sections/StudioDeepDive';
 import { GithubDeepDive } from './sections/GithubDeepDive';
 import { MoreBriefly } from './sections/MoreBriefly';
+import { Letter } from './sections/Letter';
 import { Comparison } from './sections/Comparison';
 import { CTA } from './sections/CTA';
 import { Footer } from './sections/Footer';
@@ -21,14 +21,14 @@ export function App() {
       <main>
         {/* above the fold: the reason + install/github + app overview */}
         <Hero />
-        {/* the human note, sets the voice before the features */}
-        <Letter />
-        {/* the key points */}
+        {/* the key points first: features carry the page */}
         <SessionsDeepDive />
         <ContextDeepDive />
         <StudioDeepDive />
         <GithubDeepDive />
         <MoreBriefly />
+        {/* the human note, after the features, before the close */}
+        <Letter />
         {/* close */}
         <Comparison />
         <CTA />


### PR DESCRIPTION
## Summary

- **README rewritten** in the new human voice from the website rework: problem first, no "AI" term, no buzzwords, no em-dashes. GitHub Studio section added now that the feature ships. Cost meter and Workflows promoted from one-liners to short, concrete scenarios.
- **`docs/tone-of-voice.md`** added so future copy stays consistent: two voices (product / author), words to avoid, punctuation rules, before/after examples for headlines, features and in-app micro-copy. Linked from the README.
- **Website**: Letter section moved from immediately after Hero down to between MoreBriefly and Comparison. Features now carry the page, the note becomes the human breath before the close.

## Test plan

- [ ] Re-read README top to bottom out loud, gut-check the voice
- [ ] Skim `docs/tone-of-voice.md`, confirm it's the rulebook you'd want a copy-helper to follow
- [ ] `npm --prefix ./website run dev`, scroll the page, confirm the order is Hero → 4 deep dives → MoreBriefly → Letter → Comparison → CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)