### PR TITLE
fix(desktop): eliminate unrelated permission prompts on startup

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1386,6 +1386,7 @@ dependencies = [
  "keyring",
  "libc",
  "log",
+ "objc2",
  "portable-pty",
  "regex",
  "reqwest 0.12.28",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -35,3 +35,6 @@ libc = "0.2"
 portable-pty = "0.8"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -28,8 +28,25 @@ pub use secrets::read as read_secret;
 
 use std::sync::Mutex;
 
+#[cfg(target_os = "macos")]
+fn suppress_webkit_media_remote() {
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    unsafe {
+        let defaults: *mut AnyObject = msg_send![class!(NSUserDefaults), standardUserDefaults];
+        let key: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: c"WebKitMediaRemoteEnabled".as_ptr()
+        ];
+        let no: i8 = 0;
+        let _: () = msg_send![defaults, setBool: no, forKey: key];
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "macos")]
+    suppress_webkit_media_remote();
   let database = db::open().expect("failed to open Goodboy database");
   let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
   let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -42,9 +42,16 @@ export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
   const exportConfig = useAppStore((s) => s.exportConfig);
   const importConfig = useAppStore((s) => s.importConfig);
   const wipeLocalDatabase = useAppStore((s) => s.wipeLocalDatabase);
+  const loadDetectedEditors = useAppStore((s) => s.loadDetectedEditors);
   const detectedEditors = useAppStore((s) => s.detectedEditors);
 
   const [editorBinary, setEditorBinary] = useState(DEFAULT_EDITOR_BINARY);
+
+  useEffect(() => {
+    if (detectedEditors.length === 0) {
+      void loadDetectedEditors();
+    }
+  }, []);
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [error, setError] = useState<string | null>(null);
   const [exportState, setExportState] = useState<'idle' | 'busy' | 'done' | 'error'>('idle');

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
@@ -8,6 +8,7 @@ const { state, toastMock } = vi.hoisted(() => ({
   state: {
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
     renameTask: vi.fn(async () => undefined),
+    loadDetectedEditors: vi.fn(async () => undefined),
     sessionExternalTasks: {} as Record<string, unknown>,
     detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
     sessionBranches: {} as Record<string, string | null>,

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -29,11 +29,18 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
     (s) => s.sessionExternalTasks?.[session.id as SessionId] ?? null,
   );
   const detectedEditors = useAppStore((s) => s.detectedEditors);
+  const loadDetectedEditors = useAppStore((s) => s.loadDetectedEditors);
   const { showToast } = useToast();
 
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState('');
   const [renameError, setRenameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (detectedEditors.length === 0) {
+      void loadDetectedEditors();
+    }
+  }, []);
 
   const launchEditor = async (binary: string) => {
     if (!worktreePath) {

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -64,15 +64,12 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         });
 
         set({ bootPhase: 'detecting-cli' });
-        const [providerStatus, cursorStatus, codexStatus, geminiStatus, detectedEditors] =
-          await Promise.all([
-            getProviderStatus('anthropic'),
-            getCursorStatus(),
-            getCodexStatus(),
-            getGeminiStatus(),
-            detectEditors(),
-          ]);
-        set({ detectedEditors });
+        const [providerStatus, cursorStatus, codexStatus, geminiStatus] = await Promise.all([
+          getProviderStatus('anthropic'),
+          getCursorStatus(),
+          getCodexStatus(),
+          getGeminiStatus(),
+        ]);
         const statuses: ProviderStatuses = {
           anthropic: providerStatus,
           cursor: cursorStatus,

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -13,7 +13,6 @@ import {
   type ProviderAuthResults,
   type ProviderStatuses,
 } from '../../../features/providers/providers';
-import { detectEditors } from '../../../shared/lib/editor';
 import { setWindowTitle, targetWorkspaceFromHash } from '../../../features/workspace/window';
 import {
   SETTING_EDITOR_BINARY,

--- a/apps/desktop/src/store/slices/boot/index.ts
+++ b/apps/desktop/src/store/slices/boot/index.ts
@@ -1,8 +1,10 @@
 import { hydrate } from './hydrate';
+import { loadDetectedEditors } from './loadDetectedEditors';
 import type { GetFn, SetFn } from './types';
 
 export const createBootSlice = (set: SetFn, get: GetFn) => {
   return {
     hydrate: hydrate(set, get),
+    loadDetectedEditors: loadDetectedEditors(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/boot/loadDetectedEditors.ts
+++ b/apps/desktop/src/store/slices/boot/loadDetectedEditors.ts
@@ -1,0 +1,13 @@
+import { detectEditors } from '../../../shared/lib/editor';
+import type { GetFn, SetFn } from './types';
+
+export const loadDetectedEditors = (set: SetFn, _get: GetFn) => {
+  return async (): Promise<void> => {
+    try {
+      const editors = await detectEditors();
+      set({ detectedEditors: editors });
+    } catch {
+      set({ detectedEditors: [] });
+    }
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -300,6 +300,7 @@ export type AppActions = {
   hydrate(): Promise<void>;
   checkForUpdates(): Promise<void>;
   installUpdate(): Promise<void>;
+  loadDetectedEditors(): Promise<void>;
   setCurrentWorkspace(id: WorkspaceId | null): Promise<void>;
   openWorkspace(id: WorkspaceId, title: string): Promise<void>;
   setWindowPresence(label: string, workspaceId: WorkspaceId | null): void;


### PR DESCRIPTION
## Summary
Suppress webkit media remote TCC prompt on startup and defer editor detection to avoid unnecessary system-resource access on first launch.

WKWebView (via wry) registers MediaRemote/Now Playing at startup, triggering a macOS TCC prompt regardless of app need. This fix writes `WebKitMediaRemoteEnabled=NO` to NSUserDefaults before WebKit initialization.

- Suppress webkit media remote TCC prompt via objc2 NSUserDefaults before WKWebView init
- Defer editor detection to on-demand (no longer called during bootstrap)
- Mock editor detection in SessionDetailPanel tests to prevent permission prompts in tests
- Remove unused imports from hydrate logic

## Test plan
- [x] Compile-verified clean
- [ ] Local TCC test: `tccutil reset MediaLibrary com.goodboy.desktop` → launch app → verify no prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)