### PR TITLE
fix(desktop): restore script-run feedback in overflow menu and composer

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -37,6 +37,9 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     acceptSessionNudgeHandoff: () => Promise<void>;
     spawnAgent: () => Promise<void>;
     runScript: () => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+    runWorkspaceScript: () => Promise<void>;
+    dismissScriptResult: () => void;
+    sessionScriptResult: Record<string, never>;
     loadScripts: () => Promise<void>;
     selectAgent: () => Promise<void>;
     attachWorkflowToSession: () => Promise<void>;
@@ -81,6 +84,9 @@ const { sendTurnMock, cancelCurrentTurnMock, mockStore } = await vi.hoisted(asyn
     acceptSessionNudgeHandoff: async () => undefined,
     spawnAgent: async () => undefined,
     runScript: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+    runWorkspaceScript: async () => undefined,
+    dismissScriptResult: () => undefined,
+    sessionScriptResult: {},
     loadScripts: async () => undefined,
     selectAgent: async () => undefined,
     attachWorkflowToSession: async () => undefined,

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -45,7 +45,6 @@ import {
   buildWorkflowActions,
   parseQuery,
   type QuickActionItem,
-  type ScriptResultState,
 } from '../../../quick-actions';
 import { type VerbosityLevel } from '../../../../features/settings/verbosity';
 import { EFFORT_LEVELS, type EffortLevel, suggestLighterModel } from '../../utils/chat-constants';
@@ -185,7 +184,9 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   const workspaceScripts = useAppStore(
     useShallow((s) => s.workspaceScripts[session.workspaceId] ?? EMPTY_ARRAY),
   );
-  const runScript = useAppStore((s) => s.runScript);
+  const runWorkspaceScript = useAppStore((s) => s.runWorkspaceScript);
+  const dismissScriptResult = useAppStore((s) => s.dismissScriptResult);
+  const scriptResult = useAppStore((s) => s.sessionScriptResult[session.id] ?? null);
   const sessionWorktree = useAppStore((s) => (s.sessionWorktrees[session.id] ?? [])[0] ?? null);
   const loadScripts = useAppStore((s) => s.loadScripts);
   const workspaceWorkflows = useAppStore(
@@ -243,9 +244,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
     );
   });
   const [showPopover, setShowPopover] = useState(false);
-  const [scriptResult, setScriptResult] = useState<ScriptResultState | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const runSeqRef = useRef(0);
 
   const parsed = useMemo(() => parseQuery(value), [value]);
   const inPrefixMode = CHAT_PREFIX_RE.test(value);
@@ -320,33 +319,16 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   };
 
   const onPickScript = useCallback(
-    async (script: WorkspaceScript) => {
+    (script: WorkspaceScript) => {
       if (!sessionWorktree) {
         showToast('warning', `${script.name}, open a session worktree to run scripts`);
         return;
       }
-      const seq = ++runSeqRef.current;
       setValue('');
       setShowPopover(false);
-      setScriptResult({ script, status: 'pending', result: null });
-      try {
-        const result = await runScript(session.id, script.id, sessionWorktree);
-        if (runSeqRef.current !== seq) return;
-        setScriptResult({
-          script,
-          status: result.exitCode === 0 ? 'ok' : 'error',
-          result,
-        });
-      } catch (err) {
-        if (runSeqRef.current !== seq) return;
-        setScriptResult({
-          script,
-          status: 'error',
-          result: { stdout: '', stderr: formatError(err), exitCode: -1 },
-        });
-      }
+      void runWorkspaceScript(session.id, script, sessionWorktree);
     },
-    [runScript, setValue, session.id, sessionWorktree, showToast],
+    [runWorkspaceScript, setValue, session.id, sessionWorktree, showToast],
   );
 
   const onPickSkill = useCallback(
@@ -902,11 +884,6 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
     void loadPhaseRunsForSession(session.id);
   }, [session.id, loadPhaseRunsForSession]);
 
-  // Script results are session-scoped, drop them when the session changes.
-  useEffect(() => {
-    setScriptResult(null);
-  }, [session.id]);
-
   const onKeyDown = (event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (
       popoverOpen &&
@@ -1050,7 +1027,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
         ) : null}
         <SuggestionStack items={suggestions} />
         {scriptResult ? (
-          <ScriptResultRow state={scriptResult} onDismiss={() => setScriptResult(null)} />
+          <ScriptResultRow state={scriptResult} onDismiss={() => dismissScriptResult(session.id)} />
         ) : null}
         <div
           ref={composerRef}

