### PR TITLE
feat(desktop): consume active plan from non-implementer workflow agents

### DIFF
--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentKind,
   inferAgentKindFromName,
   inferAgentKindFromStep,
+  kindConsumesPlan,
   resolveAgentKind,
 } from './agent-kind';
 
@@ -175,6 +176,20 @@ describe('inferAgentKindFromName', () => {
     ['agent 1', 'generic'],
   ] as [string, AgentKind][])('name %s → %s', (name, expected) => {
     expect(inferAgentKindFromName(name)).toBe(expected);
+  });
+});
+
+describe('kindConsumesPlan', () => {
+  const CONSUMING: ReadonlyArray<AgentKind> = ['implementer', 'debugger', 'generic'];
+
+  it.each(ALL_KINDS)('%s partitions into consumer vs passthrough', (kind) => {
+    expect(kindConsumesPlan(kind)).toBe(CONSUMING.includes(kind));
+  });
+
+  it('keeps read/test/doc roles as passthrough', () => {
+    for (const kind of ['scout', 'reviewer', 'tester', 'docs', 'planner', 'resolver'] as const) {
+      expect(kindConsumesPlan(kind)).toBe(false);
+    }
   });
 });
 

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -15,6 +15,16 @@ export const AGENT_KIND_ORDER: ReadonlyArray<AgentKind> = [
   'generic',
 ];
 
