### PR TITLE
feat(desktop): update without restarting the app

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -38,6 +38,7 @@ import {
 } from './store';
 import { refreshPricingTable } from './features/providers/provider-pricing';
 import { useGithubPolling } from './features/github/hooks/useGithubPolling';
+import { useUpdaterPolling } from './features/updater/hooks/useUpdaterPolling';
 import { STORAGE_PREFIXES } from './shared/lib/storage-keys';
 import { openUrl } from './shared/lib/editor';
 import { applyStoredZoom, zoomIn, zoomOut, zoomReset } from './shared/lib/zoom';
@@ -124,6 +125,7 @@ export function App() {
 
   useGithubPolling();
   useProviderRefreshOnFocus();
+  useUpdaterPolling();
 
   useEffect(() => {
     void applyStoredZoom();

--- a/apps/desktop/src/features/updater/hooks/useUpdaterPolling/index.ts
+++ b/apps/desktop/src/features/updater/hooks/useUpdaterPolling/index.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useAppStore } from '../../../../store';
+
+const POLL_INTERVAL_MS = 60 * 60_000;
+const RECHECK_TTL_MS = 30 * 60_000;
+
+export function useUpdaterPolling(): void {
+  const checkForUpdates = useAppStore((s) => s.checkForUpdates);
+
+  useEffect(() => {
+    if (!import.meta.env.PROD) return;
+
+    let lastRunAt = 0;
+
+    const maybeCheck = (): void => {
+      const status = useAppStore.getState().updaterStatus;
+      if (status === 'checking' || status === 'downloading' || status === 'available') return;
+      if (Date.now() - lastRunAt < RECHECK_TTL_MS) return;
+      lastRunAt = Date.now();
+      void checkForUpdates();
+    };
+
+    const tick = (): void => {
+      if (document.visibilityState === 'visible') maybeCheck();
+    };
+
+    const intervalId = window.setInterval(tick, POLL_INTERVAL_MS);
+    window.addEventListener('focus', maybeCheck);
+    document.addEventListener('visibilitychange', tick);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener('focus', maybeCheck);
+      document.removeEventListener('visibilitychange', tick);
+    };
+  }, [checkForUpdates]);
+}

--- a/packaging/goodboy.rb
+++ b/packaging/goodboy.rb
@@ -9,6 +9,8 @@ cask "goodboy" do
   desc "AI workspace orchestrator, local-first and provider-agnostic"
   homepage "https://github.com/akhayam99/goodboy"
 
+  auto_updates true
+
   app "Goodboy.app"
 
   zap trash: [


### PR DESCRIPTION
## Why

Today the update check runs only once, in the boot \`useEffect\` (`App.tsx`, PROD-gated). Stay in the app and it never re-checks, so the only way to discover a new release is to quit and relaunch. The in-app update UI (`UpdateIndicator` pip/dialog, download + install + relaunch) already exists and works without a restart, it just never gets told a release is available.

## What

- **`useUpdaterPolling`** hook: re-runs `checkForUpdates()` on an interval (60m) and on window focus / visibility, mirroring `useGithubPolling` + `useProviderRefreshOnFocus`. Guards skip when a check is in flight, an update is already surfaced, or one ran in the last 30m. PROD-only. Mounted in `App.tsx` next to the other polling hooks. No backend change, no new UI: the existing pip lights up on its own when status flips to `available`.
- **Cask `auto_updates true`** (`packaging/goodboy.rb`): the app self-updates via the Tauri updater, so Homebrew should defer to it. Without this the Caskroom version drifts behind the self-updated `.app`, `brew outdated` flags it, and `brew upgrade` reinstalls redundantly. `auto_updates true` is the standard stanza for self-updating casks (vscode, chrome, slack).

## Notes

- The divergence existed already (self-update is not new); this just makes self-update discoverable while the app is open and lets brew step back cleanly.
- Self-update endpoint and cask are both rendered from the same release event, so they stay in sync at publish time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)