### PR TITLE
chore(repo): bump version to 0.1.11

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.10"
+version = "0.1.11"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Bump version 0.1.10 → 0.1.11 across all 5 version files (package.json, apps/desktop/package.json, tauri.conf.json, Cargo.toml, Cargo.lock).

Release prep for v0.1.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)