### PR TITLE
feat(desktop): attach documents (pdf/csv/docs), not just images

### DIFF
--- a/apps/desktop/src-tauri/src/attachment.rs
+++ b/apps/desktop/src-tauri/src/attachment.rs
@@ -72,8 +72,41 @@ fn mime_for(path: &Path) -> &'static str {
         Some("webp") => "image/webp",
         Some("svg") => "image/svg+xml",
         Some("bmp") => "image/bmp",
+        Some("pdf") => "application/pdf",
+        Some("csv") => "text/csv",
+        Some("tsv") => "text/tab-separated-values",
+        Some("txt") | Some("log") => "text/plain",
+        Some("md") | Some("markdown") => "text/markdown",
+        Some("json") => "application/json",
+        Some("xml") => "application/xml",
+        Some("yaml") | Some("yml") => "application/yaml",
+        Some("docx") => {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        }
+        Some("xlsx") => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         _ => "application/octet-stream",
     }
+}
+
+/// Whitelist guard shared by the drag-drop path. Images plus a curated set of
+/// document types the spawned agent can actually read (PDF/CSV/text) or parse
+/// with its own tooling (office formats). Unknown binaries are rejected so a
+/// stray drop never lands an unreadable blob in the worktree.
+fn is_allowed_mime(mime: &str) -> bool {
+    mime.starts_with("image/")
+        || matches!(
+            mime,
+            "application/pdf"
+                | "text/csv"
+                | "text/tab-separated-values"
+                | "text/plain"
+                | "text/markdown"
+                | "application/json"
+                | "application/xml"
+                | "application/yaml"
+                | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
 }
 
 /// Writes a base64-encoded image into `<worktree>/.goodboy/attachments/` and
@@ -117,7 +150,7 @@ pub struct DroppedAttachment {
 
 /// Reads a file the user dragged from the OS into the composer and returns the
 /// bytes as base64 so the frontend can reuse the existing attachment pipeline.
-/// Only image MIMEs are accepted, mirroring the composer-side `accept="image/*"`
+/// Accepts the same whitelist as the composer picker, mirroring its `accept`
 /// filter — the second guard exists because OS drag-drop bypasses the picker.
 #[tauri::command]
 pub fn attachment_read_dropped(abs_path: String) -> Result<DroppedAttachment, AttachmentError> {
@@ -131,7 +164,7 @@ pub fn attachment_read_dropped(abs_path: String) -> Result<DroppedAttachment, At
     }
 
     let mime = mime_for(path);
-    if !mime.starts_with("image/") {
+    if !is_allowed_mime(mime) {
         return Err(AttachmentError::UnsupportedMime(mime.to_string()));
     }
 
@@ -143,7 +176,7 @@ pub fn attachment_read_dropped(abs_path: String) -> Result<DroppedAttachment, At
     let file_name = path
         .file_name()
         .and_then(|s| s.to_str())
-        .unwrap_or("image")
+        .unwrap_or("file")
         .to_string();
 
     Ok(DroppedAttachment {
@@ -220,14 +253,32 @@ mod tests {
     }
 
     #[test]
-    fn read_dropped_rejects_non_image() {
+    fn read_dropped_rejects_unsupported_type() {
         let dir = std::env::temp_dir().join(format!("goodboy-drop-{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         fs::create_dir_all(&dir).unwrap();
-        let txt = dir.join("notes.txt");
-        fs::write(&txt, b"hello").unwrap();
-        let err = attachment_read_dropped(txt.to_string_lossy().to_string());
+        let blob = dir.join("payload.bin");
+        fs::write(&blob, b"\x00\x01\x02").unwrap();
+        let err = attachment_read_dropped(blob.to_string_lossy().to_string());
         assert!(matches!(err, Err(AttachmentError::UnsupportedMime(_))));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_dropped_accepts_documents() {
+        let dir = std::env::temp_dir().join(format!("goodboy-drop-doc-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let csv = dir.join("data.csv");
+        fs::write(&csv, b"a,b\n1,2\n").unwrap();
+        let out = attachment_read_dropped(csv.to_string_lossy().to_string()).unwrap();
+        assert_eq!(out.file_name, "data.csv");
+        assert_eq!(out.mime_type, "text/csv");
+
+        let pdf = dir.join("doc.pdf");
+        fs::write(&pdf, b"%PDF-1.4\n").unwrap();
+        let out = attachment_read_dropped(pdf.to_string_lossy().to_string()).unwrap();
+        assert_eq!(out.mime_type, "application/pdf");
         let _ = fs::remove_dir_all(&dir);
     }
 

--- a/apps/desktop/src/features/chat/attachment-kinds.ts
+++ b/apps/desktop/src/features/chat/attachment-kinds.ts
@@ -1,0 +1,70 @@
+import { File, FileCode, FileJson, FileSpreadsheet, FileText, type LucideIcon } from 'lucide-react';
+
+const IMAGE_EXTENSIONS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp']);
+
+const DOC_MIME_BY_EXTENSION: Readonly<Record<string, string>> = {
+  pdf: 'application/pdf',
+  csv: 'text/csv',
+  tsv: 'text/tab-separated-values',
+  txt: 'text/plain',
+  log: 'text/plain',
+  md: 'text/markdown',
+  markdown: 'text/markdown',
+  json: 'application/json',
+  xml: 'application/xml',
+  yaml: 'application/yaml',
+  yml: 'application/yaml',
+  docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+};
+
+export const ATTACHMENT_ACCEPT = [
+  'image/*',
+  ...Object.keys(DOC_MIME_BY_EXTENSION).map((e) => `.${e}`),
+].join(',');
+
+function extensionOf(fileName: string): string {
+  const dot = fileName.lastIndexOf('.');
+  return dot >= 0 ? fileName.slice(dot + 1).toLowerCase() : '';
+}
+
+export function attachmentKindFor(mimeType: string): 'image' | 'file' {
+  return mimeType.startsWith('image/') ? 'image' : 'file';
+}
+
+export function isAllowedAttachment(file: {
+  readonly name: string;
+  readonly type: string;
+}): boolean {
+  if (file.type.startsWith('image/')) return true;
+  const ext = extensionOf(file.name);
+  return IMAGE_EXTENSIONS.has(ext) || ext in DOC_MIME_BY_EXTENSION;
+}
+
+export function resolveAttachmentMime(file: {
+  readonly name: string;
+  readonly type: string;
+}): string {
+  if (file.type.length > 0) return file.type;
+  return DOC_MIME_BY_EXTENSION[extensionOf(file.name)] ?? 'application/octet-stream';
+}
+
+export function fileIconFor(mimeType: string): LucideIcon {
+  if (mimeType === 'application/json') return FileJson;
+  if (
+    mimeType === 'text/csv' ||
+    mimeType === 'text/tab-separated-values' ||
+    mimeType.includes('spreadsheetml')
+  ) {
+    return FileSpreadsheet;
+  }
+  if (mimeType === 'application/xml' || mimeType === 'application/yaml') return FileCode;
+  if (
+    mimeType === 'application/pdf' ||
+    mimeType.startsWith('text/') ||
+    mimeType.includes('wordprocessingml')
+  ) {
+    return FileText;
+  }
+  return File;
+}

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -10,7 +10,7 @@ import {
   type ReactNode,
 } from 'react';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
-import { Clock, ImagePlus, Send, Square, Telescope, X } from 'lucide-react';
+import { Clock, Paperclip, Send, Square, Telescope, X } from 'lucide-react';
 import { Divider, Textarea } from '@goodboy/ui';
 import type {
   Agent,
@@ -53,6 +53,13 @@ import { ModelPicker } from '../ModelPicker';
 import { PermissionModePicker } from '../../../../features/permissions/components/PermissionModePicker';
 import { RightSizeCard } from '../RightSizeCard';
 import { ImageLightbox } from '../ImageLightbox';
+import {
+  ATTACHMENT_ACCEPT,
+  attachmentKindFor,
+  fileIconFor,
+  isAllowedAttachment,
+  resolveAttachmentMime,
+} from '../../attachment-kinds';
 import { NudgeCard } from '../NudgeCard';
 import { ClipboardCheck } from 'lucide-react';
 import { SESSION_FEATURES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
@@ -434,24 +441,32 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
 
   const addFiles = useCallback(
     async (files: ReadonlyArray<File>) => {
-      const images = files.filter((f) => f.type.startsWith('image/'));
-      if (images.length === 0) return;
+      const allowed = files.filter(isAllowedAttachment);
+      const skipped = files.length - allowed.length;
+      if (skipped > 0) {
+        showToast(
+          'warning',
+          `${skipped} file${skipped === 1 ? '' : 's'} skipped, unsupported type`,
+        );
+      }
+      if (allowed.length === 0) return;
       const accepted: PendingAttachment[] = [];
-      for (const file of images) {
+      for (const file of allowed) {
         if (file.size > MAX_ATTACHMENT_BYTES) {
-          showToast('error', `${file.name || 'image'} is over 15MB`);
+          showToast('error', `${file.name || 'file'} is over 15MB`);
           continue;
         }
         try {
           const dataUrl = await readFileAsDataUrl(file);
+          const mimeType = resolveAttachmentMime(file);
           accepted.push({
             id: crypto.randomUUID(),
-            fileName: file.name || `pasted-image.${extFromMime(file.type)}`,
-            mimeType: file.type,
+            fileName: file.name || `pasted-file.${extFromMime(mimeType)}`,
+            mimeType,
             dataUrl,
           });
         } catch {
-          showToast('error', `could not read ${file.name || 'image'}`);
+          showToast('error', `could not read ${file.name || 'file'}`);
         }
       }
       if (accepted.length === 0) return;
@@ -476,12 +491,10 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
 
   const onPaste = useCallback(
     (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
-      const images = Array.from(event.clipboardData.files).filter((f) =>
-        f.type.startsWith('image/'),
-      );
-      if (images.length > 0) {
+      const files = Array.from(event.clipboardData.files).filter(isAllowedAttachment);
+      if (files.length > 0) {
         event.preventDefault();
-        void addFiles(images);
+        void addFiles(files);
       }
     },
     [addFiles],
@@ -787,7 +800,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
             dataUrl: `data:${r.mimeType};base64,${r.dataBase64}`,
           });
         } catch {
-          // Non-image / oversize drops are silently skipped: otherwise a
+          // Unsupported / oversize drops are silently skipped: otherwise a
           // folder drop would spam a toast per child.
         }
       }
@@ -1106,7 +1119,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
                 isDragging ? 'scale-100' : 'scale-95'
               }`}
             >
-              <ImagePlus size={14} aria-hidden />
+              <Paperclip size={14} aria-hidden />
               drop to attach
             </div>
           </div>
@@ -1176,16 +1189,16 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
                 type="button"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={providerDisconnected}
-                title="attach images"
-                aria-label="attach images"
+                title="attach files"
+                aria-label="attach files"
                 className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
               >
-                <ImagePlus size={15} aria-hidden />
+                <Paperclip size={15} aria-hidden />
               </button>
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*"
+                accept={ATTACHMENT_ACCEPT}
                 multiple
                 className="hidden"
                 onChange={onFileInputChange}
@@ -1270,9 +1283,11 @@ function QueuedMessages({
       </div>
       {items.map((item, i) => {
         const trimmed = item.content.trim();
-        const imageCount = item.attachments.length;
+        const attachmentCount = item.attachments.length;
         const preview =
-          trimmed.length > 0 ? trimmed : `${imageCount} image${imageCount === 1 ? '' : 's'}`;
+          trimmed.length > 0
+            ? trimmed
+            : `${attachmentCount} attachment${attachmentCount === 1 ? '' : 's'}`;
         return (
           <div
             key={item.id}
@@ -1290,10 +1305,10 @@ function QueuedMessages({
             >
               {preview}
             </button>
-            {imageCount > 0 && trimmed.length > 0 ? (
+            {attachmentCount > 0 && trimmed.length > 0 ? (
               <span className="inline-flex shrink-0 items-center gap-0.5 text-2xs text-muted-foreground">
-                <ImagePlus size={10} aria-hidden />
-                {imageCount}
+                <Paperclip size={10} aria-hidden />
+                {attachmentCount}
               </span>
             ) : null}
             <button
@@ -1320,37 +1335,70 @@ function AttachmentChip({
   readonly onRemove: () => void;
 }) {
   const [previewOpen, setPreviewOpen] = useState(false);
+  const removeButton = (
+    <button
+      type="button"
+      onClick={onRemove}
+      title={`remove ${attachment.fileName}`}
+      aria-label={`remove ${attachment.fileName}`}
+      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground group-hover:opacity-100"
+    >
+      <X size={10} aria-hidden />
+    </button>
+  );
+
+  if (attachmentKindFor(attachment.mimeType) === 'image') {
+    return (
+      <div className="group relative h-16 w-16 overflow-hidden rounded-md ring-1 ring-border-soft">
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          title={`preview ${attachment.fileName}`}
+          aria-label={`preview ${attachment.fileName}`}
+          className="block h-full w-full cursor-zoom-in"
+        >
+          <img
+            src={attachment.dataUrl}
+            alt={attachment.fileName}
+            className="h-full w-full object-cover"
+          />
+        </button>
+        {previewOpen ? (
+          <ImageLightbox
+            src={attachment.dataUrl}
+            alt={attachment.fileName}
+            onClose={() => setPreviewOpen(false)}
+          />
+        ) : null}
+        {removeButton}
+      </div>
+    );
+  }
+
+  const Icon = fileIconFor(attachment.mimeType);
+  const isPdf = attachment.mimeType === 'application/pdf';
   return (
-    <div className="group relative h-16 w-16 overflow-hidden rounded-md ring-1 ring-border-soft">
+    <div className="group relative flex h-16 max-w-[12rem] items-center gap-2 rounded-md bg-background/60 py-2 pl-2.5 pr-6 ring-1 ring-border-soft">
       <button
         type="button"
+        disabled={!isPdf}
         onClick={() => setPreviewOpen(true)}
-        title={`preview ${attachment.fileName}`}
-        aria-label={`preview ${attachment.fileName}`}
-        className="block h-full w-full cursor-zoom-in"
+        title={isPdf ? `preview ${attachment.fileName}` : attachment.fileName}
+        aria-label={isPdf ? `preview ${attachment.fileName}` : attachment.fileName}
+        className="flex min-w-0 items-center gap-2 enabled:cursor-zoom-in"
       >
-        <img
-          src={attachment.dataUrl}
-          alt={attachment.fileName}
-          className="h-full w-full object-cover"
-        />
+        <Icon size={18} aria-hidden className="shrink-0 text-muted-foreground" />
+        <span className="truncate text-xs text-foreground/80">{attachment.fileName}</span>
       </button>
-      {previewOpen ? (
+      {previewOpen && isPdf ? (
         <ImageLightbox
-          src={attachment.dataUrl}
+          media="pdf"
+          src={`data:application/pdf;base64,${dataUrlToBase64(attachment.dataUrl)}`}
           alt={attachment.fileName}
           onClose={() => setPreviewOpen(false)}
         />
       ) : null}
-      <button
-        type="button"
-        onClick={onRemove}
-        title={`remove ${attachment.fileName}`}
-        aria-label={`remove ${attachment.fileName}`}
-        className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground group-hover:opacity-100"
-      >
-        <X size={10} aria-hidden />
-      </button>
+      {removeButton}
     </div>
   );
 }

--- a/apps/desktop/src/features/chat/components/ImageLightbox/index.tsx
+++ b/apps/desktop/src/features/chat/components/ImageLightbox/index.tsx
@@ -6,6 +6,7 @@ interface Props {
   readonly src: string;
   readonly alt: string;
   readonly onClose: () => void;
+  readonly media?: 'image' | 'pdf';
 }
 
 const EXIT_MS = 180;
@@ -22,7 +23,7 @@ const EXIT_MS = 180;
  *            the exit transition so the unmount happens at the end of
  *            the animation, not the start.
  */
-export function ImageLightbox({ src, alt, onClose }: Props) {
+export function ImageLightbox({ src, alt, onClose, media = 'image' }: Props) {
   const [phase, setPhase] = useState<'enter' | 'open' | 'leave'>('enter');
   const exitTimerRef = useRef<number | null>(null);
 
@@ -87,16 +88,27 @@ export function ImageLightbox({ src, alt, onClose }: Props) {
       >
         <X size={18} aria-hidden />
       </button>
-      <img
-        src={src}
-        alt={alt}
-        // Stop propagation so clicking the image itself doesn't dismiss.
-        // Only the surrounding backdrop closes the preview.
-        onClick={(event) => event.stopPropagation()}
-        className={`max-h-full max-w-full rounded-lg object-contain shadow-2xl transition-all duration-[180ms] ease-out ${
-          visible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
-        }`}
-      />
+      {media === 'pdf' ? (
+        <iframe
+          src={src}
+          title={alt}
+          onClick={(event) => event.stopPropagation()}
+          className={`h-full w-full max-w-3xl rounded-lg bg-white shadow-2xl transition-all duration-[180ms] ease-out ${
+            visible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
+          }`}
+        />
+      ) : (
+        <img
+          src={src}
+          alt={alt}
+          // Stop propagation so clicking the image itself doesn't dismiss.
+          // Only the surrounding backdrop closes the preview.
+          onClick={(event) => event.stopPropagation()}
+          className={`max-h-full max-w-full rounded-lg object-contain shadow-2xl transition-all duration-[180ms] ease-out ${
+            visible ? 'scale-100 opacity-100' : 'scale-95 opacity-0'
+          }`}
+        />
+      )}
     </div>,
     document.body,
   );

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -7,6 +7,7 @@ import type { TranscriptItem } from '../../utils/transcript-items';
 import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provider-brand';
 import { PROVIDER_LABEL, modelLabel } from '../../utils/chat-constants';
 import { readAttachment } from '../../turn';
+import { fileIconFor } from '../../attachment-kinds';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { ImageLightbox } from '../ImageLightbox';
 import { SkillInvocationCard } from '../SkillInvocationCard';
@@ -268,6 +269,19 @@ function AttachmentThumb({
   attachment: MessageAttachment;
   workingDir: string | null;
 }) {
+  if (attachment.kind === 'file') {
+    return <AttachmentFileCard attachment={attachment} workingDir={workingDir} />;
+  }
+  return <AttachmentImage attachment={attachment} workingDir={workingDir} />;
+}
+
+function AttachmentImage({
+  attachment,
+  workingDir,
+}: {
+  attachment: MessageAttachment;
+  workingDir: string | null;
+}) {
   const [src, setSrc] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
@@ -330,6 +344,63 @@ function AttachmentThumb({
   );
 }
 
+function AttachmentFileCard({
+  attachment,
+  workingDir,
+}: {
+  attachment: MessageAttachment;
+  workingDir: string | null;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const Icon = fileIconFor(attachment.mimeType);
+  const isPdf = attachment.mimeType === 'application/pdf';
+
+  const openPreview = () => {
+    if (!isPdf || !workingDir) return;
+    if (src !== null) {
+      setPreviewOpen(true);
+      return;
+    }
+    setLoading(true);
+    readAttachment(workingDir, attachment.relPath)
+      .then((dataUrl) => {
+        setSrc(dataUrl);
+        setPreviewOpen(true);
+      })
+      .catch(() => undefined)
+      .finally(() => setLoading(false));
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={!isPdf}
+        onClick={openPreview}
+        title={isPdf ? `preview ${attachment.fileName}` : attachment.fileName}
+        aria-label={isPdf ? `preview ${attachment.fileName}` : attachment.fileName}
+        className="flex max-w-[16rem] items-center gap-2 rounded-lg bg-foreground/5 px-3 py-2 ring-1 ring-border-soft transition-colors enabled:cursor-zoom-in enabled:hover:bg-foreground/10"
+      >
+        <Icon size={16} aria-hidden className="shrink-0 text-muted-foreground" />
+        <span className="truncate text-xs text-foreground/80">{attachment.fileName}</span>
+        {loading ? (
+          <span className="shrink-0 text-2xs text-muted-foreground">loading...</span>
+        ) : null}
+      </button>
+      {previewOpen && src !== null ? (
+        <ImageLightbox
+          media="pdf"
+          src={src}
+          alt={attachment.fileName}
+          onClose={() => setPreviewOpen(false)}
+        />
+      ) : null}
+    </>
+  );
+}
+
 function UserText({
   text,
   at,
@@ -345,12 +416,12 @@ function UserText({
   model?: string;
   workingDir?: string | null;
 }) {
-  const images = attachments ?? [];
+  const atts = attachments ?? [];
   return (
     <div className="ml-auto flex w-fit max-w-[85%] flex-col gap-1.5 rounded-md border border-info/30 bg-info/10 px-4 pb-1.5 pt-2.5">
-      {images.length > 0 ? (
+      {atts.length > 0 ? (
         <div className="flex flex-wrap justify-end gap-1.5">
-          {images.map((a) => (
+          {atts.map((a) => (
             <AttachmentThumb key={a.id} attachment={a} workingDir={workingDir} />
           ))}
         </div>

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -77,6 +77,7 @@ import {
   runTurn,
   writeAttachment,
 } from '../../../features/chat/turn';
+import { attachmentKindFor } from '../../../features/chat/attachment-kinds';
 import { verbosityDirective } from '../../../features/settings/verbosity';
 import { detectDrift } from '../../../features/session/drift-detection';
 import {
@@ -215,7 +216,13 @@ export function sendTurn(set: SetFn, get: GetFn) {
               fileName: a.fileName,
               dataBase64: a.dataBase64,
             });
-            return { id: a.id, kind: 'image', fileName: a.fileName, mimeType: a.mimeType, relPath };
+            return {
+              id: a.id,
+              kind: attachmentKindFor(a.mimeType),
+              fileName: a.fileName,
+              mimeType: a.mimeType,
+              relPath,
+            };
           }),
         );
       } catch (err) {

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -50,17 +50,17 @@ import { buildProviderSpendBreakdown } from './slices/budget';
 import type { SessionNudge } from './store';
 import type { SetFn, GetFn } from './slice-types';
 
-// The provider CLIs have no API content-block channel, images reach the model
-// only as files named in the prompt text. Paths stay worktree-relative so they
+// The provider CLIs have no API content-block channel, files reach the model
+// only as paths named in the prompt text. Paths stay worktree-relative so they
 // resolve against the CLI's cwd and never trip the worktree-scope guard.
 export function buildAttachmentPromptBlock(refs: ReadonlyArray<MessageAttachment>): string {
   const list = refs.map((r) => `- ${r.relPath}`).join('\n');
   return [
-    '[attached-images]',
-    `The user attached ${refs.length} image${refs.length === 1 ? '' : 's'} to this message.`,
-    'Use your Read tool on each path below to view the image:',
+    '[attached-files]',
+    `The user attached ${refs.length} file${refs.length === 1 ? '' : 's'} to this message.`,
+    'Inspect each path below before answering. Images and PDFs render with your Read tool; for spreadsheets or other binary formats, read or parse the file with the appropriate tool:',
     list,
-    '[/attached-images]',
+    '[/attached-files]',
   ].join('\n');
 }
 

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -3,19 +3,21 @@ import type { TurnProviderOverride } from './provider-preference';
 
 export type MessageRole = 'user' | 'assistant' | 'system';
 
-// An image written to disk and referenced by the spawned provider CLI. The CLI
+// A file written to disk and referenced by the spawned provider CLI. The CLI
 // reads it from `relPath` (resolved against the session worktree, its cwd) to
-// see the image — providers have no API content-block channel here.
+// see the content — providers have no API content-block channel here. `kind`
+// drives rendering only: images get an inline thumbnail, everything else a
+// file chip.
 export type MessageAttachment = Readonly<{
   id: string;
-  kind: 'image';
+  kind: 'image' | 'file';
   fileName: string;
   mimeType: string;
   /** Path relative to the session worktree root (the spawned CLI's cwd). */
   relPath: string;
 }>;
 
-// Composer → store hand-off: raw image bytes not yet written to disk. The store
+// Composer → store hand-off: raw file bytes not yet written to disk. The store
 // persists them via the `attachment_write` Tauri command, producing a
 // `MessageAttachment` with a stable `relPath`.
 export type AttachmentInput = Readonly<{


### PR DESCRIPTION
## What

Extends chat attachments beyond images to a whitelist of document types: **pdf, csv, tsv, txt, log, md, json, xml, yaml, docx, xlsx**.

## How it reaches the model

Delivery channel unchanged. An attachment is written to `.goodboy/attachments/` in the worktree and its relative path is injected into the prompt; the spawned agent reads it with its Read tool (images/PDF render directly; binary office formats are parsed with the agent's own tooling). No new content-block path needed.

## Changes

- **attachment.rs**: extend `mime_for`, add `is_allowed_mime` whitelist, accept documents on the drag-drop path (unknown binaries rejected via `UnsupportedMime`).
- **types**: `MessageAttachment.kind` widened to `'image' | 'file'` (additive; turn events are opaque JSON, no migration).
- **attachment-kinds.ts** (new): shared whitelist, `attachmentKindFor`, `resolveAttachmentMime`, `isAllowedAttachment`, `ATTACHMENT_ACCEPT`, `fileIconFor`.
- **composer**: picker/paste/drag filter via whitelist (toast on skipped); image thumbnails vs file chips; PDF chip opens inline preview.
- **transcript**: `AttachmentFileCard` for non-images with lazy PDF preview.
- **ImageLightbox**: optional `media="pdf"` variant (iframe).

## Decisions

- Whitelist (not accept-any): unknown types are rejected.
- 15MB size limit unchanged.
- File chip + inline PDF preview; csv/other docs are chips only.

## Verification

- `pnpm typecheck`: 5/5 ✓
- desktop vitest: 876/876 ✓
- `cargo test attachment`: 6/6 ✓ (3 new: rejects unsupported `.bin`, accepts csv/pdf)

🤖 Generated with [Claude Code](https://claude.com/claude-code)