### PR TITLE
feat(repo): polish marketing site copy, responsive, and mobile actions

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -15,9 +15,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Primary -->
-    <title>Goodboy</title>
-    <meta name="description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app. Your machine, your keys, your data." />
-    <meta name="keywords" content="AI orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
+    <title>Goodboy: stop re-explaining yourself</title>
+    <meta name="description" content="The AI agent orchestrator that holds your context once, then hands it to Claude, Cursor, Codex or Gemini. Stop re-explaining yourself. Open source." />
+    <meta name="keywords" content="AI orchestrator, AI agent orchestrator, Claude, Cursor, Codex, Gemini, multi-agent, local-first, workspace, AI agents, developer tools, TypeScript, Tauri" />
     <meta name="author" content="Amin Khayam" />
     <link rel="canonical" href="https://goodboy.dev/" />
 
@@ -26,7 +26,7 @@
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
     <meta property="og:title" content="Goodboy: stop re-explaining yourself" />
-    <meta property="og:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta property="og:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -38,7 +38,7 @@
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
     <meta name="twitter:title" content="Goodboy: stop re-explaining yourself" />
-    <meta name="twitter:description" content="Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first. Your machine, your keys, your data." />
+    <meta name="twitter:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
     <meta name="twitter:image:alt" content="Goodboy: stop re-explaining yourself" />
 
@@ -52,7 +52,8 @@
       "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "Goodboy",
-      "description": "AI workspace orchestrator. Route agents across Claude, Cursor, Codex, and Gemini. Share context, structure plans, track budgets in real time. Local-first desktop app.",
+      "alternateName": "Goodboy AI agent orchestrator",
+      "description": "The AI agent orchestrator that holds your goal and context once, then hands them to Claude, Cursor, Codex or Gemini. Stop re-explaining yourself. Local-first, open source desktop app.",
       "url": "https://goodboy.dev/",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Windows, Linux",
@@ -69,7 +70,7 @@
       },
       "license": "https://opensource.org/licenses/MIT",
       "codeRepository": "https://github.com/akhayam99/goodboy",
