### PR TITLE
refactor(db): centralize context-slot history in the upsert path

### DIFF
--- a/apps/desktop/src/store/slices/slots/upsertSessionSlot.ts
+++ b/apps/desktop/src/store/slices/slots/upsertSessionSlot.ts
@@ -1,6 +1,6 @@
 import type { ContextSlot, SessionId } from '@goodboy/types';
 import type { SlotKey } from '@goodboy/core';
-import { insertContextSlotHistory, listContextSlotHistory, upsertContextSlot } from '@goodboy/db';
+import { listContextSlotHistory, upsertContextSlot } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { mergeSlots, type GetFn, type SetFn } from './types';
 
@@ -8,18 +8,8 @@ export function upsertSessionSlot(set: SetFn, get: GetFn) {
   return async (sessionId: SessionId, key: SlotKey, value: string) => {
     const existing = get().sessionSlots[sessionId] ?? [];
     const prev = existing.find((s) => s.key === key);
-    if (prev && prev.value !== value) {
-      await insertContextSlotHistory(
-        tauriDatabase,
-        sessionId,
-        crypto.randomUUID(),
-        key,
-        prev.value,
-        'user',
-      );
-    }
     const next: ContextSlot = { key, value, enabled: prev?.enabled ?? true };
-    await upsertContextSlot(tauriDatabase, sessionId, next);
+    await upsertContextSlot(tauriDatabase, sessionId, next, 'user');
     const refreshedHistory = await listContextSlotHistory(tauriDatabase, sessionId, key);
     set((state) => ({
       sessionSlots: {

--- a/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/reprocessGoalForWorkflow.ts
@@ -1,6 +1,6 @@
 import type { ContextSlot, SessionId } from '@goodboy/types';
 import { rewriteWorkflowGoal } from '@goodboy/core';
-import { insertContextSlotHistory, upsertContextSlot } from '@goodboy/db';
+import { upsertContextSlot } from '@goodboy/db';
 import { invoke } from '@tauri-apps/api/core';
 import { tauriDatabase } from '../../../shared/lib/db';
 import type { GetFn, SetFn } from './types';
@@ -34,16 +34,8 @@ export function reprocessGoalForWorkflow(set: SetFn, get: GetFn) {
       const cleaned = rewritten?.trim() ?? '';
       if (cleaned.length === 0 || cleaned === goal) return;
 
-      await insertContextSlotHistory(
-        tauriDatabase,
-        sessionId,
-        crypto.randomUUID(),
-        'goal',
-        goal,
-        'summarizer',
-      );
       const next: ContextSlot = { key: 'goal', value: cleaned, enabled: goalSlot?.enabled ?? true };
-      await upsertContextSlot(tauriDatabase, sessionId, next);
+      await upsertContextSlot(tauriDatabase, sessionId, next, 'summarizer');
 
       set((s) => {
         const existing = s.sessionSlots[sessionId] ?? [];

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -9,7 +9,6 @@ import {
   type SlotKey,
 } from '@goodboy/core';
 import {
-  insertContextSlotHistory,
   insertNudgeEvent,
   insertProviderRun,
   insertTelemetry,
@@ -186,22 +185,12 @@ async function runSummarizer(
         result.delta.upserts.map(async (upsert) => {
           const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
           const prevValue = existing && existing.value !== upsert.value ? existing.value : null;
-          if (prevValue !== null) {
-            await insertContextSlotHistory(
-              tauriDatabase,
-              sessionId,
-              crypto.randomUUID(),
-              upsert.key,
-              prevValue,
-              'summarizer',
-            );
-          }
           const next: ContextSlot = {
             key: upsert.key,
             value: upsert.value,
             enabled: existing?.enabled ?? true,
           };
-          await upsertContextSlot(tauriDatabase, sessionId, next);
+          await upsertContextSlot(tauriDatabase, sessionId, next, 'summarizer');
           return prevValue !== null ? upsert.key : null;
         }),
       )

--- a/packages/db/src/queries/context-slot.test.ts
+++ b/packages/db/src/queries/context-slot.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from '../migrations/runner';
+import { listContextSlotHistory, upsertContextSlot } from './context-slot';
+
+const workspaceId = 'w1' as WorkspaceId;
+const sessionId = 's1' as SessionId;
+
+async function seed() {
+  const db = makeTestDatabase();
+  await migrate(db);
+  const now = Date.now();
+  await db.execute(
+    `INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+    [workspaceId, 'ws', '/tmp/ws', now, now],
+  );
+  await db.execute(
+    `INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+    [sessionId, workspaceId, 'goal', 'idle', now, now],
+  );
+  return db;
+}
+
+describe('upsertContextSlot history', () => {
+  it('records no history on the first write of a slot', async () => {
+    const db = await seed();
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'ship v0.1', enabled: true });
+
+    const history = await listContextSlotHistory(db, sessionId, 'goal');
+    expect(history).toHaveLength(0);
+  });
+
+  it('snapshots the previous value when a slot value changes', async () => {
+    const db = await seed();
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'ship v0.1', enabled: true });
+    await upsertContextSlot(db, sessionId, {
+      key: 'goal',
+      value: 'ship v0.1 quickly',
+      enabled: true,
+    });
+
+    const history = await listContextSlotHistory(db, sessionId, 'goal');
+    expect(history).toHaveLength(1);
+    expect(history[0]!.value).toBe('ship v0.1');
+  });
+
+  it('attributes the snapshot to the supplied author', async () => {
+    const db = await seed();
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'first', enabled: true }, 'user');
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'second', enabled: true }, 'user');
+
+    const history = await listContextSlotHistory(db, sessionId, 'goal');
+    expect(history[0]!.author).toBe('user');
+  });
+
+  it('skips history when only the enabled flag changes', async () => {
+    const db = await seed();
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'stable', enabled: true });
+    await upsertContextSlot(db, sessionId, { key: 'goal', value: 'stable', enabled: false });
+
+    const history = await listContextSlotHistory(db, sessionId, 'goal');
+    expect(history).toHaveLength(0);
+  });
+
+  it('caps retained snapshots at the history limit', async () => {
+    const db = await seed();
+    for (let i = 0; i < 23; i += 1) {
+      await upsertContextSlot(db, sessionId, { key: 'goal', value: `v${i}`, enabled: true });
+    }
+
+    const history = await listContextSlotHistory(db, sessionId, 'goal');
+    expect(history).toHaveLength(20);
+  });
+});

