### PR TITLE
ci(repo): make rust fmt and clippy blocking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,12 +56,10 @@ jobs:
       - name: fmt
         working-directory: apps/desktop/src-tauri
         run: cargo fmt --check
-        continue-on-error: true
 
       - name: clippy
         working-directory: apps/desktop/src-tauri
         run: cargo clippy --locked --all-targets -- -D warnings
-        continue-on-error: true
 
       - name: test
         working-directory: apps/desktop/src-tauri


### PR DESCRIPTION
## What
Remove `continue-on-error: true` from the `fmt` and `clippy` steps in `rust.yml`, making them blocking gates alongside `test`.

## Why
When the workflow first ran (#692), `cargo fmt --check` and `cargo clippy --locked --all-targets -- -D warnings` both passed (they were soft as a hedge, since the crate had never been linted in CI). They are clean today, so there is no reason to keep them advisory. This completes the original intent: fmt, clippy, and test all gate Rust changes.

Follow-up to #692.

🤖 Generated with [Claude Code](https://claude.com/claude-code)