### PR TITLE
fix(desktop): run plan activates pre-created step, no duplicate agent

### DIFF
--- a/apps/desktop/src/store/slices/plans/index.test.ts
+++ b/apps/desktop/src/store/slices/plans/index.test.ts
@@ -22,7 +22,6 @@ vi.mock('../../../shared/lib/db', () => ({
 }));
 
 import { createPlansSlice } from './index';
-import { AGENT_KIND_DEFAULTS } from '../../../features/session/agent-kind';
 
 const WS_ID = 'ws-1' as WorkspaceId;
 const WF_ID = 'wf-refactor' as WorkflowId;
@@ -109,6 +108,7 @@ interface FakeState {
   sessionPhaseRuns: Record<SessionId, ReadonlyArray<Agent>>;
   phaseTemplates: Record<WorkspaceId, ReadonlyArray<Workflow>>;
   spawnAgent: ReturnType<typeof vi.fn>;
+  activateWorkflowAgent: ReturnType<typeof vi.fn>;
 }
 
 function buildSlice(state: FakeState) {
@@ -148,6 +148,7 @@ function defaultState(overrides: Partial<FakeState> = {}): FakeState {
     sessionPhaseRuns: { [SESSION_ID]: [creator, nextImpl] },
     phaseTemplates: { [WS_ID]: [wf] },
     spawnAgent: vi.fn(async () => 'spawned' as AgentId),
+    activateWorkflowAgent: vi.fn(async () => undefined),
     ...overrides,
   };
 }
@@ -157,36 +158,27 @@ describe('runPlan, workflow-aware spawn routing', () => {
     vi.clearAllMocks();
   });
 
