### PR TITLE
fix(desktop): push before resolving review thread

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -83,6 +83,34 @@ fn run_gh(
     })
 }
 
+fn run_git_push(args: &[&str], cwd: &str, token: Option<&str>) -> Result<GhRunResult, GithubError> {
+    let mut cmd = crate::path_env::command("git");
+    if gh_available() {
+        cmd.args([
+            "-c",
+            "credential.https://github.com.helper=",
+            "-c",
+            "credential.https://github.com.helper=!gh auth git-credential",
+        ]);
+    }
+    cmd.args(args);
+    if !cwd.is_empty() {
+        cmd.current_dir(cwd);
+    }
+    if let Some(t) = token {
+        if !t.is_empty() {
+            cmd.env("GH_TOKEN", t);
+            cmd.env("GITHUB_TOKEN", t);
+        }
+    }
+    let output = cmd.output()?;
+    Ok(GhRunResult {
+        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        exit_code: output.status.code().unwrap_or(-1),
+    })
+}
+
 fn parse_version(stdout: &str) -> Option<String> {
     stdout
         .lines()
@@ -205,6 +233,25 @@ pub async fn gh_run(
         let token = read_token(workspace_id.as_deref());
         let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         run_gh(&arg_refs, cwd.as_deref(), token.as_deref())
+    })
+    .await
+    .map_err(|e| GithubError::Spawn(std::io::Error::other(e.to_string())))?
+}
+
+#[tauri::command]
+pub async fn git_push(
+    cwd: String,
+    branch: Option<String>,
+    workspace_id: Option<String>,
+) -> Result<GhRunResult, GithubError> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let token = read_token(workspace_id.as_deref());
+        let mut args: Vec<&str> = vec!["push"];
+        if let Some(b) = branch.as_deref().filter(|b| !b.is_empty()) {
+            args.push("origin");
+            args.push(b);
+        }
+        run_git_push(&args, &cwd, token.as_deref())
     })
     .await
     .map_err(|e| GithubError::Spawn(std::io::Error::other(e.to_string())))?

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -183,6 +183,7 @@ pub fn run() {
       github::gh_set_token,
       github::gh_clear_token,
       github::gh_run,
+      github::git_push,
       github::gh_pr_diff,
       linear::linear_connect,
       linear::linear_disconnect,

--- a/apps/desktop/src/features/chat/components/CommentResolvedChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/CommentResolvedChip/index.test.tsx
@@ -8,7 +8,10 @@ const { extractMock, resolveMock } = vi.hoisted(() => ({
   resolveMock: vi.fn(async () => true),
 }));
 
-vi.mock('@goodboy/core', () => ({ extractCommentResolved: extractMock }));
+vi.mock('@goodboy/core', () => ({
+  extractCommentResolved: extractMock,
+  isReviewThreadId: (id: string) => /^PRT_/.test(id),
+}));
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(
     selector: (s: {
@@ -33,13 +36,26 @@ describe('CommentResolvedChip', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('renders nothing when the marker references a local diff comment id', () => {
+    extractMock.mockReturnValue({
+      threadId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      commitSha: 'abcdef1234567890',
+    });
+    const { container } = render(
+      <CommentResolvedChip assistantText="x" sessionId={'s' as never} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
   it('resolves the thread when the confirm button is clicked', async () => {
-    extractMock.mockReturnValue({ threadId: 'th-1', commitSha: 'abcdef1234567890' });
+    extractMock.mockReturnValue({ threadId: 'PRT_kwDOABC123', commitSha: 'abcdef1234567890' });
     render(<CommentResolvedChip assistantText="x" sessionId={'s' as never} />);
     await act(async () => {
       fireEvent.click(screen.getByTestId('comment-resolved-confirm'));
     });
-    expect(resolveMock).toHaveBeenCalledWith('s', 'th-1', { commitSha: 'abcdef1234567890' });
+    expect(resolveMock).toHaveBeenCalledWith('s', 'PRT_kwDOABC123', {
+      commitSha: 'abcdef1234567890',
+    });
     expect(screen.getByText(/conversation resolved/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { CheckCheck, GitCommit, Loader2, X } from 'lucide-react';
-import { extractCommentResolved } from '@goodboy/core';
+import { extractCommentResolved, isReviewThreadId } from '@goodboy/core';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 
@@ -57,7 +57,7 @@ export function CommentResolvedChip({ assistantText, sessionId }: Props) {
     readDismissed(marker?.threadId) ? { kind: 'dismissed' } : { kind: 'idle' },
   );
 
-  if (!marker) return null;
+  if (!marker || !isReviewThreadId(marker.threadId)) return null;
 
   const shaShort = marker.commitSha.slice(0, 7);
 

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useState } from 'react';
 import { ArrowUpRight, Check, ChevronRight, Copy, FileEdit, ImageOff, Wrench } from 'lucide-react';
 import { CopyButton, Divider, Markdown, cn, formatUsd } from '@goodboy/ui';
 import type { AgentId, MessageAttachment, SessionId } from '@goodboy/types';
+import { extractCommentResolved, isReviewThreadId } from '@goodboy/core';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { readAttachment } from '../../turn';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
@@ -191,8 +192,9 @@ function AssistantText({ text, sessionId }: { text: string; sessionId: SessionId
   // same corner of the assistant bubble crashes into that primary action
   // on short messages, and copying the marker prose isn't useful anyway.
   // Hide copy when the marker is present.
-  const hasCommentResolvedMarker = COMMENT_RESOLVED_MARKER_RE.test(text);
-  COMMENT_RESOLVED_MARKER_RE.lastIndex = 0;
+  const resolvedMarker = extractCommentResolved(text);
+  const hasCommentResolvedMarker =
+    resolvedMarker !== null && isReviewThreadId(resolvedMarker.threadId);
   return (
     <div className="group relative text-[13px]">
       {hasCommentResolvedMarker ? null : (

--- a/apps/desktop/src/features/github/github.ts
+++ b/apps/desktop/src/features/github/github.ts
@@ -77,6 +77,24 @@ export async function ghPrDiff(
   }
 }
 
+export async function gitPush(
+  cwd: string,
+  branch: string | null,
+  workspaceId?: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const raw = await invoke<RawGhRunResult>('git_push', {
+      cwd,
+      branch: branch ?? undefined,
+      workspaceId,
+    });
+    return { stdout: raw.stdout, stderr: raw.stderr, exitCode: raw.exitCode };
+  } catch (err) {
+    const msg = formatError(err);
+    throw new Error(`git push failed: ${msg}`, { cause: err });
+  }
+}
+
 export async function ghPrsForBranch(
   cwd: string,
   branch: string,

--- a/apps/desktop/src/store/slices/github/index.test.ts
+++ b/apps/desktop/src/store/slices/github/index.test.ts
@@ -317,11 +317,15 @@ const ghStatusSpy: ReturnType<typeof vi.fn> = vi.fn<() => Promise<GhTokenStatus>
 }));
 const ghSetTokenSpy = vi.fn();
 const ghClearTokenSpy = vi.fn(async () => undefined);
+const gitPushSpy = vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 }));
+const resolveThreadSpy = vi.fn(async () => undefined);
+const addReplySpy = vi.fn(async () => undefined);
 
 vi.mock('../../../features/github/github', () => ({
   ghStatus: ghStatusSpy,
   ghSetToken: ghSetTokenSpy,
   ghClearToken: ghClearTokenSpy,
+  gitPush: gitPushSpy,
   tauriGhRunner: { run: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })) },
   createTauriPrCacheStore: () => ({ get: vi.fn(), upsert: vi.fn(), delete: vi.fn() }),
 }));
@@ -337,8 +341,8 @@ vi.mock('@goodboy/core', async (importOriginal) => {
     getPrForBranch: vi.fn(async () => null),
     fetchPrDetail: vi.fn(async () => null),
     fetchLinkedIssues: vi.fn(async () => []),
-    resolveReviewThread: vi.fn(async () => undefined),
-    addReviewThreadReply: vi.fn(async () => undefined),
+    resolveReviewThread: resolveThreadSpy,
+    addReviewThreadReply: addReplySpy,
     seedWorkflowLibrary: vi.fn(async () => undefined),
   };
 });
@@ -604,6 +608,62 @@ describe('store contract', () => {
       // Should not throw or invoke any refresh paths.
       store.getState().sweepGithub();
       expect(store.getState().sessionGithub[SESSION_ID]).toBeUndefined();
+    });
+
+    it('resolveGithubThread pushes the session branch before replying and resolving', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+      });
+      const ok = await store
+        .getState()
+        .resolveGithubThread(SESSION_ID, 'PRT_1', { commitSha: 'abcdef1234567890' });
+      expect(ok).toBe(true);
+      expect(gitPushSpy).toHaveBeenCalledWith('/tmp/repo/.wt/x', 'ak/feat-x', WS_ID);
+      const pushOrder = gitPushSpy.mock.invocationCallOrder[0] ?? 0;
+      const replyOrder = addReplySpy.mock.invocationCallOrder[0] ?? 0;
+      expect(pushOrder).toBeGreaterThan(0);
+      expect(replyOrder).toBeGreaterThan(0);
+      expect(pushOrder).toBeLessThan(replyOrder);
+      expect(resolveThreadSpy).toHaveBeenCalled();
+    });
+
+    it('resolveGithubThread leaves the thread open and skips resolve when the push fails', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+        sessionBranches: { [SESSION_ID]: 'ak/feat-x' },
+        sessionWorktrees: { [SESSION_ID]: ['/tmp/repo/.wt/x'] },
+      });
+      gitPushSpy.mockResolvedValueOnce({
+        stdout: '',
+        stderr: 'rejected: non-fast-forward',
+        exitCode: 1,
+      });
+      const ok = await store
+        .getState()
+        .resolveGithubThread(SESSION_ID, 'PRT_1', { commitSha: 'abcdef1234567890' });
+      expect(ok).toBe(false);
+      expect(addReplySpy).not.toHaveBeenCalled();
+      expect(resolveThreadSpy).not.toHaveBeenCalled();
+    });
+
+    it('resolveGithubThread does not push for a reason-only closure', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace()],
+        sessions: [buildSession()],
+      });
+      const ok = await store
+        .getState()
+        .resolveGithubThread(SESSION_ID, 'PRT_1', { reason: 'not applicable' });
+      expect(ok).toBe(true);
+      expect(gitPushSpy).not.toHaveBeenCalled();
+      expect(resolveThreadSpy).toHaveBeenCalled();
     });
   });
 });

