### PR TITLE
fix(desktop): unify ad-hoc & workflow cluster fan-out (hotfix 0.1.13)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.12"
+version = "0.1.13"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -41,7 +41,10 @@ vi.mock('../../../features/plans/plans', () => ({
   listPlansForSession: listPlansForSessionSpy,
 }));
 
-vi.mock('../workflows/clusterImplementation', () => ({ fanOutClusters: fanOutClustersSpy }));
+vi.mock('../workflows/clusterImplementation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../workflows/clusterImplementation')>();
+  return { ...actual, fanOutClusters: fanOutClustersSpy };
+});
 
 import { spawnAgent } from './spawnAgent';
 
@@ -166,10 +169,23 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
 
   it('fans out a plan with 2+ clusters even if status is not active', async () => {
     const { sendTurn, spawn } = buildHarness([
-      makePlan({ clusters: TWO_CLUSTERS, status: 'done' }),
+      makePlan({ clusters: TWO_CLUSTERS, status: 'superseded' }),
     ]);
 
     await spawn(SESSION_ID, { triggeredPlanId: PLAN_ID, kindOverride: 'implementer' });
+
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('fans out an earlier clustered plan when the latest-overall plan has no clusters', async () => {
+    const CLUSTERED_ID = 'plan-clustered' as PlanId;
+    const { sendTurn, spawn } = buildHarness([
+      makePlan({ id: CLUSTERED_ID, clusters: TWO_CLUSTERS }),
+      makePlan({ id: 'plan-latest' as PlanId, clusters: undefined, status: 'active' }),
+    ]);
+
+    await spawn(SESSION_ID, { kindOverride: 'implementer' });
 
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
     expect(sendTurn).not.toHaveBeenCalled();

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -163,4 +163,15 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
     expect(sendTurn).toHaveBeenCalledTimes(1);
   });
+
+  it('fans out a plan with 2+ clusters even if status is not active', async () => {
+    const { sendTurn, spawn } = buildHarness([
+      makePlan({ clusters: TWO_CLUSTERS, status: 'done' }),
+    ]);
+
+    await spawn(SESSION_ID, { triggeredPlanId: PLAN_ID, kindOverride: 'implementer' });
+
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -21,7 +21,7 @@ import {
   type AgentKind,
 } from '../../../features/session/agent-kind';
 import { buildPlanKickoffSection, composeKickoff } from '../../kickoff';
-import { fanOutClusters } from '../workflows/clusterImplementation';
+import { fanOutClusters, selectFanOutPlan } from '../workflows/clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
 type SpawnArgs = {
@@ -131,12 +131,13 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
     let planSection = '';
     let planToConsume: PlanWithCount | null = null;
     let planForKickoff: PlanWithCount | null = null;
+    let explicitPlan: PlanWithCount | null = null;
     if (engagePlan) {
       const { section: latestSection, plan: latestPlan } = await buildPlanKickoffSection(
         sessionId,
         args.workflowRunId,
       );
-      const explicitPlan =
+      explicitPlan =
         args.triggeredPlanId !== undefined
           ? (get().sessionPlans[sessionId]?.find((p) => p.id === args.triggeredPlanId) ?? null)
           : null;
@@ -148,13 +149,12 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
       planToConsume = explicitPlan ?? (workflowAutoConsume ? latestPlan : null);
     }
 
+    const fanOutPlan =
+      isImplementer && !args.deferKickoff
+        ? selectFanOutPlan(get, sessionId, { workflowRunId: args.workflowRunId, explicitPlan })
+        : null;
     const clusters =
-      isImplementer &&
-      !args.deferKickoff &&
-      planForKickoff?.clusters?.length &&
-      planForKickoff.clusters.length >= 2
-        ? planForKickoff.clusters
-        : undefined;
+      fanOutPlan?.clusters && fanOutPlan.clusters.length >= 2 ? fanOutPlan.clusters : undefined;
     if (clusters && clusters.length >= 2) {
       if (planToConsume) {
         await invokeAddPlanConsumption(planToConsume.id, inserted.id);
@@ -165,7 +165,7 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
           planConsumptions: { ...s.planConsumptions, [planToConsume.id]: consumptions },
         }));
       }
-      await fanOutClusters(set, get, sessionId, inserted, clusters, planForKickoff!.title);
+      await fanOutClusters(set, get, sessionId, inserted, clusters, fanOutPlan!.title);
       return inserted.id;
     }
 

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -149,7 +149,10 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
     }
 
     const clusters =
-      isImplementer && !args.deferKickoff && planForKickoff?.status === 'active'
+      isImplementer &&
+      !args.deferKickoff &&
+      planForKickoff?.clusters?.length &&
+      planForKickoff.clusters.length >= 2
         ? planForKickoff.clusters
         : undefined;
     if (clusters && clusters.length >= 2) {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -36,7 +36,10 @@ vi.mock('../../../features/plans/plans', () => ({
   listPlansForSession: listPlansForSessionSpy,
 }));
 
-vi.mock('./clusterImplementation', () => ({ fanOutClusters: fanOutClustersSpy }));
+vi.mock('./clusterImplementation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./clusterImplementation')>();
+  return { ...actual, fanOutClusters: fanOutClustersSpy };
+});
 
 import { activateWorkflowAgent } from './activateWorkflowAgent';
 
