### PR TITLE
feat(core): integrate fable 5 + tier-based model right-sizing

### DIFF
--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { parseModelId, suggestLighterModel } from '../features/chat/utils/chat-constants';
+import {
+  parseModelId,
+  suggestHeavierModel,
+  suggestLighterModel,
+} from '../features/chat/utils/chat-constants';
 
 const ANTHROPIC = [
   'claude-haiku-4-5',
@@ -8,22 +12,27 @@ const ANTHROPIC = [
   'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-fable-5',
 ];
 
+const CODEX = ['gpt-5.4-mini', 'gpt-5.2', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5'];
+
+const GEMINI = ['gemini-2.5-flash-lite', 'gemini-2.5-flash', 'gemini-2.5-pro'];
+
 describe('suggestLighterModel', () => {
-  it('Opus 4.8 → Sonnet 4.6 (drops to cheapest non-floor tier, most capable in it)', () => {
+  it('Opus 4.8 → Sonnet 4.6 (drops one cost tier, most capable in it)', () => {
     expect(suggestLighterModel('claude-opus-4-8', ANTHROPIC)).toBe('claude-sonnet-4-6');
   });
 
-  it('Opus 4.6 → Sonnet 4.6 (same target from a lighter Opus)', () => {
-    expect(suggestLighterModel('claude-opus-4-6', ANTHROPIC)).toBe('claude-sonnet-4-6');
+  it('Fable 5 → Sonnet 4.6 (top tier drops to mid, never to cheap)', () => {
+    expect(suggestLighterModel('claude-fable-5', ANTHROPIC)).toBe('claude-sonnet-4-6');
   });
 
-  it('never suggests below the Haiku floor', () => {
+  it('never suggests below the cheap-tier floor', () => {
     expect(suggestLighterModel('claude-opus-4-8', ANTHROPIC)).not.toMatch(/haiku/);
   });
 
-  it('no nag when already mid-tier (gap below threshold)', () => {
+  it('no nag when already mid-tier (cheap tier is floored out)', () => {
     expect(suggestLighterModel('claude-sonnet-4-6', ANTHROPIC)).toBeNull();
   });
 
@@ -31,6 +40,40 @@ describe('suggestLighterModel', () => {
     expect(
       suggestLighterModel('claude-sonnet-4-6', ['claude-sonnet-4-6', 'claude-haiku-4-5']),
     ).toBeNull();
+  });
+
+  it('codex: GPT-5.5 → GPT-5.4 (small weight gaps no longer block tier drops)', () => {
+    expect(suggestLighterModel('gpt-5.5', CODEX)).toBe('gpt-5.4');
+  });
+
+  it('gemini: Pro has no mid tier, so no suggestion instead of falling to Flash', () => {
+    expect(suggestLighterModel('gemini-2.5-pro', GEMINI)).toBeNull();
+  });
+});
+
+describe('suggestHeavierModel', () => {
+  it('Opus 4.8 → Fable 5 (escalates to the strongest same-or-higher tier model)', () => {
+    expect(suggestHeavierModel('claude-opus-4-8', ANTHROPIC)).toBe('claude-fable-5');
+  });
+
+  it('Sonnet 4.6 → Fable 5 (heavy task escalates straight to the top)', () => {
+    expect(suggestHeavierModel('claude-sonnet-4-6', ANTHROPIC)).toBe('claude-fable-5');
+  });
+
+  it('no suggestion when already on the top model', () => {
+    expect(suggestHeavierModel('claude-fable-5', ANTHROPIC)).toBeNull();
+  });
+
+  it('codex: GPT-5.4 → GPT-5.5', () => {
+    expect(suggestHeavierModel('gpt-5.4', CODEX)).toBe('gpt-5.5');
+  });
+
+  it('gemini: Flash → Pro', () => {
+    expect(suggestHeavierModel('gemini-2.5-flash', GEMINI)).toBe('gemini-2.5-pro');
+  });
+
+  it('never downgrades the cost tier to gain weight', () => {
+    expect(suggestHeavierModel('gemini-2.5-pro', GEMINI)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -51,6 +51,7 @@ import {
   EFFORT_LEVELS,
   type EffortLevel,
   clampEffort,
+  suggestHeavierModel,
   suggestLighterModel,
 } from '../../utils/chat-constants';
 import { ProviderUsagePill } from '../ProviderUsagePill';
@@ -674,7 +675,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
       }
     }
 
-    if (allowOverride && !isRunning && rightSizeSuggested !== null && rightSizePending === null) {
+    if (allowOverride && !isRunning && rightSizeSuggestion !== null && rightSizePending === null) {
       setRightSizePending({ content, attachments: atts });
       return;
     }
@@ -732,7 +733,7 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
   const onUseSuggested = async () => {
     const pending = rightSizePending;
     if (pending === null) return;
-    const suggested = rightSizeSuggested;
+    const suggested = rightSizeSuggestion?.model ?? null;
     setRightSizePending(null);
     setRightSizeDismissed(true);
     setValue('');
@@ -952,18 +953,35 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
     return Array.from(ids);
   }, [providerModels, effectiveModel]);
 
-  const rightSizeSuggested = useMemo<string | null>(() => {
+  const rightSizeSuggestion = useMemo<{
+    readonly direction: 'lighter' | 'heavier';
+    readonly model: string;
+  } | null>(() => {
     if (!isFirstTurnForAgent || rightSizeDismissed) return null;
-    const weight = assessTurnWeight(value);
-    if (weight !== 'light') return null;
-    return suggestLighterModel(effectiveModel, modelCandidates);
-  }, [isFirstTurnForAgent, rightSizeDismissed, value, effectiveModel, modelCandidates]);
+    const weight = assessTurnWeight(value, { attachmentCount: attachments.length });
+    if (weight === 'light') {
+      const model = suggestLighterModel(effectiveModel, modelCandidates);
+      return model ? { direction: 'lighter', model } : null;
+    }
+    if (weight === 'heavy') {
+      const model = suggestHeavierModel(effectiveModel, modelCandidates);
+      return model ? { direction: 'heavier', model } : null;
+    }
+    return null;
+  }, [
+    isFirstTurnForAgent,
+    rightSizeDismissed,
+    value,
+    effectiveModel,
+    modelCandidates,
+    attachments,
+  ]);
 
   useEffect(() => {
-    if (rightSizePending !== null && rightSizeSuggested === null) {
+    if (rightSizePending !== null && rightSizeSuggestion === null) {
       setRightSizePending(null);
     }
-  }, [rightSizePending, rightSizeSuggested]);
+  }, [rightSizePending, rightSizeSuggestion]);
 
   // Priority-ranked suggestions, folded into one stack so a pile of nudges
   // can't shove the composer below the fold (plan §D.1). Order: plan-ready >
@@ -1078,13 +1096,14 @@ export function ChatInput({ session, providerDisconnected = false }: Props) {
       ),
     });
   }
-  if (rightSizePending !== null && rightSizeSuggested !== null) {
+  if (rightSizePending !== null && rightSizeSuggestion !== null) {
     suggestions.push({
       key: 'right-size',
       node: (
         <RightSizeCard
+          direction={rightSizeSuggestion.direction}
           currentModel={effectiveModel}
-          suggestedModel={rightSizeSuggested}
+          suggestedModel={rightSizeSuggestion.model}
           onUseSuggested={() => void onUseSuggested()}
           onKeepCurrent={() => void onKeepCurrent()}
           onChangeModel={onChangeModel}

--- a/apps/desktop/src/features/chat/components/RightSizeCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/RightSizeCard/index.test.tsx
@@ -7,6 +7,7 @@ import { RightSizeCard } from './index';
 afterEach(cleanup);
 
 const baseProps = {
+  direction: 'lighter' as const,
   currentModel: 'claude-opus-4-5',
   suggestedModel: 'claude-haiku-4-5',
   onUseSuggested: vi.fn(),
@@ -18,6 +19,16 @@ describe('RightSizeCard', () => {
   it('renders the right-sizing nudge with both model labels', () => {
     render(<RightSizeCard {...baseProps} />);
     expect(screen.getByLabelText(/right-sizing/i)).toBeDefined();
+  });
+
+  it('renders the lighter copy for downgrades', () => {
+    render(<RightSizeCard {...baseProps} />);
+    expect(screen.getByText(/this looks light/i)).toBeDefined();
+  });
+
+  it('renders the heavier copy for escalations', () => {
+    render(<RightSizeCard {...baseProps} direction="heavier" suggestedModel="claude-fable-5" />);
+    expect(screen.getByText(/this looks heavy/i)).toBeDefined();
   });
 
   it('triggers use-suggested when primary is clicked', () => {

--- a/apps/desktop/src/features/chat/components/RightSizeCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/RightSizeCard/index.tsx
@@ -5,6 +5,7 @@ import { modelLabel, modelTier, TIER_TEXT } from '../../utils/chat-constants';
 import { NudgeCard } from '../NudgeCard';
 
 export interface Props {
+  readonly direction: 'lighter' | 'heavier';
   readonly currentModel: string;
   readonly suggestedModel: string;
   readonly onUseSuggested: () => void;
@@ -13,6 +14,7 @@ export interface Props {
 }
 
 export function RightSizeCard({
+  direction,
   currentModel,
   suggestedModel,
   onUseSuggested,
@@ -28,7 +30,7 @@ export function RightSizeCard({
       autoFocusPrimary
       title={
         <>
-          This looks light. Run with{' '}
+          {direction === 'lighter' ? 'This looks light.' : 'This looks heavy.'} Run with{' '}
           <span className={cn('font-semibold', TIER_TEXT[modelTier(suggestedModel)])}>
             {modelLabel(suggestedModel)}
           </span>{' '}

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -77,6 +77,7 @@ const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'claude-opus-4-6': { weight: 60, tier: 'expensive' },
   'claude-opus-4-7': { weight: 75, tier: 'expensive' },
   'claude-opus-4-8': { weight: 80, tier: 'expensive' },
+  'claude-fable-5': { weight: 90, tier: 'expensive' },
 };
 
 export const TIER_TEXT: Record<CostTier, string> = {
@@ -219,34 +220,38 @@ export function modelWeight(model: string): number {
   return MODEL_COST[model]?.weight ?? 10;
 }
 
-// Heuristic floor used by the first-turn right-sizing card.
-// Never suggest Haiku, user explicitly disallows it for this workspace.
-const SUGGESTION_FLOOR_PATTERN = /haiku|small|mini|nano|cursor-small/i;
-
-// Weight delta below which a suggestion is not worth surfacing (avoid nagging
-// for marginal savings like Sonnet 4.6 → 4.5).
-const MIN_WEIGHT_GAP = 20;
-
 const TIER_RANK: Record<CostTier, number> = { cheap: 0, mid: 1, expensive: 2 };
 
 export function suggestLighterModel(
   current: string,
   candidates: ReadonlyArray<string>,
 ): string | null {
-  const currentWeight = modelWeight(current);
-  const eligible = candidates.filter((id) => {
-    if (id === current) return false;
-    if (SUGGESTION_FLOOR_PATTERN.test(id)) return false;
-    const w = modelWeight(id);
-    return w < currentWeight && currentWeight - w >= MIN_WEIGHT_GAP;
-  });
-  if (eligible.length === 0) return null;
-  let best: { id: string; tierRank: number; weight: number } | null = null;
-  for (const id of eligible) {
-    const tierRank = TIER_RANK[modelTier(id)];
+  const currentRank = TIER_RANK[modelTier(current)];
+  let best: { id: string; weight: number } | null = null;
+  for (const id of candidates) {
+    if (id === current) continue;
+    const rank = TIER_RANK[modelTier(id)];
+    if (rank >= currentRank || rank === TIER_RANK.cheap) continue;
     const weight = modelWeight(id);
-    if (!best || tierRank < best.tierRank || (tierRank === best.tierRank && weight > best.weight)) {
-      best = { id, tierRank, weight };
+    if (!best || weight > best.weight) best = { id, weight };
+  }
+  return best?.id ?? null;
+}
+
+export function suggestHeavierModel(
+  current: string,
+  candidates: ReadonlyArray<string>,
+): string | null {
+  const currentRank = TIER_RANK[modelTier(current)];
+  const currentWeight = modelWeight(current);
+  let best: { id: string; rank: number; weight: number } | null = null;
+  for (const id of candidates) {
+    if (id === current) continue;
+    const rank = TIER_RANK[modelTier(id)];
+    const weight = modelWeight(id);
+    if (rank < currentRank || weight <= currentWeight) continue;
+    if (!best || rank > best.rank || (rank === best.rank && weight > best.weight)) {
+      best = { id, rank, weight };
     }
   }
   return best?.id ?? null;
@@ -266,6 +271,7 @@ const SUBFAMILY_LABEL: Record<string, string> = {
   haiku: 'Haiku',
   sonnet: 'Sonnet',
   opus: 'Opus',
+  fable: 'Fable',
   'gpt-5': 'GPT-5',
   codex: 'Codex',
   mini: 'Mini',
@@ -277,6 +283,7 @@ const SUBFAMILY_TIER: Record<string, CostTier> = {
   haiku: 'cheap',
   sonnet: 'mid',
   opus: 'expensive',
+  fable: 'expensive',
   'gpt-5': 'mid',
   codex: 'mid',
   mini: 'cheap',

--- a/apps/desktop/src/features/session/agent-row-format.test.ts
+++ b/apps/desktop/src/features/session/agent-row-format.test.ts
@@ -59,6 +59,7 @@ describe('shortModel', () => {
     expect(shortModel('claude-haiku-4-5')).toBe('haiku');
     expect(shortModel('claude-sonnet-4-6')).toBe('sonnet');
     expect(shortModel('claude-opus-4-7')).toBe('opus');
+    expect(shortModel('claude-fable-5')).toBe('fable');
   });
 
   it('passes non-claude models through', () => {

--- a/apps/desktop/src/features/session/agent-row-format.ts
+++ b/apps/desktop/src/features/session/agent-row-format.ts
@@ -13,14 +13,14 @@ export function formatTokens(n: number): string {
 export const formatCost = formatUsd;
 
 export function shortModel(model: string): string {
-  const m = model.match(/claude-(haiku|sonnet|opus)/i);
+  const m = model.match(/claude-(haiku|sonnet|opus|fable)/i);
   if (m && m[1]) return m[1].toLowerCase();
   return getModelDescriptor(model)?.label ?? model;
 }
 
 export function shortModelWithVersion(model: string): string {
-  const m = model.match(/claude-(haiku|sonnet|opus)-(\d+)-(\d+)/i);
-  if (m && m[1] && m[2] && m[3]) return `${m[1].toLowerCase()} ${m[2]}.${m[3]}`;
+  const m = model.match(/claude-(haiku|sonnet|opus|fable)-(\d+)(?:-(\d+))?/i);
+  if (m && m[1] && m[2]) return `${m[1].toLowerCase()} ${m[2]}${m[3] ? `.${m[3]}` : ''}`;
   return shortModel(model);
 }
 

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -22,6 +22,18 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
         effort: OPUS_EFFORT,
       },
       {
+        id: 'claude-fable-5',
+        tier: 'turn',
+        contextWindow: 1_000_000,
+        family: 'claude',
+        subfamily: 'fable',
+        label: 'Fable 5',
+        variantLabel: '5',
+        costTier: 'expensive',
+        weight: 90,
+        effort: OPUS_EFFORT,
+      },
+      {
         id: 'claude-opus-4-7',
         tier: 'turn',
         contextWindow: 1_000_000,

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -18,7 +18,13 @@ const CAPABILITIES: ProviderCapabilities = {
   fileEdits: true,
   contextWindow: 1_000_000,
   defaultModel: 'claude-opus-4-8',
-  availableModels: ['claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+  availableModels: [
+    'claude-opus-4-8',
+    'claude-fable-5',
+    'claude-opus-4-7',
+    'claude-sonnet-4-6',
+    'claude-haiku-4-5',
+  ],
 };
 
 export interface ClaudeAdapterDeps {

--- a/packages/core/src/providers/claude/cost.test.ts
+++ b/packages/core/src/providers/claude/cost.test.ts
@@ -10,16 +10,20 @@ const usage: ProviderUsage = {
 };
 
 describe('computeCostUsd', () => {
+  it('fable-5 pricing, not the sonnet fallback', () => {
+    expect(computeCostUsd(usage, 'claude-fable-5')).toBeCloseTo(10 + 50);
+  });
+
   it('opus pricing', () => {
-    expect(computeCostUsd(usage, 'claude-opus-4-7')).toBeCloseTo(15 + 75);
+    expect(computeCostUsd(usage, 'claude-opus-4-7')).toBeCloseTo(5 + 25);
   });
 
   it('opus-4-8 is priced as opus', () => {
-    expect(computeCostUsd(usage, 'claude-opus-4-8')).toBeCloseTo(15 + 75);
+    expect(computeCostUsd(usage, 'claude-opus-4-8')).toBeCloseTo(5 + 25);
   });
 
   it('opus-4-6 is priced as opus, not the sonnet fallback', () => {
-    expect(computeCostUsd(usage, 'claude-opus-4-6')).toBeCloseTo(15 + 75);
+    expect(computeCostUsd(usage, 'claude-opus-4-6')).toBeCloseTo(5 + 25);
   });
 
   it('sonnet pricing', () => {

--- a/packages/core/src/providers/claude/cost.ts
+++ b/packages/core/src/providers/claude/cost.ts
@@ -6,10 +6,15 @@ interface ModelPrice {
   readonly cachedInputPerMtok: number;
 }
 
+const FABLE_PRICE: ModelPrice = {
+  inputPerMtok: 10,
+  outputPerMtok: 50,
+  cachedInputPerMtok: 1,
+};
 const OPUS_PRICE: ModelPrice = {
-  inputPerMtok: 15,
-  outputPerMtok: 75,
-  cachedInputPerMtok: 1.5,
+  inputPerMtok: 5,
+  outputPerMtok: 25,
+  cachedInputPerMtok: 0.5,
 };
 const SONNET_PRICE: ModelPrice = {
   inputPerMtok: 3,
@@ -21,6 +26,7 @@ const SONNET_PRICE: ModelPrice = {
 // priced here. A model missing from this table silently bills at the sonnet
 // FALLBACK, which under-counts Opus spend ~5x.
 const PRICES: Record<string, ModelPrice> = {
+  'claude-fable-5': FABLE_PRICE,
   'claude-opus-4-8': OPUS_PRICE,
   'claude-opus-4-7': OPUS_PRICE,
   'claude-opus-4-6': OPUS_PRICE,

--- a/packages/core/src/providers/turn-weight.test.ts
+++ b/packages/core/src/providers/turn-weight.test.ts
@@ -53,4 +53,38 @@ describe('assessTurnWeight', () => {
     const bullets = '- foo\n- bar\n- baz';
     expect(assessTurnWeight(bullets)).not.toBe('light');
   });
+
+  it('flags 3+ distinct file paths as heavy', () => {
+    expect(
+      assessTurnWeight(
+        'update src/foo/bar.ts and packages/core/index.ts and apps/desktop/main.tsx',
+      ),
+    ).toBe('heavy');
+  });
+
+  it('does not flag 2 distinct paths in short text as heavy', () => {
+    expect(assessTurnWeight('look at src/foo/bar.ts and packages/core/index.ts')).not.toBe('heavy');
+  });
+
+  it('does not flag the same path repeated 3 times as heavy', () => {
+    expect(assessTurnWeight('src/foo/bar.ts src/foo/bar.ts src/foo/bar.ts')).not.toBe('heavy');
+  });
+
+  it('flags 3+ numbered list lines as heavy', () => {
+    expect(assessTurnWeight('1. install deps\n2. run migrations\n3. start the server')).toBe(
+      'heavy',
+    );
+  });
+
+  it('flags attachmentCount >= 2 as heavy', () => {
+    expect(assessTurnWeight('fix this', { attachmentCount: 2 })).toBe('heavy');
+  });
+
+  it('does not flag attachmentCount 1 with short text as heavy', () => {
+    expect(assessTurnWeight('fix this', { attachmentCount: 1 })).not.toBe('heavy');
+  });
+
+  it('does not count e.g. or version numbers as file paths', () => {
+    expect(assessTurnWeight('e.g. use version 4.5 and 2.0 here')).not.toBe('heavy');
+  });
 });

--- a/packages/core/src/providers/turn-weight.ts
+++ b/packages/core/src/providers/turn-weight.ts
@@ -33,7 +33,14 @@ const ARCHITECTURAL_VERBS =
 const MULTI_STEP =
   /\bfirst\b.+\bthen\b.+\bthen\b|\bimplement\b.+\band\s+also\b|\brefactor\b.+\bacross\b/i;
 
-// Hard wrap of length-related heuristic constants so heavy/light bands are explicit.
+const BARE_FILENAME_TOKEN =
+  /(?:^|[\s"'`(,])([a-zA-Z0-9_-]+\.(?:ts|tsx|js|jsx|rs|py|go|rb|java|kt|swift|cpp|c|cs|sh|toml|json|yaml|yml|md|sql|html|css|scss))(?=[\s"'`),]|$)/gm;
+
+const SLASH_PATH_TOKEN =
+  /(?:^|[\s"'`(,])((?:[a-zA-Z0-9_.-]+\/)+[a-zA-Z0-9_.-]+\.[a-zA-Z]{1,6})(?=[\s"'`),]|$)/gm;
+
+const NUMBERED_LIST_LINE = /^\s*\d+[.)]\s/gm;
+
 const SHORT_LEN = 200;
 const QUESTION_LEN = 400;
 const HEAVY_LEN = 1500;
@@ -70,7 +77,30 @@ function countDistinctAsks(text: string): number {
   return matches?.length ?? 0;
 }
 
-export function assessTurnWeight(firstTurnText: string): TurnWeight {
+function countDistinctFilePaths(text: string): number {
+  const found = new Set<string>();
+  let m: RegExpExecArray | null;
+  SLASH_PATH_TOKEN.lastIndex = 0;
+  while ((m = SLASH_PATH_TOKEN.exec(text)) !== null) {
+    found.add(m[1]!.toLowerCase());
+  }
+  BARE_FILENAME_TOKEN.lastIndex = 0;
+  while ((m = BARE_FILENAME_TOKEN.exec(text)) !== null) {
+    found.add(m[1]!.toLowerCase());
+  }
+  return found.size;
+}
+
+function hasInlinedPlan(text: string): boolean {
+  NUMBERED_LIST_LINE.lastIndex = 0;
+  const matches = text.match(NUMBERED_LIST_LINE);
+  return matches !== null && matches.length >= 3;
+}
+
+export function assessTurnWeight(
+  firstTurnText: string,
+  opts?: { attachmentCount?: number },
+): TurnWeight {
   const text = firstTurnText ?? '';
   const trimmed = text.trim();
   if (!trimmed) return 'unknown';
@@ -80,6 +110,9 @@ export function assessTurnWeight(firstTurnText: string): TurnWeight {
   if (MULTI_STEP.test(trimmed)) return 'heavy';
   if (ARCHITECTURAL_VERBS.test(trimmed)) return 'heavy';
   if (countDistinctAsks(trimmed) >= 1 && trimmed.length > SHORT_LEN) return 'heavy';
+  if (countDistinctFilePaths(trimmed) >= 3) return 'heavy';
+  if (hasInlinedPlan(trimmed)) return 'heavy';
+  if ((opts?.attachmentCount ?? 0) >= 2) return 'heavy';
 
   if (isGreeting(trimmed)) return 'light';
 


### PR DESCRIPTION
## What

Adds Claude Fable 5 to the registry and reworks the model right-sizing nudge into a registry-driven, provider-agnostic engine.

### Registry
- `claude-fable-5` model tier: 1M ctx, `$10/$50` per MTok (cached `$1`), weight 90, opus effort ladder.
- Added to `ClaudeAdapter.availableModels` (default stays `claude-opus-4-8`).
- Corrected `OPUS_PRICE` from a stale `15/75` to current `5/25` (cached `0.5`). The old value 3x-overcounted Opus spend in budget tracking.

### Right-sizing engine (`chat-constants.ts`)
- `suggestLighterModel`: now cost-tier based, drops at least one tier, never lands on `cheap`. Removed the id-regex floor and the `MIN_WEIGHT_GAP=20` threshold that wrongly blocked valid downgrades (e.g. codex 5.5 -> 5.4) and let cheap models slip through on others.
- `suggestHeavierModel` (new): escalates heavy first-turns to the strongest same-or-higher tier model. Works for claude/codex/gemini/cursor.
- `ChatInput` now surfaces the `heavy -> stronger model` nudge (the `heavy` signal was previously computed and discarded). Always user-overridable.

### Turn weight (`turn-weight.ts`)
- New heavy signals: `>=3` distinct file paths, inlined numbered plans (`>=3` steps), `>=2` attachments. Backward-compatible optional `opts.attachmentCount`.

## Tests
- typecheck 5/5, desktop 951 pass, core 675 pass.
- New/updated cases: fable pricing, corrected opus pricing, lighter/heavier across providers, turn-weight signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)