### PR TITLE
chore(desktop): remove debug eprintln from provider and turn paths

### DIFF
--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -302,13 +302,10 @@ fn extract_codex_identity_from_auth_json() -> Option<String> {
 fn check_claude_auth() -> AuthState {
     match run_auth_command(&["claude", "auth", "status"]) {
         Ok(out) => parse_claude_auth_output(&out.stdout),
-        Err(err) => {
-            eprintln!("[providers] check_claude_auth: command failed: {}", err);
-            AuthState {
-                state: AuthStateKind::Unknown,
-                identity: None,
-            }
-        }
+        Err(_) => AuthState {
+            state: AuthStateKind::Unknown,
+            identity: None,
+        },
     }
 }
 
@@ -316,10 +313,6 @@ fn parse_claude_auth_output(output: &str) -> AuthState {
     let value: serde_json::Value = match serde_json::from_str(output) {
         Ok(v) => v,
         Err(_) => {
-            eprintln!(
-                "[providers] parse_claude_auth_output: non-json output (first 120 chars): {}",
-                &output.chars().take(120).collect::<String>()
-            );
             return AuthState {
                 state: AuthStateKind::Unknown,
                 identity: None,
@@ -400,10 +393,6 @@ fn parse_cursor_auth_output(output: &str) -> AuthState {
     }
 }
 
-fn codex_debug_enabled() -> bool {
-    std::env::var("GOODBOY_DEBUG_CODEX").map(|v| !v.is_empty()).unwrap_or(false)
-}
-
 fn check_codex_auth() -> AuthState {
     // Subcommand layout shifted across codex versions; try most recent first.
     let candidates: &[&[&str]] = &[
@@ -413,34 +402,15 @@ fn check_codex_auth() -> AuthState {
         &["codex", "whoami"],
         &["codex", "status"],
     ];
-    let debug = codex_debug_enabled();
     for cmd in candidates {
-        if debug {
-            eprintln!("[codex-debug] auth cmd: {:?}", cmd);
-        }
-        let result = run_auth_command(cmd);
-        match result {
-            Ok(out) => {
-                if debug {
-                    eprintln!(
-                        "[codex-debug] auth ok stdout={:?} stderr={:?}",
-                        out.stdout, out.stderr
-                    );
-                }
-                let text = out.primary_text();
-                if text.trim().is_empty() {
-                    continue;
-                }
-                return parse_codex_auth_output(text);
+        if let Ok(out) = run_auth_command(cmd) {
+            let text = out.primary_text();
+            if text.trim().is_empty() {
+                continue;
             }
-            Err(err) => {
-                if debug {
-                    eprintln!("[codex-debug] auth err {:?}: {}", cmd, err);
-                }
-            }
+            return parse_codex_auth_output(text);
         }
     }
-    eprintln!("[providers] check_codex_auth: all auth subcommands returned empty");
     AuthState {
         state: AuthStateKind::Unknown,
         identity: None,
@@ -529,10 +499,6 @@ fn parse_codex_auth_output(output: &str) -> AuthState {
         };
     }
 
-    eprintln!(
-        "[providers] parse_codex_auth_output: unrecognized verdict line: {:?}",
-        first_line
-    );
     AuthState {
         state: AuthStateKind::Unknown,
         identity: None,

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -240,16 +240,6 @@ pub(crate) fn spawn_one(
     registry: &ChildRegistry,
     args: SpawnOneArgs<'_>,
 ) -> Result<String, TurnError> {
-    if args.permission_mode == "bypassPermissions"
-        && args.allowed_tools.is_empty()
-        && args.disallowed_tools.is_empty()
-    {
-        eprintln!(
-            "[spawn_one] permission_mode=bypassPermissions with no rules — \
-             relying on claude CLI native bypass; --dangerously-skip-permissions intentionally not set"
-        );
-    }
-
     let mut command = crate::path_env::command(args.binary);
     command
         .current_dir(args.working_dir)
@@ -266,15 +256,6 @@ pub(crate) fn spawn_one(
     let cli_args = build_provider_cli_args(args.binary, &args);
     for a in &cli_args {
         command.arg(a);
-    }
-
-    let codex_debug = args.binary == "codex"
-        && std::env::var("GOODBOY_DEBUG_CODEX").map(|v| !v.is_empty()).unwrap_or(false);
-    if codex_debug {
-        eprintln!(
-            "[codex-debug] turn args binary={:?} cwd={:?} cli_args={:?}",
-            args.binary, args.working_dir, cli_args
-        );
     }
 
     let mut child = command
@@ -311,14 +292,6 @@ pub(crate) fn spawn_one(
         forward_lines(&app_clone, &run_id_owned, stdout);
         let stderr_buf = stderr_handle.join().unwrap_or_default();
         let exit_code = wait_and_remove(&slot, &registry_clone, &run_id_owned);
-        if codex_debug {
-            eprintln!(
-                "[codex-debug] turn exit={:?} stderr_bytes={} stderr_tail={:?}",
-                exit_code,
-                stderr_buf.len(),
-                stderr_buf.lines().rev().take(5).collect::<Vec<_>>(),
-            );
-        }
         let _ = app_clone.emit(
             EVENT_NAME,
             TurnEventEnvelope {


### PR DESCRIPTION
## What
Remove ad-hoc `eprintln!` diagnostics from `providers.rs` and `turn.rs`, plus the now-dead `codex_debug_enabled` gate and the `codex_debug` bindings.

## Why
These were always-on (or env-gated) stderr prints left in production: `[codex-debug]` turn/auth dumps, the `[spawn_one]` bypass note, and `[providers]` auth-failure logs. One of them printed the full stdout/stderr of `codex auth whoami` (identity) when enabled. Diagnostics belong in the log facade, not raw stderr. No behavior change to auth detection.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)