### PR TITLE
fix(desktop): reliable resolve-comment push + visible failures

### DIFF
--- a/apps/desktop/src-tauri/src/github.rs
+++ b/apps/desktop/src-tauri/src/github.rs
@@ -84,7 +84,7 @@ fn run_gh(
 }
 
 fn run_git_push(args: &[&str], cwd: &str, token: Option<&str>) -> Result<GhRunResult, GithubError> {
-    let mut cmd = crate::path_env::command("git");
+    let mut cmd = crate::path_env::command_with_login_env("git");
     if gh_available() {
         cmd.args([
             "-c",

--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 static RESOLVED_PATH: OnceLock<String> = OnceLock::new();
+static RESOLVED_ENV: OnceLock<Vec<(String, String)>> = OnceLock::new();
 
 const PROBE_TIMEOUT: Duration = Duration::from_secs(3);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -26,6 +27,19 @@ pub fn resolved_path() -> &'static str {
 /// posix path set.
 pub fn command(binary: &str) -> Command {
     let mut cmd = Command::new(binary);
+    cmd.env("PATH", resolved_path());
+    cmd
+}
+
+pub fn resolved_env() -> &'static [(String, String)] {
+    RESOLVED_ENV.get_or_init(compute_env)
+}
+
+pub fn command_with_login_env(binary: &str) -> Command {
+    let mut cmd = Command::new(binary);
+    for (key, value) in resolved_env() {
+        cmd.env(key, value);
+    }
     cmd.env("PATH", resolved_path());
     cmd
 }
@@ -81,6 +95,46 @@ fn probe_login_shell_path() -> Option<String> {
         if !std::path::Path::new(sh).exists() {
             continue;
         }
+        if let Some(out) = run_with_timeout(sh, args) {
+            let trimmed = out.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn compute_env() -> Vec<(String, String)> {
+    parse_env(&probe_login_shell_env().unwrap_or_default())
+}
+
+fn parse_env(raw: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for line in raw.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() || key.contains(char::is_whitespace) {
+            continue;
+        }
+        if seen.insert(key.to_string()) {
+            out.push((key.to_string(), value.to_string()));
+        }
+    }
+    out
+}
+
+fn probe_login_shell_env() -> Option<String> {
+    const LOGIN_ARGS: &[&str] = &["-ilc", "env"];
+    const POSIX_ARGS: &[&str] = &["-lc", "env"];
+    for (sh, _) in shell_candidates() {
+        if !std::path::Path::new(sh).exists() {
+            continue;
+        }
+        let args = if *sh == "/bin/sh" { POSIX_ARGS } else { LOGIN_ARGS };
         if let Some(out) = run_with_timeout(sh, args) {
             let trimmed = out.trim();
             if !trimmed.is_empty() {
@@ -181,5 +235,33 @@ mod tests {
         for s in &segments {
             assert!(unique.insert(*s), "duplicate segment in resolved PATH: {}", s);
         }
+    }
+
+    #[test]
+    fn parse_env_keeps_first_value_and_skips_malformed() {
+        let raw = "PATH=/usr/bin\nGITHUB_PACKAGES_TOKEN=abc=123\nNOEQUALS\n bad key=x\nPATH=/override\n";
+        let env = parse_env(raw);
+        assert_eq!(
+            env.iter()
+                .find(|(k, _)| k == "GITHUB_PACKAGES_TOKEN")
+                .map(|(_, v)| v.as_str()),
+            Some("abc=123")
+        );
+        assert!(env.iter().all(|(k, _)| k != "NOEQUALS"));
+        assert!(env.iter().all(|(k, _)| !k.contains(' ')));
+        assert_eq!(
+            env.iter().filter(|(k, _)| k == "PATH").count(),
+            1,
+            "duplicate keys collapse to the first occurrence"
+        );
+    }
+
+    #[test]
+    fn command_with_login_env_sets_path() {
+        let cmd = command_with_login_env("true");
+        let env = cmd.get_envs().find(|(k, _)| *k == std::ffi::OsStr::new("PATH"));
+        assert!(env.is_some(), "command must set PATH env var");
+        let (_, val) = env.unwrap();
+        assert_eq!(val, Some(std::ffi::OsStr::new(resolved_path())));
     }
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,6 +9,7 @@ import { EndSessionDialog } from './features/session/components/EndSessionDialog
 import { ArchiveSessionDialog } from './features/session/components/ArchiveSessionDialog';
 import { SettingsDialog } from './features/settings/components/SettingsDialog';
 import { ToastProvider } from './app/components/Toast';
+import { NotificationToastBridge } from './features/notifications/components/NotificationToastBridge';
 import { ProviderModalHost } from './features/providers/components/ProviderModalHost';
 import { WorkspacesSidebar } from './features/workspace/components/WorkspacesSidebar';
 import { WorkspaceLinkDialog } from './features/workspace/components/WorkspaceLinkDialog';
@@ -432,6 +433,7 @@ export function App() {
 
   return (
     <ToastProvider>
+      <NotificationToastBridge />
       <AppShell
         leftSidebarCollapsed={leftCollapsed}
         leftSidebar={

--- a/apps/desktop/src/app/components/Toast/index.tsx
+++ b/apps/desktop/src/app/components/Toast/index.tsx
@@ -8,10 +8,19 @@ export interface ToastItem {
   readonly id: string;
   readonly kind: ToastKind;
   readonly message: string;
+  readonly title?: string;
+  readonly context?: string;
+  readonly persist?: boolean;
+}
+
+export interface ShowToastOptions {
+  readonly title?: string;
+  readonly context?: string;
+  readonly persist?: boolean;
 }
 
 interface ToastContextValue {
-  showToast: (kind: ToastKind, message: string) => void;
+  showToast: (kind: ToastKind, message: string, opts?: ShowToastOptions) => void;
 }
 
 const ToastContext = createContext<ToastContextValue | null>(null);
@@ -25,11 +34,21 @@ interface ToastProviderProps {
 export function ToastProvider({ children }: ToastProviderProps) {
   const [toasts, setToasts] = useState<ReadonlyArray<ToastItem>>([]);
 
-  const showToast = useCallback((kind: ToastKind, message: string) => {
+  const showToast = useCallback((kind: ToastKind, message: string, opts?: ShowToastOptions) => {
     const id = crypto.randomUUID();
     const formatted =
       message.length > 0 ? message.charAt(0).toUpperCase() + message.slice(1) : message;
-    setToasts((prev) => [...prev, { id, kind, message: formatted }]);
+    setToasts((prev) => [
+      ...prev,
+      {
+        id,
+        kind,
+        message: formatted,
+        title: opts?.title,
+        context: opts?.context,
+        persist: opts?.persist,
+      },
+    ]);
   }, []);
 
   const dismiss = useCallback((id: string) => {
@@ -83,21 +102,24 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
 
   useEffect(() => {
     const raf = requestAnimationFrame(() => setVisible(true));
-    timerRef.current = setTimeout(() => {
-      setVisible(false);
-      setTimeout(() => onDismiss(toast.id), 200);
-    }, AUTO_DISMISS_MS);
+    if (!toast.persist) {
+      timerRef.current = setTimeout(() => {
+        setVisible(false);
+        setTimeout(() => onDismiss(toast.id), 200);
+      }, AUTO_DISMISS_MS);
+    }
 
     return () => {
       cancelAnimationFrame(raf);
       if (timerRef.current !== null) clearTimeout(timerRef.current);
     };
-  }, [toast.id, onDismiss]);
+  }, [toast.id, toast.persist, onDismiss]);
 
   return (
     <div
       className={cn(
-        'pointer-events-auto flex max-w-xs items-start gap-2 rounded-lg border px-3 py-2.5 shadow-md motion-safe:transition-all motion-safe:duration-200',
+        'pointer-events-auto flex items-start gap-2 rounded-lg border px-3 py-2.5 shadow-md motion-safe:transition-all motion-safe:duration-200',
+        toast.title ? 'max-w-sm' : 'max-w-xs',
         visible ? 'translate-y-0 opacity-100' : '-translate-y-1 opacity-0',
         toast.kind === 'error'
           ? 'border-danger/30 bg-subtle text-danger'
@@ -109,7 +131,22 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
       )}
       role="alert"
     >
-      <span className="flex-1 text-xs leading-snug">{toast.message}</span>
+      <div className="min-w-0 flex-1">
+        {toast.title ? <p className="text-xs font-semibold leading-snug">{toast.title}</p> : null}
+        {toast.message ? (
+          <p
+            className={cn(
+              'whitespace-pre-line break-words text-xs leading-snug',
+              toast.title && 'mt-0.5 line-clamp-4 text-foreground/80',
+            )}
+          >
+            {toast.message}
+          </p>
+        ) : null}
+        {toast.context ? (
+          <p className="mt-1 truncate text-2xs opacity-70">{toast.context}</p>
+        ) : null}
+      </div>
       <button
         type="button"
         className="mt-0.5 shrink-0 opacity-60 hover:opacity-100"

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -199,7 +199,9 @@ function NotificationItem({ notification: n }: NotificationItemProps) {
       <div className="min-w-0 flex-1">
         <p className="text-xs font-medium text-foreground leading-snug">{n.title}</p>
         {n.body && (
-          <p className="mt-0.5 text-xs text-muted-foreground leading-snug truncate">{n.body}</p>
+          <p className="mt-0.5 whitespace-pre-wrap break-words text-xs leading-snug text-muted-foreground">
+            {n.body}
+          </p>
         )}
         <p className="mt-0.5 text-2xs text-muted-foreground/70">{relativeTime(n.ts)}</p>
       </div>

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { Notification } from '@goodboy/db';
+import type { Session, SessionId, Workspace, WorkspaceId } from '@goodboy/types';
+import { notificationContext, pickFreshFailures } from './';
+
+function notif(over: Partial<Notification> & { id: string }): Notification {
+  return {
+    ts: '2026-06-05T12:00:00.000Z',
+    kind: 'error',
+    title: 'something failed',
+    body: null,
+    severity: 'error',
+    sessionId: null,
+    workspaceId: null,
+    read: false,
+    ...over,
+  } as Notification;
+}
+
+const SINCE = new Date('2026-06-05T12:00:00.000Z').getTime();
+
+describe('pickFreshFailures', () => {
+  it('returns only errors and warnings newer than the cutoff', () => {
+    const seen = new Set<string>();
+    const list = [
+      notif({ id: 'old', ts: '2026-06-05T11:59:59.000Z', severity: 'error' }),
+      notif({ id: 'e1', ts: '2026-06-05T12:00:01.000Z', severity: 'error' }),
+      notif({ id: 'w1', ts: '2026-06-05T12:00:02.000Z', severity: 'warning' }),
+      notif({ id: 'i1', ts: '2026-06-05T12:00:03.000Z', severity: 'info' }),
+      notif({ id: 's1', ts: '2026-06-05T12:00:04.000Z', severity: 'success' }),
+    ];
+    expect(pickFreshFailures(list, seen, SINCE).map((n) => n.id)).toEqual(['e1', 'w1']);
+  });
+
+  it('marks every scanned id seen so historical and ignored ones never toast', () => {
+    const seen = new Set<string>();
+    const list = [
+      notif({ id: 'old', ts: '2026-06-05T11:59:59.000Z' }),
+      notif({ id: 'i1', ts: '2026-06-05T12:00:03.000Z', severity: 'info' }),
+    ];
+    pickFreshFailures(list, seen, SINCE);
+    expect(seen).toEqual(new Set(['old', 'i1']));
+  });
+
+  it('does not return a notification twice across calls', () => {
+    const seen = new Set<string>();
+    const list = [notif({ id: 'e1', ts: '2026-06-05T12:00:01.000Z' })];
+    expect(pickFreshFailures(list, seen, SINCE).map((n) => n.id)).toEqual(['e1']);
+    expect(pickFreshFailures(list, seen, SINCE)).toEqual([]);
+  });
+});
+
+describe('notificationContext', () => {
+  const workspaces = [{ id: 'w1' as WorkspaceId, name: 'app-web' } as Workspace];
+  const sessions = [{ id: 's1' as SessionId, goal: 'GRW-902 change therapist' } as Session];
+
+  it('joins workspace name and session goal', () => {
+    const n = notif({ id: 'n', workspaceId: 'w1' as WorkspaceId, sessionId: 's1' as SessionId });
+    expect(notificationContext(n, sessions, workspaces)).toBe('app-web · GRW-902 change therapist');
+  });
+
+  it('falls back to a placeholder for a blank goal', () => {
+    const blank = [{ id: 's2' as SessionId, goal: '   ' } as Session];
+    const n = notif({ id: 'n', sessionId: 's2' as SessionId });
+    expect(notificationContext(n, blank, workspaces)).toBe('untitled session');
+  });
+
+  it('returns undefined when neither session nor workspace resolves', () => {
+    expect(notificationContext(notif({ id: 'n' }), sessions, workspaces)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
@@ -1,20 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import type { Notification } from '@goodboy/db';
-import type { Session, SessionId, Workspace, WorkspaceId } from '@goodboy/types';
+import type { Notification, NotificationSeverity } from '@goodboy/db';
+import type { IsoDateTime, Session, SessionId, Workspace, WorkspaceId } from '@goodboy/types';
 import { notificationContext, pickFreshFailures } from './';
 
-function notif(over: Partial<Notification> & { id: string }): Notification {
+interface NotifOverride {
+  id: string;
+  ts?: string;
+  severity?: NotificationSeverity;
+  title?: string;
+  body?: string | null;
+  sessionId?: SessionId | null;
+  workspaceId?: WorkspaceId | null;
+}
+
+function notif(over: NotifOverride): Notification {
   return {
-    ts: '2026-06-05T12:00:00.000Z',
+    id: over.id,
+    ts: (over.ts ?? '2026-06-05T12:00:00.000Z') as IsoDateTime,
     kind: 'error',
-    title: 'something failed',
-    body: null,
-    severity: 'error',
-    sessionId: null,
-    workspaceId: null,
+    title: over.title ?? 'something failed',
+    body: over.body ?? null,
+    severity: over.severity ?? 'error',
+    sessionId: over.sessionId ?? null,
+    workspaceId: over.workspaceId ?? null,
     read: false,
-    ...over,
-  } as Notification;
+  };
 }
 
 const SINCE = new Date('2026-06-05T12:00:00.000Z').getTime();

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import type { Notification } from '@goodboy/db';
+import type { Session, Workspace } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+
+export function pickFreshFailures(
+  notifications: ReadonlyArray<Notification>,
+  seen: Set<string>,
+  since: number,
+): ReadonlyArray<Notification> {
+  const out: Array<Notification> = [];
+  for (const n of notifications) {
+    if (seen.has(n.id)) continue;
+    seen.add(n.id);
+    if (new Date(n.ts).getTime() < since) continue;
+    if (n.severity !== 'error' && n.severity !== 'warning') continue;
+    out.push(n);
+  }
+  return out;
+}
+
+export function notificationContext(
+  n: Notification,
+  sessions: ReadonlyArray<Session>,
+  workspaces: ReadonlyArray<Workspace>,
+): string | undefined {
+  const parts: Array<string> = [];
+  const ws = n.workspaceId ? workspaces.find((w) => w.id === n.workspaceId) : undefined;
+  if (ws) parts.push(ws.name);
+  const session = n.sessionId ? sessions.find((s) => s.id === n.sessionId) : undefined;
+  if (session) parts.push(session.goal.trim() || 'untitled session');
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+export function NotificationToastBridge() {
+  const notifications = useAppStore((s) => s.notifications);
+  const sessions = useAppStore((s) => s.sessions);
+  const workspaces = useAppStore((s) => s.workspaces);
+  const { showToast } = useToast();
+
+  const seen = useRef<Set<string>>(new Set());
+  const mountedAt = useRef<number>(Date.now());
+
+  useEffect(() => {
+    for (const n of pickFreshFailures(notifications, seen.current, mountedAt.current)) {
+      showToast(n.severity === 'error' ? 'error' : 'warning', n.body ?? '', {
+        title: n.title,
+        context: notificationContext(n, sessions, workspaces),
+        persist: n.severity === 'error',
+      });
+    }
+  }, [notifications, sessions, workspaces, showToast]);
+
+  return null;
+}

--- a/docs/adr/0002-subprocess-login-shell-env.md
+++ b/docs/adr/0002-subprocess-login-shell-env.md
@@ -1,0 +1,46 @@
+# ADR-0002: Spawn User-Facing Subprocesses With the Login-Shell Environment
+
+**Status**: Accepted  
+**Date**: 2026-06-05  
+**Deciders**: Amin
+
+---
+
+## Context
+
+macOS apps launched from Finder/Dock inherit only a minimal environment, not the one a user's terminal has. `path_env.rs` already works around this for `PATH`: it probes the login shell once (`zsh -ilc 'printf %s "$PATH"'`), merges the result, and hands it to spawned commands via `command()`. That fixes binary discovery (`git`, `gh`, `claude`, editors) but nothing else.
+
+The gap surfaced through the deferred review-comment resolution feature (see [[project_resolve_batch_push]]). "Push & resolve" and "Push now" funnel into `git_push` (`github.rs`), spawned with `command("git")`, PATH only. A target repo's `pre-push` hook (husky running `yarn`) reads `${GITHUB_PACKAGES_TOKEN}`, a variable the user exports in `~/.zshrc`. Absent from the GUI process env, `yarn` throws `Failed to replace env in config`, the hook exits non-zero, and the push is rejected. The branch never pushes and the review thread never resolves, while the queue (a pure DB write) keeps working. The failure looked silent because `emitNotification` records to the NotificationCenter, not a toast.
+
+The terminal (`terminal.rs`) does not have this problem: it spawns the real login shell, which sources the rc files and so carries the full exported environment. Subprocesses spawned directly by the Rust shell do not.
+
+## Decision
+
+Resolve the **full login-shell environment** once, cache it, and replay it onto subprocesses that can trigger user-authored git hooks or tooling.
+
+- `path_env::resolved_env()` probes the login shell (`zsh -ilc env`), parses `KEY=VALUE` pairs, dedups, and caches via `OnceLock`, the same lazy, cached shape as `resolved_path()`.
+- `path_env::command_with_login_env(binary)` builds a `Command` pre-loaded with that environment, then overrides `PATH` with the resolved value. Callers may still set their own vars (e.g. `GH_TOKEN`) afterward; last write wins.
+- `git_push` (`run_git_push`) uses `command_with_login_env`. The pre-push hook now sees the same environment a terminal would, so it behaves identically to a manual `git push`.
+
+`command()` (PATH only) stays the default. The login-shell env is heavier to resolve and broader in scope; it is reserved for subprocesses that run user hooks or user tooling. Internal git plumbing (`rev-parse`, worktree management) does not run hooks and keeps `command()`.
+
+Replaying the full environment is intentional: it mirrors what the user's terminal already does, so any tooling the hook depends on is satisfied. Skipping hooks (`git push --no-verify`) was rejected: it would silently bypass checks the user's repo relies on, and it does not match terminal behavior.
+
+## Consequences
+
+**Positive**
+
+- Git hooks that depend on exported environment (registry tokens, tool config) work from the app exactly as they do in a terminal.
+- The fix lives in the subprocess-spawn layer (Rust shell), so business logic in TS is untouched, consistent with the "Rust only for the shell" boundary.
+- One cached probe; no per-push cost after the first.
+
+**Negative / trade-offs**
+
+- One extra login-shell spawn on first use (a few hundred ms), amortized by the cache.
+- The whole exported environment reaches the hook process, same exposure as a terminal.
+- An interactive shell that prints to stdout from its rc files can add noise to the probe; malformed lines (no `=`, whitespace in the key) are dropped during parsing.
+
+## What this does NOT cover
+
+- Surfacing push/resolve failures as a transient toast: today they land only in the NotificationCenter, which is why this failure read as "nothing happened." Tracked separately.
+- Windows subprocess environment: there is no login-shell probe there; this decision is macOS/Linux scoped.


### PR DESCRIPTION
## Why

"Push & resolve" / "Push now" for resolver agents failed silently on real PRs. Root cause was not in the resolve code: the app spawned `git push` via `path_env::command("git")`, which injects only `PATH`, not the login-shell environment. macOS GUI apps (Finder/Dock) do not inherit `~/.zshrc` exports, so a repo `pre-push` hook (husky running `yarn`, reading `${GITHUB_PACKAGES_TOKEN}`) threw and the push was rejected. The push runs before the resolve, so nothing pushed and nothing resolved. The failure looked silent because error notifications only landed in the NotificationCenter, never a toast.

Diagnosed from the persisted error in the `notifications` table:
`Failed to replace env in config: ${GITHUB_PACKAGES_TOKEN}` -> `push di alcuni riferimenti ... non riuscito`.

## What

**Fix (root cause)** - `fix(desktop): spawn git push with the login-shell environment`
- `path_env::resolved_env()` + `command_with_login_env()`: probe the login shell once (`zsh -ilc env`), cache it, replay onto subprocesses that can trigger user git hooks.
- `run_git_push` uses it, so the pre-push hook sees the same env a terminal would. Only push needs it; rev-parse/worktree git do not run hooks.
- Decision recorded in [docs/adr/0002](docs/adr/0002-subprocess-login-shell-env.md). `--no-verify` was rejected (would bypass the repo's checks).

**Surface failures** - `feat(desktop): surface failure notifications as toasts`
- Error/warning notifications now also fire a toast (errors persist until dismissed), carrying workspace + session context.
- NotificationCenter body wraps so the full error is readable.
- `NotificationToastBridge` dedups via mount-time + seen-set so historical notifications never spam on boot. Pure helpers unit-tested.

## Verification

- `cargo check` green.
- Frontend test added (`NotificationToastBridge`); not run locally (worktree has no installed deps), validated by CI.
- Note: CI exercises build + tests, not the real git-push-through-hook. Merging does not release (a `v*` tag does), so this lands on main without shipping to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)