### PR TITLE
fix(desktop,core): restore slot-history button + keep goal slot high-level

### DIFF
--- a/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
@@ -1,13 +1,25 @@
-import type { SessionId } from '@goodboy/types';
-import { listContextSlotsForSession } from '@goodboy/db';
+import type { ContextSlotHistoryEntry, SessionId } from '@goodboy/types';
+import { listContextSlotHistory, listContextSlotsForSession } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import type { SetFn } from './types';
 
 export function loadSessionSlots(set: SetFn) {
   return async (sessionId: SessionId) => {
     const slots = await listContextSlotsForSession(tauriDatabase, sessionId);
+    const histories = await Promise.all(
+      slots.map((slot) => listContextSlotHistory(tauriDatabase, sessionId, slot.key)),
+    );
+    const slotHistory: Record<string, ReadonlyArray<ContextSlotHistoryEntry>> = {};
+    slots.forEach((slot, i) => {
+      const entries = histories[i];
+      if (entries.length > 0) slotHistory[slot.key] = entries;
+    });
     set((state) => ({
       sessionSlots: { ...state.sessionSlots, [sessionId]: slots },
+      slotHistory: {
+        ...state.slotHistory,
+        [sessionId]: { ...(state.slotHistory[sessionId] ?? {}), ...slotHistory },
+      },
     }));
   };
 }

