### PR TITLE
chore(repo): bump version to 0.1.14

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.13"
+version = "0.1.14"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version `0.1.13` → `0.1.14` across all four manifests (+ `Cargo.lock`): root `package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml`.
- Cuts release **v0.1.14**. Tag pushed after merge triggers the universal `.dmg` build + draft GitHub Release (`release.yml`).

## Ships since v0.1.13
- feat(desktop): unified diff surface, inline questions, scripts panel (#811)
- fix(desktop): align session deletion with archive semantics (#812)

## Release steps (post-merge, per docs/release.md)
- [ ] (optional) rc dry-run tag to validate signing/notarization
- [ ] tag `v0.1.14` on merged main → build draft release
- [ ] write notes, publish draft → fires Homebrew cask bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)