### PR TITLE
feat(desktop): discardable workflows + collapsible workflow rail

### DIFF
--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -1,10 +1,28 @@
 <!doctype html>
-<html lang="en" class="light">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="color-scheme" content="light" />
     <title>Goodboy</title>
+    <style>
+      html {
+        background: oklch(0.25 0.006 255);
+        color-scheme: dark;
+      }
+      html[data-theme='light'] {
+        background: oklch(0.948 0.004 250);
+        color-scheme: light;
+      }
+    </style>
+    <script>
+      (function () {
+        try {
+          if (localStorage.getItem('goodboy:theme') === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-background text-foreground antialiased">
     <div id="root"></div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -5,8 +5,10 @@ import { Button, Dialog, Divider, Popover, ScrollArea, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
+  Ban,
   Check,
   ChevronDown,
+  ChevronRight,
   ChevronUp,
   Clock,
   DollarSign,
@@ -457,23 +459,53 @@ function QuickAction({
   );
 }
 
-function WorkflowKindLabel({ workflow }: { workflow: Workflow }) {
-  const presetName = useMemo(() => {
-    const needle = workflow.name.trim().toLowerCase();
-    if (!needle) return null;
-    const match = WORKFLOW_LIBRARY.find((entry) => entry.name.toLowerCase() === needle);
-    return match?.name.toLowerCase() ?? null;
-  }, [workflow.name]);
+function workflowKindName(workflow: Workflow): string {
+  const needle = workflow.name.trim().toLowerCase();
+  if (!needle) return 'custom';
+  const match = WORKFLOW_LIBRARY.find((entry) => entry.name.toLowerCase() === needle);
+  return match?.name.toLowerCase() ?? 'custom';
+}
 
-  const label = presetName ?? 'custom';
-  const isPreset = presetName !== null;
+function WorkflowKillButton({ onConfirm }: { onConfirm: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+  if (confirming) {
+    return (
+      <span className="flex shrink-0 items-center gap-0.5 rounded-md border border-border bg-background/95 px-1 py-0.5 shadow-sm">
+        <span className="px-0.5 text-2xs text-muted-foreground">Discard?</span>
+        <button
+          type="button"
+          onClick={() => {
+            setConfirming(false);
+            onConfirm();
+          }}
+          title="confirm discard"
+          aria-label="confirm discard workflow"
+          className="rounded p-0.5 text-danger transition-colors hover:bg-danger/10"
+        >
+          <Check size={12} aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={() => setConfirming(false)}
+          title="cancel"
+          aria-label="cancel discard workflow"
+          className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+        >
+          <X size={12} aria-hidden />
+        </button>
+      </span>
+    );
+  }
   return (
-    <span
-      title={isPreset ? `${label} preset` : 'custom workflow'}
-      className="min-w-0 max-w-[8rem] truncate text-2xs text-muted-foreground/70"
+    <button
+      type="button"
+      onClick={() => setConfirming(true)}
+      title="discard workflow"
+      aria-label="discard workflow"
+      className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-danger/10 hover:text-danger"
     >
-      {label}
-    </span>
+      <Ban size={11} aria-hidden />
+    </button>
   );
 }
 
@@ -524,7 +556,9 @@ function PlanReadySuggestion({ task }: { task: Session }) {
     return null;
   }
 
+  const discarded = new Set(task.discardedWorkflowIds ?? []);
   for (const wid of task.workflowIds) {
+    if (discarded.has(wid)) continue;
     const workflow = phaseTemplates.find((t) => t.id === wid);
     if (!workflow) continue;
     const nextStep = pickNextWorkflowStep(workflow, phaseRuns);
@@ -692,14 +726,22 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const phaseTemplates = useAppStore(
     (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
   );
-  const attachedWorkflows = useMemo<ReadonlyArray<Workflow>>(
-    () =>
-      task.workflowIds
-        .map((wid) => phaseTemplates.find((t) => t.id === wid))
-        .filter((t): t is Workflow => t !== undefined),
-    [task.workflowIds, phaseTemplates],
+  const sessionWorkflows = useAppStore(
+    (s) => s.sessionWorkflows[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
   );
-  const detachWorkflowFromSession = useAppStore((s) => s.detachWorkflowFromSession);
+  const attachedWorkflows = useMemo<ReadonlyArray<Workflow>>(() => {
+    const byId = new Map<string, Workflow>();
+    for (const w of phaseTemplates) byId.set(w.id, w);
+    for (const w of sessionWorkflows) byId.set(w.id, w);
+    return task.workflowIds
+      .map((wid) => byId.get(wid))
+      .filter((t): t is Workflow => t !== undefined);
+  }, [task.workflowIds, phaseTemplates, sessionWorkflows]);
+  const discardedWorkflowIds = useMemo(
+    () => new Set(task.discardedWorkflowIds ?? EMPTY_ARRAY),
+    [task.discardedWorkflowIds],
+  );
+  const discardWorkflow = useAppStore((s) => s.discardWorkflow);
   const reorderSessionWorkflows = useAppStore((s) => s.reorderSessionWorkflows);
   const openQuestions = useSessionOpenQuestions(task.id);
   const loading = useSessionLoading(task.id);
@@ -707,6 +749,14 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const [spawnError, setSpawnError] = useState<string | null>(null);
   const [startWorkflowOpen, setStartWorkflowOpen] = useState(false);
   const [editingId, setEditingId] = useState<AgentId | null>(null);
+  const [workflowExpand, setWorkflowExpand] = useState<ReadonlyMap<string, boolean>>(new Map());
+  const toggleWorkflowExpand = useCallback((id: string, isDiscarded: boolean) => {
+    setWorkflowExpand((prev) => {
+      const next = new Map(prev);
+      next.set(id, !(prev.get(id) ?? !isDiscarded));
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -757,11 +807,15 @@ function AgentsSection({ task }: AgentsSectionProps) {
   const actionableStepIdByWorkflowId = useMemo(() => {
     const map = new Map<string, string | null>();
     for (const wf of attachedWorkflows) {
+      if (discardedWorkflowIds.has(wf.id)) {
+        map.set(wf.id, null);
+        continue;
+      }
       const wfAgents = agentsByWorkflowId.get(wf.id) ?? EMPTY_ARRAY;
       map.set(wf.id, pickNextWorkflowStep(wf, wfAgents)?.id ?? null);
     }
     return map;
-  }, [attachedWorkflows, agentsByWorkflowId]);
+  }, [attachedWorkflows, agentsByWorkflowId, discardedWorkflowIds]);
   const blockReasonByWorkflowId = useMemo(() => {
     const map = new Map<string, WorkflowBlockReason | null>();
     for (const wf of attachedWorkflows) {
@@ -775,15 +829,15 @@ function AgentsSection({ task }: AgentsSectionProps) {
     return map;
   }, [attachedWorkflows, openQuestions, summarizerBusy]);
 
-  const onDetachWorkflow = useCallback(
+  const onDiscardWorkflow = useCallback(
     async (workflowId: string) => {
       try {
-        await detachWorkflowFromSession(task.id, workflowId as Workflow['id']);
+        await discardWorkflow(task.id, workflowId as Workflow['id']);
       } catch (err) {
         setSpawnError(formatError(err));
       }
     },
-    [detachWorkflowFromSession, task.id],
+    [discardWorkflow, task.id],
   );
 
   const onReorderWorkflow = useCallback(
@@ -959,141 +1013,166 @@ function AgentsSection({ task }: AgentsSectionProps) {
   };
 
   const hasAnyWorkflow = attachedWorkflows.length > 0;
-  const renderWorkflowBlock = (workflow: Workflow, idx: number) => {
+  const renderWorkflowRow = (workflow: Workflow, idx: number) => {
+    const isDiscarded = discardedWorkflowIds.has(workflow.id);
+    const expanded = workflowExpand.get(workflow.id) ?? !isDiscarded;
     const wfAgents = agentsByWorkflowId.get(workflow.id) ?? EMPTY_ARRAY;
     const actionableStepId = actionableStepIdByWorkflowId.get(workflow.id) ?? null;
     const wfBlockReason = blockReasonByWorkflowId.get(workflow.id) ?? null;
     const canMoveUp = idx > 0;
     const canMoveDown = idx < attachedWorkflows.length - 1;
+    const name = workflowKindName(workflow);
+    const total = workflow.steps.length;
+    const done = wfAgents.filter((a) => a.status === 'completed' || a.status === 'skipped').length;
     return (
-      <div key={workflow.id} className={cn('flex flex-col', idx > 0 && 'mt-4')}>
-        <header className="flex items-center gap-2 pb-1.5">
-          <span className={SECTION_LABEL}>
-            <Layers size={11} aria-hidden className="text-primary" />
-            Workflow
-          </span>
-          <span className="flex-1" />
-          <WorkflowKindLabel workflow={workflow} />
-          {attachedWorkflows.length > 1 ? (
-            <div className="flex shrink-0 items-center">
-              <button
-                type="button"
-                disabled={!canMoveUp}
-                onClick={() => void onReorderWorkflow(workflow.id, 'up')}
-                title="move workflow up"
-                aria-label="move workflow up"
-                className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
-              >
-                <ChevronUp size={11} aria-hidden />
-              </button>
-              <button
-                type="button"
-                disabled={!canMoveDown}
-                onClick={() => void onReorderWorkflow(workflow.id, 'down')}
-                title="move workflow down"
-                aria-label="move workflow down"
-                className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
-              >
-                <ChevronDown size={11} aria-hidden />
-              </button>
-            </div>
-          ) : null}
+      <div key={workflow.id} className={cn('flex flex-col', isDiscarded && 'opacity-70')}>
+        <div className="flex items-center gap-0.5">
           <button
             type="button"
-            onClick={() => void onDetachWorkflow(workflow.id)}
-            title="detach workflow"
-            aria-label="detach workflow"
-            className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-danger/10 hover:text-danger"
+            onClick={() => toggleWorkflowExpand(workflow.id, isDiscarded)}
+            title={workflow.name || name}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? 'collapse' : 'expand'} ${name} workflow`}
+            className="flex min-w-0 flex-1 items-center gap-1.5 rounded py-1 pl-1 pr-1.5 text-left transition-colors hover:bg-muted/50"
           >
-            <X size={11} aria-hidden />
+            {expanded ? (
+              <ChevronDown size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
+            ) : (
+              <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
+            )}
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+              {name}
+            </span>
+            {isDiscarded ? (
+              <span className="inline-flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                <Ban size={10} aria-hidden /> discarded
+              </span>
+            ) : total > 0 ? (
+              <span className="shrink-0 font-mono text-[10px] text-muted-foreground/50">
+                {done}/{total}
+              </span>
+            ) : null}
           </button>
-          {idx === 0 ? <AutoRunToggle session={task} /> : null}
-        </header>
-        {wfAgents.length > 0 ? (
-          <div className="flex flex-col gap-1 pl-2">
-            {wfAgents.map((run, index) => {
-              const isActionable = run.stepId === actionableStepId && run.status === 'pending';
-              const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
-              const resolvedModel =
-                agentModelOverride[run.id] ?? run.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model;
-              const clusterChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
-              return (
-                <Fragment key={run.id}>
-                  <WorkflowStepRow
-                    run={run}
-                    kind={kind}
-                    index={index}
-                    resolvedModel={resolvedModel}
-                    isActionable={isActionable}
-                    blockReason={isActionable ? wfBlockReason : null}
-                    isSelected={run.id === selectedAgentId}
-                    isEditing={editingId === run.id}
-                    telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
-                    aggregate={aggregatesByAgentId.get(run.id) ?? null}
-                    turns={turnsByAgentId.get(run.id) ?? 0}
-                    turnsLoading={run.id === selectedAgentId && loading.transcript}
-                    onStart={() => void onSpawn(run.stepId!, undefined)}
-                    onSelect={() => onPickAgent(run.id)}
-                    onRenameStart={() => setEditingId(run.id)}
-                    onRenameCommit={(name) => void onRenameCommit(run.id, name)}
-                    onRenameCancel={() => setEditingId(null)}
-                  />
-                  {clusterChildren.length > 0 ? (
-                    <div className="ml-3 flex flex-col gap-0.5 border-l border-border-soft/60 pl-2">
-                      <span className="px-2 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground/50">
-                        clusters {clusterChildren.filter((c) => c.status === 'completed').length}/
-                        {clusterChildren.length}
-                      </span>
-                      {clusterChildren.map((child, ci) => (
-                        <ClusterChildRow
-                          key={child.id}
-                          child={child}
-                          index={ci}
-                          total={clusterChildren.length}
-                          costUsd={aggregatesByAgentId.get(child.id)?.estimatedCostUsd ?? 0}
-                          isSelected={child.id === selectedAgentId}
-                          onSelect={() => onPickAgent(child.id)}
-                        />
-                      ))}
-                    </div>
-                  ) : null}
-                </Fragment>
-              );
-            })}
-          </div>
-        ) : (
-          <p className="pl-2 text-2xs text-muted-foreground/60">no agents yet for this workflow.</p>
-        )}
+          {!isDiscarded ? (
+            <div className="flex shrink-0 items-center">
+              <AutoRunToggle session={task} />
+              {attachedWorkflows.length > 1 ? (
+                <>
+                  <button
+                    type="button"
+                    disabled={!canMoveUp}
+                    onClick={() => void onReorderWorkflow(workflow.id, 'up')}
+                    title="move workflow up"
+                    aria-label="move workflow up"
+                    className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+                  >
+                    <ChevronUp size={11} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!canMoveDown}
+                    onClick={() => void onReorderWorkflow(workflow.id, 'down')}
+                    title="move workflow down"
+                    aria-label="move workflow down"
+                    className="rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-30"
+                  >
+                    <ChevronDown size={11} aria-hidden />
+                  </button>
+                </>
+              ) : null}
+              <WorkflowKillButton onConfirm={() => void onDiscardWorkflow(workflow.id)} />
+            </div>
+          ) : null}
+        </div>
+        {expanded ? (
+          wfAgents.length > 0 ? (
+            <div className="flex flex-col gap-1 pb-1 pl-5">
+              {wfAgents.map((run, index) => {
+                const isActionable = run.stepId === actionableStepId && run.status === 'pending';
+                const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
+                const resolvedModel =
+                  agentModelOverride[run.id] ??
+                  run.modelOverride ??
+                  AGENT_KIND_DEFAULTS[kind].model;
+                const clusterChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
+                return (
+                  <Fragment key={run.id}>
+                    <WorkflowStepRow
+                      run={run}
+                      kind={kind}
+                      index={index}
+                      resolvedModel={resolvedModel}
+                      isActionable={isActionable}
+                      blockReason={isActionable ? wfBlockReason : null}
+                      isSelected={run.id === selectedAgentId}
+                      isEditing={editingId === run.id}
+                      telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
+                      aggregate={aggregatesByAgentId.get(run.id) ?? null}
+                      turns={turnsByAgentId.get(run.id) ?? 0}
+                      turnsLoading={run.id === selectedAgentId && loading.transcript}
+                      onStart={() => void onSpawn(run.stepId!, undefined)}
+                      onSelect={() => onPickAgent(run.id)}
+                      onRenameStart={() => setEditingId(run.id)}
+                      onRenameCommit={(name) => void onRenameCommit(run.id, name)}
+                      onRenameCancel={() => setEditingId(null)}
+                    />
+                    {clusterChildren.length > 0 ? (
+                      <div className="ml-3 flex flex-col gap-0.5 border-l border-border-soft/60 pl-2">
+                        <span className="px-2 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground/50">
+                          clusters {clusterChildren.filter((c) => c.status === 'completed').length}/
+                          {clusterChildren.length}
+                        </span>
+                        {clusterChildren.map((child, ci) => (
+                          <ClusterChildRow
+                            key={child.id}
+                            child={child}
+                            index={ci}
+                            total={clusterChildren.length}
+                            costUsd={aggregatesByAgentId.get(child.id)?.estimatedCostUsd ?? 0}
+                            isSelected={child.id === selectedAgentId}
+                            onSelect={() => onPickAgent(child.id)}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                  </Fragment>
+                );
+              })}
+            </div>
+          ) : (
+            <p className="pb-1 pl-5 text-2xs text-muted-foreground/60">
+              no agents yet for this workflow.
+            </p>
+          )
+        ) : null}
       </div>
     );
   };
 
   return (
     <section className="mt-2 flex flex-col px-3 pb-3">
+      <header className="flex items-center justify-between gap-2 pb-1.5">
+        <span className={SECTION_LABEL}>
+          <Layers size={11} aria-hidden className="text-primary" />
+          Workflow
+        </span>
+      </header>
       {!hasAnyWorkflow ? (
-        <div className="flex flex-col gap-1.5">
-          <header className="flex items-center justify-between gap-2 pb-1.5">
-            <span className={SECTION_LABEL}>
-              <Layers size={11} aria-hidden className="text-primary" />
-              Workflow
-            </span>
-          </header>
-          <button
-            type="button"
-            onClick={() => setStartWorkflowOpen(true)}
-            className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-          >
-            <Plus size={13} aria-hidden />
-            Start a workflow
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={() => setStartWorkflowOpen(true)}
+          className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+        >
+          <Plus size={13} aria-hidden />
+          Start a workflow
+        </button>
       ) : (
         <>
-          {attachedWorkflows.map(renderWorkflowBlock)}
+          <div className="flex flex-col gap-0.5">{attachedWorkflows.map(renderWorkflowRow)}</div>
           <button
             type="button"
             onClick={() => setStartWorkflowOpen(true)}
-            className="mt-2 flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+            className="mt-1.5 flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
           >
             <Plus size={11} aria-hidden />
             Attach another workflow

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -38,7 +38,9 @@ export function runPlan(get: GetFn) {
     // C: resolve which attached workflow owns the creator step, that workflow is
     // the routing context. Without a match we fall back to free-spawn.
     const templates = state.phaseTemplates[session.workspaceId] ?? [];
+    const discarded = new Set(session.discardedWorkflowIds ?? []);
     const attached = session.workflowIds
+      .filter((wid) => !discarded.has(wid))
       .map((wid) => templates.find((t) => t.id === wid))
       .filter((t): t is NonNullable<typeof t> => t !== undefined);
     const template =

--- a/apps/desktop/src/store/slices/workflows/discardWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/discardWorkflow.ts
@@ -1,0 +1,65 @@
+import type { AgentId, IsoDateTime, SessionId, TurnState, WorkflowId } from '@goodboy/types';
+import { discardWorkflowInSession, updateSessionState } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { cancelTurn } from '../../../features/chat/turn';
+import { cancelledRunIds, deriveSessionState } from '../../session-mutators';
+import type { GetFn, SetFn } from './types';
+
+export function discardWorkflow(set: SetFn, get: GetFn) {
+  return async (sessionId: SessionId, workflowId: WorkflowId) => {
+    const state = get();
+    const session = state.sessions.find((s) => s.id === sessionId);
+    if (!session || !session.workflowIds.includes(workflowId)) return;
+    if (session.discardedWorkflowIds?.includes(workflowId)) return;
+
+    const workflow =
+      (state.sessionWorkflows[sessionId] ?? []).find((w) => w.id === workflowId) ??
+      (state.phaseTemplates[session.workspaceId] ?? []).find((w) => w.id === workflowId);
+    const stepIds = new Set((workflow?.steps ?? []).map((s) => s.id));
+    const runs = state.sessionPhaseRuns[sessionId] ?? [];
+    const directIds = new Set(
+      runs.filter((r) => r.stepId != null && stepIds.has(r.stepId)).map((r) => r.id),
+    );
+    const ownRuns = runs.filter(
+      (r) => directIds.has(r.id) || (r.parentAgentId != null && directIds.has(r.parentAgentId)),
+    );
+
+    const now = new Date().toISOString() as IsoDateTime;
+    const frozen: Record<AgentId, TurnState> = {};
+    for (const run of ownRuns) {
+      const turn = state.agentTurnState[run.id];
+      if (turn?.kind !== 'running') continue;
+      cancelledRunIds.add(turn.runId);
+      await cancelTurn(turn.runId).catch(() => undefined);
+      frozen[run.id] = { kind: 'idle', lastActivityAt: now };
+    }
+
+    await discardWorkflowInSession(tauriDatabase, sessionId, workflowId, now);
+
+    let derived: TurnState | null = null;
+    set((s) => {
+      const nextTurnState = { ...s.agentTurnState, ...frozen };
+      const sessionRuns = s.sessionPhaseRuns[sessionId] ?? [];
+      const survivorStates = sessionRuns
+        .map((a) => nextTurnState[a.id])
+        .filter((st): st is NonNullable<typeof st> => st !== undefined);
+      derived = deriveSessionState(survivorStates, now);
+      return {
+        agentTurnState: nextTurnState,
+        sessions: s.sessions.map((sess) =>
+          sess.id === sessionId
+            ? {
+                ...sess,
+                discardedWorkflowIds: [...(sess.discardedWorkflowIds ?? []), workflowId],
+                state: derived!,
+                updatedAt: now,
+              }
+            : sess,
+        ),
+      };
+    });
+    if (derived !== null) {
+      await updateSessionState(tauriDatabase, sessionId, derived, now).catch(() => undefined);
+    }
+  };
+}

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -4,6 +4,7 @@ import { attachWorkflowToSession } from './attachWorkflowToSession';
 import { deleteStepDef } from './deleteStepDef';
 import { deleteWorkflow } from './deleteWorkflow';
 import { detachWorkflowFromSession } from './detachWorkflowFromSession';
+import { discardWorkflow } from './discardWorkflow';
 import { loadPhaseRunsForSession } from './loadPhaseRunsForSession';
 import { loadPhaseTemplates } from './loadPhaseTemplates';
 import { loadStepLibrary } from './loadStepLibrary';
@@ -26,6 +27,7 @@ export function createWorkflowsSlice(set: SetFn, get: GetFn) {
     loadPhaseRunsForSession: loadPhaseRunsForSession(set),
     attachWorkflowToSession: attachWorkflowToSession(set, get),
     detachWorkflowFromSession: detachWorkflowFromSession(set, get),
+    discardWorkflow: discardWorkflow(set, get),
     reorderSessionWorkflows: reorderSessionWorkflows(set, get),
     activateWorkflowAgent: activateWorkflowAgent(set, get),
     advanceClusterImplementation: advanceClusterImplementation(set, get),

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -10,7 +10,9 @@ export function maybeAutoAdvanceWorkflow(_set: SetFn, get: GetFn) {
     const session = state.sessions.find((s) => s.id === sessionId);
     if (!session || !session.autoRun || session.workflowIds.length === 0) return;
     const templates = state.phaseTemplates[session.workspaceId] ?? [];
+    const discarded = new Set(session.discardedWorkflowIds ?? []);
     const attached = session.workflowIds
+      .filter((wid) => !discarded.has(wid))
       .map((wid) => templates.find((t) => t.id === wid))
       .filter((t): t is Workflow => t !== undefined);
     if (attached.length === 0) return;

--- a/apps/desktop/src/store/slices/workflows/savePhaseTemplate.ts
+++ b/apps/desktop/src/store/slices/workflows/savePhaseTemplate.ts
@@ -10,14 +10,17 @@ export function savePhaseTemplate(set: SetFn) {
   return async (template: WorkflowUpsertArgs) => {
     const saved = await invokeWorkflowUpsert(template);
     const presets = await invokeWorkflowList(template.workspaceId);
-    // workflow_list only returns reusable presets. A non-preset (custom) save
-    // must still land in phaseTemplates so the session can attach it right away
-    // and in-session resolution can find it.
-    const merged: ReadonlyArray<Workflow> = presets.some((t) => t.id === saved.id)
-      ? presets
-      : [...presets, saved];
-    set((state) => ({
-      phaseTemplates: { ...state.phaseTemplates, [template.workspaceId]: merged },
-    }));
+    set((state) => {
+      const freshIds = new Set([...presets.map((p) => p.id), saved.id]);
+      const retained = (state.phaseTemplates[template.workspaceId] ?? []).filter(
+        (w) => !freshIds.has(w.id) && (w.deletedAt != null || w.isPreset === false),
+      );
+      const merged: ReadonlyArray<Workflow> = presets.some((t) => t.id === saved.id)
+        ? [...presets, ...retained]
+        : [...presets, saved, ...retained];
+      return {
+        phaseTemplates: { ...state.phaseTemplates, [template.workspaceId]: merged },
+      };
+    });
   };
 }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -367,6 +367,7 @@ export interface AppActions {
     options?: { autoRun?: boolean },
   ): Promise<void>;
   detachWorkflowFromSession(sessionId: SessionId, workflowId: WorkflowId): Promise<void>;
+  discardWorkflow(sessionId: SessionId, workflowId: WorkflowId): Promise<void>;
   reorderSessionWorkflows(
     sessionId: SessionId,
     workflowIds: ReadonlyArray<WorkflowId>,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -51,6 +51,7 @@ export {
   listWorkflowsForSession,
   attachWorkflowToSession,
   detachWorkflowFromSession,
+  discardWorkflowInSession,
   updateWorkflowOrder,
   updateSessionWorkflowStep,
   type SessionWorkflowEntry,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -46,6 +46,7 @@ import { m045StepLibrary } from './m045-step-library';
 import { m046StepRole } from './m046-step-role';
 import { m047AgentParent } from './m047-agent-parent';
 import { m048PlanClusters } from './m048-plan-clusters';
+import { m049SessionWorkflowDiscard } from './m049-session-workflow-discard';
 
 export interface Migration {
   readonly version: number;
@@ -101,4 +102,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 46, sql: m046StepRole },
   { version: 47, sql: m047AgentParent },
   { version: 48, sql: m048PlanClusters },
+  { version: 49, sql: m049SessionWorkflowDiscard },
 ];

--- a/packages/db/src/migrations/m049-session-workflow-discard.ts
+++ b/packages/db/src/migrations/m049-session-workflow-discard.ts
@@ -1,0 +1,3 @@
+export const m049SessionWorkflowDiscard = /* sql */ `
+ALTER TABLE session_workflows ADD COLUMN discarded_at TEXT;
+`;

--- a/packages/db/src/queries/session-workflow.ts
+++ b/packages/db/src/queries/session-workflow.ts
@@ -98,6 +98,19 @@ export async function updateWorkflowOrder(
   }
 }
 
+export async function discardWorkflowInSession(
+  db: Database,
+  sessionId: SessionId,
+  workflowId: WorkflowId,
+  discardedAt: IsoDateTime,
+): Promise<void> {
+  await db.execute(
+    'UPDATE session_workflows SET discarded_at = ? WHERE session_id = ? AND workflow_id = ?',
+    [discardedAt, sessionId, workflowId],
+  );
+  await bumpSessionUpdatedAt(db, sessionId, discardedAt);
+}
+
 export async function updateSessionWorkflowStep(
   db: Database,
   sessionId: SessionId,

--- a/packages/db/src/queries/session.ts
+++ b/packages/db/src/queries/session.ts
@@ -81,6 +81,7 @@ function toDomain(
   contextSlots: Session['contextSlots'],
   workflowIds: ReadonlyArray<WorkflowId> = [],
   currentStepByWorkflow: Readonly<Record<WorkflowId, number>> = {},
+  discardedWorkflowIds: ReadonlyArray<WorkflowId> = [],
 ): Session {
   return {
     id: row.id as SessionId,
@@ -92,6 +93,7 @@ function toDomain(
     permissionMode: toPermissionMode(row.permission_mode),
     workflowIds,
     currentStepByWorkflow,
+    ...(discardedWorkflowIds.length > 0 && { discardedWorkflowIds }),
     autoRun: row.auto_run !== 0,
     titleUserEdited: row.title_user_edited !== 0,
     ...(row.archived_at != null && {
@@ -118,17 +120,24 @@ async function loadWorkflowsForSession(
 ): Promise<{
   workflowIds: ReadonlyArray<WorkflowId>;
   currentStepByWorkflow: Readonly<Record<WorkflowId, number>>;
+  discardedWorkflowIds: ReadonlyArray<WorkflowId>;
 }> {
-  const rows = await db.select<{ workflow_id: string; current_step_ordinal: number }>(
-    'SELECT workflow_id, current_step_ordinal FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC',
+  const rows = await db.select<{
+    workflow_id: string;
+    current_step_ordinal: number;
+    discarded_at: string | null;
+  }>(
+    'SELECT workflow_id, current_step_ordinal, discarded_at FROM session_workflows WHERE session_id = ? ORDER BY ordinal ASC',
     [sessionId],
   );
   const workflowIds = rows.map((r) => r.workflow_id as WorkflowId);
   const currentStepByWorkflow: Record<WorkflowId, number> = {};
+  const discardedWorkflowIds: WorkflowId[] = [];
   for (const r of rows) {
     currentStepByWorkflow[r.workflow_id as WorkflowId] = r.current_step_ordinal;
+    if (r.discarded_at != null) discardedWorkflowIds.push(r.workflow_id as WorkflowId);
   }
-  return { workflowIds, currentStepByWorkflow };
+  return { workflowIds, currentStepByWorkflow, discardedWorkflowIds };
 }
 
 export interface SessionConfigUpdate {
@@ -286,8 +295,9 @@ export async function getSessionById(db: Database, id: SessionId): Promise<Sessi
   const rows = await db.select<SessionRow>('SELECT * FROM sessions WHERE id = ?', [id]);
   const row = rows[0];
   if (!row) return null;
-  const { workflowIds, currentStepByWorkflow } = await loadWorkflowsForSession(db, id);
-  return toDomain(row, [], workflowIds, currentStepByWorkflow);
+  const { workflowIds, currentStepByWorkflow, discardedWorkflowIds } =
+    await loadWorkflowsForSession(db, id);
+  return toDomain(row, [], workflowIds, currentStepByWorkflow, discardedWorkflowIds);
 }
 
 async function hydrateSessions(
@@ -301,16 +311,21 @@ async function hydrateSessions(
     session_id: string;
     workflow_id: string;
     current_step_ordinal: number;
+    discarded_at: string | null;
   }>(
-    `SELECT session_id, workflow_id, current_step_ordinal FROM session_workflows WHERE session_id IN (${placeholders}) ORDER BY session_id, ordinal ASC`,
+    `SELECT session_id, workflow_id, current_step_ordinal, discarded_at FROM session_workflows WHERE session_id IN (${placeholders}) ORDER BY session_id, ordinal ASC`,
     sessionIds,
   );
 
-  type WorkflowEntry = { workflowId: WorkflowId; step: number };
+  type WorkflowEntry = { workflowId: WorkflowId; step: number; discarded: boolean };
   const workflowsBySession = new Map<string, WorkflowEntry[]>();
   for (const r of workflowRows) {
     const arr = workflowsBySession.get(r.session_id) ?? [];
-    arr.push({ workflowId: r.workflow_id as WorkflowId, step: r.current_step_ordinal });
+    arr.push({
+      workflowId: r.workflow_id as WorkflowId,
+      step: r.current_step_ordinal,
+      discarded: r.discarded_at != null,
+    });
     workflowsBySession.set(r.session_id, arr);
   }
 
@@ -318,10 +333,12 @@ async function hydrateSessions(
     const wf = workflowsBySession.get(row.id) ?? [];
     const workflowIds = wf.map((w) => w.workflowId);
     const currentStepByWorkflow: Record<WorkflowId, number> = {};
-    for (const { workflowId, step } of wf) {
+    const discardedWorkflowIds: WorkflowId[] = [];
+    for (const { workflowId, step, discarded } of wf) {
       currentStepByWorkflow[workflowId] = step;
+      if (discarded) discardedWorkflowIds.push(workflowId);
     }
-    return toDomain(row, [], workflowIds, currentStepByWorkflow);
+    return toDomain(row, [], workflowIds, currentStepByWorkflow, discardedWorkflowIds);
   });
 }
 

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -62,6 +62,7 @@ export type Session = Readonly<{
   permissionMode: ClaudePermissionMode;
   workflowIds: ReadonlyArray<WorkflowId>;
   currentStepByWorkflow: Readonly<Record<WorkflowId, number>>;
+  discardedWorkflowIds?: ReadonlyArray<WorkflowId>;
   autoRun: boolean;
   titleUserEdited: boolean;
   userStatus: SessionUserStatus;


### PR DESCRIPTION
## What

Three workflow-rail changes plus a reload-flash fix.

### feat: discard (kill) a workflow
- New per-attachment action: cancels any in-flight turn of the workflow's agents (including parallel cluster children), freezes it, and marks it discarded. Agents stay viewable as read-only history; to continue you attach a fresh workflow.
- Persisted per `session_workflows` row via `discarded_at` (migration `m049`), surfaced as `Session.discardedWorkflowIds`. Replaces the old detach button.
- Auto-advance, `runPlan`, and the plan-ready CTA all skip discarded workflows. `sendTurn` already drops advancement on cancelled turns, so a killed cluster never re-spawns.

### fix: custom workflows fell into AGENTS
- Non-preset (custom) workflows attached to a session were resolved from `phaseTemplates` (preset-centric), so they vanished from the WORKFLOW rail and their step-agents rendered as ad-hoc AGENTS. Now resolved from the authoritative `sessionWorkflows`, with `savePhaseTemplate` retaining in-memory customs so saving another workflow no longer evicts them.

### refactor: collapsible workflow rail
- Single `WORKFLOW` header (was repeated per workflow). Each workflow is now one collapsible row: kind name + progress, with inline auto-run / reorder / discard. Steps render only when expanded; discarded rows collapse by default.

### fix: white flash on reload
- Pre-paint inline `<style>` + synchronous `data-theme` script in `index.html` set the themed background before the CSS bundle applies, so CMD+R no longer flashes white in dark mode.

## Test
- Manual review; no Rust changes. CI (JS typecheck/lint/test/build) is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)