### PR TITLE
feat(desktop): explain workflow studio in empty state

### DIFF
--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/EmptyGuide/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/EmptyGuide/index.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { EmptyGuide } from './index';
+
+afterEach(cleanup);
+
+describe('EmptyGuide', () => {
+  it('explains the page with a tagline and three ordered steps', () => {
+    render(<EmptyGuide onNew={() => undefined} hasPresets={false} />);
+    expect(screen.getByText(/run it on any session/i)).toBeDefined();
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
+    expect(screen.getByText('3')).toBeDefined();
+    expect(screen.getByText(/step library on the right/i)).toBeDefined();
+  });
+
+  it('frames the first run when no presets exist yet', () => {
+    render(<EmptyGuide onNew={() => undefined} hasPresets={false} />);
+    expect(screen.getByText(/design your first workflow/i)).toBeDefined();
+    expect(screen.getByText(/5 presets ship by default/i)).toBeDefined();
+  });
+
+  it('points returning users to the preset list', () => {
+    render(<EmptyGuide onNew={() => undefined} hasPresets />);
+    expect(screen.getByText(/build a workflow/i)).toBeDefined();
+    expect(screen.getByText(/pick a preset on the left to edit/i)).toBeDefined();
+  });
+
+  it('starts a new workflow from the call to action', () => {
+    const onNew = vi.fn();
+    render(<EmptyGuide onNew={onNew} hasPresets={false} />);
+    fireEvent.click(screen.getByRole('button', { name: /new workflow/i }));
+    expect(onNew).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/EmptyGuide/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/EmptyGuide/index.tsx
@@ -1,0 +1,86 @@
+import type { LucideIcon } from 'lucide-react';
+import { ArrowLeft, ArrowRight, Layers, Plus } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+
+interface Props {
+  readonly onNew: () => void;
+  readonly hasPresets: boolean;
+}
+
+interface GuideStep {
+  readonly text: string;
+  readonly arrow?: LucideIcon;
+}
+
+const STEPS: ReadonlyArray<GuideStep> = [
+  {
+    text: 'Pick a preset on the left to clone or edit, or start a new one.',
+    arrow: ArrowLeft,
+  },
+  {
+    text: "Each step is one agent with its own role, provider and model. Steps run in order, each one's output feeds the next.",
+  },
+  {
+    text: 'Drag steps from the Step Library on the right. When it is ready, run it on a session from "Start a workflow".',
+    arrow: ArrowRight,
+  },
+];
+
+export function EmptyGuide({ onNew, hasPresets }: Props) {
+  return (
+    <div className="flex h-full items-center justify-center p-8">
+      <div className="flex w-full max-w-md flex-col items-center gap-6 text-center">
+        <div className="flex flex-col items-center gap-3">
+          <span className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            <Layers size={18} aria-hidden />
+          </span>
+          <div className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-foreground">
+              {hasPresets ? 'Build a workflow' : 'Design your first workflow'}
+            </span>
+            <span className="text-2xs text-muted-foreground">
+              Save a sequence of agents once, run it on any session.
+            </span>
+          </div>
+        </div>
+
+        <ol className="flex w-full flex-col gap-2.5 text-left">
+          {STEPS.map((step, idx) => {
+            const Arrow = step.arrow;
+            return (
+              <li
+                key={idx}
+                className="flex items-start gap-2.5 rounded-lg border border-border-soft bg-muted/10 px-3 py-2.5"
+              >
+                <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-2xs font-medium text-muted-foreground">
+                  {idx + 1}
+                </span>
+                <span className="flex-1 text-2xs leading-relaxed text-muted-foreground">
+                  {step.text}
+                </span>
+                {Arrow ? (
+                  <Arrow
+                    size={13}
+                    className="mt-0.5 shrink-0 text-muted-foreground/60"
+                    aria-hidden
+                  />
+                ) : null}
+              </li>
+            );
+          })}
+        </ol>
+
+        <div className="flex flex-col items-center gap-2">
+          <Button size="sm" onClick={onNew}>
+            <Plus size={13} aria-hidden /> New workflow
+          </Button>
+          <span className="text-2xs text-muted-foreground/70">
+            {hasPresets
+              ? 'or pick a preset on the left to edit.'
+              : '5 presets ship by default, you can edit or clone them anytime.'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowsPanel/index.tsx
@@ -28,6 +28,7 @@ import { StepDropZone } from '../WorkflowStudio/StepDropZone';
 import { PresetCard } from '../PresetCard';
 import { LibraryCard } from '../LibraryCard';
 import { LibraryStepForm } from '../LibraryStepForm';
+import { EmptyGuide } from './EmptyGuide';
 
 interface Props {
   readonly workspaceId: WorkspaceId;
@@ -422,7 +423,7 @@ export function WorkflowsPanel({ workspaceId }: Props) {
             </div>
           </ScrollFade>
         ) : (
-          <EmptyEditorHint onNew={openNew} hasPresets={presets.length > 0} />
+          <EmptyGuide onNew={openNew} hasPresets={presets.length > 0} />
         )}
       </section>
 
@@ -447,27 +448,6 @@ export function WorkflowsPanel({ workspaceId }: Props) {
           {drag.label}
         </div>
       ) : null}
-    </div>
-  );
-}
-
-function EmptyEditorHint({ onNew, hasPresets }: { onNew: () => void; hasPresets: boolean }) {
-  return (
-    <div className="flex h-full items-center justify-center p-8">
-      <EmptyState
-        icon={Layers}
-        title={hasPresets ? 'Pick a workflow to edit' : 'Design your first workflow'}
-        description={
-          hasPresets
-            ? 'Select a preset on the left, or start a new one. Drag steps in from the library on the right.'
-            : 'Chain reusable steps, each with its own role, provider and model. Drag them in from the library on the right.'
-        }
-        action={
-          <Button size="sm" onClick={onNew}>
-            <Plus size={13} aria-hidden /> New workflow
-          </Button>
-        }
-      />
     </div>
   );
 }


### PR DESCRIPTION
## What

First-time visitors to Workflow Studio couldn't tell what the page was for. The center pane only showed a one-line hint.

This replaces it with an onboarding guide:
- tagline explaining the value (save a sequence of agents, run it on any session)
- three ordered steps mapped spatially to the surrounding panels (Presets on the left, Step Library on the right)
- a `New workflow` call to action
- copy adapts to first-run vs returning users

## How

- new `WorkflowsPanel/EmptyGuide` component, replacing the old `EmptyEditorHint`
- dedicated test covering the explainer, both copy variants, and the CTA

## Test

`pnpm -C apps/desktop exec vitest run src/features/workflows/components/WorkflowsPanel` (7 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)