### PR TITLE
fix(desktop): wrap long open-question text instead of clipping

### DIFF
--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -93,7 +93,9 @@ export const QuestionCard = ({
             aria-hidden
             className="mt-0.5 shrink-0 text-muted-foreground/50"
           />
-          <p className="text-xs leading-relaxed text-foreground">{question.text}</p>
+          <p className="min-w-0 break-words text-xs leading-relaxed text-foreground">
+            {question.text}
+          </p>
         </div>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Fix text truncation in open questions by enabling text wrapping instead of overflow clipping
- Add `min-w-0 break-words` to question text container to allow long tokens to wrap naturally

## Test plan
- [x] Visual verification: long question text wraps instead of being cut off
- [x] Verified at commit 40b22d49