### PR TITLE
chore(desktop): drop unused gitlab and atlassian hosts from csp

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://api.linear.app https://gitlab.com https://*.atlassian.net"
+      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost https://api.linear.app"
     }
   },
   "bundle": {


### PR DESCRIPTION
## What
Remove `https://gitlab.com` and `https://*.atlassian.net` from the `connect-src` CSP directive in `tauri.conf.json`.

## Why
No code path calls either host today, so the CSP was granting network egress the app never uses. Trimming it shrinks the renderer's reach if it were ever compromised.

Note: the Jira integration (#664) will need to re-add `https://*.atlassian.net` when it lands.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)