### PR TITLE
feat(desktop): process-driven planner + master-detail start dialog

### DIFF
--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.test.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.test.tsx
@@ -47,14 +47,13 @@ describe('StartWorkflowDialog', () => {
     expect(screen.getByText(/start a workflow/i)).toBeDefined();
   });
 
-  it('renders the Preset and Custom mode cards', () => {
+  it('renders the describe-your-own entry in the rail', () => {
     render(<StartWorkflowDialog open onClose={vi.fn()} session={session} />);
-    expect(screen.getByRole('button', { name: /preset/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /custom/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /describe your own/i })).toBeDefined();
   });
 
   it('shows empty-state copy when no workflow presets exist', () => {
     render(<StartWorkflowDialog open onClose={vi.fn()} session={session} />);
-    expect(screen.getByText(/no workflow presets yet/i)).toBeDefined();
+    expect(screen.getByText(/no presets yet/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Button, Dialog, cn } from '@goodboy/ui';
-import { Check, Layers, Sparkles, AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Check, Layers, Sparkles } from 'lucide-react';
 import type { ProviderId, Session, Workflow, WorkflowId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { WorkflowPlanner } from '../../../workflows/components/WorkflowPlanner';
 import { StepRowCompact } from '../../../workflows/components/StepRowCompact';
+import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
+import type { AgentKind } from '../../agent-kind';
 import { AGENT_KIND_DEFAULTS, inferAgentKindFromName, ROLE_TO_KIND } from '../../agent-kind';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
@@ -15,7 +17,18 @@ interface Props {
   session: Session;
 }
 
-type Mode = 'preset' | 'custom';
+type Selection =
+  | { readonly kind: 'preset'; readonly id: WorkflowId }
+  | { readonly kind: 'custom' }
+  | null;
+
+function sortedSteps(template: Workflow): Workflow['steps'] {
+  return [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+}
+
+function stepKind(step: Workflow['steps'][number]): AgentKind {
+  return step.role ? ROLE_TO_KIND[step.role] : inferAgentKindFromName(step.name);
+}
 
 export function StartWorkflowDialog({ open, onClose, session }: Props) {
   const phaseTemplates = useAppStore(
@@ -24,8 +37,7 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
   const attachWorkflowToSession = useAppStore((s) => s.attachWorkflowToSession);
   const { showToast } = useToast();
 
-  const [mode, setMode] = useState<Mode>('preset');
-  const [presetId, setPresetId] = useState<WorkflowId | ''>('');
+  const [selection, setSelection] = useState<Selection>(null);
   const [customId, setCustomId] = useState<WorkflowId | ''>('');
   const [autoRun, setAutoRun] = useState(false);
   const [saveAsPreset, setSaveAsPreset] = useState(false);
@@ -34,8 +46,8 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
 
   useEffect(() => {
     if (!open) return;
-    setMode('preset');
-    setPresetId('');
+    const hasPresets = phaseTemplates.some((t) => t.isPreset !== false && !t.deletedAt);
+    setSelection(hasPresets ? null : { kind: 'custom' });
     setCustomId('');
     setAutoRun(false);
     setSaveAsPreset(false);
@@ -44,23 +56,21 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
   }, [open]);
 
   const providerId: ProviderId = session.providerPreference.defaultProvider;
-
-  // Only reusable, non-deleted presets are pickable. A deleted-but-attached
-  // workflow (kept in phaseTemplates for in-session resolution) or a one-off
-  // custom workflow (isPreset === false) must not appear here.
   const presets = phaseTemplates.filter((t) => t.isPreset !== false && !t.deletedAt);
 
-  const selectedId = mode === 'preset' ? presetId : customId;
+  const isCustom = selection?.kind === 'custom';
+  const effectiveId: WorkflowId | '' =
+    selection?.kind === 'preset' ? selection.id : isCustom ? customId : '';
   const selectedTemplate =
-    selectedId !== '' ? (phaseTemplates.find((t) => t.id === selectedId) ?? null) : null;
-  const canSpawn = selectedId !== '' && !busy;
+    effectiveId !== '' ? (phaseTemplates.find((t) => t.id === effectiveId) ?? null) : null;
+  const canSpawn = effectiveId !== '' && !busy;
 
   const onSpawn = async () => {
-    if (selectedId === '') return;
+    if (effectiveId === '') return;
     setError(null);
     setBusy(true);
     try {
-      await attachWorkflowToSession(session.id, selectedId as WorkflowId, { autoRun });
+      await attachWorkflowToSession(session.id, effectiveId, { autoRun });
       showToast('success', `workflow started: ${selectedTemplate?.name ?? 'workflow'}`);
       onClose();
     } catch (err) {
@@ -70,13 +80,29 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
     }
   };
 
+  const customTemplate =
+    isCustom && customId !== '' ? (phaseTemplates.find((t) => t.id === customId) ?? null) : null;
+
   return (
     <Dialog
       open={open}
       onClose={onClose}
       title="Start a workflow"
-      description="Pick a saved preset, or design a custom one. You can skip and add it later."
+      description="Pick a saved preset, or describe the process you want. Skip and add it later."
       size="xl"
+      fixedHeightClass="h-[34rem]"
+      panelWidthClass="w-64"
+      panelClassName="min-h-0 bg-subtle/40"
+      panel={
+        <WorkflowRail
+          presets={presets}
+          selection={selection}
+          customReady={customId !== ''}
+          disabled={busy}
+          onSelectPreset={(id) => setSelection({ kind: 'preset', id })}
+          onSelectCustom={() => setSelection({ kind: 'custom' })}
+        />
+      }
       footer={
         <div className="flex w-full items-center gap-3">
           <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
@@ -94,23 +120,6 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
               </span>
             </span>
           </label>
-          {/* Only meaningful while composing a custom workflow; sits by Auto-run
-              instead of taking a row in the body. */}
-          {mode === 'custom' && customId === '' ? (
-            <label
-              className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground"
-              title="Keep this workflow reusable. Otherwise it runs once for this session."
-            >
-              <input
-                type="checkbox"
-                checked={saveAsPreset}
-                onChange={(e) => setSaveAsPreset(e.target.checked)}
-                className="accent-primary"
-                disabled={busy}
-              />
-              Save as preset
-            </label>
-          ) : null}
           <div className="flex-1">
             {error ? (
               <span className="inline-flex items-center gap-1 text-xs text-danger">
@@ -128,151 +137,119 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
         </div>
       }
     >
-      {/* Tabs + caption stay pinned; only the content below scrolls, so the
-          mode switch never leaves the viewport. */}
-      <div className="flex min-h-0 flex-1 flex-col gap-3.5">
-        <ModeTabs mode={mode} onSelect={setMode} />
-        <p className="shrink-0 px-0.5 text-2xs leading-relaxed text-muted-foreground">
-          {mode === 'preset'
-            ? 'Saved pipelines. Each step spawns its own agent, in order.'
-            : 'Describe a goal and the planner drafts the steps. Tune models per step, then run.'}
-        </p>
-
-        {/* All three panes stay mounted (toggled with `hidden`) so switching
-            Preset<->Custom never unmounts the planner: an in-flight plan keeps
-            generating and a generated plan survives the round-trip. */}
-        <div className="-mx-0.5 min-h-0 flex-1 overflow-y-auto px-0.5">
-          <div className={mode === 'preset' ? undefined : 'hidden'}>
-            <PresetPicker
-              templates={presets}
-              value={presetId}
-              onChange={setPresetId}
-              disabled={busy}
-            />
-          </div>
-          <div className={mode === 'custom' && customId === '' ? undefined : 'hidden'}>
-            <WorkflowPlanner
-              workspaceId={session.workspaceId}
-              providerId={providerId}
-              initialTheme={session.goal}
-              saveAsPreset={saveAsPreset}
-              onWorkflowReady={(workflowId) => setCustomId(workflowId)}
-            />
-          </div>
-          <div className={mode === 'custom' && customId !== '' ? undefined : 'hidden'}>
-            <CustomReady
-              template={phaseTemplates.find((t) => t.id === customId) ?? null}
-              onReset={() => setCustomId('')}
-            />
-          </div>
-        </div>
-      </div>
+      <DetailPane
+        selection={selection}
+        session={session}
+        providerId={providerId}
+        template={selection?.kind === 'preset' ? selectedTemplate : null}
+        customTemplate={customTemplate}
+        saveAsPreset={saveAsPreset}
+        busy={busy}
+        onToggleSaveAsPreset={setSaveAsPreset}
+        onWorkflowReady={(id) => setCustomId(id)}
+        onResetCustom={() => setCustomId('')}
+      />
     </Dialog>
   );
 }
 
-// ----------------------------------------------------------------------------
-// Mode switch — a compact segmented control rather than two large cards, so it
-// reads at a glance and leaves the room for the actual workflow content.
-// ----------------------------------------------------------------------------
-function ModeTabs({ mode, onSelect }: { mode: Mode; onSelect: (m: Mode) => void }) {
+function WorkflowRail({
+  presets,
+  selection,
+  customReady,
+  disabled,
+  onSelectPreset,
+  onSelectCustom,
+}: {
+  presets: ReadonlyArray<Workflow>;
+  selection: Selection;
+  customReady: boolean;
+  disabled: boolean;
+  onSelectPreset: (id: WorkflowId) => void;
+  onSelectCustom: () => void;
+}) {
   return (
-    <div className="flex shrink-0 gap-1 rounded-lg border border-border-soft bg-subtle p-1">
-      <ModeTab
-        active={mode === 'preset'}
-        onClick={() => onSelect('preset')}
-        icon={<Layers size={14} aria-hidden />}
-        label="Preset"
+    <>
+      <CustomRailRow
+        active={selection?.kind === 'custom'}
+        ready={customReady}
+        disabled={disabled}
+        onClick={onSelectCustom}
       />
-      <ModeTab
-        active={mode === 'custom'}
-        onClick={() => onSelect('custom')}
-        icon={<Sparkles size={14} aria-hidden />}
-        label="Custom"
-        beta
-      />
-    </div>
+      <div className="mt-2 px-1.5 pb-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-muted-foreground/60">
+        Presets ({presets.length})
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+        {presets.length === 0 ? (
+          <p className="px-1.5 py-2 text-2xs leading-relaxed text-muted-foreground/70">
+            No presets yet. Describe your own above.
+          </p>
+        ) : (
+          presets.map((t) => (
+            <PresetRailRow
+              key={t.id}
+              template={t}
+              active={selection?.kind === 'preset' && selection.id === t.id}
+              disabled={disabled}
+              onClick={() => onSelectPreset(t.id)}
+            />
+          ))
+        )}
+      </div>
+    </>
   );
 }
 
-function ModeTab({
+function CustomRailRow({
   active,
+  ready,
+  disabled,
   onClick,
-  icon,
-  label,
-  beta,
 }: {
   active: boolean;
+  ready: boolean;
+  disabled: boolean;
   onClick: () => void;
-  icon: React.ReactNode;
-  label: string;
-  beta?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={active}
+      disabled={disabled}
       className={cn(
-        'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-xs font-medium transition-colors',
+        'flex items-center gap-2.5 rounded-lg border px-2.5 py-2 text-left transition-colors',
         active
-          ? 'bg-background text-foreground shadow-sm ring-1 ring-border-soft'
-          : 'text-muted-foreground hover:text-foreground',
+          ? 'border-primary bg-primary/5 ring-1 ring-primary/30'
+          : 'border-border-soft bg-background hover:border-border hover:bg-muted/50',
+        disabled && 'cursor-not-allowed opacity-50',
       )}
     >
-      <span className={active ? 'text-primary' : undefined}>{icon}</span>
-      {label}
-      {beta ? (
-        <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-          beta
+      <span
+        className={cn(
+          'flex size-6 shrink-0 items-center justify-center rounded-md',
+          active ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground',
+        )}
+      >
+        <Sparkles size={13} aria-hidden />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+          Describe your own
+          <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+            beta
+          </span>
         </span>
-      ) : null}
+        <span className="truncate text-[10px] text-muted-foreground/70">
+          planner drafts the steps
+        </span>
+      </span>
+      {ready ? <Check size={13} className="shrink-0 text-success" aria-hidden /> : null}
     </button>
   );
 }
 
-function PresetPicker({
-  templates,
-  value,
-  onChange,
-  disabled,
-}: {
-  templates: ReadonlyArray<Workflow>;
-  value: WorkflowId | '';
-  onChange: (id: WorkflowId | '') => void;
-  disabled: boolean;
-}) {
-  if (templates.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border-soft bg-subtle/60 px-6 py-10 text-center">
-        <Layers size={22} className="text-muted-foreground/30" aria-hidden />
-        <p className="text-sm font-medium text-foreground">No workflow presets yet</p>
-        <p className="max-w-[18rem] text-xs leading-relaxed text-muted-foreground">
-          Switch to <span className="font-medium text-foreground">Custom</span> to design your first
-          workflow with the planner.
-        </p>
-      </div>
-    );
-  }
-  return (
-    <ul className="flex flex-col gap-1.5">
-      {templates.map((t) => (
-        <li key={t.id}>
-          <PresetOption
-            template={t}
-            active={value === t.id}
-            disabled={disabled}
-            onClick={() => onChange(value === t.id ? '' : t.id)}
-          />
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// One selectable preset, rendered with the same vocabulary as the Workflow
-// Studio preset card: ordinal · avatar · role-coloured name · model·verbosity.
-function PresetOption({
+function PresetRailRow({
   template,
   active,
   disabled,
@@ -283,65 +260,142 @@ function PresetOption({
   disabled: boolean;
   onClick: () => void;
 }) {
-  const steps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+  const steps = sortedSteps(template);
+  const kinds = steps.map(stepKind);
+  const shown = kinds.slice(0, 5);
   return (
     <button
       type="button"
-      disabled={disabled}
       onClick={onClick}
+      aria-pressed={active}
+      disabled={disabled}
       className={cn(
-        'flex w-full flex-col gap-2 rounded-lg border px-3.5 py-3 text-left transition-colors',
+        'flex flex-col gap-1.5 rounded-lg border px-2.5 py-2 text-left transition-colors',
         active
           ? 'border-primary bg-primary/5 ring-1 ring-primary/30'
-          : 'border-border-soft bg-subtle hover:border-border hover:bg-muted/50',
+          : 'border-border-soft bg-background hover:border-border hover:bg-muted/50',
         disabled && 'cursor-not-allowed opacity-50',
       )}
     >
-      <div className="flex items-center gap-2">
-        <span className="shrink-0 truncate text-sm font-semibold text-foreground">
+      <span className="flex items-center gap-2">
+        <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
           {template.name}
         </span>
-        {template.description ? (
-          <span className="min-w-0 flex-1 truncate text-2xs text-muted-foreground/70">
-            {template.description}
-          </span>
+        {active ? (
+          <Check size={13} className="shrink-0 text-primary" aria-hidden />
         ) : (
-          <span className="flex-1" />
+          <span className="shrink-0 text-[10px] text-muted-foreground/50">{steps.length}</span>
         )}
-        <span className="shrink-0 text-2xs text-muted-foreground/50">
-          {steps.length} step{steps.length === 1 ? '' : 's'}
-        </span>
-        {active ? <Check size={14} className="shrink-0 text-primary" aria-hidden /> : null}
-      </div>
-      {steps.length > 0 ? (
-        <ol className="flex flex-col gap-1">
-          {steps.map((step, i) => (
-            <StepRow key={step.id} step={step} index={i} />
-          ))}
-        </ol>
-      ) : null}
+      </span>
+      <span className="flex items-center gap-1">
+        {shown.map((k, i) => (
+          <AgentAvatar key={`${k}-${i}`} kind={k} size="xs" />
+        ))}
+        {kinds.length > shown.length ? (
+          <span className="text-[10px] text-muted-foreground/40">
+            +{kinds.length - shown.length}
+          </span>
+        ) : null}
+      </span>
     </button>
   );
 }
 
-function StepRow({ step, index }: { step: Workflow['steps'][number]; index: number }) {
-  const kind = step.role ? ROLE_TO_KIND[step.role] : inferAgentKindFromName(step.name);
+function DetailPane({
+  selection,
+  session,
+  providerId,
+  template,
+  customTemplate,
+  saveAsPreset,
+  busy,
+  onToggleSaveAsPreset,
+  onWorkflowReady,
+  onResetCustom,
+}: {
+  selection: Selection;
+  session: Session;
+  providerId: ProviderId;
+  template: Workflow | null;
+  customTemplate: Workflow | null;
+  saveAsPreset: boolean;
+  busy: boolean;
+  onToggleSaveAsPreset: (value: boolean) => void;
+  onWorkflowReady: (id: WorkflowId) => void;
+  onResetCustom: () => void;
+}) {
+  if (selection === null) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+        <Layers size={22} className="text-muted-foreground/30" aria-hidden />
+        <p className="text-sm font-medium text-foreground">Pick a workflow</p>
+        <p className="max-w-[19rem] text-xs leading-relaxed text-muted-foreground">
+          Choose a preset on the left, or describe the process you want and let the planner draft
+          it.
+        </p>
+      </div>
+    );
+  }
+
+  if (selection.kind === 'preset') {
+    return template ? <PresetPreview template={template} /> : null;
+  }
+
+  if (customTemplate) {
+    return <CustomReady template={customTemplate} onReset={onResetCustom} />;
+  }
+
   return (
-    <li>
-      <StepRowCompact
-        index={index}
-        kind={kind}
-        name={step.name}
-        model={step.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model}
-        verbosity={step.verbosity ?? 'normal'}
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 rounded-md bg-subtle px-3 py-2">
+        <span className="shrink-0 text-2xs font-medium uppercase tracking-wide text-muted-foreground/60">
+          for
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs text-foreground">{session.goal}</span>
+      </div>
+      <label className="flex cursor-pointer items-center gap-2 text-2xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={saveAsPreset}
+          onChange={(e) => onToggleSaveAsPreset(e.target.checked)}
+          className="accent-primary"
+          disabled={busy}
+        />
+        Save as preset to reuse it on other sessions.
+      </label>
+      <WorkflowPlanner
+        workspaceId={session.workspaceId}
+        providerId={providerId}
+        initialProcess=""
+        saveAsPreset={saveAsPreset}
+        onWorkflowReady={onWorkflowReady}
       />
-    </li>
+    </div>
   );
 }
 
-function CustomReady({ template, onReset }: { template: Workflow | null; onReset: () => void }) {
-  if (!template) return null;
-  const steps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+function PresetPreview({ template }: { template: Workflow }) {
+  const steps = sortedSteps(template);
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-sm font-semibold text-foreground">{template.name}</div>
+        {template.description ? (
+          <p className="mt-0.5 text-2xs leading-relaxed text-muted-foreground">
+            {template.description}
+          </p>
+        ) : null}
+      </div>
+      <StepLadder steps={steps} />
+      <p className="text-2xs text-muted-foreground/60">
+        {steps.length} step{steps.length === 1 ? '' : 's'}, each spawns its own agent in order.
+      </p>
+    </div>
+  );
+}
+
+function CustomReady({ template, onReset }: { template: Workflow; onReset: () => void }) {
+  const steps = sortedSteps(template);
   return (
     <div className="flex flex-col gap-2.5">
       <div className="flex items-center gap-2">
@@ -360,13 +414,31 @@ function CustomReady({ template, onReset }: { template: Workflow | null; onReset
           <Sparkles size={10} aria-hidden /> Re-design
         </button>
       </div>
-      <div className="rounded-lg border border-border-soft bg-subtle px-3.5 py-3">
-        <ol className="flex flex-col gap-1">
-          {steps.map((step, i) => (
-            <StepRow key={step.id} step={step} index={i} />
-          ))}
-        </ol>
-      </div>
+      <StepLadder steps={steps} />
+    </div>
+  );
+}
+
+function StepLadder({ steps }: { steps: Workflow['steps'] }) {
+  return (
+    <div className="rounded-lg border border-border-soft bg-subtle px-3.5 py-3">
+      <ol className="flex flex-col gap-1.5">
+        {steps.map((step, i) => {
+          const kind = stepKind(step);
+          return (
+            <li key={step.id}>
+              <StepRowCompact
+                index={i}
+                kind={kind}
+                name={step.name}
+                model={step.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model}
+                verbosity={step.verbosity ?? 'normal'}
+                role={step.role}
+              />
+            </li>
+          );
+        })}
+      </ol>
     </div>
   );
 }

--- a/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.test.tsx
@@ -14,12 +14,12 @@ import { WorkflowPlanner } from './index';
 afterEach(cleanup);
 
 describe('WorkflowPlanner', () => {
-  it('renders the planner with a Generate plan button disabled until theme is typed', () => {
+  it('renders the planner with a Generate plan button disabled until a process is typed', () => {
     render(
       <WorkflowPlanner
         workspaceId={'ws-1' as never}
         providerId="anthropic"
-        initialTheme=""
+        initialProcess=""
         onWorkflowReady={vi.fn()}
       />,
     );
@@ -32,7 +32,7 @@ describe('WorkflowPlanner', () => {
       <WorkflowPlanner
         workspaceId={'ws-1' as never}
         providerId="anthropic"
-        initialTheme=""
+        initialProcess=""
         onWorkflowReady={vi.fn()}
       />,
     );

--- a/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.tsx
@@ -42,7 +42,7 @@ interface StepOverrides {
 interface Props {
   workspaceId: WorkspaceId;
   providerId: ProviderId;
-  initialTheme: string;
+  initialProcess: string;
   // When false (default) the generated workflow is persisted but not added to
   // the reusable preset library: the session that runs it keeps it, but it
   // won't show up in the preset picker. Tick "save as preset" to make it
@@ -57,13 +57,13 @@ const DEFAULT_VERBOSITY: VerbosityLevel = 'normal';
 export function WorkflowPlanner({
   workspaceId,
   providerId,
-  initialTheme,
+  initialProcess,
   saveAsPreset = false,
   onWorkflowReady,
   onPlanChange,
 }: Props) {
   const savePhaseTemplate = useAppStore((s) => s.savePhaseTemplate);
-  const [theme, setTheme] = useState(initialTheme);
+  const [processText, setProcessText] = useState(initialProcess);
   const [busy, setBusy] = useState(false);
   const [plan, setPlan] = useState<PlannerOutput | null>(null);
   const [overrides, setOverrides] = useState<Record<number, StepOverrides>>({});
@@ -88,7 +88,7 @@ export function WorkflowPlanner({
   };
 
   const onPlan = async () => {
-    if (theme.trim().length === 0) return;
+    if (processText.trim().length === 0) return;
     setError(null);
     setPlan(null);
     setOverrides({});
@@ -96,7 +96,7 @@ export function WorkflowPlanner({
     setBusy(true);
     try {
       const client = new PlannerClient({ providerId, invokeFn: invoke });
-      const result = await client.plan({ theme: theme.trim() });
+      const result = await client.plan({ process: processText.trim() });
       setPlan(result.output);
       onPlanChange?.(true);
       const initial: Record<number, StepOverrides> = {};
@@ -154,7 +154,7 @@ export function WorkflowPlanner({
       setPlan(null);
       onPlanChange?.(false);
       setOverrides({});
-      setTheme('');
+      setProcessText('');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -170,12 +170,12 @@ export function WorkflowPlanner({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="rounded-2xl bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15">
+      <div className="rounded-xl bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15">
         <div className="relative">
           <Textarea
-            value={theme}
-            onChange={(e) => setTheme(e.target.value)}
-            placeholder="describe the theme (e.g. migrate auth to oauth, add dark mode toggle)…"
+            value={processText}
+            onChange={(e) => setProcessText(e.target.value)}
+            placeholder="describe the process you expect (e.g. read the existing github integration, study how it works, then plan the gitlab equivalent, then implement)…"
             autoGrow
             minRows={5}
             maxRows={10}
@@ -188,7 +188,7 @@ export function WorkflowPlanner({
             <Button
               size="sm"
               onClick={onPlan}
-              disabled={busy || theme.trim().length === 0}
+              disabled={busy || processText.trim().length === 0}
               className="min-w-[6.5rem]"
             >
               {planning ? (

--- a/packages/core/src/planner/cli.test.ts
+++ b/packages/core/src/planner/cli.test.ts
@@ -52,7 +52,7 @@ describe('PlannerAgent', () => {
       spawnFn: spawnFn as never,
     });
 
-    const promise = agent.plan({ theme: 'Refactor auth module' });
+    const promise = agent.plan({ process: 'Refactor auth module' });
 
     setImmediate(() => {
       child.stdout.emit('data', Buffer.from(claudeEnvelope, 'utf8'));
@@ -76,7 +76,7 @@ describe('PlannerAgent', () => {
       spawnFn: spawnFn as never,
     });
 
-    const promise = agent.plan({ theme: 'X' });
+    const promise = agent.plan({ process: 'X' });
 
     setImmediate(() => {
       child.stderr.emit('data', Buffer.from('boom', 'utf8'));
@@ -86,7 +86,7 @@ describe('PlannerAgent', () => {
     await expect(promise).rejects.toBeInstanceOf(PlannerSpawnError);
   });
 
-  it('passes theme + repoContext into user message', async () => {
+  it('passes process + repoContext into user message', async () => {
     const claudeEnvelope = JSON.stringify({ result: validPlannerJson });
     const child = makeFakeChild();
     let capturedArgs: string[] = [];
@@ -101,7 +101,7 @@ describe('PlannerAgent', () => {
     });
 
     const promise = agent.plan({
-      theme: 'Migrate to Drizzle ORM',
+      process: 'Migrate to Drizzle ORM',
       repoContext: 'Workspace: goodboy, TypeScript monorepo',
     });
 

--- a/packages/core/src/planner/prompt.ts
+++ b/packages/core/src/planner/prompt.ts
@@ -2,10 +2,14 @@ import type { PlannerInput } from './types';
 
 export const PLANNER_SYSTEM_PROMPT = `You are a planning agent for an AI coding workspace.
 
-The user gives you a theme, a goal they want to accomplish on their codebase.
-Your job is to break that goal into a sequence of agent steps. Each step will be
-executed as its own LLM session. Steps run in order; the output of one step becomes
-context for the next.
+The user describes the process they expect to run on their codebase: the steps or
+method they want followed, not just an outcome. Your job is to turn that described
+process into a sequence of agent steps. Each step will be executed as its own LLM
+session. Steps run in order; the output of one step becomes context for the next.
+
+Follow the process the user laid out: honor their sequence and intent, and do not
+invent stages they did not ask for. When the user gives only a high-level outcome
+with no steps, decompose it into a sensible process yourself.
 
 You MUST respond with a single JSON object and nothing else. No prose, no markdown,
 no code fences. The schema is:
@@ -27,8 +31,8 @@ no code fences. The schema is:
 Rules:
 - 1 to 6 steps. Smaller is better; only add a step if it carries its own load.
 - Steps are sequential by default. The user can reorder or mark some as parallel later.
-- A step's promptPrefix should make sense without seeing the user's original theme;
-  the theme will be appended automatically as the user message.
+- A step's promptPrefix should make sense without seeing the user's original description;
+  the description will be appended automatically as the user message.
 - expectedOutput tells the post-step summarizer what to extract; be specific.
 - Pick roles from the canonical list above. Use "other" only if none fit.
 - Names should be short (1-3 words), in title case.
@@ -37,7 +41,7 @@ Rules:
   All JSON field values (workflowName, names, reasoning, promptPrefix, expectedOutput) must be in English.`;
 
 export function buildPlannerUserPrompt(input: PlannerInput): string {
-  const parts = ['Theme:', input.theme];
+  const parts = ['Process:', input.process];
   if (input.repoContext && input.repoContext.trim().length > 0) {
     parts.push('', 'Repository context:', input.repoContext.trim());
   }

--- a/packages/core/src/planner/types.ts
+++ b/packages/core/src/planner/types.ts
@@ -12,6 +12,6 @@ export interface PlannerOutput {
 }
 
 export interface PlannerInput {
-  readonly theme: string;
+  readonly process: string;
   readonly repoContext?: string;
 }


### PR DESCRIPTION
## What

Two coupled changes to the workflow creation flow.

**Planner reframe (goal -> process).** The custom-workflow planner now asks for the *process the user expects* (the steps/method), not a goal. The goal lives outside (Linear / manual session creation). The planner prompt formalizes the described process and honors the user's sequence; a bare outcome with no steps is decomposed as a graceful fallback. `PlannerInput.theme` renamed to `process`.

**Start a workflow dialog redesign (master-detail).** Rebuilt on `Dialog.panel`:
- dropped the preset/custom tabs for a single rail: a pinned "Describe your own" entry plus a scannable preset list (name + step count + role avatars).
- detail pane shows a clean preset preview, or the planner (with the session goal surfaced read-only as context), or the generated-workflow summary.
- decluttered the footer, moved save-as-preset into the custom pane, unified the preset card (no more divergent reimplementation), and the dialog opens straight to the planner when no presets exist.

## Verification

- typecheck: green (all packages)
- tests: desktop 876/876, core planner 20/20
- prettier: clean

Not pixel-verified live (Tauri app, shared SQLite makes a second dev instance risky).