### PR TITLE
feat(desktop): surface archive as first-class session action

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -6,6 +6,7 @@ import { BootSplash } from './app/components/BootSplash';
 import { ChatView } from './features/chat/components/ChatView';
 import { ContextPanel } from './features/context/components/ContextPanel';
 import { EndSessionDialog } from './features/session/components/EndSessionDialog';
+import { ArchiveSessionDialog } from './features/session/components/ArchiveSessionDialog';
 import { SettingsDialog } from './features/settings/components/SettingsDialog';
 import { ToastProvider } from './app/components/Toast';
 import { ProviderModalHost } from './features/providers/components/ProviderModalHost';
@@ -91,6 +92,7 @@ export function App() {
     undefined,
   );
   const [endOpen, setEndOpen] = useState(false);
+  const [archiveOpen, setArchiveOpen] = useState(false);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [palettePrefix, setPalettePrefix] = useState('');
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
@@ -268,6 +270,9 @@ export function App() {
   const openEndSession = useCallback(() => {
     if (currentSession) setEndOpen(true);
   }, [currentSession]);
+  const openArchiveSession = useCallback(() => {
+    if (currentSession) setArchiveOpen(true);
+  }, [currentSession]);
 
   useEffect(() => {
     const handler = () => {
@@ -275,6 +280,14 @@ export function App() {
     };
     window.addEventListener('goodboy:end-session', handler);
     return () => window.removeEventListener('goodboy:end-session', handler);
+  }, [currentSession]);
+
+  useEffect(() => {
+    const handler = () => {
+      if (currentSession) setArchiveOpen(true);
+    };
+    window.addEventListener('goodboy:archive-session', handler);
+    return () => window.removeEventListener('goodboy:archive-session', handler);
   }, [currentSession]);
   const openShortcutHelp = useCallback(() => {
     setSettingsInitialSection('shortcuts');
@@ -356,6 +369,7 @@ export function App() {
   useKeyboardShortcut('cmd+,', openSettings);
   useKeyboardShortcut('cmd+/', openShortcutHelp);
   useKeyboardShortcut('cmd+.', openEndSession);
+  useKeyboardShortcut('cmd+shift+a', openArchiveSession);
   useKeyboardShortcut('cmd+k', () => openPalette());
   useKeyboardShortcut('cmd+b', toggleLeftSidebar);
   useKeyboardShortcut('cmd+n', openNewSession, { ignoreInInputs: false });
@@ -558,6 +572,9 @@ export function App() {
       ) : null}
       {currentSession && endOpen ? (
         <EndSessionDialog session={currentSession} open onClose={() => setEndOpen(false)} />
+      ) : null}
+      {currentSession && archiveOpen ? (
+        <ArchiveSessionDialog session={currentSession} open onClose={() => setArchiveOpen(false)} />
       ) : null}
       {/* App-level modal host so the provider connect modal can be summoned
           from any surface (providers panel, chat callout, future onboarding

--- a/apps/desktop/src/features/session/components/ArchiveSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/ArchiveSessionDialog/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { Button, Dialog } from '@goodboy/ui';
+import type { Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+
+function unwrapError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const { message } = err as Record<string, unknown>;
+    if (typeof message === 'string') return message;
+  }
+  return String(err);
+}
+
+interface Props {
+  session: Session;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ArchiveSessionDialog({ session, open, onClose }: Props) {
+  const archiveTask = useAppStore((s) => s.archiveTask);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConfirm = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await archiveTask(session.id as SessionId);
+      onClose();
+    } catch (err) {
+      setError(unwrapError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Archive session?"
+      description="Moves it to the Archived tab and frees memory. The worktree, branch, and history stay on disk. Reversible anytime with Unarchive."
+      size="sm"
+      footer={
+        <>
+          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void onConfirm()} disabled={busy}>
+            {busy ? 'Archiving…' : 'Archive'}
+          </Button>
+        </>
+      }
+    >
+      <div className="rounded-md border border-border-soft bg-subtle px-3 py-2 text-xs text-muted-foreground">
+        <span className="font-mono text-foreground">{session.goal}</span>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
@@ -69,6 +69,7 @@ const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly lab
   { combo: ['⌘', '⇧', 'K'], label: 'open model picker' },
   { combo: ['⌘', '⇧', 'P'], label: 'open permission picker' },
   { combo: ['⌘', '↵'], label: 'send message (queue if running)' },
+  { combo: ['⌘', '⇧', 'A'], label: 'archive current session' },
   { combo: ['⌘', '.'], label: 'end current session' },
   { combo: ['⌘', ','], label: 'open settings' },
   { combo: ['⌘', '/'], label: 'keyboard shortcuts' },

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, FolderOpen, GitBranch, LogOut, Play, ScrollText, Settings2 } from 'lucide-react';
+import {
+  Archive,
+  Check,
+  FolderOpen,
+  GitBranch,
+  LogOut,
+  Play,
+  ScrollText,
+  Settings2,
+} from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { Session, SessionId, TelemetryRecord, WorkspaceScript } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
@@ -51,6 +60,10 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
 
   const onEndSession = () => {
     window.dispatchEvent(new CustomEvent('goodboy:end-session'));
+  };
+
+  const onArchiveSession = () => {
+    window.dispatchEvent(new CustomEvent('goodboy:archive-session'));
   };
 
   const actionItems = useMemo<ReadonlyArray<OverflowMenuItem>>(() => {
@@ -112,6 +125,14 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
       label: 'Session settings',
       icon: Settings2,
       onClick: onOpenSessionSettings,
+    });
+    items.push({
+      kind: 'item',
+      key: 'archive',
+      label: 'Archive session',
+      icon: Archive,
+      onClick: onArchiveSession,
+      hint: '⌘⇧A',
     });
     items.push({
       kind: 'item',


### PR DESCRIPTION
## What

Make **Archive session** a first-class action, on par with End session.

- **Kebab menu**: new "Archive session" entry (`SessionDetailPanel`), hint `⌘⇧A`, non-destructive styling, sits above "End session".
- **Shortcut**: `Cmd+Shift+A` archives the current session (`App.tsx`). Chosen over `Cmd+A` to avoid clashing with select-all and the input-focus skip in `useKeyboardShortcut`.
- **Confirm dialog**: new `ArchiveSessionDialog`, copy makes clear the action is reversible (worktree/branch/history preserved, undo via Unarchive).
- **Settings → Shortcuts**: shortcut listed.

## Why

Archive was reachable only via Session settings → footer, while the destructive End session sat prominently in the kebab with `⌘.`. The reversible action was harder to reach than the irreversible one.

## Notes

- No backend change: reuses the existing `archiveTask` store action.
- Wiring mirrors End session exactly (CustomEvent `goodboy:archive-session` → handler in `App.tsx`, fired from both kebab and shortcut).
- Snapshot/a11y/keyboard tests may need an update for the new kebab entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)