--- a/packages/db/src/queries/context-slot.ts
+++ b/packages/db/src/queries/context-slot.ts
@@ -26,7 +26,16 @@ export async function upsertContextSlot(
   db: Database,
   sessionId: SessionId,
   slot: ContextSlot,
+  author: ContextSlotAuthor = 'summarizer',
 ): Promise<void> {
+  const existing = await db.select<ContextSlotRow>(
+    'SELECT session_id, key, value, enabled FROM context_slots WHERE session_id = ? AND key = ?',
+    [sessionId, slot.key],
+  );
+  const prevValue = existing[0]?.value ?? null;
+  if (prevValue !== null && prevValue !== slot.value) {
+    await insertContextSlotHistory(db, sessionId, crypto.randomUUID(), slot.key, prevValue, author);
+  }
   await db.execute(
     `INSERT INTO context_slots (session_id, key, value, enabled)
      VALUES (?, ?, ?, ?)


### PR DESCRIPTION
## what

`upsertContextSlot` now reads the previous value and records a `context_slot_history` snapshot whenever the value changes, with an `author` param (default `summarizer`). History becomes a structural invariant of the DB layer instead of something every caller has to remember.

Removes the duplicated `insertContextSlotHistory` calls from:
- the summarizer turn loop (`turn-helpers.ts`)
- manual slot edits (`upsertSessionSlot.ts`)
- the workflow goal rewrite (`reprocessGoalForWorkflow.ts`)

## why

- **closes a real bypass**: slots written through `ContextEngine.upsert` (decisions / open questions parsed from `<<ctx-*>>` markers in auto-populate) were overwritten with no history. They now version like every other slot.
- removes reliance on in-memory store state for the previous-value snapshot (the compare is now a DB read inside the upsert).
- `goal` history is now guaranteed on all writers, including both LLM paths (summarizer + goal rewrite).

`ContextEngine.upsert` is untouched: it inherits history for free via the default author.

## verification

- new `packages/db/src/queries/context-slot.test.ts` (5 cases: no-history on first write, snapshot on change, author attribution, skip on enabled-only change, cap at 20)
- typecheck: db / core / desktop clean
- tests: db suite 52/52, core engine 7/7, desktop slots slice + summarizer-queue 9/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)