+export const PLAN_CONSUMING_KINDS: ReadonlySet<AgentKind> = new Set<AgentKind>([
+  'implementer',
+  'debugger',
+  'generic',
+]);
+
+export function kindConsumesPlan(kind: AgentKind): boolean {
+  return PLAN_CONSUMING_KINDS.has(kind);
+}
+
 export const AGENT_KIND_META: Record<AgentKind, { label: string; hint: string; persona: string }> =
   {
     generic: {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -55,6 +55,7 @@ import type {
   Session,
   SessionId,
   Step,
+  StepId,
   TelemetryRecord,
   TurnState,
   Workflow,
@@ -89,6 +90,7 @@ import {
   AGENT_KIND_PALETTE,
   type AgentKind,
   inferAgentKindFromName,
+  kindConsumesPlan,
   resolveAgentKind,
 } from '../../../../features/session/agent-kind';
 import { AgentKindChip } from '../../../../features/session/components/AgentKindChip';
@@ -535,9 +537,9 @@ function WorkflowKillButton({ onConfirm }: { onConfirm: () => void }) {
  *     implementer attached; no need to suggest again)
  *   - no open questions on the session (the user owes the agent an answer
  *     first; a spawn CTA on top would be noise)
- *   - if the session has a workflow whose next un-spawned step is itself an
- *     implementer, defer to WorkflowNextStepCta, two CTAs for the same
- *     action would compete
+ *   - if any pending workflow step will consume the plan itself (a
+ *     plan-consuming kind: implementer/debugger/generic), defer to the
+ *     workflow, suggesting a free-spawn on top would be noise
  *
  * Click goes through the store's runPlan, which (since the runPlan fix in
  * this branch) seeds an implementer agent with the plan body as kickoff.
@@ -572,13 +574,19 @@ function PlanReadySuggestion({ task }: { task: Session }) {
   }
 
   const discarded = new Set(task.discardedWorkflowIds ?? []);
+  const liveStepIds = new Set<StepId>();
   for (const wid of task.workflowIds) {
     if (discarded.has(wid)) continue;
-    const workflow = phaseTemplates.find((t) => t.id === wid);
-    if (!workflow) continue;
-    const nextStep = pickNextWorkflowStep(workflow, phaseRuns);
-    if (nextStep && inferAgentKindFromName(nextStep.name) === 'implementer') return null;
+    phaseTemplates.find((t) => t.id === wid)?.steps.forEach((s) => liveStepIds.add(s.id));
   }
+  const hasPendingConsumer = phaseRuns.some(
+    (a) =>
+      a.status === 'pending' &&
+      a.stepId !== undefined &&
+      liveStepIds.has(a.stepId) &&
+      kindConsumesPlan((a.kind as AgentKind | undefined) ?? inferAgentKindFromName(a.name)),
+  );
+  if (hasPendingConsumer) return null;
 
   const onSpawn = async () => {
     if (spawning) return;

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -13,7 +13,11 @@ import {
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
   listPlansForSession as invokeListPlansForSession,
 } from '../../../features/plans/plans';
-import { inferAgentKindFromName, type AgentKind } from '../../../features/session/agent-kind';
+import {
+  inferAgentKindFromName,
+  kindConsumesPlan,
+  type AgentKind,
+} from '../../../features/session/agent-kind';
 import { buildPlanKickoffSection, composeKickoff } from '../../kickoff';
 import type { GetFn, SetFn } from './types';
 
@@ -90,9 +94,11 @@ export function spawnAgent(set: SetFn, get: GetFn) {
       (inserted.kind as AgentKind | undefined) ??
       inferAgentKindFromName(resolvedName);
     const isImplementer = effectiveKind === 'implementer';
+    const hasExplicitPlanContext = args.triggeredPlanId !== undefined || args.stepId !== undefined;
+    const engagePlan = isImplementer || (kindConsumesPlan(effectiveKind) && hasExplicitPlanContext);
     let planSection = '';
     let planToConsume: PlanWithCount | null = null;
-    if (isImplementer) {
+    if (engagePlan) {
       const { section: latestSection, plan: latestPlan } = await buildPlanKickoffSection(sessionId);
       const explicitPlan =
         args.triggeredPlanId !== undefined

--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -209,6 +209,29 @@ describe('runPlan, workflow-aware spawn routing', () => {
         });
       }
     });
+
+    it.each([
+      ['Debug', AGENT_KIND_DEFAULTS.debugger.model],
+      ['Execute commits', AGENT_KIND_DEFAULTS.generic.model],
+    ])('routes %s into the workflow slot (consuming kind)', async (name, model) => {
+      const state = defaultState({
+        phaseTemplates: {
+          [WS_ID]: [
+            makeWorkflow([
+              { id: STEP_PLAN, name: 'Plan', ordinal: 0 },
+              { id: STEP_IMPL, name, ordinal: 1 },
+            ]),
+          ],
+        },
+      });
+      const slice = buildSlice(state);
+
+      await slice.runPlan(SESSION_ID, PLAN_ID);
+
+      const [, args] = state.spawnAgent.mock.calls[0]!;
+      expect(args).toEqual({ stepId: STEP_IMPL, triggeredPlanId: PLAN_ID, model });
+      expect(args).not.toHaveProperty('kindOverride');
+    });
   });
 
   describe('gate A, session has no workflows attached → free-spawn', () => {
@@ -440,7 +463,6 @@ describe('runPlan, workflow-aware spawn routing', () => {
       ['Scout', 's-scout'],
       ['Plan', 's-plan2'],
       ['Docs', 's-docs'],
-      ['Debug', 's-debug'],
     ])('free-spawns when next step is %s', async (name, id) => {
       const stepId = id as StepId;
       const wf = makeWorkflow([

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -1,5 +1,9 @@
 import type { PlanId, SessionId } from '@goodboy/types';
-import { AGENT_KIND_DEFAULTS, inferAgentKindFromName } from '../../../features/session/agent-kind';
+import {
+  AGENT_KIND_DEFAULTS,
+  inferAgentKindFromName,
+  kindConsumesPlan,
+} from '../../../features/session/agent-kind';
 import { pickNextWorkflowStep } from '../../../features/workflows/components/WorkflowNextStepCta';
 import type { GetFn } from './types';
 
@@ -63,8 +67,9 @@ export function runPlan(get: GetFn) {
       return;
     }
 
-    // E: next step must be an implementer, don't hijack reviewer/tester/etc.
-    if (inferAgentKindFromName(nextStep.name) !== 'implementer') {
+    // E: next step must execute the plan, don't hijack reviewer/scout/tester/docs.
+    const nextKind = inferAgentKindFromName(nextStep.name);
+    if (!kindConsumesPlan(nextKind)) {
       await get().spawnAgent(sessionId, {
         triggeredPlanId: planId,
         kindOverride: 'implementer',
@@ -78,7 +83,7 @@ export function runPlan(get: GetFn) {
     await get().spawnAgent(sessionId, {
       stepId: nextStep.id,
       triggeredPlanId: planId,
-      model: AGENT_KIND_DEFAULTS.implementer.model,
+      model: AGENT_KIND_DEFAULTS[nextKind].model,
     });
   };
 }

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  ImplementationCluster,
+  IsoDateTime,
+  PlanId,
+  PlanWithCount,
+  Session,
+  SessionId,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+const {
+  addPlanConsumptionSpy,
+  listConsumptionsForPlanSpy,
+  listPlansForSessionSpy,
+  fanOutClustersSpy,
+} = vi.hoisted(() => ({
+  addPlanConsumptionSpy: vi.fn(async () => undefined),
+  listConsumptionsForPlanSpy: vi.fn(async () => []),
+  listPlansForSessionSpy: vi.fn(async () => [] as ReadonlyArray<PlanWithCount>),
+  fanOutClustersSpy: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../features/plans/plans', () => ({
+  addPlanConsumption: addPlanConsumptionSpy,
+  listConsumptionsForPlan: listConsumptionsForPlanSpy,
+  listPlansForSession: listPlansForSessionSpy,
+}));
+
+vi.mock('./clusterImplementation', () => ({ fanOutClusters: fanOutClustersSpy }));
+
+import { activateWorkflowAgent } from './activateWorkflowAgent';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const WF_ID = 'wf-1' as WorkflowId;
+const SESSION_ID = 'ses-1' as SessionId;
+const PLAN_ID = 'plan-1' as PlanId;
+const AGENT_ID = 'agent-step' as AgentId;
+const STEP_ID = 's-exec' as StepId;
+const NOW = '2026-05-23T00:00:00.000Z' as IsoDateTime;
+
+function makePlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
+  return {
+    id: PLAN_ID,
+    sessionId: SESSION_ID,
+    agentId: 'agent-planner' as AgentId,
+    title: 'the plan',
+    bodyMd: 'do the thing',
+    status: 'active',
+    consumptionCount: 0,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeWorkflow(stepName: string): Workflow {
+  return {
+    id: WF_ID,
+    workspaceId: WS_ID,
+    name: 'wf',
+    description: '',
+    steps: [
+      { id: STEP_ID, workflowId: WF_ID, ordinal: 0, name: stepName, promptPrefix: 'run the step' },
+    ],
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function makeAgent(kind: string | undefined, name: string): Agent {
+  return {
+    id: AGENT_ID,
+    sessionId: SESSION_ID,
+    stepId: STEP_ID,
+    ordinal: 0,
+    name,
+    status: 'pending',
+    ...(kind !== undefined && { kind }),
+  };
+}
+
+function buildHarness(opts: {
+  agent: Agent;
+  workflow: Workflow;
+  plans: ReadonlyArray<PlanWithCount>;
+}) {
+  listPlansForSessionSpy.mockResolvedValue(opts.plans);
+  const session: Session = {
+    id: SESSION_ID,
+    workspaceId: WS_ID,
+    goal: 'g',
+    state: { kind: 'idle', lastActivityAt: NOW },
+    contextSlots: [],
+    providerPreference: {
+      defaultProvider: 'anthropic',
+      allowTurnOverride: true,
+    } as Session['providerPreference'],
+    permissionMode: 'default' as Session['permissionMode'],
+    workflowIds: [WF_ID],
+    currentStepByWorkflow: {},
+    autoRun: false,
+    titleUserEdited: false,
+    userStatus: 'wip',
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+  const sendTurn = vi.fn(
+    async (_arg: { sessionId: SessionId; agentId: AgentId; content: string }) => undefined,
+  );
+  const state = {
+    sessionPhaseRuns: { [SESSION_ID]: [opts.agent] },
+    sessions: [session],
+    phaseTemplates: { [WS_ID]: [opts.workflow] },
+    sessionPlans: { [SESSION_ID]: opts.plans },
+    planConsumptions: {},
+    selectedAgentId: {},
+    agentTurnState: {},
+    sendTurn,
+  };
+  const set = vi.fn();
+  const get = (() => state) as unknown as Parameters<typeof activateWorkflowAgent>[1];
+  return {
+    sendTurn,
+    activate: activateWorkflowAgent(
+      set as unknown as Parameters<typeof activateWorkflowAgent>[0],
+      get,
+    ),
+  };
+}
+
+describe('activateWorkflowAgent, plan consumption by kind', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listConsumptionsForPlanSpy.mockResolvedValue([]);
+  });
+
+  it('a generic step after a plan consumes it and receives the plan body', async () => {
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
+    const [payload] = sendTurn.mock.calls[0]!;
+    expect(payload.content).toContain('do the thing');
+    expect(payload.content).toContain('run the step');
+    expect(fanOutClustersSpy).not.toHaveBeenCalled();
+  });
+
+  it('a reviewer step is passthrough: no consumption, no plan body injected', async () => {
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('reviewer', 'Review'),
+      workflow: makeWorkflow('Review'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
+    const [payload] = sendTurn.mock.calls[0]!;
+    expect(payload.content).not.toContain('do the thing');
+    expect(payload.content).toBe('run the step');
+  });
+
+  it('an implementer step with multiple clusters still fans out (no regression)', async () => {
+    const clusters: ReadonlyArray<ImplementationCluster> = [
+      { title: 'a', instructions: 'i1' },
+      { title: 'b', instructions: 'i2' },
+    ];
+    const { activate } = buildHarness({
+      agent: makeAgent('implementer', 'Implement'),
+      workflow: makeWorkflow('Implement'),
+      plans: [makePlan({ clusters })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not consume an already-consumed plan', async () => {
+    const { activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan({ status: 'consumed' })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -4,7 +4,11 @@ import {
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
   listPlansForSession as invokeListPlansForSession,
 } from '../../../features/plans/plans';
-import { inferAgentKindFromName, type AgentKind } from '../../../features/session/agent-kind';
+import {
+  inferAgentKindFromName,
+  kindConsumesPlan,
+  type AgentKind,
+} from '../../../features/session/agent-kind';
 import { buildPlanKickoffSection, composeKickoff } from '../../kickoff';
 import { fanOutClusters } from './clusterImplementation';
 import type { GetFn, SetFn } from './types';
@@ -46,12 +50,12 @@ export function activateWorkflowAgent(set: SetFn, get: GetFn) {
 
     const effectiveKind: AgentKind =
       (agent.kind as AgentKind | undefined) ?? inferAgentKindFromName(agent.name);
-    const isImplementer = effectiveKind === 'implementer';
-    const { section: planSection, plan: latestPlan } = isImplementer
+    const consumesPlan = kindConsumesPlan(effectiveKind);
+    const { section: planSection, plan: latestPlan } = consumesPlan
       ? await buildPlanKickoffSection(sessionId)
       : { section: '', plan: null };
 
-    if (isImplementer && latestPlan && latestPlan.status === 'active') {
+    if (consumesPlan && latestPlan && latestPlan.status === 'active') {
       await invokeAddPlanConsumption(latestPlan.id, agentId);
       const refreshedPlans = await invokeListPlansForSession(sessionId);
       const consumptions = await invokeListConsumptionsForPlan(latestPlan.id);
@@ -62,7 +66,9 @@ export function activateWorkflowAgent(set: SetFn, get: GetFn) {
     }
 
     const clusters =
-      isImplementer && latestPlan?.status === 'active' ? latestPlan.clusters : undefined;
+      effectiveKind === 'implementer' && latestPlan?.status === 'active'
+        ? latestPlan.clusters
+        : undefined;
     if (clusters && clusters.length >= 2) {
       await fanOutClusters(set, get, sessionId, agent, clusters, latestPlan!.title);
       return;


### PR DESCRIPTION
## Problem

A workflow built as `plan → agent` (generic) left the plan stuck on **ACTIVE** forever. Plan consumption was hard-wired to the `implementer` kind in three spawn paths, so a generic (or debugger) step placed after a plan step:

1. never got the plan body injected into its kickoff (it executed blind),
2. never recorded a consumption (the plan badge never flipped to CONSUMED).

The agent that actually did the work was not an `implementer`, so none of the implementer-gated logic fired.

## Fix

Decouple consumption from the `implementer` kind. The signal is now an explicit **executor allowlist**, not "is it an implementer" and not "can it write files":

```
PLAN_CONSUMING_KINDS = { implementer, debugger, generic }
passthrough          = { scout, reviewer, tester, docs, resolver, planner }
```

- **`activateWorkflowAgent`** / **`spawnAgent`**: plan-body injection + consumption now gated on `kindConsumesPlan(kind)`. Cluster fan-out stays **implementer-only**.
- **`runPlan` gate E**: routes the plan into the next workflow slot when that step is any consuming kind (was implementer-only); model derives from the resolved kind.
- **plan-ready "spawn implementer" suggestion**: suppressed whenever *any pending downstream workflow step* will consume the plan, not just when the immediate next step is an implementer. With read-only passthrough, `plan → review → implement` correctly defers to the workflow.

### Why passthrough on read-only kinds

`tester`/`docs` write files but are not plan executors, so "write-capable" was the wrong signal. Read/test/doc kinds pass through; the plan flows downstream to the first real executor. A reviewer in `plan → review → implement` does not consume; the implementer does.

### No regression for free-spawned agents

A generic agent spawned from the Create-agent menu (no `stepId`, no `triggeredPlanId`) does **not** grab the active plan. Engagement requires explicit context. Free-spawned implementer keeps its legacy "pick up the latest plan" behavior.

## Tests

- `agent-kind.test.ts`: locks the consumer/passthrough partition.
- `runPlan` gate E: `Debug` moved from free-spawn to in-slot routing (intentional behavior change); added routing coverage for debugger + generic next steps.
- New `activateWorkflowAgent.test.ts`: generic step consumes + receives plan body; reviewer is passthrough; implementer cluster fan-out still fires; consumed plans are not re-consumed.

Verified locally: typecheck clean, full desktop suite green (840 tests), build + knip pass.

## Follow-ups (not in this PR)

- Per-step `consumesPlan` override (escape hatch for a generic "summarize" step or docs-as-executor).
- `runPlan` gate-E routing is now semi-vestigial given the suggestion-suppression change; worth a later consolidation.
- Optionally inject (without consuming) the plan into a reviewer so it can review against the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)