### PR TITLE
chore(desktop): polish user-facing copy to match website tone

### DIFF
--- a/apps/desktop/src/app/components/BootSplash/index.tsx
+++ b/apps/desktop/src/app/components/BootSplash/index.tsx
@@ -158,7 +158,7 @@ export function BootSplash({
         <div className="flex flex-col items-center gap-0.5">
           <span className="text-lg font-bold tracking-tight">Goodboy</span>
           <span className="text-[11px] uppercase tracking-widest text-muted-foreground/60">
-            AI workspace orchestrator
+            workspace orchestrator for coding agents
           </span>
         </div>
       </div>

--- a/apps/desktop/src/features/budget/components/BudgetRulesPanel/index.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetRulesPanel/index.tsx
@@ -44,15 +44,15 @@ export function BudgetRulesPanel() {
     const extraTokens = extraRaw === '' ? null : parseFloat(extraRaw);
 
     if (!isFinite(cap) || cap <= 0) {
-      setFormError('cap must be a positive number');
+      setFormError('Cap must be a positive number');
       return;
     }
     if (!isFinite(threshold) || threshold < 1 || threshold > 100) {
-      setFormError('threshold must be between 1 and 100');
+      setFormError('Threshold must be between 1 and 100');
       return;
     }
     if (extraTokens !== null && (!isFinite(extraTokens) || extraTokens < 0)) {
-      setFormError('extra-token budget must be empty or a non-negative integer');
+      setFormError('Extra-token budget must be empty or a non-negative integer');
       return;
     }
 
@@ -92,7 +92,7 @@ export function BudgetRulesPanel() {
 
       {budgetRules.length === 0 && !showForm && (
         <p className="text-xs text-muted-foreground">
-          No rules defined. Add one to cap monthly spend per provider.
+          No rules yet. Add one to cap monthly spend per provider.
         </p>
       )}
 
@@ -163,7 +163,7 @@ function AddRuleForm({
   return (
     <div className="flex flex-col gap-3 rounded-md border border-border-soft bg-subtle p-3">
       <div className="flex flex-col gap-1.5">
-        <label className="text-xs font-semibold text-foreground">provider</label>
+        <label className="text-xs font-semibold text-foreground">Provider</label>
         <Select
           size="sm"
           block
@@ -180,7 +180,7 @@ function AddRuleForm({
 
       <div className="flex gap-2">
         <div className="flex flex-1 flex-col gap-1.5">
-          <label className="text-xs font-semibold text-foreground">monthly cap (USD)</label>
+          <label className="text-xs font-semibold text-foreground">Monthly cap (USD)</label>
           <Input
             type="number"
             min="0.01"
@@ -191,7 +191,7 @@ function AddRuleForm({
           />
         </div>
         <div className="flex flex-1 flex-col gap-1.5">
-          <label className="text-xs font-semibold text-foreground">alert threshold (%)</label>
+          <label className="text-xs font-semibold text-foreground">Alert threshold (%)</label>
           <Input
             type="number"
             min="1"
@@ -206,18 +206,18 @@ function AddRuleForm({
 
       <div className="flex flex-1 flex-col gap-1.5">
         <label className="text-xs font-semibold text-foreground">
-          extra-token budget <span className="font-normal text-muted-foreground">(optional)</span>
+          Extra-token budget <span className="font-normal text-muted-foreground">(optional)</span>
         </label>
         <Input
           type="number"
           min="0"
           step="1000"
-          placeholder="leave empty for no token cap"
+          placeholder="Leave empty for no token cap"
           value={form.extraTokensBudget}
           onChange={(e) => onChange({ ...form, extraTokensBudget: e.target.value })}
         />
         <p className="text-2xs text-muted-foreground">
-          additional token allowance per period. empty = no extra-token budget.
+          Extra tokens allowed per period. Empty means no extra-token budget.
         </p>
       </div>
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -424,14 +424,14 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   const popoverOpen = showPopover && inPrefixMode && quickItems !== null;
   const quickEmptyHint =
     parsed.prefix?.symbol === '$'
-      ? 'no scripts. add them in workspace settings.'
+      ? 'no scripts yet. add them in workspace settings'
       : parsed.prefix?.symbol === '~'
         ? session.workflowIds.length > 0
-          ? 'all available workflows are already attached.'
-          : 'no workflows. create one in workspace settings.'
+          ? 'every workflow is already attached'
+          : 'no workflows yet. create one in workspace settings'
         : parsed.prefix?.symbol === '@'
-          ? 'no agents in this session.'
-          : 'no skills. create one in settings.';
+          ? 'no agents in this session yet'
+          : 'no skills yet. create one in settings';
 
   const onQuickActionSelect = useCallback((item: QuickActionItem) => item.perform(), []);
   const dismissPopover = useCallback(() => setShowPopover(false), []);
@@ -1074,11 +1074,11 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
               onPaste={onPaste}
               placeholder={
                 providerDisconnected
-                  ? 'Sign in to send a message.'
+                  ? 'Sign in to send a message'
                   : isRunning
                     ? queued
-                      ? 'Message queued. Type to replace.'
-                      : 'Turn running. Type to queue next message.'
+                      ? 'Message queued, type to replace it'
+                      : 'Turn running, type to queue the next message'
                     : CHAT_PLACEHOLDER
               }
               disabled={providerDisconnected}

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -636,7 +636,7 @@ function ChatEmptyState({ selectedAgentId, phaseRuns, hasWorkflow }: ChatEmptySt
         return {
           eyebrow: `${meta.label} agent · fresh transcript`,
           title: `You're talking to a ${meta.label} agent`,
-          body: `${meta.hint}. It already knows the session brief on the right: goal, decisions, open questions. No need to re-explain. Just say what you want next.`,
+          body: `${meta.hint}. It already knows the session brief on the right: goal, decisions, open questions. No need to re-explain. Say what you want next.`,
           hints: [
             selectedKind === 'scout' ? 'Try: "find where X is defined"' : null,
             selectedKind === 'planner' ? 'Try: "plan how to add X to Y"' : null,

--- a/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
@@ -95,7 +95,7 @@ export function CommentResolvedChip({ assistantText, sessionId }: Props) {
         {shaShort}
       </span>
       <span className="text-muted-foreground/80">
-        mark this review conversation as solved on github?
+        mark this review conversation as solved on GitHub?
       </span>
       <div className="ml-auto flex items-center gap-1">
         <button
@@ -103,11 +103,11 @@ export function CommentResolvedChip({ assistantText, sessionId }: Props) {
           onClick={() => void onResolve()}
           disabled={busy}
           data-testid="comment-resolved-confirm"
-          aria-label="Mark as Solved"
+          aria-label="mark as solved"
           className="inline-flex items-center gap-1 rounded-full bg-success px-2 py-0.5 text-[10px] font-semibold text-success-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
         >
           {busy ? <Loader2 size={9} aria-hidden className="animate-spin" /> : null}
-          Mark as Solved
+          Mark as solved
         </button>
         <button
           type="button"
@@ -116,8 +116,8 @@ export function CommentResolvedChip({ assistantText, sessionId }: Props) {
             setState({ kind: 'dismissed' });
           }}
           disabled={busy}
-          title="keep the conversation open on github"
-          aria-label="keep the conversation open on github"
+          title="keep the conversation open on GitHub"
+          aria-label="keep the conversation open on GitHub"
           className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
         >
           <X size={10} aria-hidden />

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -156,8 +156,8 @@ function FileEditBlock({ path, editType, workingDir, onOpenDiff }: FileEditBlock
       <button
         type="button"
         onClick={() => onOpenDiff(path)}
-        title="open in files modal"
-        aria-label={`open ${rel} in files modal`}
+        title="open diff"
+        aria-label={`open the diff for ${rel}`}
         className="group inline-flex w-fit max-w-full cursor-pointer items-center gap-2 rounded-md border border-info/20 bg-info/5 px-2 py-1 transition-colors hover:border-info/40 hover:bg-info/10"
       >
         {inner}

--- a/apps/desktop/src/features/context/components/ContextPanel/index.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/index.tsx
@@ -752,7 +752,7 @@ const SLOT_META: Record<Exclude<SlotKey, 'files_touched'>, SlotMeta> = {
     icon: Target,
     iconClass: 'text-primary',
     iconChipBg: 'bg-primary/10 ring-primary/20',
-    description: 'What this session is set out to achieve',
+    description: 'What this session is meant to achieve',
     emphasis: true,
     singleLine: true,
     emptyLabel: 'No goal yet',
@@ -782,7 +782,7 @@ const SLOT_META: Record<Exclude<SlotKey, 'files_touched'>, SlotMeta> = {
     icon: Activity,
     iconClass: 'text-info',
     iconChipBg: 'bg-info/10 ring-info/20',
-    description: "Summary of the assistant's most recent reply",
+    description: "Summary of the agent's most recent reply",
     collapsible: true,
     defaultCollapsed: true,
     emptyLabel: 'No output yet',
@@ -1114,7 +1114,7 @@ function SlotHistoryDialog({
                     entry.author === 'user' ? 'bg-accent/10 text-accent' : 'bg-info/10 text-info',
                   )}
                 >
-                  {entry.author === 'user' ? 'you' : 'ai'}
+                  {entry.author === 'user' ? 'you' : 'agent'}
                 </span>
                 <span className="text-2xs text-muted-foreground">
                   {formatRelative(entry.createdAt)}
@@ -1279,7 +1279,7 @@ function PlansEmpty() {
             Plans
           </span>
           <span className="text-[10px] leading-tight text-muted-foreground/60">
-            Step-by-step plans queued for this session
+            Step-by-step work queued for this session
           </span>
         </div>
       </div>

--- a/apps/desktop/src/features/github/components/Card/index.tsx
+++ b/apps/desktop/src/features/github/components/Card/index.tsx
@@ -90,7 +90,7 @@ export function GithubCard({
         <span
           className="inline-flex rounded border border-border-soft bg-subtle"
           role="tablist"
-          aria-label="github card view"
+          aria-label="GitHub card view"
         >
           {TAB_KEYS.map((k) => {
             const isActive = k === active;
@@ -122,8 +122,8 @@ export function GithubCard({
             type="button"
             onClick={onRefresh}
             disabled={detailLoading}
-            title="refresh github data"
-            aria-label="refresh github data"
+            title="refresh GitHub data"
+            aria-label="refresh GitHub data"
             className={cn(TAB_ICON_BTN, 'disabled:opacity-40')}
           >
             <RefreshCw size={10} className={cn(detailLoading && 'animate-spin')} aria-hidden />
@@ -394,7 +394,7 @@ export function CiPane({
       <EmptyRow
         text="No CI runs yet"
         actionUrl={pr.url}
-        actionLabel="view on github"
+        actionLabel="view on GitHub"
         onOpenUrl={onOpenUrl}
       />
     );
@@ -469,7 +469,7 @@ export function CommentsPane({
         type="button"
         onClick={() => onOpenUrl(pr.url)}
         className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground/70 hover:text-foreground"
-        title="open general comments on github"
+        title="open general comments on GitHub"
       >
         {generalCount} general comment{generalCount === 1 ? '' : 's'}
         <ExternalLink size={9} aria-hidden />
@@ -765,7 +765,7 @@ export function ReviewPane({
           onClick={() => onOpenUrl(pr.url)}
           className="inline-flex w-fit items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
         >
-          view on github
+          view on GitHub
           <ExternalLink size={9} aria-hidden />
         </button>
       ) : null}

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrDialog.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrDialog.tsx
@@ -130,7 +130,7 @@ export function CreatePrDialog({
             type="button"
             onClick={() => void onCreateWithAi()}
             disabled={busy !== null}
-            title="let an agent draft the title and description, then open the PR"
+            title="hand it to an agent: it drafts the title and description, then opens the PR"
             className="inline-flex items-center gap-1.5 rounded-md border border-accent/30 bg-accent/5 px-3 py-1.5 text-xs font-medium text-accent transition-colors hover:bg-accent/15 disabled:opacity-50"
           >
             {busy === 'ai' ? (
@@ -138,7 +138,7 @@ export function CreatePrDialog({
             ) : (
               <Sparkles size={13} aria-hidden />
             )}
-            Create with AI
+            Draft with an agent
           </button>
           <button
             type="button"

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -142,8 +142,8 @@ export function PrActionBar({
         <button
           type="button"
           onClick={onOpenGithub}
-          title="open on github"
-          aria-label="open on github"
+          title="open on GitHub"
+          aria-label="open on GitHub"
           className={ICON_BTN}
         >
           <ExternalLink size={14} aria-hidden />

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -215,7 +215,7 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
           Create PR
         </button>
         <p className="text-2xs text-muted-foreground/60">
-          Compose the title and description, or let AI draft it.
+          Write the title and description, or hand it to an agent.
         </p>
         {createOpen ? (
           <CreatePrDialog

--- a/apps/desktop/src/features/integrations/github/ConnectGithubDialog.tsx
+++ b/apps/desktop/src/features/integrations/github/ConnectGithubDialog.tsx
@@ -72,7 +72,7 @@ export function ConnectGithubDialog({ workspaceId, open, onClose }: Props) {
       open={open}
       onClose={onClose}
       title="Connect GitHub"
-      description="Per-workspace token (classic PAT, scope repo). Stored in your OS keychain."
+      description="Per-workspace token (classic, scope repo). Stored in your OS keychain."
       size="md"
       footer={
         <div className="flex w-full items-center justify-end gap-2">

--- a/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
+++ b/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
@@ -133,12 +133,12 @@ export function ConnectLinearDialog({ workspaceId, open, onClose }: Props) {
                 rel="noreferrer"
                 className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
               >
-                Create a PAT in Linear settings <ExternalLink size={10} aria-hidden />
+                Create a token in Linear settings <ExternalLink size={10} aria-hidden />
               </a>
             </div>
             <p className="text-2xs leading-relaxed text-muted-foreground">
               Read-only scope is enough. The token is stored encrypted in your operating system
-              keychain and never leaves this machine, Goodboy reads it from Rust only.
+              keychain and never leaves this machine.
             </p>
           </>
         )}

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -202,7 +202,7 @@ export function IssueDetailPanel({ issue, sessionId, workspaceId, onClose }: Pro
           title: issue.title,
         },
       });
-      showToast('success', `session created: ${session.goal}`);
+      showToast('success', `Session created: ${session.goal}`);
       onClose();
       if (setupWorkflow) {
         setTimeout(() => {
@@ -356,7 +356,7 @@ export function IssueDetailPanel({ issue, sessionId, workspaceId, onClose }: Pro
                       ) : prBranch ? (
                         <span className="truncate text-foreground">{prBranch}</span>
                       ) : (
-                        <span className="truncate text-danger">{prError ?? 'no branch found'}</span>
+                        <span className="truncate text-danger">{prError ?? 'No branch found'}</span>
                       )}
                     </div>
                     <span className="text-2xs leading-relaxed text-muted-foreground/70">

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
@@ -66,7 +66,7 @@ export function IssueInbox({ groups, focusedIssueId, onSelect, loading, error }:
         ) : filtered.length === 0 ? (
           <div className="flex h-full items-center justify-center px-6 text-center">
             <p className="text-2xs leading-relaxed text-muted-foreground/70">
-              {query.trim() ? 'No matching issues.' : 'No open issues assigned to you.'}
+              {query.trim() ? 'No matching issues' : 'No open issues assigned to you'}
             </p>
           </div>
         ) : (

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -62,8 +62,8 @@ export function LinearStudio({ workspaceId, workspaceName, onClose }: Props) {
           type="button"
           onClick={refetch}
           disabled={loading}
-          title="refresh issues"
-          aria-label="refresh issues"
+          title="Refresh issues"
+          aria-label="Refresh issues"
           className={cn(
             'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
             'text-muted-foreground transition-colors',
@@ -80,7 +80,7 @@ export function LinearStudio({ workspaceId, workspaceName, onClose }: Props) {
             'text-xs font-medium text-muted-foreground transition-colors',
             'hover:border-border hover:bg-muted/50 hover:text-foreground',
           )}
-          aria-label="close linear studio"
+          aria-label="Close Linear studio"
         >
           <X size={13} aria-hidden /> Done
         </button>

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -136,18 +136,18 @@ export function NotificationCenter() {
                 <header className="flex items-center justify-between gap-2 px-3 py-2">
                   <span className="text-xs font-semibold text-foreground">
                     {notifications.length}{' '}
-                    {notifications.length === 1 ? 'Notification' : 'Notifications'}
+                    {notifications.length === 1 ? 'notification' : 'notifications'}
                   </span>
                   {notifications.length > 0 ? (
                     <button
                       type="button"
                       onClick={() => void clearNotifications()}
                       className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs text-muted-foreground transition-colors hover:bg-danger/10 hover:text-danger"
-                      aria-label="clean up all notifications"
+                      aria-label="clear all notifications"
                       title="Clear all notifications"
                     >
                       <Trash2 size={11} aria-hidden />
-                      Clean up
+                      Clear all
                     </button>
                   ) : null}
                 </header>

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -61,7 +61,7 @@ function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
         ))}
       </ul>
       <p className="text-[10px] leading-snug text-muted-foreground/60">
-        {progress.completedCount} of {progress.totalCount} steps done.
+        {progress.completedCount} of {progress.totalCount} steps done
       </p>
     </>
   );

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -626,7 +626,7 @@ export function DiffViewerDialog({
                 ) : null}
                 {isGitAware ? (
                   <span className="mt-1.5 text-[11px] text-muted-foreground/60">
-                    Use the selector above to switch view.
+                    Pick another view from the selector above.
                   </span>
                 ) : null}
               </div>

--- a/apps/desktop/src/features/permissions/components/MergeDialog/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/MergeDialog/index.test.tsx
@@ -45,7 +45,7 @@ describe('MergeDialog, rendering', () => {
 
   it('renders empty-state message when no conflicts', () => {
     render(<MergeDialog open={true} conflicts={[]} onResolve={vi.fn()} onCancel={vi.fn()} />);
-    expect(screen.getByText('no conflicts detected.')).toBeDefined();
+    expect(screen.getByText('no conflicts to resolve')).toBeDefined();
   });
 
   it('renders generic run labels when no run metadata is supplied', () => {

--- a/apps/desktop/src/features/permissions/components/MergeDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/MergeDialog/index.tsx
@@ -74,7 +74,7 @@ export function MergeDialog({ open, conflicts, runMeta, onResolve, onCancel }: M
       }
     >
       {conflicts.length === 0 ? (
-        <p className="text-xs text-muted-foreground">no conflicts detected.</p>
+        <p className="text-xs text-muted-foreground">no conflicts to resolve</p>
       ) : (
         <ul className="flex flex-col gap-5">
           {conflicts.map((conflict) => (

--- a/apps/desktop/src/features/permissions/components/PermissionScopePicker/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionScopePicker/index.tsx
@@ -18,7 +18,7 @@ const SCOPE_TOAST: Record<PermissionScope, string> = {
   global: 'rule added: allow globally',
   workspace: 'rule added: allow for this workspace',
   session: 'rule added: allow for this session',
-  once: 'allowed once (volatile, not persisted)',
+  once: 'allowed once, not saved',
   deny: 'rule added: deny for this session',
 };
 

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/EscapeHatch.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/EscapeHatch.tsx
@@ -80,7 +80,7 @@ export function EscapeHatch({ command }: Props) {
       </div>
       {launchError ? (
         <span className="text-2xs text-danger">
-          Could not open external terminal: {launchError}
+          Could not open your system terminal: {launchError}
         </span>
       ) : null}
     </div>

--- a/apps/desktop/src/features/providers/components/ProviderLifecycleTile/ErrorPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderLifecycleTile/ErrorPanel.tsx
@@ -12,7 +12,7 @@ export function ErrorPanel({ tail }: Props) {
     <div className="flex flex-col gap-1.5 rounded-md border border-danger/30 bg-danger/5 px-2.5 py-2 text-2xs text-danger">
       <div className="flex items-center gap-1.5 font-semibold">
         <AlertTriangle size={11} aria-hidden />
-        <span>Something went wrong</span>
+        <span>The command failed</span>
       </div>
       <pre className="max-h-24 overflow-y-auto whitespace-pre-wrap break-words font-mono text-[10px] leading-snug text-foreground/80">
         {tail.trim() || 'No output captured.'}

--- a/apps/desktop/src/features/quick-actions/registry.ts
+++ b/apps/desktop/src/features/quick-actions/registry.ts
@@ -79,6 +79,6 @@ export function buildAgentActions(
     });
   return [
     ...switches,
-    { id: 'agent:spawn', label: '+ create new agent', group: 'agent', perform: onSpawn },
+    { id: 'agent:spawn', label: '+ new agent', group: 'agent', perform: onSpawn },
   ];
 }

--- a/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionDialog/index.tsx
@@ -415,14 +415,14 @@ export function NewSessionDialog({ open, onClose, workspaceId, onOpenSettings }:
           <div className="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs">
             <span className="mt-0.5 text-warning">⚠</span>
             <div className="flex-1 leading-relaxed text-foreground">
-              No provider is connected. Sessions need at least one of{' '}
+              No provider is connected. A session needs at least one of{' '}
               {PROVIDER_ORDER.map((id, i) => (
                 <span key={id}>
                   <span className="font-medium">{PROVIDER_LABELS[id]}</span>
                   {i < PROVIDER_ORDER.length - 1 ? ', ' : ''}
                 </span>
               ))}{' '}
-              connected before any agent can run.
+              connected to run.
               <button
                 type="button"
                 onClick={onOpenSettings}

--- a/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionSettingsDialog/index.tsx
@@ -555,7 +555,7 @@ function GeneralSection(props: GeneralSectionProps) {
                     <span className="font-semibold text-foreground">Heads up</span>
                     <ul className="list-disc pl-4 text-muted-foreground">
                       {targetOwnedByOtherSession ? (
-                        <li>Already attached to another kay.am session.</li>
+                        <li>Already attached to another session.</li>
                       ) : null}
                       {targetInUseElsewhere ? <li>Checked out in another git worktree.</li> : null}
                       {targetDirty ? <li>That worktree has uncommitted changes.</li> : null}

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -141,7 +141,7 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
         <p className="shrink-0 px-0.5 text-2xs leading-relaxed text-muted-foreground">
           {mode === 'preset'
             ? 'Saved pipelines. Each step spawns its own agent, in order.'
-            : 'Describe a goal; the planner drafts the steps. Tune models per step, then run.'}
+            : 'Describe a goal and the planner drafts the steps. Tune models per step, then run.'}
         </p>
 
         {/* All three panes stay mounted (toggled with `hidden`) so switching

--- a/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
@@ -121,16 +121,16 @@ function OverviewSection({ onJump }: { onJump: (s: Section) => void }) {
         title="What is Goodboy?"
         subtitle={
           SESSION_FEATURES.budget
-            ? 'Goodboy orchestrates AI coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo, with budget caps, audit logs, and structured workflows.'
-            : 'Goodboy orchestrates AI coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo, with audit logs and structured workflows.'
+            ? 'Goodboy orchestrates coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo, with budget caps, audit logs, and structured workflows.'
+            : 'Goodboy orchestrates coding CLIs (Claude, cursor-agent, Codex) so you can run multiple agents in parallel against your repo, with audit logs and structured workflows.'
         }
         accent="primary"
       />
 
       <Callout tone="info" icon={<Sparkles size={13} />}>
-        Goodboy does <strong className="text-foreground">not</strong> talk to AI providers directly.
-        It spawns the provider's CLI as a subprocess and streams events. Your usage, login, and
-        quotas live in the CLI itself, Goodboy just adds the workspace layer on top.
+        Goodboy does <strong className="text-foreground">not</strong> talk to providers directly. It
+        spawns the provider's CLI as a subprocess and streams events. Your usage, login, and quotas
+        live in the CLI itself. Goodboy adds the workspace layer on top.
       </Callout>
 
       <div>
@@ -292,7 +292,7 @@ function ToolsSection() {
       <SectionHeader
         icon={<Wrench size={14} aria-hidden className="text-warning" />}
         title="Tools"
-        subtitle="Actions the agent takes outside of just talking: reading files, running shell commands, editing code, fetching docs."
+        subtitle="Actions the agent takes beyond writing a reply: reading files, running shell commands, editing code, fetching docs."
         accent="warning"
       />
 

--- a/apps/desktop/src/features/settings/components/ImportConfigDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/ImportConfigDialog/index.tsx
@@ -21,9 +21,7 @@ export function ImportConfigDialog({ open, result, error, onClose }: Props) {
       open={open}
       onClose={onClose}
       title={title}
-      description={
-        result?.ok ? 'Config imported successfully.' : 'Review the issues below before retrying.'
-      }
+      description={result?.ok ? 'Config imported.' : 'Review the issues below before retrying.'}
       size="sm"
       footer={<Button onClick={onClose}>Close</Button>}
     >

--- a/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
@@ -229,7 +229,7 @@ export function SettingsDialog({ open, onClose, initialSection }: Props) {
             ) : null}
             {wipeState === 'done' ? (
               <p className="rounded-md border border-success/40 bg-success/10 px-3 py-2 text-xs text-success">
-                Database wiped. Restart the app (or just reopen settings) to start fresh.
+                Database wiped. Restart the app (or reopen settings) to start fresh.
               </p>
             ) : null}
             {wipeState === 'confirm' ? (
@@ -295,7 +295,7 @@ export function SettingsDialog({ open, onClose, initialSection }: Props) {
       open={open}
       onClose={onClose}
       title="Settings"
-      description="Configure providers, editor, and workspace defaults."
+      description="Editor, shortcuts, integrations, and workspace defaults."
       size="xl"
       fixedHeightClass="h-[640px]"
       bodyClassName="px-0 py-0 gap-0"

--- a/apps/desktop/src/features/skills/components/SkillsPanel/index.tsx
+++ b/apps/desktop/src/features/skills/components/SkillsPanel/index.tsx
@@ -169,7 +169,7 @@ export function SkillsPanel({ workspaceId }: Props) {
 
       {skills.length === 0 ? (
         <p className="text-2xs text-muted-foreground">
-          No skills for this workspace. Create one or rescan the workspace directory.
+          No skills in this workspace yet. Create one, or rescan to pick up skill files on disk.
         </p>
       ) : (
         <ul className="flex flex-col divide-y divide-border-soft overflow-hidden rounded-md border border-border-soft bg-subtle shadow-sm">

--- a/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
+++ b/apps/desktop/src/features/updater/components/UpdateIndicator/index.tsx
@@ -24,7 +24,7 @@ export function UpdateIndicator({ variant }: Props) {
 
   const downloading = status === 'downloading';
   const title = downloading
-    ? 'Downloading update, the app will restart'
+    ? 'Downloading update. Goodboy restarts when it finishes'
     : `Update available${version ? ` (${version})` : ''}`;
   const Icon = downloading ? Loader2 : ArrowUpCircle;
 

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -124,7 +124,9 @@ describe('WorkflowNextStepCta', () => {
       <WorkflowNextStepCta workflow={wf()} runs={ctaRuns} onAdvance={onAdvance} hasOpenQuestions />,
     );
     fireEvent.click(screen.getByTestId('workflow-next-step-cta'));
-    expect(screen.getByText(/open questions need resolution/i)).toBeDefined();
+    expect(
+      screen.getByText(/answer the open questions before you start the next agent/i),
+    ).toBeDefined();
     expect(onAdvance).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -132,7 +132,7 @@ export function WorkflowNextStepCta({
       {pendingConfirm ? (
         <div className="rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-[11px]">
           <p className="mb-2 font-medium text-foreground">
-            open questions need resolution before spawning an agent.
+            Answer the open questions before you start the next agent.
           </p>
           <div className="flex gap-2">
             <button
@@ -140,14 +140,14 @@ export function WorkflowNextStepCta({
               onClick={() => setPendingConfirm(false)}
               className="rounded bg-warning px-2 py-0.5 text-[10px] font-semibold text-warning-foreground hover:opacity-90"
             >
-              resolve first
+              answer first
             </button>
             <button
               type="button"
               onClick={() => void doAdvance()}
               className="rounded border border-border px-2 py-0.5 text-[10px] font-semibold text-foreground hover:bg-muted"
             >
-              force spawn
+              start anyway
             </button>
           </div>
         </div>

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -367,7 +367,7 @@ export function WorkflowsPanel({ workspaceId }: Props) {
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-4">
           {presets.length === 0 ? (
             <p className="rounded-lg border border-dashed border-border-soft bg-subtle/40 px-3 py-6 text-center text-2xs leading-relaxed text-muted-foreground">
-              No presets for this workspace. Create one to chain multiple agents per session.
+              No presets here yet. Create one to chain several agents in a single session.
             </p>
           ) : (
             <ul className="flex flex-col gap-1.5">
@@ -389,8 +389,8 @@ export function WorkflowsPanel({ workspaceId }: Props) {
           {confirmReset ? (
             <div className="flex items-center gap-1.5 rounded-md border border-warning/40 bg-warning/5 px-2.5 py-2">
               <span className="flex-1 text-2xs leading-tight text-muted-foreground">
-                Restore built-in presets? Edits to them are overwritten; your custom presets are
-                kept.
+                Restore the built-in presets? Your edits to them are overwritten. Custom presets you
+                made are kept.
               </span>
               <button
                 type="button"
@@ -1134,7 +1134,7 @@ function LibraryStepForm({
 
       {isGlobal ? (
         <p className="text-2xs leading-relaxed text-muted-foreground/70">
-          Editing a global step saves a workspace copy; the shared original stays unchanged.
+          Editing a global step saves a copy in this workspace. The shared original stays unchanged.
         </p>
       ) : null}
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -415,7 +415,7 @@ function QuickActionsRow({
       <QuickAction
         icon={<Plug size={12} className="text-info" aria-hidden />}
         label="Providers"
-        title="connect and manage AI provider accounts"
+        title="connect and manage your provider accounts"
         onClick={onOpenProviders}
         pulse={noProviderConnected}
       />
@@ -643,8 +643,8 @@ function SidebarDetailHint({ hasAnySession }: { hasAnySession: boolean }) {
     <div className="flex h-full items-center justify-center px-6 text-center">
       <p className="text-2xs leading-relaxed text-muted-foreground/70">
         {hasAnySession
-          ? 'Select a session from the rail.'
-          : 'Create your first session from the rail.'}
+          ? 'Pick a session from the list to the left.'
+          : 'Create your first session from the list to the left.'}
       </p>
     </div>
   );
@@ -662,7 +662,7 @@ function NoWorkspaceEmpty({ onAddWorkspace }: { onAddWorkspace: () => void }) {
       <div className="flex flex-col gap-1">
         <h3 className="text-sm font-semibold text-foreground">No workspace yet</h3>
         <p className="max-w-[220px] text-2xs leading-relaxed text-muted-foreground">
-          Add a git repo to create worktrees and start orchestrating sessions.
+          Point at a local git repo. Each session opens its own worktree off it.
         </p>
       </div>
       <button

--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -217,8 +217,8 @@ export function GenericTerminalPanel({
         <button
           type="button"
           onClick={onRestart}
-          title="restart shell"
-          aria-label="restart shell"
+          title="Restart shell"
+          aria-label="Restart shell"
           className="absolute right-2 top-2 z-10 rounded-sm bg-background/80 p-1 text-muted-foreground backdrop-blur hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
         >
           <RotateCcw size={12} aria-hidden />


### PR DESCRIPTION
Applies the tone-of-voice rules (refined in #706) to the desktop app, the same sharpening pass we did on the website in #702.

Ran a multi-agent sweep: one auditor per feature (20 features + shared + ui), each fixing user-facing strings against `docs/tone-of-voice.md`, then an adversarial review of the full diff.

## What changed (38 files, display strings only)
- **"AI" removed from product copy** (GuideDialog, WorkspacesSidebar, GitHub draft button, empty states) per the no-"AI" rule.
- **Leaked internal names dropped**: "rail" → "the list to the left".
- **Brand casing**: "github" → "GitHub" across tooltips, aria-labels, link text.
- **Minimizers cut** ("just talking" → "beyond writing a reply").
- **Trailing periods stripped** from short labels/fragments; body sentences keep theirs.
- **Sharper empty states, tooltips, dialog copy** (problem-then-fix, concrete over abstract).
- No logic, identifiers, classNames, props, keys, or event names touched.

## Verify pass
Adversarial review of the diff flagged and I fixed:
- 2 tests asserting on old copy (MergeDialog empty state, WorkflowNextStepCta confirm prompt) → resynced.
- ErrorPanel "stopped before it finished" overstated an unknown cause → "The command failed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)