-      "keywords": ["AI orchestrator", "Claude", "Cursor", "Codex", "Gemini", "multi-agent", "local-first", "developer tools"],
+      "keywords": ["AI orchestrator", "AI agent orchestrator", "Claude", "Cursor", "Codex", "Gemini", "multi-agent", "local-first", "developer tools"],
       "featureList": [
         "Multi-provider routing (Claude, Cursor, Codex, Gemini)",
         "Shared context panel across agents",

--- a/website/public/sitemap.xml
+++ b/website/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://goodboy.dev/</loc>
-    <lastmod>2026-05-24</lastmod>
+    <lastmod>2026-06-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/website/src/components/ProviderMarquee.tsx
+++ b/website/src/components/ProviderMarquee.tsx
@@ -1,0 +1,56 @@
+import type { CSSProperties } from 'react';
+
+type Provider = {
+  name: string;
+  color: string;
+  desc: string;
+};
+
+const providers: Provider[] = [
+  { name: 'Claude', color: 'oklch(0.74 0.15 55)', desc: 'Planning, refactors, reviews' },
+  { name: 'Cursor', color: 'oklch(0.70 0.16 290)', desc: 'Inline edits, autocomplete' },
+  { name: 'Codex', color: 'oklch(0.72 0.16 150)', desc: 'Scaffolds, one-shots' },
+  { name: 'Gemini', color: 'oklch(0.72 0.16 240)', desc: 'Long context, multimodal' },
+];
+
+const MASK: CSSProperties = {
+  WebkitMaskImage: 'linear-gradient(90deg, transparent, black 10%, black 90%, transparent)',
+  maskImage: 'linear-gradient(90deg, transparent, black 10%, black 90%, transparent)',
+};
+
+export function ProviderMarquee() {
+  return (
+    <div className="overflow-hidden" style={MASK}>
+      <div className="marquee gap-3">
+        {[...providers, ...providers].map((provider, i) => (
+          <Card
+            key={`${provider.name}-${i}`}
+            provider={provider}
+            aria-hidden={i >= providers.length}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Card({ provider, ...rest }: { provider: Provider } & { 'aria-hidden'?: boolean }) {
+  return (
+    <div
+      {...rest}
+      className="w-[220px] shrink-0 rounded-lg border border-border-soft bg-subtle p-4 text-left"
+    >
+      <div className="flex items-center gap-2.5">
+        <span
+          className="h-2 w-2 shrink-0 rounded-full"
+          style={{ background: provider.color }}
+          aria-hidden
+        />
+        <span className="text-[14px] font-semibold tracking-[-0.005em] text-foreground">
+          {provider.name}
+        </span>
+      </div>
+      <p className="mt-2 text-[12.5px] leading-snug text-muted-foreground">{provider.desc}</p>
+    </div>
+  );
+}

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -29,9 +29,9 @@ export function Section({
     >
       <div className="mx-auto max-w-6xl px-6">
         <div
-          className={`grid items-center justify-items-center gap-14 lg:grid-cols-2 lg:justify-items-stretch lg:gap-20 ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
+          className={`grid items-center gap-14 lg:grid-cols-2 lg:gap-20 ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
         >
-          <div className="reveal min-w-0 max-w-lg">
+          <div className="reveal mx-auto min-w-0 max-w-lg lg:mx-0">
             <Eyebrow>{eyebrow}</Eyebrow>
             <SectionTitle>{title}</SectionTitle>
             <div className="mt-5 max-w-prose text-pretty text-[16px] leading-[1.65] text-muted-foreground sm:text-[17px]">

--- a/website/src/components/Section.tsx
+++ b/website/src/components/Section.tsx
@@ -29,7 +29,7 @@ export function Section({
     >
       <div className="mx-auto max-w-6xl px-6">
         <div
-          className={`grid items-center gap-14 lg:grid-cols-2 lg:gap-20 ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
+          className={`grid items-center justify-items-center gap-14 lg:grid-cols-2 lg:justify-items-stretch lg:gap-20 ${reverse ? 'lg:[&>*:first-child]:order-2' : ''}`}
         >
           <div className="reveal min-w-0 max-w-lg">
             <Eyebrow>{eyebrow}</Eyebrow>

--- a/website/src/mockups/Snapshots.tsx
+++ b/website/src/mockups/Snapshots.tsx
@@ -281,7 +281,7 @@ export function SessionsSnapshot() {
                     status={state.steps[i]}
                   />
                   {i === 2 ? (
-                    <div className="ml-7 flex flex-col gap-1 border-l border-border-soft/60 pl-2.5">
+                    <div className="ml-7 flex flex-col gap-1 edge-l pl-2.5">
                       {SESSION_CLUSTERS.map((c, ci) => (
                         <ClusterRow key={c} name={c} status={state.clusters[ci]} />
                       ))}
@@ -775,7 +775,7 @@ export function StudioComposeSnapshot() {
           </div>
         </div>
 
-        <div className="w-[164px] shrink-0 border-l border-border-soft bg-[oklch(0.23_0.006_255)] p-2.5">
+        <div className="w-[164px] shrink-0 edge-l bg-[oklch(0.23_0.006_255)] p-2.5">
           <div className="pb-1.5 text-[9px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
             Step library
           </div>
@@ -972,7 +972,7 @@ export function ContextSnapshot() {
 
   return (
     <SnapshotFrame className="max-w-[460px]">
-      <div className="flex h-9 items-center gap-0.5 border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-2">
+      <div className="flex h-9 items-center gap-0.5 edge-b bg-[oklch(0.27_0.008_255)] px-2">
         {CTX_TABS.map((t) => (
           <CtxTabButton
             key={t.key}
@@ -1007,7 +1007,7 @@ export function ContextSnapshot() {
           {state.tab === 'context' && questionCount > 0 ? (
             <div
               ref={registerTarget('footer')}
-              className="flex h-full w-full items-center justify-between gap-2 border-t border-border-soft bg-warning/5 px-3 py-2 text-left text-[11px] text-warning"
+              className="flex h-full w-full items-center justify-between gap-2 edge-t bg-warning/5 px-3 py-2 text-left text-[11px] text-warning"
             >
               <span className="inline-flex items-center gap-1.5 font-medium">
                 <IconHelp size={11} />1 open question
@@ -1469,7 +1469,7 @@ export function GithubStudioSnapshot() {
         }
       />
       <div ref={stageRef} className="relative flex">
-        <div className="w-[176px] shrink-0 space-y-2.5 border-r border-border-soft p-2">
+        <div className="w-[176px] shrink-0 space-y-2.5 edge-r p-2">
           {INBOX_GROUPS.map((g) => (
             <div key={g.label} className="flex flex-col gap-0.5">
               <div className="flex items-center gap-1 px-1 pb-0.5">
@@ -1876,7 +1876,7 @@ export function LinearStudioSnapshot() {
         }
       />
       <div ref={stageRef} className="relative flex">
-        <div className="w-[196px] shrink-0 border-r border-border-soft">
+        <div className="w-[196px] shrink-0 edge-r">
           <div className="px-2 pt-2 pb-1.5">
             <div className="flex h-7 items-center gap-1.5 rounded-md border border-border-soft bg-background/40 px-2 text-[10px] text-muted-foreground/60">
               <svg
@@ -1999,7 +1999,7 @@ function LinearDetail({ launchRef }: { launchRef: TargetRef }) {
         the marketing site. Keep the existing login UI untouched.
       </p>
 
-      <div className="space-y-2 border-t border-border-soft/60 bg-subtle/40 px-3 py-2.5">
+      <div className="space-y-2 edge-t bg-subtle/40 px-3 py-2.5">
         <div className="flex items-center gap-1.5 text-[10px] font-semibold text-foreground">
           <IconTarget size={10} aria-hidden className="text-primary" /> Goal
         </div>
@@ -2022,7 +2022,7 @@ function LinearDetail({ launchRef }: { launchRef: TargetRef }) {
         </div>
       </div>
 
-      <div className="mt-auto flex items-center justify-between gap-2 border-t border-border-soft bg-primary/5 px-3 py-2 text-[10.5px]">
+      <div className="mt-auto flex items-center justify-between gap-2 edge-t bg-primary/5 px-3 py-2 text-[10.5px]">
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
           <span
             aria-hidden
@@ -2086,7 +2086,7 @@ function LinearPicker({
           </div>
         ))}
       </div>
-      <div className="mt-auto flex items-center justify-between gap-2 border-t border-border-soft bg-primary/5 px-3 py-2 text-[10.5px]">
+      <div className="mt-auto flex items-center justify-between gap-2 edge-t bg-primary/5 px-3 py-2 text-[10.5px]">
         <span className="inline-flex items-center gap-1.5 text-muted-foreground">
           <span
             aria-hidden
@@ -2298,7 +2298,7 @@ export function AgentRosterSnapshot() {
 export function NewSessionLinearSnapshot() {
   return (
     <SnapshotFrame className="max-w-[560px]">
-      <div className="flex items-start gap-3 border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-4 pt-3 pb-3">
+      <div className="flex items-start gap-3 edge-b bg-[oklch(0.27_0.008_255)] px-4 pt-3 pb-3">
         <div className="flex flex-col gap-0.5">
           <span className="text-[10px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
             New session
@@ -2355,7 +2355,7 @@ export function NewSessionLinearSnapshot() {
         </SectionRow>
 
         {/* Footer */}
-        <div className="-mx-4 -mb-4 mt-1 flex items-center gap-3 border-t border-border-soft bg-[oklch(0.22_0.005_255)] px-4 py-2.5 text-[11px]">
+        <div className="-mx-4 -mb-4 mt-1 flex items-center gap-3 edge-t bg-[oklch(0.22_0.005_255)] px-4 py-2.5 text-[11px]">
           <label className="inline-flex items-center gap-1.5 text-muted-foreground">
             <span className="inline-flex size-3 items-center justify-center rounded-sm border border-primary bg-primary/30">
               <IconCheck size={8} className="text-primary" />

--- a/website/src/mockups/primitives.tsx
+++ b/website/src/mockups/primitives.tsx
@@ -43,7 +43,7 @@ export function SnapshotFrame({
   return (
     <div
       className={[
-        'relative overflow-hidden rounded-xl border border-border-soft bg-[oklch(0.25_0.006_255)] shadow-md',
+        'relative mx-auto w-full overflow-hidden rounded-xl border border-border-soft bg-[oklch(0.25_0.006_255)] shadow-md',
         className ?? '',
       ].join(' ')}
     >
@@ -54,7 +54,7 @@ export function SnapshotFrame({
 
 export function FrameHeader({ label, right }: { label: string; right?: ReactNode }) {
   return (
-    <div className="flex h-8 items-center justify-between gap-2 border-b border-border-soft bg-[oklch(0.27_0.008_255)] px-3">
+    <div className="flex h-8 items-center justify-between gap-2 edge-b bg-[oklch(0.27_0.008_255)] px-3">
       <span className="text-[10px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
         {label}
       </span>

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -69,7 +69,43 @@ export function CTA() {
           pay for and you&apos;re running on your own machine in a minute.
         </p>
 
-        <div className="mx-auto mt-11 max-w-lg">
+        <div className="mx-auto mt-11 max-w-lg pointer-fine:hidden">
+          <p className="text-[12px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+            When you&apos;re on your Mac
+          </p>
+          <code className="mt-2.5 block overflow-x-auto whitespace-nowrap rounded-lg border border-border-soft bg-[oklch(0.22_0.007_255)] px-4 py-2.5 text-left font-mono text-[12.5px] text-foreground">
+            {brewLine}
+          </code>
+          <p className="mt-2.5 text-[11.5px] text-muted-foreground/70">
+            Or grab the .dmg from the GitHub releases.
+          </p>
+          <div className="mt-7 flex flex-col items-center gap-3">
+            <LinkButton
+              href="https://github.com/akhayam99/goodboy"
+              target="_blank"
+              rel="noreferrer"
+              size="lg"
+              variant="primary"
+              className="w-full max-w-xs"
+            >
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden>
+                <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.32c-2.23.48-2.7-1.07-2.7-1.07-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.81.06 1.24.83 1.24.83.72 1.23 1.88.87 2.34.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.96 0-.87.3-1.59.83-2.15-.08-.2-.36-1.02.08-2.13 0 0 .67-.22 2.2.82a7.6 7.6 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.11.16 1.93.08 2.13.51.56.82 1.28.82 2.15 0 3.08-1.87 3.76-3.65 3.96.29.25.54.73.54 1.48v2.2c0 .21.15.46.55.38A8 8 0 0 0 8 0Z" />
+              </svg>
+              Star on GitHub
+            </LinkButton>
+            <LinkButton
+              href="https://github.com/akhayam99/goodboy/blob/main/README.md"
+              target="_blank"
+              rel="noreferrer"
+              size="lg"
+              variant="ghost"
+            >
+              Read the docs
+            </LinkButton>
+          </div>
+        </div>
+
+        <div className="mx-auto mt-11 hidden max-w-lg pointer-fine:block">
           {/* macOS: the primary path. dmg.direct → straight to the file; the
               fallback releases page opens in a new tab. */}
           <LinkButton
@@ -114,7 +150,7 @@ export function CTA() {
           </div>
         </div>
 
-        <div className="mt-11 flex flex-col items-center justify-center gap-3 sm:flex-row">
+        <div className="mt-11 hidden flex-col items-center justify-center gap-3 pointer-fine:flex sm:flex-row">
           <LinkButton
             href="https://github.com/akhayam99/goodboy"
             target="_blank"

--- a/website/src/sections/FloatingNav.tsx
+++ b/website/src/sections/FloatingNav.tsx
@@ -4,9 +4,9 @@ import { DogMascot } from '../components/DogMascot';
 const links = [
   { href: '#sessions', label: 'Sessions' },
   { href: '#context', label: 'Context' },
-  { href: '#studio', label: 'Workflow Studio' },
-  { href: '#github', label: 'GitHub Studio' },
-  { href: '#linear', label: 'Linear Studio' },
+  { href: '#studio', label: 'Workflow' },
+  { href: '#github', label: 'GitHub' },
+  { href: '#linear', label: 'Linear' },
   { href: '#compare', label: 'Compare' },
 ];
 
@@ -43,7 +43,7 @@ export function FloatingNav() {
         className={[
           'flex items-center gap-1 rounded-full border border-border-soft bg-background/85 px-1.5 py-1.5 shadow-lg backdrop-blur-md',
           // The pill scales the gap on wide viewports so the labels can breathe.
-          'sm:gap-2 sm:px-2',
+          'md:gap-2 md:px-2',
         ].join(' ')}
       >
         <a
@@ -54,9 +54,9 @@ export function FloatingNav() {
           <DogMascot size={18} />
         </a>
 
-        <span aria-hidden className="hidden h-4 w-px bg-border-soft sm:block" />
+        <span aria-hidden className="hidden h-4 w-px bg-border-soft md:block" />
 
-        <div className="hidden items-center gap-0.5 sm:flex">
+        <div className="hidden items-center gap-0.5 md:flex">
           {links.map((l) => (
             <a
               key={l.href}
@@ -68,7 +68,7 @@ export function FloatingNav() {
           ))}
         </div>
 
-        <span aria-hidden className="hidden h-4 w-px bg-border-soft sm:block" />
+        <span aria-hidden className="hidden h-4 w-px bg-border-soft md:block" />
 
         <a
           href="https://github.com/akhayam99/goodboy"

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -4,7 +4,7 @@ export function Footer() {
   return (
     <footer className="mt-8 border-t border-border-soft/60 bg-background py-10">
       <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-5 px-6 sm:flex-row">
-        <div className="flex items-center gap-4">
+        <div className="flex flex-col items-center gap-1.5 sm:flex-row sm:gap-4">
           <Logo size={22} />
           <span className="text-[12px] text-muted-foreground">© 2026 &middot; MIT licensed</span>
         </div>

--- a/website/src/sections/Footer.tsx
+++ b/website/src/sections/Footer.tsx
@@ -8,7 +8,7 @@ export function Footer() {
           <Logo size={22} />
           <span className="text-[12px] text-muted-foreground">© 2026 &middot; MIT licensed</span>
         </div>
-        <nav className="flex items-center gap-5 text-[12.5px] text-muted-foreground">
+        <nav className="flex flex-col items-center gap-3 text-[12.5px] text-muted-foreground sm:flex-row sm:gap-5">
           <a
             href="https://github.com/akhayam99/goodboy"
             target="_blank"
@@ -34,7 +34,7 @@ export function Footer() {
           <a href="#cta" className="transition-colors hover:text-foreground">
             Install
           </a>
-          <span className="text-border" aria-hidden>
+          <span className="hidden text-border sm:inline" aria-hidden>
             &middot;
           </span>
           <a
@@ -44,6 +44,25 @@ export function Footer() {
             className="font-mono transition-colors hover:text-foreground"
           >
             Docs
+          </a>
+          <span className="hidden text-border sm:inline" aria-hidden>
+            &middot;
+          </span>
+          <a
+            href="https://www.iubenda.com/privacy-policy/46359357"
+            target="_blank"
+            rel="noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            Privacy Policy
+          </a>
+          <a
+            href="https://www.iubenda.com/privacy-policy/46359357/cookie-policy"
+            target="_blank"
+            rel="noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            Cookie Policy
           </a>
         </nav>
       </div>

--- a/website/src/sections/GithubDeepDive.tsx
+++ b/website/src/sections/GithubDeepDive.tsx
@@ -7,7 +7,7 @@ export function GithubDeepDive() {
       id="github"
       eyebrow="04 · GitHub Studio"
       reverse
-      title={<>Every pull request, in one inbox.</>}
+      title={<>Every pull request, in one place.</>}
       body={
         <>
           <p>

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -1,4 +1,5 @@
 import { DogMascot } from '../components/DogMascot';
+import { ProviderMarquee } from '../components/ProviderMarquee';
 import { LinkButton } from '../components/ui';
 
 function GitHubGlyph() {
@@ -14,13 +15,13 @@ export function Hero() {
     <section className="relative overflow-hidden pt-12 pb-20 sm:pt-16 sm:pb-24">
       <div className="relative z-10 mx-auto max-w-6xl px-6">
         <div className="mx-auto max-w-3xl text-center">
-          <div className="rise inline-flex items-center gap-2 text-[22px] font-semibold tracking-tight text-foreground">
-            <DogMascot size={30} className="text-primary" />
+          <div className="rise inline-flex items-center gap-2.5 text-[26px] font-semibold tracking-tight text-foreground">
+            <DogMascot size={34} className="text-primary" />
             <span>Goodboy</span>
           </div>
 
           <h1
-            className="rise mt-6 text-balance text-[42px] font-semibold leading-[1.02] tracking-[-0.035em] sm:text-[64px] lg:text-[72px]"
+            className="rise mt-6 text-balance text-[40px] font-semibold leading-[1.02] tracking-[-0.035em] sm:text-[58px] lg:text-[64px]"
             style={{ animationDelay: '60ms' }}
           >
             <span className="text-gradient">Stop re-explaining</span>
@@ -30,13 +31,18 @@ export function Hero() {
 
           <p
             className="rise mx-auto mt-6 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
-            style={{ animationDelay: '120ms' }}
+            style={{ animationDelay: '110ms' }}
           >
             Run Claude, Cursor, Codex and Gemini in one local workspace.
           </p>
+
+          <div className="rise mt-8" style={{ animationDelay: '150ms' }}>
+            <ProviderMarquee />
+          </div>
+
           <p
-            className="rise mx-auto mt-3 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
-            style={{ animationDelay: '160ms' }}
+            className="rise mx-auto mt-8 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
+            style={{ animationDelay: '180ms' }}
           >
             They share the same goal, plan and context, so the next agent picks up right where the
             last left off.
@@ -44,7 +50,7 @@ export function Hero() {
 
           <div
             className="rise mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row"
-            style={{ animationDelay: '180ms' }}
+            style={{ animationDelay: '210ms' }}
           >
             <LinkButton href="#cta" size="lg" variant="primary">
               Install
@@ -65,7 +71,7 @@ export function Hero() {
             className="rise mt-5 text-[12.5px] text-muted-foreground/75"
             style={{ animationDelay: '240ms' }}
           >
-            Free &amp; open source &middot; macOS &middot; bring your own subscription
+            Free and open source. Runs on macOS with the AI plans you already pay for.
           </p>
         </div>
       </div>

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -49,7 +49,32 @@ export function Hero() {
           </p>
 
           <div
-            className="rise mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row"
+            className="rise mt-8 flex flex-col items-center gap-3 pointer-fine:hidden"
+            style={{ animationDelay: '210ms' }}
+          >
+            <div className="flex w-full max-w-xs flex-col items-center gap-1.5">
+              <LinkButton
+                href="https://github.com/akhayam99/goodboy"
+                target="_blank"
+                rel="noreferrer"
+                size="lg"
+                variant="primary"
+                className="w-full"
+              >
+                <GitHubGlyph />
+                Star on GitHub
+              </LinkButton>
+              <p className="text-[12px] text-muted-foreground/75">
+                Save the repo for later, install on your Mac.
+              </p>
+            </div>
+            <LinkButton href="#cta" size="lg" variant="ghost">
+              How to install
+            </LinkButton>
+          </div>
+
+          <div
+            className="rise mt-8 hidden flex-col items-center justify-center gap-3 pointer-fine:flex sm:flex-row"
             style={{ animationDelay: '210ms' }}
           >
             <LinkButton href="#cta" size="lg" variant="primary">
@@ -68,7 +93,7 @@ export function Hero() {
           </div>
 
           <p
-            className="rise mt-5 text-[12.5px] text-muted-foreground/75"
+            className="rise mt-5 hidden text-[12.5px] text-muted-foreground/75 pointer-fine:block"
             style={{ animationDelay: '240ms' }}
           >
             Free and open source. Runs on macOS with the AI plans you already pay for.

--- a/website/src/sections/LinearDeepDive.tsx
+++ b/website/src/sections/LinearDeepDive.tsx
@@ -6,7 +6,7 @@ export function LinearDeepDive() {
     <Section
       id="linear"
       eyebrow="05 · Linear Studio"
-      title={<>Your Linear backlog, one click from a session.</>}
+      title={<>Turn a Linear issue into a session.</>}
       body={
         <>
           <p>

--- a/website/src/sections/Nav.tsx
+++ b/website/src/sections/Nav.tsx
@@ -4,9 +4,9 @@ import { LinkButton } from '../components/ui';
 const links = [
   { href: '#sessions', label: 'Sessions' },
   { href: '#context', label: 'Context' },
-  { href: '#studio', label: 'Workflow Studio' },
-  { href: '#github', label: 'GitHub Studio' },
-  { href: '#linear', label: 'Linear Studio' },
+  { href: '#studio', label: 'Workflow' },
+  { href: '#github', label: 'GitHub' },
+  { href: '#linear', label: 'Linear' },
   { href: '#compare', label: 'Compare' },
 ];
 
@@ -26,7 +26,7 @@ export function Nav() {
             <a
               key={l.href}
               href={l.href}
-              className="text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+              className="whitespace-nowrap text-[13px] text-muted-foreground transition-colors hover:text-foreground"
             >
               {l.label}
             </a>

--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -173,6 +173,43 @@ body,
   );
 }
 
+.edge-t,
+.edge-b,
+.edge-l,
+.edge-r {
+  position: relative;
+}
+.edge-t::after,
+.edge-b::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--color-border-soft), transparent);
+}
+.edge-t::after {
+  top: 0;
+}
+.edge-b::after {
+  bottom: 0;
+}
+.edge-l::after,
+.edge-r::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: linear-gradient(180deg, transparent, var(--color-border-soft), transparent);
+}
+.edge-l::after {
+  left: 0;
+}
+.edge-r::after {
+  right: 0;
+}
+
 /* Letter-set typography. Used only inside the founder note. */
 .letter {
   font-family: var(--font-serif);


### PR DESCRIPTION
## What

A pass over the marketing site: copy, responsive layout, device-aware CTAs, and the SEO meta from #682 (folded in here, so #682 can close).

### Copy
- Privacy Policy + Cookie Policy links in the footer (iubenda-hosted, reachable from every page).
- Less AI-sounding copy: GitHub title "...in one place", Linear title "Turn a Linear issue into a session", hero fineprint reworded, dropped middot triplets and "bring your own" phrasing.
- Dropped "Studio" from nav labels (Workflow / GitHub / Linear).

### Layout / responsive
- Provider marquee restored in the hero (Claude/Cursor/Codex/Gemini) between title and tagline.
- Hero type rebalanced (wordmark up, headline trimmed on large screens).
- Nav links collapse by width without overlap; footer stacks into a centered column on mobile with the copyright tucked under the logo.
- Two-column sections center below lg; mockup billboards hold a stable width (no resize during autoplay).
- Billboards use the app's fading divider (packages/ui Divider) instead of hard borders.

### Device-aware CTAs (pointer-based, not width-based)
- On touch devices the primary action is "Star on GitHub" with a "save for later, install on your Mac" note; the bottom CTA becomes a "when you're on your Mac" recap (brew + star + docs).
- Desktops keep Install / Download for macOS even in a small window.

### SEO (from #682)
- Visible title and social unfurls stay the human motto; "AI agent orchestrator" lives in machine-facing meta only.

Supersedes #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)