### PR TITLE
feat(repo): add google tag manager to website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -2,6 +2,15 @@
 <html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-5NM3VX7Q');</script>
+    <!-- End Google Tag Manager -->
+
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -78,6 +87,11 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5NM3VX7Q"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
Adds the Google Tag Manager container (`GTM-5NM3VX7Q`) to the marketing site.

- Loader `<script>` placed high in `<head>` (charset stays first).
- `<noscript>` fallback iframe immediately after `<body>`.

Standard Google-provided snippet, no consent gate (none requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)