@@ -191,6 +194,24 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('fans out a 2+ cluster plan regardless of status (count-based, status-agnostic)', async () => {
+    const clusters: ReadonlyArray<ImplementationCluster> = [
+      { title: 'a', instructions: 'i1' },
+      { title: 'b', instructions: 'i2' },
+    ];
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('implementer', 'Implement'),
+      workflow: makeWorkflow('Implement'),
+      plans: [makePlan({ clusters, status: 'consumed' })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+    expect(sendTurn).not.toHaveBeenCalled();
   });
 
   it('does not consume an already-consumed plan', async () => {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -10,7 +10,7 @@ import {
   type AgentKind,
 } from '../../../features/session/agent-kind';
 import { buildGoalKickoffSection, buildPlanKickoffSection, composeKickoff } from '../../kickoff';
-import { fanOutClusters } from './clusterImplementation';
+import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
@@ -56,7 +56,6 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
         ? await buildPlanKickoffSection(sessionId, agent.workflowRunId)
         : { section: '', plan: null };
 
-    const planForKickoff = explicitPlan ?? latestPlan;
     const planSection = consumesPlan
       ? explicitPlan
         ? ['Active plan to execute:', '', explicitPlan.bodyMd].join('\n')
@@ -74,12 +73,17 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
       }));
     }
 
+    const fanOutPlan =
+      effectiveKind === 'implementer'
+        ? selectFanOutPlan(get, sessionId, {
+            workflowRunId: agent.workflowRunId,
+            explicitPlan,
+          })
+        : null;
     const clusters =
-      effectiveKind === 'implementer' && planForKickoff?.status === 'active'
-        ? planForKickoff.clusters
-        : undefined;
+      fanOutPlan?.clusters && fanOutPlan.clusters.length >= 2 ? fanOutPlan.clusters : undefined;
     if (clusters && clusters.length >= 2) {
-      await fanOutClusters(set, get, sessionId, agent, clusters, planForKickoff!.title);
+      await fanOutClusters(set, get, sessionId, agent, clusters, fanOutPlan!.title);
       return;
     }
 

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -3,6 +3,7 @@ import type {
   AgentId,
   ImplementationCluster,
   IsoDateTime,
+  PlanWithCount,
   SessionId,
   WorkflowRunId,
 } from '@goodboy/types';
@@ -135,18 +136,33 @@ function findClustersPlan(
   workflowRunId: WorkflowRunId | undefined,
 ) {
   const plans = get().sessionPlans[sessionId] ?? [];
+  const target = workflowRunId ?? undefined;
   for (let i = plans.length - 1; i >= 0; i--) {
     const p = plans[i];
     if (!p?.clusters || p.clusters.length < 2) {
       continue;
     }
-    if (p.workflowRunId !== workflowRunId) {
+    if ((p.workflowRunId ?? undefined) !== target) {
       continue;
     }
     return p;
   }
   return null;
 }
+
+export const selectFanOutPlan = (
+  get: GetFn,
+  sessionId: SessionId,
+  opts: {
+    readonly workflowRunId?: WorkflowRunId | undefined;
+    readonly explicitPlan?: PlanWithCount | null | undefined;
+  },
+): PlanWithCount | null => {
+  if (opts.explicitPlan?.clusters && opts.explicitPlan.clusters.length >= 2) {
+    return opts.explicitPlan;
+  }
+  return findClustersPlan(get, sessionId, opts.workflowRunId);
+};
 
 export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, childAgentId: AgentId, assistantText: string) => {

--- a/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
+++ b/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
@@ -152,10 +152,14 @@ vi.mock('../shared/lib/repo', () => ({ validateGitRepo: vi.fn() }));
 
 const fanOutClustersSpy = vi.fn(async () => undefined);
 
-vi.mock('./slices/workflows/clusterImplementation', () => ({
-  fanOutClusters: fanOutClustersSpy,
-  advanceClusterImplementation: () => async () => undefined,
-}));
+vi.mock('./slices/workflows/clusterImplementation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./slices/workflows/clusterImplementation')>();
+  return {
+    ...actual,
+    fanOutClusters: fanOutClustersSpy,
+    advanceClusterImplementation: () => async () => undefined,
+  };
+});
 
 type PlanBackingStore = {
   plans: PlanWithCount[];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- ad-hoc implementers with clustered plans failed to fan out when a later non-clustered plan shadowed the clustered one; parent ran the work solo
- spawn-time and advance-time now share `selectFanOutPlan`: count-based (>=2 clusters), status-agnostic, scoped by `workflowRunId`
- supersedes #804's count-only gate (commit 67c1e60d), which fixed workflows but left ad-hoc broken
- bump patch to 0.1.13 (hotfix)

## Root cause
spawn-time selected `planForKickoff` = latest plan overall + a divergent gate (count vs status), while advance-time selected the latest plan with >=2 clusters scoped by run. ad-hoc kickoff picked the latest plan even when it had no clusters, so fan-out never triggered.

## Test plan
- [x] `spawnAgent.test.ts`: keeps status!=active fan-out; adds shadowing case (latest plan no clusters, earlier plan has 2+) -> fanOut once, sendTurn not called
- [x] `activateWorkflowAgent.test.ts`: adds count-based/status-agnostic fan-out
- [x] `store.plan-consumption-ordering.test.ts`: green (fan-out fires after plan flips to consumed)
- [x] typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)