### PR TITLE
feat(desktop): windows + linux cross-platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,47 @@ on:
     tags:
       - 'v*'
 
-# Build the macOS universal (.dmg) on tag push and publish it as a draft
-# GitHub Release. Signing + notarization run automatically when the APPLE_*
-# secrets are present; if they are unset the build still produces an unsigned
-# .dmg. See docs/release.md.
+# Build macOS (universal .dmg), Linux (.AppImage + .deb + .rpm) and Windows
+# (.msi + nsis .exe) on tag push and attach them to a single draft GitHub
+# Release. A create-release job mints the draft first so the three build jobs
+# upload to one release (avoids the duplicate-draft race of matrix builds).
+# macOS signing + notarization run automatically when the APPLE_* secrets are
+# present; if unset the build still produces an unsigned .dmg. rc tags (e.g.
+# v0.1.4-rc.1) publish as prereleases; final tags do not. See docs/release.md.
 
 permissions:
   contents: write
 
 jobs:
+  create-release:
+    name: create draft release
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.result }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: create draft release
+        id: create
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          script: |
+            const tag = context.ref.replace('refs/tags/', '');
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `Goodboy ${tag}`,
+              draft: true,
+              prerelease: tag.includes('-rc.'),
+            });
+            return data.id;
+
   macos:
     name: build universal dmg
+    needs: create-release
     runs-on: macos-14
     # Apple notarization can be slow, especially the first submission from a new
     # Developer ID account. Keep generous headroom so the runner does not get
@@ -68,13 +98,114 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # Updater signing: tauri-action signs the update artifacts and emits
           # latest.json (attached to the release) so the in-app updater can
-          # verify and apply new versions.
+          # verify and apply new versions. macOS is the only platform wired to
+          # the updater today; Windows/Linux skip it (see those jobs).
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Goodboy ${{ github.ref_name }}'
-          releaseDraft: true
-          prerelease: false
+          releaseId: ${{ needs.create-release.outputs.release_id }}
           args: --target universal-apple-darwin
+
+  linux:
+    name: build linux (appimage + deb + rpm)
+    needs: create-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-linux-${{ hashFiles('apps/desktop/src-tauri/Cargo.toml') }}
+          restore-keys: |
+            cargo-linux-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build workspace deps
+        run: pnpm turbo run build --filter=@goodboy/desktop^...
+
+      - name: install linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: build, release (linux)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/desktop
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          # Multi-platform updater (merged latest.json) is not wired yet; skip
+          # the per-platform manifest so it does not clobber the macOS one.
+          includeUpdaterJson: false
+
+  windows:
+    name: build windows (msi + nsis)
+    needs: create-release
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: setup rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-windows-${{ hashFiles('apps/desktop/src-tauri/Cargo.toml') }}
+          restore-keys: |
+            cargo-windows-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build workspace deps
+        run: pnpm turbo run build --filter=@goodboy/desktop^...
+
+      - name: build, release (windows)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: apps/desktop
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          # Multi-platform updater (merged latest.json) is not wired yet; skip
+          # the per-platform manifest so it does not clobber the macOS one.
+          includeUpdaterJson: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # createUpdaterArtifacts is on globally, so every platform's build
+          # needs the (app-level, cross-platform) updater signing key, even
+          # though includeUpdaterJson skips emitting the manifest here.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
           releaseId: ${{ needs.create-release.outputs.release_id }}
