### PR TITLE
persist workflow drafts across session switches

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { Session, Workflow } from '@goodboy/types';
+import type { WorkflowBuilderDraft } from '../../../../store/slices/workflowDrafts/types';
 
 const { mockSavePhaseTemplate, mockAttach, mockPlan, mockPolish, toastMock, storeState } =
   vi.hoisted(() => ({
@@ -14,21 +15,36 @@ const { mockSavePhaseTemplate, mockAttach, mockPlan, mockPolish, toastMock, stor
     storeState: {
       phaseTemplates: {} as Record<string, ReadonlyArray<Workflow>>,
       sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+      workflowDrafts: {} as Record<string, WorkflowBuilderDraft | undefined>,
     },
   }));
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => undefined) }));
 
-vi.mock('../../../../store', () => ({
-  EMPTY_ARRAY: Object.freeze([]),
-  useAppStore: <T,>(selector: (s: never) => T) =>
-    selector({
-      savePhaseTemplate: mockSavePhaseTemplate,
-      attachWorkflowToSession: mockAttach,
-      phaseTemplates: storeState.phaseTemplates,
-      sessionPhaseRuns: storeState.sessionPhaseRuns,
-    } as never),
-}));
+vi.mock('../../../../store', () => {
+  const setWorkflowDraft = (sessionId: string, draft: WorkflowBuilderDraft) => {
+    storeState.workflowDrafts = { ...storeState.workflowDrafts, [sessionId]: draft };
+  };
+  const clearWorkflowDraft = (sessionId: string) => {
+    const next = { ...storeState.workflowDrafts };
+    delete next[sessionId];
+    storeState.workflowDrafts = next;
+  };
+  const getState = () => ({
+    savePhaseTemplate: mockSavePhaseTemplate,
+    attachWorkflowToSession: mockAttach,
+    phaseTemplates: storeState.phaseTemplates,
+    sessionPhaseRuns: storeState.sessionPhaseRuns,
+    workflowDrafts: storeState.workflowDrafts,
+    setWorkflowDraft,
+    clearWorkflowDraft,
+  });
+  const useAppStore = Object.assign(
+    <T,>(selector: (s: never) => T) => selector(getState() as never),
+    { getState },
+  );
+  return { EMPTY_ARRAY: Object.freeze([]), useAppStore };
+});
 
 vi.mock('../../../../app/components/Toast', () => ({
   useToast: () => ({ showToast: toastMock }),
@@ -110,6 +126,7 @@ afterEach(() => {
   vi.clearAllMocks();
   storeState.phaseTemplates = {};
   storeState.sessionPhaseRuns = {};
+  storeState.workflowDrafts = {};
 });
 
 const goalField = () =>
@@ -341,5 +358,59 @@ describe('WorkflowBuilderView (goal affordances)', () => {
     );
     expect(goalField().value).toBe('rough goal');
     expect(screen.queryByRole('button', { name: /undo goal change/i })).toBeNull();
+  });
+});
+
+describe('WorkflowBuilderView (draft persistence)', () => {
+  it('rehydrates the draft after unmount and remount for the same session', () => {
+    const { unmount } = render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    fireEvent.change(goalField(), { target: { value: 'persist me' } });
+    expect(storeState.workflowDrafts['sess-1']?.goalText).toBe('persist me');
+    unmount();
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    expect(goalField().value).toBe('persist me');
+  });
+
+  it('keeps drafts isolated per session', () => {
+    const { unmount } = render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    fireEvent.change(goalField(), { target: { value: 'session one draft' } });
+    unmount();
+    const otherSession = { ...session, id: 'sess-2' } as Session;
+    render(<WorkflowBuilderView session={otherSession} onClose={vi.fn()} />);
+    expect(goalField().value).toBe('');
+    expect(storeState.workflowDrafts['sess-2']).toBeUndefined();
+  });
+
+  it('reset draft wipes local state and the stored draft', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    fireEvent.change(goalField(), { target: { value: 'throwaway' } });
+    expect(storeState.workflowDrafts['sess-1']).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /reset workflow draft/i }));
+    expect(goalField().value).toBe('');
+    expect(storeState.workflowDrafts['sess-1']).toBeUndefined();
+  });
+
+  it('hides the reset button while the draft is empty', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /reset workflow draft/i })).toBeNull();
+    fireEvent.change(goalField(), { target: { value: 'now dirty' } });
+    expect(screen.getByRole('button', { name: /reset workflow draft/i })).toBeDefined();
+  });
+
+  it('clears the draft after attaching a workflow', async () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    await draftPlan();
+    expect(storeState.workflowDrafts['sess-1']).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /start workflow/i }));
+    await waitFor(() => expect(mockAttach).toHaveBeenCalled());
+    await waitFor(() => expect(storeState.workflowDrafts['sess-1']).toBeUndefined());
+  });
+
+  it('clears the draft when cancelled', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    fireEvent.change(goalField(), { target: { value: 'discard me' } });
+    expect(storeState.workflowDrafts['sess-1']).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(storeState.workflowDrafts['sess-1']).toBeUndefined();
   });
 });

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -9,6 +9,7 @@ import {
   ListChecks,
   Loader2,
   Play,
+  RotateCcw,
   Sparkles,
   Target,
   Undo2,
@@ -39,6 +40,11 @@ import type {
   WorkflowTriggerMode,
 } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import type {
+  Mode,
+  StepEdit,
+  WorkflowBuilderDraft,
+} from '../../../../store/slices/workflowDrafts/types';
 import {
   AGENT_KIND_PALETTE,
   ROLE_LABEL,
@@ -64,8 +70,6 @@ type Props = {
   readonly onClose: () => void;
 };
 
-type Mode = 'preset' | 'custom';
-
 const planStepKind = (step: PlannerOutput['steps'][number]): AgentKind =>
   ROLE_TO_KIND[step.role as AgentRole] ?? inferAgentKindFromName(step.name);
 
@@ -74,14 +78,6 @@ const templateStepKind = (step: Workflow['steps'][number]): AgentKind =>
 
 const sortedSteps = (template: Workflow): Workflow['steps'] =>
   [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-
-type StepEdit = {
-  readonly name?: string;
-  readonly promptPrefix?: string;
-  readonly model?: string;
-  readonly effort?: EffortLevel;
-  readonly dirty?: boolean;
-};
 
 const pruneToDirty = (edits: Record<number, StepEdit>): Record<number, StepEdit> => {
   const kept: Record<number, StepEdit> = {};
@@ -93,6 +89,16 @@ const pruneToDirty = (edits: Record<number, StepEdit>): Record<number, StepEdit>
   return kept;
 };
 
+const isDraftEmpty = (d: WorkflowBuilderDraft): boolean =>
+  d.goalText.trim() === '' &&
+  d.goalHistory.length === 0 &&
+  d.selectedPresetId === null &&
+  d.processText.trim() === '' &&
+  d.plan === null &&
+  Object.keys(d.stepEdits).length === 0 &&
+  !d.saveAsPreset &&
+  !d.autoRun;
+
 export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const savePhaseTemplate = useAppStore((s) => s.savePhaseTemplate);
   const attachWorkflowToSession = useAppStore((s) => s.attachWorkflowToSession);
@@ -102,21 +108,33 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const sessionPhaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns?.[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<never>),
   );
+  const setWorkflowDraft = useAppStore((s) => s.setWorkflowDraft);
+  const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const { showToast } = useToast();
 
   const presets = phaseTemplates.filter((t) => t.isPreset !== false && !t.deletedAt);
 
-  const [mode, setMode] = useState<Mode>(presets.length > 0 ? 'preset' : 'custom');
-  const [goalText, setGoalText] = useState('');
-  const [goalHistory, setGoalHistory] = useState<ReadonlyArray<string>>([]);
+  const [initialDraft] = useState(() => useAppStore.getState().workflowDrafts[session.id]);
+
+  const [mode, setMode] = useState<Mode>(
+    initialDraft?.mode ?? (presets.length > 0 ? 'preset' : 'custom'),
+  );
+  const [goalText, setGoalText] = useState(initialDraft?.goalText ?? '');
+  const [goalHistory, setGoalHistory] = useState<ReadonlyArray<string>>(
+    initialDraft?.goalHistory ?? [],
+  );
   const [polishing, setPolishing] = useState(false);
-  const [selectedPresetId, setSelectedPresetId] = useState<WorkflowId | null>(null);
-  const [processText, setProcessText] = useState('');
-  const [plan, setPlan] = useState<PlannerOutput | null>(null);
-  const [stepEdits, setStepEdits] = useState<Record<number, StepEdit>>({});
+  const [selectedPresetId, setSelectedPresetId] = useState<WorkflowId | null>(
+    initialDraft?.selectedPresetId ?? null,
+  );
+  const [processText, setProcessText] = useState(initialDraft?.processText ?? '');
+  const [plan, setPlan] = useState<PlannerOutput | null>(initialDraft?.plan ?? null);
+  const [stepEdits, setStepEdits] = useState<Record<number, StepEdit>>(
+    initialDraft?.stepEdits ?? {},
+  );
   const [planning, setPlanning] = useState(false);
-  const [saveAsPreset, setSaveAsPreset] = useState(false);
-  const [autoRun, setAutoRun] = useState(false);
+  const [saveAsPreset, setSaveAsPreset] = useState(initialDraft?.saveAsPreset ?? false);
+  const [autoRun, setAutoRun] = useState(initialDraft?.autoRun ?? false);
   const [triggerMode, setTriggerMode] = useState<WorkflowTriggerMode>('immediate');
   const [chainAfterId, setChainAfterId] = useState<WorkflowRunId | null>(null);
   const [busy, setBusy] = useState(false);
@@ -149,6 +167,58 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     }
   }, [activeRuns.length, triggerMode]);
 
