### PR TITLE
fix(desktop): reconcile stale session pr in github inbox

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -36,6 +36,7 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
   });
   const workspaceId = session?.workspaceId;
   const refreshSessionPrDetail = useAppStore((s) => s.refreshSessionPrDetail);
+  const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const markPrReady = useAppStore((s) => s.markPrReady);
   const convertPrToDraft = useAppStore((s) => s.convertPrToDraft);
   const mergePr = useAppStore((s) => s.mergePr);
@@ -86,6 +87,7 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
 
   useEffect(() => {
     setSelectedNumber(null);
+    setPrs([]);
     setLocalDetail(null);
     setLocalDetailError(null);
     setMergeConfirm(false);
@@ -125,6 +127,12 @@ export function PrDetailPanel({ sessionId, onClose }: Props) {
     github?.detailError,
     refreshSessionPrDetail,
   ]);
+
+  useEffect(() => {
+    if (!sessionId || prs.length === 0) return;
+    if ((prs[0]?.number ?? null) === primaryNumber) return;
+    void refreshSessionPr(sessionId, { force: true, silent: true });
+  }, [sessionId, prs, primaryNumber, refreshSessionPr]);
 
   useEffect(() => {
     if (!activePr || isPrimary) return;


### PR DESCRIPTION
## Problem

GitHub studio inbox groups sessions by the cached `sessionGithub[id].pr`. When a PR is opened **outside the app** (agent terminal, external tool), that cached value stays `null`:

- the reactive sweep ran before the PR existed -> cached `pr: null`
- the steady-state sweep skips known-null sessions (`skipUnknownPr`)
- `refreshSessionPrDetail` early-returns when `pr === null`, so it never backfills

Meanwhile the detail panel resolves the PR **live** via branch lookup (`ghPrsForBranch`), so the panel showed the PR while the list stayed stuck in "No PR yet". Only a reboot / workspace switch fixed it.

## Fix

The panel already fetches the live PR list. When `prs[0]` diverges from the store's cached `pr`, force a silent `refreshSessionPr` so the store reconciles and the inbox re-groups on open. Also clear `prs` on session switch to avoid reconciling with the previous session's data and to kill a PR-switcher flash.

## Performance

No regression. The reconcile gh call fires **only on real divergence** (rare):
- already-synced open: `prs[0].number === primaryNumber` -> no call
- divergence: one force refresh; after the store updates, the condition clears -> no loop
- loading window: `primaryNumber` stays null (unchanged dep) -> effect does not re-run
- silent failure: no error chip, no retry loop

## Verification

- `tsc --noEmit` (desktop) green
- github feature + store-slice vitest: 18/18 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)