### PR TITLE
fix(desktop): queued-turn crash + start-workflow modal polish

### DIFF
--- a/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/StartWorkflowDialog/index.tsx
@@ -89,9 +89,9 @@ export function StartWorkflowDialog({ open, onClose, session }: Props) {
       onClose={onClose}
       title="Start a workflow"
       description="Pick a saved preset, or describe the process you want. Skip and add it later."
-      size="xl"
-      fixedHeightClass="h-[34rem]"
-      panelWidthClass="w-64"
+      size="2xl"
+      fixedHeightClass="h-[40rem]"
+      panelWidthClass="w-72"
       panelClassName="min-h-0 bg-subtle/40"
       panel={
         <WorkflowRail
@@ -433,7 +433,6 @@ function StepLadder({ steps }: { steps: Workflow['steps'] }) {
                 name={step.name}
                 model={step.modelOverride ?? AGENT_KIND_DEFAULTS[kind].model}
                 verbosity={step.verbosity ?? 'normal'}
-                role={step.role}
               />
             </li>
           );

--- a/apps/desktop/src/features/workflows/components/StepRowCompact/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/StepRowCompact/index.test.tsx
@@ -21,18 +21,4 @@ describe('StepRowCompact', () => {
     expect(screen.getByText('build it')).toBeDefined();
     expect(screen.getByText(/brief/)).toBeDefined();
   });
-
-  it('shows a role badge when a role is passed', () => {
-    render(
-      <StepRowCompact
-        index={0}
-        kind="planner"
-        name="design schema"
-        model="gpt-5"
-        verbosity="normal"
-        role="planner"
-      />,
-    );
-    expect(screen.getByText('Planner')).toBeDefined();
-  });
 });

--- a/apps/desktop/src/features/workflows/components/StepRowCompact/index.tsx
+++ b/apps/desktop/src/features/workflows/components/StepRowCompact/index.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@goodboy/ui';
 import type { AgentKind } from '../../../session/agent-kind';
-import { AGENT_KIND_PALETTE, ROLE_LABEL } from '../../../session/agent-kind';
-import type { AgentRole, VerbosityLevel } from '@goodboy/types';
+import { AGENT_KIND_PALETTE } from '../../../session/agent-kind';
+import type { VerbosityLevel } from '@goodboy/types';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
 import { shortModel } from '../../../session/agent-row-format';
 
@@ -11,30 +11,19 @@ interface Props {
   readonly name: string;
   readonly model: string;
   readonly verbosity: VerbosityLevel;
-  readonly role?: AgentRole;
   readonly className?: string;
 }
 
