### PR TITLE
feat(desktop): themed work-in-progress indicator

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -31,6 +31,8 @@ import {
   reduceTranscript,
 } from '../../utils/transcript-items';
 import { clusterOperations } from '../../utils/cluster-operations';
+import { classifyThinkingContext } from '../../utils/thinking-context';
+import { ThinkingIndicator } from '../ThinkingIndicator';
 import { TranscriptCard } from '../TranscriptCards';
 import { OperationsCluster } from '../OperationsCluster';
 import { AuthRequiredCallout } from '../AuthRequiredCallout';
@@ -189,23 +191,6 @@ function TranscriptSkeleton() {
   );
 }
 
-function ThinkingIndicator() {
-  return (
-    <div
-      role="status"
-      aria-label="claude is thinking"
-      className="flex w-fit items-center gap-1.5 px-1 py-0.5 text-2xs italic text-muted-foreground/80"
-    >
-      <span className="flex gap-0.5">
-        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:0ms]" />
-        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:150ms]" />
-        <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/70 [animation-delay:300ms]" />
-      </span>
-      thinking
-    </div>
-  );
-}
-
 export function ChatView({ session, isActive = true }: ChatViewProps) {
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[session.id] ?? null,
@@ -299,6 +284,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
     agentKind === 'running' &&
     (lastItem?.kind ?? 'user_text') !== 'assistant_text' &&
     !lastClusterRunning;
+  const thinkingContext = useMemo(() => classifyThinkingContext({ lastItem }), [lastItem]);
 
   const parallelRunIds = useMemo<ReadonlyArray<ProviderRunId>>(
     () => (flagOn ? detectParallelRunIds(events) : []),
@@ -570,7 +556,7 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
               })()}
               {isThinking ? (
                 <li className="mt-2.5">
-                  <ThinkingIndicator />
+                  <ThinkingIndicator context={thinkingContext} />
                 </li>
               ) : null}
             </ul>

