### PR TITLE
fix(desktop): exclusive question chips + premium questions tab polish

### DIFF
--- a/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/CustomAnswerField/index.tsx
@@ -23,9 +23,9 @@ export function CustomAnswerField({
         onClick={onToggle}
         title="add custom answer"
         className={cn(
-          'inline-flex items-center gap-1 rounded-full border border-dashed border-border/50 px-2.5 py-1',
-          'text-xs text-muted-foreground transition-all duration-150',
-          'hover:border-primary/50 hover:bg-primary/5 hover:text-primary active:scale-[0.97]',
+          'inline-flex items-center gap-1 rounded-full border border-dashed border-border/60 px-2.5 py-1',
+          'text-xs text-muted-foreground transition-[color,background-color,border-color,transform] duration-150',
+          'hover:border-border hover:bg-muted hover:text-foreground active:scale-[0.97]',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         )}
       >
@@ -37,9 +37,7 @@ export function CustomAnswerField({
 
   return (
     <div className="mt-1 flex w-full flex-col gap-1 motion-safe:animate-fade-in">
-      <span className="px-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">
-        your answer
-      </span>
+      <span className="px-0.5 text-2xs font-medium text-muted-foreground">your answer</span>
       <Textarea
         autoFocus
         value={value}
@@ -48,7 +46,7 @@ export function CustomAnswerField({
         autoGrow
         minRows={2}
         maxRows={6}
-        className="rounded-md text-xs"
+        className="rounded-md border-border-soft bg-subtle text-xs shadow-none"
       />
     </div>
   );

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -62,17 +62,19 @@ export function QuestionCard({
   return (
     <div
       className={cn(
-        'group relative overflow-hidden rounded-lg border bg-elevated pl-3 pr-2.5 py-2.5 shadow-sm',
-        'transition-all duration-200 motion-safe:animate-fade-in',
-        hasPendingAnswer ? 'border-primary/40' : 'border-border-soft hover:border-border',
-        animate && 'scale-[1.01] border-primary/60 bg-primary/5',
+        'group relative overflow-hidden rounded-lg border border-border-soft bg-elevated py-2.5 pl-3 pr-2.5 shadow-sm',
+        'transition-[border-color,background-color,box-shadow,transform] duration-200',
+        !hasPendingAnswer && 'hover:border-border',
+        animate
+          ? 'motion-safe:animate-answer-lock motion-reduce:bg-success/5'
+          : 'motion-safe:animate-fade-in',
       )}
     >
       <span
         aria-hidden
         className={cn(
-          'absolute inset-y-2 left-0 w-0.5 rounded-full transition-colors duration-200',
-          hasPendingAnswer ? 'bg-primary' : 'bg-transparent',
+          'pointer-events-none absolute inset-y-2 left-0 w-0.5 rounded-full transition-colors duration-200',
+          hasPendingAnswer ? 'bg-primary/70' : 'bg-transparent',
         )}
       />
 
@@ -89,15 +91,15 @@ export function QuestionCard({
           type="button"
           onClick={() => onDismiss(question.id)}
           className={cn(
-            'shrink-0 rounded-md p-1 text-muted-foreground/60 opacity-0 transition-all',
+            'shrink-0 rounded-md p-1 text-muted-foreground/60 opacity-0 transition-[opacity,color,background-color] duration-150',
             'hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40',
-            'group-hover:opacity-100',
+            'group-hover:opacity-100 motion-reduce:opacity-60',
             animate && 'opacity-100',
           )}
           title="dismiss question"
           aria-label="dismiss question"
         >
-          {animate ? <Check size={12} className="text-primary" /> : <X size={12} />}
+          {animate ? <Check size={12} className="text-success" /> : <X size={12} />}
         </button>
       </div>
 
@@ -118,10 +120,10 @@ export function QuestionCard({
         />
       </div>
 
-      <div className="mt-2 flex items-center gap-2 pl-[21px] text-[10px] text-muted-foreground/70">
+      <div className="mt-2 flex items-center gap-2 pl-[21px] text-2xs text-muted-foreground">
         <span>{relativeAge(question.createdAt)}</span>
         {question.ownedByStepOrdinal != null && (
-          <span className="rounded bg-muted px-1 py-0.5 font-mono">
+          <span className="rounded bg-muted px-1 py-0.5 font-mono text-2xs text-muted-foreground">
             step {question.ownedByStepOrdinal}
           </span>
         )}

--- a/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
@@ -7,30 +7,34 @@ interface Props {
   onToggle: () => void;
 }
 
+const isCodeLike = (label: string) => /^\S+$/.test(label) && /[_().:[\]/]/.test(label);
+
 export function SuggestionChip({ label, selected, onToggle }: Props) {
   return (
     <button
       type="button"
       onClick={onToggle}
       aria-pressed={selected}
+      title={label}
       className={cn(
-        'group inline-flex items-center rounded-full border text-xs font-medium transition-all duration-150',
+        'group inline-flex max-w-full items-center rounded-full border text-xs font-medium transition-[color,background-color,border-color,box-shadow,transform] duration-150',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        isCodeLike(label) && 'font-mono text-2xs',
         selected
-          ? 'border-primary/50 bg-primary/10 py-1 pl-1.5 pr-2.5 text-primary shadow-[0_0_0_1px_var(--color-primary)]'
+          ? 'border-transparent bg-primary/10 py-1 pl-1.5 pr-2.5 text-primary ring-1 ring-primary/30 shadow-[inset_0_1px_2px_oklch(from_var(--color-primary)_l_c_h_/_0.18)]'
           : 'border-border-soft bg-muted/40 px-2.5 py-1 text-muted-foreground hover:border-border hover:bg-muted hover:text-foreground active:scale-[0.97]',
       )}
     >
       <span
         aria-hidden
         className={cn(
-          'grid place-items-center overflow-hidden transition-all duration-150',
+          'grid shrink-0 place-items-center overflow-hidden transition-all duration-150',
           selected ? 'mr-1 w-3.5 opacity-100' : 'w-0 opacity-0',
         )}
       >
         <Check size={11} strokeWidth={3} />
       </span>
-      {label}
+      <span className="truncate">{label}</span>
     </button>
   );
 }

--- a/apps/desktop/src/features/context/components/QuestionsTab/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/index.tsx
@@ -6,7 +6,7 @@ import {
   MessageCircleQuestion,
   Undo2,
 } from 'lucide-react';
-import { EmptyState, ScrollFade, cn } from '@goodboy/ui';
+import { Button, EmptyState, ScrollFade, cn } from '@goodboy/ui';
 import type { Agent, AgentId, OpenQuestionId, SessionId, Workflow } from '@goodboy/types';
 import { useAppStore, useSessionOpenQuestions } from '../../../../store';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
@@ -131,17 +131,20 @@ export function QuestionsTab({ sessionId }: Props) {
       <div className="shrink-0 px-1 pb-2.5">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <MessageCircleQuestion size={13} aria-hidden className="text-primary" />
+            <MessageCircleQuestion size={13} aria-hidden className="text-muted-foreground" />
             <span className="text-xs font-medium text-foreground">open questions</span>
           </div>
-          <span className="text-[10px] font-medium tabular-nums text-muted-foreground">
+          <span className="text-2xs font-medium tabular-nums text-muted-foreground">
             {totalAnswered}/{totalOpen} answered
           </span>
         </div>
         {totalOpen > 0 && (
           <div className="mt-1.5 h-1 overflow-hidden rounded-full bg-muted">
             <div
-              className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
+              className={cn(
+                'h-full rounded-full transition-[width,background-color] duration-300 ease-out',
+                totalAnswered === totalOpen ? 'bg-success/70' : 'bg-primary/70',
+              )}
               style={{ width: `${(totalAnswered / totalOpen) * 100}%` }}
             />
           </div>
@@ -164,11 +167,11 @@ export function QuestionsTab({ sessionId }: Props) {
               <div
                 key={cluster.ownerAgentId ?? '__orphan__'}
                 className={cn(
-                  'flex flex-col gap-2.5 rounded-xl border bg-subtle/50 p-2.5 transition-colors duration-200',
-                  complete ? 'border-primary/40' : 'border-border-soft',
+                  'flex flex-col gap-2.5 rounded-xl border border-border-soft bg-subtle p-2.5 shadow-sm transition-[box-shadow,border-color] duration-200 motion-safe:animate-fade-in',
+                  complete && 'ring-1 ring-border',
                 )}
               >
-                <header className="flex items-center justify-between gap-2 px-0.5">
+                <header className="flex items-center justify-between gap-2.5 px-0.5">
                   <div className="flex min-w-0 items-center gap-2">
                     <AgentAvatar kind={kind} size="md" className="shrink-0" />
                     <div className="flex min-w-0 flex-col">
@@ -176,12 +179,12 @@ export function QuestionsTab({ sessionId }: Props) {
                         {ownerLabel}
                       </span>
                       {cluster.creatorAgentName ? (
-                        <span className="flex items-center gap-1 text-[10px] text-muted-foreground/70">
+                        <span className="flex items-center gap-1 text-2xs text-muted-foreground">
                           <ArrowDownRight size={9} aria-hidden />
                           via {cluster.creatorAgentName}
                         </span>
                       ) : (
-                        <span className="text-[10px] text-muted-foreground/70">
+                        <span className="text-2xs text-muted-foreground">
                           {complete ? 'ready to send' : 'awaiting your answer'}
                         </span>
                       )}
@@ -189,8 +192,8 @@ export function QuestionsTab({ sessionId }: Props) {
                   </div>
                   <span
                     className={cn(
-                      'flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium tabular-nums transition-colors',
-                      complete ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground',
+                      'flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-medium tabular-nums transition-colors',
+                      complete ? 'bg-success/12 text-success' : 'bg-muted text-muted-foreground',
                     )}
                   >
                     {complete && <CheckCircle2 size={10} aria-hidden />}
@@ -220,15 +223,12 @@ export function QuestionsTab({ sessionId }: Props) {
                 </div>
 
                 {answeredCount > 0 && (
-                  <button
+                  <Button
                     type="button"
+                    variant="primary"
+                    size="md"
                     onClick={() => void handleSubmitCluster(cluster)}
-                    className={cn(
-                      'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
-                      'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
-                      'hover:brightness-105 active:scale-[0.99]',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-                    )}
+                    className="group w-full"
                   >
                     <span>
                       send {answeredCount} answer{answeredCount !== 1 ? 's' : ''} to{' '}
@@ -237,9 +237,9 @@ export function QuestionsTab({ sessionId }: Props) {
                     <ArrowRight
                       size={13}
                       aria-hidden
-                      className="transition-transform group-hover:translate-x-0.5"
+                      className="motion-safe:transition-transform group-hover:translate-x-0.5"
                     />
-                  </button>
+                  </Button>
                 )}
               </div>
             );
@@ -254,7 +254,7 @@ export function QuestionsTab({ sessionId }: Props) {
             <button
               type="button"
               onClick={handleUndo}
-              className="flex items-center gap-1 text-xs font-medium text-primary hover:underline focus-visible:outline-none"
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs font-medium text-primary transition-colors hover:bg-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
             >
               <Undo2 size={11} />
               undo

--- a/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
+++ b/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
@@ -40,10 +40,7 @@ export const useOpenQuestions = create<OpenQuestionsUiState>((set, get) => ({
   toggleSuggestion: (questionId, suggestion) => {
     const drafts = { ...get().drafts };
     const draft = drafts[questionId] ?? emptyDraft();
-    const current = draft.selectedSuggestions;
-    const next = current.includes(suggestion)
-      ? current.filter((s) => s !== suggestion)
-      : [...current, suggestion];
+    const next = draft.selectedSuggestions.includes(suggestion) ? [] : [suggestion];
     drafts[questionId] = { ...draft, selectedSuggestions: next };
     set({ drafts });
   },

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -2,8 +2,9 @@
 @source '../../../packages/ui/src/**/*.{ts,tsx}';
 
 @theme {
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, 'Cascadia Mono', monospace;
 
   /* Dark palette (default), soft desaturated darks, lifted black base.
      Surface elevation ramp (brighter L = more elevated):
@@ -11,11 +12,11 @@
   --color-background: oklch(0.25 0.006 255);
   --color-foreground: oklch(0.91 0.006 90);
   --color-subtle: oklch(0.29 0.008 255);
-  --color-muted: oklch(0.33 0.010 255);
+  --color-muted: oklch(0.33 0.01 255);
   --color-elevated: oklch(0.37 0.011 255);
   --color-muted-foreground: oklch(0.68 0.015 255);
-  --color-border: oklch(0.40 0.012 255);
-  --color-border-soft: oklch(0.32 0.010 255);
+  --color-border: oklch(0.4 0.012 255);
+  --color-border-soft: oklch(0.32 0.01 255);
 
   /* Brand accent, teal/cyan. */
   --color-primary: oklch(0.74 0.11 200);
@@ -32,12 +33,12 @@
   --color-info-foreground: oklch(0.15 0 0);
   --color-accent: oklch(0.74 0.11 200);
   --color-accent-foreground: oklch(0.15 0.02 200);
-  --color-merged: oklch(0.70 0.15 305);
+  --color-merged: oklch(0.7 0.15 305);
   --color-merged-foreground: oklch(0.15 0.02 305);
 
   /* Per-provider accent. */
   --color-provider-anthropic: oklch(0.74 0.15 55);
-  --color-provider-cursor: oklch(0.70 0.16 290);
+  --color-provider-cursor: oklch(0.7 0.16 290);
   --color-provider-codex: oklch(0.72 0.16 150);
   --color-provider-gemini: oklch(0.72 0.16 240);
   --color-provider-linear: oklch(0.57 0.16 277);
@@ -56,14 +57,14 @@
      `comfortable`. Tool-call / system rows in the transcript may opt down to
      `cozy` to read as devtool while prose stays conversational. */
   --density-compact-text: var(--text-2xs);
-  --density-compact-gap: 0.375rem;     /* 6px */
-  --density-compact-pad: 0.5rem;        /* 8px */
+  --density-compact-gap: 0.375rem; /* 6px */
+  --density-compact-pad: 0.5rem; /* 8px */
   --density-cozy-text: var(--text-xs);
-  --density-cozy-gap: 0.625rem;         /* 10px */
-  --density-cozy-pad: 0.75rem;          /* 12px */
+  --density-cozy-gap: 0.625rem; /* 10px */
+  --density-cozy-pad: 0.75rem; /* 12px */
   --density-comfortable-text: var(--text-sm);
-  --density-comfortable-gap: 0.875rem;  /* 14px */
-  --density-comfortable-pad: 1rem;      /* 16px */
+  --density-comfortable-gap: 0.875rem; /* 14px */
+  --density-comfortable-pad: 1rem; /* 16px */
 
   --radius-sm: 4px;
   --radius-md: 8px;
@@ -73,20 +74,32 @@
   --animate-soft-pulse: soft-pulse 2.8s ease-in-out infinite;
 
   @keyframes soft-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.45; }
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
   }
 
   /* Border-only pulse, anima il border-color, lascia il contenuto stabile.
      Usato sulle session card in pending: il bordo respira giallo per
      attirare l'occhio, ma il testo resta leggibile a opacità piena. */
   @keyframes border-pulse {
-    0%, 100% { border-color: oklch(from var(--color-warning) l c h / 0.75); }
-    50%      { border-color: oklch(from var(--color-warning) l c h / 0.2); }
+    0%,
+    100% {
+      border-color: oklch(from var(--color-warning) l c h / 0.75);
+    }
+    50% {
+      border-color: oklch(from var(--color-warning) l c h / 0.2);
+    }
   }
 
   @keyframes spin-border {
-    to { --spin-angle: 360deg; }
+    to {
+      --spin-angle: 360deg;
+    }
   }
 
   /* Tab / panel content swap, a quick fade + 2px rise so the new content
@@ -101,6 +114,32 @@
     to {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  --animate-answer-lock: answer-lock 700ms cubic-bezier(0.2, 0, 0, 1);
+
+  @keyframes answer-lock {
+    0% {
+      transform: scale(1);
+      background-color: var(--color-elevated);
+      box-shadow:
+        var(--shadow-sm),
+        0 0 0 0 oklch(from var(--color-success) l c h / 0);
+    }
+    35% {
+      transform: scale(1.005);
+      background-color: oklch(from var(--color-success) l c h / 0.08);
+      box-shadow:
+        var(--shadow-sm),
+        inset 0 0 0 1px oklch(from var(--color-success) l c h / 0.45);
+    }
+    100% {
+      transform: scale(1);
+      background-color: var(--color-elevated);
+      box-shadow:
+        var(--shadow-sm),
+        0 0 0 0 oklch(from var(--color-success) l c h / 0);
     }
   }
 
@@ -131,16 +170,12 @@
   }
 
   /* Dark shadows, subtle drop + faint inner highlight to lift cards on dark bg. */
-  --shadow-sm:
-    0 1px 2px 0 oklch(0 0 0 / 0.28),
-    inset 0 1px 0 0 oklch(1 0 0 / 0.03);
+  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.28), inset 0 1px 0 0 oklch(1 0 0 / 0.03);
   --shadow-md:
-    0 6px 16px -4px oklch(0 0 0 / 0.44),
-    0 2px 4px -1px oklch(0 0 0 / 0.30),
+    0 6px 16px -4px oklch(0 0 0 / 0.44), 0 2px 4px -1px oklch(0 0 0 / 0.3),
     inset 0 1px 0 0 oklch(1 0 0 / 0.04);
   --shadow-lg:
-    0 18px 40px -10px oklch(0 0 0 / 0.52),
-    0 6px 12px -4px oklch(0 0 0 / 0.38),
+    0 18px 40px -10px oklch(0 0 0 / 0.52), 0 6px 12px -4px oklch(0 0 0 / 0.38),
     inset 0 1px 0 0 oklch(1 0 0 / 0.05);
 
   --motion-fast: 100ms;
@@ -156,7 +191,7 @@
 /* Light palette, applied when html[data-theme="light"].
    Elevation model mirrors dark mode: brighter L = more elevated. Monotonic ramp:
    background (canvas) < subtle (panels) < muted (rails, chips) < elevated (top cards). */
-html[data-theme="light"] {
+html[data-theme='light'] {
   --color-background: oklch(0.948 0.004 250);
   --color-foreground: oklch(0.21 0.005 250);
   --color-subtle: oklch(0.967 0.004 250);
@@ -165,12 +200,12 @@ html[data-theme="light"] {
   --color-muted-foreground: oklch(0.44 0.006 250);
   --color-border: oklch(0.85 0.005 250);
   --color-border-soft: oklch(0.91 0.004 250);
-  --color-primary: oklch(0.50 0.13 200);
+  --color-primary: oklch(0.5 0.13 200);
   --color-primary-foreground: oklch(0.99 0.003 200);
   /* Semantic, tuned for AA on light bg (text use) and white-fg readability (bg use).
      Warning hue shifted from pure yellow (78) to amber (55), pure yellow at AA-passing
      L is brownish; amber stays recognizable while clearing 4.5:1 against bg. */
-  --color-danger: oklch(0.50 0.19 22);
+  --color-danger: oklch(0.5 0.19 22);
   --color-danger-foreground: oklch(0.99 0 0);
   --color-warning: oklch(0.56 0.17 55);
   --color-warning-foreground: oklch(0.99 0 0);
@@ -178,25 +213,19 @@ html[data-theme="light"] {
   --color-success-foreground: oklch(0.99 0 0);
   --color-info: oklch(0.48 0.14 238);
   --color-info-foreground: oklch(0.99 0 0);
-  --color-accent: oklch(0.50 0.13 200);
+  --color-accent: oklch(0.5 0.13 200);
   --color-accent-foreground: oklch(0.99 0.003 200);
-  --color-merged: oklch(0.50 0.18 305);
+  --color-merged: oklch(0.5 0.18 305);
   --color-merged-foreground: oklch(0.99 0.003 305);
   --color-provider-anthropic: oklch(0.54 0.16 55);
-  --color-provider-cursor: oklch(0.50 0.17 290);
+  --color-provider-cursor: oklch(0.5 0.17 290);
   --color-provider-codex: oklch(0.48 0.15 148);
-  --color-provider-gemini: oklch(0.50 0.16 240);
-  --color-focus-ring: oklch(0.50 0.13 200 / 0.45);
+  --color-provider-gemini: oklch(0.5 0.16 240);
+  --color-focus-ring: oklch(0.5 0.13 200 / 0.45);
   /* Light shadows, softer, multi-layered for depth without harshness. */
-  --shadow-sm:
-    0 1px 2px 0 oklch(0 0 0 / 0.06),
-    0 1px 3px 0 oklch(0 0 0 / 0.08);
-  --shadow-md:
-    0 4px 12px -2px oklch(0 0 0 / 0.10),
-    0 2px 4px -1px oklch(0 0 0 / 0.08);
-  --shadow-lg:
-    0 16px 36px -8px oklch(0 0 0 / 0.14),
-    0 6px 12px -4px oklch(0 0 0 / 0.10);
+  --shadow-sm: 0 1px 2px 0 oklch(0 0 0 / 0.06), 0 1px 3px 0 oklch(0 0 0 / 0.08);
+  --shadow-md: 0 4px 12px -2px oklch(0 0 0 / 0.1), 0 2px 4px -1px oklch(0 0 0 / 0.08);
+  --shadow-lg: 0 16px 36px -8px oklch(0 0 0 / 0.14), 0 6px 12px -4px oklch(0 0 0 / 0.1);
   color-scheme: light;
 }
 
@@ -272,7 +301,7 @@ dialog[open]::backdrop {
    card perimeter for running / auto-running states. The mask trick clips
    the gradient to a 1px ring so it doesn't bleed into the card body. */
 @property --spin-angle {
-  syntax: "<angle>";
+  syntax: '<angle>';
   initial-value: 0deg;
   inherits: false;
 }
@@ -282,7 +311,7 @@ dialog[open]::backdrop {
 }
 
 .spin-border::before {
-  content: "";
+  content: '';
   position: absolute;
   inset: 0;
   border-radius: inherit;
@@ -298,14 +327,20 @@ dialog[open]::backdrop {
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
-          mask-composite: exclude;
+  mask-composite: exclude;
   animation: spin-border 3.6s linear infinite;
   pointer-events: none;
 }
 
-.spin-border-info  { --spin-border-color: var(--color-info); }
-.spin-border-danger { --spin-border-color: var(--color-danger); }
-.spin-border-primary { --spin-border-color: var(--color-primary); }
+.spin-border-info {
+  --spin-border-color: var(--color-info);
+}
+.spin-border-danger {
+  --spin-border-color: var(--color-danger);
+}
+.spin-border-primary {
+  --spin-border-color: var(--color-primary);
+}
 
 .animate-border-pulse {
   animation: border-pulse 2.8s ease-in-out infinite;
@@ -320,7 +355,7 @@ dialog[open]::backdrop {
     box-shadow:
       0 0 0 0 oklch(from var(--color-success) l c h / 0),
       0 0 0 0 oklch(from var(--color-success) l c h / 0);
-    background-color: oklch(from var(--color-success) l c h / 0.10);
+    background-color: oklch(from var(--color-success) l c h / 0.1);
   }
   25% {
     box-shadow:
@@ -332,7 +367,7 @@ dialog[open]::backdrop {
     box-shadow:
       0 0 0 0 oklch(from var(--color-success) l c h / 0),
       0 0 0 0 oklch(from var(--color-success) l c h / 0);
-    background-color: oklch(from var(--color-success) l c h / 0.10);
+    background-color: oklch(from var(--color-success) l c h / 0.1);
   }
 }
 
@@ -378,7 +413,9 @@ dialog[open]::backdrop {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;


### PR DESCRIPTION
## What

Two fixes to the open questions surface:

**Behavior**: suggestion chips were multi-select; picking one answer now deselects the others (re-click toggles off). Custom answer field unchanged.

**Visual**: the tab read below the app's bar, teal borders stacked on every state. Reworked against DESIGN.md:

- structural teal borders removed; depth now comes from the elevation ramp (subtle cluster, elevated cards) plus shadow-sm
- teal reserved for three jobs: selected chip, pending accent bar (softened to /70), send CTA
- completion is a success semantic: green count badge, progress fill flips green at 100%, achromatic ring seal on complete clusters
- selected chip: single ring + inset shadow (pressed feel) instead of doubled border+shadow; no layout shift on toggle
- code-like suggestion labels render mono at 11px with truncate + title tooltip (long identifiers no longer overflow the card)
- custom answer textarea recessed to bg-subtle instead of near-black canvas
- send CTA moved to the Button primitive
- new answer-lock keyframe (success-tinted, 700ms) replaces the teal scale flash; mutually exclusive with fade-in so it actually plays
- a11y: pointer-events-none on accent bar, motion-reduce fallbacks, focus ring on undo

styles.css shows whole-file churn because the pre-commit prettier hook reformatted it (file was not prettier-clean on main).

## Verification

- typecheck clean, 27/27 tests green in the context feature
- verified in browser (vite harness, real components): both themes, chip exclusivity, answer-lock animation runtime, no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)