### PR TITLE
feat(desktop): fold chat tool operations into a collapsible cluster

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -30,7 +30,9 @@ import {
   filterEventsByRunId,
   reduceTranscript,
 } from '../../utils/transcript-items';
+import { clusterOperations } from '../../utils/cluster-operations';
 import { TranscriptCard } from '../TranscriptCards';
+import { OperationsCluster } from '../OperationsCluster';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { ChatBreadcrumb } from '../ChatBreadcrumb';
 import { ChatInput } from '../ChatInput';
@@ -226,6 +228,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   const deferredTagged = useDeferredValue(taggedItems);
   const transcriptStale = deferredTagged.agentId !== selectedAgentId;
   const deferredItems = deferredTagged.items;
+  const rows = useMemo(() => clusterOperations(deferredItems), [deferredItems]);
   const loading = useSessionLoading(session.id);
   const transcriptCached = useAppStore((s) =>
     selectedAgentId ? s.transcripts[selectedAgentId] !== undefined : true,
@@ -290,8 +293,13 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
   const agentKind = agentState?.kind ?? session.state.kind;
   const isEnded = agentKind === 'ended';
   const lastItem = items[items.length - 1];
+  const lastRow = rows[rows.length - 1];
+  const lastClusterRunning =
+    lastRow?.kind === 'operations' && lastRow.items.some((i) => i.kind === 'tool_call' && !i.ended);
   const isThinking =
-    agentKind === 'running' && (lastItem?.kind ?? 'user_text') !== 'assistant_text';
+    agentKind === 'running' &&
+    (lastItem?.kind ?? 'user_text') !== 'assistant_text' &&
+    !lastClusterRunning;
 
   const parallelRunIds = useMemo<ReadonlyArray<ProviderRunId>>(
     () => (flagOn ? detectParallelRunIds(events) : []),
@@ -495,32 +503,20 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
               aria-relevant="additions"
             >
               {(() => {
-                const toolishKinds = new Set([
-                  'tool_call',
-                  'file_edit',
-                  'skill_invocation',
-                  'permission_request',
-                  'permission_decision',
-                  'usage',
-                ]);
                 let lastDay: string | null = null;
-                return deferredItems.map((item, idx) => {
-                  const prev = idx > 0 ? (deferredItems[idx - 1] ?? null) : null;
-                  const tightToTool =
-                    prev !== null &&
-                    toolishKinds.has(item.kind) &&
-                    (toolishKinds.has(prev.kind) || prev.kind === 'assistant_text');
+                return rows.map((row, idx) => {
                   const node: React.ReactNode[] = [];
                   let isTurnBreak = false;
-                  if (item.kind === 'user_text') {
-                    const day = dayKey(item.at);
+                  if (row.kind === 'item' && row.item.kind === 'user_text') {
+                    const at = row.item.at;
+                    const day = dayKey(at);
                     const dayChanged = day !== lastDay;
                     // Divider marks the boundary between turns; on a day change
                     // the date pill already separates them, so skip it there.
                     if (idx > 0 && !dayChanged) {
                       isTurnBreak = true;
                       node.push(
-                        <li key={`turn-${item.key}`} className="my-2.5">
+                        <li key={`turn-${row.key}`} className="my-2.5">
                           <Divider />
                         </li>,
                       );
@@ -529,22 +525,17 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
                       node.push(
                         <li key={`day-${day}-${idx}`} className="my-2.5 flex justify-center">
                           <span className="rounded-full border border-border-soft bg-background px-2 py-0.5 text-2xs uppercase tracking-wide text-muted-foreground">
-                            {formatDayLabel(item.at)}
+                            {formatDayLabel(at)}
                           </span>
                         </li>,
                       );
                       lastDay = day;
                     }
                   }
-                  const itemSpacing = (() => {
-                    if (tightToTool) return 'mt-0.5';
-                    if (idx === 0) return '';
-                    if (isTurnBreak) return '';
-                    return 'mt-2.5';
-                  })();
+                  const itemSpacing = idx === 0 || isTurnBreak ? '' : 'mt-2.5';
                   node.push(
                     <li
-                      key={item.key}
+                      key={row.key}
                       className={cn(
                         itemSpacing,
                         // Browser-native virtualization: skip layout/paint of
@@ -554,14 +545,25 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
                         '[content-visibility:auto] [contain-intrinsic-size:80px]',
                       )}
                     >
-                      <TranscriptCard
-                        item={item}
-                        sessionId={session.id}
-                        agentId={selectedAgentId}
-                        workingDir={worktreePath}
-                        onRefreshAuth={handleRefreshAuth}
-                        onOpenDiff={handleOpenDiff}
-                      />
+                      {row.kind === 'operations' ? (
+                        <OperationsCluster
+                          items={row.items}
+                          sessionId={session.id}
+                          agentId={selectedAgentId}
+                          workingDir={worktreePath}
+                          onRefreshAuth={handleRefreshAuth}
+                          onOpenDiff={handleOpenDiff}
+                        />
+                      ) : (
+                        <TranscriptCard
+                          item={row.item}
+                          sessionId={session.id}
+                          agentId={selectedAgentId}
+                          workingDir={worktreePath}
+                          onRefreshAuth={handleRefreshAuth}
+                          onOpenDiff={handleOpenDiff}
+                        />
+                      )}
                     </li>,
                   );
                   return node;

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { TranscriptItem } from '../../utils/transcript-items';
+
+vi.mock('../TranscriptCards', () => ({
+  TranscriptCard: ({ item }: { item: TranscriptItem }) => <div data-testid="card">{item.key}</div>,
+}));
+
+import { OperationsCluster } from './index';
+
+function tool(id: string, ended = true, isError = false): TranscriptItem {
+  return {
+    kind: 'tool_call',
+    key: `tool-${id}`,
+    toolUseId: id,
+    toolName: id === 'b' ? 'grep' : 'read',
+    input: null,
+    output: null,
+    isError,
+    ended,
+  };
+}
+
+afterEach(cleanup);
+
+describe('OperationsCluster', () => {
+  it('renders collapsed with a count and hides children', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b')]} />);
+    expect(screen.getByText('operations')).toBeTruthy();
+    expect(screen.getByText('2')).toBeTruthy();
+    expect(screen.queryByTestId('card')).toBeNull();
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('reveals child cards when expanded', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b')]} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByTestId('card')).toHaveLength(2);
+  });
+
+  it('shows the running tool name in the header while collapsed', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b', false)]} />);
+    expect(screen.getByText('grep')).toBeTruthy();
+  });
+
+  it('shows no running label when all tools have ended', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b')]} />);
+    expect(screen.queryByText('grep')).toBeNull();
+  });
+
+  it('surfaces a failure count when a collapsed child errored', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b', true, true)]} />);
+    expect(screen.getByText('1 failed')).toBeTruthy();
+  });
+
+  it('suppresses the failure badge while a tool is still running', () => {
+    render(<OperationsCluster items={[tool('a', true, true), tool('b', false)]} />);
+    expect(screen.queryByText(/failed/)).toBeNull();
+    expect(screen.getByText('grep')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react';
+import { AlertTriangle, ChevronRight, Layers } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { AgentId, SessionId } from '@goodboy/types';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { TranscriptCard } from '../TranscriptCards';
+
+interface OperationsClusterProps {
+  readonly items: ReadonlyArray<TranscriptItem>;
+  readonly sessionId?: SessionId | null;
+  readonly agentId?: AgentId | null;
+  readonly workingDir?: string | null;
+  readonly onRefreshAuth?: () => void;
+  readonly onOpenDiff?: (filePath: string) => void;
+}
+
+function runningTool(
+  items: ReadonlyArray<TranscriptItem>,
+): Extract<TranscriptItem, { kind: 'tool_call' }> | null {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i]!;
+    if (item.kind === 'tool_call' && !item.ended) return item;
+  }
+  return null;
+}
+
+export function OperationsCluster({
+  items,
+  sessionId = null,
+  agentId = null,
+  workingDir = null,
+  onRefreshAuth,
+  onOpenDiff,
+}: OperationsClusterProps) {
+  const [open, setOpen] = useState(false);
+  const running = runningTool(items);
+  const errorCount = items.reduce((n, i) => (i.kind === 'tool_call' && i.isError ? n + 1 : n), 0);
+  const showError = !running && errorCount > 0;
+
+  const ariaLabel = `operations, ${items.length} ${items.length === 1 ? 'item' : 'items'}${
+    running ? `, running ${running.toolName}` : showError ? `, ${errorCount} failed` : ''
+  }`;
+
+  return (
+    <div className="group">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60',
+          showError && 'text-danger',
+        )}
+      >
+        <ChevronRight
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-muted-foreground/60 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <Layers
+          size={11}
+          aria-hidden
+          className={cn('shrink-0', showError ? 'text-danger' : 'text-muted-foreground')}
+        />
+        <span className={cn('font-medium', showError ? 'text-danger' : 'text-foreground/80')}>
+          operations
+        </span>
+        <span
+          className={cn(
+            'rounded-full px-1.5 text-2xs tabular-nums',
+            showError ? 'bg-danger/10 text-danger' : 'bg-muted text-muted-foreground',
+          )}
+        >
+          {items.length}
+        </span>
+        {running ? (
+          <span className="flex min-w-0 items-center gap-1.5 text-muted-foreground/80">
+            <span aria-hidden className="text-muted-foreground/40">
+              ·
+            </span>
+            <span className="truncate font-mono">{running.toolName}</span>
+            <span className="flex shrink-0 gap-0.5">
+              <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
+              <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
+              <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
+            </span>
+          </span>
+        ) : showError ? (
+          <span className="flex shrink-0 items-center gap-1 text-danger">
+            <AlertTriangle size={10} aria-hidden />
+            <span className="text-2xs uppercase tracking-wide">{errorCount} failed</span>
+          </span>
+        ) : null}
+      </button>
+      {open ? (
+        <div className="ml-2 mt-0.5 flex min-w-0 flex-col gap-0.5 border-l border-border-soft pl-3">
+          {items.map((item) => (
+            <TranscriptCard
+              key={item.key}
+              item={item}
+              sessionId={sessionId}
+              agentId={agentId}
+              workingDir={workingDir}
+              onRefreshAuth={onRefreshAuth}
+              onOpenDiff={onOpenDiff}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/chat/utils/cluster-operations.test.ts
+++ b/apps/desktop/src/features/chat/utils/cluster-operations.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import type { TranscriptItem } from './transcript-items';
+import { clusterOperations } from './cluster-operations';
+
+function tool(id: string, ended = true): TranscriptItem {
+  return {
+    kind: 'tool_call',
+    key: `tool-${id}`,
+    toolUseId: id,
+    toolName: 'grep',
+    input: null,
+    output: null,
+    isError: false,
+    ended,
+  };
+}
+
+function userText(key: string): TranscriptItem {
+  return { kind: 'user_text', key, text: 'hi', at: '2026-06-08T10:00:00.000Z' } as TranscriptItem;
+}
+
+function assistantText(key: string): TranscriptItem {
+  return { kind: 'assistant_text', key, text: 'done' };
+}
+
+function edit(key: string): TranscriptItem {
+  return { kind: 'file_edit', key, path: '/a/b.ts', editType: 'modify' };
+}
+
+function usage(key: string): TranscriptItem {
+  return {
+    kind: 'usage',
+    key,
+    usage: {
+      inputTokens: 1,
+      outputTokens: 1,
+      cachedInputTokens: 0,
+      estimatedCostUsd: 0,
+    },
+  };
+}
+
+function permission(key: string): TranscriptItem {
+  return {
+    kind: 'permission_request',
+    key,
+    toolUseId: key,
+    toolName: 'Bash',
+    runId: 'run-1',
+    input: null,
+    at: '2026-06-08T10:00:00.000Z',
+  } as TranscriptItem;
+}
+
+describe('clusterOperations', () => {
+  it('groups a consecutive run of clustered kinds into one operations row', () => {
+    const rows = clusterOperations([
+      userText('u1'),
+      tool('a'),
+      edit('e1'),
+      tool('b'),
+      assistantText('t1'),
+    ]);
+    expect(rows.map((r) => r.kind)).toEqual(['item', 'operations', 'item']);
+    const ops = rows[1]!;
+    expect(ops.kind === 'operations' && ops.items).toHaveLength(3);
+  });
+
+  it('keeps non-clustered items (text, permissions) as standalone item rows', () => {
+    const rows = clusterOperations([
+      assistantText('t1'),
+      permission('p1'),
+      tool('a'),
+      userText('u1'),
+    ]);
+    expect(rows.map((r) => r.kind)).toEqual(['item', 'item', 'operations', 'item']);
+  });
+
+  it('breaks the cluster when a non-clustered item interrupts the run', () => {
+    const rows = clusterOperations([tool('a'), permission('p1'), tool('b')]);
+    expect(rows.map((r) => r.kind)).toEqual(['operations', 'item', 'operations']);
+  });
+
+  it('derives a stable key from the first item in the group', () => {
+    const rows = clusterOperations([tool('a'), tool('b')]);
+    expect(rows[0]!.key).toBe('ops-tool-a');
+  });
+
+  it('returns an empty array for no items', () => {
+    expect(clusterOperations([])).toEqual([]);
+  });
+
+  it('renders a lone usage line inline, not as a 1-item operations cluster', () => {
+    const rows = clusterOperations([assistantText('t1'), usage('u1'), assistantText('t2')]);
+    expect(rows.map((r) => r.kind)).toEqual(['item', 'item', 'item']);
+  });
+
+  it('absorbs usage into a cluster when it sits next to a real operation', () => {
+    const rows = clusterOperations([tool('a'), usage('u1')]);
+    expect(rows.map((r) => r.kind)).toEqual(['operations']);
+    const ops = rows[0]!;
+    expect(ops.kind === 'operations' && ops.items).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/chat/utils/cluster-operations.ts
+++ b/apps/desktop/src/features/chat/utils/cluster-operations.ts
@@ -1,0 +1,41 @@
+import type { TranscriptItem } from './transcript-items';
+
+const OPERATION_KINDS = new Set<TranscriptItem['kind']>([
+  'tool_call',
+  'file_edit',
+  'skill_invocation',
+]);
+
+const ABSORBED_KINDS = new Set<TranscriptItem['kind']>(['usage']);
+
+export type TranscriptRow =
+  | { kind: 'item'; key: string; item: TranscriptItem }
+  | { kind: 'operations'; key: string; items: ReadonlyArray<TranscriptItem> };
+
+export function clusterOperations(
+  items: ReadonlyArray<TranscriptItem>,
+): ReadonlyArray<TranscriptRow> {
+  const rows: TranscriptRow[] = [];
+  let buffer: TranscriptItem[] = [];
+
+  const flush = () => {
+    if (buffer.length === 0) return;
+    if (buffer.some((i) => OPERATION_KINDS.has(i.kind))) {
+      rows.push({ kind: 'operations', key: `ops-${buffer[0]!.key}`, items: buffer });
+    } else {
+      for (const item of buffer) rows.push({ kind: 'item', key: item.key, item });
+    }
+    buffer = [];
+  };
+
+  for (const item of items) {
+    if (OPERATION_KINDS.has(item.kind) || ABSORBED_KINDS.has(item.kind)) {
+      buffer.push(item);
+    } else {
+      flush();
+      rows.push({ kind: 'item', key: item.key, item });
+    }
+  }
+  flush();
+  return rows;
+}


### PR DESCRIPTION
## What

Collapses consecutive tool activity in the chat transcript into a single foldable **operations** row, so the chat reads clean and you only drill in when curious.

- Clustered kinds: `tool_call`, `file_edit`, `skill_invocation`, `usage`.
- Collapsed by default. Header shows a count badge; while a turn is live it appends the running tool name + a pulse (`⌄ operations [4] · grep •••`).
- Expand → child cards render via the existing `TranscriptCard`, threaded under a left rule. Each tool row keeps its own input/output disclosure.

## UX / no-regression guards

- **Permissions, errors, auth callouts and dividers stay inline** — never buried inside a collapsed cluster (interactive/critical signal stays visible).
- A lone `usage` token-line renders inline (no pointless `operations · 1` wrapper); usage only gets absorbed when adjacent to real ops.
- A failed tool inside a collapsed cluster surfaces a danger-tinted header + `⚠ N failed`; the specific failure keeps its red badge on expand.
- During a live run the standalone `thinking` line is suppressed (the cluster header already pulses) — no double indicator.
- Opening a cluster is local state → no autoscroll/re-pin side effects. `content-visibility` virtualization, day-pills and turn-dividers untouched.
- Reuses existing visual tokens/idioms (chevron rotate, pulse dots, danger palette) — no new vocabulary.

## Verification

- `tsc --noEmit` clean.
- 14/14 unit tests: `cluster-operations` (grouping, usage inline-vs-absorbed, interrupts, stable keys) + `OperationsCluster` (collapse/expand, running label, failure badge, suppression) + existing `ChatView` test still green.
- prettier clean.

Parallel split-view columns (`experimental.enable_parallel_agents`) intentionally left flat — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)