--- a/apps/desktop/src/features/chat/components/ThinkingIndicator/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ThinkingIndicator/index.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { ThinkingIndicator } from './index';
+
+const mockMatchMedia = (reduced: boolean) => {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: reduced,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockMatchMedia(false);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('ThinkingIndicator', () => {
+  it('shows a phrase from the active context bucket', () => {
+    render(<ThinkingIndicator context="search" />);
+    expect(screen.getByText('sniffing through files')).toBeTruthy();
+  });
+
+  it('rotates the phrase on the tick interval', () => {
+    render(<ThinkingIndicator context="run" />);
+    expect(screen.getByText('digging in')).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(2600);
+    });
+    expect(screen.getByText('off to fetch')).toBeTruthy();
+  });
+
+  it('settles into a reassurance phrase after a long wait', () => {
+    render(<ThinkingIndicator context="think" />);
+    act(() => {
+      vi.advanceTimersByTime(2600 * 8);
+    });
+    expect(screen.getByText('still on the trail')).toBeTruthy();
+  });
+
+  it('freezes on the first phrase under reduced motion', () => {
+    mockMatchMedia(true);
+    render(<ThinkingIndicator context="think" />);
+    expect(screen.getByText('sniffing it out')).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(2600 * 4);
+    });
+    expect(screen.getByText('sniffing it out')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ThinkingIndicator/index.tsx
+++ b/apps/desktop/src/features/chat/components/ThinkingIndicator/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { cn } from '@goodboy/ui';
+import { DogMascot } from '../../../../shared/components/DogMascot';
+import type { ThinkingContext } from '../../utils/thinking-context';
+
+type Props = {
+  readonly context: ThinkingContext;
+};
+
+const PHRASES: Record<ThinkingContext, readonly string[]> = {
+  think: ['sniffing it out', 'on the scent', 'nose down', 'chewing it over', 'tracking it down'],
+  search: ['sniffing through files', 'following the trail', 'nose to the ground', 'nosing around'],
+  edit: ['leaving its mark', 'shaping it up', 'tidying the yard'],
+  run: ['digging in', 'off to fetch', 'fetching results'],
+};
+
+const ROTATE_MS = 2600;
+const SETTLE_AFTER_TICKS = 8;
+const SETTLED_PHRASE = 'still on the trail';
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+export function ThinkingIndicator({ context }: Props) {
+  const [reduced] = useState(prefersReducedMotion);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    if (reduced) return;
+    const id = window.setInterval(() => setTick((t) => t + 1), ROTATE_MS);
+    return () => window.clearInterval(id);
+  }, [reduced]);
+
+  const phrases = PHRASES[context];
+  const phrase =
+    !reduced && tick >= SETTLE_AFTER_TICKS ? SETTLED_PHRASE : phrases[tick % phrases.length];
+
+  return (
+    <div
+      role="status"
+      aria-label="goodboy is working"
+      className="flex w-fit items-center gap-1.5 px-1 py-0.5 text-2xs italic"
+    >
+      <DogMascot size={12} className="text-muted-foreground/70 motion-safe:animate-soft-pulse" />
+      <span aria-hidden className={reduced ? 'text-muted-foreground/80' : 'text-shimmer'}>
+        {phrase}
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/chat/utils/thinking-context.test.ts
+++ b/apps/desktop/src/features/chat/utils/thinking-context.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import type { TranscriptItem } from './transcript-items';
+import { classifyThinkingContext } from './thinking-context';
+
+const toolCall = (toolName: string): TranscriptItem => ({
+  kind: 'tool_call',
+  key: `tool-${toolName}`,
+  toolUseId: toolName,
+  toolName,
+  input: null,
+  output: null,
+  isError: false,
+  ended: true,
+});
+
+describe('classifyThinkingContext', () => {
+  it('defaults to think when there is no last item', () => {
+    expect(classifyThinkingContext({ lastItem: undefined })).toBe('think');
+  });
+
+  it('treats reasoning and user turns as think', () => {
+    const userText: TranscriptItem = {
+      kind: 'user_text',
+      key: 'u1',
+      text: 'hi',
+      at: '2026-06-09T10:00:00.000Z',
+    } as TranscriptItem;
+    expect(classifyThinkingContext({ lastItem: userText })).toBe('think');
+  });
+
+  it('maps file edits to edit', () => {
+    const fileEdit: TranscriptItem = {
+      kind: 'file_edit',
+      key: 'f1',
+      path: 'src/index.ts',
+      editType: 'modify',
+    };
+    expect(classifyThinkingContext({ lastItem: fileEdit })).toBe('edit');
+  });
+
+  it('maps read-like tools to search', () => {
+    expect(classifyThinkingContext({ lastItem: toolCall('Grep') })).toBe('search');
+    expect(classifyThinkingContext({ lastItem: toolCall('Read') })).toBe('search');
+  });
+
+  it('maps write-like tools to edit', () => {
+    expect(classifyThinkingContext({ lastItem: toolCall('Write') })).toBe('edit');
+    expect(classifyThinkingContext({ lastItem: toolCall('apply_patch') })).toBe('edit');
+  });
+
+  it('falls back to run for shell or unknown tools', () => {
+    expect(classifyThinkingContext({ lastItem: toolCall('Bash') })).toBe('run');
+    expect(classifyThinkingContext({ lastItem: toolCall('some_mcp_thing') })).toBe('run');
+  });
+});

--- a/apps/desktop/src/features/chat/utils/thinking-context.ts
+++ b/apps/desktop/src/features/chat/utils/thinking-context.ts
@@ -1,0 +1,23 @@
+import type { TranscriptItem } from './transcript-items';
+
+export type ThinkingContext = 'think' | 'search' | 'edit' | 'run';
+
+const TOOL_CONTEXT: ReadonlyArray<readonly [RegExp, ThinkingContext]> = [
+  [/edit|write|patch|apply|create|replace|insert|modif/i, 'edit'],
+  [/read|grep|glob|search|find|list|cat|fetch|lookup/i, 'search'],
+];
+
+export const classifyThinkingContext = ({
+  lastItem,
+}: {
+  lastItem: TranscriptItem | undefined;
+}): ThinkingContext => {
+  if (lastItem?.kind === 'file_edit') return 'edit';
+  if (lastItem?.kind === 'tool_call') {
+    for (const [pattern, ctx] of TOOL_CONTEXT) {
+      if (pattern.test(lastItem.toolName)) return ctx;
+    }
+    return 'run';
+  }
+  return 'think';
+};

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -357,6 +357,26 @@ dialog[open]::backdrop {
   animation: shrink-bar var(--shrink-duration, 4s) linear forwards;
 }
 
+@keyframes text-shimmer {
+  to {
+    background-position: -200% center;
+  }
+}
+
+.text-shimmer {
+  background-image: linear-gradient(
+    100deg,
+    oklch(from var(--color-muted-foreground) l c h / 0.85) 38%,
+    var(--color-foreground) 50%,
+    oklch(from var(--color-muted-foreground) l c h / 0.85) 62%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: text-shimmer 2.6s linear infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;


### PR DESCRIPTION
## what

Replaces the static `thinking` three-dot indicator (between the last message and the composer) with an animated, on-brand work-in-progress state.

- **shimmer sweep** over the label (`.text-shimmer`) instead of pulsing dots, plus a softly-pulsing `DogMascot` glyph
- **rotating copy** every 2.6s, **contextual** to the last transcript item:
  - `search` (read/grep/glob): `sniffing through files` · `following the trail` · `nose to the ground` · `nosing around`
  - `edit` (write/patch): `leaving its mark` · `shaping it up` · `tidying the yard`
  - `run` (bash/other tools): `digging in` · `off to fetch` · `fetching results`
  - `think` (reasoning): `sniffing it out` · `on the scent` · `nose down` · `chewing it over` · `tracking it down`
- after ~21s settles into `still on the trail` (reassurance, like Claude's "still working")
- `prefers-reduced-motion` → frozen phrase, no shimmer; `role=status` with a static label, rotating text is `aria-hidden`

## structure

- `utils/thinking-context.ts` — pure `lastItem → context` classifier (+ test)
- `components/ThinkingIndicator/` — presentational rotation + reduced-motion handling (+ test)
- `styles.css` — `text-shimmer` keyframe/utility
- `ChatView` — drops the local indicator, computes context, passes it down

## verification

- `pnpm typecheck` green
- full desktop vitest suite green (930 tests); new files: 10 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)