### PR TITLE
chore(desktop): tighten workflow step block messages

### DIFF
--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1563,8 +1563,8 @@ function WorkflowStepRow({
         <div className="rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
           <p className="mb-2 font-medium text-foreground">
             {blockReason === 'summarizer'
-              ? 'the summarizer is running. wait for it to finish before starting this step.'
-              : 'open questions need resolution before starting this step.'}
+              ? 'the summarizer is still running.'
+              : 'open questions to resolve first.'}
           </p>
           <div className="flex gap-2">
             <button


### PR DESCRIPTION
Follow-up to [#677](https://github.com/akhayam99/goodboy/pull/677).

Tightens the two block messages on a gated workflow step. The dismiss button already states the action, so the `before starting this step` tail was redundant.

| reason | before | after | button |
| --- | --- | --- | --- |
| questions | `open questions need resolution before starting this step.` | `open questions to resolve first.` | `resolve first` |
| summarizer | `the summarizer is running. wait for it to finish before starting this step.` | `the summarizer is still running.` | `wait` |

Each message now mirrors its own button. Shorter, concrete, per `docs/tone-of-voice.md`. No logic change (priority stays questions → summarizer → free); `force spawn` and tooltips unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)