### PR TITLE
feat(desktop): visible message queue + provider/model footnote

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
-import { ImagePlus, Send, Square, Telescope, X } from 'lucide-react';
+import { Clock, ImagePlus, Send, Square, Telescope, X } from 'lucide-react';
 import { Divider, Textarea } from '@goodboy/ui';
 import type {
   Agent,
@@ -270,11 +270,12 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   const currentVerbosityRef = useRef(verbosity);
   currentVerbosityRef.current = verbosity;
   interface QueuedTurn {
+    readonly id: string;
     readonly content: string;
     readonly attachments: ReadonlyArray<PendingAttachment>;
     readonly override: TurnProviderOverride | undefined;
   }
-  const [queued, setQueued] = useState<QueuedTurn | null>(null);
+  const [queue, setQueue] = useState<ReadonlyArray<QueuedTurn>>([]);
   interface RightSizePending {
     readonly content: string;
     readonly attachments: ReadonlyArray<PendingAttachment>;
@@ -583,12 +584,31 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
         : undefined;
 
     if (isRunning) {
-      setQueued({ content, attachments: atts, override });
+      setQueue((prev) => [
+        ...prev,
+        { id: crypto.randomUUID(), content, attachments: atts, override },
+      ]);
       return;
     }
 
     await dispatchTurn(content, atts, override);
   };
+
+  const removeQueued = useCallback((id: string) => {
+    setQueue((prev) => prev.filter((q) => q.id !== id));
+  }, []);
+
+  const editQueued = useCallback(
+    (id: string) => {
+      const item = queue.find((q) => q.id === id);
+      if (!item) return;
+      setQueue((prev) => prev.filter((q) => q.id !== id));
+      setValue(item.content);
+      setAttachments(item.attachments);
+      wrapperRef.current?.querySelector('textarea')?.focus();
+    },
+    [queue, setValue],
+  );
 
   const onSend = async () => {
     const content = value.trim();
@@ -714,12 +734,12 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   useEffect(() => {
     const wasRun = wasRunning.current;
     wasRunning.current = isRunning;
-    if (wasRun && !isRunning && queued) {
-      const { content, attachments: queuedAttachments, override } = queued;
-      setQueued(null);
-      void dispatchTurn(content, queuedAttachments, override);
+    if (wasRun && !isRunning && queue.length > 0) {
+      const [next, ...rest] = queue;
+      setQueue(rest);
+      if (next) void dispatchTurn(next.content, next.attachments, next.override);
     }
-  }, [isRunning, queued, dispatchTurn]);
+  }, [isRunning, queue, dispatchTurn]);
 
   // Native drag-drop. Tauri swallows DOM drop events for OS-file drags by
   // default (dragDropEnabled=true) and emits a window-global event instead.
@@ -861,6 +881,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
     if (restoredVerbosity !== null) setVerbosityState(restoredVerbosity);
 
     setAttachments([]);
+    setQueue([]);
     setRightSizePending(null);
     setRightSizeDismissed(false);
     setScopePending(null);
@@ -1062,6 +1083,12 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
         {scriptResult ? (
           <ScriptResultRow state={scriptResult} onDismiss={() => dismissScriptResult(session.id)} />
         ) : null}
+        <QueuedMessages
+          items={queue}
+          canEdit={value.trim().length === 0 && attachments.length === 0}
+          onEdit={editQueued}
+          onRemove={removeQueued}
+        />
         <div
           ref={composerRef}
           className={`relative flex flex-col rounded-md ring-1 transition-all focus-within:ring-2 focus-within:ring-primary/40 dark:bg-muted/40 ${
@@ -1108,8 +1135,8 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
                 providerDisconnected
                   ? 'Sign in to send a message'
                   : isRunning
-                    ? queued
-                      ? 'Message queued, type to replace it'
+                    ? queue.length > 0
+                      ? 'Type to queue another message'
                       : 'Turn running, type to queue the next message'
                     : CHAT_PLACEHOLDER
               }
@@ -1163,24 +1190,6 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
                 className="hidden"
                 onChange={onFileInputChange}
               />
-              {queued ? (
-                <span className="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-2 py-0.5 text-2xs text-primary">
-                  queued
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setQueued(null);
-                      setValue(queued.content);
-                      setAttachments(queued.attachments);
-                    }}
-                    title="cancel queued message (returns to input)"
-                    aria-label="cancel queued message"
-                    className="rounded-full p-0.5 hover:bg-primary/20"
-                  >
-                    <X size={10} aria-hidden />
-                  </button>
-                </span>
-              ) : null}
             </div>
             <div className="flex items-center gap-2">
               <ProviderUsagePill provider={effectiveProvider} />
@@ -1227,6 +1236,78 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
           </div>
         ) : null}
       </div>
+    </div>
+  );
+}
+
+interface QueuedItem {
+  readonly id: string;
+  readonly content: string;
+  readonly attachments: ReadonlyArray<PendingAttachment>;
+}
+
+function QueuedMessages({
+  items,
+  canEdit,
+  onEdit,
+  onRemove,
+}: {
+  readonly items: ReadonlyArray<QueuedItem>;
+  readonly canEdit: boolean;
+  readonly onEdit: (id: string) => void;
+  readonly onRemove: (id: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1 rounded-[6px] bg-subtle/80 p-1 ring-1 ring-border-soft">
+      <div className="flex items-center gap-1.5 px-1.5 pt-0.5 text-2xs text-muted-foreground">
+        <Clock size={11} aria-hidden />
+        <span>
+          {items.length === 1
+            ? 'queued, sends when the current turn finishes'
+            : `${items.length} queued, send in order`}
+        </span>
+      </div>
+      {items.map((item, i) => {
+        const trimmed = item.content.trim();
+        const imageCount = item.attachments.length;
+        const preview =
+          trimmed.length > 0 ? trimmed : `${imageCount} image${imageCount === 1 ? '' : 's'}`;
+        return (
+          <div
+            key={item.id}
+            className="group flex items-center gap-2 rounded bg-background/60 px-1.5 py-1"
+          >
+            <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-primary/15 text-2xs font-medium text-primary">
+              {i + 1}
+            </span>
+            <button
+              type="button"
+              disabled={!canEdit}
+              onClick={() => onEdit(item.id)}
+              title={canEdit ? 'edit, moves it back to the composer' : 'clear the composer to edit'}
+              className="min-w-0 flex-1 truncate text-left text-xs text-foreground/80 transition-colors enabled:hover:text-foreground disabled:cursor-default"
+            >
+              {preview}
+            </button>
+            {imageCount > 0 && trimmed.length > 0 ? (
+              <span className="inline-flex shrink-0 items-center gap-0.5 text-2xs text-muted-foreground">
+                <ImagePlus size={10} aria-hidden />
+                {imageCount}
+              </span>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => onRemove(item.id)}
+              title="remove from queue"
+              aria-label="remove queued message"
+              className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+            >
+              <X size={11} aria-hidden />
+            </button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -1,9 +1,11 @@
 import { memo, useEffect, useState } from 'react';
 import { ArrowUpRight, Check, ChevronRight, Copy, FileEdit, ImageOff, Wrench } from 'lucide-react';
 import { CopyButton, Divider, Markdown, cn, formatUsd } from '@goodboy/ui';
-import type { AgentId, MessageAttachment, SessionId } from '@goodboy/types';
+import type { AgentId, MessageAttachment, ProviderId, SessionId } from '@goodboy/types';
 import { extractCommentResolved, isReviewThreadId } from '@goodboy/core';
 import type { TranscriptItem } from '../../utils/transcript-items';
+import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provider-brand';
+import { PROVIDER_LABEL, modelLabel } from '../../utils/chat-constants';
 import { readAttachment } from '../../turn';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { ImageLightbox } from '../ImageLightbox';
@@ -45,6 +47,8 @@ function TranscriptCardImpl({
           text={item.text}
           at={item.at}
           attachments={item.attachments}
+          provider={item.provider}
+          model={item.model}
           workingDir={workingDir}
         />
       );
@@ -330,11 +334,15 @@ function UserText({
   text,
   at,
   attachments,
+  provider,
+  model,
   workingDir = null,
 }: {
   text: string;
   at: string;
   attachments?: ReadonlyArray<MessageAttachment>;
+  provider?: ProviderId;
+  model?: string;
   workingDir?: string | null;
 }) {
   const images = attachments ?? [];
@@ -353,10 +361,26 @@ function UserText({
         </div>
       ) : null}
       <div className="flex items-center justify-end gap-1.5 text-2xs text-foreground/55">
+        {provider ? <ProviderFootnote provider={provider} model={model} /> : null}
         <span className="font-mono">{formatHHMM(at)}</span>
         {text.length > 0 ? <InlineCopyButton value={text} /> : null}
       </div>
     </div>
+  );
+}
+
+function ProviderFootnote({ provider, model }: { provider: ProviderId; model?: string }) {
+  const Icon = PROVIDER_BRAND[provider].icon;
+  const label = PROVIDER_LABEL[provider];
+  return (
+    <span
+      className="mr-auto inline-flex items-center gap-1 text-foreground/45"
+      title={`sent to ${label}${model ? ` · ${modelLabel(model)}` : ''}`}
+    >
+      <Icon size={11} aria-hidden style={{ color: brandColor(provider) }} />
+      <span>{label}</span>
+      {model ? <span className="text-foreground/35">· {modelLabel(model)}</span> : null}
+    </span>
   );
 }
 

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -15,6 +15,8 @@ export type TranscriptItem =
       key: string;
       text: string;
       attachments?: ReadonlyArray<MessageAttachment>;
+      provider?: ProviderId;
+      model?: string;
       at: IsoDateTime;
     }
   | { kind: 'assistant_text'; key: string; text: string }
@@ -120,6 +122,8 @@ export function reduceTranscript(events: ReadonlyArray<TurnEvent>): ReadonlyArra
           ...(event.attachments && event.attachments.length > 0
             ? { attachments: event.attachments }
             : {}),
+          ...(event.provider ? { provider: event.provider } : {}),
+          ...(event.model ? { model: event.model } : {}),
           at: event.at,
         });
         break;

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -437,6 +437,8 @@ export function sendTurn(set: SetFn, get: GetFn) {
         runId,
         text: userTurnText,
         ...(attachmentRefs.length > 0 ? { attachments: attachmentRefs } : {}),
+        provider,
+        model,
         at: userMessage.createdAt,
       });
 
@@ -603,6 +605,8 @@ export function sendTurn(set: SetFn, get: GetFn) {
         kind: 'user_text',
         runId: groupSessionRunId,
         text: userTurnText,
+        provider,
+        model,
         at: userMessage.createdAt,
       });
       let nextStateP: TurnState = session.state;

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,6 +1,7 @@
 import type { IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
 import type { MessageAttachment } from './message';
 import type { ProviderName } from './provider';
+import type { ProviderId } from './provider-registry';
 
 export interface ProviderCapabilities {
   readonly streaming: boolean;
@@ -46,6 +47,8 @@ export type TurnEvent =
       runId: ProviderRunId;
       text: string;
       attachments?: ReadonlyArray<MessageAttachment>;
+      provider?: ProviderId;
+      model?: string;
       at: IsoDateTime;
     }
   | { kind: 'assistant_text'; runId: ProviderRunId; delta: string; at: IsoDateTime }


### PR DESCRIPTION
## What

Two chat composer improvements.

### Visible message queue
Queueing a turn while another runs no longer hides what you wrote.
- queue is a FIFO list rendered **above the composer** (same slot as a script result)
- each pending message shows its text, order (1, 2, 3...) and image count
- click a row to **edit** (pulls it back into the composer); X to remove
- multiple messages can queue and dispatch in order as turns complete
- replaces the old context-free "queued" chip; queue clears on agent switch

### Provider/model footnote
Every user message now carries a small footnote with the provider brand logo, provider name and the model it was sent to.
- threaded via new optional `provider`/`model` fields on the `user_text` turn event
- persisted in the event JSON payload, so it survives reload with **no migration**
- old messages without the data render without the footnote (graceful)

## Test
- `pnpm typecheck` green (5/5)
- `pnpm test` green (874/874)
- prettier + commitlint clean

## Notes
- queue is per-session/agent component state (clears on session switch); not persisted to the store by design (kept scope tight)
- brand logos reuse the existing `PROVIDER_BRAND` icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)