### PR TITLE
feat(desktop): confirm before switching workspace with running agents

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -12,6 +12,7 @@ import { ToastProvider } from './app/components/Toast';
 import { ProviderModalHost } from './features/providers/components/ProviderModalHost';
 import { WorkspacesSidebar } from './features/workspace/components/WorkspacesSidebar';
 import { WorkspaceLinkDialog } from './features/workspace/components/WorkspaceLinkDialog';
+import { WorkspaceSwitchDialog } from './features/workspace/components/WorkspaceSwitchDialog';
 import { WorkflowStudio } from './features/workflows/components/WorkflowStudio';
 import { GitHubStudio } from './features/github/components/GitHubStudio';
 import { LinearStudio } from './features/integrations/linear/LinearStudio';
@@ -319,16 +320,17 @@ export function App() {
     });
   }, []);
 
-  const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
+  const requestWorkspaceSwitch = useAppStore((s) => s.requestWorkspaceSwitch);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const pendingWorkspaceSwitch = useAppStore((s) => s.pendingWorkspaceSwitch);
   const currentWorkspaceSessions = useSessions();
 
   const selectWorkspaceByIndex = useCallback(
     (idx: number) => {
       const w = workspaces[idx];
-      if (w) void setCurrentWorkspace(w.id);
+      if (w) void requestWorkspaceSwitch(w.id);
     },
-    [workspaces, setCurrentWorkspace],
+    [workspaces, requestWorkspaceSwitch],
   );
 
   const navigateSession = useCallback(
@@ -591,6 +593,7 @@ export function App() {
       {currentSession && archiveOpen ? (
         <ArchiveSessionDialog session={currentSession} open onClose={() => setArchiveOpen(false)} />
       ) : null}
+      {pendingWorkspaceSwitch ? <WorkspaceSwitchDialog /> : null}
       {/* App-level modal host so the provider connect modal can be summoned
           from any surface (providers panel, chat callout, future onboarding
           cards) via a CustomEvent, without prop-drilling. */}

--- a/apps/desktop/src/features/session/components/CommandPalette/index.test.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.test.tsx
@@ -11,7 +11,7 @@ const { state, toastMock } = vi.hoisted(() => ({
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
     agentKindOverride: {} as Record<string, string>,
-    setCurrentWorkspace: vi.fn(async () => undefined),
+    requestWorkspaceSwitch: vi.fn(async () => undefined),
     setCurrentSession: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
     runScript: vi.fn(async () => ({ exitCode: 0 })),

--- a/apps/desktop/src/features/session/components/CommandPalette/index.tsx
+++ b/apps/desktop/src/features/session/components/CommandPalette/index.tsx
@@ -93,7 +93,7 @@ export function CommandPalette({
   const sessions = useSessions();
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
-  const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
+  const requestWorkspaceSwitch = useAppStore((s) => s.requestWorkspaceSwitch);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const skills = useAppStore((s) =>
@@ -127,7 +127,7 @@ export function CommandPalette({
         label: w.name,
         sublabel: w.rootPath,
         group: 'workspace',
-        onSelect: () => void setCurrentWorkspace(w.id),
+        onSelect: () => void requestWorkspaceSwitch(w.id),
       });
     }
 
@@ -258,7 +258,7 @@ export function CommandPalette({
     runScript,
     showToast,
     agentKindOverride,
-    setCurrentWorkspace,
+    requestWorkspaceSwitch,
     setCurrentSession,
     selectAgent,
     onOpenSettings,

--- a/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.test.tsx
@@ -7,7 +7,7 @@ import type { Workspace } from '@goodboy/types';
 interface MockState {
   workspaces: ReadonlyArray<Workspace>;
   currentWorkspace: Workspace | null;
-  setCurrentWorkspace: ReturnType<typeof vi.fn>;
+  requestWorkspaceSwitch: ReturnType<typeof vi.fn>;
   workspaceHasUnread: boolean;
 }
 
@@ -15,15 +15,15 @@ const { state } = vi.hoisted<{ state: MockState }>(() => ({
   state: {
     workspaces: [],
     currentWorkspace: null,
-    setCurrentWorkspace: vi.fn(async () => undefined),
+    requestWorkspaceSwitch: vi.fn(async () => undefined),
     workspaceHasUnread: false,
   },
 }));
 
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(
-    selector: (s: { setCurrentWorkspace: typeof state.setCurrentWorkspace }) => T,
-  ) => selector({ setCurrentWorkspace: state.setCurrentWorkspace }),
+    selector: (s: { requestWorkspaceSwitch: typeof state.requestWorkspaceSwitch }) => T,
+  ) => selector({ requestWorkspaceSwitch: state.requestWorkspaceSwitch }),
   useCurrentWorkspace: () => state.currentWorkspace,
   useWorkspaceHasUnread: () => state.workspaceHasUnread,
   useWorkspaces: () => state.workspaces,
@@ -41,16 +41,16 @@ beforeEach(() => {
     { id: 'ws-b', name: 'bravo' } as Workspace,
   ];
   state.currentWorkspace = state.workspaces[0] ?? null;
-  state.setCurrentWorkspace = vi.fn(async () => undefined);
+  state.requestWorkspaceSwitch = vi.fn(async () => undefined);
   state.workspaceHasUnread = false;
 });
 afterEach(cleanup);
 
 describe('WorkspaceSelect', () => {
-  it('lists each linked workspace and triggers setCurrentWorkspace on click', () => {
+  it('lists each linked workspace and requests a switch on click', () => {
     render(<WorkspaceSelect onAddWorkspace={vi.fn()} />);
     fireEvent.click(screen.getByText('bravo'));
-    expect(state.setCurrentWorkspace).toHaveBeenCalledWith('ws-b');
+    expect(state.requestWorkspaceSwitch).toHaveBeenCalledWith('ws-b');
   });
 
   it('shows the count + cap label in the header', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSelect/index.tsx
@@ -23,7 +23,7 @@ interface WorkspaceTarget {
 export function WorkspaceSelect({ onAddWorkspace }: Props) {
   const workspaces = useWorkspaces();
   const currentWorkspace = useCurrentWorkspace();
-  const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
+  const requestWorkspaceSwitch = useAppStore((s) => s.requestWorkspaceSwitch);
   // Two pieces of state instead of one nullable target so the dialog can
   // stay mounted across opens. Mount-on-first-click was racing with the
   // <dialog>.showModal() effect under React 19 strict mode and silently
@@ -80,7 +80,7 @@ export function WorkspaceSelect({ onAddWorkspace }: Props) {
             key={ws.id}
             workspace={ws}
             isActive={ws.id === currentWorkspace?.id}
-            onSelect={() => void setCurrentWorkspace(ws.id)}
+            onSelect={() => void requestWorkspaceSwitch(ws.id)}
             onOpenSettings={() => openSettings({ id: ws.id, name: ws.name })}
           />
         ))}

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitchDialog/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitchDialog/index.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { IsoDateTime, ProviderRunId, Session, Workspace, WorkspaceId } from '@goodboy/types';
+
+interface MockState {
+  pendingWorkspaceSwitch: { targetId: WorkspaceId | null } | null;
+  sessions: ReadonlyArray<Session>;
+  workspaces: ReadonlyArray<Workspace>;
+  confirmWorkspaceSwitch: ReturnType<typeof vi.fn>;
+  cancelWorkspaceSwitch: ReturnType<typeof vi.fn>;
+}
+
+const { state } = vi.hoisted<{ state: MockState }>(() => ({
+  state: {
+    pendingWorkspaceSwitch: null,
+    sessions: [],
+    workspaces: [],
+    confirmWorkspaceSwitch: vi.fn(async () => undefined),
+    cancelWorkspaceSwitch: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: MockState) => T) => selector(state),
+  useWorkspaces: () => state.workspaces,
+}));
+
+import { WorkspaceSwitchDialog } from './index';
+
+const NOW = '2026-06-05T00:00:00.000Z' as IsoDateTime;
+
+function buildRunningSession(id: string, goal: string): Session {
+  return {
+    id,
+    workspaceId: 'ws-a',
+    goal,
+    state: { kind: 'running', runId: 'run-1' as ProviderRunId, startedAt: NOW },
+    workflowRuns: [],
+  } as unknown as Session;
+}
+
+beforeEach(() => {
+  state.pendingWorkspaceSwitch = { targetId: 'ws-b' as WorkspaceId };
+  state.sessions = [buildRunningSession('session-1', 'ship the thing')];
+  state.workspaces = [
+    { id: 'ws-a', name: 'alpha' } as Workspace,
+    { id: 'ws-b', name: 'bravo' } as Workspace,
+  ];
+  state.confirmWorkspaceSwitch = vi.fn(async () => undefined);
+  state.cancelWorkspaceSwitch = vi.fn();
+});
+afterEach(cleanup);
+
+describe('WorkspaceSwitchDialog', () => {
+  it('renders nothing when no switch is pending', () => {
+    state.pendingWorkspaceSwitch = null;
+    render(<WorkspaceSwitchDialog />);
+    expect(screen.queryByText('Switch workspace?')).toBeNull();
+  });
+
+  it('warns about the running agents and lists each one', () => {
+    render(<WorkspaceSwitchDialog />);
+    expect(screen.getByText('Switch workspace?')).toBeDefined();
+    expect(screen.getByText(/1 agent is still running/i)).toBeDefined();
+    expect(screen.getByText('ship the thing')).toBeDefined();
+  });
+
+  it('confirms the switch with the target workspace name on the action button', () => {
+    render(<WorkspaceSwitchDialog />);
+    fireEvent.click(screen.getByText('Switch to bravo'));
+    expect(state.confirmWorkspaceSwitch).toHaveBeenCalledOnce();
+  });
+
+  it('cancels the switch when the user chooses to stay', () => {
+    render(<WorkspaceSwitchDialog />);
+    fireEvent.click(screen.getByText('Stay here'));
+    expect(state.cancelWorkspaceSwitch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspaceSwitchDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceSwitchDialog/index.tsx
@@ -1,0 +1,72 @@
+import { Loader2 } from 'lucide-react';
+import { Button, Dialog, cn } from '@goodboy/ui';
+import { useAppStore, useWorkspaces } from '../../../../store';
+
+export function WorkspaceSwitchDialog() {
+  const pending = useAppStore((s) => s.pendingWorkspaceSwitch);
+  const sessions = useAppStore((s) => s.sessions);
+  const workspaces = useWorkspaces();
+  const confirmWorkspaceSwitch = useAppStore((s) => s.confirmWorkspaceSwitch);
+  const cancelWorkspaceSwitch = useAppStore((s) => s.cancelWorkspaceSwitch);
+
+  if (!pending) return null;
+
+  const running = sessions.filter((s) => s.state.kind === 'running');
+  const count = running.length;
+  const targetName =
+    pending.targetId === null
+      ? null
+      : (workspaces.find((w) => w.id === pending.targetId)?.name ?? null);
+  const subject = count === 1 ? 'agent is' : 'agents are';
+  const them = count === 1 ? 'it' : 'them';
+
+  return (
+    <Dialog
+      open
+      onClose={cancelWorkspaceSwitch}
+      title="Switch workspace?"
+      description={`${count} ${subject} still running here. Switching away stops ${them} right now.`}
+      size="sm"
+      footer={
+        <>
+          <Button variant="ghost" onClick={cancelWorkspaceSwitch}>
+            Stay here
+          </Button>
+          <Button variant="warning" onClick={() => void confirmWorkspaceSwitch()}>
+            {targetName ? `Switch to ${targetName}` : 'Switch anyway'}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <ul className="flex flex-col gap-1.5">
+          {running.map((s) => {
+            const isAutoMode = s.workflowRuns.some((r) => r.autoRun && !r.discardedAt);
+            return (
+              <li
+                key={s.id}
+                className="flex items-center gap-2 rounded-md border border-border-soft bg-subtle px-3 py-2 text-xs"
+              >
+                <Loader2
+                  size={12}
+                  aria-hidden
+                  className={cn('shrink-0 animate-spin', isAutoMode ? 'text-danger' : 'text-info')}
+                />
+                <span className="min-w-0 flex-1 truncate text-foreground">{s.goal}</span>
+                {isAutoMode ? (
+                  <span className="shrink-0 text-2xs font-medium uppercase tracking-wide text-danger">
+                    auto
+                  </span>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Interrupted turns don&apos;t resume on their own. Anything already streamed is kept, so you
+          can re-run after switching.
+        </p>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/store/slices/workspaces/cancelWorkspaceSwitch.ts
+++ b/apps/desktop/src/store/slices/workspaces/cancelWorkspaceSwitch.ts
@@ -1,0 +1,7 @@
+import type { SetFn } from './types';
+
+export function cancelWorkspaceSwitch(set: SetFn) {
+  return (): void => {
+    set({ pendingWorkspaceSwitch: null });
+  };
+}

--- a/apps/desktop/src/store/slices/workspaces/confirmWorkspaceSwitch.ts
+++ b/apps/desktop/src/store/slices/workspaces/confirmWorkspaceSwitch.ts
@@ -1,0 +1,10 @@
+import type { GetFn, SetFn } from './types';
+
+export function confirmWorkspaceSwitch(set: SetFn, get: GetFn) {
+  return async (): Promise<void> => {
+    const pending = get().pendingWorkspaceSwitch;
+    if (!pending) return;
+    set({ pendingWorkspaceSwitch: null });
+    await get().setCurrentWorkspace(pending.targetId);
+  };
+}

--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -476,6 +476,7 @@ describe('store contract', () => {
         sessions: [],
         archivedSessions: {},
         currentSessionId: null,
+        pendingWorkspaceSwitch: null,
         settings: {},
         sessionSummary: null,
         providerStatus: null,
@@ -595,6 +596,71 @@ describe('store contract', () => {
       const s = store.getState();
       expect(s.currentWorkspaceId).toBeNull();
       expect(s.providerSpendBreakdown).toEqual([]);
+    });
+
+    it('requestWorkspaceSwitch switches immediately when no agent is running', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace(), buildWorkspace({ id: WS_ID_2, name: 'ws2' })],
+        currentWorkspaceId: WS_ID,
+        sessions: [buildSession()],
+      });
+      const spy = vi.fn(async () => undefined);
+      const real = store.getState().setCurrentWorkspace;
+      store.setState({ setCurrentWorkspace: spy } as never);
+      try {
+        await store.getState().requestWorkspaceSwitch(WS_ID_2);
+        expect(spy).toHaveBeenCalledWith(WS_ID_2);
+        expect(store.getState().pendingWorkspaceSwitch).toBeNull();
+      } finally {
+        store.setState({ setCurrentWorkspace: real } as never);
+      }
+    });
+
+    it('requestWorkspaceSwitch defers and records the target when an agent is running', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace(), buildWorkspace({ id: WS_ID_2, name: 'ws2' })],
+        currentWorkspaceId: WS_ID,
+        sessions: [buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } })],
+      });
+      await store.getState().requestWorkspaceSwitch(WS_ID_2);
+      const s = store.getState();
+      expect(s.currentWorkspaceId).toBe(WS_ID);
+      expect(s.pendingWorkspaceSwitch).toEqual({ targetId: WS_ID_2 });
+    });
+
+    it('confirmWorkspaceSwitch clears the pending switch and delegates to the target', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace(), buildWorkspace({ id: WS_ID_2, name: 'ws2' })],
+        currentWorkspaceId: WS_ID,
+        sessions: [buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } })],
+        pendingWorkspaceSwitch: { targetId: WS_ID_2 },
+      });
+      const spy = vi.fn(async () => undefined);
+      const real = store.getState().setCurrentWorkspace;
+      store.setState({ setCurrentWorkspace: spy } as never);
+      try {
+        await store.getState().confirmWorkspaceSwitch();
+        expect(store.getState().pendingWorkspaceSwitch).toBeNull();
+        expect(spy).toHaveBeenCalledWith(WS_ID_2);
+      } finally {
+        store.setState({ setCurrentWorkspace: real } as never);
+      }
+    });
+
+    it('cancelWorkspaceSwitch drops the pending switch and stays put', async () => {
+      const store = await getStore();
+      store.setState({
+        workspaces: [buildWorkspace(), buildWorkspace({ id: WS_ID_2, name: 'ws2' })],
+        currentWorkspaceId: WS_ID,
+        pendingWorkspaceSwitch: { targetId: WS_ID_2 },
+      });
+      store.getState().cancelWorkspaceSwitch();
+      const s = store.getState();
+      expect(s.currentWorkspaceId).toBe(WS_ID);
+      expect(s.pendingWorkspaceSwitch).toBeNull();
     });
   });
 });

--- a/apps/desktop/src/store/slices/workspaces/index.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.ts
@@ -1,5 +1,8 @@
 import { addWorkspace } from './addWorkspace';
+import { cancelWorkspaceSwitch } from './cancelWorkspaceSwitch';
+import { confirmWorkspaceSwitch } from './confirmWorkspaceSwitch';
 import { deleteWorkspace } from './deleteWorkspace';
+import { requestWorkspaceSwitch } from './requestWorkspaceSwitch';
 import { setCurrentWorkspace } from './setCurrentWorkspace';
 import { wipeLocalDatabase } from './wipeLocalDatabase';
 import type { GetFn, SetFn } from './types';
@@ -7,7 +10,10 @@ import type { GetFn, SetFn } from './types';
 export function createWorkspacesSlice(set: SetFn, get: GetFn) {
   return {
     addWorkspace: addWorkspace(set, get),
+    cancelWorkspaceSwitch: cancelWorkspaceSwitch(set),
+    confirmWorkspaceSwitch: confirmWorkspaceSwitch(set, get),
     deleteWorkspace: deleteWorkspace(set, get),
+    requestWorkspaceSwitch: requestWorkspaceSwitch(set, get),
     setCurrentWorkspace: setCurrentWorkspace(set, get),
     wipeLocalDatabase: wipeLocalDatabase(set, get),
   };

--- a/apps/desktop/src/store/slices/workspaces/requestWorkspaceSwitch.ts
+++ b/apps/desktop/src/store/slices/workspaces/requestWorkspaceSwitch.ts
@@ -1,0 +1,17 @@
+import type { WorkspaceId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+export function requestWorkspaceSwitch(set: SetFn, get: GetFn) {
+  return async (id: WorkspaceId | null): Promise<void> => {
+    if (id === get().currentWorkspaceId) {
+      await get().setCurrentWorkspace(id);
+      return;
+    }
+    const hasRunning = get().sessions.some((s) => s.state.kind === 'running');
+    if (!hasRunning) {
+      await get().setCurrentWorkspace(id);
+      return;
+    }
+    set({ pendingWorkspaceSwitch: { targetId: id } });
+  };
+}

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -187,6 +187,7 @@ export interface AppState extends UpdaterState {
   // them, they exist only as historical info.
   readonly archivedSessions: Readonly<Record<WorkspaceId, ReadonlyArray<Session>>>;
   readonly currentSessionId: SessionId | null;
+  readonly pendingWorkspaceSwitch: { readonly targetId: WorkspaceId | null } | null;
   readonly settings: Readonly<Record<string, string>>;
   readonly sessionSummary: TelemetrySummary | null;
   readonly providerStatus: ProviderStatus | null;
@@ -336,6 +337,9 @@ export interface AppActions {
   checkForUpdates(): Promise<void>;
   installUpdate(): Promise<void>;
   setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
+  requestWorkspaceSwitch(id: WorkspaceId | null): Promise<void>;
+  confirmWorkspaceSwitch(): Promise<void>;
+  cancelWorkspaceSwitch(): void;
   setCurrentSession(id: SessionId | null): Promise<void>;
   refreshSessions(workspaceId: WorkspaceId): Promise<void>;
   // Lazily load archived sessions for a workspace. Called when the Archived
@@ -647,6 +651,7 @@ export const initialState: AppState = {
   sessions: [],
   archivedSessions: {},
   currentSessionId: null,
+  pendingWorkspaceSwitch: null,
   settings: {},
   sessionSummary: null,
   providerStatus: null,


### PR DESCRIPTION
## What

Switching workspaces silently killed any agent still running in the workspace you were leaving. `setCurrentWorkspace` cancels every running turn (it kills the provider child processes so they stop emitting events into stale sessions) before wiping the in-memory cache, so in-flight agents died with no warning.

This adds an explicit confirmation step.

## How

- New store state `pendingWorkspaceSwitch` + actions `requestWorkspaceSwitch` / `confirmWorkspaceSwitch` / `cancelWorkspaceSwitch` in the workspaces slice.
- `requestWorkspaceSwitch` is the gate: no running agents -> switches straight through (zero friction); one or more running -> records the target and opens a confirm dialog.
- `WorkspaceSwitchDialog` lists each running session (spinner, goal, auto-mode badge) and explains the turns stop now and won't resume on their own, with `Stay here` / `Switch to <name>`.
- The three user entry points route through the gate: sidebar workspace cards, command palette, and the index keyboard shortcut.
- Programmatic switches (boot restore, add-workspace, delete) keep calling `setCurrentWorkspace` directly and bypass the prompt by design.

## Notes

- Confirm button uses the `warning` variant, not `danger`: interrupting a turn is not permanent data loss (transcript is kept, the agent can be re-run), so red is reserved for End/Delete.

## Tests

- Slice contract: switch-through when idle, defer + record target when running, confirm clears pending and moves, cancel stays put.
- Component: renders nothing when no pending switch, warns and lists running agents, confirm/cancel wiring.
- Updated the existing WorkspaceSelect and CommandPalette test mocks for the renamed action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)