--- a/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
+++ b/apps/desktop/src/store/slices/slots/loadSessionSlots.ts
@@ -12,7 +12,7 @@ export function loadSessionSlots(set: SetFn) {
     const slotHistory: Record<string, ReadonlyArray<ContextSlotHistoryEntry>> = {};
     slots.forEach((slot, i) => {
       const entries = histories[i];
-      if (entries.length > 0) slotHistory[slot.key] = entries;
+      if (entries && entries.length > 0) slotHistory[slot.key] = entries;
     });
     set((state) => ({
       sessionSlots: { ...state.sessionSlots, [sessionId]: slots },

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -5,6 +5,7 @@ import {
   extractPlanFromMarker,
   Summarizer,
   type ExtractedHandoff,
+  type SlotKey,
 } from '@goodboy/core';
 import {
   insertContextSlotHistory,
@@ -202,7 +203,7 @@ async function runSummarizer(
           return prevValue !== null ? upsert.key : null;
         }),
       )
-    ).filter((k): k is string => k !== null);
+    ).filter((k): k is SlotKey => k !== null);
 
     // If the summarizer carried a GitHub PR URL into any slot value and we
     // still have no PR cached for this session, pull the PR state now so the

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -11,6 +11,7 @@ import {
   insertNudgeEvent,
   insertProviderRun,
   insertTelemetry,
+  listContextSlotHistory,
   listContextSlotsForSession,
   listTelemetryForSession,
   renameSession as renameSessionInDb,
@@ -177,28 +178,31 @@ async function runSummarizer(
       : null;
     const result = await summarizer.summarize({ prevSlots, turnInput, turnOutput, prState });
 
-    // Parallel slot history + upsert writes, no serial await per slot.
-    await Promise.all(
-      result.delta.upserts.map(async (upsert) => {
-        const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
-        if (existing && existing.value !== upsert.value) {
-          await insertContextSlotHistory(
-            tauriDatabase,
-            sessionId,
-            crypto.randomUUID(),
-            upsert.key,
-            existing.value,
-            'summarizer',
-          );
-        }
-        const next: ContextSlot = {
-          key: upsert.key,
-          value: upsert.value,
-          enabled: existing?.enabled ?? true,
-        };
-        await upsertContextSlot(tauriDatabase, sessionId, next);
-      }),
-    );
+    const changedKeys = (
+      await Promise.all(
+        result.delta.upserts.map(async (upsert) => {
+          const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
+          const prevValue = existing && existing.value !== upsert.value ? existing.value : null;
+          if (prevValue !== null) {
+            await insertContextSlotHistory(
+              tauriDatabase,
+              sessionId,
+              crypto.randomUUID(),
+              upsert.key,
+              prevValue,
+              'summarizer',
+            );
+          }
+          const next: ContextSlot = {
+            key: upsert.key,
+            value: upsert.value,
+            enabled: existing?.enabled ?? true,
+          };
+          await upsertContextSlot(tauriDatabase, sessionId, next);
+          return prevValue !== null ? upsert.key : null;
+        }),
+      )
+    ).filter((k): k is string => k !== null);
 
     // If the summarizer carried a GitHub PR URL into any slot value and we
     // still have no PR cached for this session, pull the PR state now so the
@@ -226,6 +230,7 @@ async function runSummarizer(
       telemetry,
       providerSummaries,
       budgetRules,
+      changedHistory,
     ] = await Promise.all([
       listContextSlotsForSession(tauriDatabase, sessionId),
       insertProviderRun(tauriDatabase, {
@@ -262,11 +267,24 @@ async function runSummarizer(
       listTelemetryForSession(tauriDatabase, sessionId),
       summarizeWorkspaceProviderTelemetry(tauriDatabase, session.workspaceId),
       invokeBudgetRuleList(),
+      Promise.all(
+        changedKeys.map(
+          async (key) =>
+            [key, await listContextSlotHistory(tauriDatabase, sessionId, key)] as const,
+        ),
+      ),
     ]);
 
     // Single batched set, one re-render for the entire summarizer completion.
     set((state) => ({
       sessionSlots: { ...state.sessionSlots, [sessionId]: refreshed },
+      slotHistory: {
+        ...state.slotHistory,
+        [sessionId]: {
+          ...(state.slotHistory[sessionId] ?? {}),
+          ...Object.fromEntries(changedHistory),
+        },
+      },
       sessionSummary,
       workspaceSummary,
       sessionTelemetry: { ...state.sessionTelemetry, [sessionId]: telemetry },

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -98,7 +98,7 @@ You receive the previous slot values plus the most recent user turn and assistan
 CONTEXT PRESERVATION (critical)
 Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
 Never silently drop facts that are still valid. Per slot:
-- goal: refine over time as intent clarifies, sharpen wording, surface implicit constraints, drop vague phrasing. Do not erase prior framing if still valid.
+- goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent.
 - decisions: append new decisions to the existing list. Never remove accepted ones.
 - open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
 - files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
@@ -114,7 +114,7 @@ Rules:
 - Do NOT use markdown headings (#), the slot label is already the heading.
 - Do NOT wrap the value in code fences unless quoting actual code.
 - Exclude raw tool output and chat-style narration.
-- The "goal" slot stays as one tight sentence or two, no bullets needed unless multiple sub-goals exist.
+- The "goal" slot is one tight high-level sentence (two at most). No bullets, no status, no progress, no per-turn detail.
 
 OUTPUT
 You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.


### PR DESCRIPTION
## What

Two related context-panel fixes.

### 1. Slot-history button regression (`desktop`)
The context panel gates each slot's history button on cached entries (`history.length > 0`), but the **summarizer wrote history rows to the DB without ever refreshing the store cache**, and nothing hydrated it on session load. So `decisions` / `last_output_summary` (populated by the summarizer, not manual edits) never showed the button and their prior versions were unreachable.

- Hydrate `slotHistory` on session load (`loadSessionSlots`).
- Refresh the changed keys in the summarizer completion batch (`runSummarizer`) so the gate sees real entries immediately after a pass.

Regression introduced in `4c4f1bc` (context panel ux rework); original behavior was an always-visible button (#372).

### 2. Goal slot drifting into status text (`core`)
The cheap summarizer model folded per-turn status into the `goal` slot (e.g. *"feature-complete (clusters 1-5, review passed), remove 11 code comments"*). Goal should describe the feature / refactor / fix at a high level and stay stable.

Tightened the summarizer system prompt: goal is the session intent only, never a status line; bars completion markers, phase / step numbers, counts, file paths, and per-turn detail (those route to `last_output_summary` / `decisions`); self-heals an already-polluted goal back to clean intent.

## Notes
- No DB/schema changes; history rows were already written, just not surfaced.
- Existing summarizer test (`goal: auth refactor`) asserts the user prompt, not the system prompt; unaffected. Slot-slice mocks already stub `listContextSlotHistory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)