### PR TITLE
fix(desktop): give sidebar quick-actions row bottom padding

### DIFF
--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -358,7 +358,7 @@ function QuickActionsRow({
     (s) => !s.providers.some((p) => p.connection === 'connected'),
   );
   return (
-    <div className="flex shrink-0 items-center gap-1 px-2.5 pt-2">
+    <div className="flex shrink-0 items-center gap-1 px-2.5 py-2">
       {skillsEnabled ? (
         <QuickAction
           icon={<Sparkles size={12} className="text-warning" aria-hidden />}


### PR DESCRIPTION
## Summary
- Sidebar quick-actions row (Workflows / Providers / GitHub) sat flush against the window's bottom edge. Changed `pt-2` → `py-2` so the bottom matches the existing top padding.

## Notes
- Ships in v0.1.14. Cosmetic only, no changelog entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)