### PR TITLE
fix(desktop): normalize invalid agent role to prevent undefined lookups

### DIFF
--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }: Props) => {
   const [confirming, setConfirming] = useState(false);
-  const kind = ROLE_TO_KIND[def.role];
+  const kind = ROLE_TO_KIND[def.role] ?? 'generic';
   const isGlobal = def.workspaceId === null;
   return (
     <li

--- a/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.test.tsx
@@ -39,7 +39,7 @@ const PLAN_FIXTURE = {
     { name: 'scout', role: 'scout', promptPrefix: 'scout prefix', expectedOutput: 'scout output' },
     {
       name: 'implementer',
-      role: 'engineer',
+      role: 'implementer',
       promptPrefix: 'eng prefix',
       expectedOutput: 'eng output',
     },
@@ -93,7 +93,7 @@ describe('WorkflowPlanner', () => {
     it('persists the planner-assigned role on each step', async () => {
       const saved = await planAndSave();
       expect(saved.steps[0]!.role).toBe('scout');
-      expect(saved.steps[1]!.role).toBe('engineer');
+      expect(saved.steps[1]!.role).toBe('implementer');
     });
 
     it('preserves ordinal order matching planner output', async () => {
@@ -115,8 +115,8 @@ describe('WorkflowPlanner', () => {
           reasoning: '',
           steps: [
             { name: 'planner', role: 'architect', promptPrefix: '', expectedOutput: '' },
-            { name: 'coder', role: 'engineer', promptPrefix: '', expectedOutput: '' },
-            { name: 'qa', role: 'qa', promptPrefix: '', expectedOutput: '' },
+            { name: 'coder', role: 'implementer', promptPrefix: '', expectedOutput: '' },
+            { name: 'qa', role: 'tester', promptPrefix: '', expectedOutput: '' },
           ],
         },
       });
@@ -134,7 +134,7 @@ describe('WorkflowPlanner', () => {
       await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
       const saved = mockSavePhaseTemplate.mock.calls[0]![0] as Workflow;
       const roles = saved.steps.map((s) => s.role);
-      expect(roles).toEqual(['architect', 'engineer', 'qa']);
+      expect(roles).toEqual(['architect', 'implementer', 'tester']);
     });
 
     it('saves a role even for steps whose name would resolve to a different kind by regex', async () => {
@@ -145,7 +145,7 @@ describe('WorkflowPlanner', () => {
           steps: [
             {
               name: 'planner agent',
-              role: 'engineer',
+              role: 'implementer',
               promptPrefix: '',
               expectedOutput: '',
             },
@@ -165,7 +165,7 @@ describe('WorkflowPlanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /use this workflow/i }));
       await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
       const saved = mockSavePhaseTemplate.mock.calls[0]![0] as Workflow;
-      expect(saved.steps[0]!.role).toBe('engineer');
+      expect(saved.steps[0]!.role).toBe('implementer');
     });
 
     it('calls onWorkflowReady with the generated workflowId on save', async () => {
@@ -199,7 +199,7 @@ describe('WorkflowPlanner', () => {
         output: {
           workflowName: 'Second Plan',
           reasoning: '',
-          steps: [{ name: 'debugger', role: 'debugger', promptPrefix: '', expectedOutput: '' }],
+          steps: [{ name: 'debugger', role: 'investigator', promptPrefix: '', expectedOutput: '' }],
         },
       });
       render(
@@ -217,7 +217,31 @@ describe('WorkflowPlanner', () => {
       fireEvent.click(screen.getByRole('button', { name: /use this workflow/i }));
       await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
       const saved = mockSavePhaseTemplate.mock.calls[0]![0] as Workflow;
-      expect(saved.steps[0]!.role).toBe('debugger');
+      expect(saved.steps[0]!.role).toBe('investigator');
+    });
+
+    it('normalizes an out-of-vocab planner role to custom on save', async () => {
+      mockPlan.mockResolvedValue({
+        output: {
+          workflowName: 'Unknown Role',
+          reasoning: '',
+          steps: [{ name: 'misc', role: 'other', promptPrefix: '', expectedOutput: '' }],
+        },
+      });
+      render(
+        <WorkflowPlanner
+          workspaceId={'ws-7' as never}
+          providerId="anthropic"
+          initialProcess="unknown role"
+          onWorkflowReady={vi.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+      await waitFor(() => screen.getByText('Unknown Role'));
+      fireEvent.click(screen.getByRole('button', { name: /use this workflow/i }));
+      await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
+      const saved = mockSavePhaseTemplate.mock.calls[0]![0] as Workflow;
+      expect(saved.steps[0]!.role).toBe('custom');
     });
 
     it('shows a plan error and does not call savePhaseTemplate when planning fails', async () => {

--- a/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowPlanner/index.tsx
@@ -134,7 +134,7 @@ export const WorkflowPlanner = ({
           ordinal,
           name: s.name,
           promptPrefix: s.promptPrefix,
-          role: s.role as AgentRole,
+          role: (ROLE_TO_KIND[s.role as AgentRole] ? s.role as AgentRole : 'custom'),
           modelOverride: o.model,
           effort: o.effort as AgentEffort,
           verbosity: o.verbosity as VerbosityLevel,

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/StepEditor.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/StepEditor.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const StepEditor = ({ def, ordinal, connectedProviders, onUpdate, onClose }: Props) => {
-  const kind = ROLE_TO_KIND[def.role];
+  const kind = ROLE_TO_KIND[def.role] ?? 'generic';
   const effProvider: ProviderId =
     (def.providerOverride as ProviderId) || connectedProviders[0] || 'anthropic';
   const modelValue = def.modelOverride || getDefaultTurnModel(effProvider);

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/StepFlowCard.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/StepFlowCard.tsx
@@ -34,7 +34,7 @@ export const StepFlowCard = ({
   onMoveLeft,
   onMoveRight,
 }: Props) => {
-  const kind = ROLE_TO_KIND[def.role];
+  const kind = ROLE_TO_KIND[def.role] ?? 'generic';
   const effProvider: ProviderId =
     (def.providerOverride as ProviderId) || connectedProviders[0] || 'anthropic';
   const modelValue = def.modelOverride || getDefaultTurnModel(effProvider);


### PR DESCRIPTION
## summary

fixes crash caused by planner prompt allowing "other" agent role → stored verbatim via `as AgentRole` cast → undefined lookups in AGENT_KIND_PALETTE + AGENT_KIND_DEFAULTS.

root cause: PR #793 preserved workflow step role on model selection, but planner allows "other" role (not in ROLE_TO_KIND map) → crashes render sites.

## changes

- **WorkflowPlanner** (line 137): normalize unknown role → 'custom' at save (blocks new bad data)
- **StepFlowCard, StepEditor, LibraryCard**: add ?? 'generic' fallback (defensive for legacy data)

## notes

- retroactive migration for pre-existing role="other" data deferred (requires DB update)
- fallback literals currently inconsistent ('custom' vs 'generic'); pending unification
- PresetCard + StartWorkflowDialog still exposed to legacy data via StepRowCompact (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)