### PR TITLE
fix(desktop): smooth chat scroll-up with remembered intrinsic size

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -524,10 +524,12 @@ export function ChatView({ session, isActive = true }: ChatViewProps) {
                       className={cn(
                         itemSpacing,
                         // Browser-native virtualization: skip layout/paint of
-                        // off-screen cards. Intrinsic size keeps the scroll bar
-                        // accurate (avg card ~80px). With 100+ turns, scroll
-                        // and switch stay smooth without a virtualizer dep.
-                        '[content-visibility:auto] [contain-intrinsic-size:80px]',
+                        // off-screen cards. The `auto` keyword makes the engine
+                        // remember each card's last-rendered height as its
+                        // placeholder, so scrolling back up doesn't jump (the
+                        // 80px seed only applies to never-yet-painted cards).
+                        // With 100+ turns, scroll stays smooth, no virtualizer dep.
+                        '[content-visibility:auto] [contain-intrinsic-size:auto_80px]',
                       )}
                     >
                       {row.kind === 'operations' ? (


### PR DESCRIPTION
## what

Chat transcript scroll-up was janky: it "jumped" every ~50px and the scrollbar thumb skittered.

## why

The chat list virtualizes via CSS `content-visibility:auto` with a **fixed** `contain-intrinsic-size:80px`. Off-screen cards collapse to 80px, but real cards (assistant text, tool clusters, diffs) are much taller. Scrolling up repaints them at real height → content above the viewport grows → scroll position and scrollbar jump. Scrolling off again reverts to 80px → height oscillates.

## fix

One line: `contain-intrinsic-size: 80px` → `auto 80px`. The `auto` keyword makes the engine remember each card's last-rendered height and reuse it as the placeholder, so the estimate stops being wrong after first paint. No virtualizer dep, no data-layer change (full history is already eagerly loaded).

Residual: the very first upward scroll after load may still nudge slightly (cards open pinned to bottom, so above-viewport cards start with the 80px seed), but each self-corrects on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)