### PR TITLE
feat(desktop): composite multi-project workspaces (beta)

### DIFF
--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -84,6 +84,8 @@ pub struct CreateArgs {
     /// `existing_branch` is set.
     #[serde(rename = "baseBranch", default)]
     pub base_branch: Option<String>,
+    #[serde(rename = "dirName", default)]
+    pub dir_name: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -163,7 +165,15 @@ pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeErro
     let dir_slug = existing_branch
         .map(sanitize_slug)
         .unwrap_or_else(|| slug.clone());
-    let worktree_path = parent.join(format!("{}-{dir_slug}", args.branch_prefix));
+    let explicit_dir = args
+        .dir_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let worktree_path = match explicit_dir {
+        Some(name) => parent.join(name),
+        None => parent.join(format!("{}-{dir_slug}", args.branch_prefix)),
+    };
 
     ensure_gitignore_entry(&repo_path, ".goodboy/")?;
 

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
-import { Button, Dialog, Input } from '@goodboy/ui';
-import { Check, FolderPlus, Loader2 } from 'lucide-react';
+import { Button, Dialog, Input, cn } from '@goodboy/ui';
+import type { Workspace, WorkspaceId } from '@goodboy/types';
+import { Boxes, Check, FolderGit2, FolderPlus, Loader2 } from 'lucide-react';
 import { useAppStore, useWorkspaces } from '../../../../store';
-import { MAX_WORKSPACES } from '../../../../shared/lib/features';
 import { formatError } from '../../../../shared/lib/errors';
 import { validateGitRepo } from '../../../../shared/lib/repo';
 
@@ -12,18 +12,31 @@ interface Props {
   onClose: () => void;
 }
 
-/**
- * Add a new workspace by pointing at a local git repo. The launcher and
- * switcher already list all linked workspaces, so this dialog focuses on the
- * single thing they can't do: link a new
- * one. Past versions also hosted a "Recent" tab; that overlapped with the
- * switcher and confused the primary action, so it was dropped.
- */
+type Mode = 'single' | 'multi';
+
+const lastSegment = (p: string): string => p.split('/').filter(Boolean).at(-1) ?? p;
+
+const commonParentDir = (paths: ReadonlyArray<string>): string => {
+  if (paths.length === 0) return '';
+  const split = paths.map((p) => p.split('/'));
+  const first = split[0]!;
+  const shared: string[] = [];
+  for (let i = 0; i < first.length; i += 1) {
+    const seg = first[i];
+    if (split.every((s) => s[i] === seg)) shared.push(seg!);
+    else break;
+  }
+  return shared.join('/');
+};
+
 export function WorkspaceLinkDialog({ open, onClose }: Props) {
   const addWorkspace = useAppStore((s) => s.addWorkspace);
+  const addCompositeWorkspace = useAppStore((s) => s.addCompositeWorkspace);
   const setCurrentWorkspace = useAppStore((s) => s.setCurrentWorkspace);
   const workspaces = useWorkspaces();
-  const atCap = workspaces.length >= MAX_WORKSPACES;
+  const linkable = useMemo(() => workspaces.filter((w) => w.kind !== 'composite'), [workspaces]);
+
+  const [mode, setMode] = useState<Mode>('single');
 
   const [path, setPath] = useState('');
   const [validating, setValidating] = useState(false);
@@ -32,16 +45,28 @@ export function WorkspaceLinkDialog({ open, onClose }: Props) {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
+  const [selected, setSelected] = useState<ReadonlyArray<WorkspaceId>>([]);
+  const [mountNames, setMountNames] = useState<Record<string, string>>({});
+  const [containerPath, setContainerPath] = useState('');
+  const [containerEdited, setContainerEdited] = useState(false);
+  const [compositeName, setCompositeName] = useState('');
+
   const pathInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
+    setMode('single');
     setPath('');
     setValidating(false);
     setValidPath(false);
     setValidationError(null);
     setSubmitError(null);
     setBusy(false);
+    setSelected([]);
+    setMountNames({});
+    setContainerPath('');
+    setContainerEdited(false);
+    setCompositeName('');
   }, [open]);
 
   useEffect(() => {
@@ -75,6 +100,33 @@ export function WorkspaceLinkDialog({ open, onClose }: Props) {
     return () => clearTimeout(timer);
   }, [path]);
 
+  const selectedWorkspaces = useMemo(
+    () =>
+      selected
+        .map((id) => linkable.find((w) => w.id === id))
+        .filter((w): w is Workspace => w !== undefined),
+    [selected, linkable],
+  );
+
+  const suggestedContainer = useMemo(() => {
+    if (selectedWorkspaces.length < 2) return '';
+    const parent = commonParentDir(selectedWorkspaces.map((w) => w.rootPath));
+    if (parent.length === 0) return '';
+    const mounts = selectedWorkspaces.map((w) => mountNames[w.id] ?? lastSegment(w.rootPath));
+    return `${parent}/${mounts.join('+')}`;
+  }, [selectedWorkspaces, mountNames]);
+
+  useEffect(() => {
+    if (!containerEdited) setContainerPath(suggestedContainer);
+  }, [suggestedContainer, containerEdited]);
+
+  const toggleMember = useCallback((ws: Workspace) => {
+    setSelected((prev) =>
+      prev.includes(ws.id) ? prev.filter((id) => id !== ws.id) : [...prev, ws.id],
+    );
+    setMountNames((prev) => (prev[ws.id] ? prev : { ...prev, [ws.id]: lastSegment(ws.rootPath) }));
+  }, []);
+
   const onPick = useCallback(async () => {
     const picked = await openDialog({ directory: true, multiple: false });
     if (typeof picked === 'string') {
@@ -83,7 +135,15 @@ export function WorkspaceLinkDialog({ open, onClose }: Props) {
     }
   }, []);
 
-  const onSubmit = useCallback(async () => {
+  const onPickContainer = useCallback(async () => {
+    const picked = await openDialog({ directory: true, multiple: false });
+    if (typeof picked === 'string') {
+      setContainerEdited(true);
+      setContainerPath(picked);
+    }
+  }, []);
+
+  const onSubmitSingle = useCallback(async () => {
     setBusy(true);
     setSubmitError(null);
     try {
@@ -97,7 +157,46 @@ export function WorkspaceLinkDialog({ open, onClose }: Props) {
     }
   }, [path, addWorkspace, setCurrentWorkspace, onClose]);
 
-  const primaryDisabled = busy || !validPath || atCap;
+  const onSubmitMulti = useCallback(async () => {
+    setBusy(true);
+    setSubmitError(null);
+    try {
+      const members = selectedWorkspaces.map((w) => ({
+        workspaceId: w.id,
+        mountName: (mountNames[w.id] ?? lastSegment(w.rootPath)).trim(),
+      }));
+      const ws = await addCompositeWorkspace({
+        name: compositeName,
+        containerPath: containerPath.trim(),
+        members,
+      });
+      await setCurrentWorkspace(ws.id);
+      onClose();
+    } catch (err) {
+      setSubmitError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    selectedWorkspaces,
+    mountNames,
+    compositeName,
+    containerPath,
+    addCompositeWorkspace,
+    setCurrentWorkspace,
+    onClose,
+  ]);
+
+  const mountValues = selectedWorkspaces.map((w) =>
+    (mountNames[w.id] ?? lastSegment(w.rootPath)).trim(),
+  );
+  const mountsValid =
+    mountValues.every((m) => m.length > 0) && new Set(mountValues).size === mountValues.length;
+  const multiDisabled =
+    busy || selectedWorkspaces.length < 2 || containerPath.trim().length === 0 || !mountsValid;
+  const primaryDisabled = mode === 'single' ? busy || !validPath : multiDisabled;
+
+  const previewMounts = selectedWorkspaces.map((w) => mountNames[w.id] ?? lastSegment(w.rootPath));
 
   return (
     <Dialog
@@ -105,62 +204,228 @@ export function WorkspaceLinkDialog({ open, onClose }: Props) {
       onClose={onClose}
       size="md"
       title="Add workspace"
-      description="Point Goodboy at a local git repo. Each session opens its own worktree off it."
+      description="Point Goodboy at a local git repo, or link several into one."
       footer={
         <>
           {submitError ? <span className="mr-auto text-xs text-danger">{submitError}</span> : null}
           <Button variant="ghost" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={() => void onSubmit()} disabled={primaryDisabled} aria-busy={busy}>
-            {busy ? <Loader2 size={14} className="animate-spin" /> : 'Add workspace'}
+          <Button
+            onClick={() => void (mode === 'single' ? onSubmitSingle() : onSubmitMulti())}
+            disabled={primaryDisabled}
+            aria-busy={busy}
+          >
+            {busy ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : mode === 'single' ? (
+              'Add workspace'
+            ) : (
+              'Link projects'
+            )}
           </Button>
         </>
       }
     >
-      <div className="flex flex-col gap-3">
-        <div className="flex items-center gap-2">
-          <FolderPlus size={15} className="shrink-0 text-muted-foreground" aria-hidden />
-          <span className="font-semibold">repository</span>
+      <div className="flex flex-col gap-4">
+        <div
+          role="tablist"
+          aria-label="Workspace type"
+          className="grid grid-cols-2 gap-1 rounded-lg border border-border bg-muted/40 p-1"
+        >
+          {(['single', 'multi'] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              role="tab"
+              aria-selected={mode === m}
+              onClick={() => setMode(m)}
+              className={cn(
+                'flex items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-semibold transition-colors',
+                mode === m
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {m === 'single' ? (
+                <FolderGit2 size={13} aria-hidden />
+              ) : (
+                <Boxes size={13} aria-hidden />
+              )}
+              {m === 'single' ? 'Single project' : 'Multi project'}
+              {m === 'multi' ? (
+                <span className="rounded bg-primary/15 px-1 text-2xs font-bold uppercase tracking-wide text-primary">
+                  beta
+                </span>
+              ) : null}
+            </button>
+          ))}
         </div>
-        {atCap ? (
-          <div className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs leading-relaxed text-warning">
-            Workspace limit reached ({MAX_WORKSPACES}). Disconnect one before adding another.
+
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {mode === 'single'
+            ? 'Work in one git repository.'
+            : 'Working on both a frontend and a backend? Link them into one workspace so a single chat can work across all of them.'}
+        </p>
+
+        {mode === 'single' ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <FolderPlus size={15} className="shrink-0 text-muted-foreground" aria-hidden />
+              <span className="font-semibold">repository</span>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <span className="text-xs font-semibold text-foreground">repository path</span>
+              <div className="flex gap-2">
+                <Input
+                  ref={pathInputRef}
+                  autoFocus
+                  value={path}
+                  placeholder="/path/to/repo"
+                  onChange={(e) => setPath(e.target.value)}
+                  className="flex-1"
+                />
+                <Button variant="secondary" onClick={() => void onPick()} disabled={busy}>
+                  Browse
+                </Button>
+              </div>
+              {validating ? (
+                <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                  <Loader2 size={11} className="animate-spin" aria-hidden />
+                  checking…
+                </span>
+              ) : validPath ? (
+                <span className="flex items-center gap-1 text-xs text-success">
+                  <Check size={11} aria-hidden />
+                  valid git repository
+                </span>
+              ) : validationError && path.length > 0 ? (
+                <span className="text-xs text-danger">{validationError}</span>
+              ) : (
+                <p className="text-xs leading-relaxed text-muted-foreground">
+                  the directory needs a <code>.git</code> folder.
+                </p>
+              )}
+            </div>
           </div>
-        ) : null}
-        <div className="flex flex-col gap-1.5">
-          <span className="text-xs font-semibold text-foreground">repository path</span>
-          <div className="flex gap-2">
-            <Input
-              ref={pathInputRef}
-              autoFocus
-              value={path}
-              placeholder="/path/to/repo"
-              onChange={(e) => setPath(e.target.value)}
-              className="flex-1"
-            />
-            <Button variant="secondary" onClick={() => void onPick()} disabled={busy}>
-              Browse
-            </Button>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {linkable.length < 2 ? (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs leading-relaxed text-muted-foreground">
+                Add at least two single-project workspaces first, then link them here.
+              </div>
+            ) : (
+              <>
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs font-semibold text-foreground">pick repos to link</span>
+                  <ul className="flex max-h-44 flex-col gap-0.5 overflow-y-auto">
+                    {linkable.map((ws) => {
+                      const isOn = selected.includes(ws.id);
+                      return (
+                        <li key={ws.id}>
+                          <button
+                            type="button"
+                            onClick={() => toggleMember(ws)}
+                            className={cn(
+                              'flex w-full items-center gap-2 rounded-md border px-2.5 py-1.5 text-left text-xs transition-colors',
+                              isOn
+                                ? 'border-primary/50 bg-primary/5'
+                                : 'border-transparent hover:bg-muted/50',
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                'flex size-4 shrink-0 items-center justify-center rounded border',
+                                isOn
+                                  ? 'border-primary bg-primary text-primary-foreground'
+                                  : 'border-border',
+                              )}
+                            >
+                              {isOn ? <Check size={11} aria-hidden /> : null}
+                            </span>
+                            <span className="font-medium text-foreground">{ws.name}</span>
+                            <span className="ml-auto truncate text-muted-foreground">
+                              {ws.rootPath}
+                            </span>
+                          </button>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+
+                {selectedWorkspaces.length > 0 ? (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-semibold text-foreground">mount names</span>
+                    {selectedWorkspaces.map((ws) => (
+                      <div key={ws.id} className="flex items-center gap-2">
+                        <span className="w-28 shrink-0 truncate text-xs text-muted-foreground">
+                          {ws.name}
+                        </span>
+                        <Input
+                          value={mountNames[ws.id] ?? lastSegment(ws.rootPath)}
+                          onChange={(e) =>
+                            setMountNames((prev) => ({ ...prev, [ws.id]: e.target.value }))
+                          }
+                          className="flex-1"
+                        />
+                      </div>
+                    ))}
+                    {!mountsValid ? (
+                      <span className="text-xs text-danger">
+                        mount names must be non-empty and unique.
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs font-semibold text-foreground">save into folder</span>
+                  <div className="flex gap-2">
+                    <Input
+                      value={containerPath}
+                      placeholder="/path/to/container"
+                      onChange={(e) => {
+                        setContainerEdited(true);
+                        setContainerPath(e.target.value);
+                      }}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="secondary"
+                      onClick={() => void onPickContainer()}
+                      disabled={busy}
+                    >
+                      Browse
+                    </Button>
+                  </div>
+                </div>
+
+                {selectedWorkspaces.length >= 2 && containerPath.trim().length > 0 ? (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-xs font-semibold text-foreground">preview</span>
+                    <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 px-3 py-2 text-2xs leading-relaxed text-muted-foreground">
+                      {`${lastSegment(containerPath)}/\n└── <session>/\n${previewMounts
+                        .map(
+                          (m, i) => `    ${i === previewMounts.length - 1 ? '└──' : '├──'} ${m}/`,
+                        )
+                        .join('\n')}`}
+                    </pre>
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-1.5">
+                  <span className="text-xs font-semibold text-foreground">name</span>
+                  <Input
+                    value={compositeName}
+                    placeholder={previewMounts.join(' + ')}
+                    onChange={(e) => setCompositeName(e.target.value)}
+                  />
+                </div>
+              </>
+            )}
           </div>
-          {validating ? (
-            <span className="flex items-center gap-1 text-xs text-muted-foreground">
-              <Loader2 size={11} className="animate-spin" aria-hidden />
-              checking…
-            </span>
-          ) : validPath ? (
-            <span className="flex items-center gap-1 text-xs text-success">
-              <Check size={11} aria-hidden />
-              valid git repository
-            </span>
-          ) : validationError && path.length > 0 ? (
-            <span className="text-xs text-danger">{validationError}</span>
-          ) : (
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              the directory needs a <code>.git</code> folder.
-            </p>
-          )}
-        </div>
+        )}
       </div>
     </Dialog>
   );

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -48,7 +48,7 @@ import {
 import { SessionSettingsDialog } from '../../../session/components/SessionSettingsDialog';
 import { GuideDialog } from '../../../settings/components/GuideDialog';
 import { NotificationCenter } from '../../../../features/notifications/components/NotificationCenter';
-import { MAX_WORKSPACES, WORKSPACE_FEATURES } from '../../../../shared/lib/features';
+import { WORKSPACE_FEATURES } from '../../../../shared/lib/features';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import { UpdateIndicator } from '../../../updater/components/UpdateIndicator';
 import { OnboardingChip } from '../../../onboarding/OnboardingCard';

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -15,6 +15,7 @@ export interface CreateWorktreeArgs {
   readonly parentDir?: string;
   readonly existingBranch?: string;
   readonly baseBranch?: string;
+  readonly dirName?: string;
 }
 
 export async function createWorktree(args: CreateWorktreeArgs): Promise<CreatedWorktree> {

--- a/apps/desktop/src/shared/lib/features.ts
+++ b/apps/desktop/src/shared/lib/features.ts
@@ -1,10 +1,3 @@
-/**
- * Max workspaces a user can keep connected at once.
- * Beta-phase cap: keeps disk/worktree footprint predictable and forces
- * users to disconnect stale repos rather than hoarding them.
- */
-export const MAX_WORKSPACES = 5;
-
 export const WORKSPACE_FEATURES = {
   workflows: true,
   skills: false,

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -9,6 +9,7 @@ import type {
   WorkflowId,
   WorkflowRunId,
   WorkspaceId,
+  WorkspaceMember,
 } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import {
@@ -30,6 +31,14 @@ import {
 } from '../../../features/session/agent-kind';
 import { SETTING_LAST_SESSION_ID } from '../../../features/settings/settings';
 import type { GetFn, SetFn } from './types';
+
+const slugifyDir = (raw: string): string =>
+  raw
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40) || 'session';
 
 interface Input {
   workspaceId: WorkspaceId;
@@ -71,12 +80,39 @@ export function createSession(set: SetFn, get: GetFn) {
     const slugSeed =
       branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
     const trimmedExisting = existingBranch?.trim();
-    const worktree = await createWorktree({
-      repoPath: workspace.rootPath,
-      branchPrefix: prefix,
-      slug: slugSeed,
-      ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
-    });
+    const sessionId = crypto.randomUUID() as SessionId;
+    const isComposite = workspace.kind === 'composite';
+    const members = isComposite ? (workspace.members ?? []) : [];
+    if (isComposite && members.length < 2) {
+      throw new Error(`multi-project workspace has no linked repos: ${workspaceId}`);
+    }
+
+    let worktree: CreatedWorktree;
+    const memberWorktrees: Array<{ member: WorkspaceMember; worktree: CreatedWorktree }> = [];
+    if (isComposite) {
+      const dirSlug = `${slugifyDir(slugSeed)}-${sessionId.slice(0, 8)}`;
+      const compositeDir = `${workspace.rootPath}/${dirSlug}`;
+      for (const member of members) {
+        const wt = await createWorktree({
+          repoPath: member.rootPath,
+          branchPrefix: prefix,
+          slug: dirSlug,
+          parentDir: compositeDir,
+          dirName: member.mountName,
+          ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
+        });
+        memberWorktrees.push({ member, worktree: wt });
+      }
+      const branchName = memberWorktrees[0]?.worktree.branchName ?? `${prefix}/${dirSlug}`;
+      worktree = { worktreePath: compositeDir, branchName, slug: dirSlug, reused: false };
+    } else {
+      worktree = await createWorktree({
+        repoPath: workspace.rootPath,
+        branchPrefix: prefix,
+        slug: slugSeed,
+        ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
+      });
+    }
 
     // Make sure workspace overrides are cached before reading defaultProviderId,
     // otherwise a fresh boot would silently fall back to anthropic for the
@@ -100,7 +136,7 @@ export function createSession(set: SetFn, get: GetFn) {
     const workflowRunId =
       workflowId !== undefined ? (crypto.randomUUID() as WorkflowRunId) : undefined;
     const session: Session = {
-      id: crypto.randomUUID() as SessionId,
+      id: sessionId,
       workspaceId,
       goal: goal.trim() || worktree.slug,
       state: initialState,
@@ -144,6 +180,19 @@ export function createSession(set: SetFn, get: GetFn) {
       parallelIndex: 0,
       createdAt: Date.now(),
     });
+    for (let i = 0; i < memberWorktrees.length; i += 1) {
+      const { member, worktree: wt } = memberWorktrees[i]!;
+      await insertSessionWorktree(tauriDatabase, {
+        id: crypto.randomUUID(),
+        sessionId: session.id,
+        worktreePath: wt.worktreePath,
+        branch: wt.branchName,
+        parallelIndex: i + 1,
+        mountWorkspaceId: member.workspaceId,
+        mountName: member.mountName,
+        createdAt: Date.now(),
+      });
+    }
 
     // Seed the goal context slot so the session prompt carries the user's
     // stated goal from turn 1. Otherwise the goal lives only on the session
@@ -244,7 +293,10 @@ export function createSession(set: SetFn, get: GetFn) {
         : state.sessionExternalTasks,
       sessionWorktrees: {
         ...state.sessionWorktrees,
-        [session.id]: [worktree.worktreePath],
+        [session.id]: [
+          worktree.worktreePath,
+          ...memberWorktrees.map((m) => m.worktree.worktreePath),
+        ],
       },
       sessionBranches: {
         ...state.sessionBranches,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -816,14 +816,27 @@ export function sendTurn(set: SetFn, get: GetFn) {
 
     // Worktree scope guard, claude/cursor/codex all accept absolute paths
     // in their Write/Edit tools and won't refuse to write outside cwd.
-    const scopeGuard = [
-      '[worktree-scope]',
-      `You are operating inside an isolated git worktree at: ${workingDir}`,
-      'ALL file operations (Read/Write/Edit/Bash file paths) MUST resolve inside this worktree.',
-      'NEVER write to absolute paths that exit this directory, especially not to the parent project checkout.',
-      'Prefer paths relative to your current working directory. If a user request implies editing files outside the worktree, stop and ask for explicit confirmation before touching them.',
-      '[/worktree-scope]',
-    ].join('\n');
+    const scopeWorkspace = get().workspaces.find((w) => w.id === session.workspaceId);
+    const scopeMembers = scopeWorkspace?.kind === 'composite' ? (scopeWorkspace.members ?? []) : [];
+    const scopeGuard = (
+      scopeMembers.length > 0
+        ? [
+            '[multi-repo-scope]',
+            `You are operating across ${scopeMembers.length} linked git repositories mounted under: ${workingDir}`,
+            `Each repo lives in its own subfolder: ${scopeMembers.map((m) => m.mountName).join(', ')}.`,
+            'Each subfolder is a separate git repository with its own branch. Run git commands inside the relevant subfolder, never at the container root.',
+            'ALL file operations MUST resolve inside one of these subfolders. Do NOT create files at the container root or outside it.',
+            '[/multi-repo-scope]',
+          ]
+        : [
+            '[worktree-scope]',
+            `You are operating inside an isolated git worktree at: ${workingDir}`,
+            'ALL file operations (Read/Write/Edit/Bash file paths) MUST resolve inside this worktree.',
+            'NEVER write to absolute paths that exit this directory, especially not to the parent project checkout.',
+            'Prefer paths relative to your current working directory. If a user request implies editing files outside the worktree, stop and ask for explicit confirmation before touching them.',
+            '[/worktree-scope]',
+          ]
+    ).join('\n');
     const fullSystemPrompt = kindSystemPrompt ? `${scopeGuard}\n\n${kindSystemPrompt}` : scopeGuard;
 
     if (provider !== 'anthropic') {

--- a/apps/desktop/src/store/slices/workspaces/addCompositeWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/addCompositeWorkspace.ts
@@ -1,0 +1,63 @@
+import type { IsoDateTime, Workspace, WorkspaceId, WorkspaceMember } from '@goodboy/types';
+import { seedWorkflowLibrary } from '@goodboy/core';
+import { insertWorkspace, insertWorkspaceMembers } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { invokeWorkflowList } from '../../../features/workflows/workflows';
+import type { GetFn, SetFn } from './types';
+
+interface Input {
+  name?: string;
+  containerPath: string;
+  members: ReadonlyArray<{ workspaceId: WorkspaceId; mountName: string }>;
+}
+
+export function addCompositeWorkspace(set: SetFn, get: GetFn) {
+  return async ({ name, containerPath, members }: Input): Promise<Workspace> => {
+    if (members.length < 2) {
+      throw new Error('a multi-project workspace needs at least two repos');
+    }
+    const seenMounts = new Set<string>();
+    for (const m of members) {
+      const mount = m.mountName.trim();
+      if (mount.length === 0) throw new Error('every repo needs a mount name');
+      if (seenMounts.has(mount)) throw new Error(`duplicate mount name: ${mount}`);
+      seenMounts.add(mount);
+    }
+
+    const known = get().workspaces;
+    const resolved: WorkspaceMember[] = members.map((m) => {
+      const ws = known.find((w) => w.id === m.workspaceId);
+      if (!ws) throw new Error('member workspace not found');
+      if (ws.kind === 'composite') {
+        throw new Error('cannot nest a multi-project workspace inside another');
+      }
+      return { workspaceId: m.workspaceId, rootPath: ws.rootPath, mountName: m.mountName.trim() };
+    });
+
+    const now = new Date().toISOString() as IsoDateTime;
+    const workspace: Workspace = {
+      id: crypto.randomUUID() as WorkspaceId,
+      name: name?.trim() || resolved.map((m) => m.mountName).join(' + '),
+      rootPath: containerPath,
+      kind: 'composite',
+      members: resolved,
+      createdAt: now,
+      updatedAt: now,
+      lastAccessedAt: now,
+    };
+
+    await insertWorkspace(tauriDatabase, workspace);
+    await insertWorkspaceMembers(
+      tauriDatabase,
+      workspace.id,
+      resolved.map((m) => ({ workspaceId: m.workspaceId, mountName: m.mountName })),
+    );
+    set((state) => ({ workspaces: [workspace, ...state.workspaces] }));
+
+    await seedWorkflowLibrary({ db: tauriDatabase }, workspace.id).catch(() => undefined);
+    const templates = await invokeWorkflowList(workspace.id).catch(() => []);
+    set((state) => ({ phaseTemplates: { ...state.phaseTemplates, [workspace.id]: templates } }));
+
+    return workspace;
+  };
+}

--- a/apps/desktop/src/store/slices/workspaces/addWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/addWorkspace.ts
@@ -7,7 +7,6 @@ import {
 } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { validateGitRepo } from '../../../shared/lib/repo';
-import { MAX_WORKSPACES } from '../../../shared/lib/features';
 import { formatError } from '../../../shared/lib/errors';
 import { invokeWorkflowList } from '../../../features/workflows/workflows';
 import { invokeSkillRescan } from '../../../features/skills/skills';
@@ -34,12 +33,6 @@ export function addWorkspace(set: SetFn, get: GetFn) {
       if (!onDisk.disconnectedAt) {
         throw new Error(`workspace already exists: ${onDisk.name}`);
       }
-      // Cap counts only active workspaces.
-      if (get().workspaces.length >= MAX_WORKSPACES) {
-        throw new Error(
-          `workspace limit reached (${MAX_WORKSPACES}). disconnect one before adding another.`,
-        );
-      }
       const now = new Date().toISOString() as IsoDateTime;
       await reconnectWorkspaceInDb(tauriDatabase, onDisk.id, now);
       const reactivated: Workspace = { ...onDisk, updatedAt: now, lastAccessedAt: now };
@@ -62,13 +55,6 @@ export function addWorkspace(set: SetFn, get: GetFn) {
         // non-fatal: templates can be re-fetched on next workspace switch
       }
       return reactivated;
-    }
-
-    // New workspace path → enforce cap before insert.
-    if (get().workspaces.length >= MAX_WORKSPACES) {
-      throw new Error(
-        `workspace limit reached (${MAX_WORKSPACES}). disconnect one before adding another.`,
-      );
     }
 
     const inferredName =

--- a/apps/desktop/src/store/slices/workspaces/index.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.ts
@@ -1,4 +1,5 @@
 import { addWorkspace } from './addWorkspace';
+import { addCompositeWorkspace } from './addCompositeWorkspace';
 import { deleteWorkspace } from './deleteWorkspace';
 import { setCurrentWorkspace } from './setCurrentWorkspace';
 import { wipeLocalDatabase } from './wipeLocalDatabase';
@@ -7,6 +8,7 @@ import type { GetFn, SetFn } from './types';
 export function createWorkspacesSlice(set: SetFn, get: GetFn) {
   return {
     addWorkspace: addWorkspace(set, get),
+    addCompositeWorkspace: addCompositeWorkspace(set, get),
     deleteWorkspace: deleteWorkspace(set, get),
     setCurrentWorkspace: setCurrentWorkspace(set, get),
     wipeLocalDatabase: wipeLocalDatabase(set, get),

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -363,6 +363,11 @@ export interface AppActions {
   logoutProvider(providerId: ProviderId): Promise<void>;
   cancelProviderLifecycle(providerId: ProviderId): Promise<void>;
   addWorkspace(input: { rootPath: string; name?: string }): Promise<Workspace>;
+  addCompositeWorkspace(input: {
+    name?: string;
+    containerPath: string;
+    members: ReadonlyArray<{ workspaceId: WorkspaceId; mountName: string }>;
+  }): Promise<Workspace>;
   deleteWorkspace(id: WorkspaceId): Promise<void>;
   loadIntegrations(workspaceId: WorkspaceId): Promise<void>;
   connectLinear(workspaceId: WorkspaceId, token: string): Promise<LinearViewer>;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -16,6 +16,7 @@ export {
   touchWorkspaceLastAccessed,
   deleteWorkspace,
 } from './queries/workspace';
+export { insertWorkspaceMembers } from './queries/workspace-member';
 export {
   upsertWorkspaceIntegration,
   listIntegrationsForWorkspace,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -53,6 +53,7 @@ import { m052PendingResolutions } from './m052-pending-resolutions';
 import { m053ScoutFanout } from './m053-scout-fanout';
 import { m054WorkflowRunInstances } from './m054-workflow-run-instances';
 import { m055ResolverCommentLink } from './m055-resolver-comment-link';
+import { m056CompositeWorkspaces } from './m056-composite-workspaces';
 
 export interface Migration {
   readonly version: number;
@@ -115,4 +116,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 53, sql: m053ScoutFanout },
   { version: 54, sql: m054WorkflowRunInstances },
   { version: 55, sql: m055ResolverCommentLink },
+  { version: 56, sql: m056CompositeWorkspaces },
 ];

--- a/packages/db/src/migrations/m056-composite-workspaces.ts
+++ b/packages/db/src/migrations/m056-composite-workspaces.ts
@@ -1,0 +1,16 @@
+export const m056CompositeWorkspaces = /* sql */ `
+ALTER TABLE workspaces ADD COLUMN kind TEXT NOT NULL DEFAULT 'repo';
+CREATE TABLE IF NOT EXISTS workspace_members (
+  id TEXT PRIMARY KEY,
+  composite_workspace_id TEXT NOT NULL,
+  member_workspace_id TEXT NOT NULL,
+  mount_name TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (composite_workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (member_workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_workspace_members_composite ON workspace_members(composite_workspace_id);
+ALTER TABLE session_worktrees ADD COLUMN mount_workspace_id TEXT;
+ALTER TABLE session_worktrees ADD COLUMN mount_name TEXT;
+`;

--- a/packages/db/src/queries/session-worktree.ts
+++ b/packages/db/src/queries/session-worktree.ts
@@ -1,4 +1,4 @@
-import type { SessionId } from '@goodboy/types';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
 import type { Database } from '../client';
 
 interface SessionWorktreeRow {
@@ -7,6 +7,8 @@ interface SessionWorktreeRow {
   worktree_path: string;
   branch: string;
   parallel_index: number;
+  mount_workspace_id: string | null;
+  mount_name: string | null;
   created_at: number;
 }
 
@@ -16,6 +18,8 @@ export interface SessionWorktree {
   readonly worktreePath: string;
   readonly branch: string;
   readonly parallelIndex: number;
+  readonly mountWorkspaceId?: WorkspaceId;
+  readonly mountName?: string;
   readonly createdAt: number;
 }
 
@@ -26,6 +30,10 @@ function toDomain(row: SessionWorktreeRow): SessionWorktree {
     worktreePath: row.worktree_path,
     branch: row.branch,
     parallelIndex: row.parallel_index,
+    ...(row.mount_workspace_id != null
+      ? { mountWorkspaceId: row.mount_workspace_id as WorkspaceId }
+      : {}),
+    ...(row.mount_name != null ? { mountName: row.mount_name } : {}),
     createdAt: row.created_at,
   };
 }
@@ -36,14 +44,16 @@ export async function insertSessionWorktree(
 ): Promise<void> {
   await db.execute(
     `INSERT INTO session_worktrees
-      (id, session_id, worktree_path, branch, parallel_index, created_at)
-     VALUES (?, ?, ?, ?, ?, ?)`,
+      (id, session_id, worktree_path, branch, parallel_index, mount_workspace_id, mount_name, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       worktree.id,
       worktree.sessionId,
       worktree.worktreePath,
       worktree.branch,
       worktree.parallelIndex,
+      worktree.mountWorkspaceId ?? null,
+      worktree.mountName ?? null,
       worktree.createdAt,
     ],
   );

--- a/packages/db/src/queries/workspace-member.ts
+++ b/packages/db/src/queries/workspace-member.ts
@@ -1,0 +1,58 @@
+import type { WorkspaceId, WorkspaceMember } from '@goodboy/types';
+import type { Database } from '../client';
+
+interface WorkspaceMemberRow {
+  member_workspace_id: string;
+  mount_name: string;
+  root_path: string;
+}
+
+function toDomain(row: WorkspaceMemberRow): WorkspaceMember {
+  return {
+    workspaceId: row.member_workspace_id as WorkspaceId,
+    rootPath: row.root_path,
+    mountName: row.mount_name,
+  };
+}
+
+export async function listMembersForWorkspaces(
+  db: Database,
+  compositeWorkspaceIds: ReadonlyArray<WorkspaceId>,
+): Promise<Map<WorkspaceId, ReadonlyArray<WorkspaceMember>>> {
+  const out = new Map<WorkspaceId, WorkspaceMember[]>();
+  if (compositeWorkspaceIds.length === 0) return out;
+  const placeholders = compositeWorkspaceIds.map(() => '?').join(', ');
+  const rows = await db.select<WorkspaceMemberRow & { composite_workspace_id: string }>(
+    `SELECT wm.composite_workspace_id, wm.member_workspace_id, wm.mount_name, w.root_path
+     FROM workspace_members wm
+     JOIN workspaces w ON w.id = wm.member_workspace_id
+     WHERE wm.composite_workspace_id IN (${placeholders})
+     ORDER BY wm.composite_workspace_id, wm.sort_order ASC`,
+    compositeWorkspaceIds,
+  );
+  for (const row of rows) {
+    const compositeId = row.composite_workspace_id as WorkspaceId;
+    const bucket = out.get(compositeId) ?? [];
+    bucket.push(toDomain(row));
+    out.set(compositeId, bucket);
+  }
+  return out;
+}
+
+export async function insertWorkspaceMembers(
+  db: Database,
+  compositeWorkspaceId: WorkspaceId,
+  members: ReadonlyArray<{ workspaceId: WorkspaceId; mountName: string }>,
+): Promise<void> {
+  const now = Date.now();
+  let index = 0;
+  for (const member of members) {
+    await db.execute(
+      `INSERT INTO workspace_members
+        (id, composite_workspace_id, member_workspace_id, mount_name, sort_order, created_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [crypto.randomUUID(), compositeWorkspaceId, member.workspaceId, member.mountName, index, now],
+    );
+    index += 1;
+  }
+}

--- a/packages/db/src/queries/workspace.ts
+++ b/packages/db/src/queries/workspace.ts
@@ -1,10 +1,12 @@
-import type { IsoDateTime, Workspace, WorkspaceId } from '@goodboy/types';
+import type { IsoDateTime, Workspace, WorkspaceId, WorkspaceKind } from '@goodboy/types';
 import type { Database } from '../client';
+import { listMembersForWorkspaces } from './workspace-member';
 
 interface WorkspaceRow {
   id: string;
   name: string;
   root_path: string;
+  kind: string | null;
   created_at: number;
   updated_at: number;
   disconnected_at: number | null;
@@ -16,6 +18,7 @@ function toDomain(row: WorkspaceRow): Workspace {
     id: row.id as WorkspaceId,
     name: row.name,
     rootPath: row.root_path,
+    kind: (row.kind === 'composite' ? 'composite' : 'repo') as WorkspaceKind,
     createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
     updatedAt: new Date(row.updated_at).toISOString() as IsoDateTime,
     ...(row.disconnected_at != null
@@ -27,20 +30,42 @@ function toDomain(row: WorkspaceRow): Workspace {
   };
 }
 
+async function attachMembers(
+  db: Database,
+  workspaces: ReadonlyArray<Workspace>,
+): Promise<ReadonlyArray<Workspace>> {
+  const compositeIds = workspaces.filter((w) => w.kind === 'composite').map((w) => w.id);
+  if (compositeIds.length === 0) return workspaces;
+  const membersByComposite = await listMembersForWorkspaces(db, compositeIds);
+  return workspaces.map((w) =>
+    w.kind === 'composite' ? { ...w, members: membersByComposite.get(w.id) ?? [] } : w,
+  );
+}
+
 export async function insertWorkspace(db: Database, workspace: Workspace): Promise<void> {
   const created = Date.parse(workspace.createdAt);
   const updated = Date.parse(workspace.updatedAt);
   const accessed = workspace.lastAccessedAt ? Date.parse(workspace.lastAccessedAt) : updated;
   await db.execute(
-    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at, last_accessed_at) VALUES (?, ?, ?, ?, ?, ?)',
-    [workspace.id, workspace.name, workspace.rootPath, created, updated, accessed],
+    'INSERT INTO workspaces (id, name, root_path, kind, created_at, updated_at, last_accessed_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+    [
+      workspace.id,
+      workspace.name,
+      workspace.rootPath,
+      workspace.kind ?? 'repo',
+      created,
+      updated,
+      accessed,
+    ],
   );
 }
 
 export async function getWorkspaceById(db: Database, id: WorkspaceId): Promise<Workspace | null> {
   const rows = await db.select<WorkspaceRow>('SELECT * FROM workspaces WHERE id = ?', [id]);
   const row = rows[0];
-  return row ? toDomain(row) : null;
+  if (!row) return null;
+  const [withMembers] = await attachMembers(db, [toDomain(row)]);
+  return withMembers ?? null;
 }
 
 /**
@@ -51,7 +76,7 @@ export async function listWorkspaces(db: Database): Promise<ReadonlyArray<Worksp
   const rows = await db.select<WorkspaceRow>(
     'SELECT * FROM workspaces WHERE disconnected_at IS NULL ORDER BY created_at DESC',
   );
-  return rows.map(toDomain);
+  return attachMembers(db, rows.map(toDomain));
 }
 
 /**
@@ -66,7 +91,7 @@ export async function listDisconnectedWorkspaces(
     'SELECT * FROM workspaces WHERE disconnected_at IS NOT NULL ORDER BY disconnected_at DESC LIMIT ?',
     [limit],
   );
-  return rows.map(toDomain);
+  return attachMembers(db, rows.map(toDomain));
 }
 
 /**
@@ -82,7 +107,9 @@ export async function findWorkspaceByRootPath(
     [rootPath],
   );
   const row = rows[0];
-  return row ? toDomain(row) : null;
+  if (!row) return null;
+  const [withMembers] = await attachMembers(db, [toDomain(row)]);
+  return withMembers ?? null;
 }
 
 /** Soft delete. Sessions, worktrees, transcripts stay intact. */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,8 @@ export type {
   SessionUserStatus,
   TurnState,
   Workspace,
+  WorkspaceKind,
+  WorkspaceMember,
   WorkflowRun,
   WorkspaceIntegration,
   WorkspaceIntegrationProvider,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -12,10 +12,20 @@ import type { SessionProviderPreference } from './provider-preference';
 import type { ModelEffort } from './provider-registry';
 import type { ClaudePermissionMode } from './permission';
 
+export type WorkspaceKind = 'repo' | 'composite';
+
+export type WorkspaceMember = Readonly<{
+  workspaceId: WorkspaceId;
+  rootPath: string;
+  mountName: string;
+}>;
+
 export type Workspace = Readonly<{
   id: WorkspaceId;
   name: string;
   rootPath: string;
+  kind?: WorkspaceKind;
+  members?: ReadonlyArray<WorkspaceMember>;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
   /**


### PR DESCRIPTION
## What

Phase 1 of multi-repo workspaces: link several repos into one **composite workspace**. The user picks a container folder; each session mounts every member repo as a git worktree inside a per-session dir, and the agent runs with cwd = that dir, so **one chat operates across all linked repos**. Commits and branches stay per-repo.

```
<container>/
└── <session-slug>-<sid>/      agent cwd
    ├── app-web/               worktree of app-web @ session branch
    └── api/                   worktree of api     @ session branch
```

## Changes

- **types**: `Workspace.kind` (`repo` | `composite`) + `members` (`WorkspaceMember`)
- **db**: m056 (`workspaces.kind`, `workspace_members`, mount columns on `session_worktrees`), member-aware mappers
- **rust**: `worktree_create` accepts `dirName` to name the checkout subfolder
- **store**: `addCompositeWorkspace` action; `createSession` forks on `kind === 'composite'` to create N member worktrees under the session container
- **sendTurn**: composite sessions get a `[multi-repo-scope]` guard describing the mounts
- **UI**: add-workspace dialog gets a `Single project | Multi project (BETA)` segmented control; multi mode = repo multiselect, mount names, container picker (common-parent default), live preview tree
- **removed**: `MAX_WORKSPACES` cap (beta-era perf guard, no longer needed)

## Anti-regression

Every composite path is gated behind `workspace.kind === 'composite'`; single-repo sessions run the exact pre-existing code path. No existing test was modified.

## Verification

- typecheck 5/5, tests 938/938 (JS) + 58 (Rust `cargo test --locked`), knip clean, build green

## Deferred to phase 2

Per-member push/PR/diff surfaces, composite session deletion cleanup, GitHubStudio multi-panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)