--- a/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
+++ b/apps/desktop/src/features/quick-actions/ScriptResultRow/index.tsx
@@ -1,14 +1,7 @@
 import { useRef, useState } from 'react';
 import { ScrollText, X } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { WorkspaceScript } from '@goodboy/types';
-import type { ScriptRunResult } from '../../scripts';
-
-export interface ScriptResultState {
-  readonly script: WorkspaceScript;
-  readonly status: 'pending' | 'ok' | 'error';
-  readonly result: ScriptRunResult | null;
-}
+import type { ScriptResultState, ScriptRunResult } from '../../scripts';
 
 interface Props {
   readonly state: ScriptResultState;

--- a/apps/desktop/src/features/quick-actions/index.ts
+++ b/apps/desktop/src/features/quick-actions/index.ts
@@ -9,4 +9,3 @@ export {
 } from './registry';
 export { QuickActionsPopover } from './QuickActionsPopover';
 export { ScriptResultRow } from './ScriptResultRow';
-export type { ScriptResultState } from './ScriptResultRow';

--- a/apps/desktop/src/features/scripts/index.ts
+++ b/apps/desktop/src/features/scripts/index.ts
@@ -1,2 +1,2 @@
 export { ScriptsPanel } from './components/ScriptsPanel';
-export type { ScriptRunResult } from './scripts';
+export type { ScriptResultState, ScriptRunResult } from './scripts';

--- a/apps/desktop/src/features/scripts/scripts.ts
+++ b/apps/desktop/src/features/scripts/scripts.ts
@@ -1,6 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import type { WorkspaceScriptId } from '@goodboy/types';
+import type { WorkspaceScript, WorkspaceScriptId } from '@goodboy/types';
 
 export interface ScriptRunResult {
   readonly stdout: string;
@@ -14,6 +14,12 @@ export interface ScriptRunRecord {
   readonly status: ScriptRunStatus;
   readonly result: ScriptRunResult | null;
   readonly runId: string;
+}
+
+export interface ScriptResultState {
+  readonly script: WorkspaceScript;
+  readonly status: 'pending' | 'ok' | 'error';
+  readonly result: ScriptRunResult | null;
 }
 
 export interface ScriptOutputPayload {

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
@@ -13,7 +13,7 @@ const { state, toastMock } = vi.hoisted(() => ({
     detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
     workspaceScripts: {} as Record<string, ReadonlyArray<unknown>>,
     loadScripts: vi.fn(async () => undefined),
-    runScript: vi.fn(async () => ({ exitCode: 0 })),
+    runWorkspaceScript: vi.fn(async () => undefined),
     sessionBranches: {} as Record<string, string | null>,
     sessionTelemetry: {} as Record<string, ReadonlyArray<unknown>>,
   },

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -25,7 +25,7 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
   const detectedEditors = useAppStore((s) => s.detectedEditors);
   const scripts = useAppStore((s) => s.workspaceScripts[session.workspaceId]);
   const loadScripts = useAppStore((s) => s.loadScripts);
-  const runScript = useAppStore((s) => s.runScript);
+  const runWorkspaceScript = useAppStore((s) => s.runWorkspaceScript);
   const { showToast } = useToast();
 
   useEffect(() => {
@@ -47,7 +47,7 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
 
   const onRunScript = (script: WorkspaceScript) => {
     if (!worktreePath) return;
-    void runScript(session.id as SessionId, script.id, worktreePath);
+    void runWorkspaceScript(session.id as SessionId, script, worktreePath);
   };
 
   const onEndSession = () => {

--- a/apps/desktop/src/store/slices/scripts/dismissScriptResult.ts
+++ b/apps/desktop/src/store/slices/scripts/dismissScriptResult.ts
@@ -1,0 +1,9 @@
+import type { SessionId } from '@goodboy/types';
+import type { SetFn } from './types';
+
+export function dismissScriptResult(set: SetFn) {
+  return (sessionId: SessionId) =>
+    set((state) => ({
+      sessionScriptResult: { ...state.sessionScriptResult, [sessionId]: null },
+    }));
+}

--- a/apps/desktop/src/store/slices/scripts/index.test.ts
+++ b/apps/desktop/src/store/slices/scripts/index.test.ts
@@ -435,6 +435,19 @@ function buildPlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   };
 }
 
+function buildScript(overrides: Partial<WorkspaceScript> = {}): WorkspaceScript {
+  return {
+    id: 'sc-1' as WorkspaceScriptId,
+    workspaceId: WS_ID,
+    name: 'sync env',
+    body: 'echo hi',
+    sortOrder: 0,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
 // ─── store reset helper ──────────────────────────────────────────────────
 
 async function getStore() {
@@ -505,6 +518,7 @@ describe('store contract', () => {
         skills: {},
         workspaceScripts: {},
         scriptRuns: {},
+        sessionScriptResult: {},
         phaseTemplates: {},
         sessionWorkflows: {},
         sessionPhaseRuns: {},
@@ -579,6 +593,59 @@ describe('store contract', () => {
       store.setState({ workspaceScripts: { [WS_ID]: [script] } });
       await store.getState().deleteScript(script.id, WS_ID);
       expect(store.getState().workspaceScripts[WS_ID]).toEqual([]);
+    });
+
+    it('runWorkspaceScript writes a pending result synchronously', async () => {
+      const store = await getStore();
+      const script = buildScript();
+      void store.getState().runWorkspaceScript(SESSION_ID, script, '/wt');
+      expect(store.getState().sessionScriptResult[SESSION_ID]).toEqual({
+        script,
+        status: 'pending',
+        result: null,
+      });
+    });
+
+    it('runWorkspaceScript maps a zero exit to an ok result', async () => {
+      const store = await getStore();
+      const original = store.getState().runScript;
+      store.setState({ runScript: async () => ({ stdout: 'done', stderr: '', exitCode: 0 }) });
+      const script = buildScript();
+      try {
+        await store.getState().runWorkspaceScript(SESSION_ID, script, '/wt');
+        expect(store.getState().sessionScriptResult[SESSION_ID]).toEqual({
+          script,
+          status: 'ok',
+          result: { stdout: 'done', stderr: '', exitCode: 0 },
+        });
+      } finally {
+        store.setState({ runScript: original });
+      }
+    });
+
+    it('runWorkspaceScript maps a non-zero exit to an error result', async () => {
+      const store = await getStore();
+      const original = store.getState().runScript;
+      store.setState({ runScript: async () => ({ stdout: '', stderr: 'boom', exitCode: 1 }) });
+      const script = buildScript();
+      try {
+        await store.getState().runWorkspaceScript(SESSION_ID, script, '/wt');
+        expect(store.getState().sessionScriptResult[SESSION_ID]?.status).toBe('error');
+      } finally {
+        store.setState({ runScript: original });
+      }
+    });
+
+    it('dismissScriptResult clears the session result', async () => {
+      const store = await getStore();
+      const script = buildScript();
+      store.setState({
+        sessionScriptResult: {
+          [SESSION_ID]: { script, status: 'ok', result: { stdout: '', stderr: '', exitCode: 0 } },
+        },
+      });
+      store.getState().dismissScriptResult(SESSION_ID);
+      expect(store.getState().sessionScriptResult[SESSION_ID]).toBeNull();
     });
   });
 });

--- a/apps/desktop/src/store/slices/scripts/index.ts
+++ b/apps/desktop/src/store/slices/scripts/index.ts
@@ -1,7 +1,9 @@
 import { cancelScript } from './cancelScript';
 import { deleteScript } from './deleteScript';
+import { dismissScriptResult } from './dismissScriptResult';
 import { loadScripts } from './loadScripts';
 import { runScript } from './runScript';
+import { runWorkspaceScript } from './runWorkspaceScript';
 import { saveScript } from './saveScript';
 import type { GetFn, SetFn } from './types';
 
@@ -12,5 +14,7 @@ export function createScriptsSlice(set: SetFn, get: GetFn) {
     deleteScript: deleteScript(set),
     runScript: runScript(set, get),
     cancelScript: cancelScript(set, get),
+    runWorkspaceScript: runWorkspaceScript(set, get),
+    dismissScriptResult: dismissScriptResult(set),
   };
 }

--- a/apps/desktop/src/store/slices/scripts/runWorkspaceScript.ts
+++ b/apps/desktop/src/store/slices/scripts/runWorkspaceScript.ts
@@ -1,0 +1,33 @@
+import type { SessionId, WorkspaceScript } from '@goodboy/types';
+import type { ScriptResultState } from '../../../features/scripts/scripts';
+import { formatError } from '../../../shared/lib/errors';
+import type { GetFn, SetFn } from './types';
+
+const runSeqs = new Map<string, number>();
+
+export function runWorkspaceScript(set: SetFn, get: GetFn) {
+  return async (sessionId: SessionId, script: WorkspaceScript, cwd: string) => {
+    const seq = (runSeqs.get(sessionId) ?? 0) + 1;
+    runSeqs.set(sessionId, seq);
+
+    const write = (result: ScriptResultState | null) =>
+      set((state) => ({
+        sessionScriptResult: { ...state.sessionScriptResult, [sessionId]: result },
+      }));
+
+    write({ script, status: 'pending', result: null });
+
+    try {
+      const result = await get().runScript(sessionId, script.id, cwd);
+      if (runSeqs.get(sessionId) !== seq) return;
+      write({ script, status: result.exitCode === 0 ? 'ok' : 'error', result });
+    } catch (err) {
+      if (runSeqs.get(sessionId) !== seq) return;
+      write({
+        script,
+        status: 'error',
+        result: { stdout: '', stderr: formatError(err), exitCode: -1 },
+      });
+    }
+  };
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -74,7 +74,11 @@ import { DEFAULT_BRANCH_PREFIX } from '../features/settings/settings';
 import { AGENT_FEATURES } from '../shared/lib/features';
 import { type CreatedWorktree } from '../features/worktree/worktree';
 import { type SkillUpsertArgs } from '../features/skills/skills';
-import type { ScriptRunResult, ScriptRunRecord } from '../features/scripts/scripts';
+import type {
+  ScriptRunResult,
+  ScriptRunRecord,
+  ScriptResultState,
+} from '../features/scripts/scripts';
 import { type WorkflowUpsertArgs, type StepDefUpsertArgs } from '../features/workflows/workflows';
 import { type AgentKind } from '../features/session/agent-kind';
 import { createNotificationsSlice } from './slices/notifications';
@@ -204,6 +208,7 @@ export interface AppState extends UpdaterState {
   readonly scriptRuns: Readonly<
     Record<SessionId, Readonly<Record<WorkspaceScriptId, ScriptRunRecord>>>
   >;
+  readonly sessionScriptResult: Readonly<Record<SessionId, ScriptResultState | null>>;
   readonly phaseTemplates: Readonly<Record<WorkspaceId, ReadonlyArray<Workflow>>>;
   readonly stepLibrary: Readonly<Record<WorkspaceId, ReadonlyArray<StepDef>>>;
   readonly sessionWorkflows: Readonly<Record<SessionId, ReadonlyArray<Workflow>>>;
@@ -428,6 +433,8 @@ export interface AppActions {
     rows?: number,
   ): Promise<ScriptRunResult>;
   cancelScript(sessionId: SessionId, scriptId: WorkspaceScriptId): Promise<void>;
+  runWorkspaceScript(sessionId: SessionId, script: WorkspaceScript, cwd: string): Promise<void>;
+  dismissScriptResult(sessionId: SessionId): void;
   loadPhaseTemplates(workspaceId: WorkspaceId): Promise<void>;
   savePhaseTemplate(template: WorkflowUpsertArgs): Promise<void>;
   deleteWorkflow(id: WorkflowId, workspaceId: WorkspaceId): Promise<void>;
@@ -614,6 +621,7 @@ export const initialState: AppState = {
   skills: {},
   workspaceScripts: {},
   scriptRuns: {},
+  sessionScriptResult: {},
   phaseTemplates: {},
   stepLibrary: {},
   sessionWorkflows: {},


### PR DESCRIPTION
## What

Running a workspace script from the session overflow menu (la tendina) produced no visible feedback: clicking a script fired the run and closed the menu, with status, output, and errors never surfaced.

## Why

PR #641 collapsed the rich `RunScriptControl` dropdown (status dots, live output, cancel) into plain overflow-menu items that called `runScript` fire-and-forget. The only consumer of script-run state (`RunScriptControl`) was left unmounted, so nothing rendered the result.

## How

Lift the script-run result into a session-scoped store slot (`sessionScriptResult`) behind a shared `runWorkspaceScript` thunk. Both the `$` quick-action and the session overflow menu now write to it and render the same `ScriptResultRow` (status, exit code, expandable output, dismiss).

No new UI components: the existing, polished result surface is reused across both entry points, so the overflow-menu UX from #641 stays intact.

## Verify

- `tsc --noEmit` clean
- full desktop vitest suite green (809 tests), including new store coverage for `runWorkspaceScript` (pending / ok / error mapping) and `dismissScriptResult`
- prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