-export function StepRowCompact({ index, kind, name, model, verbosity, role, className }: Props) {
+export function StepRowCompact({ index, kind, name, model, verbosity, className }: Props) {
   const pal = AGENT_KIND_PALETTE[kind];
   return (
-    <div className={cn('flex items-center gap-2', className)}>
+    <div className={cn('flex items-center gap-2.5', className)}>
       <span className="w-3 shrink-0 text-right font-mono text-2xs text-muted-foreground/40">
         {index + 1}
       </span>
       <AgentAvatar kind={kind} size="xs" />
       <span className={cn('min-w-0 flex-1 truncate text-2xs font-medium', pal.fg)}>{name}</span>
-      {role ? (
-        <span
-          className={cn(
-            'shrink-0 rounded bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em]',
-            pal.fg,
-          )}
-        >
-          {ROLE_LABEL[role]}
-        </span>
-      ) : null}
-      <span className="shrink-0 truncate font-mono text-[10px] text-muted-foreground/50">
+      <span className="shrink-0 whitespace-nowrap text-right font-mono text-[10px] tabular-nums text-muted-foreground/50">
         {shortModel(model)} · {verbosity}
       </span>
     </div>

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -706,13 +706,14 @@ export function sendTurn(set: SetFn, get: GetFn) {
           await updateSessionState(tauriDatabase, sessionId, errorState, now());
           applySessionUpdate(set, sessionId, errorState, activeAgentId);
         } else {
-          const doneState = turnReducer(
-            get().sessions.find((s) => s.id === sessionId)?.state ?? nextStateP,
-            {
-              kind: 'receive_event',
-              event: { kind: 'done', runId: result.runIds[0]!, at: now() },
-            },
-          );
+          const current = get().sessions.find((s) => s.id === sessionId)?.state ?? nextStateP;
+          const doneState: TurnState =
+            current.kind === 'running'
+              ? turnReducer(current, {
+                  kind: 'receive_event',
+                  event: { kind: 'done', runId: result.runIds[0]!, at: now() },
+                })
+              : { kind: 'idle', lastActivityAt: now() };
           await updateSessionState(tauriDatabase, sessionId, doneState, now());
           applySessionUpdate(set, sessionId, doneState, activeAgentId);
         }
@@ -968,7 +969,7 @@ export function sendTurn(set: SetFn, get: GetFn) {
         }
 
         const currentAgentState = get().agentTurnState[activeAgentId];
-        if (currentAgentState) {
+        if (currentAgentState?.kind === 'running') {
           const reduced = turnReducer(currentAgentState, { kind: 'receive_event', event });
           if (reduced !== currentAgentState) {
             const derived = applyAgentTurnState(set, sessionId, activeAgentId, reduced, now());

--- a/packages/ui/src/components/Dialog.tsx
+++ b/packages/ui/src/components/Dialog.tsx
@@ -2,7 +2,7 @@ import { useId, useEffect, useRef, type MouseEvent, type ReactNode } from 'react
 import { cn } from '../cn';
 import { Divider } from './Divider';
 
-export type DialogSize = 'sm' | 'md' | 'lg' | 'xl';
+export type DialogSize = 'sm' | 'md' | 'lg' | 'xl' | '2xl';
 
 export interface DialogProps {
   open: boolean;
@@ -55,6 +55,7 @@ const SIZE: Record<DialogSize, string> = {
   md: 'w-[32rem]',
   lg: 'w-[44rem]',
   xl: 'w-[56rem]',
+  '2xl': 'w-[64rem]',
 };
 
 // Per-size baseline min-height. Without this the dialog collapses to the
@@ -66,6 +67,7 @@ const MIN_HEIGHT: Record<DialogSize, string> = {
   md: 'min-h-[24rem]',
   lg: 'min-h-[28rem]',
   xl: 'min-h-[32rem]',
+  '2xl': 'min-h-[34rem]',
 };
 
 const SMALL_VIEWPORT = 'max-md:w-screen max-md:h-screen max-md:max-h-screen max-md:max-w-none';


### PR DESCRIPTION
## what

Two fixes from n-bro's review.

### 1. queued message crash (\`illegal transition: cannot apply receive_event in state idle\`)
The streaming loop fed every provider event into \`turnReducer\` as \`receive_event\`, which is only legal in \`running\`. When a queued turn fired the instant the prior turn left \`running\` (workflow auto-advance / tail events reset the agent state mid-stream), a stray event hit the reducer in \`idle\` and threw, failing the whole turn.

- main loop: only reduce \`receive_event\` while the agent state is \`running\`; late events are ignored, not fatal (transcript + assistant text still accumulate; loop-end force-idle reconciles state).
- parallel branch done-state: guarded the same way (idle directly if not running).

### 2. start-workflow modal
- bigger: new \`2xl\` Dialog size (\`w-[64rem]\`); dialog now 2xl, height 34→40rem, rail 64→72.
- dedup: step rows showed the name ("Plan") **and** a role badge ("PLANNER") = same info twice. Dropped the badge (avatar already color-codes the kind).
- alignment: the variable-width badges were what made the model column ragged. Removed → model·effort is right-aligned, \`tabular-nums\`. \`StepRowCompact\` lost the now-dead \`role\` prop + imports.

## verification
- typecheck (ui + desktop): green
- tests: reducer 40/40, StepRowCompact, ChatInput, StartWorkflowDialog all green
- not exercised in the running app yet (Tauri); the queue race was reproduced by reasoning, not a live repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)