### PR TITLE
chore(repo): align website copy, readme and meta tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ a local SQLite on your machine. Your keys, your data, your bandwidth.
 
 <img width="3972" height="2234" alt="CleanShot 2026-06-02 at 04 59 56@2x" src="https://github.com/user-attachments/assets/45ed6f2d-f22a-4c6a-9278-ee4cddc7533c" />
 
-
 ## Why it exists
 
 Switching between `Claude`, `Codex`, `Cursor` and `Gemini` ten times a day was
@@ -32,7 +31,7 @@ hand when the agents get it wrong. The next agent shows up already briefed.
 
 **Provider swap mid-task, without amnesia.** Each turn is rebuilt from the
 shared context, never resumed from a vendor's session blob. Drop Claude
-halfway, hand the same task to Cursor or Codex, watch it pick up clean.
+halfway, hand the same task to Cursor, Codex or Gemini, watch it pick up clean.
 
 **Workflows for the multi-step stuff.** Refactor incoming? Line up a sequence:
 a cheap model to scout the area, a smart one to plan it, a mid one to

--- a/VISION.md
+++ b/VISION.md
@@ -46,7 +46,7 @@ After each agent turn, the summarizer infers what should happen next: scout (exp
 
 ### Provider routing & balance
 
-Register your AI providers (Anthropic, Cursor, Codex). Set priorities. Set budgets. Goodboy routes work to the right provider automatically.
+Register your AI providers (Anthropic, Cursor, Codex, Gemini). Set priorities. Set budgets. Goodboy routes work to the right provider automatically.
 
 - Provider 1 hits 75% budget → fallback to provider 2.
 - Quick task → fast cheap model. Complex architecture → best available model.

--- a/website/index.html
+++ b/website/index.html
@@ -26,7 +26,7 @@
     <meta property="og:site_name" content="Goodboy" />
     <meta property="og:url" content="https://goodboy.dev/" />
     <meta property="og:title" content="Goodboy: stop re-explaining yourself" />
-    <meta property="og:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
+    <meta property="og:description" content="Run Claude, Cursor, Codex and Gemini in one local workspace. Shared goals, plans, and context let the next agent pick up where the last left off." />
     <meta property="og:image" content="https://goodboy.dev/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -38,7 +38,7 @@
     <meta name="twitter:site" content="@akhayam99" />
     <meta name="twitter:creator" content="@akhayam99" />
     <meta name="twitter:title" content="Goodboy: stop re-explaining yourself" />
-    <meta name="twitter:description" content="One local workspace for Claude, Cursor, Codex and Gemini. They share your goal, plan and context, so the next agent picks up where the last left off." />
+    <meta name="twitter:description" content="Run Claude, Cursor, Codex and Gemini in one local workspace. Shared goals, plans, and context let the next agent pick up where the last left off." />
     <meta name="twitter:image" content="https://goodboy.dev/og-image.png" />
     <meta name="twitter:image:alt" content="Goodboy: stop re-explaining yourself" />
 

--- a/website/src/sections/CTA.tsx
+++ b/website/src/sections/CTA.tsx
@@ -66,7 +66,7 @@ export function CTA() {
         </p>
         <p className="mx-auto mt-7 max-w-xl text-[18px] leading-[1.5] text-foreground/85 sm:text-[20px]">
           No waitlist, no email, no sign-up. Plug in the Claude, Cursor, Codex or Gemini you already
-          pay for and you&apos;re running on your own machine in a minute.
+          pay for and you&apos;ll be running on your own machine in a minute.
         </p>
 
         <div className="mx-auto mt-11 max-w-lg pointer-fine:hidden">

--- a/website/src/sections/Comparison.tsx
+++ b/website/src/sections/Comparison.tsx
@@ -14,20 +14,20 @@ const rows: ReadonlyArray<Row> = [
     goodboy: 'The next agent shows up already briefed',
   },
   {
-    stack: 'Each tool is locked to its own model',
+    stack: 'Each tool is tied to its own model',
     goodboy: 'Claude, Cursor, Codex and Gemini in one session',
   },
   {
-    stack: 'You babysit which model gets which task',
+    stack: 'You micromanage which model gets which task',
     goodboy: 'Goodboy taps your shoulder before you overpay',
   },
   {
-    stack: 'The PR lives in yet another browser tab',
+    stack: 'The PR lives in another browser tab',
     goodboy: 'Every PR sits in one inbox, next to the work',
   },
   {
-    stack: 'Your code and keys ride through someone’s cloud',
-    goodboy: 'Everything runs on your machine. Always',
+    stack: 'Your code and keys move through someone else’s cloud',
+    goodboy: 'Everything runs on your machine, always',
   },
 ];
 
@@ -75,10 +75,10 @@ export function Comparison() {
       <div className="mx-auto max-w-5xl px-6">
         <div className="reveal mb-12 max-w-2xl">
           <p className="text-[11px] font-semibold uppercase tracking-[0.10em] text-muted-foreground">
-            Why a layer, not another tool
+            A layer, not a tool
           </p>
           <h2 className="mt-4 text-pretty text-[30px] sm:text-[40px] leading-[1.12] tracking-[-0.02em] font-semibold text-foreground">
-            A step above the tools you already use.
+            A step above the tools you already use
           </h2>
           <p className="mt-5 max-w-prose text-pretty text-[16px] leading-[1.65] text-muted-foreground sm:text-[17px]">
             Keep your editor, keep your subscriptions. Goodboy doesn&apos;t replace any of it, it

--- a/website/src/sections/ContextDeepDive.tsx
+++ b/website/src/sections/ContextDeepDive.tsx
@@ -7,13 +7,12 @@ export function ContextDeepDive() {
       id="context"
       eyebrow="02 · Shared context"
       reverse
-      title={<>Your next agent shows up already briefed.</>}
+      title={<>Your next agent shows up already briefed</>}
       body={
         <p>
-          The goal, the calls you&apos;ve already made, the files in play, the questions still open:
-          it all lives next to the chat, not buried inside it. So when the next agent takes over, it
-          already knows the story, whatever provider or model it runs on. You stop explaining
-          yourself twice.
+          The goal, previous calls, files in play, and open questions all live next to the chat, so
+          when a new agent takes over, it already knows the full story. No need to re-explain
+          yourself.
         </p>
       }
     >

--- a/website/src/sections/GithubDeepDive.tsx
+++ b/website/src/sections/GithubDeepDive.tsx
@@ -7,18 +7,18 @@ export function GithubDeepDive() {
       id="github"
       eyebrow="04 · GitHub Studio"
       reverse
-      title={<>Every pull request, in one place.</>}
+      title={<>One inbox for every pull request</>}
       body={
         <>
           <p>
-            Every session&apos;s PR lands in one inbox, sorted by what it needs from you: draft, in
-            review, changes requested, ready to merge. No more digging through github.com to find
-            the one that&apos;s blocking you.
+            Every session&apos;s PR lands in the same inbox, sorted by status: draft, in review,
+            changes requested, ready to merge. Forget about digging through GitHub to find
+            what&apos;s blocking you.
           </p>
           <p className="mt-4">
-            Open one and the conversation, the checks and the reviewers are right there, next to the
-            buttons that mark it ready or squash-merge it. A reviewer leaves a comment? Hand it to
-            an agent and it pushes the fix straight back to the thread.
+            Open one PR and everything is right there: conversation, checks, and reviewers. Merge or
+            squash when it&apos;s ready. A reviewer leaves a comment? Hand it to an agent and the
+            fix goes straight back into the thread.
           </p>
         </>
       }

--- a/website/src/sections/Hero.tsx
+++ b/website/src/sections/Hero.tsx
@@ -33,7 +33,7 @@ export function Hero() {
             className="rise mx-auto mt-6 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
             style={{ animationDelay: '110ms' }}
           >
-            Run Claude, Cursor, Codex and Gemini in one local workspace.
+            Run Claude, Cursor, Codex and Gemini in the same workspace.
           </p>
 
           <div className="rise mt-8" style={{ animationDelay: '150ms' }}>
@@ -44,14 +44,17 @@ export function Hero() {
             className="rise mx-auto mt-8 max-w-xl text-pretty text-[17px] leading-[1.6] text-muted-foreground sm:text-[19px]"
             style={{ animationDelay: '180ms' }}
           >
-            They share the same goal, plan and context, so the next agent picks up right where the
-            last left off.
+            Shared goals, plans, and context let the next agent pick up right where the last left
+            off.
           </p>
 
           <div
             className="rise mt-8 flex flex-col items-center gap-3 pointer-fine:hidden"
             style={{ animationDelay: '210ms' }}
           >
+            <p className="text-[13px] font-medium text-foreground/80">
+              Goodboy is free and open source.
+            </p>
             <div className="flex w-full max-w-xs flex-col items-center gap-1.5">
               <LinkButton
                 href="https://github.com/akhayam99/goodboy"
@@ -74,30 +77,31 @@ export function Hero() {
           </div>
 
           <div
-            className="rise mt-8 hidden flex-col items-center justify-center gap-3 pointer-fine:flex sm:flex-row"
+            className="rise mt-8 hidden flex-col items-center justify-center gap-3 pointer-fine:flex"
             style={{ animationDelay: '210ms' }}
           >
-            <LinkButton href="#cta" size="lg" variant="primary">
-              Install
-            </LinkButton>
-            <LinkButton
-              href="https://github.com/akhayam99/goodboy"
-              target="_blank"
-              rel="noreferrer"
-              size="lg"
-              variant="secondary"
-            >
-              <GitHubGlyph />
-              GitHub
-            </LinkButton>
+            <p className="text-[13px] font-medium text-foreground/80">
+              Goodboy is free and open source.
+            </p>
+            <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <LinkButton href="#cta" size="lg" variant="primary">
+                Install
+              </LinkButton>
+              <LinkButton
+                href="https://github.com/akhayam99/goodboy"
+                target="_blank"
+                rel="noreferrer"
+                size="lg"
+                variant="secondary"
+              >
+                <GitHubGlyph />
+                GitHub
+              </LinkButton>
+            </div>
+            <p className="text-[12.5px] text-muted-foreground/75">
+              Runs on macOS with the AI plans you already pay for.
+            </p>
           </div>
-
-          <p
-            className="rise mt-5 hidden text-[12.5px] text-muted-foreground/75 pointer-fine:block"
-            style={{ animationDelay: '240ms' }}
-          >
-            Free and open source. Runs on macOS with the AI plans you already pay for.
-          </p>
         </div>
       </div>
     </section>

--- a/website/src/sections/Letter.tsx
+++ b/website/src/sections/Letter.tsx
@@ -11,24 +11,24 @@ export function Letter() {
 
         <div className="letter mt-10 space-y-6 text-[19px] text-foreground/90">
           <p>
-            Not too long ago I had three chats open. Claude for plans. Cursor for edits I trusted.
-            Codex when I needed a scaffold. Each one knew a slice of the work. None knew the whole.
+            Not too long ago, I had three chats open. Claude for plans. Cursor for edits. Codex for
+            scaffolding. Each one knew a piece of the work. None had the full picture.
           </p>
           <p>
             I would ship something half-built, then re-paste the goal into the next window because
-            the model that should review it had no idea what we&apos;d decided. By evening I had
-            spent more time re-explaining than building.
+            the model reviewing it had no idea what we&apos;d decided. By evening, I spent more time
+            re-explaining myself than building.
           </p>
           <p>
-            Goodboy is the tool I wanted that week and couldn&apos;t find. It sits above the
-            providers, not in place of them. The context lives outside the chat, so the next agent
-            arrives already briefed. The cost ticks live next to the work. The PR shows up where
-            I&apos;m already looking.
+            Goodboy is the tool I needed in that moment and couldn&apos;t find. It sits above all
+            providers, not in their place. The context lives outside the chat, so the next agent
+            shows up already briefed. Costs update in real time next to your work. The PR lands
+            where I&apos;m already looking.
           </p>
           <p>
-            It is open source because tools you trust to type into your terminal should be yours to
-            read. It is local-first because what runs on your machine stays there. It is opinionated
-            where it had to be, and quiet everywhere else.
+            It is open source because tools you trust in your terminal should be yours to read. It
+            is local-first because what runs on your machine stays there. It is opinionated where it
+            has to be, and quiet everywhere else.
           </p>
           <p>
             If you&apos;ve felt the same, clone it. Tell me what&apos;s broken. We&apos;ll fix it

--- a/website/src/sections/LinearDeepDive.tsx
+++ b/website/src/sections/LinearDeepDive.tsx
@@ -6,18 +6,17 @@ export function LinearDeepDive() {
     <Section
       id="linear"
       eyebrow="05 · Linear Studio"
-      title={<>Turn a Linear issue into a session.</>}
+      title={<>Turn any issue into a session</>}
       body={
         <>
           <p>
-            Every open issue assigned to you, bucketed by Linear state. Pick one and the goal is
-            already written, the branch is named, the linked PR is recognized. Hit launch and a
-            session is on it, with the issue tagged in the rail above.
+            Every issue assigned to you is grouped by state. Just pick one and the goal is set, the
+            branch is named, and the PR is automatically linked. Now hit launch and a session kicks
+            off, with the issue tracked above.
           </p>
           <p className="mt-4">
-            Already shipped a PR for that issue and got review comments? Pick &ldquo;Continue on
-            PR&rdquo; instead of &ldquo;Start fresh&rdquo; and the same branch comes back, ready to
-            push the next round.
+            Already shipped a PR and got review comments? Choose &ldquo;Continue on PR&rdquo;
+            instead of &ldquo;Start fresh&rdquo; and continue where you left off.
           </p>
         </>
       }

--- a/website/src/sections/MoreBriefly.tsx
+++ b/website/src/sections/MoreBriefly.tsx
@@ -5,24 +5,24 @@ import { useInView } from '../components/Reveal';
    no mockups. The five sections above carry the weight; this is the tail. */
 const ITEMS: ReadonlyArray<{ k: string; v: string }> = [
   {
-    k: 'Routing & cost',
-    v: 'Each task goes to the model that fits it, and Goodboy nudges you before you burn Opus on a one-liner. Every session shows what it is costing you as it runs.',
+    k: 'Costs',
+    v: 'Each task goes to the right model, and Goodboy gives you a heads-up before you burn Opus on a one-liner. Every session shows its cost in real time.',
   },
   {
-    k: 'Seven agent roles',
-    v: 'Scout, plan, implement, debug, test, review, docs. Each one sticks to its own job, so the reviewer never quietly rewrites your code.',
+    k: 'Seven agents',
+    v: 'Scout, plan, implement, debug, test, review, docs: each agent sticks to its role and no one steps into someone else’s job.',
   },
   {
     k: 'Plans',
-    v: 'Agents write the plan before they touch your code, and it stays put: something you can read and edit, not a message that scrolls away.',
+    v: 'Agents write the plan before touching your code. It stays in place: you can easily read and edit it. It’s not a message that scrolls away.',
   },
   {
     k: 'Local-first',
-    v: 'Runs on your machine, with your keys and your data. Bring the subscription you already pay for.',
+    v: 'Runs on your machine, with your keys and data. Just use the subscription you already have.',
   },
   {
     k: 'Open source',
-    v: 'MIT licensed, out in the open. Try it, break it, send feedback.',
+    v: 'MIT licensed, fully open. Try it, break it, send feedback.',
   },
 ];
 
@@ -35,9 +35,9 @@ export function MoreBriefly() {
     >
       <div className="mx-auto max-w-5xl px-6">
         <div className="reveal max-w-2xl">
-          <Eyebrow>06 &middot; The rest, briefly</Eyebrow>
+          <Eyebrow>06 &middot; Everything else</Eyebrow>
           <p className="mt-4 text-pretty text-[16px] leading-[1.6] text-muted-foreground sm:text-[17px]">
-            The stuff that matters but doesn&apos;t need its own billboard.
+            The stuff that matters, kept short.
           </p>
         </div>
         <dl

--- a/website/src/sections/SessionsDeepDive.tsx
+++ b/website/src/sections/SessionsDeepDive.tsx
@@ -6,12 +6,12 @@ export function SessionsDeepDive() {
     <Section
       id="sessions"
       eyebrow="01 · Sessions"
-      title={<>Everything you have running, in one rail.</>}
+      title={<>Keep an eye on everything you&apos;re running</>}
       body={
         <p>
-          Each task keeps its own goal, branch, agents and PR, all in one place. One glance and you
-          know what&apos;s working and what&apos;s waiting on you, instead of digging through ten
-          terminal tabs trying to remember where you left each one.
+          Each task has its own goal, branch, agents, and PR all in one place. It&apos;s easy to see
+          what&apos;s working and what needs your attention: no need to dig through multiple tabs to
+          figure out where you left off.
         </p>
       }
     >

--- a/website/src/sections/StudioDeepDive.tsx
+++ b/website/src/sections/StudioDeepDive.tsx
@@ -6,17 +6,16 @@ export function StudioDeepDive() {
     <Section
       id="studio"
       eyebrow="03 · Workflow Studio"
-      title={<>Build the flow once. Reuse it forever.</>}
+      title={<>Build it once, reuse it forever</>}
       body={
         <>
           <p>
-            Refactor incoming? Line up a sequence: a cheap model to scout the area, a smart one to
-            plan it, a mid one to implement, another to review, a cheap one to open the PR. Each
-            step picks its own provider and model, so you&apos;re never paying Opus prices to run a
-            grep.
+            Refactor incoming? Set up a sequence: a cheap model to scout, a smart one to plan, a mid
+            one to implement, another to review, and a final one to open the PR. Each step uses the
+            right model, so you&apos;re never paying Opus prices to run a grep.
           </p>
           <p className="mt-4">
-            Don&apos;t like that flow? Drag the steps around, swap the models, save it as your own.
+            Don&apos;t like that flow? Drag the steps around, swap models, and save it as your own.
           </p>
         </>
       }


### PR DESCRIPTION
Editorial pass on the marketing site copy plus doc/meta alignment.

## Website
- **Hero**: subhead to "in the same workspace"; "Shared goals, plans, and context..."; moved "Goodboy is free and open source." right above the Install button, "Runs on macOS..." below (desktop + mobile).
- **01 Sessions / 02 Context / 03 Studio / 04 GitHub / 05 Linear**: section titles reworded, trailing periods dropped, bodies tightened (less "in one place" repetition, "rail" removed, re-explain-yourself callback reused).
- **06**: "Everything else" / "The stuff that matters, kept short."; item blurbs rewritten.
- **Comparison**: header to "A layer, not a tool"; rows reworded (tied/micromanage/another tab/someone else's cloud/"machine, always").
- **Letter**: paragraphs updated.
- **CTA**: "you'll be running".

## Meta / docs
- `index.html`: og:description + twitter:description aligned to the new headline.
- `README.md`: provider-swap example now includes Gemini.
- `VISION.md`: provider list now includes Gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)