+  const draft: WorkflowBuilderDraft = {
+    mode,
+    goalText,
+    goalHistory,
+    selectedPresetId,
+    processText,
+    plan,
+    stepEdits,
+    saveAsPreset,
+    autoRun,
+  };
+  const draftEmpty = isDraftEmpty(draft);
+
+  useEffect(() => {
+    if (draftEmpty) {
+      clearWorkflowDraft(session.id);
+    } else {
+      setWorkflowDraft(session.id, draft);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    session.id,
+    mode,
+    goalText,
+    goalHistory,
+    selectedPresetId,
+    processText,
+    plan,
+    stepEdits,
+    saveAsPreset,
+    autoRun,
+  ]);
+
+  const resetDraft = () => {
+    setMode(presets.length > 0 ? 'preset' : 'custom');
+    setGoalText('');
+    setGoalHistory([]);
+    setSelectedPresetId(null);
+    setProcessText('');
+    setPlan(null);
+    setStepEdits({});
+    setSaveAsPreset(false);
+    setAutoRun(false);
+    setError(null);
+    clearWorkflowDraft(session.id);
+  };
+
+  const handleClose = () => {
+    clearWorkflowDraft(session.id);
+    onClose();
+  };
+
   const providerId: ProviderId = session.providerPreference.defaultProvider;
   const blocked = busy || planning;
 
@@ -169,12 +239,13 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && !blocked) {
         e.preventDefault();
-        onClose();
+        handleClose();
       }
     };
     window.addEventListener('keydown', onKey, { capture: true });
     return () => window.removeEventListener('keydown', onKey, { capture: true });
