### PR TITLE
feat(desktop): per-provider api key auth + workspace bindings

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod path_env;
 mod permissions;
 mod planner;
 mod workflows;
+mod provider_credentials;
 mod provider_lifecycle;
 mod providers;
 mod repo;
@@ -101,6 +102,7 @@ pub fn run() {
       providers::get_gemini_status,
       providers::refresh_gemini_status,
       providers::check_provider_auth,
+      provider_credentials::provider_api_key_validate,
       provider_lifecycle::provider_lifecycle_run,
       provider_lifecycle::provider_lifecycle_write,
       provider_lifecycle::provider_lifecycle_resize,

--- a/apps/desktop/src-tauri/src/parallel_groups.rs
+++ b/apps/desktop/src-tauri/src/parallel_groups.rs
@@ -406,6 +406,10 @@ pub struct ParallelSpawnArgs {
     pub allowed_tools: Vec<String>,
     #[serde(default)]
     pub disallowed_tools: Vec<String>,
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+    #[serde(default)]
+    pub credential_id: Option<String>,
 }
 
 /// Spawn N child processes concurrently (one per `ParallelRunSpec`).
@@ -444,6 +448,8 @@ pub fn parallel_agent_spawn(
                 disallowed_tools: &args.disallowed_tools,
                 resume_session_id: None,
                 system_prompt: None,
+                api_key_env: args.api_key_env.as_deref(),
+                credential_id: args.credential_id.as_deref(),
             },
         ) {
             Ok(run_id) => run_ids.push(run_id),

--- a/apps/desktop/src-tauri/src/provider_credentials.rs
+++ b/apps/desktop/src-tauri/src/provider_credentials.rs
@@ -1,0 +1,98 @@
+use serde::Serialize;
+use std::time::Duration;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiKeyCheck {
+    pub valid: bool,
+    pub message: Option<String>,
+}
+
+enum Probe {
+    Header {
+        url: &'static str,
+        headers: Vec<(&'static str, String)>,
+    },
+    Query {
+        base: &'static str,
+        key: String,
+    },
+    Skip,
+}
+
+fn probe_for(provider_id: &str, api_key: &str) -> Probe {
+    match provider_id {
+        "anthropic" => Probe::Header {
+            url: "https://api.anthropic.com/v1/models?limit=1",
+            headers: vec![
+                ("x-api-key", api_key.to_string()),
+                ("anthropic-version", "2023-06-01".to_string()),
+            ],
+        },
+        "codex" => Probe::Header {
+            url: "https://api.openai.com/v1/models",
+            headers: vec![("authorization", format!("Bearer {api_key}"))],
+        },
+        "gemini" => Probe::Query {
+            base: "https://generativelanguage.googleapis.com/v1beta/models",
+            key: api_key.to_string(),
+        },
+        _ => Probe::Skip,
+    }
+}
+
+#[tauri::command]
+pub async fn provider_api_key_validate(
+    provider_id: String,
+    api_key: String,
+) -> Result<ApiKeyCheck, String> {
+    let key = api_key.trim();
+    if key.is_empty() {
+        return Ok(ApiKeyCheck {
+            valid: false,
+            message: Some("API key is empty".to_string()),
+        });
+    }
+
+    let probe = probe_for(&provider_id, key);
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let request = match probe {
+        Probe::Skip => {
+            return Ok(ApiKeyCheck {
+                valid: true,
+                message: None,
+            });
+        }
+        Probe::Header { url, headers } => {
+            let mut req = client.get(url);
+            for (name, value) in headers {
+                req = req.header(name, value);
+            }
+            req
+        }
+        Probe::Query { base, key } => client.get(base).query(&[("key", key.as_str())]),
+    };
+
+    let response = request.send().await.map_err(|e| e.to_string())?;
+    let status = response.status();
+    if status.is_success() {
+        return Ok(ApiKeyCheck {
+            valid: true,
+            message: None,
+        });
+    }
+
+    let message = match status.as_u16() {
+        401 | 403 => "API key rejected (unauthorized)".to_string(),
+        429 => "rate limited; key looks valid but could not confirm".to_string(),
+        other => format!("provider returned HTTP {other}"),
+    };
+    Ok(ApiKeyCheck {
+        valid: status.as_u16() == 429,
+        message: Some(message),
+    })
+}

--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -15,6 +15,19 @@ pub struct SettingsOverrides {
     pub parallel_enabled: Option<bool>,
     #[serde(rename = "defaultVerbosity")]
     pub default_verbosity: Option<String>,
+    #[serde(rename = "providerBindings")]
+    pub provider_bindings: Option<serde_json::Value>,
+}
+
+fn bindings_to_text(value: &Option<serde_json::Value>) -> Option<String> {
+    match value {
+        Some(serde_json::Value::Null) | None => None,
+        Some(v) => Some(v.to_string()),
+    }
+}
+
+fn bindings_from_text(raw: Option<String>) -> Option<serde_json::Value> {
+    raw.and_then(|s| serde_json::from_str(&s).ok())
 }
 
 #[tauri::command]
@@ -24,7 +37,7 @@ pub fn get_workspace_overrides(
 ) -> Result<Option<SettingsOverrides>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
-        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity
+        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings
          FROM workspaces WHERE id = ?1",
     )?;
     let mut rows = stmt.query_map(rusqlite::params![workspace_id], |row| {
@@ -35,6 +48,7 @@ pub fn get_workspace_overrides(
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
             default_verbosity: row.get(4)?,
+            provider_bindings: bindings_from_text(row.get(5)?),
         })
     })?;
     match rows.next() {
@@ -59,14 +73,16 @@ pub fn set_workspace_overrides(
              default_branch_prefix = ?3,
              parallel_enabled = ?4,
              default_verbosity = ?5,
-             updated_at = ?6
-         WHERE id = ?7",
+             provider_bindings = ?6,
+             updated_at = ?7
+         WHERE id = ?8",
         rusqlite::params![
             overrides.default_provider_id,
             overrides.default_workflow_id,
             overrides.default_branch_prefix,
             parallel_val,
             overrides.default_verbosity,
+            bindings_to_text(&overrides.provider_bindings),
             now,
             workspace_id,
         ],
@@ -81,7 +97,7 @@ pub fn get_session_overrides(
 ) -> Result<Option<SettingsOverrides>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
-        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
+        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, provider_bindings
          FROM sessions WHERE id = ?1",
     )?;
     let mut rows = stmt.query_map(rusqlite::params![session_id], |row| {
@@ -92,6 +108,7 @@ pub fn get_session_overrides(
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
             default_verbosity: None,
+            provider_bindings: bindings_from_text(row.get(4)?),
         })
     })?;
     match rows.next() {
@@ -115,13 +132,15 @@ pub fn set_session_overrides(
              default_workflow_id = ?2,
              default_branch_prefix = ?3,
              parallel_enabled = ?4,
-             updated_at = ?5
-         WHERE id = ?6",
+             provider_bindings = ?5,
+             updated_at = ?6
+         WHERE id = ?7",
         rusqlite::params![
             overrides.default_provider_id,
             overrides.default_workflow_id,
             overrides.default_branch_prefix,
             parallel_val,
+            bindings_to_text(&overrides.provider_bindings),
             now,
             session_id,
         ],

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -78,6 +78,10 @@ pub struct SpawnArgs {
     // Used to bias planner/implementer/debugger agents toward their role.
     #[serde(default)]
     pub system_prompt: Option<String>,
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+    #[serde(default)]
+    pub credential_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -228,6 +232,8 @@ pub struct SpawnOneArgs<'a> {
     pub disallowed_tools: &'a [String],
     pub resume_session_id: Option<&'a str>,
     pub system_prompt: Option<&'a str>,
+    pub api_key_env: Option<&'a str>,
+    pub credential_id: Option<&'a str>,
 }
 
 /// Spawns one child process, registers it in the registry, and starts the
@@ -252,6 +258,12 @@ pub(crate) fn spawn_one(
         .env_remove("CLAUDECODE")
         .env_remove("CLAUDE_CODE_ENTRYPOINT")
         .env_remove("CLAUDE_AGENT_SDK_VERSION");
+
+    if let (Some(env_name), Some(cred_id)) = (args.api_key_env, args.credential_id) {
+        if let Ok(Some(secret)) = crate::secrets::read(&format!("provider_credential.{cred_id}")) {
+            command.env(env_name, secret);
+        }
+    }
 
     let cli_args = build_provider_cli_args(args.binary, &args);
     for a in &cli_args {
@@ -334,6 +346,8 @@ pub fn turn_spawn(
             disallowed_tools: &args.disallowed_tools,
             resume_session_id: args.resume_session_id.as_deref(),
             system_prompt: args.system_prompt.as_deref(),
+            api_key_env: args.api_key_env.as_deref(),
+            credential_id: args.credential_id.as_deref(),
         },
     )
 }
@@ -466,6 +480,8 @@ mod tests {
             disallowed_tools: &disallowed,
             resume_session_id: None,
             system_prompt: None,
+            api_key_env: None,
+            credential_id: None,
         };
         assert_eq!(args.run_id, "run-1");
         assert_eq!(args.binary, "echo");
@@ -488,6 +504,8 @@ mod tests {
             disallowed_tools: empty,
             resume_session_id: resume,
             system_prompt,
+            api_key_env: None,
+            credential_id: None,
         }
     }
 
@@ -596,6 +614,8 @@ mod tests {
             disallowed_tools: &disallowed,
             resume_session_id: None,
             system_prompt: None,
+            api_key_env: None,
+            credential_id: None,
         };
         let cli = build_provider_cli_args("codex", &args);
         let out = std::process::Command::new("codex")

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { AppShell } from '@goodboy/ui';
-import type { SessionId } from '@goodboy/types';
+import type { ProviderId, SessionId } from '@goodboy/types';
 import { CommandPalette } from './features/session/components/CommandPalette';
 import { BootSplash } from './app/components/BootSplash';
 import { ChatView } from './features/chat/components/ChatView';
@@ -95,6 +95,7 @@ export function App() {
   const [workflowStudioOpen, setWorkflowStudioOpen] = useState(false);
   const [linearStudioOpen, setLinearStudioOpen] = useState(false);
   const [providerStudioOpen, setProviderStudioOpen] = useState(false);
+  const [providerStudioFocus, setProviderStudioFocus] = useState<ProviderId | null>(null);
   const [githubStudioOpen, setGithubStudioOpen] = useState(false);
   const [githubStudioSession, setGithubStudioSession] = useState<SessionId | null>(null);
   const [commitDiff, setCommitDiff] = useState<{ repo: string; sha: string } | null>(null);
@@ -156,7 +157,11 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const handler = () => setProviderStudioOpen(true);
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ providerId?: ProviderId }>).detail;
+      setProviderStudioFocus(detail?.providerId ?? null);
+      setProviderStudioOpen(true);
+    };
     window.addEventListener('goodboy:open-provider-studio', handler);
     return () => window.removeEventListener('goodboy:open-provider-studio', handler);
   }, []);