--- a/apps/desktop/src/store/slices/github/resolveGithubThread.ts
+++ b/apps/desktop/src/store/slices/github/resolveGithubThread.ts
@@ -1,18 +1,12 @@
 import { addReviewThreadReply, resolveReviewThread } from '@goodboy/core';
 import type { SessionId } from '@goodboy/types';
-import { tauriGhRunner } from '../../../features/github/github';
+import { gitPush, tauriGhRunner } from '../../../features/github/github';
 import { formatError } from '../../../shared/lib/errors';
 import { buildResolutionReplyBody } from './buildResolutionReplyBody';
 import type { GetFn, SetFn } from './types';
 
 type Params = { commitSha?: string; reason?: string };
 
-// Closes a review thread on github with a contextual reply, then flips the
-// thread to resolved. The reply is built from the optional `closure`
-// payload, a commit sha turns into `Resolved in [<short>](commit url)`,
-// a free-text reason posts that verbatim. Without a closure the thread is
-// resolved silently (back-compat for any caller that still hits the bare
-// form). Returns true on success so the chip can collapse its CTA.
 export function resolveGithubThread(_set: SetFn, get: GetFn) {
   return async (sessionId: SessionId, threadId: string, closure?: Params): Promise<boolean> => {
     const session = get().sessions.find((s) => s.id === sessionId);
@@ -20,7 +14,36 @@ export function resolveGithubThread(_set: SetFn, get: GetFn) {
     const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
     const pr = get().sessionGithub[sessionId]?.pr ?? null;
     const replyBody = buildResolutionReplyBody(closure, pr?.url ?? null);
+    const notifyTarget = { sessionId, ...(workspace && { workspaceId: workspace.id }) };
     try {
+      if (closure?.commitSha) {
+        const cwd = get().sessionWorktrees[sessionId]?.[0] ?? workspace?.rootPath;
+        if (!cwd) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'cannot publish fix, thread left open',
+            'no worktree resolved for this session to push from',
+            notifyTarget,
+          );
+          return false;
+        }
+        const push = await gitPush(
+          cwd,
+          get().sessionBranches[sessionId] ?? null,
+          session.workspaceId,
+        );
+        if (push.exitCode !== 0) {
+          void get().emitNotification(
+            'error',
+            'error',
+            'push failed, thread left open',
+            push.stderr.trim() || `git push exited with ${push.exitCode}`,
+            notifyTarget,
+          );
+          return false;
+        }
+      }
       if (replyBody) {
         await addReviewThreadReply(tauriGhRunner, threadId, replyBody, {
           cwd: workspace?.rootPath,
@@ -34,10 +57,13 @@ export function resolveGithubThread(_set: SetFn, get: GetFn) {
       await get().refreshSessionPrDetail(sessionId, { force: true });
       return true;
     } catch (err) {
-      void get().emitNotification('error', 'error', 'resolve thread failed', formatError(err), {
-        sessionId,
-        ...(workspace && { workspaceId: workspace.id }),
-      });
+      void get().emitNotification(
+        'error',
+        'error',
+        'resolve thread failed',
+        formatError(err),
+        notifyTarget,
+      );
       return false;
     }
   };

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -9,6 +9,7 @@ import {
   extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
+  isReviewThreadId,
   mergeIntoSlot,
 } from './extractors';
 
@@ -268,6 +269,19 @@ describe('extractCommentResolved', () => {
       threadId: 'PRT_2',
       commitSha: 'bbb',
     });
+  });
+});
+
+describe('isReviewThreadId', () => {
+  it('accepts github review thread node ids', () => {
+    expect(isReviewThreadId('PRT_kwDOABC123')).toBe(true);
+    expect(isReviewThreadId('PRT_1')).toBe(true);
+  });
+
+  it('rejects local diff comment uuids and other ids', () => {
+    expect(isReviewThreadId('f47ac10b-58cc-4372-a567-0e02b2c3d479')).toBe(false);
+    expect(isReviewThreadId('th-1')).toBe(false);
+    expect(isReviewThreadId('')).toBe(false);
   });
 });
 

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -201,6 +201,12 @@ export function extractCommentResolved(assistantText: string): ExtractedCommentR
   return last;
 }
 
