### PR TITLE
ci(repo): pin release workflow actions to commit sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,24 +23,25 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm
 
       - name: setup rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: cache cargo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ~/.cargo/registry
@@ -57,7 +58,7 @@ jobs:
         run: pnpm turbo run build --filter=@goodboy/desktop^...
 
       - name: build, release (universal)
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@fce9c6108b31ea247710505d3aaaa893ee6768d4 # v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}


### PR DESCRIPTION
## What
Pin every third-party action in `release.yml` to a full commit SHA (with the tag in a trailing comment): `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `actions/cache`, `dtolnay/rust-toolchain`, `tauri-apps/tauri-action`. Add an explicit `toolchain: stable` to the rust-toolchain step since pinning to a SHA drops the ref-name-based toolchain inference.

## Why
The release job has the Apple signing certificate, the Apple notarization credentials, and the Tauri updater private key in its environment. Mutable tags (`@v0`, `@stable`, `@v4`) can be moved by the action owner or an attacker who compromises their account, and the moved code would run with those secrets. Pinning to a SHA freezes the reviewed code. Dependabot can still bump the SHAs via PR.

No behavior change to the build; `release.yml` only runs on tag push.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)