### PR TITLE
fix(desktop): wipe localStorage on db wipe + tidy delete-session modal

### DIFF
--- a/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/navigation.test.tsx
@@ -116,19 +116,19 @@ describe('keyboard, DeleteSessionDialog', () => {
     expect(focused?.tagName.toLowerCase()).toBe('button');
   });
 
-  it('Enter on "delete session" button keeps it keyboard-reachable', async () => {
+  it('Enter on delete button keeps it keyboard-reachable', async () => {
     const user = userEvent.setup();
     render(<DeleteSessionDialog session={makeSession()} open={true} onClose={vi.fn()} />);
-    const deleteBtn = screen.getByRole('button', { name: /delete session/i });
+    const deleteBtn = screen.getByRole('button', { name: /^delete$/i });
     deleteBtn.focus();
     await user.keyboard('{Enter}');
     expect(document.activeElement).toBe(deleteBtn);
   });
 
-  it('exposes both archive-instead and delete actions', () => {
+  it('exposes both archive and delete actions', () => {
     render(<DeleteSessionDialog session={makeSession()} open={true} onClose={vi.fn()} />);
-    expect(screen.getByRole('button', { name: /archive instead/i })).toBeDefined();
-    expect(screen.getByRole('button', { name: /delete session/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /^archive$/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeDefined();
   });
 
   it('Tab cycles through cancel → archive → delete buttons', async () => {

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1018,7 +1018,7 @@ exports[`snapshot, error states > DeleteSessionDialog: error state 1`] = `
   open=""
 >
   <div
-    class="flex flex-col max-h-[85vh] min-h-[16rem] w-[24rem]"
+    class="flex flex-col max-h-[85vh] min-h-[24rem] w-[32rem]"
   >
     <header
       class="flex shrink-0 items-start justify-between gap-4 px-6 py-4"
@@ -1124,13 +1124,13 @@ exports[`snapshot, error states > DeleteSessionDialog: error state 1`] = `
             d="M10 12h4"
           />
         </svg>
-        Archive instead
+        Archive
       </button>
       <button
         class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-danger text-danger-foreground hover:bg-danger/90 h-8 px-3 text-sm"
         type="button"
       >
-        Delete session
+        Delete
       </button>
     </footer>
   </div>

--- a/apps/desktop/src/features/session/components/DeleteSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/DeleteSessionDialog/index.tsx
@@ -57,7 +57,7 @@ export function DeleteSessionDialog({ session, open, onClose }: Props) {
       onClose={onClose}
       title="Delete session?"
       description="Permanently removes the worktree and transcripts for this session from this device. The branch is preserved for manual merge."
-      size="sm"
+      size="md"
       footer={
         <>
           {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
@@ -66,10 +66,10 @@ export function DeleteSessionDialog({ session, open, onClose }: Props) {
           </Button>
           <Button variant="secondary" onClick={() => void onArchiveInstead()} disabled={busy}>
             <Archive size={13} aria-hidden className="mr-1.5" />
-            {busy ? 'Working…' : 'Archive instead'}
+            {busy ? 'Working…' : 'Archive'}
           </Button>
           <Button variant="danger" onClick={() => void onConfirmDelete()} disabled={busy}>
-            {busy ? 'Deleting…' : 'Delete session'}
+            {busy ? 'Deleting…' : 'Delete'}
           </Button>
         </>
       }

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -15,3 +15,13 @@ export const STORAGE_PREFIXES = {
   diffView: `${PREFIX}diff-view:`,
   sessionView: `${PREFIX}session-view:`,
 } as const;
+
+export function wipeLocalStorage(): void {
+  if (typeof localStorage === 'undefined') return;
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (key?.startsWith(PREFIX)) keys.push(key);
+  }
+  for (const key of keys) localStorage.removeItem(key);
+}

--- a/apps/desktop/src/store/slices/workspaces/wipeLocalDatabase.ts
+++ b/apps/desktop/src/store/slices/workspaces/wipeLocalDatabase.ts
@@ -1,5 +1,6 @@
 import { setSetting as dbSetSetting } from '@goodboy/db';
 import { tauriDatabase, wipeDb } from '../../../shared/lib/db';
+import { wipeLocalStorage } from '../../../shared/lib/storage-keys';
 import { SETTING_LAST_SESSION_ID } from '../../../features/settings/settings';
 import { initialState } from '../../store';
 import type { GetFn, SetFn } from './types';
@@ -7,6 +8,7 @@ import type { GetFn, SetFn } from './types';
 export function wipeLocalDatabase(set: SetFn, get: GetFn) {
   return async () => {
     await wipeDb();
+    wipeLocalStorage();
     set({
       ...initialState,
       hydrated: get().hydrated,


### PR DESCRIPTION
## What

Two desktop polish fixes:

1. **Local db wipe also clears localStorage.** `wipeLocalDatabase` now calls a new `wipeLocalStorage()` helper that sweeps every `goodboy:`-prefixed key (theme, zoom, sidebar, context-panel, session-view, diff-view, dismissed comment chips, setup-workflow toggle, migration marker). Previously the wipe dropped the sqlite db but left UI state behind, leaving half-states referencing dead workspaces/sessions.
2. **Delete-session modal tidy.** Widened `sm` to `md` so the footer CTAs fit on one line; labels shortened `Archive instead` to `Archive` and `Delete session` to `Delete`.

## Notes

- Namespace sweep is future-proof: new `goodboy:` keys are caught automatically.
- Side-effect: pure UI prefs (theme, zoom) reset too, consistent with the modal's "restart to start fresh" copy.
- Wiping the migration marker is a harmless no-op on next boot (db + legacy keys already gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)