### PR TITLE
fix(desktop): make cmd+r reload the app

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -117,15 +117,20 @@ export function App() {
 
   useEffect(() => {
     void applyStoredZoom();
-    const onZoom = (e: KeyboardEvent) => {
+    const onShortcut = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.key === 'r' || e.key === 'R') {
+        e.preventDefault();
+        window.location.reload();
+        return;
+      }
       const action = ZOOM_ACTIONS[e.key];
       if (!action) return;
       e.preventDefault();
       void action();
     };
-    window.addEventListener('keydown', onZoom);
-    return () => window.removeEventListener('keydown', onZoom);
+    window.addEventListener('keydown', onShortcut);
+    return () => window.removeEventListener('keydown', onShortcut);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What

Cmd+R did nothing — the webview's default reload was inert, so the shortcut was effectively unbound.

## Fix

Intercept Cmd/Ctrl+`r`/`R` in the same global keydown handler that already powers the zoom shortcuts, and call `window.location.reload()` explicitly. Same approach we used to make Cmd+`+`/Cmd+`-` work.

Zoom handling is unchanged — the reload branch runs before the `ZOOM_ACTIONS` lookup.

## Test

`pnpm tauri dev` → Cmd+R reloads the frontend; Cmd+`+`/`-`/`0` still zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)