### PR TITLE
fix(desktop): set session title only from founding agent

### DIFF
--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -469,9 +469,10 @@ export async function applyHeuristicTitle(
 
     const agentRecord = (get().sessionPhaseRuns[sessionId] ?? []).find((r) => r.id === agentId);
     const agentNameEditable = agentRecord ? /^(agent|puppy) \d+$/i.test(agentRecord.name) : false;
+    const isFoundingAgent = agentRecord?.ordinal === 0;
 
     const titleNow = new Date().toISOString() as IsoDateTime;
-    if (!session.titleUserEdited) {
+    if (isFoundingAgent && !session.titleUserEdited) {
       set((state) => ({
         sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, goal: title } : s)),
       }));


### PR DESCRIPTION
## problem

session title (`session.goal`) changed unexpectedly on every new agent. `applyHeuristicTitle` ran on each agent's first turn (`isFirstTurn` is per-agent), and the only guard was `!titleUserEdited`, so spawning agent 2/3/... re-derived the session title from that agent's prompt.

## fix

gate session-title derivation to the founding agent (`ordinal === 0`). first agent in a session is always ordinal 0; spawned agents get `max+1`. subsequent agents still self-rename ("agent N" → heuristic) but no longer clobber the session goal.

single line in [turn-helpers.ts](apps/desktop/src/store/turn-helpers.ts) `applyHeuristicTitle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)