### PR TITLE
fix(desktop): scroll chat to bottom on agent switch

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -54,10 +54,14 @@ interface ChatViewProps {
 const PIN_TOLERANCE_PX = 32;
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-function useScrollPin(deps: ReadonlyArray<unknown>) {
+function useScrollPin(deps: ReadonlyArray<unknown>, resetKey?: unknown) {
   const scrollerRef = useRef<HTMLDivElement>(null);
   const [pinned, setPinned] = useState(true);
   const [atTop, setAtTop] = useState(true);
+
+  useEffect(() => {
+    setPinned(true);
+  }, [resetKey]);
 
   useEffect(() => {
     const el = scrollerRef.current;
@@ -273,7 +277,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   // setting write re-renders the whole chat view (and its transcript) if we
   // pull the entire object.
   const flagOn = useAppStore((s) => s.settings['experimental.enable_parallel_agents'] === 'true');
-  const { scrollerRef, pinned, atTop, onScroll } = useScrollPin([items]);
+  const { scrollerRef, pinned, atTop, onScroll } = useScrollPin([deferredItems], selectedAgentId);
 
   const provider = session.providerPreference.defaultProvider;
   const providerAuthState = authResults?.[provider]?.state ?? null;


### PR DESCRIPTION
## what

Switching from one agent to another left the chat transcript scrolled to the **top** instead of the latest message.

## why

`useScrollPin` had two issues:

1. The main scroller pinned against the eager `items` array but rendered `deferredItems`. On agent switch the `scrollTop = scrollHeight` effect fired while the **loading skeleton** was still mounted (small height), landing near the top; when the real transcript settled the dep didn't change again, so it stayed up.
2. `pinned` persisted across switches: scrolling up on agent A left the next agent stranded at the top.

## fix

- Pin against `deferredItems` (the actually-rendered list) so the scroll fires after the real transcript paints.
- Re-pin to bottom whenever `selectedAgentId` changes via a new `resetKey` arg.

`ParallelColumn` is untouched (it renders `items` directly, dep already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)