### PR TITLE
chore(repo): bump version to 0.1.6

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.5"
+version = "0.1.6"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Release bump for **v0.1.6 "Terminal"**. Sets version to `0.1.6` across `package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml`, `Cargo.lock`.

Headline since v0.1.5:
- feat(desktop): main-view overhaul — embedded terminal (cmux), chat modernization, studios (#710)
- feat(desktop): budget studio spend hub (#708)
- feat(ui): product brand icons for llm providers + provider studio (#705)
- feat(desktop): per-provider api key auth + workspace bindings (#704)
- feat: new goodboy mascot + redesigned agent empty states (#703)

Once green + merged, the release is cut per [docs/release.md](docs/release.md): rc dry-run (`v0.1.6-rc.1`) then `v0.1.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)