### PR TITLE
fix(desktop): sync pty size to fitted xterm dimensions

### DIFF
--- a/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
+++ b/apps/desktop/src/shared/components/GenericTerminalPanel/index.tsx
@@ -102,7 +102,7 @@ export function GenericTerminalPanel({
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
+  const fitAndSyncRef = useRef<(() => void) | null>(null);
 
   const theme = useThemeStore((s) => s.theme);
 
@@ -124,10 +124,17 @@ export function GenericTerminalPanel({
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(container);
-    if (isActive) fitAddon.fit();
+
+    const fitAndSync = () => {
+      if (!container.clientWidth || !container.clientHeight) return;
+      fitAddon.fit();
+      driver.resize(term.cols, term.rows);
+    };
+
+    if (isActive) fitAndSync();
 
     termRef.current = term;
-    fitAddonRef.current = fitAddon;
+    fitAndSyncRef.current = fitAndSync;
 
     // Replay cached output so switching tabs/remounts don't lose history.
     const cached = outputCache.get(terminalId) ?? [];
@@ -144,6 +151,7 @@ export function GenericTerminalPanel({
     let unlistenOutput: (() => void) | null = null;
     let unlistenExit: (() => void) | null = null;
     let mounted = true;
+    let firstOutputSynced = false;
 
     driver
       .onOutput((bytes) => {
@@ -152,7 +160,13 @@ export function GenericTerminalPanel({
           cache.push(bytes);
           outputCache.set(terminalId, cache);
         }
-        if (mounted) term.write(bytes);
+        if (mounted) {
+          term.write(bytes);
+          if (!firstOutputSynced) {
+            firstOutputSynced = true;
+            fitAndSync();
+          }
+        }
       })
       .then((fn) => {
         if (mounted) unlistenOutput = fn;
@@ -171,8 +185,7 @@ export function GenericTerminalPanel({
       });
 
     const ro = new ResizeObserver(() => {
-      fitAddon.fit();
-      driver.resize(term.cols, term.rows);
+      fitAndSync();
     });
     ro.observe(container);
 
@@ -184,7 +197,7 @@ export function GenericTerminalPanel({
       ro.disconnect();
       term.dispose();
       termRef.current = null;
-      fitAddonRef.current = null;
+      fitAndSyncRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terminalId]);
@@ -198,7 +211,7 @@ export function GenericTerminalPanel({
   useEffect(() => {
     if (isActive) {
       const id = requestAnimationFrame(() => {
-        fitAddonRef.current?.fit();
+        fitAndSyncRef.current?.();
         if (!readOnly) termRef.current?.focus();
       });
       return () => cancelAnimationFrame(id);


### PR DESCRIPTION
## Problem

The embedded terminal opened the PTY at a hardcoded `100x24` and never realigned it to the fitted xterm size:

- the `isActive` activation effect called `fit()` but **not** `driver.resize()`, so xterm reflowed while the PTY kept the old size;
- the only resize→PTY path (the `ResizeObserver` initial callback) **raced the async PTY spawn** and was dropped before the session was registered.

Result: the shell (zsh/p10k) drew its prompt for 100 columns inside a narrower viewport → wrapped path, right-prompt clock jammed next to `❯`, and it stayed broken until a window resize forced a fresh resize after spawn.

## Fix (frontend-only, race-proof)

- centralize `fit()` + `driver.resize(cols, rows)` into a single `fitAndSync()` (guards against zero-size container) and dispatch it on mount, on `ResizeObserver`, and on **activation**;
- re-sync once on the **first output chunk** — the first byte means the shell is alive and the session is registered, so the resize is guaranteed to land.

No backend change.

## Test

- `vitest` TerminalPanel → pass
- `tsc --noEmit` → clean

Runtime behavior (prompt drawn at correct width, stays aligned on resize) verified by inspection; needs a live `tauri:dev` check for full confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)