### PR TITLE
chore(repo): seo title + keep copy ai-free but findable by it

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary -->
-    <title>Goodboy</title>
-    <meta name="description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
-    <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
+    <title>Goodboy: stop re-explaining yourself</title>
+    <meta name="description" content="The AI agent orchestrator that holds your context once, then hands it to Claude, Cursor, Codex or Gemini. Stop re-explaining yourself. Open source." />
+    <meta name="keywords" content="AI orchestrator, AI agent orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
     <meta name="author" content="Amin Khayam" />
     <link rel="canonical" href="https://goodboy.dev/" />
 
@@ -17,7 +17,7 @@
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
     <meta property="og:title" content="Goodboy: stop re-explaining yourself" />
-    <meta property="og:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta property="og:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -29,7 +29,7 @@
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
     <meta name="twitter:title" content="Goodboy: stop re-explaining yourself" />
-    <meta name="twitter:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta name="twitter:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
     <meta name="twitter:image:alt" content="Goodboy: stop re-explaining yourself" />
 
@@ -43,7 +43,8 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Goodboy",
-      "description": "AI workspace orchestrator. Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app.",
+      "alternateName": "Goodboy AI agent orchestrator",
+      "description": "The AI agent orchestrator that holds your goal and context once, then hands them to Claude, Cursor, Codex or Gemini. Stop re-explaining yourself. Local-first, open source desktop app.",
       "url": "https://goodboy.dev/",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Windows, Linux",
@@ -60,7 +61,7 @@
       },
       "license": "https://opensource.org/licenses/MIT",
       "codeRepository": "https://github.com/akhayam99/goodboy",
-      "keywords": ["AI orchestrator", "Claude", "Cursor", "Codex", "Gemini", "multi-agent", "local-first", "developer tools"],
+      "keywords": ["AI orchestrator", "AI agent orchestrator", "Claude", "Cursor", "Codex", "Gemini", "multi-agent", "local-first", "developer tools"],
       "featureList": [
         "Multi-provider routing (Claude, Cursor, Codex, Gemini)",
         "Shared context panel across agents",

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://goodboy.dev/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## What

The SERP link rendered bare (`<title>Goodboy</title>`) and Google still showed the stale cached "every AI agent, one shared brain". This sets the visible title to the motto and threads the "AI" terms through the machine-facing layers only.

| Surface | Renders | "AI"? |
|---|---|---|
| `<title>` (SERP link) | `Goodboy: stop re-explaining yourself` | no |
| og / twitter (social unfurl) | motto + human subtext | no |
| meta description (SERP snippet) | leads with "AI agent orchestrator", ends on the motto | yes |
| JSON-LD + keywords (machine only) | "AI agent orchestrator" + alternateName | yes |

Net: a search for "goodboy AI orchestrator" can surface the page, but the displayed title and the social unfurls stay the human motto.

- Bumped `sitemap.xml` lastmod to nudge a re-crawl.

## Notes / limits

- `<meta keywords>` is ignored by Google (kept, harmless, minor Bing weight).
- Branded query ("goodboy AI orchestrator") will rank easily once recrawled. Generic "AI orchestrator" (no brand) is competitive and won't be won by meta alone.
- **External step still needed**: Google Search Console → Request Indexing on `https://goodboy.dev/` to force the recrawl, otherwise Google picks it up on its own schedule (days to weeks).

## Test plan

- [ ] View source on the deployed site: `<title>` is the motto, meta description leads with "AI agent orchestrator"
- [ ] Paste the URL into a LinkedIn/Slack message: unfurl title = motto, no "AI" in the subtext
- [ ] JSON-LD validates (Google Rich Results test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)