### PR TITLE
fix(desktop): model selection applied on send

### DIFF
--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -361,7 +361,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const agentOverride: TurnProviderOverride | undefined = agentProvider
       ? { providerId: agentProvider, ...(agentModelPin != null && { model: agentModelPin }) }
       : undefined;
-    const effectiveOverride = phaseOverride ?? agentOverride ?? turnOverride;
+    const effectiveOverride = phaseOverride ?? turnOverride ?? agentOverride;
 
     const routingPreference =
       effectiveOverride === agentOverride && agentOverride !== undefined
@@ -388,10 +388,13 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
 
     const provider: ProviderId = routingDecision.selectedProvider;
     const agentKindModel = get().agentModelOverride[activeAgentId] ?? null;
+    const turnOverrideActive = turnOverride !== undefined && effectiveOverride === turnOverride;
     const model =
       phaseDefinition?.modelOverride && phaseDefinition.providerOverride === undefined
         ? phaseDefinition.modelOverride
-        : (agentKindModel ?? routingDecision.selectedModel);
+        : turnOverrideActive
+          ? routingDecision.selectedModel
+          : (agentKindModel ?? routingDecision.selectedModel);
 
     const wsBindings = get().workspaceOverrides[session.workspaceId]?.providerBindings ?? {};
     const sessBindings = get().sessionOverrides[sessionId]?.providerBindings ?? {};

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -533,6 +533,94 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     expect(useAppStore.getState().pendingResolverKickoff[AGENT_B]).toBe('kick B');
   });
 
+  it('an explicit per-turn model override beats the agent kind model pin', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+        },
+      ],
+      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+    });
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-3-5-sonnet-latest',
+      reason: 'override',
+    });
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: { providerId: 'anthropic', model: 'claude-3-5-sonnet-latest' },
+    });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-sonnet-latest');
+  });
+
+  it('keeps the agent kind model pin when no per-turn override is supplied', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    useAppStore.setState({
+      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-haiku-latest');
+  });
+
+  it('an explicit per-turn model override beats both the agent provider and model pin', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+        },
+      ],
+      agentProviderOverride: { [AGENT_A]: 'anthropic' },
+      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+    });
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-3-5-sonnet-latest',
+      reason: 'override',
+    });
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: { providerId: 'anthropic', model: 'claude-3-5-sonnet-latest' },
+    });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-sonnet-latest');
+  });
+
+  it('keeps both the agent provider and model pin when no per-turn override is supplied', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    useAppStore.setState({
+      agentProviderOverride: { [AGENT_A]: 'anthropic' },
+      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-haiku-latest');
+  });
+
   it('activateNextResolver runs only the head of the queue and dequeues it', async () => {
     const useAppStore = await importStore();
     useAppStore.setState({


### PR DESCRIPTION
## Summary

When user selects a model in the composer and sends a message, the chat previously remained on the agent's pinned model instead of using the newly selected one.

## Root cause

Override precedence ranked agent pins (`agentOverride`) above per-turn selections (`turnOverride`), causing the routing decision to ignore user selection when an agent had a persistent model pin.

## Changes

- Reorder precedence: `phaseOverride ?? turnOverride ?? agentOverride`
  - Per-turn composer selection always wins over persistent agent pins
  - Resolver/scout auto-kickoffs unaffected (no `turnOverride` passed)
- Add `turnOverrideActive` guard to model selection logic
  - Respects `routingDecision.selectedModel` when turn override drives routing

## Test plan

- ✅ All 15 sendTurn-agent-routing tests pass
- ✅ Full suite (970) passes, no regressions
- Manual: select model dropdown → send message → verify chat uses selected model, not agent pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)