@@ -397,7 +402,10 @@ export function App() {
               onOpenPalette={openPalette}
               onOpenWorkflows={() => setWorkflowStudioOpen(true)}
               onOpenLinear={() => setLinearStudioOpen(true)}
-              onOpenProviders={() => setProviderStudioOpen(true)}
+              onOpenProviders={() => {
+                setProviderStudioFocus(null);
+                setProviderStudioOpen(true);
+              }}
               onOpenGithub={() => {
                 setGithubStudioSession(currentSession?.id ?? null);
                 setGithubStudioOpen(true);
@@ -504,6 +512,7 @@ export function App() {
       {providerStudioOpen && currentWorkspace ? (
         <ProviderStudio
           workspaceName={currentWorkspace.name}
+          initialFocus={providerStudioFocus}
           onClose={() => setProviderStudioOpen(false)}
         />
       ) : null}

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -524,7 +524,9 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
 
   const onSelectProvider = (id: ProviderId) => {
     if (!connectedProviderIds.includes(id)) {
-      window.dispatchEvent(new CustomEvent('goodboy:open-provider-studio'));
+      window.dispatchEvent(
+        new CustomEvent('goodboy:open-provider-studio', { detail: { providerId: id } }),
+      );
       return;
     }
     if (!allowOverride || isRunning) return;

--- a/apps/desktop/src/features/chat/turn.ts
+++ b/apps/desktop/src/features/chat/turn.ts
@@ -87,6 +87,8 @@ interface SpawnArgs {
   readonly permissionMode?: ClaudePermissionMode;
   readonly resumeSessionId?: string;
   readonly systemPrompt?: string;
+  readonly apiKeyEnv?: string;
+  readonly credentialId?: string;
 }
 
 type RawTurnEnvelope =
@@ -251,6 +253,8 @@ export interface ParallelSpawnArgs {
   readonly permissionMode?: ClaudePermissionMode;
   readonly allowedTools?: ReadonlyArray<string>;
   readonly disallowedTools?: ReadonlyArray<string>;
+  readonly apiKeyEnv?: string;
+  readonly credentialId?: string;
 }
 
 /**

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderBindingsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderBindingsSection.tsx
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import { Select } from '@goodboy/ui';
+import { FolderGit2 } from 'lucide-react';
+import { CLI_CREDENTIAL, type ProviderId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { SectionHeader } from './SectionHeader';
+
+interface Props {
+  readonly providerId: ProviderId;
+  readonly cliIdentity: string | null;
+}
+
+export function ProviderBindingsSection({ providerId, cliIdentity }: Props) {
+  const credentials = useAppStore((s) => s.providerCredentials);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const workspaceOverrides = useAppStore((s) => s.workspaceOverrides);
+  const setWorkspaceProviderBinding = useAppStore((s) => s.setWorkspaceProviderBinding);
+
+  const mine = useMemo(
+    () => credentials.filter((c) => c.providerId === providerId),
+    [credentials, providerId],
+  );
+  const connected = useMemo(() => workspaces.filter((w) => !w.disconnectedAt), [workspaces]);
+
+  if (mine.length === 0 || connected.length === 0) return null;
+
+  const cliLabel = cliIdentity ? `CLI login (${cliIdentity})` : 'CLI login';
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeader
+        label="Workspace credentials"
+        hint={`Pick which credential each workspace uses for ${providerId}.`}
+      />
+      <ul className="flex flex-col gap-2">
+        {connected.map((ws) => {
+          const bound = workspaceOverrides[ws.id]?.providerBindings?.[providerId] ?? CLI_CREDENTIAL;
+          const usingKey = bound !== CLI_CREDENTIAL;
+          return (
+            <li
+              key={ws.id}
+              className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/20 p-3"
+            >
+              <span
+                className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                aria-hidden
+              >
+                <FolderGit2 size={14} />
+              </span>
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-medium text-foreground">{ws.name}</span>
+                <span className="text-2xs text-muted-foreground/70">
+                  {usingKey ? 'billed to API key' : 'billed to CLI login'}
+                </span>
+              </div>
+              <div className="flex-1" />
+              <Select
+                size="sm"
+                value={bound}
+                onChange={(e) => {
+                  const next = e.target.value;
+                  void setWorkspaceProviderBinding(
+                    ws.id,
+                    providerId,
+                    next === CLI_CREDENTIAL ? null : next,
+                  );
+                }}
+              >
+                <option value={CLI_CREDENTIAL}>{cliLabel}</option>
+                {mine.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.label}
+                  </option>
+                ))}
+              </Select>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useMemo, useState } from 'react';
+import { Button, Input } from '@goodboy/ui';
+import { KeyRound, Loader2, Plus, Trash2 } from 'lucide-react';
+import { PROVIDER_API_KEY_ENV, type ProviderId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { SectionHeader } from './SectionHeader';
+
+interface Props {
+  readonly providerId: ProviderId;
+}
+
+export function ProviderCredentialsSection({ providerId }: Props) {
+  const credentials = useAppStore((s) => s.providerCredentials);
+  const createCredential = useAppStore((s) => s.createCredential);
+  const deleteCredential = useAppStore((s) => s.deleteCredential);
+
+  const mine = useMemo(
+    () => credentials.filter((c) => c.providerId === providerId),
+    [credentials, providerId],
+  );
+
+  const [adding, setAdding] = useState(false);
+  const [label, setLabel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setAdding(false);
+    setLabel('');
+    setApiKey('');
+    setError(null);
+  }, []);
+
+  const onSave = useCallback(async () => {
+    if (!apiKey.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await createCredential(providerId, label, apiKey);
+      reset();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [apiKey, label, providerId, createCredential, reset]);
+
+  return (
+    <section className="flex flex-col gap-2">
+      <SectionHeader
+        label="API keys"
+        hint={`Add one or more ${PROVIDER_API_KEY_ENV[providerId]} keys, then assign one to a workspace below to bill its runs to that key instead of the CLI login.`}
+        action={
+          !adding ? (
+            <button
+              type="button"
+              onClick={() => setAdding(true)}
+              className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <Plus size={12} aria-hidden /> Add key
+            </button>
+          ) : null
+        }
+      />
+
+      {mine.length === 0 && !adding ? (
+        <div className="flex flex-col items-center gap-1.5 rounded-lg border border-dashed border-border-soft bg-muted/10 px-6 py-8 text-center">
+          <KeyRound size={18} className="text-muted-foreground/70" aria-hidden />
+          <span className="text-2xs text-muted-foreground">No API keys yet</span>
+        </div>
+      ) : null}
+
+      {mine.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {mine.map((c) => (
+            <li
+              key={c.id}
+              className="group flex items-center gap-3 rounded-lg border border-border-soft bg-muted/20 p-3 transition-colors hover:bg-muted/30"
+            >
+              <span
+                className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground"
+                aria-hidden
+              >
+                <KeyRound size={14} />
+              </span>
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-sm font-medium text-foreground">{c.label}</span>
+                <span className="font-mono text-2xs text-muted-foreground/70">{c.hint}</span>
+              </div>
+              <div className="flex-1" />
+              <button
+                type="button"
+                aria-label={`Remove ${c.label}`}
+                onClick={() => void deleteCredential(c.id)}
+                className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-danger/10 hover:text-danger group-hover:opacity-100"
+              >
+                <Trash2 size={13} aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {adding ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-muted/20 p-3">
+          <Input
+            autoFocus
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            placeholder="Label (e.g. work, personal)"
+          />
+          <Input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={`${PROVIDER_API_KEY_ENV[providerId]} value`}
+          />
+          {error ? <p className="text-2xs text-danger">{error}</p> : null}
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="sm" onClick={reset} disabled={busy}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={() => void onSave()} disabled={busy || !apiKey.trim()}>
+              {busy ? <Loader2 size={13} className="animate-spin" aria-hidden /> : null}
+              {busy ? 'Validating' : 'Save key'}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { cn } from '@goodboy/ui';
+import { cn, Divider } from '@goodboy/ui';
 import {
   ArrowRight,
   Download,
@@ -15,6 +15,9 @@ import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
 import { openProviderModal } from '../ProviderModalHost';
+import { ProviderCredentialsSection } from './ProviderCredentialsSection';
+import { ProviderBindingsSection } from './ProviderBindingsSection';
+import { SectionHeader } from './SectionHeader';
 
 interface Props {
   readonly info: ProviderInfo | null;
@@ -58,7 +61,7 @@ function Detail({ info }: { readonly info: ProviderInfo }) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-center gap-3 px-6 py-4">
+      <div className="flex items-center gap-3 px-8 py-4">
         <span
           className="flex size-11 items-center justify-center rounded-xl"
           style={{ backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`, color }}
@@ -82,50 +85,63 @@ function Detail({ info }: { readonly info: ProviderInfo }) {
           <RotateCw size={14} className={refreshing ? 'animate-spin' : undefined} aria-hidden />
         </button>
       </div>
+      <Divider />
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
-        <p className="mb-2 text-2xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Accounts
-        </p>
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 py-6">
+          <section className="flex flex-col gap-2">
+            <SectionHeader label="Account" />
+            {inFlight ? (
+              <InFlightCard
+                label={lifecycle.phase}
+                onView={() =>
+                  openProviderModal({ providerId: id, action: lifecycle.action ?? 'install' })
+                }
+              />
+            ) : info.connection === 'error' ? (
+              <ErrorCard
+                message={info.error}
+                onRetry={() => void onRefresh()}
+                retrying={refreshing}
+              />
+            ) : info.connection === 'missing' ? (
+              <EmptyCard
+                icon={Download}
+                title={`${info.label} CLI not installed`}
+                description="Install the CLI to connect an account from Goodboy."
+                ctaLabel={`Install ${info.label}`}
+                onCta={() => openProviderModal({ providerId: id, action: 'install' })}
+              />
+            ) : info.connection === 'connected' ? (
+              <ConnectedAccount
+                identity={info.identity}
+                confirmDisconnect={confirmDisconnect}
+                onReauth={() => openProviderModal({ providerId: id, action: 'login' })}
+                onAskDisconnect={() => setConfirmDisconnect(true)}
+                onCancelDisconnect={() => setConfirmDisconnect(false)}
+                onConfirmDisconnect={() => {
+                  setConfirmDisconnect(false);
+                  void logoutProvider(id);
+                }}
+              />
+            ) : (
+              <EmptyCard
+                icon={LogIn}
+                title="No account connected"
+                description="Sign in to connect an account. Every step runs in the embedded terminal."
+                ctaLabel="Connect account"
+                onCta={() => openProviderModal({ providerId: id, action: 'login' })}
+              />
+            )}
+          </section>
 
-        {inFlight ? (
-          <InFlightCard
-            label={lifecycle.phase}
-            onView={() =>
-              openProviderModal({ providerId: id, action: lifecycle.action ?? 'install' })
-            }
-          />
-        ) : info.connection === 'error' ? (
-          <ErrorCard message={info.error} onRetry={() => void onRefresh()} retrying={refreshing} />
-        ) : info.connection === 'missing' ? (
-          <EmptyCard
-            icon={Download}
-            title={`${info.label} CLI not installed`}
-            description="Install the CLI to connect an account from Goodboy."
-            ctaLabel={`Install ${info.label}`}
-            onCta={() => openProviderModal({ providerId: id, action: 'install' })}
-          />
-        ) : info.connection === 'connected' ? (
-          <ConnectedAccount
-            identity={info.identity}
-            confirmDisconnect={confirmDisconnect}
-            onReauth={() => openProviderModal({ providerId: id, action: 'login' })}
-            onAskDisconnect={() => setConfirmDisconnect(true)}
-            onCancelDisconnect={() => setConfirmDisconnect(false)}
-            onConfirmDisconnect={() => {
-              setConfirmDisconnect(false);
-              void logoutProvider(id);
-            }}
-          />
-        ) : (
-          <EmptyCard
-            icon={LogIn}
-            title="No account connected"
-            description="Sign in to connect an account. Every step runs in the embedded terminal."
-            ctaLabel="Connect account"
-            onCta={() => openProviderModal({ providerId: id, action: 'login' })}
-          />
-        )}
+          {info.connection !== 'missing' ? (
+            <>
+              <ProviderCredentialsSection providerId={id} />
+              <ProviderBindingsSection providerId={id} cliIdentity={info.identity} />
+            </>
+          ) : null}
+        </div>
       </div>
     </div>
   );
@@ -147,7 +163,7 @@ function ConnectedAccount({
   readonly onConfirmDisconnect: () => void;
 }) {
   return (
-    <div className="flex items-center gap-3 rounded-lg border bg-subtle p-4 shadow-sm">
+    <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/20 p-4">
       <span className="size-2 shrink-0 rounded-full bg-success" aria-hidden />
       <div className="flex min-w-0 flex-col">
         <span className="truncate text-sm font-medium text-foreground">
@@ -207,7 +223,7 @@ function EmptyCard({
   readonly onCta: () => void;
 }) {
   return (
-    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed bg-subtle/50 px-6 py-10 text-center">
+    <div className="flex flex-col items-center gap-3 rounded-lg border border-dashed border-border-soft bg-muted/10 px-6 py-10 text-center">
       <span className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
         <Icon size={18} aria-hidden />
       </span>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/SectionHeader.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/SectionHeader.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  readonly label: string;
+  readonly hint?: string;
+  readonly action?: ReactNode;
+}
+
+export function SectionHeader({ label, hint, action }: Props) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center justify-between">
+        <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          {label}
+        </span>
+        {action ?? null}
+      </div>
+      {hint ? <p className="text-2xs text-muted-foreground/70">{hint}</p> : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
@@ -12,12 +12,13 @@ const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 interface Props {
   readonly workspaceName: string;
+  readonly initialFocus?: ProviderId | null;
   readonly onClose: () => void;
 }
 
-export function ProviderStudio({ workspaceName, onClose }: Props) {
+export function ProviderStudio({ workspaceName, initialFocus, onClose }: Props) {
   const providers = useAppStore((s) => s.providers);
-  const [focused, setFocused] = useState<ProviderId | null>(null);
+  const [focused, setFocused] = useState<ProviderId | null>(initialFocus ?? null);
 
   const ordered = PROVIDER_ORDER.map((id) => providers.find((p) => p.id === id)).filter(
     (p): p is ProviderInfo => p !== undefined,

--- a/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSettingsDialog/index.tsx
@@ -135,6 +135,7 @@ export function WorkspaceSettingsDialog({
         defaultBranchPrefix: wsOverrides?.defaultBranchPrefix ?? null,
         parallelEnabled: wsOverrides?.parallelEnabled ?? null,
         defaultVerbosity: verbosity,
+        providerBindings: wsOverrides?.providerBindings ?? null,
       };
       await storeSetWorkspaceOverrides(workspaceId, mergedOverrides);
       setSavedVerbosity(verbosity);

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -224,6 +224,8 @@ export interface RunParallelBranchDeps {
   readonly permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'dontAsk' | 'plan';
   readonly allowedTools?: ReadonlyArray<string>;
   readonly disallowedTools?: ReadonlyArray<string>;
+  readonly apiKeyEnv?: string;
+  readonly credentialId?: string;
   readonly effects: ParallelBranchEffects;
 }
 
@@ -370,6 +372,8 @@ export async function runParallelBranch(
       ...(deps.permissionMode !== undefined && { permissionMode: deps.permissionMode }),
       ...(deps.allowedTools !== undefined && { allowedTools: deps.allowedTools }),
       ...(deps.disallowedTools !== undefined && { disallowedTools: deps.disallowedTools }),
+      ...(deps.apiKeyEnv !== undefined && { apiKeyEnv: deps.apiKeyEnv }),
+      ...(deps.credentialId !== undefined && { credentialId: deps.credentialId }),
     });
   });
 

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -93,6 +93,9 @@ export function hydrate(set: SetFn, get: GetFn) {
         set({ authResults, providers: buildProviderList(statuses, authResults) });
 
         set({ bootPhase: 'loading-workspaces' });
+        await get()
+          .loadCredentials()
+          .catch(() => {});
         const workspaces = await listWorkspaces(tauriDatabase);
         set({ workspaces });
         // Hydrate integrations cache for every active workspace so the

--- a/apps/desktop/src/store/slices/credentials/createCredential.ts
+++ b/apps/desktop/src/store/slices/credentials/createCredential.ts
@@ -1,0 +1,38 @@
+import { invoke } from '@tauri-apps/api/core';
+import { insertProviderCredential } from '@goodboy/db';
+import type { CredentialId, IsoDateTime, ProviderCredential, ProviderId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { credentialSecretKey, maskApiKey } from './credentialKey';
+import type { SetFn } from './types';
+
+interface ApiKeyCheck {
+  readonly valid: boolean;
+  readonly message: string | null;
+}
+
+export function createCredential(set: SetFn) {
+  return async (
+    providerId: ProviderId,
+    label: string,
+    apiKey: string,
+  ): Promise<ProviderCredential> => {
+    const check = await invoke<ApiKeyCheck>('provider_api_key_validate', {
+      providerId,
+      apiKey: apiKey.trim(),
+    });
+    if (!check.valid) {
+      throw new Error(check.message ?? 'API key validation failed');
+    }
+    const credential: ProviderCredential = {
+      id: crypto.randomUUID() as CredentialId,
+      providerId,
+      label: label.trim() || 'api key',
+      hint: maskApiKey(apiKey),
+      createdAt: new Date().toISOString() as IsoDateTime,
+    };
+    await invoke('secret_set', { key: credentialSecretKey(credential.id), value: apiKey.trim() });
+    await insertProviderCredential(tauriDatabase, credential);
+    set((state) => ({ providerCredentials: [...state.providerCredentials, credential] }));
+    return credential;
+  };
+}

--- a/apps/desktop/src/store/slices/credentials/credentialKey.ts
+++ b/apps/desktop/src/store/slices/credentials/credentialKey.ts
@@ -1,0 +1,10 @@
+import type { CredentialId } from '@goodboy/types';
+
+export function credentialSecretKey(id: CredentialId): string {
+  return `provider_credential.${id}`;
+}
+
+export function maskApiKey(value: string): string {
+  const tail = value.trim().slice(-4);
+  return tail ? `••••${tail}` : '••••';
+}

--- a/apps/desktop/src/store/slices/credentials/deleteCredential.ts
+++ b/apps/desktop/src/store/slices/credentials/deleteCredential.ts
@@ -1,0 +1,38 @@
+import { invoke } from '@tauri-apps/api/core';
+import { deleteProviderCredential } from '@goodboy/db';
+import type { CredentialId, OverrideSettings, WorkspaceId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { credentialSecretKey } from './credentialKey';
+import type { GetFn, SetFn } from './types';
+
+export function deleteCredential(set: SetFn, get: GetFn) {
+  return async (id: CredentialId): Promise<void> => {
+    await invoke('secret_delete', { key: credentialSecretKey(id) });
+    await deleteProviderCredential(tauriDatabase, id);
+
+    const nextOverrides = { ...get().workspaceOverrides };
+    const scrubbed: Array<[WorkspaceId, OverrideSettings]> = [];
+    for (const [wsId, override] of Object.entries(get().workspaceOverrides)) {
+      const bindings = override.providerBindings;
+      if (!bindings || !Object.values(bindings).includes(id)) continue;
+      const cleaned = Object.fromEntries(
+        Object.entries(bindings).filter(([, credId]) => credId !== id),
+      );
+      const next: OverrideSettings = {
+        ...override,
+        providerBindings: Object.keys(cleaned).length > 0 ? cleaned : null,
+      };
+      nextOverrides[wsId as WorkspaceId] = next;
+      scrubbed.push([wsId as WorkspaceId, next]);
+    }
+
+    for (const [wsId, override] of scrubbed) {
+      await invoke('set_workspace_overrides', { workspaceId: wsId, overrides: override });
+    }
+
+    set((state) => ({
+      providerCredentials: state.providerCredentials.filter((c) => c.id !== id),
+      workspaceOverrides: nextOverrides,
+    }));
+  };
+}

--- a/apps/desktop/src/store/slices/credentials/index.ts
+++ b/apps/desktop/src/store/slices/credentials/index.ts
@@ -1,0 +1,14 @@
+import { createCredential } from './createCredential';
+import { deleteCredential } from './deleteCredential';
+import { loadCredentials } from './loadCredentials';
+import { renameCredential } from './renameCredential';
+import type { GetFn, SetFn } from './types';
+
+export function createCredentialsSlice(set: SetFn, get: GetFn) {
+  return {
+    loadCredentials: loadCredentials(set),
+    createCredential: createCredential(set),
+    deleteCredential: deleteCredential(set, get),
+    renameCredential: renameCredential(set),
+  };
+}

--- a/apps/desktop/src/store/slices/credentials/loadCredentials.ts
+++ b/apps/desktop/src/store/slices/credentials/loadCredentials.ts
@@ -1,0 +1,10 @@
+import { listProviderCredentials } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+export function loadCredentials(set: SetFn) {
+  return async (): Promise<void> => {
+    const credentials = await listProviderCredentials(tauriDatabase);
+    set({ providerCredentials: credentials });
+  };
+}

--- a/apps/desktop/src/store/slices/credentials/renameCredential.ts
+++ b/apps/desktop/src/store/slices/credentials/renameCredential.ts
@@ -1,0 +1,16 @@
+import { renameProviderCredential } from '@goodboy/db';
+import type { CredentialId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+export function renameCredential(set: SetFn) {
+  return async (id: CredentialId, label: string): Promise<void> => {
+    const trimmed = label.trim() || 'api key';
+    await renameProviderCredential(tauriDatabase, id, trimmed);
+    set((state) => ({
+      providerCredentials: state.providerCredentials.map((c) =>
+        c.id === id ? { ...c, label: trimmed } : c,
+      ),
+    }));
+  };
+}

--- a/apps/desktop/src/store/slices/credentials/types.ts
+++ b/apps/desktop/src/store/slices/credentials/types.ts
@@ -1,0 +1,1 @@
+export type { SetFn, GetFn } from '../../slice-types';

--- a/apps/desktop/src/store/slices/overrides/index.ts
+++ b/apps/desktop/src/store/slices/overrides/index.ts
@@ -2,12 +2,14 @@ import { loadSessionOverrides } from './loadSessionOverrides';
 import { loadWorkspaceOverrides } from './loadWorkspaceOverrides';
 import { setTaskOverrides } from './setTaskOverrides';
 import { setWorkspaceOverrides } from './setWorkspaceOverrides';
+import { setWorkspaceProviderBinding } from './setWorkspaceProviderBinding';
 import type { GetFn, SetFn } from './types';
 
-export function createOverridesSlice(set: SetFn, _get: GetFn) {
+export function createOverridesSlice(set: SetFn, get: GetFn) {
   return {
     loadWorkspaceOverrides: loadWorkspaceOverrides(set),
     setWorkspaceOverrides: setWorkspaceOverrides(set),
+    setWorkspaceProviderBinding: setWorkspaceProviderBinding(set, get),
     loadSessionOverrides: loadSessionOverrides(set),
     setTaskOverrides: setTaskOverrides(set),
   };

--- a/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
+++ b/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
@@ -1,0 +1,36 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { OverrideSettings, ProviderId, WorkspaceId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+const EMPTY_OVERRIDE: OverrideSettings = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+};
+
+export function setWorkspaceProviderBinding(set: SetFn, get: GetFn) {
+  return async (
+    workspaceId: WorkspaceId,
+    providerId: ProviderId,
+    credentialId: string | null,
+  ): Promise<void> => {
+    const current = get().workspaceOverrides[workspaceId] ?? EMPTY_OVERRIDE;
+    const bindings = { ...(current.providerBindings ?? {}) };
+    if (credentialId === null) {
+      delete bindings[providerId];
+    } else {
+      bindings[providerId] = credentialId;
+    }
+    const next: OverrideSettings = {
+      ...current,
+      providerBindings: Object.keys(bindings).length > 0 ? bindings : null,
+    };
+    await invoke('set_workspace_overrides', { workspaceId, overrides: next });
+    set((state) => ({
+      workspaceOverrides: { ...state.workspaceOverrides, [workspaceId]: next },
+    }));
+  };
+}

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -51,6 +51,7 @@ import type {
   TurnState,
   Workflow,
 } from '@goodboy/types';
+import { CLI_CREDENTIAL, PROVIDER_API_KEY_ENV } from '@goodboy/types';
 import { useOpenQuestions } from '../../../features/context/components/QuestionsTab/useOpenQuestions';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeBudgetAlertsList, invokeBudgetRuleList } from '../../../features/budget/budget';
@@ -374,8 +375,16 @@ export function sendTurn(set: SetFn, get: GetFn) {
         ? phaseDefinition.modelOverride
         : (agentKindModel ?? routingDecision.selectedModel);
 
+    const wsBindings = get().workspaceOverrides[session.workspaceId]?.providerBindings ?? {};
+    const sessBindings = get().sessionOverrides[sessionId]?.providerBindings ?? {};
+    const boundCredentialId = { ...wsBindings, ...sessBindings }[provider];
+    const apiKeyBinding =
+      boundCredentialId && boundCredentialId !== CLI_CREDENTIAL
+        ? { apiKeyEnv: PROVIDER_API_KEY_ENV[provider], credentialId: boundCredentialId }
+        : undefined;
+
     const authState = get().authResults?.[provider] ?? null;
-    if (authState?.state === 'disconnected') {
+    if (authState?.state === 'disconnected' && !apiKeyBinding) {
       const runId = crypto.randomUUID() as ProviderRunId;
       get().appendTurnEvent(activeAgentId, sessionId, {
         kind: 'error',
@@ -642,6 +651,7 @@ export function sendTurn(set: SetFn, get: GetFn) {
             ...(claudeFlags.disallowedTools !== undefined && {
               disallowedTools: claudeFlags.disallowedTools,
             }),
+            ...(apiKeyBinding ?? {}),
             effects,
           },
         );
@@ -794,6 +804,7 @@ export function sendTurn(set: SetFn, get: GetFn) {
         binary: providerInfo?.binary,
         ...(resumeSessionId !== undefined && { resumeSessionId }),
         systemPrompt: fullSystemPrompt,
+        ...(apiKeyBinding ?? {}),
         ...claudeFlags,
       })) {
         get().appendTurnEvent(activeAgentId, sessionId, event);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -38,6 +38,8 @@ import type {
   Workflow,
   WorkflowId,
   ProviderId,
+  ProviderCredential,
+  CredentialId,
   ProviderRunId,
   ResolvedSettings,
   VerbosityLevel,
@@ -102,6 +104,7 @@ import {
 import { createAgentsSlice } from './slices/agents';
 import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
+import { createCredentialsSlice } from './slices/credentials';
 import { createWorkflowsSlice } from './slices/workflows';
 import { createSettingsSlice } from './slices/settings';
 import { createConflictsSlice } from './slices/conflicts';
@@ -183,6 +186,7 @@ export interface AppState extends UpdaterState {
   readonly authResults: ProviderAuthResults | null;
   readonly providers: ReadonlyArray<ProviderInfo>;
   readonly providerLifecycle: ProviderLifecycleMap;
+  readonly providerCredentials: ReadonlyArray<ProviderCredential>;
   readonly hydrated: boolean;
   readonly bootPhase: BootPhase;
   readonly error: string | null;
@@ -473,8 +477,21 @@ export interface AppActions {
   ): Promise<void>;
   loadWorkspaceOverrides(workspaceId: WorkspaceId): Promise<void>;
   setWorkspaceOverrides(workspaceId: WorkspaceId, overrides: OverrideSettings): Promise<void>;
+  setWorkspaceProviderBinding(
+    workspaceId: WorkspaceId,
+    providerId: ProviderId,
+    credentialId: string | null,
+  ): Promise<void>;
   loadSessionOverrides(sessionId: SessionId): Promise<void>;
   setTaskOverrides(sessionId: SessionId, overrides: OverrideSettings): Promise<void>;
+  loadCredentials(): Promise<void>;
+  createCredential(
+    providerId: ProviderId,
+    label: string,
+    apiKey: string,
+  ): Promise<ProviderCredential>;
+  deleteCredential(id: CredentialId): Promise<void>;
+  renameCredential(id: CredentialId, label: string): Promise<void>;
   setAgentVerbosity(sessionId: SessionId, agentId: AgentId, level: VerbosityLevel): Promise<void>;
   renameTask(sessionId: SessionId, goal: string): Promise<void>;
   autoTitleSession(sessionId: SessionId, title: string): Promise<void>;
@@ -602,6 +619,7 @@ export const initialState: AppState = {
   authResults: null,
   providers: buildProviderList({ anthropic: null, cursor: null, codex: null, gemini: null }),
   providerLifecycle: INITIAL_LIFECYCLE_MAP,
+  providerCredentials: [],
   hydrated: false,
   bootPhase: 'pending',
   error: null,
@@ -681,6 +699,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createAgentsSlice(set, get),
   ...createSlotsSlice(set, get),
   ...createOverridesSlice(set, get),
+  ...createCredentialsSlice(set, get),
   ...createWorkflowsSlice(set, get),
   ...createSettingsSlice(set, get),
   ...createConflictsSlice(set, get),

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -18,6 +18,7 @@ const NULL_OVERRIDE: OverrideSettings = {
   defaultBranchPrefix: null,
   parallelEnabled: null,
   defaultVerbosity: null,
+  providerBindings: null,
 };
 
 describe('resolveSettings', () => {
@@ -36,6 +37,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: true,
       defaultVerbosity: 'verbose',
+      providerBindings: null,
     };
     const result = resolveSettings({ global: GLOBAL, workspaceOverride: wsOverride });
     expect(result.defaultProviderId).toBe('cursor');
@@ -52,6 +54,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: 'sess-prefix',
       parallelEnabled: true,
       defaultVerbosity: null,
+      providerBindings: null,
     };
     const result = resolveSettings({ global: GLOBAL, sessionOverride: sessOverride });
     expect(result.defaultProviderId).toBe('codex');
@@ -68,6 +71,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: false,
       defaultVerbosity: 'verbose',
+      providerBindings: null,
     };
     const sessOverride: OverrideSettings = {
       defaultProviderId: 'codex' as ProviderId,
@@ -75,6 +79,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: 'sess-prefix',
       parallelEnabled: true,
       defaultVerbosity: null,
+      providerBindings: null,
     };
     const result = resolveSettings({
       global: GLOBAL,
@@ -95,6 +100,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: 'ws-prefix',
       parallelEnabled: true,
       defaultVerbosity: 'verbose',
+      providerBindings: null,
     };
     const sessOverride: OverrideSettings = {
       defaultProviderId: null,
@@ -102,6 +108,7 @@ describe('resolveSettings', () => {
       defaultBranchPrefix: null,
       parallelEnabled: null,
       defaultVerbosity: null,
+      providerBindings: null,
     };
     const result = resolveSettings({
       global: GLOBAL,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -147,6 +147,12 @@ export {
   setSessionOverrides,
 } from './queries/settings-overrides';
 export {
+  listProviderCredentials,
+  insertProviderCredential,
+  renameProviderCredential,
+  deleteProviderCredential,
+} from './queries/provider-credential';
+export {
   getGithubPrCache,
   upsertGithubPrCache,
   deleteGithubPrCache,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -47,6 +47,8 @@ import { m046StepRole } from './m046-step-role';
 import { m047AgentParent } from './m047-agent-parent';
 import { m048PlanClusters } from './m048-plan-clusters';
 import { m049SessionWorkflowDiscard } from './m049-session-workflow-discard';
+import { m050ProviderCredentials } from './m050-provider-credentials';
+import { m051ProviderBindings } from './m051-provider-bindings';
 
 export interface Migration {
   readonly version: number;
@@ -103,4 +105,6 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 47, sql: m047AgentParent },
   { version: 48, sql: m048PlanClusters },
   { version: 49, sql: m049SessionWorkflowDiscard },
+  { version: 50, sql: m050ProviderCredentials },
+  { version: 51, sql: m051ProviderBindings },
 ];

--- a/packages/db/src/migrations/m050-provider-credentials.ts
+++ b/packages/db/src/migrations/m050-provider-credentials.ts
@@ -1,0 +1,10 @@
+export const m050ProviderCredentials = /* sql */ `
+CREATE TABLE IF NOT EXISTS provider_credentials (
+  id TEXT PRIMARY KEY,
+  provider_id TEXT NOT NULL,
+  label TEXT NOT NULL,
+  hint TEXT NOT NULL DEFAULT '',
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_provider_credentials_provider_id ON provider_credentials(provider_id);
+`;

--- a/packages/db/src/migrations/m051-provider-bindings.ts
+++ b/packages/db/src/migrations/m051-provider-bindings.ts
@@ -1,0 +1,4 @@
+export const m051ProviderBindings = /* sql */ `
+ALTER TABLE workspaces ADD COLUMN provider_bindings TEXT;
+ALTER TABLE sessions ADD COLUMN provider_bindings TEXT;
+`;

--- a/packages/db/src/queries/provider-credential.ts
+++ b/packages/db/src/queries/provider-credential.ts
@@ -1,0 +1,58 @@
+import type { CredentialId, IsoDateTime, ProviderCredential, ProviderId } from '@goodboy/types';
+import type { Database } from '../client';
+
+interface ProviderCredentialRow {
+  id: string;
+  provider_id: string;
+  label: string;
+  hint: string;
+  created_at: number;
+}
+
+function toDomain(row: ProviderCredentialRow): ProviderCredential {
+  return {
+    id: row.id as CredentialId,
+    providerId: row.provider_id as ProviderId,
+    label: row.label,
+    hint: row.hint,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+  };
+}
+
+export async function listProviderCredentials(
+  db: Database,
+): Promise<ReadonlyArray<ProviderCredential>> {
+  const rows = await db.select<ProviderCredentialRow>(
+    'SELECT * FROM provider_credentials ORDER BY created_at ASC',
+  );
+  return rows.map(toDomain);
+}
+
+export async function insertProviderCredential(
+  db: Database,
+  credential: ProviderCredential,
+): Promise<void> {
+  await db.execute(
+    `INSERT INTO provider_credentials (id, provider_id, label, hint, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+    [
+      credential.id,
+      credential.providerId,
+      credential.label,
+      credential.hint,
+      Date.parse(credential.createdAt),
+    ],
+  );
+}
+
+export async function renameProviderCredential(
+  db: Database,
+  id: CredentialId,
+  label: string,
+): Promise<void> {
+  await db.execute('UPDATE provider_credentials SET label = ? WHERE id = ?', [label, id]);
+}
+
+export async function deleteProviderCredential(db: Database, id: CredentialId): Promise<void> {
+  await db.execute('DELETE FROM provider_credentials WHERE id = ?', [id]);
+}

--- a/packages/db/src/queries/settings-overrides.ts
+++ b/packages/db/src/queries/settings-overrides.ts
@@ -1,5 +1,6 @@
 import type {
   OverrideSettings,
+  ProviderBindings,
   SessionId,
   VerbosityLevel,
   WorkflowId,
@@ -14,6 +15,7 @@ interface WorkspaceOverrideRow {
   default_branch_prefix: string | null;
   parallel_enabled: number | null;
   default_verbosity: string | null;
+  provider_bindings: string | null;
 }
 
 interface SessionOverrideRow {
@@ -21,6 +23,20 @@ interface SessionOverrideRow {
   default_workflow_id: string | null;
   default_branch_prefix: string | null;
   parallel_enabled: number | null;
+  provider_bindings: string | null;
+}
+
+function parseBindings(raw: string | null): ProviderBindings | null {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ProviderBindings;
+  } catch {
+    return null;
+  }
+}
+
+function serializeBindings(bindings: ProviderBindings | null): string | null {
+  return bindings && Object.keys(bindings).length > 0 ? JSON.stringify(bindings) : null;
 }
 
 function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
@@ -30,6 +46,7 @@ function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
     defaultBranchPrefix: row.default_branch_prefix,
     parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
     defaultVerbosity: row.default_verbosity as VerbosityLevel | null,
+    providerBindings: parseBindings(row.provider_bindings),
   };
 }
 
@@ -40,6 +57,7 @@ function sessionRowToOverride(row: SessionOverrideRow): OverrideSettings {
     defaultBranchPrefix: row.default_branch_prefix,
     parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
     defaultVerbosity: null,
+    providerBindings: parseBindings(row.provider_bindings),
   };
 }
 
@@ -48,7 +66,7 @@ export async function getWorkspaceOverrides(
   workspaceId: WorkspaceId,
 ): Promise<OverrideSettings | null> {
   const rows = await db.select<WorkspaceOverrideRow>(
-    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity
+    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings
      FROM workspaces WHERE id = ?`,
     [workspaceId],
   );
@@ -68,6 +86,7 @@ export async function setWorkspaceOverrides(
          default_branch_prefix = ?,
          parallel_enabled = ?,
          default_verbosity = ?,
+         provider_bindings = ?,
          updated_at = ?
      WHERE id = ?`,
     [
@@ -76,6 +95,7 @@ export async function setWorkspaceOverrides(
       overrides.defaultBranchPrefix,
       overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
       overrides.defaultVerbosity,
+      serializeBindings(overrides.providerBindings),
       Date.now(),
       workspaceId,
     ],
@@ -87,7 +107,7 @@ export async function getSessionOverrides(
   sessionId: SessionId,
 ): Promise<OverrideSettings | null> {
   const rows = await db.select<SessionOverrideRow>(
-    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled
+    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, provider_bindings
      FROM sessions WHERE id = ?`,
     [sessionId],
   );
@@ -106,6 +126,7 @@ export async function setSessionOverrides(
          default_workflow_id = ?,
          default_branch_prefix = ?,
          parallel_enabled = ?,
+         provider_bindings = ?,
          updated_at = ?
      WHERE id = ?`,
     [
@@ -113,6 +134,7 @@ export async function setSessionOverrides(
       overrides.defaultWorkflowId,
       overrides.defaultBranchPrefix,
       overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
+      serializeBindings(overrides.providerBindings),
       Date.now(),
       sessionId,
     ],

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -19,3 +19,5 @@ export type PermissionRequestId = string & { readonly __brand: 'PermissionReques
 
 export type OpenQuestionId = string & { readonly __brand: 'OpenQuestionId' };
 export type WorkspaceIntegrationId = string & { readonly __brand: 'WorkspaceIntegrationId' };
+
+export type CredentialId = string & { readonly __brand: 'CredentialId' };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   AgentId,
+  CredentialId,
   IsoDateTime,
   MessageId,
   OpenQuestionId,
@@ -54,6 +55,9 @@ export type {
   ProviderId,
   ProviderRegistryCapabilities,
 } from './provider-registry';
+export { PROVIDER_API_KEY_ENV } from './provider-registry';
+export type { ProviderCredential } from './provider-credential';
+export { CLI_CREDENTIAL } from './provider-credential';
 export type {
   ProviderLifecycleAction,
   ProviderLifecycleCommands,
@@ -91,6 +95,7 @@ export type {
 export type {
   GlobalSettings,
   OverrideSettings,
+  ProviderBindings,
   ResolvedSettings,
   SettingsScope,
   VerbosityLevel,

--- a/packages/types/src/provider-credential.ts
+++ b/packages/types/src/provider-credential.ts
@@ -1,0 +1,12 @@
+import type { CredentialId, IsoDateTime } from './ids';
+import type { ProviderId } from './provider-registry';
+
+export const CLI_CREDENTIAL = 'cli';
+
+export interface ProviderCredential {
+  readonly id: CredentialId;
+  readonly providerId: ProviderId;
+  readonly label: string;
+  readonly hint: string;
+  readonly createdAt: IsoDateTime;
+}

--- a/packages/types/src/provider-registry.ts
+++ b/packages/types/src/provider-registry.ts
@@ -23,3 +23,10 @@ export interface ProviderInfo {
   readonly version: string | null;
   readonly identity: string | null;
 }
+
+export const PROVIDER_API_KEY_ENV: Record<ProviderId, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  cursor: 'CURSOR_API_KEY',
+  codex: 'OPENAI_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+};

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -3,6 +3,8 @@ import type { ProviderId } from './provider-registry';
 
 export type VerbosityLevel = 'brief' | 'normal' | 'verbose';
 
+export type ProviderBindings = Partial<Record<ProviderId, string>>;
+
 /** Fields that can be overridden at workspace or session scope. Null = inherit from parent. */
 export type OverrideSettings = Readonly<{
   defaultProviderId: ProviderId | null;
@@ -10,6 +12,7 @@ export type OverrideSettings = Readonly<{
   defaultBranchPrefix: string | null;
   parallelEnabled: boolean | null;
   defaultVerbosity: VerbosityLevel | null;
+  providerBindings: ProviderBindings | null;
 }>;
 
 /** Fully-resolved settings after applying global → workspace → session cascade. */

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -159,6 +159,9 @@ export function Dialog({
     <dialog
       ref={ref}
       onClick={onBackdropClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') e.stopPropagation();
+      }}
       aria-labelledby={titleId}
       aria-describedby={descId}
       className={cn(


### PR DESCRIPTION
## What

Adds API-key authentication for each provider **alongside** the existing CLI login (parallel, not a replacement). Reuses the binding model from the reverted multi-account epic, but swaps per-account HOME isolation (the part that broke the macOS keychain) for **API key in keychain + env var injection** at spawn, so that regression does not recur.

## How it works

- store N API keys per provider (claude / cursor / codex / gemini): secret value in the OS keychain (`provider_credential.<id>`), metadata + masked hint in SQLite (`provider_credentials`)
- per-workspace binding (`provider_bindings` JSON on workspaces/sessions) selects which credential authenticates each provider: CLI login (default) or one of the keys
- at spawn (`turn.rs` / `parallel_groups.rs`) the bound key is read from the keychain and injected as the provider env var (`ANTHROPIC_API_KEY` / `CURSOR_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY`); the secret never round-trips through the frontend, only the credential id does
- the disconnected-CLI auth gate is bypassed when a key is bound, so a workspace can run on a key with no CLI login
- live key validation before save for claude/codex/gemini (`provider_api_key_validate` hits each provider's `/models`); cursor has no reliable cheap endpoint, so it is saved without a check

## Also in here

- model-picker chip for a disconnected provider opens Provider Studio focused on that provider (was defaulting to cursor)
- Provider Studio detail redesigned to match GitHub Studio (centered, shared section headers, `Account` singular)
- `Dialog` swallows Escape so a modal no longer closes the studio beneath it

## Migrations

- `m050` `provider_credentials` table
- `m051` `provider_bindings` columns on workspaces + sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)