### PR TITLE
feat(desktop): full-screen first-run onboarding wizard

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -25,6 +25,7 @@ import { ghCommitDiff } from './features/github/github';
 import { worktreeDiffCommit } from './features/worktree/worktree';
 import { DogMascot } from './shared/components/DogMascot';
 import { OnboardingCard } from './features/onboarding/OnboardingCard';
+import { OnboardingWizard } from './features/onboarding/OnboardingWizard';
 import { markStepComplete } from './features/onboarding/onboarding-store';
 import { BookOpen, MessageSquare, MessagesSquare } from 'lucide-react';
 import { useKeyboardShortcut } from './shared/hooks/useKeyboardShortcut';
@@ -195,6 +196,12 @@ export function App() {
     };
     window.addEventListener('goodboy:open-linear-studio', handler);
     return () => window.removeEventListener('goodboy:open-linear-studio', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => setAddWorkspaceOpen(true);
+    window.addEventListener('goodboy:add-workspace', handler);
+    return () => window.removeEventListener('goodboy:add-workspace', handler);
   }, []);
 
   useEffect(() => {
@@ -602,6 +609,7 @@ export function App() {
           from any surface (providers panel, chat callout, future onboarding
           cards) via a CustomEvent, without prop-drilling. */}
       <ProviderModalHost />
+      <OnboardingWizard />
     </ToastProvider>
   );
 }

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Stepper.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@goodboy/ui';
+
+interface Props {
+  readonly current: number;
+  readonly total: number;
+}
+
+export function Stepper({ current, total }: Props) {
+  return (
+    <div className="flex items-center justify-center gap-2" aria-hidden>
+      {Array.from({ length: total }, (_, i) => (
+        <span
+          key={i}
+          className={cn(
+            'h-1.5 rounded-full motion-safe:transition-all',
+            i < current ? 'w-6 bg-primary' : 'w-1.5 bg-border',
+          )}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button, cn, type ButtonVariant } from '@goodboy/ui';
+import { finishWizard } from '../onboarding-store';
+import { useOnboardingWizard } from './useOnboardingWizard';
+import { Stepper } from './Stepper';
+import { WelcomeStep } from './steps/WelcomeStep';
+import { ProvidersStep } from './steps/ProvidersStep';
+import { WorkspaceStep } from './steps/WorkspaceStep';
+import { ReadyStep } from './steps/ReadyStep';
+
+const STEP_COUNT = 4;
+const EXIT_MS = 200;
+
+interface Cta {
+  readonly label: string;
+  readonly onClick: () => void;
+  readonly variant: ButtonVariant;
+}
+
+export function OnboardingWizard() {
+  const { open, providersConnected, hasWorkspace } = useOnboardingWizard();
+  const [step, setStep] = useState(0);
+  const [closing, setClosing] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setStep(0);
+    setClosing(false);
+    containerRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  const last = STEP_COUNT - 1;
+  const goNext = () => setStep((s) => Math.min(s + 1, last));
+  const goBack = () => setStep((s) => Math.max(s - 1, 0));
+  const dismiss = () => {
+    setClosing(true);
+    window.setTimeout(finishWizard, EXIT_MS);
+  };
+
+  let body = <WelcomeStep />;
+  let cta: Cta = { label: 'Get started', onClick: goNext, variant: 'primary' };
+
+  if (step === 1) {
+    body = <ProvidersStep />;
+    cta =
+      providersConnected > 0
+        ? { label: 'Continue', onClick: goNext, variant: 'primary' }
+        : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
+  } else if (step === 2) {
+    body = <WorkspaceStep hasWorkspace={hasWorkspace} />;
+    cta = hasWorkspace
+      ? { label: 'Continue', onClick: goNext, variant: 'primary' }
+      : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
+  } else if (step === 3) {
+    body = <ReadyStep />;
+    cta = { label: 'Start using Goodboy', onClick: dismiss, variant: 'primary' };
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Goodboy setup"
+      tabIndex={-1}
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col overflow-hidden bg-background outline-none',
+        closing ? 'motion-safe:animate-studio-out' : 'motion-safe:animate-studio-in',
+      )}
+    >
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(ellipse at center, transparent 0%, transparent 45%, var(--color-background) 100%)',
+        }}
+        aria-hidden
+      />
+
+      <header className="relative flex shrink-0 items-center justify-end px-6 pt-5">
+        {step < last ? (
+          <button
+            type="button"
+            onClick={dismiss}
+            className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          >
+            Skip setup
+          </button>
+        ) : null}
+      </header>
+
+      <main className="relative min-h-0 flex-1 overflow-y-auto">
+        <div className="flex min-h-full items-center justify-center px-6 py-10">
+          <div className="flex w-full max-w-xl flex-col gap-8">
+            {step > 0 ? <Stepper current={step} total={last} /> : null}
+            <div key={step} className="motion-safe:animate-fade-in">
+              {body}
+            </div>
+            <div
+              className={cn(
+                'flex items-center pt-2',
+                step > 0 ? 'justify-between' : 'justify-center',
+              )}
+            >
+              {step > 0 ? (
+                <Button variant="ghost" size="sm" onClick={goBack}>
+                  Back
+                </Button>
+              ) : null}
+              <Button variant={cta.variant} onClick={cta.onClick}>
+                {cta.label}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
@@ -1,0 +1,75 @@
+import { Check } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+import type { ProviderId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { PROVIDER_LABEL_LOWER, type ProviderInfo } from '../../../providers/providers';
+import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provider-brand';
+import { StatusPill } from '../../../providers/components/ProviderLifecycleTile/StatusPill';
+import { openProviderModal } from '../../../providers/components/ProviderModalHost';
+import type { ProviderLifecyclePhase } from '../../../../store/slices/providers';
+
+const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'codex', 'cursor', 'gemini'];
+
+export function ProvidersStep() {
+  const providers = useAppStore((s) => s.providers);
+  const lifecycle = useAppStore((s) => s.providerLifecycle);
+  const ordered = PROVIDER_ORDER.map((id) => providers.find((p) => p.id === id)).filter(
+    (p): p is ProviderInfo => p !== undefined,
+  );
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2 text-center">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Connect a provider
+        </h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Goodboy runs your agents through these CLIs. Connect at least one to start; add the others
+          whenever.
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-2">
+        {ordered.map((info) => (
+          <ProviderRow key={info.id} info={info} phase={lifecycle[info.id].phase} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ProviderRow({ info, phase }: { info: ProviderInfo; phase: ProviderLifecyclePhase }) {
+  const Icon = PROVIDER_BRAND[info.id].icon;
+  const connected = info.connection === 'connected';
+  const action = info.connection === 'missing' ? 'install' : 'login';
+
+  return (
+    <li className="flex items-center gap-3 rounded-lg border border-border-soft/50 bg-subtle/20 px-3.5 py-2.5">
+      <span
+        className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted/30"
+        style={{ color: brandColor(info.id) }}
+      >
+        <Icon size={18} aria-hidden />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className="text-sm font-medium capitalize text-foreground">
+          {PROVIDER_LABEL_LOWER[info.id]}
+        </span>
+        <StatusPill phase={phase} connection={info.connection} />
+      </div>
+      {connected ? (
+        <span className="inline-flex items-center gap-1 text-xs font-medium text-success">
+          <Check size={14} aria-hidden /> Connected
+        </span>
+      ) : (
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={() => openProviderModal({ providerId: info.id, action })}
+        >
+          Connect
+        </Button>
+      )}
+    </li>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ReadyStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ReadyStep.tsx
@@ -1,0 +1,41 @@
+import { CheckCircle2 } from 'lucide-react';
+import { KbdPill } from '@goodboy/ui';
+
+const TIPS: ReadonlyArray<{ readonly combo: ReadonlyArray<string>; readonly label: string }> = [
+  { combo: ['⌘', 'K'], label: 'command palette' },
+  { combo: ['⌘', 'N'], label: 'new session' },
+];
+
+export function ReadyStep() {
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span className="flex size-14 items-center justify-center rounded-2xl border border-success/30 bg-success/10 text-success">
+        <CheckCircle2 size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">You are all set</h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Create a session from the sidebar to get going. The checklist in the corner covers the
+          rest.
+        </p>
+      </div>
+
+      <ul className="flex w-full max-w-sm flex-col gap-2">
+        {TIPS.map((tip) => (
+          <li
+            key={tip.label}
+            className="flex items-center justify-between rounded-lg border border-border-soft/40 bg-subtle/20 px-3.5 py-2.5"
+          >
+            <span className="text-xs text-foreground">{tip.label}</span>
+            <span className="flex items-center gap-0.5">
+              {tip.combo.map((k) => (
+                <KbdPill key={k}>{k}</KbdPill>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WelcomeStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WelcomeStep.tsx
@@ -1,0 +1,59 @@
+import { FolderGit2, Plug } from 'lucide-react';
+import { DogMascot } from '../../../../shared/components/DogMascot';
+
+export function WelcomeStep() {
+  return (
+    <div className="flex flex-col items-center gap-7 text-center">
+      <div className="relative">
+        <div className="absolute -inset-6 rounded-full bg-primary/10 blur-2xl" />
+        <div className="relative flex h-24 w-24 items-center justify-center rounded-2xl border border-border-soft/40 bg-subtle/40 shadow-lg backdrop-blur-sm">
+          <DogMascot size={56} className="text-foreground" />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Welcome to Goodboy
+        </h2>
+        <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+          Two steps and you are ready to run agents.
+        </p>
+      </div>
+
+      <div className="flex w-full max-w-sm flex-col gap-2">
+        <SetupRow
+          icon={<Plug size={15} className="text-info" aria-hidden />}
+          title="Connect a provider"
+          detail="The CLI that runs your agents (claude, codex, and more)."
+        />
+        <SetupRow
+          icon={<FolderGit2 size={15} className="text-primary" aria-hidden />}
+          title="Connect a workspace"
+          detail="A git repo. Every session gets its own worktree and branch."
+        />
+      </div>
+    </div>
+  );
+}
+
+function SetupRow({
+  icon,
+  title,
+  detail,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  detail: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-3.5 py-3 text-left">
+      <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted/40">
+        {icon}
+      </span>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-xs font-semibold text-foreground">{title}</span>
+        <span className="text-2xs leading-relaxed text-muted-foreground/80">{detail}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/WorkspaceStep.tsx
@@ -1,0 +1,35 @@
+import { Check, FolderGit2 } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+
+export function WorkspaceStep({ hasWorkspace }: { hasWorkspace: boolean }) {
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span className="flex size-14 items-center justify-center rounded-2xl border border-border-soft/40 bg-subtle/40 text-primary">
+        <FolderGit2 size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Connect a workspace
+        </h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Point at a git repo to create your first workspace. Every session gets its own worktree
+          and branch, so your checkout stays clean.
+        </p>
+      </div>
+
+      {hasWorkspace ? (
+        <span className="inline-flex items-center gap-1.5 rounded-md border border-success/40 bg-success/10 px-3 py-1.5 text-xs font-medium text-success">
+          <Check size={14} aria-hidden /> Workspace connected
+        </span>
+      ) : (
+        <Button
+          variant="secondary"
+          onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+        >
+          <FolderGit2 size={14} aria-hidden /> Add workspace
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderConnectionState } from '@goodboy/types';
+import { OPEN_WIZARD_EVENT } from '../../onboarding-store';
+import { useOnboardingWizard } from './index';
+
+let wizardDone = false;
+const providers: Array<{ connection: ProviderConnectionState }> = [];
+const workspaces: Array<{ id: string }> = [];
+
+vi.mock('../../onboarding-store', () => ({
+  OPEN_WIZARD_EVENT: 'goodboy:open-onboarding-wizard',
+  isWizardDone: () => wizardDone,
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: (selector: (s: { providers: typeof providers }) => unknown) =>
+    selector({ providers }),
+  useWorkspaces: () => workspaces,
+}));
+
+function reset() {
+  wizardDone = false;
+  providers.length = 0;
+  workspaces.length = 0;
+}
+
+describe('useOnboardingWizard', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  it('opens on a genuine first run with nothing connected', () => {
+    const { result } = renderHook(() => useOnboardingWizard());
+    expect(result.current.open).toBe(true);
+  });
+
+  it('stays closed when a workspace already exists', () => {
+    workspaces.push({ id: 'w1' });
+    const { result } = renderHook(() => useOnboardingWizard());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('still opens when a provider is connected but no workspace exists yet', () => {
+    providers.push({ connection: 'connected' });
+    const { result } = renderHook(() => useOnboardingWizard());
+    expect(result.current.open).toBe(true);
+    expect(result.current.providersConnected).toBe(1);
+  });
+
+  it('stays closed once the wizard was finished', () => {
+    wizardDone = true;
+    const { result } = renderHook(() => useOnboardingWizard());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('reopens on the open-wizard event even after being done', () => {
+    wizardDone = true;
+    const { result } = renderHook(() => useOnboardingWizard());
+    expect(result.current.open).toBe(false);
+    act(() => {
+      window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+    });
+    expect(result.current.open).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { useAppStore, useWorkspaces } from '../../../../store';
+import { isWizardDone, OPEN_WIZARD_EVENT } from '../../onboarding-store';
+
+export interface OnboardingWizardState {
+  readonly open: boolean;
+  readonly providersConnected: number;
+  readonly hasWorkspace: boolean;
+}
+
+export function useOnboardingWizard(): OnboardingWizardState {
+  const providersConnected = useAppStore(
+    (s) => s.providers.filter((p) => p.connection === 'connected').length,
+  );
+  const hasWorkspace = useWorkspaces().length > 0;
+
+  const [open, setOpen] = useState(() => !isWizardDone() && !hasWorkspace);
+
+  useEffect(() => {
+    const onOpen = () => setOpen(true);
+    const onProgress = () => {
+      if (isWizardDone()) setOpen(false);
+    };
+    window.addEventListener(OPEN_WIZARD_EVENT, onOpen);
+    window.addEventListener('goodboy:onboarding-progress', onProgress);
+    return () => {
+      window.removeEventListener(OPEN_WIZARD_EVENT, onOpen);
+      window.removeEventListener('goodboy:onboarding-progress', onProgress);
+    };
+  }, []);
+
+  return { open, providersConnected, hasWorkspace };
+}

--- a/apps/desktop/src/features/onboarding/onboarding-store.ts
+++ b/apps/desktop/src/features/onboarding/onboarding-store.ts
@@ -46,6 +46,9 @@ export const ONBOARDING_STEPS: ReadonlyArray<{
 const SETTING_PROGRESS = 'onboarding.progress';
 const SETTING_COLLAPSED = 'onboarding.collapsed';
 const SETTING_FINISHED = 'onboarding.finished';
+const SETTING_WIZARD = 'onboarding.wizard';
+
+export const OPEN_WIZARD_EVENT = 'goodboy:open-onboarding-wizard';
 
 const STEP_IDS: ReadonlyArray<OnboardingStepId> = [
   'workspace',
@@ -59,12 +62,14 @@ interface OnboardingCache {
   completed: ReadonlyArray<OnboardingStepId>;
   collapsed: boolean;
   finished: boolean;
+  wizardDone: boolean;
 }
 
 const cache: OnboardingCache = {
   completed: [],
   collapsed: false,
   finished: false,
+  wizardDone: false,
 };
 
 function parseCompleted(raw: string | null): ReadonlyArray<OnboardingStepId> {
@@ -84,14 +89,16 @@ function parseCompleted(raw: string | null): ReadonlyArray<OnboardingStepId> {
 }
 
 export async function hydrateOnboardingFromDb(): Promise<void> {
-  const [rawProgress, rawCollapsed, rawFinished] = await Promise.all([
+  const [rawProgress, rawCollapsed, rawFinished, rawWizard] = await Promise.all([
     getSetting(tauriDatabase, SETTING_PROGRESS),
     getSetting(tauriDatabase, SETTING_COLLAPSED),
     getSetting(tauriDatabase, SETTING_FINISHED),
+    getSetting(tauriDatabase, SETTING_WIZARD),
   ]);
   cache.completed = parseCompleted(rawProgress);
   cache.collapsed = rawCollapsed === '1';
   cache.finished = rawFinished === '1';
+  cache.wizardDone = rawWizard === 'done';
   window.dispatchEvent(new CustomEvent('goodboy:onboarding-progress'));
 }
 
@@ -141,4 +148,19 @@ export function finish(): void {
   cache.finished = true;
   flushFlag(SETTING_FINISHED, true);
   window.dispatchEvent(new CustomEvent('goodboy:onboarding-progress'));
+}
+
+export function isWizardDone(): boolean {
+  return cache.wizardDone;
+}
+
+export function finishWizard(): void {
+  if (cache.wizardDone) return;
+  cache.wizardDone = true;
+  void setSetting(tauriDatabase, SETTING_WIZARD, 'done');
+  window.dispatchEvent(new CustomEvent('goodboy:onboarding-progress'));
+}
+
+export function reopenWizard(): void {
+  window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
 }

--- a/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsDialog/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { DollarSign, FileDown, FolderCode, Keyboard, Link2, Trash2 } from 'lucide-react';
+import { DollarSign, FileDown, FolderCode, Keyboard, Link2, Sparkles, Trash2 } from 'lucide-react';
 import { Button, Dialog, Input, KbdPill } from '@goodboy/ui';
 import { GithubPanel } from '../../../../features/github/components/Panel';
 import { ImportConfigDialog } from '../ImportConfigDialog';
@@ -9,6 +9,7 @@ import {
   SETTING_EDITOR_BINARY,
 } from '../../../../features/settings/settings';
 import { SESSION_FEATURES } from '../../../../shared/lib/features';
+import { reopenWizard } from '../../../onboarding/onboarding-store';
 import { formatError } from '../../../../shared/lib/errors';
 import type { SaveState } from '../../../../shared/types/saveState';
 import { useAppStore } from '../../../../store';
@@ -186,6 +187,21 @@ export function SettingsDialog({ open, onClose, initialSection }: Props) {
               Workspace-specific defaults (branch prefix, skills, workflows) live in the gear icon
               next to each workspace row.
             </p>
+            <Field
+              label="Setup guide"
+              help="Replay the first-run walkthrough for providers and workspaces."
+            >
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => {
+                  onClose();
+                  reopenWizard();
+                }}
+              >
+                <Sparkles size={14} aria-hidden /> Run setup again
+              </Button>
+            </Field>
           </div>
         );
       case 'shortcuts':


### PR DESCRIPTION
## What

Replaces the dispersive first run (a welcome screen that only offered **Add workspace** and never surfaced providers) with a guided full-screen wizard:

**welcome → connect a provider → connect a workspace → ready**

Each step is skippable; the whole wizard is skippable via "Skip setup". After it finishes it hands off to the existing floating checklist for the learn-the-app steps (session / agent / plan / palette).

## Why

Without a connected provider every agent fails, but the old first run never pointed there (only a pulsing dot on the sidebar). New users hit a dead end with no signpost.

## Behaviour

- Shows only on a genuine first run. Gate is `!hasWorkspace`, **snapshotted once** at mount so connecting a provider mid-flow does not auto-close it. Deliberately not gated on "no provider connected" since this audience usually has `claude` already authed in their shell. Existing installs (always have a workspace) never see it.
- Reopen via **Settings → App → Run setup again**.
- Live state: provider/workspace steps self-satisfy as the user acts (store-driven).

## Reuse, no new backend

`openProviderModal` (provider connect modal), `WorkspaceLinkDialog` (via a new `goodboy:add-workspace` event), `StatusPill` + `PROVIDER_BRAND` + brand icons, and the studio enter/exit (`animate-studio-in/out`) + `animate-fade-in` motion (all `motion-safe:` gated).

## A11y / polish

`role="dialog"` + `aria-modal` + `aria-label`, focus moved into the wizard on open, focus-visible ring, scroll-safe on small windows. ESC is intentionally not bound (avoids clobbering the provider modal's own ESC).

## Verify

`tsc --noEmit` clean; full desktop suite green (149 files / 881 tests), incl. new `useOnboardingWizard` first-run-suppression + reopen tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)