### PR TITLE
fix(desktop): show approval mode is not enforced for cursor and gemini

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -1135,7 +1135,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
           <Divider />
           <div className="flex items-center justify-between gap-2 px-2.5 py-2">
             <div className="flex items-center gap-2">
-              <PermissionModePicker session={session} />
+              <PermissionModePicker session={session} activeProvider={effectiveProvider} />
               <button
                 type="button"
                 onClick={() => fileInputRef.current?.click()}

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.test.tsx
@@ -26,12 +26,12 @@ afterEach(cleanup);
 
 describe('PermissionModePicker', () => {
   it('shows the current mode label as trigger', () => {
-    render(<PermissionModePicker session={makeSession()} />);
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
     expect(screen.getByText('Default')).toBeDefined();
   });
 
   it('opens a dialog with all 4 mode options when clicked', () => {
-    render(<PermissionModePicker session={makeSession()} />);
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
     fireEvent.click(screen.getByRole('button', { name: /default/i }));
     expect(screen.getByRole('dialog', { name: /permission mode/i })).toBeDefined();
     expect(screen.getByText('Bypass')).toBeDefined();
@@ -40,10 +40,25 @@ describe('PermissionModePicker', () => {
   });
 
   it('updates session mode when a different option is picked', () => {
-    render(<PermissionModePicker session={makeSession()} />);
+    render(<PermissionModePicker session={makeSession()} activeProvider="anthropic" />);
     fireEvent.click(screen.getByRole('button', { name: /default/i }));
     fireEvent.click(screen.getByText('Edits'));
     expect(setModeMock).toHaveBeenCalledWith('sess-1', 'acceptEdits');
+  });
+
+  it.each(['cursor', 'gemini'] as const)(
+    'flags that the mode is not enforced for %s',
+    (provider) => {
+      render(<PermissionModePicker session={makeSession()} activeProvider={provider} />);
+      fireEvent.click(screen.getByRole('button', { name: /default/i }));
+      expect(screen.getByText(/not enforced for cursor and gemini/i)).toBeDefined();
+    },
+  );
+
+  it.each(['anthropic', 'codex'] as const)('does not flag enforcement for %s', (provider) => {
+    render(<PermissionModePicker session={makeSession()} activeProvider={provider} />);
+    fireEvent.click(screen.getByRole('button', { name: /default/i }));
+    expect(screen.queryByText(/not enforced for cursor and gemini/i)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionModePicker/index.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { ClaudePermissionMode, Session } from '@goodboy/types';
+import type { ClaudePermissionMode, ProviderId, Session } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+
+const MODE_UNENFORCED_PROVIDERS: ReadonlyArray<ProviderId> = ['cursor', 'gemini'];
 
 interface ModeMeta {
   readonly value: ClaudePermissionMode;
@@ -49,13 +51,15 @@ export function permissionModeMeta(mode: ClaudePermissionMode): ModeMeta {
 
 interface Props {
   readonly session: Session;
+  readonly activeProvider: ProviderId;
 }
 
-export function PermissionModePicker({ session }: Props) {
+export function PermissionModePicker({ session, activeProvider }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const setSessionPermissionMode = useAppStore((s) => s.setSessionPermissionMode);
   const current = permissionModeMeta(session.permissionMode);
+  const unenforced = MODE_UNENFORCED_PROVIDERS.includes(activeProvider);
 
   useEffect(() => {
     if (!open) return;
@@ -89,7 +93,7 @@ export function PermissionModePicker({ session }: Props) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        title={current.description}
+        title={unenforced ? 'Not enforced for cursor and gemini' : current.description}
         aria-haspopup="dialog"
         aria-expanded={open}
         className="inline-flex items-center gap-1.5 rounded-full bg-subtle px-2.5 py-0.5 text-xs transition-colors hover:bg-muted"
@@ -140,6 +144,11 @@ export function PermissionModePicker({ session }: Props) {
               </button>
             );
           })}
+          {unenforced ? (
+            <p className="px-2.5 pb-1 pt-1.5 text-2xs text-muted-foreground/80">
+              Not enforced for cursor and gemini.
+            </p>
+          ) : null}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## What
`PermissionModePicker` now takes the active provider and, when it is `cursor` or `gemini`, shows that the selected approval mode is not enforced: a muted helper line in the open dialog and a matching tooltip on the trigger. No change for `anthropic` / `codex`.

## Why
In `turn.rs` `build_provider_cli_args`, `cursor-agent` always runs with `--force` and `gemini` applies no permission/sandbox flag, both discarding `permission_mode`. Only claude (`--permission-mode`) and codex (sandbox vs bypass) honor it. The picker was shown for every provider, so the user's choice was silently ignored for two of them. This makes the limitation visible instead of misleading.

The provider value is `effectiveProvider` (the provider that will run the next turn), threaded from `ChatInput` at the single render site. Picker test extended with cases for cursor/gemini (note shown) and anthropic/codex (absent).

Part of the repo-wide security/quality scan (1 task = 1 PR). Implemented by a sub-agent, reviewed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)