### PR TITLE
feat(desktop): link studios to their reference session

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -96,6 +96,7 @@ export function App() {
   const [addWorkspaceOpen, setAddWorkspaceOpen] = useState(false);
   const [workflowStudioOpen, setWorkflowStudioOpen] = useState(false);
   const [linearStudioOpen, setLinearStudioOpen] = useState(false);
+  const [linearStudioFocus, setLinearStudioFocus] = useState<string | null>(null);
   const [providerStudioOpen, setProviderStudioOpen] = useState(false);
   const [providerStudioFocus, setProviderStudioFocus] = useState<ProviderId | null>(null);
   const [githubStudioOpen, setGithubStudioOpen] = useState(false);
@@ -178,6 +179,16 @@ export function App() {
     };
     window.addEventListener('goodboy:open-budget-studio', handler);
     return () => window.removeEventListener('goodboy:open-budget-studio', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ issueExternalId?: string }>).detail;
+      setLinearStudioFocus(detail?.issueExternalId ?? null);
+      setLinearStudioOpen(true);
+    };
+    window.addEventListener('goodboy:open-linear-studio', handler);
+    return () => window.removeEventListener('goodboy:open-linear-studio', handler);
   }, []);
 
   useEffect(() => {
@@ -415,7 +426,10 @@ export function App() {
               onOpenSettings={openSettings}
               onOpenPalette={openPalette}
               onOpenWorkflows={() => setWorkflowStudioOpen(true)}
-              onOpenLinear={() => setLinearStudioOpen(true)}
+              onOpenLinear={() => {
+                setLinearStudioFocus(null);
+                setLinearStudioOpen(true);
+              }}
               onOpenProviders={() => {
                 setProviderStudioFocus(null);
                 setProviderStudioOpen(true);
@@ -545,6 +559,7 @@ export function App() {
         <LinearStudio
           workspaceId={currentWorkspace.id}
           workspaceName={currentWorkspace.name}
+          initialIssueId={linearStudioFocus}
           onClose={() => setLinearStudioOpen(false)}
         />
       ) : null}

--- a/apps/desktop/src/features/budget/components/BudgetStudio/PanelShell.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/PanelShell.tsx
@@ -6,6 +6,7 @@ interface Props {
   readonly icon?: ReactNode;
   readonly title: string;
   readonly subtitle?: string;
+  readonly action?: ReactNode;
   readonly maxWidthClass?: string;
   readonly children: ReactNode;
 }
@@ -14,6 +15,7 @@ export function PanelShell({
   icon,
   title,
   subtitle,
+  action,
   maxWidthClass = 'max-w-3xl',
   children,
 }: Props) {
@@ -27,6 +29,7 @@ export function PanelShell({
             <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
           ) : null}
         </div>
+        {action ? <div className="ml-auto shrink-0">{action}</div> : null}
       </div>
       <Divider />
       <div className="min-h-0 flex-1">

--- a/apps/desktop/src/features/budget/components/BudgetStudio/SessionPanel.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/SessionPanel.tsx
@@ -1,5 +1,7 @@
 import { useMemo } from 'react';
 import { formatUsdPrecise } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 import { ModelTable } from './ModelTable';
 import { PanelShell } from './PanelShell';
 import { Sparkline } from './Sparkline';
@@ -9,12 +11,14 @@ import { Widget } from './Widget';
 import { buildModelBreakdown, chronologicalTurnCosts, type WorkspaceTurn } from './lib';
 
 interface Props {
+  readonly sessionId: SessionId;
   readonly goal: string;
   readonly isCurrent: boolean;
   readonly turns: ReadonlyArray<WorkspaceTurn>;
+  readonly onOpened: () => void;
 }
 
-export function SessionPanel({ goal, isCurrent, turns }: Props) {
+export function SessionPanel({ sessionId, goal, isCurrent, turns, onOpened }: Props) {
   const records = useMemo(() => turns.map((t) => t.record), [turns]);
   const models = useMemo(() => buildModelBreakdown(records), [records]);
   const turnCosts = useMemo(() => chronologicalTurnCosts(records), [records]);
@@ -31,7 +35,11 @@ export function SessionPanel({ goal, isCurrent, turns }: Props) {
   const providerCount = new Set(records.map((r) => r.provider)).size;
 
   return (
-    <PanelShell title={goal} subtitle={isCurrent ? 'current session' : 'session spend'}>
+    <PanelShell
+      title={goal}
+      subtitle={isCurrent ? 'current session' : 'session spend'}
+      action={<OpenSessionButton sessionId={sessionId} onOpened={onOpened} variant="secondary" />}
+    >
       <div className="grid grid-cols-3 gap-3">
         <StatCard label="session cost" value={formatUsdPrecise(sessionCost)} />
         <StatCard label="summarizer" value={formatUsdPrecise(summarizer)} />

--- a/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
+++ b/apps/desktop/src/features/budget/components/BudgetStudio/index.tsx
@@ -89,7 +89,7 @@ export function BudgetStudio({ workspaceName, initialScope, onClose }: Props) {
       closeLabel="close budget studio"
       onClose={onClose}
     >
-      {() => (
+      {(requestClose) => (
         <>
           <ScrollFade className="w-72 shrink-0">
             <ScopeRail
@@ -119,9 +119,11 @@ export function BudgetStudio({ workspaceName, initialScope, onClose }: Props) {
               />
             ) : selectedSession ? (
               <SessionPanel
+                sessionId={selectedSession.id}
                 goal={selectedSession.goal}
                 isCurrent={selectedSession.id === currentSessionId}
                 turns={turns.filter((t) => t.sessionId === selectedSession.id)}
+                onOpened={requestClose}
               />
             ) : null}
           </div>

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -1,4 +1,4 @@
-import type { PullRequestState } from '@goodboy/types';
+import type { PullRequestState, SessionId } from '@goodboy/types';
 import { cn, Divider } from '@goodboy/ui';
 import {
   ExternalLink,
@@ -11,6 +11,7 @@ import {
   Send,
   XCircle,
 } from 'lucide-react';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 
 export type ActionBusy = 'ready' | 'undraft' | 'merge' | 'close' | 'reopen' | null;
 
@@ -30,6 +31,8 @@ const TONE = {
 
 interface Props {
   readonly pr: PullRequestState;
+  readonly sessionId: SessionId;
+  readonly onOpenSession: () => void;
   readonly busy: ActionBusy;
   readonly detailLoading: boolean;
   readonly mergeConfirm: boolean;
@@ -48,6 +51,8 @@ interface Props {
 
 export function PrActionBar({
   pr,
+  sessionId,
+  onOpenSession,
   busy,
   detailLoading,
   mergeConfirm,
@@ -139,6 +144,7 @@ export function PrActionBar({
       ) : null}
 
       <div className="ml-auto flex items-center gap-1.5">
+        <OpenSessionButton sessionId={sessionId} onOpened={onOpenSession} variant="ghost" />
         <button
           type="button"
           onClick={onOpenGithub}

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../chat/spawn-from-comment';
 import { openUrl } from '../../../../shared/lib/editor';
 import { ScrollFade } from '../../../../shared/components/ScrollFade';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore, useSessions } from '../../../../store';
 import { ghPrDetailByNumber, ghPrsForBranch } from '../../github';
@@ -214,10 +215,13 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
           title="Ready to open a pull request"
           description="Write the title and description, or hand it to an agent."
           action={
-            <Button size="sm" onClick={() => setCreateOpen(true)}>
-              <Plus size={14} aria-hidden />
-              Create PR
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button size="sm" onClick={() => setCreateOpen(true)}>
+                <Plus size={14} aria-hidden />
+                Create PR
+              </Button>
+              <OpenSessionButton sessionId={sessionId} onOpened={onClose} variant="secondary" />
+            </div>
           }
         />
         {createOpen ? (
@@ -262,6 +266,8 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
       <div className="flex min-w-0 flex-1 flex-col">
         <PrActionBar
           pr={activePr}
+          sessionId={sessionId}
+          onOpenSession={onClose}
           busy={busy}
           detailLoading={detailLoading}
           mergeConfirm={mergeConfirm}

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { ScrollFade } from '../../../../shared/components/ScrollFade';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
@@ -104,7 +105,6 @@ function prStatusTone(status: string | null): string {
 
 export function IssueDetailPanel({ issue, sessionId, workspaceId, onClose }: Props) {
   const createSession = useAppStore((s) => s.createSession);
-  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
   const rootPath = useAppStore(
     (s) => s.workspaces.find((w) => w.id === workspaceId)?.rootPath ?? null,
@@ -185,11 +185,6 @@ export function IssueDetailPanel({ issue, sessionId, workspaceId, onClose }: Pro
   }
 
   const openableSessionId = sessionId ?? branchSessionId;
-
-  const onOpenSession = (id: SessionId) => {
-    void setCurrentSession(id);
-    onClose();
-  };
 
   const branchReady =
     mode === 'pr' ? Boolean(prBranch) && !prResolving : isValidBranchSlug(branchSlug);
@@ -317,7 +312,7 @@ export function IssueDetailPanel({ issue, sessionId, workspaceId, onClose }: Pro
                         : 'A session is already on this PR branch.'}
                     </span>
                   </div>
-                  <Button onClick={() => onOpenSession(openableSessionId)}>Open session</Button>
+                  <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
                 </div>
               ) : (
                 <div className="flex flex-col gap-4 rounded-xl border border-border-soft bg-muted/10 p-4">

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -11,19 +11,29 @@ import type { LinearIssue } from '../client';
 interface Props {
   readonly workspaceId: WorkspaceId;
   readonly workspaceName: string;
+  readonly initialIssueId?: string | null;
   readonly onClose: () => void;
 }
 
-export function LinearStudio({ workspaceId, workspaceName, onClose }: Props) {
+export function LinearStudio({ workspaceId, workspaceName, initialIssueId, onClose }: Props) {
   const { groups, loading, error, refetch } = useLinearIssues(workspaceId);
   const [focused, setFocused] = useState<LinearIssue | null>(null);
   const { closing, requestClose } = useStudioOverlay(onClose);
 
   useEffect(() => {
     if (focused !== null) return;
+    if (initialIssueId) {
+      for (const group of groups) {
+        const row = group.rows.find((r) => r.issue.id === initialIssueId);
+        if (row) {
+          setFocused(row.issue);
+          return;
+        }
+      }
+    }
     const first = groups[0]?.rows[0]?.issue ?? null;
     if (first) setFocused(first);
-  }, [focused, groups]);
+  }, [focused, groups, initialIssueId]);
 
   const focusedRow = useMemo(() => {
     if (!focused) return null;

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -188,16 +188,21 @@ export function SessionDetailPanel({ session, onOpenSessionSettings }: SessionDe
           )}
         </div>
         {externalTask ? (
-          <a
-            href={externalTask.url}
-            target="_blank"
-            rel="noreferrer"
+          <button
+            type="button"
+            onClick={() =>
+              window.dispatchEvent(
+                new CustomEvent('goodboy:open-linear-studio', {
+                  detail: { issueExternalId: externalTask.externalId },
+                }),
+              )
+            }
             title={`${externalTask.identifier}: ${externalTask.title}`}
             className="shrink-0 inline-flex items-center gap-1 rounded-md border border-provider-linear/30 bg-provider-linear/5 px-1.5 py-0.5 text-2xs font-medium text-provider-linear transition-colors hover:border-provider-linear/60 hover:bg-provider-linear/10"
-            aria-label={`open ${externalTask.identifier} in linear`}
+            aria-label={`open ${externalTask.identifier} in linear studio`}
           >
             <span className="font-mono">{externalTask.identifier}</span>
-          </a>
+          </button>
         ) : null}
         <OverflowMenu items={actionItems} label="session actions" />
       </div>

--- a/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
+++ b/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { SessionId } from '@goodboy/types';
 import { OpenSessionButton } from './index';
 
@@ -8,6 +8,8 @@ const openSession = vi.fn();
 vi.mock('../../hooks/useOpenSession', () => ({
   useOpenSession: () => openSession,
 }));
+
+afterEach(cleanup);
 
 describe('OpenSessionButton', () => {
   it('renders the default label', () => {

--- a/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
+++ b/apps/desktop/src/shared/components/OpenSessionButton/index.test.tsx
@@ -1,0 +1,24 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import { OpenSessionButton } from './index';
+
+const openSession = vi.fn();
+
+vi.mock('../../hooks/useOpenSession', () => ({
+  useOpenSession: () => openSession,
+}));
+
+describe('OpenSessionButton', () => {
+  it('renders the default label', () => {
+    render(<OpenSessionButton sessionId={'s1' as SessionId} />);
+    expect(screen.getByRole('button', { name: /open session/i })).toBeTruthy();
+  });
+
+  it('opens the session and runs onOpened on click', () => {
+    const onOpened = vi.fn();
+    render(<OpenSessionButton sessionId={'s1' as SessionId} onOpened={onOpened} />);
+    fireEvent.click(screen.getByRole('button', { name: /open session/i }));
+    expect(openSession).toHaveBeenCalledWith('s1', onOpened);
+  });
+});

--- a/apps/desktop/src/shared/components/OpenSessionButton/index.tsx
+++ b/apps/desktop/src/shared/components/OpenSessionButton/index.tsx
@@ -1,0 +1,28 @@
+import type { SessionId } from '@goodboy/types';
+import { Button, type ButtonSize, type ButtonVariant } from '@goodboy/ui';
+import { MessagesSquare } from 'lucide-react';
+import { useOpenSession } from '../../hooks/useOpenSession';
+
+interface Props {
+  readonly sessionId: SessionId;
+  readonly onOpened?: () => void;
+  readonly label?: string;
+  readonly size?: ButtonSize;
+  readonly variant?: ButtonVariant;
+}
+
+export function OpenSessionButton({
+  sessionId,
+  onOpened,
+  label = 'Open session',
+  size = 'sm',
+  variant,
+}: Props) {
+  const openSession = useOpenSession();
+  return (
+    <Button size={size} variant={variant} onClick={() => openSession(sessionId, onOpened)}>
+      <MessagesSquare size={14} aria-hidden />
+      {label}
+    </Button>
+  );
+}

--- a/apps/desktop/src/shared/hooks/useOpenSession/index.test.ts
+++ b/apps/desktop/src/shared/hooks/useOpenSession/index.test.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import { useOpenSession } from './index';
+
+const setCurrentSession = vi.fn();
+
+vi.mock('../../../store', () => ({
+  useAppStore: (selector: (s: { setCurrentSession: typeof setCurrentSession }) => unknown) =>
+    selector({ setCurrentSession }),
+}));
+
+describe('useOpenSession', () => {
+  beforeEach(() => {
+    setCurrentSession.mockClear();
+  });
+
+  it('sets the current session', () => {
+    const { result } = renderHook(() => useOpenSession());
+    result.current('s1' as SessionId);
+    expect(setCurrentSession).toHaveBeenCalledWith('s1');
+  });
+
+  it('runs onOpened after navigating', () => {
+    const onOpened = vi.fn();
+    const { result } = renderHook(() => useOpenSession());
+    result.current('s2' as SessionId, onOpened);
+    expect(onOpened).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/shared/hooks/useOpenSession/index.ts
+++ b/apps/desktop/src/shared/hooks/useOpenSession/index.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../store';
+
+export function useOpenSession(): (sessionId: SessionId, onOpened?: () => void) => void {
+  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  return useCallback(
+    (sessionId: SessionId, onOpened?: () => void) => {
+      void setCurrentSession(sessionId);
+      onOpened?.();
+    },
+    [setCurrentSession],
+  );
+}


### PR DESCRIPTION
## What

Make studio <-> reference-session navigation bidirectional across all three studios.

- New shared `useOpenSession` hook + `OpenSessionButton` (one affordance, used everywhere).
- **GitHub studio**: Open session in the PR toolbar + the no-PR empty state (every inbox row is a session).
- **Budget studio**: Open session in the session-scope panel header.
- **Linear studio**: refactored to use the shared button (was inline).
- **Session -> Linear studio**: the session's Linear chip now opens the in-app studio focused on that issue (was a raw web link; the external link still lives inside the issue panel).

## Why

Before, only Linear studio could jump back to its session. GitHub and Budget were one-way. Now opening is symmetric in both directions, with a single consistent control.

## Test plan

- `turbo run typecheck test --filter=@goodboy/desktop` green locally.
- New unit tests: `useOpenSession` (navigates + runs onOpened), `OpenSessionButton` (renders label, click opens session).

Note: if a session's linked Linear issue is not in the current fetch (closed/unassigned), the studio falls back to focusing the first issue.