### PR TITLE
ci(repo): add rust fmt, clippy and test workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,68 @@
+name: rust
+
+on:
+  pull_request:
+    paths:
+      - 'apps/desktop/src-tauri/**'
+      - '.github/workflows/rust.yml'
+  push:
+    paths:
+      - 'apps/desktop/src-tauri/**'
+      - '.github/workflows/rust.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: fmt + clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: install tauri system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            apps/desktop/src-tauri/target
+          key: cargo-check-${{ runner.os }}-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            cargo-check-${{ runner.os }}-
+
+      - name: install
+        run: pnpm install --frozen-lockfile
+
+      - name: build frontend
+        run: pnpm turbo run build --filter=@goodboy/desktop
+
+      - name: fmt
+        working-directory: apps/desktop/src-tauri
+        run: cargo fmt --check
+        continue-on-error: true
+
+      - name: clippy
+        working-directory: apps/desktop/src-tauri
+        run: cargo clippy --locked --all-targets -- -D warnings
+        continue-on-error: true
+
+      - name: test
+        working-directory: apps/desktop/src-tauri
+        run: cargo test --locked


### PR DESCRIPTION
## What
Add `.github/workflows/rust.yml`: on changes under `apps/desktop/src-tauri/**`, run `cargo fmt --check`, `cargo clippy --locked -D warnings`, and `cargo test --locked` (ubuntu + Tauri system deps, frontend built first so `generate_context!` has its assets). Actions are SHA-pinned.

## Why
The `ci` workflow is JS-only (`turbo --affected`), so a Rust change that breaks a unit test can merge. Only CodeQL `Analyze (rust)` compiles the backend, and it does not run the unit tests. This adds `cargo test --locked` as a hard gate.

`fmt` and `clippy -D warnings` are `continue-on-error: true` for now: the crate has never been linted in CI, so they are very likely to surface pre-existing findings. They run and show in the logs; once a cleanup pass makes them clean, flip them to blocking (fast-follow). Shipping them hard today would just paint the gate red and block every Rust PR.

Part of the repo-wide security/quality scan (1 task = 1 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)