-  }, [blocked, onClose]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [blocked]);
 
   const replaceGoal = (next: string) => {
     setGoalHistory((h) => [...h, goalText]);
@@ -237,7 +308,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     try {
       await attachWorkflowToSession(session.id, selectedPreset.id, attachOptions());
       showToast('success', `workflow started: ${selectedPreset.name}`);
-      onClose();
+      handleClose();
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -322,7 +393,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       await savePhaseTemplate(workflow);
       await attachWorkflowToSession(session.id, workflowId, attachOptions());
       showToast('success', `workflow started: ${plan.workflowName}`);
-      onClose();
+      handleClose();
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -344,9 +415,24 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
           <span className="truncate text-2xs text-muted-foreground">for: {session.goal}</span>
         </div>
         <div className="flex-1" />
+        {!draftEmpty ? (
+          <button
+            type="button"
+            onClick={resetDraft}
+            disabled={blocked}
+            className={cn(
+              'inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5 text-xs font-semibold text-muted-foreground transition-colors',
+              'hover:border-border hover:bg-muted/50 hover:text-foreground',
+              blocked && 'cursor-not-allowed opacity-50',
+            )}
+            aria-label="reset workflow draft"
+          >
+            <RotateCcw size={13} aria-hidden /> Reset draft
+          </button>
+        ) : null}
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           disabled={blocked}
           className={cn(
             'inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5 text-xs font-semibold text-muted-foreground transition-colors',
@@ -778,7 +864,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
           disabled={busy}
         />
         <span className="h-5 w-px bg-border-soft" aria-hidden />
-        <Button variant="ghost" onClick={onClose} disabled={busy}>
+        <Button variant="ghost" onClick={handleClose} disabled={busy}>
           Cancel
         </Button>
         <Button onClick={() => void onStart()} disabled={startDisabled}>

--- a/apps/desktop/src/store/slices/agents/index.test.ts
+++ b/apps/desktop/src/store/slices/agents/index.test.ts
@@ -497,6 +497,7 @@ describe('store contract', () => {
         agentModelOverride: {},
         agentKindOverride: {},
         agentDraft: {},
+        workflowDrafts: {},
         diffComments: {},
         notifications: [],
         sessionPlans: {},

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -40,12 +40,15 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
       for (const agent of state.sessionPhaseRuns[sessionId] ?? []) {
         delete nextTranscripts[agent.id];
       }
+      const nextWorkflowDrafts = { ...state.workflowDrafts };
+      delete nextWorkflowDrafts[sessionId];
       return {
         sessions: state.sessions.filter((s) => s.id !== sessionId),
         currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
         sessionWorktrees: nextWorktrees,
         sessionBranches: nextBranches,
         transcripts: nextTranscripts,
+        workflowDrafts: nextWorkflowDrafts,
       };
     });
     void get().emitNotification(

--- a/apps/desktop/src/store/slices/workflowDrafts/clearWorkflowDraft.ts
+++ b/apps/desktop/src/store/slices/workflowDrafts/clearWorkflowDraft.ts
@@ -1,0 +1,15 @@
+import type { SessionId } from '@goodboy/types';
+import type { SetFn } from './types';
+
+export const clearWorkflowDraft = (set: SetFn) => {
+  return (sessionId: SessionId) => {
+    set((s) => {
+      if (!(sessionId in s.workflowDrafts)) {
+        return s;
+      }
+      const next = { ...s.workflowDrafts };
+      delete next[sessionId];
+      return { workflowDrafts: next };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/workflowDrafts/index.test.ts
+++ b/apps/desktop/src/store/slices/workflowDrafts/index.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest';
+import { createStore } from 'zustand';
+import type { SessionId } from '@goodboy/types';
+import { createWorkflowDraftsSlice } from './index';
+import type { SetFn, GetFn, WorkflowBuilderDraft } from './types';
+
+const SESSION_ID = 'session-1' as SessionId;
+const SESSION_ID_2 = 'session-2' as SessionId;
+
+type TestState = {
+  workflowDrafts: Record<string, WorkflowBuilderDraft | undefined>;
+  setWorkflowDraft: (sessionId: SessionId, draft: WorkflowBuilderDraft) => void;
+  clearWorkflowDraft: (sessionId: SessionId) => void;
+};
+
+const buildDraft = (overrides: Partial<WorkflowBuilderDraft> = {}): WorkflowBuilderDraft => ({
+  mode: 'custom',
+  goalText: 'ship it',
+  goalHistory: [],
+  selectedPresetId: null,
+  processText: '',
+  plan: null,
+  stepEdits: {},
+  saveAsPreset: false,
+  autoRun: false,
+  ...overrides,
+});
+
+const makeStore = () =>
+  createStore<TestState>((set, get) => ({
+    workflowDrafts: {},
+    ...createWorkflowDraftsSlice(set as SetFn, get as GetFn),
+  }));
+
+describe('workflowDrafts slice', () => {
+  it('setWorkflowDraft stores the draft per session', () => {
+    const store = makeStore();
+    const draft = buildDraft({ goalText: 'wip' });
+    store.getState().setWorkflowDraft(SESSION_ID, draft);
+    expect(store.getState().workflowDrafts[SESSION_ID]).toEqual(draft);
+  });
+
+  it('clearWorkflowDraft removes the per-session entry', () => {
+    const store = makeStore();
+    store.getState().setWorkflowDraft(SESSION_ID, buildDraft());
+    store.getState().clearWorkflowDraft(SESSION_ID);
+    expect(store.getState().workflowDrafts[SESSION_ID]).toBeUndefined();
+  });
+
+  it('keeps drafts isolated between sessions', () => {
+    const store = makeStore();
+    const draftA = buildDraft({ goalText: 'a' });
+    const draftB = buildDraft({ goalText: 'b' });
+    store.getState().setWorkflowDraft(SESSION_ID, draftA);
+    store.getState().setWorkflowDraft(SESSION_ID_2, draftB);
+    store.getState().clearWorkflowDraft(SESSION_ID);
+    expect(store.getState().workflowDrafts[SESSION_ID]).toBeUndefined();
+    expect(store.getState().workflowDrafts[SESSION_ID_2]).toEqual(draftB);
+  });
+
+  it('clearWorkflowDraft is a no-op when the key is absent', () => {
+    const store = makeStore();
+    const before = store.getState().workflowDrafts;
+    store.getState().clearWorkflowDraft(SESSION_ID);
+    expect(store.getState().workflowDrafts).toBe(before);
+  });
+});

--- a/apps/desktop/src/store/slices/workflowDrafts/index.ts
+++ b/apps/desktop/src/store/slices/workflowDrafts/index.ts
@@ -1,0 +1,10 @@
+import { clearWorkflowDraft } from './clearWorkflowDraft';
+import { setWorkflowDraft } from './setWorkflowDraft';
+import type { GetFn, SetFn } from './types';
+
+export const createWorkflowDraftsSlice = (set: SetFn, _get: GetFn) => {
+  return {
+    setWorkflowDraft: setWorkflowDraft(set),
+    clearWorkflowDraft: clearWorkflowDraft(set),
+  };
+};

--- a/apps/desktop/src/store/slices/workflowDrafts/setWorkflowDraft.ts
+++ b/apps/desktop/src/store/slices/workflowDrafts/setWorkflowDraft.ts
@@ -1,0 +1,8 @@
+import type { SessionId } from '@goodboy/types';
+import type { SetFn, WorkflowBuilderDraft } from './types';
+
+export const setWorkflowDraft = (set: SetFn) => {
+  return (sessionId: SessionId, draft: WorkflowBuilderDraft) => {
+    set((s) => ({ workflowDrafts: { ...s.workflowDrafts, [sessionId]: draft } }));
+  };
+};

--- a/apps/desktop/src/store/slices/workflowDrafts/types.ts
+++ b/apps/desktop/src/store/slices/workflowDrafts/types.ts
@@ -1,0 +1,27 @@
+import type { WorkflowId } from '@goodboy/types';
+import type { PlannerOutput } from '@goodboy/core';
+import type { EffortLevel } from '../../../features/chat/utils/chat-constants';
+
+export type { SetFn, GetFn } from '../../slice-types';
+
+export type Mode = 'preset' | 'custom';
+
+export type StepEdit = {
+  readonly name?: string;
+  readonly promptPrefix?: string;
+  readonly model?: string;
+  readonly effort?: EffortLevel;
+  readonly dirty?: boolean;
+};
+
+export type WorkflowBuilderDraft = {
+  readonly mode: Mode;
+  readonly goalText: string;
+  readonly goalHistory: ReadonlyArray<string>;
+  readonly selectedPresetId: WorkflowId | null;
+  readonly processText: string;
+  readonly plan: PlannerOutput | null;
+  readonly stepEdits: Record<number, StepEdit>;
+  readonly saveAsPreset: boolean;
+  readonly autoRun: boolean;
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -108,6 +108,8 @@ import {
 } from './slices/providers';
 import { createAgentsSlice } from './slices/agents';
 import type { DraftAttachment } from './slices/agents/setAgentAttachments';
+import { createWorkflowDraftsSlice } from './slices/workflowDrafts';
+import type { WorkflowBuilderDraft } from './slices/workflowDrafts/types';
 import { createSlotsSlice } from './slices/slots';
 import { createOverridesSlice } from './slices/overrides';
 import { createCredentialsSlice } from './slices/credentials';
@@ -247,6 +249,7 @@ export type AppState = UpdaterState & {
   readonly pendingResolverKickoff: Readonly<Record<AgentId, string>>;
   readonly resolverState: Readonly<Record<AgentId, 'awaiting' | 'committed' | 'wontfix'>>;
   readonly agentDraft: Readonly<Record<AgentId, string>>;
+  readonly workflowDrafts: Readonly<Record<SessionId, WorkflowBuilderDraft | undefined>>;
   readonly agentAttachments: Readonly<Record<AgentId, ReadonlyArray<DraftAttachment>>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
   readonly notifications: ReadonlyArray<Notification>;
@@ -469,6 +472,8 @@ export type AppActions = {
   setAgentEffortOverride(agentId: AgentId, effort: string): void;
   setAgentDraft(agentId: AgentId, value: string): void;
   clearAgentDraft(agentId: AgentId): void;
+  setWorkflowDraft(sessionId: SessionId, draft: WorkflowBuilderDraft): void;
+  clearWorkflowDraft(sessionId: SessionId): void;
   setAgentAttachments(agentId: AgentId, attachments: ReadonlyArray<DraftAttachment>): void;
   clearAgentAttachments(agentId: AgentId): void;
   deleteAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
@@ -698,6 +703,7 @@ export const initialState: AppState = {
   pendingResolverKickoff: {},
   resolverState: {},
   agentDraft: {},
+  workflowDrafts: {},
   agentAttachments: {},
   diffComments: {},
   notifications: [],
@@ -732,6 +738,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createPermissionsSlice(set, get),
   ...createProvidersSlice(set, get),
   ...createAgentsSlice(set, get),
+  ...createWorkflowDraftsSlice(set, get),
   ...createSlotsSlice(set, get),
   ...createOverridesSlice(set, get),
   ...createCredentialsSlice(set, get),


### PR DESCRIPTION
## Summary

Preserves workflow creation state (goals, process, plan, step edits, presets, autorun) when users switch sessions, allowing them to resume mid-creation without losing work.

## Implementation

- **workflowDrafts slice**: session-scoped Zustand store (new: `apps/desktop/src/store/slices/workflowDrafts/`)
- **Hydration**: WorkflowBuilderView lazily initializes from draft on mount via `useAppStore.getState()`
- **Mirror effect**: smart save—writes non-empty draft, clears when empty (preserves `mode` separately)
- **Cleanup**: explicit triggers on Cancel/Esc/attach-success; preserved across session switch (no onClose cleanup)
- **Reset button**: visible only when draft non-empty, clears both draft and local state

## Testing

- 23 tests passing (new + updated)
- TypeScript clean
- Verified: hydration, mirroring, cleanup, session switch preservation

## Related

Resolves goal: Workflow persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)