### PR TITLE
feat(desktop): batch cluster answers for same-turn open questions

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { OpenQuestion } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    answerOpenQuestions: vi.fn(async () => undefined),
+    dismissOpenQuestion: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+import { OpenQuestionCluster } from './OpenQuestionCluster';
+import { useOpenQuestions } from '../../../context/components/QuestionsTab/useOpenQuestions';
+
+const makeQuestion = (
+  overrides: { id: string; text: string } & Partial<Record<keyof OpenQuestion, unknown>>,
+): OpenQuestion =>
+  ({
+    sessionId: 'sess-1',
+    suggestedAnswers: [],
+    userAnswer: null,
+    status: 'open',
+    createdByAgentId: 'agent-1',
+    turnOrdinal: 1,
+    createdAt: '2026-06-13T00:00:00.000Z',
+    ...overrides,
+  }) as unknown as OpenQuestion;
+
+const dbQuestion = makeQuestion({
+  id: 'oq-1',
+  text: 'Use Postgres or SQLite?',
+  suggestedAnswers: ['Postgres', 'SQLite'],
+});
+
+const cacheQuestion = makeQuestion({
+  id: 'oq-2',
+  text: 'Redis or Memcached?',
+  suggestedAnswers: ['Redis', 'Memcached'],
+});
+
+beforeEach(() => {
+  state.answerOpenQuestions.mockClear();
+  state.dismissOpenQuestion.mockClear();
+  useOpenQuestions.setState({ drafts: {}, justAnswered: [], pendingUndo: null });
+});
+afterEach(cleanup);
+
+describe('OpenQuestionCluster', () => {
+  it('batches every drafted answer in the cluster into a single submit', async () => {
+    render(
+      <OpenQuestionCluster questions={[dbQuestion, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    fireEvent.click(screen.getByText('Postgres'));
+    fireEvent.click(screen.getByText('Redis'));
+
+    const submit = await screen.findByText('send 2 answers');
+    fireEvent.click(submit);
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledTimes(1);
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
+      'sess-1',
+      [
+        { id: 'oq-1', text: 'Use Postgres or SQLite?', answer: 'Postgres' },
+        { id: 'oq-2', text: 'Redis or Memcached?', answer: 'Redis' },
+      ],
+      'agent-1',
+    );
+  });
+
+  it('renders no submit button until at least one answer is drafted', () => {
+    render(
+      <OpenQuestionCluster questions={[dbQuestion, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    expect(screen.queryByText('send answer')).toBeNull();
+    expect(screen.queryByText(/send \d+ answers/)).toBeNull();
+  });
+
+  it('uses the singular label and a single-element batch for one drafted question', async () => {
+    render(<OpenQuestionCluster questions={[dbQuestion]} sessionId={'sess-1' as never} />);
+
+    fireEvent.click(screen.getByText('Postgres'));
+
+    const submit = await screen.findByText('send answer');
+    fireEvent.click(submit);
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledTimes(1);
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
+      'sess-1',
+      [{ id: 'oq-1', text: 'Use Postgres or SQLite?', answer: 'Postgres' }],
+      'agent-1',
+    );
+  });
+
+  it('submits only the drafted question when the cluster is partially filled', async () => {
+    render(
+      <OpenQuestionCluster questions={[dbQuestion, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    fireEvent.click(screen.getByText('Redis'));
+
+    const submit = await screen.findByText('send answer');
+    fireEvent.click(submit);
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledTimes(1);
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
+      'sess-1',
+      [{ id: 'oq-2', text: 'Redis or Memcached?', answer: 'Redis' }],
+      'agent-1',
+    );
+  });
+
+  it('excludes already-answered questions from the batch', async () => {
+    const answered = makeQuestion({
+      id: 'oq-1',
+      text: 'Use Postgres or SQLite?',
+      suggestedAnswers: ['Postgres', 'SQLite'],
+      status: 'answered',
+      userAnswer: 'Postgres',
+    });
+
+    render(
+      <OpenQuestionCluster questions={[answered, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    fireEvent.click(screen.getByText('Redis'));
+
+    const submit = await screen.findByText('send answer');
+    fireEvent.click(submit);
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
+      'sess-1',
+      [{ id: 'oq-2', text: 'Redis or Memcached?', answer: 'Redis' }],
+      'agent-1',
+    );
+  });
+
+  it('shows no submit button when every question is already answered', () => {
+    const a1 = makeQuestion({
+      id: 'oq-1',
+      text: 'Use Postgres or SQLite?',
+      status: 'answered',
+      userAnswer: 'Postgres',
+    });
+    const a2 = makeQuestion({
+      id: 'oq-2',
+      text: 'Redis or Memcached?',
+      status: 'answered',
+      userAnswer: 'Redis',
+    });
+
+    render(<OpenQuestionCluster questions={[a1, a2]} sessionId={'sess-1' as never} />);
+
+    expect(screen.queryByText('send answer')).toBeNull();
+    expect(screen.queryByText(/send \d+ answers/)).toBeNull();
+  });
+
+  it('prefers a custom answer over selected suggestions', async () => {
+    render(<OpenQuestionCluster questions={[dbQuestion]} sessionId={'sess-1' as never} />);
+
+    fireEvent.click(screen.getByText('Postgres'));
+    fireEvent.click(screen.getByText('other'));
+    fireEvent.change(screen.getByPlaceholderText('write your own answer…'), {
+      target: { value: '  use Neon  ' },
+    });
+
+    const submit = await screen.findByText('send answer');
+    fireEvent.click(submit);
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
+      'sess-1',
+      [{ id: 'oq-1', text: 'Use Postgres or SQLite?', answer: 'use Neon' }],
+      'agent-1',
+    );
+  });
+
+  it('drops a question whose draft was emptied (select then deselect)', () => {
+    render(<OpenQuestionCluster questions={[dbQuestion]} sessionId={'sess-1' as never} />);
+
+    fireEvent.click(screen.getByText('Postgres'));
+    expect(screen.queryByText('send answer')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Postgres'));
+    expect(screen.queryByText('send answer')).toBeNull();
+  });
+
+  it('targets the agent that authored the first question in the cluster', async () => {
+    const fromAgent2 = makeQuestion({
+      id: 'oq-1',
+      text: 'Use Postgres or SQLite?',
+      suggestedAnswers: ['Postgres', 'SQLite'],
+      createdByAgentId: 'agent-2',
+    });
+
+    render(
+      <OpenQuestionCluster questions={[fromAgent2, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    fireEvent.click(screen.getByText('Postgres'));
+    fireEvent.click(screen.getByText('Redis'));
+
+    fireEvent.click(await screen.findByText('send 2 answers'));
+
+    expect(state.answerOpenQuestions).toHaveBeenCalledWith('sess-1', expect.any(Array), 'agent-2');
+  });
+
+  it('flashes the submitted ids and clears their drafts on submit', async () => {
+    render(
+      <OpenQuestionCluster questions={[dbQuestion, cacheQuestion]} sessionId={'sess-1' as never} />,
+    );
+
+    fireEvent.click(screen.getByText('Postgres'));
+    fireEvent.click(screen.getByText('Redis'));
+
+    fireEvent.click(await screen.findByText('send 2 answers'));
+
+    const ui = useOpenQuestions.getState();
+    expect(ui.justAnswered).toEqual(['oq-1', 'oq-2']);
+    expect(ui.drafts).toEqual({});
+    expect(screen.queryByText('send 2 answers')).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionCluster.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from 'react';
+import { ArrowRight } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { OpenQuestion, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import {
+  deriveDraftAnswer,
+  useOpenQuestions,
+} from '../../../context/components/QuestionsTab/useOpenQuestions';
+import { OpenQuestionInlineCard } from './OpenQuestionInlineCard';
+
+type Props = {
+  questions: ReadonlyArray<OpenQuestion>;
+  sessionId: SessionId;
+};
+
+export const OpenQuestionCluster = ({ questions, sessionId }: Props) => {
+  const drafts = useOpenQuestions((s) => s.drafts);
+  const flashAnswered = useOpenQuestions((s) => s.flashAnswered);
+  const answerOpenQuestions = useAppStore((s) => s.answerOpenQuestions);
+
+  const pendingPairs = questions
+    .filter((q) => q.status !== 'answered')
+    .map((q) => ({ id: q.id, text: q.text, answer: deriveDraftAnswer(drafts[q.id]) }))
+    .filter((pair) => pair.answer.length > 0);
+  const targetAgentId = questions[0]?.createdByAgentId ?? null;
+
+  const handleSubmit = useCallback(async () => {
+    if (pendingPairs.length === 0) {
+      return;
+    }
+    flashAnswered(pendingPairs.map((pair) => pair.id));
+    await answerOpenQuestions(sessionId, pendingPairs, targetAgentId);
+  }, [pendingPairs, flashAnswered, answerOpenQuestions, sessionId, targetAgentId]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {questions.map((q) => (
+        <OpenQuestionInlineCard key={q.id} question={q} sessionId={sessionId} />
+      ))}
+      {pendingPairs.length > 0 && (
+        <button
+          type="button"
+          onClick={() => void handleSubmit()}
+          className={cn(
+            'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
+            'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
+            'hover:brightness-105 active:scale-[0.99]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          )}
+        >
+          <span>
+            {pendingPairs.length > 1 ? `send ${pendingPairs.length} answers` : 'send answer'}
+          </span>
+          <ArrowRight
+            size={13}
+            aria-hidden
+            className="transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.test.tsx
@@ -38,22 +38,6 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('OpenQuestionInlineCard', () => {
-  it('renders the open question interactively and submits the chosen answer', async () => {
-    render(<OpenQuestionInlineCard question={baseQuestion} sessionId={'sess-1' as never} />);
-
-    expect(screen.getByText('Use Postgres or SQLite?')).toBeTruthy();
-    fireEvent.click(screen.getByText('Postgres'));
-
-    const submit = await screen.findByText('send answer');
-    fireEvent.click(submit);
-
-    expect(state.answerOpenQuestions).toHaveBeenCalledWith(
-      'sess-1',
-      [{ id: 'oq-1', text: 'Use Postgres or SQLite?', answer: 'Postgres' }],
-      'agent-1',
-    );
-  });
-
   it('carries the data-oq-anchor on the open card', () => {
     const { container } = render(
       <OpenQuestionInlineCard question={baseQuestion} sessionId={'sess-1' as never} />,

--- a/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/OpenQuestionInlineCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
-import { ArrowRight, Bot, CheckCircle2, ChevronDown } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { Bot, CheckCircle2, ChevronDown } from 'lucide-react';
+import { cn, Markdown } from '@goodboy/ui';
 import type { OpenQuestion, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { QuestionCard } from '../../../context/components/QuestionsTab/QuestionCard';
@@ -36,30 +36,11 @@ const InteractiveCard = ({ question, sessionId }: Props) => {
     toggleSuggestion,
     setCustomAnswer,
     toggleCustomField,
-    flashAnswered,
     clearJustAnswered,
   } = useOpenQuestions();
-  const answerOpenQuestions = useAppStore((s) => s.answerOpenQuestions);
   const dismissOpenQuestion = useAppStore((s) => s.dismissOpenQuestion);
 
   const draft = drafts[question.id];
-  const answer =
-    (draft?.customAnswer.trim().length ?? 0) > 0
-      ? draft!.customAnswer.trim()
-      : (draft?.selectedSuggestions ?? []).join(', ');
-  const hasPendingAnswer = answer.length > 0;
-
-  const handleSubmit = useCallback(async () => {
-    if (answer.length === 0) {
-      return;
-    }
-    flashAnswered([question.id]);
-    await answerOpenQuestions(
-      sessionId,
-      [{ id: question.id, text: question.text, answer }],
-      question.createdByAgentId ?? null,
-    );
-  }, [answer, flashAnswered, answerOpenQuestions, sessionId, question]);
 
   const handleDismiss = useCallback(() => {
     void dismissOpenQuestion(sessionId, question);
@@ -79,25 +60,6 @@ const InteractiveCard = ({ question, sessionId }: Props) => {
         onDismiss={handleDismiss}
         onClearJustAnswered={clearJustAnswered}
       />
-      {hasPendingAnswer && (
-        <button
-          type="button"
-          onClick={() => void handleSubmit()}
-          className={cn(
-            'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
-            'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
-            'hover:brightness-105 active:scale-[0.99]',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-          )}
-        >
-          <span>send answer</span>
-          <ArrowRight
-            size={13}
-            aria-hidden
-            className="transition-transform group-hover:translate-x-0.5"
-          />
-        </button>
-      )}
     </div>
   );
 };
@@ -125,14 +87,16 @@ const AnsweredCard = ({ question }: { question: OpenQuestion }) => {
           ) : (
             <CheckCircle2 size={13} aria-hidden className="mt-0.5 shrink-0 text-success" />
           )}
-          <p
-            className={cn(
-              'min-w-0 break-words text-xs leading-relaxed text-foreground',
-              !expanded && 'line-clamp-1',
-            )}
-          >
-            {question.text}
-          </p>
+          {expanded ? (
+            <Markdown
+              text={question.text}
+              className="min-w-0 gap-1.5 break-words text-[13px] leading-relaxed text-foreground"
+            />
+          ) : (
+            <p className="min-w-0 break-words text-xs leading-relaxed text-foreground line-clamp-1">
+              {question.text}
+            </p>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-1.5 text-2xs text-muted-foreground">
           <span>{relativeTime(answeredAt)}</span>
@@ -151,9 +115,10 @@ const AnsweredCard = ({ question }: { question: OpenQuestion }) => {
           ) : (
             <>
               <span className="text-2xs font-medium text-muted-foreground">You answered:</span>
-              <p className="mt-0.5 break-words text-xs leading-relaxed text-foreground">
-                {question.userAnswer}
-              </p>
+              <Markdown
+                text={question.userAnswer ?? ''}
+                className="mt-0.5 gap-1.5 break-words text-[13px] leading-relaxed text-foreground"
+              />
             </>
           )}
         </div>

--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -1,12 +1,13 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
-const { state, openQuestions, answeredQuestions } = vi.hoisted(() => ({
+const { state, openQuestions, answeredQuestions, transcriptItems } = vi.hoisted(() => ({
   openQuestions: { current: [] as ReadonlyArray<unknown> },
   answeredQuestions: { current: [] as ReadonlyArray<unknown> },
+  transcriptItems: { current: [] as ReadonlyArray<unknown> },
   state: {
     selectedAgentId: {} as Record<string, string | null>,
     transcripts: {} as Record<string, unknown>,
@@ -42,10 +43,16 @@ vi.mock('./OpenQuestionInlineCard', () => ({
   OpenQuestionInlineCard: () => null,
 }));
 
+vi.mock('./OpenQuestionCluster', () => ({
+  OpenQuestionCluster: ({ questions }: { questions: ReadonlyArray<{ id: string }> }) => (
+    <div data-testid="cluster">{questions.map((q) => q.id).join(',')}</div>
+  ),
+}));
+
 vi.mock('../../utils/transcript-items', () => ({
   detectParallelRunIds: () => [],
   filterEventsByRunId: () => [],
-  reduceTranscript: () => [],
+  reduceTranscript: () => transcriptItems.current,
 }));
 
 vi.mock('../TranscriptCards', () => ({
@@ -113,6 +120,7 @@ beforeEach(() => {
   state.clearOpenQuestionScroll.mockClear();
   openQuestions.current = [];
   answeredQuestions.current = [];
+  transcriptItems.current = [];
   (Element.prototype as unknown as { scrollTo: unknown }).scrollTo = vi.fn();
   (Element.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = vi.fn();
 });
@@ -135,5 +143,66 @@ describe('ChatView', () => {
     state.openQuestionScrollTarget = { agentId: 'agent-1', questionId: 'oq-1' };
     render(<ChatView session={session} />);
     expect(state.clearOpenQuestionScroll).toHaveBeenCalled();
+  });
+
+  it('clusters same-turn questions for the selected agent, sorted by createdAt', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [{ kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' }];
+    openQuestions.current = [
+      {
+        id: 'q-late',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 0,
+        createdAt: '2026-06-13T00:00:02.000Z',
+      },
+      {
+        id: 'q-early',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 0,
+        createdAt: '2026-06-13T00:00:01.000Z',
+      },
+      {
+        id: 'q-other-agent',
+        createdByAgentId: 'agent-2',
+        turnOrdinal: 0,
+        createdAt: '2026-06-13T00:00:00.000Z',
+      },
+      {
+        id: 'q-no-ordinal',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: null,
+        createdAt: '2026-06-13T00:00:00.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.textContent).toBe('q-early,q-late');
+  });
+
+  it('splits questions from different turns into separate clusters', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [{ kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' }];
+    openQuestions.current = [
+      {
+        id: 'q-turn0',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 0,
+        createdAt: '2026-06-13T00:00:00.000Z',
+      },
+      {
+        id: 'q-turn1',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 1,
+        createdAt: '2026-06-13T00:00:01.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters.map((c) => c.textContent)).toEqual(['q-turn0', 'q-turn1']);
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../../../features/permissions/components/MergeDialog';
 import { DiffViewerDialog } from '../../../../features/permissions/components/DiffViewerDialog';
 import { worktreeDiff } from '../../../../features/worktree/worktree';
-import { OpenQuestionInlineCard } from './OpenQuestionInlineCard';
+import { OpenQuestionCluster } from './OpenQuestionCluster';
 
 type ChatViewProps = {
   session: Session;
@@ -580,10 +580,8 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
                     return;
                   }
                   out.push(
-                    <li key={`oq-${ordinal}`} className="mt-2.5 flex flex-col gap-2">
-                      {cards.map((q) => (
-                        <OpenQuestionInlineCard key={q.id} question={q} sessionId={session.id} />
-                      ))}
+                    <li key={`oq-${ordinal}`} className="mt-2.5">
+                      <OpenQuestionCluster questions={cards} sessionId={session.id} />
                     </li>,
                   );
                 };

--- a/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/QuestionCard/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Check, MessageCircleQuestion, X } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { cn, Markdown } from '@goodboy/ui';
 import type { OpenQuestion, OpenQuestionId } from '@goodboy/types';
 import { SuggestionChip } from '../SuggestionChip';
 import { CustomAnswerField } from '../CustomAnswerField';
@@ -95,9 +95,10 @@ export const QuestionCard = ({
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 items-start gap-2">
           <MessageCircleQuestion size={13} aria-hidden className="mt-0.5 shrink-0 text-warning" />
-          <p className="min-w-0 break-words text-xs font-medium leading-relaxed text-foreground">
-            {question.text}
-          </p>
+          <Markdown
+            text={question.text}
+            className="min-w-0 gap-1.5 break-words text-[13px] font-medium leading-relaxed text-foreground"
+          />
         </div>
         <button
           type="button"

--- a/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
+++ b/apps/desktop/src/features/context/components/QuestionsTab/SuggestionChip/index.tsx
@@ -40,7 +40,7 @@ export const SuggestionChip = ({ label, selected, recommended = false, onToggle 
       {recommended && !selected && (
         <Sparkles size={11} aria-hidden className="mr-1 shrink-0 text-warning" />
       )}
-      <span className="truncate">{label}</span>
+      <span className="min-w-0 break-words text-left">{label}</span>
     </button>
   );
 };

--- a/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
+++ b/apps/desktop/src/features/context/components/QuestionsTab/useOpenQuestions.ts
@@ -31,6 +31,11 @@ function emptyDraft(): QuestionDraft {
   return { selectedSuggestions: [], customAnswer: '', showCustomField: false };
 }
 
+export const deriveDraftAnswer = (draft: QuestionDraft | undefined): string =>
+  (draft?.customAnswer.trim().length ?? 0) > 0
+    ? draft!.customAnswer.trim()
+    : (draft?.selectedSuggestions ?? []).join(', ');
+
 export const useOpenQuestions = create<OpenQuestionsUiState>((set, get) => ({
   drafts: {},
   justAnswered: [],

--- a/apps/desktop/src/store/slices/open-questions/answerOpenQuestions.test.ts
+++ b/apps/desktop/src/store/slices/open-questions/answerOpenQuestions.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentId, SessionId } from '@goodboy/types';
+
+const { markOpenQuestionAnswered, removeQuestionsFromSlot } = vi.hoisted(() => ({
+  markOpenQuestionAnswered: vi.fn(async () => undefined),
+  removeQuestionsFromSlot: vi.fn(async () => false),
+}));
+
+vi.mock('@goodboy/db', () => ({ markOpenQuestionAnswered }));
+vi.mock('@goodboy/core', () => ({ removeQuestionsFromSlot }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { answerOpenQuestions } from './answerOpenQuestions';
+
+const deps = {
+  loadSessionOpenQuestions: vi.fn(async () => undefined),
+  loadSessionAnsweredQuestions: vi.fn(async () => undefined),
+  loadSessionSlots: vi.fn(async () => undefined),
+  sendTurn: vi.fn(
+    async (_turn: { sessionId: SessionId; content: string; agentId?: string }) => undefined,
+  ),
+};
+
+const get = (() => deps) as never;
+const run = answerOpenQuestions(get);
+const sessionId = 'sess-1' as SessionId;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  removeQuestionsFromSlot.mockResolvedValue(false);
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe('answerOpenQuestions', () => {
+  it('marks every pair answered and sends a single combined turn', async () => {
+    await run(
+      sessionId,
+      [
+        { id: 'oq-1' as never, text: 'Q1?', answer: 'A1' },
+        { id: 'oq-2' as never, text: 'Q2?', answer: 'A2' },
+      ],
+      'agent-1' as AgentId,
+    );
+
+    expect(markOpenQuestionAnswered).toHaveBeenCalledTimes(2);
+    expect(markOpenQuestionAnswered).toHaveBeenCalledWith(expect.anything(), 'oq-1', 'A1');
+    expect(markOpenQuestionAnswered).toHaveBeenCalledWith(expect.anything(), 'oq-2', 'A2');
+
+    expect(removeQuestionsFromSlot).toHaveBeenCalledTimes(1);
+    expect(removeQuestionsFromSlot).toHaveBeenCalledWith(expect.anything(), sessionId, [
+      'Q1?',
+      'Q2?',
+    ]);
+
+    expect(deps.sendTurn).toHaveBeenCalledTimes(1);
+    const turn = deps.sendTurn.mock.calls[0]![0] as {
+      sessionId: SessionId;
+      content: string;
+      agentId?: string;
+    };
+    expect(turn.sessionId).toBe(sessionId);
+    expect(turn.agentId).toBe('agent-1');
+    expect(turn.content).toContain('Q: Q1?');
+    expect(turn.content).toContain('A: A1');
+    expect(turn.content).toContain('Q: Q2?');
+    expect(turn.content).toContain('A: A2');
+  });
+
+  it('drops empty and whitespace-only answers before marking or sending', async () => {
+    await run(
+      sessionId,
+      [
+        { id: 'oq-1' as never, text: 'Q1?', answer: '   ' },
+        { id: 'oq-2' as never, text: 'Q2?', answer: 'A2' },
+        { id: 'oq-3' as never, text: 'Q3?', answer: '' },
+      ],
+      'agent-1' as AgentId,
+    );
+
+    expect(markOpenQuestionAnswered).toHaveBeenCalledTimes(1);
+    expect(markOpenQuestionAnswered).toHaveBeenCalledWith(expect.anything(), 'oq-2', 'A2');
+    expect(removeQuestionsFromSlot).toHaveBeenCalledWith(expect.anything(), sessionId, ['Q2?']);
+    expect(deps.sendTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('is a no-op when no answer has content', async () => {
+    await run(
+      sessionId,
+      [
+        { id: 'oq-1' as never, text: 'Q1?', answer: '' },
+        { id: 'oq-2' as never, text: 'Q2?', answer: '  ' },
+      ],
+      'agent-1' as AgentId,
+    );
+
+    expect(markOpenQuestionAnswered).not.toHaveBeenCalled();
+    expect(removeQuestionsFromSlot).not.toHaveBeenCalled();
+    expect(deps.sendTurn).not.toHaveBeenCalled();
+    expect(deps.loadSessionOpenQuestions).not.toHaveBeenCalled();
+  });
+
+  it('reloads slots only when the slot actually changed', async () => {
+    removeQuestionsFromSlot.mockResolvedValueOnce(true);
+    await run(sessionId, [{ id: 'oq-1' as never, text: 'Q1?', answer: 'A1' }], null);
+    expect(deps.loadSessionSlots).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    removeQuestionsFromSlot.mockResolvedValue(false);
+    await run(sessionId, [{ id: 'oq-1' as never, text: 'Q1?', answer: 'A1' }], null);
+    expect(deps.loadSessionSlots).not.toHaveBeenCalled();
+  });
+
+  it('passes agentId undefined when no target agent is given', async () => {
+    await run(sessionId, [{ id: 'oq-1' as never, text: 'Q1?', answer: 'A1' }], null);
+    const turn = deps.sendTurn.mock.calls[0]![0] as { agentId?: string };
+    expect(turn.agentId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Lift open-question submit from per-card to cluster level: every drafted answer in a turn-ordinal group is sent in one `answerOpenQuestions` call (fixes the buggy single-element call path).
- New `OpenQuestionCluster` renders the same-turn questions plus a single `send answer` / `send N answers` button; per-card submit removed.
- Render question and answered-record text via shared `<Markdown>` (chat inline + context panel) so agent formatting survives; `SuggestionChip` wraps long labels instead of truncating.

## Edge cases
- Partial fill sends only drafted answers; all-answered group shows no button; mixed answered+open includes open+drafted only; store double-filters empty answers.

## Test plan
- [x] `pnpm typecheck` clean
- [x] 23 tests pass across `OpenQuestionCluster`, `OpenQuestionInlineCard`, `ChatView/index`, `answerOpenQuestions`
- [x] prettier format check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)