### PR TITLE
fix(desktop): group pr review comments by thread in resolve board

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -97,6 +97,23 @@ describe('spawn-from-comment', () => {
     expect(args.kind).toBe('resolver');
   });
 
+  it('includes thread replies as context after the head comment', () => {
+    const args = buildCommentAgentArgs(makeComment(), PR, {}, [
+      makeComment({ id: 'review-2', author: 'bob', body: 'agree, but rename it' }),
+    ]);
+    expect(args.initialPrompt).toContain('Replies in this thread');
+    expect(args.initialPrompt).toContain('bob:');
+    expect(args.initialPrompt).toContain('agree, but rename it');
+    expect(args.initialPrompt.indexOf('this should use a helper')).toBeLessThan(
+      args.initialPrompt.indexOf('agree, but rename it'),
+    );
+  });
+
+  it('omits the replies section when the thread has no replies', () => {
+    const args = buildCommentAgentArgs(makeComment(), PR);
+    expect(args.initialPrompt).not.toContain('Replies in this thread');
+  });
+
   it('passes the review thread id into the kickoff when present', () => {
     const args = buildCommentAgentArgs(makeComment({ threadId: 'PRT_42' }), PR);
     expect(args.initialPrompt).toContain('PRT_42');

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -20,14 +20,11 @@ export function buildCommentAgentTitle(c: PrComment): string {
   return truncate(`resolve: ${who} comment`, TITLE_MAX);
 }
 
-/**
- * Build the kickoff prompt for a resolver agent spawned from a single
- * review comment. The commit-locally policy, EASY/NON-TRIVIAL classifier,
- * and `<<comment-resolved>>` marker emission rule all live in the resolver
- * kind's systemPrompt (agent-kind.ts), so this prompt only supplies the
- * comment-specific context: PR + author + body + path + thread id.
- */
-function buildCommentAgentPrompt(c: PrComment, pr: PullRequestState): string {
+function buildCommentAgentPrompt(
+  c: PrComment,
+  pr: PullRequestState,
+  replies: ReadonlyArray<PrComment>,
+): string {
   const lines: Array<string> = [];
   lines.push(`Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`);
   if (c.source === 'review' && c.path) {
@@ -38,6 +35,17 @@ function buildCommentAgentPrompt(c: PrComment, pr: PullRequestState): string {
   lines.push('');
   for (const ln of (c.body.trim() || '(empty body)').split('\n')) {
     lines.push(`> ${ln}`);
+  }
+  if (replies.length > 0) {
+    lines.push('');
+    lines.push('Replies in this thread (chronological, for context; resolve the comment above):');
+    for (const r of replies) {
+      lines.push('');
+      lines.push(`${r.author}:`);
+      for (const ln of (r.body.trim() || '(empty body)').split('\n')) {
+        lines.push(`> ${ln}`);
+      }
+    }
   }
   lines.push('');
   lines.push(`Comment URL: ${c.url}`);
@@ -69,6 +77,7 @@ export function buildCommentAgentArgs(
   c: PrComment,
   pr: PullRequestState,
   choice: ResolveModelChoice = {},
+  replies: ReadonlyArray<PrComment> = [],
 ): CommentAgentArgs {
   const defaults = AGENT_KIND_DEFAULTS.resolver;
   return {
@@ -77,7 +86,7 @@ export function buildCommentAgentArgs(
     model: choice.model ?? defaults.model,
     ...(choice.provider !== undefined && { provider: choice.provider }),
     effort: choice.effort ?? defaults.effort,
-    initialPrompt: buildCommentAgentPrompt(c, pr),
+    initialPrompt: buildCommentAgentPrompt(c, pr, replies),
     ...(c.source === 'review' && c.threadId ? { sourceThreadId: c.threadId } : {}),
     sourceCommentUrl: c.url,
   };

--- a/apps/desktop/src/features/github/comment-threads.ts
+++ b/apps/desktop/src/features/github/comment-threads.ts
@@ -5,31 +5,23 @@ export interface CommentThread {
   readonly replies: ReadonlyArray<PrComment>;
 }
 
-/**
- * Groups review replies under their head comment. Issue comments and orphan
- * review comments (no resolvable parent) each become their own single-message
- * thread. Replies are sorted by createdAt ascending so the UI reads top-down.
- */
 export function groupThreads(comments: ReadonlyArray<PrComment>): ReadonlyArray<CommentThread> {
-  const byId = new Map<string, PrComment>();
-  for (const c of comments) byId.set(c.id, c);
-  const heads: Array<PrComment> = [];
-  const repliesByHead = new Map<string, Array<PrComment>>();
+  const groups = new Map<string, Array<PrComment>>();
+  const order: Array<string> = [];
   for (const c of comments) {
-    if (c.source === 'review' && c.inReplyToId && byId.has(c.inReplyToId)) {
-      const arr = repliesByHead.get(c.inReplyToId) ?? [];
+    const key = c.source === 'review' && c.threadId ? `t:${c.threadId}` : `c:${c.id}`;
+    const arr = groups.get(key);
+    if (arr) {
       arr.push(c);
-      repliesByHead.set(c.inReplyToId, arr);
     } else {
-      heads.push(c);
+      groups.set(key, [c]);
+      order.push(key);
     }
   }
-  return heads.map((head) => ({
-    head,
-    replies: (repliesByHead.get(head.id) ?? []).sort((a, b) =>
-      a.createdAt.localeCompare(b.createdAt),
-    ),
-  }));
+  return order.map((key) => {
+    const sorted = [...groups.get(key)!].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return { head: sorted[0]!, replies: sorted.slice(1) };
+  });
 }
 
 /** Open review > issue > resolved review. Smaller = higher priority. */

--- a/apps/desktop/src/features/github/components/Card/index.tsx
+++ b/apps/desktop/src/features/github/components/Card/index.tsx
@@ -277,7 +277,9 @@ function computeCiStatus(
 }
 
 function computeCommentsStatus(comments: ReadonlyArray<PrComment>): TabStatus | null {
-  const heads = comments.filter((c) => c.source === 'review' && !c.inReplyToId);
+  const heads = groupThreads(comments)
+    .map((t) => t.head)
+    .filter((c) => c.source === 'review');
   if (heads.length === 0) return null;
   const open = heads.filter((c) => c.resolved === false).length;
   if (open > 0)

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import type { PrComment, PrDetail, PullRequestState, SessionId } from '@goodboy/types';
+import type { PrDetail, PullRequestState, SessionId } from '@goodboy/types';
 import { Button, Divider, EmptyState } from '@goodboy/ui';
 import { AlertCircle, GitPullRequest, Inbox, Loader2, Plus, RefreshCw } from 'lucide-react';
 import {
@@ -13,6 +13,7 @@ import { OpenSessionButton } from '../../../../shared/components/OpenSessionButt
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore, useSessions } from '../../../../store';
 import { ghPrDetailByNumber, ghPrsForBranch } from '../../github';
+import { groupThreads, type CommentThread } from '../../comment-threads';
 import { CreatePrDialog } from './CreatePrDialog';
 import { PrActionBar, type ActionBusy } from './PrActionBar';
 import { PrChecks } from './PrChecks';
@@ -204,11 +205,11 @@ export function PrDetailPanel({
     return agentId;
   };
 
-  const onSpawnOne = (comment: PrComment, choice: ResolveModelChoice) => {
+  const onSpawnOne = (thread: CommentThread, choice: ResolveModelChoice) => {
     if (!activePr) return;
     void (async () => {
       const agentId = await spawnResolver(
-        buildCommentAgentArgs(comment, activePr, choice),
+        buildCommentAgentArgs(thread.head, activePr, choice, thread.replies),
         choice,
         false,
       );
@@ -219,14 +220,18 @@ export function PrDetailPanel({
   };
 
   const onSpawnBatch = (
-    batch: ReadonlyArray<PrComment>,
+    batch: ReadonlyArray<CommentThread>,
     choiceById: Readonly<Record<string, ResolveModelChoice>>,
   ) => {
     if (!activePr || batch.length === 0) return;
     void (async () => {
-      for (const c of batch) {
-        const choice = choiceById[c.id] ?? {};
-        await spawnResolver(buildCommentAgentArgs(c, activePr, choice), choice, true);
+      for (const t of batch) {
+        const choice = choiceById[t.head.id] ?? {};
+        await spawnResolver(
+          buildCommentAgentArgs(t.head, activePr, choice, t.replies),
+          choice,
+          true,
+        );
       }
       await activateNextResolver(sessionId);
       await setCurrentSession(sessionId);
@@ -351,8 +356,8 @@ export function PrDetailPanel({
             >
               {section === 'resolve' ? (
                 <ResolveBoard
-                  comments={(detail?.comments ?? []).filter(
-                    (c) => c.source === 'review' && c.resolved === false,
+                  threads={groupThreads(detail?.comments ?? []).filter(
+                    (t) => t.head.source === 'review' && t.head.resolved === false,
                   )}
                   onSpawnOne={onSpawnOne}
                   onSpawnBatch={onSpawnBatch}

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { PrComment } from '@goodboy/types';
+import type { CommentThread } from '../../../comment-threads';
 
 const h = vi.hoisted(() => ({
   providers: [{ id: 'anthropic', connection: 'connected' }] as Array<{
@@ -35,6 +36,13 @@ function comment(over: Partial<PrComment> = {}): PrComment {
   };
 }
 
+function thread(
+  over: Partial<PrComment> = {},
+  replies: ReadonlyArray<PrComment> = [],
+): CommentThread {
+  return { head: comment(over), replies };
+}
+
 beforeEach(() => {
   h.providers = [{ id: 'anthropic', connection: 'connected' }];
 });
@@ -45,7 +53,7 @@ describe('ResolveBoard', () => {
     const onSpawnBatch = vi.fn();
     render(
       <ResolveBoard
-        comments={[comment({ id: 'c1' }), comment({ id: 'c2', threadId: 'PRRT_2' })]}
+        threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
         onSpawnOne={vi.fn()}
         onSpawnBatch={onSpawnBatch}
         onOpenThread={vi.fn()}
@@ -63,15 +71,15 @@ describe('ResolveBoard', () => {
       fireEvent.click(screen.getByRole('button', { name: /Spawn resolver for 1 comment/i }));
     });
     expect(onSpawnBatch).toHaveBeenCalledTimes(1);
-    const batchArg = onSpawnBatch.mock.calls[0]?.[0] as ReadonlyArray<PrComment>;
-    expect(batchArg.map((c) => c.id)).toEqual(['c2']);
+    const batchArg = onSpawnBatch.mock.calls[0]?.[0] as ReadonlyArray<CommentThread>;
+    expect(batchArg.map((t) => t.head.id)).toEqual(['c2']);
   });
 
   it('spawns a single comment via its Resolve button', () => {
     const onSpawnOne = vi.fn();
     render(
       <ResolveBoard
-        comments={[comment({ id: 'c1' })]}
+        threads={[thread({ id: 'c1' })]}
         onSpawnOne={onSpawnOne}
         onSpawnBatch={vi.fn()}
         onOpenThread={vi.fn()}
@@ -81,13 +89,31 @@ describe('ResolveBoard', () => {
       fireEvent.click(screen.getByRole('button', { name: /^Resolve$/i }));
     });
     expect(onSpawnOne).toHaveBeenCalledTimes(1);
-    expect(onSpawnOne.mock.calls[0]?.[0]?.id).toBe('c1');
+    expect(onSpawnOne.mock.calls[0]?.[0]?.head?.id).toBe('c1');
+  });
+
+  it('renders the head comment plus its replies as context', () => {
+    render(
+      <ResolveBoard
+        threads={[
+          thread({ id: 'c1', body: 'main request' }, [
+            comment({ id: 'r1', author: 'bob', body: 'agree, ship it' }),
+          ]),
+        ]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/main request/i)).toBeDefined();
+    expect(screen.getByText(/agree, ship it/i)).toBeDefined();
+    expect(screen.getByText('bob')).toBeDefined();
   });
 
   it('renders an empty state when there are no open comments', () => {
     render(
       <ResolveBoard
-        comments={[]}
+        threads={[]}
         onSpawnOne={vi.fn()}
         onSpawnBatch={vi.fn()}
         onOpenThread={vi.fn()}

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { PrComment, ProviderId } from '@goodboy/types';
+import type { ProviderId } from '@goodboy/types';
 import { cn, EmptyState } from '@goodboy/ui';
 import { ChevronDown, ExternalLink, Sliders, Sparkles } from 'lucide-react';
 import {
@@ -14,20 +14,21 @@ import { ProviderSelect } from '../../../../session/components/ProviderSelect';
 import { ModelSelect } from '../../../../session/components/ModelSelect';
 import { EffortSelect } from '../../../../session/components/EffortSelect';
 import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
+import type { CommentThread } from '../../../comment-threads';
 import { useAppStore } from '../../../../../store';
 import { DEFAULT_CONFIG, aggregateConfig, clampEffort, configFor, type CardConfig } from './config';
 
 interface Props {
-  readonly comments: ReadonlyArray<PrComment>;
-  readonly onSpawnOne: (comment: PrComment, choice: ResolveModelChoice) => void;
+  readonly threads: ReadonlyArray<CommentThread>;
+  readonly onSpawnOne: (thread: CommentThread, choice: ResolveModelChoice) => void;
   readonly onSpawnBatch: (
-    comments: ReadonlyArray<PrComment>,
+    threads: ReadonlyArray<CommentThread>,
     choiceById: Readonly<Record<string, ResolveModelChoice>>,
   ) => void;
   readonly onOpenThread: (threadId: string) => void;
 }
 
-export function ResolveBoard({ comments, onSpawnOne, onSpawnBatch, onOpenThread }: Props) {
+export function ResolveBoard({ threads, onSpawnOne, onSpawnBatch, onOpenThread }: Props) {
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
@@ -39,16 +40,16 @@ export function ResolveBoard({ comments, onSpawnOne, onSpawnBatch, onOpenThread 
   const patchConfig = (id: string, next: CardConfig) =>
     setConfigById((prev) => ({ ...prev, [id]: next }));
   const applyToAll = (next: CardConfig) =>
-    setConfigById(() => Object.fromEntries(comments.map((c) => [c.id, next])));
+    setConfigById(() => Object.fromEntries(threads.map((t) => [t.head.id, next])));
 
   const selected = useMemo(
-    () => comments.filter((c) => !deselected.has(c.id)),
-    [comments, deselected],
+    () => threads.filter((t) => !deselected.has(t.head.id)),
+    [threads, deselected],
   );
-  const allSelected = selected.length === comments.length;
-  const aggregate = aggregateConfig(comments.map((c) => getConfig(c.id)));
+  const allSelected = selected.length === threads.length;
+  const aggregate = aggregateConfig(threads.map((t) => getConfig(t.head.id)));
 
-  if (comments.length === 0) {
+  if (threads.length === 0) {
     return (
       <EmptyState
         bordered
@@ -67,10 +68,10 @@ export function ResolveBoard({ comments, onSpawnOne, onSpawnBatch, onOpenThread 
       return next;
     });
   const toggleAll = () =>
-    setDeselected(allSelected ? new Set(comments.map((c) => c.id)) : new Set());
+    setDeselected(allSelected ? new Set(threads.map((t) => t.head.id)) : new Set());
 
   const choiceById: Record<string, ResolveModelChoice> = Object.fromEntries(
-    comments.map((c) => [c.id, getConfig(c.id)]),
+    threads.map((t) => [t.head.id, getConfig(t.head.id)]),
   );
 
   return (
@@ -135,17 +136,19 @@ export function ResolveBoard({ comments, onSpawnOne, onSpawnBatch, onOpenThread 
       </div>
 
       <ul className="flex flex-col gap-2">
-        {comments.map((c) => (
-          <li key={c.id}>
+        {threads.map((t) => (
+          <li key={t.head.id}>
             <ResolveCard
-              comment={c}
-              config={getConfig(c.id)}
-              checked={!deselected.has(c.id)}
+              thread={t}
+              config={getConfig(t.head.id)}
+              checked={!deselected.has(t.head.id)}
               connectedProviders={connectedProviders}
-              onToggle={() => toggle(c.id)}
-              onConfig={(next) => patchConfig(c.id, next)}
-              onResolve={() => onSpawnOne(c, getConfig(c.id))}
-              onOpenThread={c.threadId ? () => onOpenThread(c.threadId as string) : undefined}
+              onToggle={() => toggle(t.head.id)}
+              onConfig={(next) => patchConfig(t.head.id, next)}
+              onResolve={() => onSpawnOne(t, getConfig(t.head.id))}
+              onOpenThread={
+                t.head.threadId ? () => onOpenThread(t.head.threadId as string) : undefined
+              }
             />
           </li>
         ))}
@@ -155,7 +158,7 @@ export function ResolveBoard({ comments, onSpawnOne, onSpawnBatch, onOpenThread 
 }
 
 function ResolveCard({
-  comment,
+  thread,
   config,
   checked,
   connectedProviders,
@@ -164,7 +167,7 @@ function ResolveCard({
   onResolve,
   onOpenThread,
 }: {
-  comment: PrComment;
+  thread: CommentThread;
   config: CardConfig;
   checked: boolean;
   connectedProviders: ReadonlyArray<ProviderId>;
@@ -174,9 +177,8 @@ function ResolveCard({
   onOpenThread?: () => void;
 }) {
   const [configOpen, setConfigOpen] = useState(false);
-  const loc = comment.path
-    ? `${comment.path}${comment.line ? `:${comment.line}` : ''}`
-    : 'conversation';
+  const { head, replies } = thread;
+  const loc = head.path ? `${head.path}${head.line ? `:${head.line}` : ''}` : 'conversation';
   return (
     <div
       className={cn(
@@ -189,12 +191,12 @@ function ResolveCard({
           type="checkbox"
           checked={checked}
           onChange={onToggle}
-          aria-label={`include comment by ${comment.author}`}
+          aria-label={`include comment by ${head.author}`}
           className="mt-0.5 size-3.5 accent-primary"
         />
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">{comment.author}</span>
+            <span className="font-medium text-foreground">{head.author}</span>
             <span className="opacity-50">·</span>
             <span className="min-w-0 truncate font-mono text-[11px]">{loc}</span>
             {onOpenThread ? (
@@ -210,8 +212,21 @@ function ResolveCard({
             ) : null}
           </div>
           <p className="mt-1 line-clamp-3 whitespace-pre-wrap text-[13px] leading-snug text-foreground [overflow-wrap:anywhere]">
-            {comment.body.trim() || '(empty)'}
+            {head.body.trim() || '(empty)'}
           </p>
+
+          {replies.length > 0 ? (
+            <div className="mt-2 flex flex-col gap-1.5 border-l border-border-soft pl-2.5">
+              {replies.map((r) => (
+                <div key={r.id} className="flex flex-col gap-0.5">
+                  <span className="text-[11px] font-medium text-muted-foreground">{r.author}</span>
+                  <p className="line-clamp-2 whitespace-pre-wrap text-[12px] leading-snug text-muted-foreground/80 [overflow-wrap:anywhere]">
+                    {r.body.trim() || '(empty)'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : null}
 
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
             <div className="relative">


### PR DESCRIPTION
## What

Resolve board grouped review comments by \`inReplyToId\`. Bugbot and multi-comment threads often leave \`replyTo\` null, so every comment became its own head: the board showed one card per reply and spawned a resolver from the last (meaningless) comment instead of the principal one.

## Change

- Group review comments by \`threadId\` (canonical: every comment in a GitHub review-thread node shares it). Head = earliest, replies = rest chronological.
- Resolve board: one card per thread, head as the actionable comment, replies rendered nested for context.
- Resolver kickoff prompt now includes the thread replies after the main comment, so the agent has the full discussion.
- Same grouping fix corrects the unresolved-comment count badge on the PR card.

Tests updated for the new \`threads\` prop shape and the replies-in-prompt behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)