### PR TITLE
ci(ci): run rust check on every pr so js-only prs aren't blocked

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,6 @@ name: rust
 
 on:
   pull_request:
-    paths:
-      - 'apps/desktop/src-tauri/**'
-      - '.github/workflows/rust.yml'
   push:
     paths:
       - 'apps/desktop/src-tauri/**'
@@ -19,25 +16,54 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: detect rust changes
+        id: changes
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || echo "__ERR__")
+          if [ "$files" = "__ERR__" ]; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$files" | grep -qE '^(apps/desktop/src-tauri/|\.github/workflows/rust\.yml$)'; then
+            echo "rust=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "rust=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: install tauri system deps
+        if: steps.changes.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev libsoup-3.0-dev
 
       - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        if: steps.changes.outputs.rust == 'true'
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        if: steps.changes.outputs.rust == 'true'
         with:
           node-version: 22
           cache: pnpm
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: steps.changes.outputs.rust == 'true'
         with:
           toolchain: stable
           components: rustfmt, clippy
 
       - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        if: steps.changes.outputs.rust == 'true'
         with:
           path: |
             ~/.cargo/registry
@@ -48,21 +74,26 @@ jobs:
             cargo-check-${{ runner.os }}-
 
       - name: install
+        if: steps.changes.outputs.rust == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: build frontend
+        if: steps.changes.outputs.rust == 'true'
         run: pnpm turbo run build --filter=@goodboy/desktop
 
       - name: fmt
+        if: steps.changes.outputs.rust == 'true'
         working-directory: apps/desktop/src-tauri
         run: cargo fmt --check
         continue-on-error: true
 
       - name: clippy
+        if: steps.changes.outputs.rust == 'true'
         working-directory: apps/desktop/src-tauri
         run: cargo clippy --locked --all-targets -- -D warnings
         continue-on-error: true
 
       - name: test
+        if: steps.changes.outputs.rust == 'true'
         working-directory: apps/desktop/src-tauri
         run: cargo test --locked


### PR DESCRIPTION
## Problem

`fmt + clippy + test` (from `rust.yml`) is a **required** status check on `main`, but the workflow only triggered on `apps/desktop/src-tauri/**` (and `rust.yml`) changes. A PR touching no Rust never produces that context, so it sits in "Expected" indefinitely and the branch shows `BLOCKED` even with every other check green. PR #749 had to be merged with an admin override for exactly this reason, and every future JS-only PR would hit the same wall.

## Fix

- Trigger the `rust` workflow on **every** `pull_request` (drop the PR-level path filter).
- Add a `detect rust changes` step that diffs the PR against its base and gates the heavy steps (system deps, toolchain, cache, frontend build, fmt, clippy, test) behind `steps.changes.outputs.rust == 'true'`.

Behaviour:
- **No Rust changes** -> heavy steps skip, the job reports success in seconds, the required context is satisfied.
- **Rust changes (including a mixed PR)** -> the full check runs, so a real failure can never be masked by a skip.
- **push** keeps its path filter (it is not a required-check surface), and forces `rust=true` when it does run.

This PR itself touches `rust.yml`, so the full Rust check runs here and both required contexts report normally (no admin override needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)