### PR TITLE
fix(desktop): respect session permission mode on rule-load error

### DIFF
--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -526,11 +526,14 @@ export function sendTurn(set: SetFn, get: GetFn) {
           permissionMode: flags.permissionMode,
         };
       } catch (err) {
-        console.error('permission rule load failed; falling back to empty rule set', err);
+        console.error(
+          'permission rule load failed; using session permission mode with no rules',
+          err,
+        );
         claudeFlags = {
           allowedTools: [],
           disallowedTools: [],
-          permissionMode: 'bypassPermissions',
+          permissionMode: session.permissionMode,
         };
       }
     }


### PR DESCRIPTION
## What
In `sendTurn.ts`, the `catch` that handles a permission-rule load failure no longer hardcodes `bypassPermissions`. It now falls back to `session.permissionMode`.

## Why
A transient error loading permission rules silently escalated a session to full bypass, even when the user had explicitly chosen a gated mode in the picker. This makes the failure mode respect the user's choice instead of failing open. Sessions left at the default (`bypassPermissions`) are unaffected.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)