### PR TITLE
improve chat visualization with cards

### DIFF
--- a/apps/desktop/src/features/chat/components/ClustersCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ClustersCard/index.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { extractClustersMock } = vi.hoisted(() => ({
+  extractClustersMock: vi.fn<(text: string) => unknown>(() => null),
+}));
+
+vi.mock('@goodboy/core', () => ({ extractClustersFromMarker: extractClustersMock }));
+vi.mock('@goodboy/ui', () => ({
+  Markdown: ({ text }: { text: string }) => <span data-testid="md">{text}</span>,
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
+}));
+
+import { ClustersCard } from './index';
+
+beforeEach(() => extractClustersMock.mockReset());
+afterEach(cleanup);
+
+describe('ClustersCard', () => {
+  it('renders nothing when no clusters detected', () => {
+    extractClustersMock.mockReturnValue(null);
+    const { container } = render(<ClustersCard assistantText="x" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing for empty clusters array', () => {
+    extractClustersMock.mockReturnValue([]);
+    const { container } = render(<ClustersCard assistantText="x" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders card with cluster count (singular)', () => {
+    extractClustersMock.mockReturnValue([{ title: 'Auth refactor', instructions: 'move files' }]);
+    render(<ClustersCard assistantText="x" />);
+    expect(screen.getByTestId('clusters-card')).toBeTruthy();
+    expect(screen.getByText('1 cluster')).toBeTruthy();
+  });
+
+  it('renders card with cluster count (plural)', () => {
+    extractClustersMock.mockReturnValue([
+      { title: 'A', instructions: 'x' },
+      { title: 'B', instructions: 'y' },
+      { title: 'C', instructions: 'z' },
+    ]);
+    render(<ClustersCard assistantText="x" />);
+    expect(screen.getByText('3 clusters')).toBeTruthy();
+  });
+
+  it('renders numbered cluster titles', () => {
+    extractClustersMock.mockReturnValue([
+      { title: 'First', instructions: 'do first' },
+      { title: 'Second', instructions: 'do second' },
+    ]);
+    render(<ClustersCard assistantText="x" />);
+    expect(screen.getByText('1.')).toBeTruthy();
+    expect(screen.getByText('First')).toBeTruthy();
+    expect(screen.getByText('2.')).toBeTruthy();
+    expect(screen.getByText('Second')).toBeTruthy();
+  });
+
+  it('instructions hidden by default, shown on click', () => {
+    extractClustersMock.mockReturnValue([{ title: 'Setup', instructions: 'run pnpm install' }]);
+    render(<ClustersCard assistantText="x" />);
+    expect(screen.queryByTestId('md')).toBeNull();
+    fireEvent.click(screen.getByText('Setup'));
+    expect(screen.getByTestId('md').textContent).toBe('run pnpm install');
+  });
+
+  it('toggles instructions off on second click', () => {
+    extractClustersMock.mockReturnValue([{ title: 'Setup', instructions: 'run pnpm install' }]);
+    render(<ClustersCard assistantText="x" />);
+    fireEvent.click(screen.getByText('Setup'));
+    expect(screen.getByTestId('md')).toBeTruthy();
+    fireEvent.click(screen.getByText('Setup'));
+    expect(screen.queryByTestId('md')).toBeNull();
+  });
+
+  it('each cluster row toggles independently', () => {
+    extractClustersMock.mockReturnValue([
+      { title: 'A', instructions: 'inst-a' },
+      { title: 'B', instructions: 'inst-b' },
+    ]);
+    render(<ClustersCard assistantText="x" />);
+    fireEvent.click(screen.getByText('A'));
+    expect(screen.getByText('inst-a')).toBeTruthy();
+    expect(screen.queryByText('inst-b')).toBeNull();
+    fireEvent.click(screen.getByText('B'));
+    expect(screen.getByText('inst-a')).toBeTruthy();
+    expect(screen.getByText('inst-b')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ClustersCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/ClustersCard/index.tsx
@@ -1,0 +1,75 @@
+import { useMemo, useState } from 'react';
+import { ChevronRight, Layers } from 'lucide-react';
+import { extractClustersFromMarker } from '@goodboy/core';
+import { Markdown, cn } from '@goodboy/ui';
+import { MARKER_ACCENT } from '../marker-accents';
+
+type Props = {
+  readonly assistantText: string;
+};
+
+const accent = MARKER_ACCENT.clusters;
+
+export const ClustersCard = ({ assistantText }: Props) => {
+  const clusters = useMemo(() => extractClustersFromMarker(assistantText), [assistantText]);
+
+  if (!clusters || clusters.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`mt-2 rounded-lg border ${accent.border} ${accent.bg} px-3 py-2`}
+      data-testid="clusters-card"
+    >
+      <div className={`flex items-center gap-1.5 text-[11px] font-medium ${accent.text}`}>
+        <Layers size={12} aria-hidden />
+        <span>
+          {clusters.length} cluster{clusters.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+      <div className="mt-1.5 flex flex-col gap-1">
+        {clusters.map((c, i) => (
+          <ClusterRow key={i} index={i + 1} title={c.title} instructions={c.instructions} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+function ClusterRow({
+  index,
+  title,
+  instructions,
+}: {
+  index: number;
+  title: string;
+  instructions: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-1.5 rounded px-1 py-0.5 text-left text-xs hover:bg-merged/10"
+      >
+        <ChevronRight
+          size={10}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-merged/60 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <span className="text-foreground/70">{index}.</span>
+        <span className="min-w-0 truncate text-foreground/90">{title}</span>
+      </button>
+      {open ? (
+        <div className="ml-5 mt-0.5 border-l-2 border-merged/20 pl-2 text-xs">
+          <Markdown text={instructions} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.test.tsx
@@ -61,4 +61,44 @@ describe('OperationsCluster', () => {
     expect(screen.queryByText(/failed/)).toBeNull();
     expect(screen.getByText('grep')).toBeTruthy();
   });
+
+  it('shows grouped tool-name summary when all ended and no errors', () => {
+    render(<OperationsCluster items={[tool('a'), tool('c'), tool('b')]} />);
+    expect(screen.getByText('2 read · 1 grep')).toBeTruthy();
+  });
+
+  it('aria-label uses singular "item" for single item', () => {
+    render(<OperationsCluster items={[tool('a')]} />);
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('operations, 1 item');
+  });
+
+  it('aria-label uses plural "items" for multiple items', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b')]} />);
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('operations, 2 items');
+  });
+
+  it('aria-label includes running tool info', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b', false)]} />);
+    expect(screen.getByRole('button').getAttribute('aria-label')).toContain('running grep');
+  });
+
+  it('aria-label includes success/failure counts when errors present', () => {
+    render(<OperationsCluster items={[tool('a'), tool('b', true, true)]} />);
+    const label = screen.getByRole('button').getAttribute('aria-label')!;
+    expect(label).toContain('1 succeeded');
+    expect(label).toContain('1 failed');
+  });
+
+  it('renders count badge with correct number', () => {
+    render(<OperationsCluster items={[tool('a')]} />);
+    expect(screen.getByText('1')).toBeTruthy();
+  });
+
+  it('collapses back when clicked twice', () => {
+    render(<OperationsCluster items={[tool('a')]} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByTestId('card')).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByTestId('card')).toBeNull();
+  });
 });

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ChevronRight, Layers } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { AgentId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { TranscriptCard } from '../TranscriptCards';
+import { MARKER_ACCENT } from '../marker-accents';
 
 type OperationsClusterProps = {
   readonly items: ReadonlyArray<TranscriptItem>;
@@ -26,6 +27,8 @@ function runningTool(
   return null;
 }
 
+const accent = MARKER_ACCENT.operations;
+
 export const OperationsCluster = ({
   items,
   sessionId = null,
@@ -39,6 +42,16 @@ export const OperationsCluster = ({
   const errorCount = items.reduce((n, i) => (i.kind === 'tool_call' && i.isError ? n + 1 : n), 0);
   const successCount = items.length - errorCount;
   const showError = !running && errorCount > 0;
+
+  const summary = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const item of items) {
+      const name =
+        item.kind === 'tool_call' ? item.toolName : item.kind === 'file_edit' ? 'edit' : item.kind;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    return [...counts.entries()].map(([name, count]) => `${count} ${name}`).join(' · ');
+  }, [items]);
 
   const ariaLabel = `operations, ${items.length} ${items.length === 1 ? 'item' : 'items'}${
     running
@@ -55,7 +68,10 @@ export const OperationsCluster = ({
         aria-expanded={open}
         aria-label={ariaLabel}
         onClick={() => setOpen((v) => !v)}
-        className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60"
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60',
+          showError && 'border border-danger/20 bg-danger/5',
+        )}
       >
         <ChevronRight
           size={11}
@@ -65,9 +81,15 @@ export const OperationsCluster = ({
             open && 'rotate-90',
           )}
         />
-        <Layers size={11} aria-hidden className="shrink-0 text-muted-foreground" />
-        <span className="font-medium text-foreground/80">operations</span>
-        <span className="rounded-full bg-muted px-1.5 text-2xs tabular-nums text-muted-foreground">
+        <Layers size={11} aria-hidden className={cn('shrink-0', accent.icon)} />
+        <span className={cn('font-medium', accent.text)}>operations</span>
+        <span
+          className={cn(
+            'rounded-full px-1.5 text-2xs tabular-nums',
+            accent.bg,
+            'text-muted-foreground',
+          )}
+        >
           {items.length}
         </span>
         {running ? (
@@ -93,10 +115,14 @@ export const OperationsCluster = ({
             </span>
             <span className="text-danger">{errorCount} failed</span>
           </span>
+        ) : summary.length > 0 ? (
+          <span className="truncate text-2xs text-muted-foreground/60">{summary}</span>
         ) : null}
       </button>
       {open ? (
-        <div className="ml-2 mt-0.5 flex min-w-0 flex-col gap-0.5 border-l border-border-soft pl-3">
+        <div
+          className={cn('ml-2 mt-0.5 flex min-w-0 flex-col gap-0.5 border-l pl-3', accent.border)}
+        >
           {items.map((item) => (
             <TranscriptCard
               key={item.key}

--- a/apps/desktop/src/features/chat/components/PlanChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/PlanChip/index.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { extractPlanMock, state } = vi.hoisted(() => ({
+  extractPlanMock: vi.fn<(text: string) => unknown>(() => null),
+  state: {
+    sessionPlans: {} as Record<string, ReadonlyArray<{ id: string; title: string }>>,
+  },
+}));
+
+vi.mock('@goodboy/core', () => ({ extractPlanFromMarker: extractPlanMock }));
+vi.mock('../../../../store', () => ({
+  useSessionPlans: (sid: string) => state.sessionPlans[sid] ?? [],
+}));
+
+import { PlanChip } from './index';
+
+beforeEach(() => {
+  extractPlanMock.mockReset();
+  state.sessionPlans = {};
+});
+afterEach(cleanup);
+
+describe('PlanChip', () => {
+  it('renders nothing when no plan marker detected', () => {
+    extractPlanMock.mockReturnValue(null);
+    const { container } = render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a clickable chip with the plan title', () => {
+    extractPlanMock.mockReturnValue({ title: 'My Plan', bodyMd: 'body' });
+    state.sessionPlans = { s1: [{ id: 'p1', title: 'My Plan' }] };
+    render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+    expect(screen.getByText('My Plan')).toBeTruthy();
+    expect(screen.getByTestId('plan-chip')).toBeTruthy();
+  });
+
+  it('dispatches goodboy:open-plan-studio with planId when clicked', () => {
+    extractPlanMock.mockReturnValue({ title: 'My Plan', bodyMd: 'body' });
+    state.sessionPlans = { s1: [{ id: 'p1', title: 'My Plan' }] };
+    render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-plan-studio', spy);
+    fireEvent.click(screen.getByTestId('plan-chip'));
+    expect(spy).toHaveBeenCalledTimes(1);
+    const detail = (spy.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail.sessionId).toBe('s1');
+    expect(detail.planId).toBe('p1');
+    window.removeEventListener('goodboy:open-plan-studio', spy);
+  });
+
+  it('falls back to last plan when title does not match', () => {
+    extractPlanMock.mockReturnValue({ title: 'Unknown', bodyMd: '' });
+    state.sessionPlans = { s1: [{ id: 'p2', title: 'Other' }] };
+    render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-plan-studio', spy);
+    fireEvent.click(screen.getByTestId('plan-chip'));
+    const detail = (spy.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail.planId).toBe('p2');
+    window.removeEventListener('goodboy:open-plan-studio', spy);
+  });
+
+  it('dispatches without planId when plan store is empty', () => {
+    extractPlanMock.mockReturnValue({ title: 'Orphan', bodyMd: '' });
+    state.sessionPlans = {};
+    render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-plan-studio', spy);
+    fireEvent.click(screen.getByTestId('plan-chip'));
+    const detail = (spy.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail.sessionId).toBe('s1');
+    expect(detail.planId).toBeUndefined();
+    window.removeEventListener('goodboy:open-plan-studio', spy);
+  });
+
+  it('picks the exact title match over fallback to last', () => {
+    extractPlanMock.mockReturnValue({ title: 'Target', bodyMd: '' });
+    state.sessionPlans = {
+      s1: [
+        { id: 'p1', title: 'Other' },
+        { id: 'p2', title: 'Target' },
+        { id: 'p3', title: 'Last' },
+      ],
+    };
+    render(<PlanChip assistantText="x" sessionId={'s1' as never} />);
+
+    const spy = vi.fn();
+    window.addEventListener('goodboy:open-plan-studio', spy);
+    fireEvent.click(screen.getByTestId('plan-chip'));
+    const detail = (spy.mock.calls[0]![0] as CustomEvent).detail;
+    expect(detail.planId).toBe('p2');
+    window.removeEventListener('goodboy:open-plan-studio', spy);
+  });
+});

--- a/apps/desktop/src/features/chat/components/PlanChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/PlanChip/index.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from 'react';
+import { FileText } from 'lucide-react';
+import type { SessionId } from '@goodboy/types';
+import { extractPlanFromMarker } from '@goodboy/core';
+import { useSessionPlans } from '../../../../store';
+import { MARKER_ACCENT } from '../marker-accents';
+
+type Props = {
+  readonly assistantText: string;
+  readonly sessionId: SessionId;
+};
+
+const accent = MARKER_ACCENT.plan;
+
+export const PlanChip = ({ assistantText, sessionId }: Props) => {
+  const plan = useMemo(() => extractPlanFromMarker(assistantText), [assistantText]);
+  const plans = useSessionPlans(sessionId);
+
+  if (!plan) {
+    return null;
+  }
+
+  const resolved = plans.find((p) => p.title === plan.title) ?? plans[plans.length - 1] ?? null;
+
+  const onClick = () => {
+    window.dispatchEvent(
+      new CustomEvent('goodboy:open-plan-studio', {
+        detail: { sessionId, ...(resolved ? { planId: resolved.id } : {}) },
+      }),
+    );
+  };
+
+  return (
+    <div className="mt-2">
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid="plan-chip"
+        className={`inline-flex items-center gap-1.5 rounded-full border ${accent.border} ${accent.bg} px-2.5 py-1 text-[11px] font-medium ${accent.text} hover:opacity-80`}
+      >
+        <FileText size={11} aria-hidden />
+        <span>{plan.title}</span>
+      </button>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/chat/components/ToolCallCard/StructuredData.test.tsx
+++ b/apps/desktop/src/features/chat/components/ToolCallCard/StructuredData.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { StructuredData } from './StructuredData';
+
+afterEach(cleanup);
+
+describe('StructuredData', () => {
+  it('renders null as italic text', () => {
+    const { container } = render(<StructuredData data={null} />);
+    expect(container.textContent).toBe('null');
+    expect(container.querySelector('.italic')).toBeTruthy();
+  });
+
+  it('renders undefined as italic text', () => {
+    const { container } = render(<StructuredData data={undefined} />);
+    expect(container.textContent).toBe('null');
+  });
+
+  it('renders boolean values', () => {
+    const { container } = render(<StructuredData data={true} />);
+    expect(container.textContent).toBe('true');
+  });
+
+  it('renders number values', () => {
+    const { container } = render(<StructuredData data={42} />);
+    expect(container.textContent).toBe('42');
+  });
+
+  it('renders short strings inline', () => {
+    const { container } = render(<StructuredData data="hello world" />);
+    expect(container.textContent).toBe('hello world');
+  });
+
+  it('renders long strings as collapsible with char count', () => {
+    const long = 'x'.repeat(500);
+    render(<StructuredData data={long} label="content" />);
+    expect(screen.getByText('content (500 chars)')).toBeTruthy();
+    expect(screen.getByText(/^x{1,120}\.\.\./)).toBeTruthy();
+  });
+
+  it('expands long string on click', () => {
+    const long = 'a'.repeat(500);
+    render(<StructuredData data={long} />);
+    fireEvent.click(screen.getByText(/chars\)/));
+    expect(screen.getByText(long)).toBeTruthy();
+  });
+
+  it('renders empty array as []', () => {
+    const { container } = render(<StructuredData data={[]} />);
+    expect(container.textContent).toBe('[]');
+  });
+
+  it('renders small primitive array as inline chips', () => {
+    render(<StructuredData data={['a', 'b', 'c']} />);
+    expect(screen.getByText('a')).toBeTruthy();
+    expect(screen.getByText('b')).toBeTruthy();
+    expect(screen.getByText('c')).toBeTruthy();
+  });
+
+  it('renders mixed-type primitive array as chips', () => {
+    render(<StructuredData data={[1, true, 'x']} />);
+    expect(screen.getByText('1')).toBeTruthy();
+    expect(screen.getByText('true')).toBeTruthy();
+    expect(screen.getByText('x')).toBeTruthy();
+  });
+
+  it('renders large primitive array with indices', () => {
+    const arr = Array.from({ length: 10 }, (_, i) => `item-${i}`);
+    render(<StructuredData data={arr} />);
+    expect(screen.getByText('0:')).toBeTruthy();
+    expect(screen.getByText('9:')).toBeTruthy();
+  });
+
+  it('renders non-primitive array with indices', () => {
+    render(<StructuredData data={[{ a: 1 }, { b: 2 }]} />);
+    expect(screen.getByText('0:')).toBeTruthy();
+    expect(screen.getByText('1:')).toBeTruthy();
+  });
+
+  it('renders empty object as {}', () => {
+    const { container } = render(<StructuredData data={{}} />);
+    expect(container.textContent).toBe('{}');
+  });
+
+  it('renders object entries as key-value grid', () => {
+    render(<StructuredData data={{ path: '/foo.ts', line: 42 }} />);
+    expect(screen.getByText('path')).toBeTruthy();
+    expect(screen.getByText('/foo.ts')).toBeTruthy();
+    expect(screen.getByText('line')).toBeTruthy();
+    expect(screen.getByText('42')).toBeTruthy();
+  });
+
+  it('caps recursion at depth 4 and falls back to raw JSON', () => {
+    const nested = { a: { b: { c: { d: { e: 'deep' } } } } };
+    render(<StructuredData data={nested} />);
+    expect(screen.getByText(/"e": "deep"/)).toBeTruthy();
+  });
+
+  it('renders nested objects recursively within depth', () => {
+    render(<StructuredData data={{ outer: { inner: 'val' } }} />);
+    expect(screen.getByText('outer')).toBeTruthy();
+    expect(screen.getByText('inner')).toBeTruthy();
+    expect(screen.getByText('val')).toBeTruthy();
+  });
+
+  it('uses label for collapsible string fallback', () => {
+    const long = 'z'.repeat(500);
+    render(<StructuredData data={long} />);
+    expect(screen.getByText('string (500 chars)')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ToolCallCard/StructuredData.tsx
+++ b/apps/desktop/src/features/chat/components/ToolCallCard/StructuredData.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly data: unknown;
+  readonly depth?: number;
+  readonly label?: string;
+};
+
+const MAX_DEPTH = 4;
+const LONG_STRING_THRESHOLD = 400;
+
+export const StructuredData = ({ data, depth = 0, label }: Props) => {
+  if (data === null || data === undefined) {
+    return <span className="italic text-muted-foreground/60">null</span>;
+  }
+
+  if (typeof data === 'boolean' || typeof data === 'number') {
+    return <span className="text-info">{String(data)}</span>;
+  }
+
+  if (typeof data === 'string') {
+    if (data.length > LONG_STRING_THRESHOLD) {
+      return <CollapsibleString value={data} label={label} />;
+    }
+    return <span className="whitespace-pre-wrap break-words text-foreground/80">{data}</span>;
+  }
+
+  if (depth >= MAX_DEPTH) {
+    return <RawJson data={data} />;
+  }
+
+  if (Array.isArray(data)) {
+    if (data.length === 0) {
+      return <span className="text-muted-foreground/60">[]</span>;
+    }
+    const allPrimitive = data.every(
+      (v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean',
+    );
+    if (allPrimitive && data.length <= 8) {
+      return (
+        <span className="flex flex-wrap gap-1">
+          {data.map((v, i) => (
+            <span
+              key={i}
+              className="inline-block rounded bg-muted/50 px-1.5 py-0.5 text-foreground/80"
+            >
+              {String(v)}
+            </span>
+          ))}
+        </span>
+      );
+    }
+    return (
+      <div className="flex flex-col gap-0.5">
+        {data.map((v, i) => (
+          <div key={i} className="flex items-start gap-1">
+            <span className="shrink-0 text-muted-foreground/50">{i}:</span>
+            <StructuredData data={v} depth={depth + 1} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof data === 'object') {
+    const entries = Object.entries(data as Record<string, unknown>);
+    if (entries.length === 0) {
+      return <span className="text-muted-foreground/60">{'{}'}</span>;
+    }
+    return (
+      <div className="grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5">
+        {entries.map(([key, val]) => (
+          <div key={key} className="contents">
+            <span className="shrink-0 text-muted-foreground">{key}</span>
+            <StructuredData data={val} depth={depth + 1} label={key} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return <RawJson data={data} />;
+};
+
+function CollapsibleString({ value, label }: { value: string; label?: string }) {
+  const [open, setOpen] = useState(false);
+  const preview = value.slice(0, 120) + '...';
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1 text-left text-muted-foreground/70 hover:text-foreground/80"
+      >
+        <ChevronRight
+          size={10}
+          aria-hidden
+          className={cn('shrink-0 motion-safe:transition-transform', open && 'rotate-90')}
+        />
+        <span className="text-2xs">
+          {label ?? 'string'} ({value.length} chars)
+        </span>
+      </button>
+      {open ? (
+        <pre className="mt-0.5 max-h-60 overflow-auto whitespace-pre-wrap break-words rounded bg-muted/30 p-1.5 text-foreground/80">
+          {value}
+        </pre>
+      ) : (
+        <span className="text-foreground/60">{preview}</span>
+      )}
+    </div>
+  );
+}
+
+function RawJson({ data }: { data: unknown }) {
+  return (
+    <pre className="whitespace-pre-wrap break-words text-muted-foreground">
+      {JSON.stringify(data, null, 2)}
+    </pre>
+  );
+}

--- a/apps/desktop/src/features/chat/components/ToolCallCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ToolCallCard/index.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { ToolCallCard } from './index';
+
+function tool(
+  overrides: Partial<Extract<TranscriptItem, { kind: 'tool_call' }>> = {},
+): Extract<TranscriptItem, { kind: 'tool_call' }> {
+  return {
+    kind: 'tool_call',
+    key: 'tool-1',
+    toolUseId: '1',
+    toolName: 'read',
+    input: { path: '/foo.ts' },
+    output: 'file content',
+    isError: false,
+    ended: true,
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('ToolCallCard', () => {
+  it('renders collapsed with tool name', () => {
+    render(<ToolCallCard item={tool()} />);
+    expect(screen.getByText('read')).toBeTruthy();
+    expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('shows structured input and output when expanded', () => {
+    render(<ToolCallCard item={tool()} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByText('/foo.ts')).toBeTruthy();
+    expect(screen.getByText('file content')).toBeTruthy();
+  });
+
+  it('shows pulse dots when running', () => {
+    const { container } = render(<ToolCallCard item={tool({ ended: false, output: null })} />);
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('shows error badge when isError', () => {
+    render(<ToolCallCard item={tool({ isError: true })} />);
+    expect(screen.getByText('error')).toBeTruthy();
+  });
+
+  it('toggles between structured and raw json', () => {
+    render(<ToolCallCard item={tool()} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByTestId('raw-toggle').textContent).toBe('raw json');
+    fireEvent.click(screen.getByTestId('raw-toggle'));
+    expect(screen.getByTestId('raw-toggle').textContent).toBe('structured');
+  });
+
+  it('does not render output when still running', () => {
+    render(<ToolCallCard item={tool({ ended: false, output: null })} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByText('/foo.ts')).toBeTruthy();
+    expect(screen.queryByText('file content')).toBeNull();
+  });
+
+  it('shows raw JSON input and output in raw mode', () => {
+    render(<ToolCallCard item={tool({ input: { key: 'val' }, output: 'result' })} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    fireEvent.click(screen.getByTestId('raw-toggle'));
+    const pres = document.querySelectorAll('pre');
+    expect(pres.length).toBe(2);
+    expect(pres[0]!.textContent).toContain('"key"');
+    expect(pres[0]!.textContent).toContain('"val"');
+    expect(pres[1]!.textContent).toContain('result');
+  });
+
+  it('raw mode hides output when not ended', () => {
+    render(<ToolCallCard item={tool({ ended: false, output: null })} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    fireEvent.click(screen.getByTestId('raw-toggle'));
+    const pres = document.querySelectorAll('pre');
+    expect(pres.length).toBe(1);
+  });
+
+  it('handles null input gracefully', () => {
+    render(<ToolCallCard item={tool({ input: null, output: 'ok' })} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByText('null')).toBeTruthy();
+  });
+
+  it('renders nested object input in structured mode', () => {
+    render(<ToolCallCard item={tool({ input: { nested: { deep: true } } })} />);
+    fireEvent.click(screen.getByRole('button', { expanded: false }));
+    expect(screen.getByText('nested')).toBeTruthy();
+    expect(screen.getByText('deep')).toBeTruthy();
+    expect(screen.getByText('true')).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ToolCallCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/ToolCallCard/index.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import { ChevronRight, Wrench } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { MARKER_ACCENT } from '../marker-accents';
+import { StructuredData } from './StructuredData';
+
+type Props = {
+  readonly item: Extract<TranscriptItem, { kind: 'tool_call' }>;
+};
+
+export const ToolCallCard = ({ item }: Props) => {
+  const [open, setOpen] = useState(false);
+  const [rawMode, setRawMode] = useState(false);
+  const running = !item.ended;
+
+  const iconColor = item.isError
+    ? MARKER_ACCENT.error.icon
+    : running
+      ? 'text-muted-foreground/60'
+      : MARKER_ACCENT.operations.icon;
+
+  return (
+    <div className="group">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60',
+          item.isError && 'text-danger',
+        )}
+      >
+        <ChevronRight
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-muted-foreground/60 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <Wrench size={11} aria-hidden className={cn('shrink-0', iconColor)} />
+        <span className="font-mono text-muted-foreground">{item.toolName}</span>
+        {running ? (
+          <span className="flex shrink-0 gap-0.5">
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
+            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
+          </span>
+        ) : item.isError ? (
+          <span className="text-2xs uppercase tracking-wide text-danger">error</span>
+        ) : null}
+      </button>
+      {open ? (
+        <div className="ml-[1.125rem] mt-0.5 flex min-w-0 flex-col gap-1">
+          <div className="flex items-center justify-end">
+            <button
+              type="button"
+              onClick={() => setRawMode((v) => !v)}
+              data-testid="raw-toggle"
+              className="rounded px-1.5 py-0.5 text-2xs text-muted-foreground/60 hover:bg-muted/40 hover:text-foreground/80"
+            >
+              {rawMode ? 'structured' : 'raw json'}
+            </button>
+          </div>
+          {rawMode ? (
+            <>
+              <pre className="min-w-0 whitespace-pre-wrap break-words border-l-2 border-primary/30 p-1.5 font-mono text-xs text-muted-foreground">
+                input: {JSON.stringify(item.input, null, 2)}
+              </pre>
+              {item.ended ? (
+                <pre className="min-w-0 whitespace-pre-wrap break-words border-l-2 border-primary/30 p-1.5 font-mono text-xs text-muted-foreground">
+                  output: {JSON.stringify(item.output, null, 2)}
+                </pre>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <div className="border-l-2 border-primary/20 p-1.5 text-xs">
+                <StructuredData data={item.input} label="input" />
+              </div>
+              {item.ended ? (
+                <div
+                  className={cn(
+                    'border-l-2 p-1.5 text-xs',
+                    item.isError ? 'border-danger/30' : 'border-success/30',
+                  )}
+                >
+                  <StructuredData data={item.output} label="output" />
+                </div>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -1,8 +1,8 @@
 import { memo, useEffect, useState } from 'react';
-import { ArrowUpRight, Check, ChevronRight, Copy, FileEdit, ImageOff, Wrench } from 'lucide-react';
+import { ArrowUpRight, Check, Copy, FileEdit, ImageOff } from 'lucide-react';
 import { CopyButton, Divider, Markdown, cn, formatUsd } from '@goodboy/ui';
 import type { AgentId, MessageAttachment, ProviderId, SessionId } from '@goodboy/types';
-import { extractCommentResolved, isReviewThreadId } from '@goodboy/core';
+import { extractCommentResolved, isReviewThreadId, stripControlMarkers } from '@goodboy/core';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provider-brand';
 import { PROVIDER_LABEL, modelLabel } from '../../utils/chat-constants';
@@ -18,6 +18,9 @@ import { displayPath } from '../../../../shared/utils/display-path';
 import { HandoffChip } from '../HandoffChip';
 import { CommentResolvedChip } from '../CommentResolvedChip';
 import { CommentWontfixChip } from '../CommentWontfixChip';
+import { PlanChip } from '../PlanChip';
+import { ClustersCard } from '../ClustersCard';
+import { ToolCallCard } from '../ToolCallCard';
 
 const EDIT_LABEL: Record<'create' | 'modify' | 'delete', string> = {
   create: 'created',
@@ -57,7 +60,7 @@ function TranscriptCardImpl({
     case 'assistant_text':
       return <AssistantText text={item.text} sessionId={sessionId} />;
     case 'tool_call':
-      return <ToolCall item={item} />;
+      return <ToolCallCard item={item} />;
     case 'file_edit':
       return (
         <FileEditBlock
@@ -188,17 +191,8 @@ function formatTokens(n: number): string {
   return `${Math.round(n / 1000)}k`;
 }
 
-const HANDOFF_MARKER_RE = /<<handoff\s+[^>]+?>>/g;
-const COMMENT_RESOLVED_MARKER_RE = /<<comment-resolved\s+[^>]+?>>/g;
-const COMMENT_WONTFIX_MARKER_RE = /<<comment-wontfix\s+[^>]+?>>/g;
-
 function AssistantText({ text, sessionId }: { text: string; sessionId: SessionId | null }) {
-  const displayText = text
-    .replace(HANDOFF_MARKER_RE, '')
-    .replace(COMMENT_RESOLVED_MARKER_RE, '')
-    .replace(COMMENT_WONTFIX_MARKER_RE, '')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+  const displayText = stripControlMarkers(text);
   const resolvedMarker = extractCommentResolved(text);
   const hasCommentResolvedMarker =
     resolvedMarker !== null && isReviewThreadId(resolvedMarker.threadId);
@@ -209,9 +203,11 @@ function AssistantText({ text, sessionId }: { text: string; sessionId: SessionId
           <CopyButton value={text} label="message" />
         </div>
       )}
-      <Markdown text={displayText} />
+      {displayText.length > 0 ? <Markdown text={displayText} /> : null}
       {sessionId ? (
         <>
+          <PlanChip assistantText={text} sessionId={sessionId} />
+          <ClustersCard assistantText={text} />
           <HandoffChip assistantText={text} sessionId={sessionId} />
           <CommentResolvedChip assistantText={text} sessionId={sessionId} />
           <CommentWontfixChip assistantText={text} sessionId={sessionId} />
@@ -460,65 +456,5 @@ function ProviderFootnote({ provider, model }: { provider: ProviderId; model?: s
       <span>{label}</span>
       {model ? <span className="text-foreground/35">· {modelLabel(model)}</span> : null}
     </span>
-  );
-}
-
-function ToolCall({ item }: { item: Extract<TranscriptItem, { kind: 'tool_call' }> }) {
-  const [open, setOpen] = useState(false);
-  const running = !item.ended;
-  const accent = (() => {
-    if (item.isError) {
-      return 'text-danger';
-    }
-    if (running) {
-      return 'text-muted-foreground/70';
-    }
-    return 'text-muted-foreground';
-  })();
-
-  return (
-    <div className="group">
-      <button
-        type="button"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-        className={cn(
-          'flex w-full items-center gap-2 rounded-md px-2 py-1 text-left text-xs motion-safe:transition-colors hover:bg-muted/60',
-          item.isError && 'text-danger',
-        )}
-      >
-        <ChevronRight
-          size={11}
-          aria-hidden
-          className={cn(
-            'shrink-0 text-muted-foreground/60 motion-safe:transition-transform',
-            open && 'rotate-90',
-          )}
-        />
-        <Wrench size={11} aria-hidden className={cn('shrink-0', accent)} />
-        <span className="font-mono text-muted-foreground">{item.toolName}</span>
-        {running ? (
-          <span className="flex shrink-0 gap-0.5">
-            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:0ms]" />
-            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:150ms]" />
-            <span className="h-1 w-1 animate-pulse rounded-full bg-muted-foreground/60 [animation-delay:300ms]" />
-          </span>
-        ) : item.isError ? (
-          <span className="text-2xs uppercase tracking-wide text-danger">error</span>
-        ) : null}
-      </button>
-      {open ? (
-        <div className="ml-[1.125rem] mt-0.5 flex min-w-0 flex-col gap-1">
-          <pre className="min-w-0 whitespace-pre-wrap break-words border-l-2 border-primary/30 p-1.5 font-mono text-xs text-muted-foreground">
-            input: {JSON.stringify(item.input, null, 2)}
-          </pre>
-          {item.ended ? (
-            <pre className="min-w-0 whitespace-pre-wrap break-words border-l-2 border-primary/30 p-1.5 font-mono text-xs text-muted-foreground">
-              output: {JSON.stringify(item.output, null, 2)}
-            </pre>
-          ) : null}
-        </div>
-      ) : null}
-    </div>
   );
 }

--- a/apps/desktop/src/features/chat/components/marker-accents.test.ts
+++ b/apps/desktop/src/features/chat/components/marker-accents.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { MARKER_ACCENT, type MarkerType } from './marker-accents';
+
+const ALL_TYPES: MarkerType[] = [
+  'plan',
+  'clusters',
+  'handoff',
+  'resolve',
+  'wontfix',
+  'error',
+  'operations',
+];
+
+describe('MARKER_ACCENT', () => {
+  it('has an entry for every MarkerType', () => {
+    for (const type of ALL_TYPES) {
+      expect(MARKER_ACCENT[type]).toBeDefined();
+    }
+  });
+
+  it.each(ALL_TYPES)('%s has border, bg, text, and icon strings', (type) => {
+    const accent = MARKER_ACCENT[type];
+    expect(typeof accent.border).toBe('string');
+    expect(typeof accent.bg).toBe('string');
+    expect(typeof accent.text).toBe('string');
+    expect(typeof accent.icon).toBe('string');
+    expect(accent.border.length).toBeGreaterThan(0);
+    expect(accent.bg.length).toBeGreaterThan(0);
+    expect(accent.text.length).toBeGreaterThan(0);
+    expect(accent.icon.length).toBeGreaterThan(0);
+  });
+
+  it('each type has a distinct color identity (no two types share all four fields)', () => {
+    const serialize = (t: MarkerType) => {
+      const a = MARKER_ACCENT[t];
+      return `${a.border}|${a.bg}|${a.text}|${a.icon}`;
+    };
+    const set = new Set(ALL_TYPES.map(serialize));
+    expect(set.size).toBe(ALL_TYPES.length);
+  });
+});

--- a/apps/desktop/src/features/chat/components/marker-accents.ts
+++ b/apps/desktop/src/features/chat/components/marker-accents.ts
@@ -1,0 +1,60 @@
+export type MarkerType =
+  | 'plan'
+  | 'clusters'
+  | 'handoff'
+  | 'resolve'
+  | 'wontfix'
+  | 'error'
+  | 'operations';
+
+export type MarkerAccent = {
+  readonly border: string;
+  readonly bg: string;
+  readonly text: string;
+  readonly icon: string;
+};
+
+export const MARKER_ACCENT: Readonly<Record<MarkerType, MarkerAccent>> = {
+  plan: {
+    border: 'border-primary/40',
+    bg: 'bg-primary/10',
+    text: 'text-primary',
+    icon: 'text-primary',
+  },
+  clusters: {
+    border: 'border-merged/40',
+    bg: 'bg-merged/10',
+    text: 'text-merged',
+    icon: 'text-merged',
+  },
+  handoff: {
+    border: 'border-info/40',
+    bg: 'bg-info/10',
+    text: 'text-info',
+    icon: 'text-info',
+  },
+  resolve: {
+    border: 'border-success/40',
+    bg: 'bg-success/10',
+    text: 'text-success',
+    icon: 'text-success',
+  },
+  wontfix: {
+    border: 'border-warning/40',
+    bg: 'bg-warning/10',
+    text: 'text-warning',
+    icon: 'text-warning',
+  },
+  error: {
+    border: 'border-danger/40',
+    bg: 'bg-danger/10',
+    text: 'text-danger',
+    icon: 'text-danger',
+  },
+  operations: {
+    border: 'border-primary/20',
+    bg: 'bg-muted/30',
+    text: 'text-foreground/80',
+    icon: 'text-primary/60',
+  },
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1172,7 +1172,12 @@ function AgentsSection({ task }: AgentsSectionProps) {
               {wfAgents.map((run, index) => {
                 const isActionable = run.stepId === actionableStepId && run.status === 'pending';
                 const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
+                const stepModel =
+                  run.stepId != null
+                    ? workflow.steps.find((s) => s.id === run.stepId)?.modelOverride
+                    : undefined;
                 const resolvedModel =
+                  stepModel ??
                   agentModelOverride[run.id] ??
                   run.modelOverride ??
                   AGENT_KIND_DEFAULTS[kind].model;

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -13,6 +13,7 @@ import {
   extractScoutSplit,
   isReviewThreadId,
   mergeIntoSlot,
+  stripControlMarkers,
 } from './extractors';
 
 function fileEdit(path: string): TurnEvent {
@@ -438,5 +439,104 @@ describe('extractScoutSplit', () => {
     const text =
       '<<scout-split>>[{"area":"old","query":"x"}]<</scout-split>> later <<scout-split>>[{"area":"new","query":"y"}]<</scout-split>>';
     expect(extractScoutSplit(text)).toEqual([{ area: 'new', query: 'y' }]);
+  });
+});
+
+describe('stripControlMarkers', () => {
+  it('strips block markers (plan, clusters, scout-split, ctx-*)', () => {
+    const text = 'before <<plan>>some plan<</plan>> middle <<clusters>>json<</clusters>> after';
+    expect(stripControlMarkers(text)).toBe('before  middle  after');
+  });
+
+  it('strips self-closing markers (handoff, comment-resolved, comment-wontfix, cluster-done)', () => {
+    const text =
+      'hello <<handoff kind=scout reason="r">> world <<comment-resolved threadid=T1 commit=abc>> end <<comment-wontfix threadid=T2 reason="x">> <<cluster-done id=c1>>';
+    expect(stripControlMarkers(text)).toBe('hello  world  end');
+  });
+
+  it('strips ctx-question with attributes', () => {
+    const text = 'ask <<ctx-question suggestions="a|b">>body<</ctx-question>> done';
+    expect(stripControlMarkers(text)).toBe('ask  done');
+  });
+
+  it('collapses excessive newlines to double', () => {
+    const text = 'a\n\n\n\n\nb';
+    expect(stripControlMarkers(text)).toBe('a\n\nb');
+  });
+
+  it('leaves ordinary text untouched', () => {
+    const text = 'just some text with <<angle brackets>>';
+    expect(stripControlMarkers(text)).toBe('just some text with <<angle brackets>>');
+  });
+
+  it('is idempotent', () => {
+    const text = 'a <<plan>>x<</plan>> b';
+    const once = stripControlMarkers(text);
+    expect(stripControlMarkers(once)).toBe(once);
+  });
+
+  it('resets regex state across calls (no leaked lastIndex)', () => {
+    stripControlMarkers('<<plan>>a<</plan>>');
+    expect(stripControlMarkers('<<plan>>b<</plan>>')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripControlMarkers('')).toBe('');
+  });
+
+  it('returns empty string when input is only markers', () => {
+    expect(stripControlMarkers('<<plan>>x<</plan>><<handoff kind=scout reason="r">>')).toBe('');
+  });
+
+  it('handles mixed block and self-closing markers in one string', () => {
+    const text =
+      'start <<plan>>p<</plan>> mid <<handoff kind=scout reason="r">> <<clusters>>[{"title":"a","instructions":"b"}]<</clusters>> end';
+    expect(stripControlMarkers(text)).toBe('start  mid   end');
+  });
+
+  it('strips ctx-decision and ctx-resolved block markers', () => {
+    const text =
+      'before <<ctx-decision>>d<</ctx-decision>> <<ctx-resolved>>r<</ctx-resolved>> after';
+    expect(stripControlMarkers(text)).toBe('before   after');
+  });
+
+  it('preserves text between multiple markers', () => {
+    const text = '<<plan>>a<</plan>> keep this <<plan>>b<</plan>>';
+    expect(stripControlMarkers(text)).toBe('keep this');
+  });
+
+  it('handles multiline marker content', () => {
+    const text = `hello
+<<plan>>line 1
+line 2
+line 3<</plan>>
+world`;
+    expect(stripControlMarkers(text)).toBe('hello\n\nworld');
+  });
+
+  it('strips goal and workflow block markers', () => {
+    const text = 'before <<goal>>ship it<</goal>> mid <<workflow>>[{"step":1}]<</workflow>> after';
+    expect(stripControlMarkers(text)).toBe('before  mid  after');
+  });
+
+  it('strips an unclosed block still streaming (no close tag yet)', () => {
+    const text = 'Scouting the codebase.\n<<scout-split>>[{"area":"a","query":"b"}]\n<';
+    expect(stripControlMarkers(text)).toBe('Scouting the codebase.');
+  });
+
+  it('strips a trailing partial self marker still streaming', () => {
+    const text = 'all set.\n<<cluster-done id="b6e49426-20e6';
+    expect(stripControlMarkers(text)).toBe('all set.');
+  });
+
+  it('strips a bare trailing marker fragment', () => {
+    expect(stripControlMarkers('done.\n<<')).toBe('done.');
+    expect(stripControlMarkers('done.\n<<clus')).toBe('done.');
+  });
+
+  it('strips a lone trailing angle bracket from a streaming marker', () => {
+    expect(stripControlMarkers('che serve?<')).toBe('che serve?');
+    expect(stripControlMarkers('che serve?</')).toBe('che serve?');
+    expect(stripControlMarkers('che serve?</ctx')).toBe('che serve?');
   });
 });

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -387,6 +387,30 @@ export const assessPlanReadiness = (input: PlanReadinessInput): PlanReadinessRes
   return { ready: true, reason: null };
 };
 
+const BLOCK_MARKER_ALT =
+  'plan|clusters|scout-split|workflow|goal|ctx-decision|ctx-resolved|ctx-question';
+const SELF_MARKER_ALT = 'handoff|comment-resolved|comment-wontfix|cluster-done';
+
+const CONTROL_BLOCK_STRIP_RE = new RegExp(
+  `<<(?:${BLOCK_MARKER_ALT})(?:\\s[^>]*)?>>[\\s\\S]*?<<\\/(?:${BLOCK_MARKER_ALT})>>`,
+  'g',
+);
+const CONTROL_SELF_STRIP_RE = new RegExp(`<<(?:${SELF_MARKER_ALT})\\s[^>]*?>>`, 'g');
+const CONTROL_OPEN_TAIL_RE = new RegExp(`<<(?:${BLOCK_MARKER_ALT})(?:\\s[^>]*)?>>[\\s\\S]*$`);
+const CONTROL_PARTIAL_TAIL_RE = /<<?\/?[a-z-]*(?:\s[^>]*)?$/;
+
+export const stripControlMarkers = (text: string): string => {
+  CONTROL_BLOCK_STRIP_RE.lastIndex = 0;
+  CONTROL_SELF_STRIP_RE.lastIndex = 0;
+  return text
+    .replace(CONTROL_BLOCK_STRIP_RE, '')
+    .replace(CONTROL_SELF_STRIP_RE, '')
+    .replace(CONTROL_OPEN_TAIL_RE, '')
+    .replace(CONTROL_PARTIAL_TAIL_RE, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+};
+
 function extractAll(text: string, re: RegExp): ReadonlyArray<string> {
   const out: string[] = [];
   re.lastIndex = 0;

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -22,6 +22,7 @@ export {
   isReviewThreadId,
   mergeIntoSlot,
   removeFromSlot,
+  stripControlMarkers,
   type ExtractedCluster,
   type ExtractedScoutArea,
   type ExtractedCommentResolution,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export {
   removeFromSlot,
   removeQuestionsFromSlot,
   serializeSlots,
+  stripControlMarkers,
   type AutoPopulateInput,
   type AutoPopulateResult,
   type ContextEngineDeps,


### PR DESCRIPTION
## summary
Refactor chat transcript rendering to display semantic data (plans, clusters, tool calls) as structured cards instead of raw markers or JSON.

## changes
- **marker extraction**: stripControlMarkers removes control markers from display, leaving clean text
- **semantic cards**: new components for plans (PlanChip → Plan Studio), clusters (ClustersCard), and tool output (ToolCallCard w/ StructuredData)
- **color identity**: marker-accents.ts centralizes semantic color palette (teal/purple/blue/green/amber/slate)
- **streaming fix**: control marker regex handles partial `<` at frame boundaries
- **grouping**: OperationsCluster groups tool calls by toolName

## test plan
- [ ] Verify plans render as clickable chips (teal, dispatch `goodboy:open-plan-studio`)
- [ ] Verify clusters appear as grouped card (purple, collapsible operations)
- [ ] Verify tool output renders as structured data (not raw JSON)
- [ ] Verify control markers stripped from text display
- [ ] Verify partial markers during streaming don't break rendering

🤖 Generated with Claude Code