### PR TITLE
feat(desktop): auto-start first workflow agent on launch

### DIFF
--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -98,6 +98,10 @@ export function attachWorkflowToSession(set: SetFn, get: GetFn) {
 
     void get().reprocessGoalForWorkflow(sessionId);
 
-    if (autoRun) void get().maybeAutoAdvanceWorkflow(sessionId);
+    if (autoRun) {
+      void get().maybeAutoAdvanceWorkflow(sessionId);
+    } else if (newAgents.length > 0) {
+      void get().activateWorkflowAgent(sessionId, newAgents[0]!.id);
+    }
   };
 }


### PR DESCRIPTION
## What

When a workflow is attached to an existing session via **Start workflow** with auto-run **off**, every step was left `pending` and the user had to make one extra click to start the first agent.

Now the first step (lowest ordinal) is activated on attach through the **same `activateWorkflowAgent` path the manual click uses** ([WorkspacesSidebar `onStartStepAgent`](apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx)) — it starts and is selected immediately. No extra behavior: it's exactly the saved click.

## Why it's safe

- Mirrors `createSession`, which already auto-starts + selects the first step regardless of auto-run.
- Auto-run keeps its meaning: advance subsequent steps.
- Reuses `activateWorkflowAgent` (covered by `activateWorkflowAgent.test.ts`).

## Change

`apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts`:

\`\`\`ts
if (autoRun) {
  void get().maybeAutoAdvanceWorkflow(sessionId);
} else if (newAgents.length > 0) {
  void get().activateWorkflowAgent(sessionId, newAgents[0]!.id);
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)