@@ -203,6 +208,11 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # createUpdaterArtifacts is on globally, so every platform's build
+          # needs the (app-level, cross-platform) updater signing key, even
+          # though includeUpdaterJson skips emitting the manifest here.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: apps/desktop
           releaseId: ${{ needs.create-release.outputs.release_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,13 @@ on:
       - 'v*'
 
 # Build macOS (universal .dmg), Linux (.AppImage + .deb + .rpm) and Windows
-# (.msi + nsis .exe) on tag push and attach them to a single draft GitHub
-# Release. A create-release job mints the draft first so the three build jobs
-# upload to one release (avoids the duplicate-draft race of matrix builds).
-# macOS signing + notarization run automatically when the APPLE_* secrets are
+# (.msi + nsis .exe) on tag push and attach them to a single GitHub Release.
+# A create-release job mints the release first so the three build jobs upload
+# to one release (avoids the duplicate-draft race of matrix builds). macOS
+# signing + notarization run automatically when the APPLE_* secrets are
 # present; if unset the build still produces an unsigned .dmg. rc tags (e.g.
-# v0.1.4-rc.1) publish as prereleases; final tags do not. See docs/release.md.
+# v0.2.0-rc.1) publish straight to a prerelease so testers can download them;
+# final tags create a draft for manual notes + publish. See docs/release.md.
 
 permissions:
   contents: write
@@ -33,13 +34,16 @@ jobs:
           result-encoding: string
           script: |
             const tag = context.ref.replace('refs/tags/', '');
+            const isRc = tag.includes('-rc.');
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
               name: `Goodboy ${tag}`,
-              draft: true,
-              prerelease: tag.includes('-rc.'),
+              // rc tags publish straight to a prerelease so testers can download
+              // the artifacts; final tags stay draft for manual notes + publish.
+              draft: !isRc,
+              prerelease: isRc,
             });
             return data.id;
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.4"
+version = "0.2.0"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.3"
+version = "0.1.4"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/src/editor.rs
+++ b/apps/desktop/src-tauri/src/editor.rs
@@ -37,7 +37,11 @@ fn detect_editors_inner() -> Vec<DetectedEditor> {
 }
 
 fn which_binary(binary: &str) -> Option<()> {
-    let status = crate::path_env::command("which").arg(binary).output().ok()?;
+    #[cfg(windows)]
+    let locate = "where";
+    #[cfg(not(windows))]
+    let locate = "which";
+    let status = crate::path_env::command(locate).arg(binary).output().ok()?;
     if status.status.success() { Some(()) } else { None }
 }
 