+const REVIEW_THREAD_ID_RE = /^PRT_/;
+
+export function isReviewThreadId(threadId: string): boolean {
+  return REVIEW_THREAD_ID_RE.test(threadId);
+}
+
 const CLUSTERS_RE = /<<clusters>>([\s\S]*?)<<\/clusters>>/g;
 const CLUSTER_DONE_RE = /<<cluster-done\s+([^>]+?)>>/g;
 

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -17,6 +17,7 @@ export {
   extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
+  isReviewThreadId,
   mergeIntoSlot,
   removeFromSlot,
   type ExtractedCluster,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export {
   extractHandoff,
   extractMarkers,
   extractPlanFromMarker,
+  isReviewThreadId,
   isSlotKey,
   mergeIntoSlot,
   removeFromSlot,


### PR DESCRIPTION
## What

Two fixes to the review-comment resolution chip ("Mark as Solved").

**1. Push before resolving.** The chip posted `Resolved in <sha>` and resolved the GitHub review thread without pushing the local commit, so the referenced SHA never existed on the remote. It now pushes the session branch first (new `git_push` Tauri command, reusing gh credentials via an inline credential helper). If the push fails, the thread is left open and the error is surfaced; the chip returns to idle so it can be retried.

**2. Scope the chip to GitHub threads.** The chip rendered for any `<<comment-resolved>>` marker. The resolver agent spawned for local diff notes emits the marker with the local note's UUID, so the chip leaked onto local comments (which already track their own consumed/resolved state in the diff modal). The chip (and the copy-button suppression in `TranscriptCards`) now render only when the marker threadId is a real GitHub review thread node id (`PRT_` prefix). Factored `isReviewThreadId` into core.

## Test plan

- `pnpm turbo run typecheck test --filter=@goodboy/desktop --filter=@goodboy/core` green (809 desktop tests + core).
- `cargo test --locked` green (48 passed).
- Added: push-before-resolve / abort-on-push-fail / no-push-on-reason (store), chip renders nothing for a UUID threadId, `isReviewThreadId` unit tests.

## Notes

- `cargo fmt` / `clippy` flag pre-existing issues in untouched files (worktree.rs, main.rs, scripts.rs, etc.). Both steps are `continue-on-error` in CI and my changes are clean, so left out to keep the diff scoped.
