### PR TITLE
feat(repo): add linkedin link to website footer

### DIFF
--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -17,6 +17,14 @@ export function Footer() {
           >
             GitHub
           </a>
+          <a
+            href="https://www.linkedin.com/company/goodboy-ai/"
+            target="_blank"
+            rel="noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            LinkedIn
+          </a>
           <a href="#sessions" className="transition-colors hover:text-foreground">
             Features
           </a>


### PR DESCRIPTION
## What

Adds a LinkedIn link to the website footer, next to the existing GitHub link → https://www.linkedin.com/company/goodboy-ai/

## Why

Footer is the standard home for company/social links (vscode, cursor, linear, vercel precedent). Top-nav GitHub stays a clean primary CTA.

## Notes

- Text link `LinkedIn` mirroring the adjacent GitHub anchor (same classes, `target="_blank"`, `rel="noreferrer"`).
- Verified in local preview (1499): footer renders `GitHub · LinkedIn · ...`, href/target/rel correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)