### PR TITLE
fix(desktop): reject worktree branch names starting with a dash

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -298,6 +298,11 @@ pub fn worktree_change_branch(args: ChangeBranchArgs) -> Result<(), WorktreeErro
             message: "branch name is empty".to_string(),
         });
     }
+    if trimmed.starts_with('-') {
+        return Err(WorktreeError::Git {
+            message: "branch name cannot start with '-'".to_string(),
+        });
+    }
     if args.create_new {
         git(wt, &["switch", "-c", trimmed])?;
     } else {


### PR DESCRIPTION
## What
`worktree_change_branch` now rejects branch names that start with `-`.

## Why
The trimmed branch name was passed to `git switch` / `git switch -c` as an argument. A name starting with `-` could be interpreted as a git flag rather than a branch name (argument injection). It is argv (no shell), so impact is limited to git-flag confusion, but rejecting it closes the gap.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)