### PR TITLE
chore(repo): add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,57 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      workspace-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: '/website'
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    groups:
+      website-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: cargo
+    directory: '/apps/desktop/src-tauri'
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
## what

Adds `.github/dependabot.yml` to enable automated dependency updates. Repo had no config, so Dependabot was producing no version-update PRs.

## coverage

| ecosystem | dir | scope |
|-----------|-----|-------|
| npm (pnpm) | `/` | workspace root → `apps/*` + `packages/*` |
| npm (pnpm) | `/website` | standalone (separate lockfile) |
| cargo | `/apps/desktop/src-tauri` | tauri backend |
| github-actions | `/` | the 4 workflows |

## choices

- **weekly (mon)** to limit noise.
- **minor+patch grouped** per ecosystem → 1 PR/week each; **majors stay individual** so they can be reviewed case by case (e.g. vite 8 was correctly rejected before).
- commit prefix `chore(deps)` / `ci(deps)`. The `deps` scope isn't in commitlint's `scope-enum`, but commitlint runs only as a local lefthook hook (not in CI), which Dependabot bypasses. Matches the precedent of already-merged #639.

## note

Dependabot only reads this from the default branch, so it activates once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)