### PR TITLE
fix(desktop): recover zombie running agents on app reload

### DIFF
--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -102,6 +102,7 @@ vi.mock('@goodboy/db', () => ({
   unarchiveSession: vi.fn(async () => undefined),
   updateSessionConfig: vi.fn(async () => undefined),
   updateAgentConfig: vi.fn(async () => undefined),
+  updateAgentStatus: vi.fn(async () => undefined),
   summarizeSessionTelemetry: vi.fn(async () => null),
   summarizeWorkspaceTelemetry: vi.fn(async () => null),
   summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
@@ -157,9 +158,13 @@ vi.mock('../../../features/onboarding/onboarding-store', () => ({
   hydrateOnboardingFromDb: vi.fn(async () => undefined),
 }));
 
+const cancelTurnSpy = vi.fn(async () => undefined);
+const listLiveRunIdsSpy = vi.fn(async () => new Set<string>());
+
 vi.mock('../../../features/chat/turn', () => ({
   runTurn: vi.fn(),
-  cancelTurn: vi.fn(async () => undefined),
+  cancelTurn: cancelTurnSpy,
+  listLiveRunIds: listLiveRunIdsSpy,
   writeAttachment: vi.fn(async () => 'rel/path'),
   encodeAuthRequiredMessage: () => '',
   isAuthErrorMessage: () => false,
@@ -553,6 +558,54 @@ describe('store contract', () => {
     it('deleteWorkspace throws when workspace does not exist', async () => {
       const store = await getStore();
       await expect(store.getState().deleteWorkspace(WS_ID)).rejects.toThrow(/workspace not found/);
+    });
+
+    it('setCurrentWorkspace recovers an orphaned running session+agent left over after a reload', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const turn = await import('../../../features/chat/turn');
+      vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+        buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } }),
+        buildSession({ id: SESSION_ID_2 }),
+      ]);
+      vi.mocked(db.listAgentsForSessions).mockResolvedValueOnce(
+        new Map([[SESSION_ID, [buildAgent({ id: AGENT_ID, status: 'running', runId: RUN_ID })]]]),
+      );
+      vi.mocked(turn.listLiveRunIds).mockResolvedValueOnce(new Set([RUN_ID as string]));
+      store.setState({ workspaces: [buildWorkspace()] });
+
+      await store.getState().setCurrentWorkspace(WS_ID);
+
+      const orphan = store.getState().sessions.find((s) => s.id === SESSION_ID);
+      expect(orphan?.state.kind).toBe('idle');
+      expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.status).toBe('pending');
+      expect(turn.cancelTurn).toHaveBeenCalledWith(RUN_ID);
+      expect(db.updateAgentStatus).toHaveBeenCalledWith(expect.anything(), AGENT_ID, {
+        status: 'pending',
+      });
+    });
+
+    it('setCurrentWorkspace clears a dead running agent without cancelling (backend already gone)', async () => {
+      const store = await getStore();
+      const db = await import('@goodboy/db');
+      const turn = await import('../../../features/chat/turn');
+      vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+        buildSession({ state: { kind: 'running', runId: RUN_ID, startedAt: NOW } }),
+        buildSession({ id: SESSION_ID_2 }),
+      ]);
+      vi.mocked(db.listAgentsForSessions).mockResolvedValueOnce(
+        new Map([[SESSION_ID, [buildAgent({ id: AGENT_ID, status: 'running', runId: RUN_ID })]]]),
+      );
+      vi.mocked(turn.listLiveRunIds).mockResolvedValueOnce(new Set<string>());
+      store.setState({ workspaces: [buildWorkspace()] });
+
+      await store.getState().setCurrentWorkspace(WS_ID);
+
+      expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.status).toBe('pending');
+      expect(turn.cancelTurn).not.toHaveBeenCalled();
+      expect(db.updateAgentStatus).toHaveBeenCalledWith(expect.anything(), AGENT_ID, {
+        status: 'pending',
+      });
     });
 
     it('setCurrentWorkspace(null) clears the active workspace and resets workspaceSummary etc.', async () => {

--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -244,6 +244,8 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeWorkflowList: invokeWorkflowListSpy,
   invokeWorkflowUpsert: invokeWorkflowUpsertSpy,
   invokeWorkflowDelete: invokeWorkflowDeleteSpy,
+  invokeWorkflowsForSession: vi.fn(async () => [] as ReadonlyArray<Workflow>),
+  invokeStepDefList: vi.fn(async () => []),
   invokeAgentList: invokeAgentListSpy,
   invokeAgentInsert: invokeAgentInsertSpy,
   invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -16,6 +16,7 @@ import {
   summarizeWorkspaceProviderTelemetry,
   summarizeWorkspaceTelemetry,
   touchWorkspaceLastAccessed,
+  updateAgentStatus,
   updateSessionState,
 } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
@@ -93,7 +94,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
             return s;
           }
           if (liveRunIds.has(s.state.runId)) {
-            return s;
+            await cancelTurn(s.state.runId).catch(() => undefined);
           }
           const idleState: TurnState = { kind: 'idle', lastActivityAt: recoveryNow };
           await updateSessionState(tauriDatabase, s.id, idleState, recoveryNow).catch(
@@ -102,6 +103,18 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
           return { ...s, state: idleState, updatedAt: recoveryNow };
         }),
       );
+      const recoverOrphanAgent = async (run: Agent): Promise<Agent> => {
+        if (run.status !== 'running') {
+          return run;
+        }
+        if (run.runId && liveRunIds.has(run.runId)) {
+          await cancelTurn(run.runId).catch(() => undefined);
+        }
+        await updateAgentStatus(tauriDatabase, run.id, { status: 'pending' }).catch(
+          () => undefined,
+        );
+        return { ...run, status: 'pending' };
+      };
       const sessionIds = sessions.map((s) => s.id);
       const [worktreesBySession, agentsBySession, externalTasks] = await Promise.all([
         listWorktreesForSessions(tauriDatabase, sessionIds),
@@ -121,7 +134,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
             sessionBranches[s.id] = primaryRow.branch;
           }
         }
-        const runs = agentsBySession.get(s.id) ?? [];
+        const runs = await Promise.all((agentsBySession.get(s.id) ?? []).map(recoverOrphanAgent));
         sessionPhaseRuns[s.id] = runs;
         for (const run of runs) {
           if (run.kind) {


### PR DESCRIPTION
## Summary

- on `tauri dev` HMR refresh, the Rust backend survives so `liveRunIds` still contained the orphaned `runId` — the existing session reconciliation kept the session as `running` forever, locking the composer with no way to cancel or queue
- on full app close+restart, both session and agent remained stuck as `running` in the DB with no live process

**Fix:** any session with `state.kind === 'running'` at workspace load time is now always reset to `idle` — the JS stream listener never survives a reload, so re-attach is impossible; if the backend process is still live we cancel it first. Running agents follow the same pattern: reset to `pending` so the workflow step remains actionable (Play button, `activateWorkflowAgent`) without aborting the whole run.

## Test plan

- [x] `setCurrentWorkspace` unit tests: scenario A (backend alive → cancel + reset), scenario B (backend dead → reset only, no cancel call)
- [ ] manual: start a workflow agent, hot-reload (`tauri dev`), verify session/agent recover to idle/pending immediately on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)