### PR TITLE
feat(repo): add linear studio section to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ bucketed by state (draft, in review, approved, merged). Open one and you've
 got the body, the lifecycle controls and the unresolved comments in a single
 view. Reply yourself, or hand a comment to an agent to resolve.
 
-**Linear in the side panel.** Pick an issue and the goal and branch fill
-themselves in. A proper Linear Studio is on the way.
+**Linear Studio.** Every open issue assigned to you, bucketed by Linear
+state. Pick one and the goal is already written, the branch is named, the
+linked PR is recognized. Hit launch and a session is on it, with the issue
+tagged in the rail above. Already shipped a PR for that issue? Pick
+"Continue on PR" instead of "Start fresh" and the same branch comes back,
+ready for the next round.
 
 **Cost meter that taps your shoulder.** Every session shows what it's costing
 as it runs. Goodboy nudges you before you burn Opus on a one-liner.

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -7,6 +7,7 @@ import { SessionsDeepDive } from './sections/SessionsDeepDive';
 import { ContextDeepDive } from './sections/ContextDeepDive';
 import { StudioDeepDive } from './sections/StudioDeepDive';
 import { GithubDeepDive } from './sections/GithubDeepDive';
+import { LinearDeepDive } from './sections/LinearDeepDive';
 import { MoreBriefly } from './sections/MoreBriefly';
 import { Letter } from './sections/Letter';
 import { Comparison } from './sections/Comparison';
@@ -26,6 +27,7 @@ export function App() {
         <ContextDeepDive />
         <StudioDeepDive />
         <GithubDeepDive />
+        <LinearDeepDive />
         <MoreBriefly />
         {/* the human note, after the features, before the close */}
         <Letter />

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -1280,6 +1280,202 @@ export function GithubStudioSnapshot() {
   );
 }
 