-  describe('in-workflow spawn (all gates pass)', () => {
-    it('routes to the next implementer step via stepId when plan was created inside the workflow', async () => {
+  describe('in-workflow activation (all gates pass)', () => {
+    it('activates the pre-created pending step agent, routing the clicked plan, with no spawn', async () => {
       const state = defaultState();
       const slice = buildSlice(state);
 
       await slice.runPlan(SESSION_ID, PLAN_ID);
 
-      expect(state.spawnAgent).toHaveBeenCalledTimes(1);
-      const [sid, args] = state.spawnAgent.mock.calls[0]!;
-      expect(sid).toBe(SESSION_ID);
-      expect(args).toEqual({
-        stepId: STEP_IMPL,
-        workflowRunId: RUN_ID,
-        triggeredPlanId: PLAN_ID,
-        model: AGENT_KIND_DEFAULTS.implementer.model,
-      });
-      // No kindOverride, agent kind must come from the step name so the
-      // workflow slot's role wins over the implementer default.
-      expect(args).not.toHaveProperty('kindOverride');
+      expect(state.spawnAgent).not.toHaveBeenCalled();
+      expect(state.activateWorkflowAgent).toHaveBeenCalledTimes(1);
+      expect(state.activateWorkflowAgent).toHaveBeenCalledWith(SESSION_ID, IMPL_AGENT_ID, PLAN_ID);
     });
 
-    it('uses implementer model default (sonnet) for the in-workflow spawn', async () => {
+    it('does not insert a duplicate agent for a step that already has a pending slot', async () => {
       const state = defaultState();
+      const before = state.sessionPhaseRuns[SESSION_ID]!.length;
       const slice = buildSlice(state);
 
       await slice.runPlan(SESSION_ID, PLAN_ID);
 
-      const [, args] = state.spawnAgent.mock.calls[0]!;
-      expect(args.model).toBe('claude-sonnet-4-5');
-      expect(args.model).toBe(AGENT_KIND_DEFAULTS.implementer.model);
+      expect(state.sessionPhaseRuns[SESSION_ID]).toHaveLength(before);
+      expect(state.spawnAgent).not.toHaveBeenCalled();
     });
 
     it('recognizes implementer aliases ("Implement", "Build", "Refactor", "Code", "Feature", "Develop")', async () => {
@@ -206,41 +198,36 @@ describe('runPlan, workflow-aware spawn routing', () => {
 
         await slice.runPlan(SESSION_ID, PLAN_ID);
 
-        const [, args] = state.spawnAgent.mock.calls[0]!;
-        expect(args, `alias "${name}" should route in-workflow`).toMatchObject({
-          stepId: STEP_IMPL,
-          triggeredPlanId: PLAN_ID,
-        });
+        expect(state.spawnAgent, `alias "${name}" must not free-spawn`).not.toHaveBeenCalled();
+        expect(state.activateWorkflowAgent, `alias "${name}" should activate the slot`).toHaveBeenCalledWith(
+          SESSION_ID,
+          IMPL_AGENT_ID,
+          PLAN_ID,
+        );
       }
     });
 
-    it.each([
-      ['Debug', AGENT_KIND_DEFAULTS.debugger.model],
-      ['Execute commits', AGENT_KIND_DEFAULTS.generic.model],
-    ])('routes %s into the workflow slot (consuming kind)', async (name, model) => {
-      const state = defaultState({
-        phaseTemplates: {
-          [WS_ID]: [
-            makeWorkflow([
-              { id: STEP_PLAN, name: 'Plan', ordinal: 0 },
-              { id: STEP_IMPL, name, ordinal: 1 },
-            ]),
-          ],
-        },
-      });
-      const slice = buildSlice(state);
+    it.each([['Debug'], ['Execute commits']])(
+      'activates the workflow slot for %s (consuming kind)',
+      async (name) => {
+        const state = defaultState({
+          phaseTemplates: {
+            [WS_ID]: [
+              makeWorkflow([
+                { id: STEP_PLAN, name: 'Plan', ordinal: 0 },
+                { id: STEP_IMPL, name, ordinal: 1 },
+              ]),
+            ],
+          },
+        });
+        const slice = buildSlice(state);
 
-      await slice.runPlan(SESSION_ID, PLAN_ID);
+        await slice.runPlan(SESSION_ID, PLAN_ID);
 
-      const [, args] = state.spawnAgent.mock.calls[0]!;
-      expect(args).toEqual({
-        stepId: STEP_IMPL,
-        workflowRunId: RUN_ID,
-        triggeredPlanId: PLAN_ID,
-        model,
-      });
-      expect(args).not.toHaveProperty('kindOverride');
-    });
+        expect(state.spawnAgent).not.toHaveBeenCalled();
+        expect(state.activateWorkflowAgent).toHaveBeenCalledWith(SESSION_ID, IMPL_AGENT_ID, PLAN_ID);
+      },
+    );
   });
 
   describe('gate A, session has no workflows attached → free-spawn', () => {
@@ -512,16 +499,23 @@ describe('runPlan, workflow-aware spawn routing', () => {
   });
 
   describe('invariants', () => {
-    it('exactly one spawnAgent call per runPlan (no double-spawn between gates)', async () => {
-      const state = defaultState();
-      const slice = buildSlice(state);
+    it('exactly one dispatch per runPlan (in-workflow activates, fallback spawns, never both)', async () => {
+      const inWorkflow = defaultState();
+      await buildSlice(inWorkflow).runPlan(SESSION_ID, PLAN_ID);
+      expect(
+        inWorkflow.spawnAgent.mock.calls.length + inWorkflow.activateWorkflowAgent.mock.calls.length,
+      ).toBe(1);
+      expect(inWorkflow.activateWorkflowAgent).toHaveBeenCalledTimes(1);
 
-      await slice.runPlan(SESSION_ID, PLAN_ID);
-
-      expect(state.spawnAgent).toHaveBeenCalledTimes(1);
+      const freeSpawn = defaultState({ sessions: [makeSession({ workflowRuns: [] })] });
+      await buildSlice(freeSpawn).runPlan(SESSION_ID, PLAN_ID);
+      expect(
+        freeSpawn.spawnAgent.mock.calls.length + freeSpawn.activateWorkflowAgent.mock.calls.length,
+      ).toBe(1);
+      expect(freeSpawn.spawnAgent).toHaveBeenCalledTimes(1);
     });
 
-    it('triggeredPlanId is the clicked plan in every branch (in-workflow + every free-spawn fallback)', async () => {
+    it('the clicked plan is routed in every branch (in-workflow activation + every free-spawn fallback)', async () => {
       const scenarios: Array<{ name: string; state: FakeState }> = [
         { name: 'happy path', state: defaultState() },
         {
@@ -575,8 +569,13 @@ describe('runPlan, workflow-aware spawn routing', () => {
         const slice = buildSlice(state);
         await slice.runPlan(SESSION_ID, PLAN_ID);
 
-        const [, args] = state.spawnAgent.mock.calls[0]!;
-        expect(args.triggeredPlanId, `${name} must carry triggeredPlanId`).toBe(PLAN_ID);
+        if (state.activateWorkflowAgent.mock.calls.length > 0) {
+          const [, , planId] = state.activateWorkflowAgent.mock.calls[0]!;
+          expect(planId, `${name} must route the clicked plan`).toBe(PLAN_ID);
+        } else {
+          const [, args] = state.spawnAgent.mock.calls[0]!;
+          expect(args.triggeredPlanId, `${name} must carry triggeredPlanId`).toBe(PLAN_ID);
+        }
       }
     });
   });

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -1,19 +1,15 @@
 import type { PlanId, SessionId } from '@goodboy/types';
 import { runsForWorkflowRun } from '@goodboy/core';
-import {
-  AGENT_KIND_DEFAULTS,
-  inferAgentKindFromName,
-  kindConsumesPlan,
-} from '../../../features/session/agent-kind';
+import { inferAgentKindFromName, kindConsumesPlan } from '../../../features/session/agent-kind';
 import { pickNextWorkflowStep } from '../../../features/workflows/components/WorkflowNextStepCta';
 import type { GetFn } from './types';
 
-// Force the spawned agent to be an implementer so spawnAgent injects the
-// plan body into the kickoff prompt. Without kindOverride the agent
+// Free-spawn path: force the agent to be an implementer so spawnAgent injects
+// the plan body into the kickoff prompt. Without kindOverride the agent
 // defaults to 'generic' and the plan section is silently dropped (the
 // implementer branch in spawnAgent is the only one that builds it).
-// Inside a workflow, if the next step is itself an implementer slot, we
-// route the spawn into that slot (stepId) instead of free-spawning.
+// In-workflow path: the next step already has a pre-created pending agent, so
+// activate that slot (routing the chosen plan) instead of inserting a duplicate.
 export function runPlan(get: GetFn) {
   return async (sessionId: SessionId, planId: PlanId) => {
     const state = get();
@@ -77,14 +73,14 @@ export function runPlan(get: GetFn) {
       return;
     }
 
-    // In-workflow spawn: stepId routes the agent into the workflow slot.
-    // triggeredPlanId → explicit plan injected + consumed by spawnAgent.
-    // No kindOverride: kind resolved by inferAgentKindFromName(step.name).
-    await get().spawnAgent(sessionId, {
-      stepId: nextStep.id,
-      workflowRunId: creatorRun.id,
-      triggeredPlanId: planId,
-      model: AGENT_KIND_DEFAULTS[nextKind].model,
-    });
+    const stepAgent = runAgents.find((r) => r.stepId === nextStep.id && r.status === 'pending');
+    if (!stepAgent) {
+      await get().spawnAgent(sessionId, {
+        triggeredPlanId: planId,
+        kindOverride: 'implementer',
+      });
+      return;
+    }
+    await get().activateWorkflowAgent(sessionId, stepAgent.id, planId);
   };
 }

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -205,4 +205,36 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
 
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
   });
+
+  it('injects and consumes an explicit plan, ignoring the latest active plan for the run', async () => {
+    const EXPLICIT_ID = 'plan-explicit' as PlanId;
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('implementer', 'Implement'),
+      workflow: makeWorkflow('Implement'),
+      plans: [
+        makePlan({ id: EXPLICIT_ID, bodyMd: 'explicit body' }),
+        makePlan({ bodyMd: 'do the thing' }),
+      ],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, EXPLICIT_ID);
+
+    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(EXPLICIT_ID, AGENT_ID);
+    expect(addPlanConsumptionSpy).not.toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
+    const [payload] = sendTurn.mock.calls[0]!;
+    expect(payload.content).toContain('explicit body');
+    expect(payload.content).not.toContain('do the thing');
+  });
+
+  it('replays an explicit plan even when it is already consumed', async () => {
+    const { activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan({ status: 'consumed' })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, PLAN_ID);
+
+    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
+  });
 });

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -1,4 +1,4 @@
-import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+import type { AgentId, IsoDateTime, PlanId, SessionId } from '@goodboy/types';
 import {
   addPlanConsumption as invokeAddPlanConsumption,
   listConsumptionsForPlan as invokeListConsumptionsForPlan,
@@ -14,7 +14,7 @@ import { fanOutClusters } from './clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
 export function activateWorkflowAgent(set: SetFn, get: GetFn) {
-  return async (sessionId: SessionId, agentId: AgentId) => {
+  return async (sessionId: SessionId, agentId: AgentId, explicitPlanId?: PlanId) => {
     const runs = get().sessionPhaseRuns[sessionId] ?? [];
     const agent = runs.find((r) => r.id === agentId);
     if (!agent || !agent.stepId) throw new Error('agent not found or not a workflow agent');
@@ -44,26 +44,39 @@ export function activateWorkflowAgent(set: SetFn, get: GetFn) {
     const effectiveKind: AgentKind =
       (agent.kind as AgentKind | undefined) ?? inferAgentKindFromName(agent.name);
     const consumesPlan = kindConsumesPlan(effectiveKind);
-    const { section: planSection, plan: latestPlan } = consumesPlan
-      ? await buildPlanKickoffSection(sessionId, agent.workflowRunId)
-      : { section: '', plan: null };
+    const explicitPlan =
+      explicitPlanId !== undefined
+        ? (get().sessionPlans[sessionId]?.find((p) => p.id === explicitPlanId) ?? null)
+        : null;
+    const { section: latestSection, plan: latestPlan } =
+      consumesPlan && !explicitPlan
+        ? await buildPlanKickoffSection(sessionId, agent.workflowRunId)
+        : { section: '', plan: null };
 
-    if (consumesPlan && latestPlan && latestPlan.status === 'active') {
-      await invokeAddPlanConsumption(latestPlan.id, agentId);
+    const planForKickoff = explicitPlan ?? latestPlan;
+    const planSection = consumesPlan
+      ? explicitPlan
+        ? ['Active plan to execute:', '', explicitPlan.bodyMd].join('\n')
+        : latestSection
+      : '';
+    const planToConsume = explicitPlan ?? (latestPlan?.status === 'active' ? latestPlan : null);
+
+    if (consumesPlan && planToConsume) {
+      await invokeAddPlanConsumption(planToConsume.id, agentId);
       const refreshedPlans = await invokeListPlansForSession(sessionId);
-      const consumptions = await invokeListConsumptionsForPlan(latestPlan.id);
+      const consumptions = await invokeListConsumptionsForPlan(planToConsume.id);
       set((state) => ({
         sessionPlans: { ...state.sessionPlans, [sessionId]: refreshedPlans },
-        planConsumptions: { ...state.planConsumptions, [latestPlan.id]: consumptions },
+        planConsumptions: { ...state.planConsumptions, [planToConsume.id]: consumptions },
       }));
     }
 
     const clusters =
-      effectiveKind === 'implementer' && latestPlan?.status === 'active'
-        ? latestPlan.clusters
+      effectiveKind === 'implementer' && planForKickoff?.status === 'active'
+        ? planForKickoff.clusters
         : undefined;
     if (clusters && clusters.length >= 2) {
-      await fanOutClusters(set, get, sessionId, agent, clusters, latestPlan!.title);
+      await fanOutClusters(set, get, sessionId, agent, clusters, planForKickoff!.title);
       return;
     }
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -407,7 +407,11 @@ export interface AppActions {
     workflowRunIds: ReadonlyArray<WorkflowRunId>,
   ): Promise<void>;
   setSessionUserStatus(sessionId: SessionId, status: SessionUserStatus): Promise<void>;
-  activateWorkflowAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
+  activateWorkflowAgent(
+    sessionId: SessionId,
+    agentId: AgentId,
+    explicitPlanId?: PlanId,
+  ): Promise<void>;
   advanceClusterImplementation(
     sessionId: SessionId,
     childAgentId: AgentId,


### PR DESCRIPTION
## problem

Running a plan from the plans modal on a workflow whose next step is an implementer created a **second, orphaned agent** for that step. The workflow already pre-creates one pending agent per step at attach time, so the run produced a phantom extra step (greyed, clock icon) that can never execute.

## root cause

`runPlan`'s in-workflow branch called `spawnAgent({ stepId })`, which always `invokeAgentInsert`s a new agent. But `pickNextWorkflowStep` only returns a step whose agent is still `pending`, so that slot already existed. No unique constraint on `(step_id, workflow_run_id)` let the duplicate through. The sidebar (`onStartStepAgent`) and auto-advance (`maybeAutoAdvanceWorkflow`) both correctly **activate** the existing pending agent via `activateWorkflowAgent`; `runPlan` was the only path inserting a duplicate.

## fix

- `runPlan` in-workflow branch now finds the pre-created pending agent for the next step and calls `activateWorkflowAgent(sessionId, agentId, planId)` instead of spawning. Free-spawn fallback kept for the (unreachable) no-slot case.
- `activateWorkflowAgent` gains an optional `explicitPlanId` so the modal-chosen plan is injected and consumed, rather than "latest active plan for the run". This avoids consuming the wrong plan when more than one run is ready.
- store signature updated.

## tests

- Rewrote the in-workflow + invariant blocks in `plans/index.test.ts`: assert activation (not spawn), plus a new "no duplicate agent" case.
- Added explicit-plan coverage in `activateWorkflowAgent.test.ts` (explicit plan injected/consumed over latest; consumed-plan replay).

## not in scope

Sessions already corrupted keep their orphan pending agent in the DB; this only prevents new duplicates. A cleanup pass can be done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)