### PR TITLE
fix(desktop): align session deletion with archive semantics

### DIFF
--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -7,7 +7,11 @@ import type { GetFn, SetFn } from './types';
 
 export const deleteTask = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId) => {
-    const session = get().sessions.find((s) => s.id === sessionId);
+    const session =
+      get().sessions.find((s) => s.id === sessionId) ??
+      Object.values(get().archivedSessions)
+        .flat()
+        .find((s) => s.id === sessionId);
     if (!session) {
       throw new Error(`session not found: ${sessionId}`);
     }
@@ -32,22 +36,55 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
     const sessionWorkspaceId = session.workspaceId;
     await deleteSessionFromDb(tauriDatabase, sessionId);
     set((state) => {
+      const phaseRuns = state.sessionPhaseRuns[sessionId] ?? [];
+      const nextTranscripts = { ...state.transcripts };
+      const nextMessages = { ...state.messages };
+      for (const agent of phaseRuns) {
+        delete nextTranscripts[agent.id];
+        delete nextMessages[agent.id];
+      }
       const nextWorktrees = { ...state.sessionWorktrees };
       delete nextWorktrees[sessionId];
       const nextBranches = { ...state.sessionBranches };
       delete nextBranches[sessionId];
-      const nextTranscripts = { ...state.transcripts };
-      for (const agent of state.sessionPhaseRuns[sessionId] ?? []) {
-        delete nextTranscripts[agent.id];
-      }
+      const nextPhaseRuns = { ...state.sessionPhaseRuns };
+      delete nextPhaseRuns[sessionId];
+      const nextGithub = { ...state.sessionGithub };
+      delete nextGithub[sessionId];
+      const nextLoading = { ...state.sessionLoading };
+      delete nextLoading[sessionId];
+      const nextSelected = { ...state.selectedAgentId };
+      delete nextSelected[sessionId];
+      const nextConflicts = { ...state.sessionMergeConflicts };
+      delete nextConflicts[sessionId];
+      const nextOpenQs = { ...state.sessionOpenQuestions };
+      delete nextOpenQs[sessionId];
+      const nextWorkflows = { ...state.sessionWorkflows };
+      delete nextWorkflows[sessionId];
       const nextWorkflowDrafts = { ...state.workflowDrafts };
       delete nextWorkflowDrafts[sessionId];
+      const cachedArchived = state.archivedSessions[sessionWorkspaceId];
+      const nextArchived = cachedArchived
+        ? {
+            ...state.archivedSessions,
+            [sessionWorkspaceId]: cachedArchived.filter((s) => s.id !== sessionId),
+          }
+        : state.archivedSessions;
       return {
         sessions: state.sessions.filter((s) => s.id !== sessionId),
+        archivedSessions: nextArchived,
         currentSessionId: state.currentSessionId === sessionId ? null : state.currentSessionId,
+        transcripts: nextTranscripts,
+        messages: nextMessages,
         sessionWorktrees: nextWorktrees,
         sessionBranches: nextBranches,
-        transcripts: nextTranscripts,
+        sessionPhaseRuns: nextPhaseRuns,
+        sessionGithub: nextGithub,
+        sessionLoading: nextLoading,
+        selectedAgentId: nextSelected,
+        sessionMergeConflicts: nextConflicts,
+        sessionOpenQuestions: nextOpenQs,
+        sessionWorkflows: nextWorkflows,
         workflowDrafts: nextWorkflowDrafts,
       };
     });

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -604,6 +604,24 @@ describe('store contract', () => {
       expect(s.sessions.find((x) => x.id === SESSION_ID)).toBeDefined();
       expect(s.archivedSessions[WS_ID]).toEqual([]);
     });
+
+    it('deleteTask removes an archived session from the archived cache', async () => {
+      const store = await getStore();
+      const archived: Session = {
+        ...buildSession(),
+        archivedAt: NOW,
+      } as Session;
+      store.setState({
+        workspaces: [buildWorkspace()],
+        currentWorkspaceId: WS_ID,
+        currentSessionId: SESSION_ID,
+        archivedSessions: { [WS_ID]: [archived] },
+      });
+      await store.getState().deleteTask(SESSION_ID);
+      const s = store.getState();
+      expect(s.archivedSessions[WS_ID]).toEqual([]);
+      expect(s.currentSessionId).toBeNull();
+    });
   });
 
   describe('config', () => {


### PR DESCRIPTION
## Summary

- deleteTask was only searching active sessions, missing archived ones that currentSessionId could resolve to → throws "session not found"
- Aligned in-memory cleanup with archiveTask: messages, phaseRuns, github, loading, selectedAgentId, conflicts, openQuestions, workflows
- Clear archived session from cache on delete

## Test plan

- [x] existing session delete tests pass
- [x] new test: delete archived session removes it from cache