--- a/apps/desktop/src-tauri/src/external_terminal.rs
+++ b/apps/desktop/src-tauri/src/external_terminal.rs
@@ -48,7 +48,7 @@ fn spawn_in_external_terminal(command: &str) -> Result<(), String> {
 #[cfg(target_os = "windows")]
 fn spawn_in_external_terminal(command: &str) -> Result<(), String> {
     Command::new("cmd")
-        .args(["/c", "start", "cmd", "/k", command])
+        .args(["/c", "start", "", "cmd", "/k", command])
         .spawn()
         .map_err(|e| e.to_string())?;
     Ok(())

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod repo;
 mod scripts;
 mod secrets;
 mod settings_overrides;
+mod shell;
 mod skills;
 mod summarize;
 mod terminal;

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -4,11 +4,20 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
 static RESOLVED_PATH: OnceLock<String> = OnceLock::new();
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const SEP: char = if cfg!(windows) { ';' } else { ':' };
+
+// CREATE_NO_WINDOW: a GUI (windows-subsystem) process spawning a console child
+// allocates a console window for it, which flashes on screen. This suppresses
+// it. Applies to both .spawn() and .output().
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 /// PATH inherited from the user's login shell, merged with the process's own
 /// PATH and common install locations, deduplicated, cached after first call.
@@ -28,6 +37,8 @@ pub fn resolved_path() -> &'static str {
 pub fn command(binary: &str) -> Command {
     let mut cmd = Command::new(binary);
     cmd.env("PATH", resolved_path());
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
     cmd
 }
 
@@ -95,13 +106,15 @@ fn probe_login_shell_path() -> Option<String> {
 }
 
 fn run_with_timeout(bin: &str, args: &[&str]) -> Option<String> {
-    let mut child = Command::new(bin)
+    let mut builder = Command::new(bin);
+    builder
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-        .ok()?;
+        .stdin(Stdio::null());
+    #[cfg(windows)]
+    builder.creation_flags(CREATE_NO_WINDOW);
+    let mut child = builder.spawn().ok()?;
 
     let deadline = Instant::now() + PROBE_TIMEOUT;
     loop {
@@ -159,8 +172,17 @@ fn common_install_paths() -> String {
 
     #[cfg(windows)]
     {
-        // npm global dir hosts the `npm install -g` shims (claude.cmd,
-        // codex.cmd, gemini.cmd); data_dir() resolves to %APPDATA% on Windows.
+        // Discover npm's real global prefix and add it: on Windows the
+        // `npm install -g` shims (claude.cmd, codex.cmd, gemini.cmd) live
+        // directly there. Probing covers non-default prefixes (nvm-windows,
+        // volta, scoop, or a custom `npm config set prefix`) that data_dir()
+        // would miss. data_dir()/npm stays as the default fallback.
+        if let Some(prefix) = run_with_timeout("cmd", &["/C", "npm", "config", "get", "prefix"]) {
+            let prefix = prefix.trim();
+            if !prefix.is_empty() {
+                parts.push(prefix.to_string());
+            }
+        }
         if let Some(npm) = dirs::data_dir().map(|p| p.join("npm")) {
             if let Some(npm) = npm.to_str() {
                 parts.push(npm.to_string());

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -8,6 +8,7 @@ static RESOLVED_PATH: OnceLock<String> = OnceLock::new();
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+const SEP: char = if cfg!(windows) { ';' } else { ':' };
 
 /// PATH inherited from the user's login shell, merged with the process's own
 /// PATH and common install locations, deduplicated, cached after first call.
@@ -38,14 +39,14 @@ fn compute_path() -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();
     for source in [shell.as_str(), inherited.as_str(), common.as_str()] {
-        for segment in source.split(':') {
+        for segment in source.split(SEP) {
             let segment = segment.trim();
             if !segment.is_empty() && seen.insert(segment.to_string()) {
                 parts.push(segment.to_string());
             }
         }
     }
-    parts.join(":")
+    parts.join(&SEP.to_string())
 }
 
 #[cfg(target_os = "macos")]
@@ -68,6 +69,8 @@ fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
 
 #[cfg(target_os = "windows")]
 fn shell_candidates() -> &'static [(&'static str, &'static [&'static str])] {
+    // Windows GUI processes already inherit the full user PATH, so falling back
+    // to the inherited PATH is correct and no login-shell probe is needed.
     &[]
 }
 
@@ -123,29 +126,52 @@ fn run_with_timeout(bin: &str, args: &[&str]) -> Option<String> {
 }
 
 fn common_install_paths() -> String {
-    let home = std::env::var("HOME").unwrap_or_default();
-    let mut parts: Vec<String> = vec![
-        "/opt/homebrew/bin".into(),
-        "/opt/homebrew/sbin".into(),
-        "/usr/local/bin".into(),
-        "/usr/local/sbin".into(),
-        "/usr/bin".into(),
-        "/bin".into(),
-        "/usr/sbin".into(),
-        "/sbin".into(),
-    ];
-    if !home.is_empty() {
-        for sub in &[
-            "/.bun/bin",
-            "/.cargo/bin",
-            "/.local/bin",
-            "/.deno/bin",
-            "/.volta/bin",
-        ] {
-            parts.push(format!("{}{}", home, sub));
+    let home = dirs::home_dir().and_then(|p| p.to_str().map(str::to_string));
+    let mut parts: Vec<String> = Vec::new();
+
+    #[cfg(not(windows))]
+    {
+        parts.extend(
+            [
+                "/opt/homebrew/bin",
+                "/opt/homebrew/sbin",
+                "/usr/local/bin",
+                "/usr/local/sbin",
+                "/usr/bin",
+                "/bin",
+                "/usr/sbin",
+                "/sbin",
+            ]
+            .map(String::from),
+        );
+        if let Some(home) = home.as_deref() {
+            for sub in &[
+                "/.bun/bin",
+                "/.cargo/bin",
+                "/.local/bin",
+                "/.deno/bin",
+                "/.volta/bin",
+            ] {
+                parts.push(format!("{}{}", home, sub));
+            }
         }
     }
-    parts.join(":")
+
+    #[cfg(windows)]
+    {
+        // npm global dir hosts the `npm install -g` shims (claude.cmd,
+        // codex.cmd, gemini.cmd); data_dir() resolves to %APPDATA% on Windows.
+        if let Some(npm) = dirs::data_dir().map(|p| p.join("npm")) {
+            if let Some(npm) = npm.to_str() {
+                parts.push(npm.to_string());
+            }
+        }
+        if let Some(home) = home {
+            parts.push(home);
+        }
+    }
+
+    parts.join(&SEP.to_string())
 }
 
 #[cfg(test)]
@@ -156,8 +182,9 @@ mod tests {
     fn resolved_path_is_non_empty_and_contains_bin() {
         let p = resolved_path();
         assert!(!p.is_empty(), "resolved PATH must not be empty");
+        #[cfg(not(windows))]
         assert!(
-            p.split(':').any(|seg| seg == "/bin"),
+            p.split(SEP).any(|seg| seg == "/bin"),
             "resolved PATH should include /bin, got: {}",
             p
         );
@@ -176,7 +203,7 @@ mod tests {
     #[test]
     fn compute_path_dedups_segments() {
         let merged = compute_path();
-        let segments: Vec<&str> = merged.split(':').collect();
+        let segments: Vec<&str> = merged.split(SEP).collect();
         let mut unique = HashSet::new();
         for s in &segments {
             assert!(unique.insert(*s), "duplicate segment in resolved PATH: {}", s);

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -36,9 +36,9 @@ pub fn resolved_path() -> &'static str {
 /// posix path set.
 pub fn command(binary: &str) -> Command {
     #[cfg(windows)]
-    let mut cmd = match resolve_program(binary) {
-        Some(full) => batch_aware_command(full),
-        None => Command::new(binary),
+    let mut cmd = {
+        let resolved = resolve_program(binary).unwrap_or_else(|| std::path::PathBuf::from(binary));
+        batch_aware_command(resolved)
     };
     #[cfg(not(windows))]
     let mut cmd = Command::new(binary);
@@ -100,6 +100,7 @@ fn batch_aware_command(full: std::path::PathBuf) -> Command {
     );
     if is_batch {
         if let Some(js) = shim_js_target(&full) {
+            log::info!("windows spawn: node-direct {} -> {}", full.display(), js.display());
             let mut c = match resolve_program("node") {
                 Some(node) => Command::new(node),
                 None => Command::new("node"),
@@ -107,25 +108,48 @@ fn batch_aware_command(full: std::path::PathBuf) -> Command {
             c.arg(js);
             return c;
         }
+        log::warn!(
+            "windows spawn: no node target found in shim {}; using batch (multi-line/special args may fail)",
+            full.display()
+        );
     }
     Command::new(full)
 }
 
+// Extract the real `node` entry script a .cmd/.bat shim runs. npm cmd-shims
+// reference it as a .js path prefixed with the shim dir (%dp0% / %~dp0), but the
+// exact layout varies across npm/pnpm/yarn/volta versions, so scan every
+// quote- or whitespace-delimited token for one ending in .js and resolve it
+// against the shim directory (or as an absolute path). Logs the shim head when
+// nothing resolves, so a still-failing setup is diagnosable from the app log.
 #[cfg(windows)]
 fn shim_js_target(shim: &std::path::Path) -> Option<std::path::PathBuf> {
     let contents = std::fs::read_to_string(shim).ok()?;
     let dir = shim.parent()?;
-    for token in contents.split('"') {
-        let lower = token.to_ascii_lowercase();
-        if lower.ends_with(".js") && (lower.contains("%dp0%") || lower.contains("%~dp0")) {
-            let rel = token.replace("%dp0%", "").replace("%~dp0", "");
-            let rel = rel.trim().trim_start_matches(|c| c == '\\' || c == '/');
-            let candidate = dir.join(rel);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
+    for raw in contents.split(|c: char| c == '"' || c.is_whitespace()) {
+        let tok = raw.trim();
+        if tok.is_empty() || !tok.to_ascii_lowercase().ends_with(".js") {
+            continue;
+        }
+        let rel = tok
+            .replace("%~dp0", "")
+            .replace("%dp0%", "")
+            .replace("%CD%", "");
+        let rel = rel.trim_start_matches(|c| c == '\\' || c == '/');
+        let candidate = dir.join(rel);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        let abs = std::path::Path::new(tok);
+        if abs.is_absolute() && abs.is_file() {
+            return Some(abs.to_path_buf());
         }
     }
+    log::warn!(
+        "shim_js_target: no .js entry resolved in {}; head: {:?}",
+        shim.display(),
+        contents.chars().take(300).collect::<String>()
+    );
     None
 }
 

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -35,11 +35,52 @@ pub fn resolved_path() -> &'static str {
 /// `Command::new` whenever the target binary may live outside the minimal
 /// posix path set.
 pub fn command(binary: &str) -> Command {
+    #[cfg(windows)]
+    let mut cmd = match resolve_program(binary) {
+        Some(full) => Command::new(full),
+        None => Command::new(binary),
+    };
+    #[cfg(not(windows))]
     let mut cmd = Command::new(binary);
     cmd.env("PATH", resolved_path());
     #[cfg(windows)]
     cmd.creation_flags(CREATE_NO_WINDOW);
     cmd
+}
+
+// Command::new on Windows only finds <name>.exe by bare name; it does NOT find
+// the .cmd/.bat shims npm creates for global CLIs (claude.cmd, codex.cmd, ...),
+// so spawning "claude" directly fails with "program not found". Resolve the
+// bare name against the merged PATH using PATHEXT and hand Command a full path
+// it can launch. A resolved .cmd/.bat path is run by Rust via cmd with proper
+// argument escaping. Names that are already qualified (a path or an explicit
+// extension) are left untouched.
+#[cfg(windows)]
+fn resolve_program(binary: &str) -> Option<std::path::PathBuf> {
+    use std::path::Path;
+    let raw = Path::new(binary);
+    if raw.components().count() > 1 || raw.extension().is_some() {
+        return None;
+    }
+    let exts: Vec<String> = std::env::var("PATHEXT")
+        .unwrap_or_else(|_| ".COM;.EXE;.BAT;.CMD".to_string())
+        .split(';')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    for dir in resolved_path().split(SEP) {
+        let dir = dir.trim();
+        if dir.is_empty() {
+            continue;
+        }
+        for ext in &exts {
+            let candidate = Path::new(dir).join(format!("{}{}", binary, ext));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 fn compute_path() -> String {

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -37,7 +37,7 @@ pub fn resolved_path() -> &'static str {
 pub fn command(binary: &str) -> Command {
     #[cfg(windows)]
     let mut cmd = match resolve_program(binary) {
-        Some(full) => Command::new(full),
+        Some(full) => batch_aware_command(full),
         None => Command::new(binary),
     };
     #[cfg(not(windows))]
@@ -75,6 +75,52 @@ fn resolve_program(binary: &str) -> Option<std::path::PathBuf> {
         }
         for ext in &exts {
             let candidate = Path::new(dir).join(format!("{}{}", binary, ext));
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+// npm .cmd/.bat shims run the real CLI as `node <cli.js> %*`. Routing args
+// through cmd (which a .cmd inherently does) cannot carry multi-line or some
+// special-char arguments, so a multi-line chat prompt would fail to spawn.
+// Spawn node + the target script directly instead: node.exe takes args the
+// standard way and the CLI sees the identical argv. Falls back to the shim
+// when the script cannot be located.
+#[cfg(windows)]
+fn batch_aware_command(full: std::path::PathBuf) -> Command {
+    let is_batch = matches!(
+        full.extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref(),
+        Some("cmd") | Some("bat")
+    );
+    if is_batch {
+        if let Some(js) = shim_js_target(&full) {
+            let mut c = match resolve_program("node") {
+                Some(node) => Command::new(node),
+                None => Command::new("node"),
+            };
+            c.arg(js);
+            return c;
+        }
+    }
+    Command::new(full)
+}
+
+#[cfg(windows)]
+fn shim_js_target(shim: &std::path::Path) -> Option<std::path::PathBuf> {
+    let contents = std::fs::read_to_string(shim).ok()?;
+    let dir = shim.parent()?;
+    for token in contents.split('"') {
+        let lower = token.to_ascii_lowercase();
+        if lower.ends_with(".js") && (lower.contains("%dp0%") || lower.contains("%~dp0")) {
+            let rel = token.replace("%dp0%", "").replace("%~dp0", "");
+            let rel = rel.trim().trim_start_matches(|c| c == '\\' || c == '/');
+            let candidate = dir.join(rel);
             if candidate.is_file() {
                 return Some(candidate);
             }

--- a/apps/desktop/src-tauri/src/provider_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/provider_lifecycle.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{native_pty_system, PtySize};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
@@ -157,18 +157,21 @@ pub async fn provider_lifecycle_run(
             })
             .map_err(|e| LifecycleError::Io(e.to_string()))?;
 
-        let mut cmd = CommandBuilder::new("bash");
-        cmd.arg("-c");
-        cmd.arg(&command);
-        let cwd = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
+        let mut cmd = crate::shell::command_in_shell(&command);
+        let cwd = dirs::home_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|| ".".to_string());
         cmd.cwd(&cwd);
         cmd.env("PATH", crate::path_env::resolved_path());
         cmd.env("TERM", "xterm-256color");
-        if let Ok(home) = std::env::var("HOME") {
-            cmd.env("HOME", home);
-        }
-        if let Ok(user) = std::env::var("USER") {
-            cmd.env("USER", user);
+        #[cfg(not(windows))]
+        {
+            if let Ok(home) = std::env::var("HOME") {
+                cmd.env("HOME", home);
+            }
+            if let Ok(user) = std::env::var("USER") {
+                cmd.env("USER", user);
+            }
         }
 
         let child = pair

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -102,6 +102,7 @@ fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
     {
         Ok(child) => child,
         Err(err) => {
+            log::warn!("provider detect '{}': spawn failed: {}", binary, err);
             return ProviderStatus {
                 id: id.to_string(),
                 binary: binary.to_string(),
@@ -124,6 +125,7 @@ fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
                     .trim()
                     .to_string();
                 if status.success() {
+                    log::info!("provider detect '{}': available ({})", binary, stdout);
                     return ProviderStatus {
                         id: id.to_string(),
                         binary: binary.to_string(),
@@ -132,18 +134,28 @@ fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
                         error: None,
                     };
                 } else {
+                    let stderr = child
+                        .stderr
+                        .take()
+                        .map(read_to_string)
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string();
+                    let code = status.code().unwrap_or(-1);
+                    log::warn!("provider detect '{}': exit {} stderr: {}", binary, code, stderr);
                     return ProviderStatus {
                         id: id.to_string(),
                         binary: binary.to_string(),
                         available: false,
                         version: None,
-                        error: Some(format!("exited with code {}", status.code().unwrap_or(-1))),
+                        error: Some(format!("exited with code {}: {}", code, stderr)),
                     };
                 }
             }
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
+                    log::warn!("provider detect '{}': timed out", binary);
                     return ProviderStatus {
                         id: id.to_string(),
                         binary: binary.to_string(),
@@ -188,11 +200,17 @@ impl AuthCommandOutput {
 
 fn run_auth_command(args: &[&str]) -> Result<AuthCommandOutput, String> {
     let (binary, rest) = args.split_first().ok_or_else(|| "empty command".to_string())?;
-    let mut child = auth_command(binary, rest)
+    let mut child = match auth_command(binary, rest)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| e.to_string())?;
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("provider auth '{}': spawn failed: {}", args.join(" "), e);
+            return Err(e.to_string());
+        }
+    };
 
     let deadline = Instant::now() + AUTH_TIMEOUT;
     loop {
@@ -213,8 +231,15 @@ fn run_auth_command(args: &[&str]) -> Result<AuthCommandOutput, String> {
                     .trim()
                     .to_string();
                 if status.success() {
+                    log::info!("provider auth '{}': ok", args.join(" "));
                     return Ok(AuthCommandOutput { stdout, stderr });
                 } else {
+                    log::warn!(
+                        "provider auth '{}': exit {} stderr: {}",
+                        args.join(" "),
+                        status.code().unwrap_or(-1),
+                        stderr
+                    );
                     let msg = if stderr.is_empty() { stdout } else { stderr };
                     return Err(msg);
                 }
@@ -222,6 +247,7 @@ fn run_auth_command(args: &[&str]) -> Result<AuthCommandOutput, String> {
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
+                    log::warn!("provider auth '{}': timed out", args.join(" "));
                     return Err("auth check timed out".to_string());
                 }
                 std::thread::sleep(POLL_INTERVAL);

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -24,6 +24,38 @@ pub struct ProviderStatus {
     pub error: Option<String>,
 }
 
+fn version_command(binary: &str) -> std::process::Command {
+    #[cfg(windows)]
+    {
+        let mut c = path_env::command("cmd");
+        c.arg("/C").arg(binary).arg("--version");
+        c
+    }
+    #[cfg(not(windows))]
+    {
+        let mut c = path_env::command(binary);
+        c.arg("--version");
+        c
+    }
+}
+
+// npm-installed CLIs land as .cmd shims on Windows, which CreateProcess cannot
+// launch directly; route auth subcommands through cmd so the shim resolves.
+fn auth_command(binary: &str, rest: &[&str]) -> std::process::Command {
+    #[cfg(windows)]
+    {
+        let mut c = path_env::command("cmd");
+        c.arg("/C").arg(binary).args(rest);
+        c
+    }
+    #[cfg(not(windows))]
+    {
+        let mut c = path_env::command(binary);
+        c.args(rest);
+        c
+    }
+}
+
 pub struct ProviderState(pub Mutex<ProviderStatus>);
 
 pub struct CursorState(pub Mutex<ProviderStatus>);
@@ -63,8 +95,7 @@ pub fn detect_gemini() -> ProviderStatus {
 }
 
 fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
-    let mut child = match path_env::command(binary)
-        .arg("--version")
+    let mut child = match version_command(binary)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -157,8 +188,7 @@ impl AuthCommandOutput {
 
 fn run_auth_command(args: &[&str]) -> Result<AuthCommandOutput, String> {
     let (binary, rest) = args.split_first().ok_or_else(|| "empty command".to_string())?;
-    let mut child = path_env::command(binary)
-        .args(rest)
+    let mut child = auth_command(binary, rest)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -452,7 +482,7 @@ fn extract_gemini_identity_from_creds() -> Option<String> {
     // an interactive login; the `email` field carries the user's Google identity.
     // Fallback paths covered: legacy `~/.config/gemini/auth.json`.
     let home = dirs::home_dir()?;
-    for rel in ["./.gemini/oauth_creds.json", "./.config/gemini/auth.json"] {
+    for rel in [".gemini/oauth_creds.json", ".config/gemini/auth.json"] {
         let path = home.join(rel);
         let Ok(content) = std::fs::read_to_string(&path) else {
             continue;

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{native_pty_system, PtySize};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
@@ -144,9 +144,7 @@ pub async fn workspace_script_run(
             })
             .map_err(|e| ScriptError::Io(e.to_string()))?;
 
-        let mut cmd = CommandBuilder::new("bash");
-        cmd.arg("-c");
-        cmd.arg(&body);
+        let mut cmd = crate::shell::command_in_shell(&body);
         cmd.cwd(&cwd);
         cmd.env("PATH", crate::path_env::resolved_path());
         cmd.env("TERM", "xterm-256color");

--- a/apps/desktop/src-tauri/src/shell.rs
+++ b/apps/desktop/src-tauri/src/shell.rs
@@ -1,0 +1,36 @@
+use portable_pty::CommandBuilder;
+
+/// Run `command` through the platform shell, non-interactively.
+/// Unix: bash -c <command>.  Windows: cmd /C <command>.
+pub fn command_in_shell(command: &str) -> CommandBuilder {
+    #[cfg(windows)]
+    {
+        let mut cmd = CommandBuilder::new("cmd");
+        cmd.arg("/C");
+        cmd.arg(command);
+        cmd
+    }
+    #[cfg(not(windows))]
+    {
+        let mut cmd = CommandBuilder::new("bash");
+        cmd.arg("-c");
+        cmd.arg(command);
+        cmd
+    }
+}
+
+/// Interactive login shell for the embedded terminal.
+/// Unix: bash -l -i.  Windows: cmd.exe.
+pub fn interactive_shell() -> CommandBuilder {
+    #[cfg(windows)]
+    {
+        CommandBuilder::new("cmd")
+    }
+    #[cfg(not(windows))]
+    {
+        let mut cmd = CommandBuilder::new("bash");
+        cmd.arg("-l");
+        cmd.arg("-i");
+        cmd
+    }
+}

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+use portable_pty::{native_pty_system, PtySize};
 use serde::Serialize;
 use tauri::{AppHandle, Emitter, State};
 
@@ -127,24 +127,27 @@ pub async fn terminal_open(
             })
             .map_err(|e| TerminalError::Io(e.to_string()))?;
 
-        let mut cmd = CommandBuilder::new("/bin/bash");
-        cmd.arg("-l");
-        cmd.arg("-i");
+        let mut cmd = crate::shell::interactive_shell();
 
         let effective_cwd = cwd.unwrap_or_else(|| {
-            std::env::var("HOME").unwrap_or_else(|_| "/".to_string())
+            dirs::home_dir()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "/".to_string())
         });
         cmd.cwd(&effective_cwd);
         cmd.env("PATH", crate::path_env::resolved_path());
         cmd.env("TERM", "xterm-256color");
 
-        if let Ok(home) = std::env::var("HOME") {
-            cmd.env("HOME", home);
+        #[cfg(not(windows))]
+        {
+            if let Ok(home) = std::env::var("HOME") {
+                cmd.env("HOME", home);
+            }
+            if let Ok(user) = std::env::var("USER") {
+                cmd.env("USER", user);
+            }
+            cmd.env("SHELL", "/bin/bash");
         }
-        if let Ok(user) = std::env::var("USER") {
-            cmd.env("USER", user);
-        }
-        cmd.env("SHELL", "/bin/bash");
 
         let child = pair
             .slave

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -174,7 +174,7 @@ type TreeNode =
 function buildTree(files: ReadonlyArray<FileDiff>): TreeNode {
   const root: TreeNode = { kind: 'dir', name: '', children: [], additions: 0, deletions: 0 };
   files.forEach((f, idx) => {
-    const parts = f.path.split('/');
+    const parts = f.path.split(/[/\\]/);
     const fileName = parts.pop() ?? f.path;
     let cur = root as Extract<TreeNode, { kind: 'dir' }>;
     for (const part of parts) {

--- a/apps/desktop/src/features/providers/provider-lifecycle.ts
+++ b/apps/desktop/src/features/providers/provider-lifecycle.ts
@@ -41,7 +41,8 @@ export function resolveLifecycleCommand(
 ): string {
   const entry = PROVIDER_LIFECYCLE_COMMANDS[providerId];
   if (action === 'install') return entry.install[platform];
-  return entry[action];
+  if (action === 'logout') return entry.logout[platform];
+  return entry.login;
 }
 
 export function invokeProviderLifecycleRun(args: {

--- a/apps/desktop/src/store/slices/workspaces/addWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/addWorkspace.ts
@@ -72,7 +72,7 @@ export function addWorkspace(set: SetFn, get: GetFn) {
     }
 
     const inferredName =
-      name?.trim() || resolvedRoot.split('/').filter(Boolean).at(-1) || 'workspace';
+      name?.trim() || resolvedRoot.split(/[/\\]/).filter(Boolean).at(-1) || 'workspace';
     const now = new Date().toISOString() as IsoDateTime;
     const workspace: Workspace = {
       id: crypto.randomUUID() as WorkspaceId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",

--- a/packages/types/src/provider-commands.ts
+++ b/packages/types/src/provider-commands.ts
@@ -13,7 +13,7 @@ export interface ProviderPlatformCommands {
 export interface ProviderLifecycleCommands {
   readonly install: ProviderPlatformCommands;
   readonly login: string;
-  readonly logout: string;
+  readonly logout: ProviderPlatformCommands;
 }
 
 // Cross-platform, npm-first. Cursor is the only non-npm exception because
@@ -27,7 +27,11 @@ export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCo
       win32: 'npm install -g @anthropic-ai/claude-code',
     },
     login: 'claude /login',
-    logout: 'claude /logout',
+    logout: {
+      darwin: 'claude /logout',
+      linux: 'claude /logout',
+      win32: 'claude /logout',
+    },
   },
   cursor: {
     install: {
@@ -36,7 +40,11 @@ export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCo
       win32: 'powershell -Command "irm https://cursor.com/install.ps1 | iex"',
     },
     login: 'cursor-agent login',
-    logout: 'cursor-agent logout',
+    logout: {
+      darwin: 'cursor-agent logout',
+      linux: 'cursor-agent logout',
+      win32: 'cursor-agent logout',
+    },
   },
   codex: {
     install: {
@@ -45,7 +53,11 @@ export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCo
       win32: 'npm install -g @openai/codex',
     },
     login: 'codex login',
-    logout: 'codex logout',
+    logout: {
+      darwin: 'codex logout',
+      linux: 'codex logout',
+      win32: 'codex logout',
+    },
   },
   gemini: {
     install: {
@@ -54,6 +66,11 @@ export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCo
       win32: 'npm install -g @google/gemini-cli',
     },
     login: 'gemini',
-    logout: 'rm -f ~/.gemini/oauth_creds.json && echo "gemini credentials removed"',
+    logout: {
+      darwin: 'rm -f ~/.gemini/oauth_creds.json && echo "gemini credentials removed"',
+      linux: 'rm -f ~/.gemini/oauth_creds.json && echo "gemini credentials removed"',
+      win32:
+        'del /f /q "%USERPROFILE%\\.gemini\\oauth_creds.json" 2>nul & echo gemini credentials removed',
+    },
   },
 };


### PR DESCRIPTION
## what

Makes Goodboy build and run on **Windows** and **Linux**, not just macOS, and extends the release pipeline to ship artifacts for all three. Prereq for cutting cross-platform release candidates.

### terminal / CLI integration (the core fix)
All three PTY spawn sites hardcoded `bash` → broken on Windows. Now routed through a new `shell.rs` abstraction:
- `command_in_shell` → `bash -c` on unix, `cmd /C` on Windows (wraps the npm install strings + the already-powershell cursor win32 string cleanly)
- `interactive_shell` → `bash -l -i` on unix, `cmd` on Windows (embedded terminal)

### portability fixes
- **`path_env.rs`**: PATH separator `;` on Windows (was hardcoded `:`), `USERPROFILE` via `dirs::home_dir()`, npm-global shim dir (`%APPDATA%\npm`) so `claude.cmd`/`codex.cmd`/`gemini.cmd` resolve.
- **`providers.rs`**: binary `--version` probe **and** auth subcommands routed through `cmd /C` on Windows (CreateProcess can't launch `.cmd` shims directly → providers/auth otherwise always read as not-installed/unknown). Cleaned gemini auth-file rel paths.
- **`editor.rs`**: `which` → `where` on Windows.
- **`external_terminal.rs`**: explicit empty `start` title so commands with spaces parse.
- **provider logout** (`@goodboy/types`): now per-platform; gemini win32 uses `del` instead of `rm`.
- frontend path splits handle `\` as well as `/`.

### release pipeline (`release.yml`)
- adds `linux` (ubuntu, AppImage+deb+rpm) and `windows` (msi+nsis) jobs alongside macOS.
- `create-release` job mints one draft release + shared `releaseId` so the three builds don't race into duplicate drafts.
- `prerelease` auto-set for `-rc.` tags. Linux/Windows skip `latest.json` (multi-platform updater not wired yet).
- version bump 0.1.3 → 0.1.4.

## verification
- `cargo check` green on macOS (Windows-only `#[cfg(windows)]` arms validated by inspection; the RC build on real runners is the real gate).
- frontend changes type-safe by construction; CI runs typecheck/test.
- **not** locally buildable for Windows from this macOS host → an RC tag (`v0.1.4-rc.1`) is the cross-platform dry run.

## deferred (out of scope, tracked separately)
- `skills.rs` still runs bash scripts (graceful no-op on Windows).
- multi-platform updater (`latest.json` merge across OSes).
- test-only `/tmp` paths in `turn.rs`/`parallel_groups.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)