+/* ---------------------------- Linear Studio ------------------------- */
+
+/* Mirrors apps/desktop/src/features/integrations/linear/LinearStudio:
+   left rail = IssueInbox (search, issues grouped by Linear state, state dots,
+   PR/session badges), right pane = IssueDetailPanel (identifier + state chip,
+   open-in-linear, title, linked PR chip, description excerpt, Goal field,
+   Branch mode tabs with PR adoption, launch button). Compressed to one screen;
+   the real surface is taller. */
+const LINEAR_INBOX: ReadonlyArray<{
+  readonly label: string;
+  readonly dot: string;
+  readonly rows: ReadonlyArray<{
+    readonly id: string;
+    readonly title: string;
+    readonly active?: boolean;
+    readonly hasPr?: boolean;
+    readonly hasSession?: boolean;
+  }>;
+}> = [
+  {
+    label: 'In progress',
+    dot: 'bg-primary',
+    rows: [
+      { id: 'GOOD-214', title: 'Password reset via email link', active: true, hasPr: true },
+      { id: 'GOOD-211', title: 'Rate limiter on /auth/*', hasSession: true },
+    ],
+  },
+  {
+    label: 'Todo',
+    dot: 'bg-info',
+    rows: [
+      { id: 'GOOD-218', title: 'Workspace switcher in command bar' },
+      { id: 'GOOD-220', title: 'Retry policy for webhook deliveries' },
+    ],
+  },
+  {
+    label: 'Backlog',
+    dot: 'bg-muted-foreground/50',
+    rows: [{ id: 'GOOD-231', title: 'Inline diffs in PR conversation' }],
+  },
+];
+
+export function LinearStudioSnapshot() {
+  return (
+    <SnapshotFrame className="max-w-[560px]">
+      <FrameHeader
+        label="Linear · goodboy"
+        right={
+          <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase tracking-wide text-warning">
+            beta
+          </span>
+        }
+      />
+      <div className="flex">
+        {/* inbox: open issues assigned to you, grouped by state */}
+        <div className="w-[196px] shrink-0 border-r border-border-soft">
+          {/* search */}
+          <div className="px-2 pt-2 pb-1.5">
+            <div className="flex h-7 items-center gap-1.5 rounded-md border border-border-soft bg-background/40 px-2 text-[10px] text-muted-foreground/60">
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+                className="shrink-0"
+              >
+                <circle cx="11" cy="11" r="7" />
+                <path d="m21 21-4.3-4.3" />
+              </svg>
+              <span>Search issues…</span>
+            </div>
+          </div>
+          <div className="space-y-2.5 px-2 pb-2.5">
+            {LINEAR_INBOX.map((g) => (
+              <div key={g.label} className="flex flex-col gap-0.5">
+                <div className="flex items-center gap-1 px-1 pb-0.5">
+                  <span className="text-[9px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+                    {g.label}
+                  </span>
+                  <span className="text-[9px] tabular-nums text-muted-foreground/50">
+                    {g.rows.length}
+                  </span>
+                  <span aria-hidden className="ml-1 h-px flex-1 bg-border-soft" />
+                </div>
+                {g.rows.map((r) => (
+                  <div
+                    key={r.id}
+                    className={[
+                      'flex items-center gap-1.5 rounded-md px-1.5 py-1',
+                      r.active ? 'bg-primary/10 ring-1 ring-primary/30' : '',
+                    ].join(' ')}
+                  >
+                    <span aria-hidden className={`size-1.5 shrink-0 rounded-full ${g.dot}`} />
+                    <span className="shrink-0 font-mono text-[9px] text-muted-foreground/70">
+                      {r.id}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-[10.5px] text-foreground/85">
+                      {r.title}
+                    </span>
+                    {r.hasPr ? (
+                      <IconPullRequest size={9} className="shrink-0 text-muted-foreground/70" />
+                    ) : null}
+                    {r.hasSession ? (
+                      <span
+                        aria-hidden
+                        title="session launched"
+                        className="size-1.5 shrink-0 rounded-full bg-success"
+                      />
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* detail: focused issue, launch session right here */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-2 px-3 pt-3 pb-1">
+            <span className="font-mono text-[10px] text-muted-foreground">GOOD-214</span>
+            <span className="chip bg-muted text-muted-foreground">In progress</span>
+            <span className="flex-1" />
+            <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/70">
+              Open in Linear
+              <svg
+                width="9"
+                height="9"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M15 3h6v6M10 14 21 3M21 14v7H3V3h7" />
+              </svg>
+            </span>
+          </div>
+          <p className="px-3 pb-2 text-[12px] font-semibold leading-snug text-foreground">
+            Password reset via email link
+          </p>
+          <div className="flex items-center gap-1.5 px-3 pb-2">
+            <span className="chip chip-success inline-flex items-center gap-1">
+              <IconPullRequest size={9} aria-hidden /> #214 · open
+            </span>
+          </div>
+          <p className="px-3 pb-3 text-[10.5px] leading-relaxed text-muted-foreground/80">
+            Add a password reset flow: request endpoint, hashed token with TTL, email template, form
+            on the marketing site. Keep the existing login UI untouched.
+          </p>
+
+          {/* launch panel: goal + branch + button */}
+          <div className="space-y-2 border-t border-border-soft/60 bg-subtle/40 px-3 py-2.5">
+            <div className="flex items-center gap-1.5 text-[10px] font-semibold text-foreground">
+              <IconTarget size={10} aria-hidden className="text-primary" /> Goal
+            </div>
+            <div className="rounded-md border border-border-soft bg-background/40 px-2 py-1.5 text-[10.5px] leading-relaxed text-foreground/85">
+              Password reset via email link. Add request endpoint, hashed token, email template.
+            </div>
+
+            <div className="flex items-center gap-1.5 pt-1 text-[10px] font-semibold text-foreground">
+              <IconBranch size={10} aria-hidden className="text-success" /> Branch
+            </div>
+            <div className="inline-flex rounded-md border border-border-soft p-0.5 text-[9.5px]">
+              <span className="rounded bg-muted px-1.5 py-0.5 font-medium text-foreground">
+                Continue on PR #214
+              </span>
+              <span className="px-1.5 py-0.5 text-muted-foreground/70">Start fresh</span>
+            </div>
+            <div className="flex items-center gap-1.5 rounded-md border border-border-soft bg-background/40 px-2 py-1 font-mono text-[10px] text-foreground/85">
+              <IconBranch size={9} aria-hidden className="text-muted-foreground" />
+              <span className="truncate">ak/password-reset</span>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-2 border-t border-border-soft bg-primary/5 px-3 py-2 text-[10.5px]">
+            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+              <span aria-hidden className="size-2.5 rounded-sm border border-muted-foreground/40" />
+              Set up workflow next
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-md border border-primary bg-primary px-2 py-1 text-[10px] font-semibold text-primary-foreground">
+              Launch session →
+            </span>
+          </div>
+        </div>
+      </div>
+    </SnapshotFrame>
+  );
+}
+
 /* ---------------------------- Session cost --------------------------- */
 
 /* Mirrors apps/desktop/src/features/providers/components/CostBadge +

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -64,10 +64,7 @@ export function CTA() {
         <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
           Open source &middot; MIT
         </p>
-        <h2 className="mt-5 text-3xl sm:text-5xl leading-[1.02] tracking-[-0.03em] font-semibold text-foreground">
-          So, my friend: stop re-explaining yourself.
-        </h2>
-        <p className="mx-auto mt-5 max-w-md text-[15px] leading-[1.65] text-muted-foreground">
+        <p className="mx-auto mt-7 max-w-xl text-[18px] leading-[1.5] text-foreground/85 sm:text-[20px]">
           No waitlist, no email, no sign-up. Plug in the Claude, Cursor, Codex or Gemini you already
           pay for and you&apos;re running on your own machine in a minute.
         </p>

--- a/website/src/sections/FloatingNav.tsx
+++ b/website/src/sections/FloatingNav.tsx
@@ -6,6 +6,7 @@ const links = [
   { href: '#context', label: 'Context' },
   { href: '#studio', label: 'Workflow Studio' },
   { href: '#github', label: 'GitHub Studio' },
+  { href: '#linear', label: 'Linear Studio' },
   { href: '#compare', label: 'Compare' },
 ];
 

--- a/website/src/sections/LinearDeepDive.tsx
+++ b/website/src/sections/LinearDeepDive.tsx
@@ -1,0 +1,28 @@
+import { Section } from '../components/Section';
+import { LinearStudioSnapshot } from '../mockups/Snapshots';
+
+export function LinearDeepDive() {
+  return (
+    <Section
+      id="linear"
+      eyebrow="05 · Linear Studio"
+      title={<>Your Linear backlog, one click from a session.</>}
+      body={
+        <>
+          <p>
+            Every open issue assigned to you, bucketed by Linear state. Pick one and the goal is
+            already written, the branch is named, the linked PR is recognized. Hit launch and a
+            session is on it, with the issue tagged in the rail above.
+          </p>
+          <p className="mt-4">
+            Already shipped a PR for that issue and got review comments? Pick &ldquo;Continue on
+            PR&rdquo; instead of &ldquo;Start fresh&rdquo; and the same branch comes back, ready to
+            push the next round.
+          </p>
+        </>
+      }
+    >
+      <LinearStudioSnapshot />
+    </Section>
+  );
+}

--- a/website/src/sections/MoreBriefly.tsx
+++ b/website/src/sections/MoreBriefly.tsx
@@ -1,8 +1,8 @@
 import { Eyebrow } from '../components/ui';
 import { useInView } from '../components/Reveal';
 
-/* The fifth "point": everything else, kept deliberately dry. One line each,
-   no mockups. The four sections above carry the weight; this is the tail. */
+/* The sixth "point": everything else, kept deliberately dry. One line each,
+   no mockups. The five sections above carry the weight; this is the tail. */
 const ITEMS: ReadonlyArray<{ k: string; v: string }> = [
   {
     k: 'Routing & cost',
@@ -15,10 +15,6 @@ const ITEMS: ReadonlyArray<{ k: string; v: string }> = [
   {
     k: 'Plans',
     v: 'Agents write the plan before they touch your code, and it stays put: something you can read and edit, not a message that scrolls away.',
-  },
-  {
-    k: 'Linear',
-    v: 'Pick a Linear issue and the goal and branch fill themselves in. A proper Linear Studio is on the way.',
   },
   {
     k: 'Local-first',
@@ -39,7 +35,7 @@ export function MoreBriefly() {
     >
       <div className="mx-auto max-w-5xl px-6">
         <div className="reveal max-w-2xl">
-          <Eyebrow>05 &middot; The rest, briefly</Eyebrow>
+          <Eyebrow>06 &middot; The rest, briefly</Eyebrow>
           <p className="mt-4 text-pretty text-[16px] leading-[1.6] text-muted-foreground sm:text-[17px]">
             The stuff that matters but doesn&apos;t need its own billboard.
           </p>

--- a/website/src/sections/Nav.tsx
+++ b/website/src/sections/Nav.tsx
@@ -6,6 +6,7 @@ const links = [
   { href: '#context', label: 'Context' },
   { href: '#studio', label: 'Workflow Studio' },
   { href: '#github', label: 'GitHub Studio' },
+  { href: '#linear', label: 'Linear Studio' },
   { href: '#compare', label: 'Compare' },
 ];
 


### PR DESCRIPTION
## Summary

- **New section 05 · Linear Studio** with a faithful mockup of the real surface: left rail = issue inbox (search, issues grouped by Linear state with state dots, PR/session badges); right pane = focused issue (identifier, state chip, open-in-linear, title, linked PR chip, description, Goal field, Branch tabs with PR-adoption, Launch button).
- **Nav + FloatingNav**: new \"Linear Studio\" link.
- **MoreBriefly**: Linear placeholder dropped (now has its own section). Renumbered to 06.
- **README**: replaced the \"Linear in the side panel\" paragraph with a real Linear Studio one, parallel in shape to the GitHub Studio paragraph.
- **CTA**: dropped the h2 (kept echoing the hero, copy wouldn't land). Eyebrow + body + button carry the close; body sized up to fill the visual slot.

## Test plan

- [ ] Scroll the full page, check the 05 · Linear Studio section reads cleanly next to GitHub Studio above and MoreBriefly below
- [ ] Nav + FloatingNav: \"Linear Studio\" link, anchor jumps to the section
- [ ] CTA renders cleanly without the h2 (eyebrow + body + button alone)
- [ ] README diff: only the Linear paragraph changed in the features list

🤖 Generated with [Claude Code](https://claude.com/claude-code)