### PR TITLE
feat(desktop): integrate sentry issue studio

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ mod providers;
 mod repo;
 mod scripts;
 mod secrets;
+mod sentry;
 mod settings_overrides;
 mod skills;
 mod summarize;
@@ -57,6 +58,7 @@ pub fn run() {
   let terminal_registry = terminal::TerminalRegistry::new();
   let provider_lifecycle_registry = provider_lifecycle::ProviderLifecycleRegistry::new();
   let linear_token_cache = linear::LinearTokenCache::new();
+  let sentry_token_cache = sentry::SentryTokenCache::new();
 
   tauri::Builder::default()
     .plugin(tauri_plugin_dialog::init())
@@ -71,6 +73,7 @@ pub fn run() {
     .manage(terminal_registry)
     .manage(provider_lifecycle_registry)
     .manage(linear_token_cache)
+    .manage(sentry_token_cache)
     .setup(|app| {
       #[cfg(desktop)]
       app
@@ -209,6 +212,10 @@ pub fn run() {
       linear::linear_connect,
       linear::linear_disconnect,
       linear::linear_fetch_assigned_issues,
+      sentry::sentry_connect,
+      sentry::sentry_disconnect,
+      sentry::sentry_fetch_issues,
+      sentry::sentry_fetch_issue_detail,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/sentry.rs
+++ b/apps/desktop/src-tauri/src/sentry.rs
@@ -1,0 +1,383 @@
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Map;
+use tauri::State;
+use thiserror::Error;
+
+use crate::secrets;
+
+const BASE_URL: &str = "https://sentry.io/api/0";
+const PAGE_LIMIT: &str = "25";
+const DEFAULT_QUERY: &str = "is:unresolved";
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct SentryConfig {
+    pub token: String,
+    pub org: String,
+    pub project: String,
+}
+
+pub struct SentryTokenCache(Mutex<HashMap<String, SentryConfig>>);
+
+impl SentryTokenCache {
+    pub fn new() -> Self {
+        Self(Mutex::new(HashMap::new()))
+    }
+}
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(reqwest::Client::new)
+}
+
+fn credential_key(workspace_id: &str) -> String {
+    format!("goodboy.workspace.{}.sentry", workspace_id)
+}
+
+#[derive(Debug, Error)]
+pub enum SentryError {
+    #[error("http error: {0}")]
+    Http(String),
+    #[error("invalid response shape: {0}")]
+    InvalidShape(String),
+    #[error("no token stored for workspace {0}")]
+    NoToken(String),
+    #[error("secret store error: {0}")]
+    Secret(#[from] secrets::SecretError),
+}
+
+impl SentryError {
+    fn kind(&self) -> &'static str {
+        match self {
+            SentryError::Http(_) => "http",
+            SentryError::InvalidShape(_) => "shape",
+            SentryError::NoToken(_) => "no_token",
+            SentryError::Secret(_) => "secret",
+        }
+    }
+}
+
+impl Serialize for SentryError {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = Map::new();
+        map.insert(
+            "kind".to_string(),
+            serde_json::Value::String(self.kind().to_string()),
+        );
+        map.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.to_string()),
+        );
+        serde_json::Value::Object(map).serialize(serializer)
+    }
+}
+
+impl From<reqwest::Error> for SentryError {
+    fn from(e: reqwest::Error) -> Self {
+        SentryError::Http(e.to_string())
+    }
+}
+
+impl From<serde_json::Error> for SentryError {
+    fn from(e: serde_json::Error) -> Self {
+        SentryError::InvalidShape(e.to_string())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SentryOrganization {
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SentryProject {
+    pub slug: String,
+    pub name: String,
+    pub organization: SentryOrganization,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SentryIssueMetadata {
+    #[serde(rename = "type", default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SentryIssue {
+    pub id: String,
+    #[serde(rename = "shortId", default)]
+    pub short_id: Option<String>,
+    pub title: String,
+    #[serde(default)]
+    pub culprit: Option<String>,
+    #[serde(default)]
+    pub level: Option<String>,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub count: Option<String>,
+    #[serde(rename = "userCount", default)]
+    pub user_count: Option<i64>,
+    #[serde(rename = "firstSeen", default)]
+    pub first_seen: Option<String>,
+    #[serde(rename = "lastSeen", default)]
+    pub last_seen: Option<String>,
+    #[serde(default)]
+    pub permalink: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<SentryIssueMetadata>,
+}
+
+#[derive(Serialize)]
+pub struct SentryIssuesPage {
+    pub issues: Vec<SentryIssue>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct SentryStackFrame {
+    pub filename: Option<String>,
+    pub function: Option<String>,
+    pub line_no: Option<i64>,
+    pub in_app: bool,
+}
+
+#[derive(Serialize)]
+pub struct SentryIssueDetail {
+    pub title: Option<String>,
+    pub culprit: Option<String>,
+    pub frames: Vec<SentryStackFrame>,
+}
+
+fn read_config(workspace_id: &str, cache: &SentryTokenCache) -> Result<SentryConfig, SentryError> {
+    if let Some(cfg) = cache.0.lock().unwrap().get(workspace_id) {
+        return Ok(cfg.clone());
+    }
+    let raw = secrets::read(&credential_key(workspace_id))?
+        .ok_or_else(|| SentryError::NoToken(workspace_id.to_string()))?;
+    let cfg: SentryConfig = serde_json::from_str(&raw)?;
+    cache
+        .0
+        .lock()
+        .unwrap()
+        .insert(workspace_id.to_string(), cfg.clone());
+    Ok(cfg)
+}
+
+fn parse_next_cursor(link: &str) -> Option<String> {
+    for segment in link.split(',') {
+        if !segment.contains("rel=\"next\"") || !segment.contains("results=\"true\"") {
+            continue;
+        }
+        let start = segment.find("cursor=\"")? + "cursor=\"".len();
+        let rest = &segment[start..];
+        let end = rest.find('"')?;
+        return Some(rest[..end].to_string());
+    }
+    None
+}
+
+fn parse_frame(frame: &serde_json::Value) -> SentryStackFrame {
+    SentryStackFrame {
+        filename: frame
+            .get("filename")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        function: frame
+            .get("function")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        line_no: frame.get("lineNo").and_then(|v| v.as_i64()),
+        in_app: frame
+            .get("inApp")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+    }
+}
+
+fn extract_frames(event: &serde_json::Value) -> Vec<SentryStackFrame> {
+    let entries = match event.get("entries").and_then(|v| v.as_array()) {
+        Some(entries) => entries,
+        None => return Vec::new(),
+    };
+    for entry in entries {
+        let kind = entry.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let data = entry.get("data");
+        let frames = match kind {
+            "exception" => data
+                .and_then(|d| d.get("values"))
+                .and_then(|v| v.as_array())
+                .and_then(|values| values.last())
+                .and_then(|value| value.get("stacktrace"))
+                .and_then(|st| st.get("frames")),
+            "stacktrace" => data.and_then(|d| d.get("frames")),
+            _ => None,
+        };
+        if let Some(frames) = frames.and_then(|f| f.as_array()) {
+            return frames.iter().map(parse_frame).collect();
+        }
+    }
+    Vec::new()
+}
+
+#[tauri::command]
+pub async fn sentry_connect(
+    workspace_id: String,
+    token: String,
+    org: String,
+    project: String,
+    cache: State<'_, SentryTokenCache>,
+) -> Result<SentryProject, SentryError> {
+    let url = format!("{}/projects/{}/{}/", BASE_URL, org, project);
+    let res = http_client().get(&url).bearer_auth(&token).send().await?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(SentryError::Http(format!("status {}: {}", status, body)));
+    }
+    let project_resp: SentryProject = res.json().await?;
+    let cfg = SentryConfig {
+        token,
+        org,
+        project,
+    };
+    secrets::set(&credential_key(&workspace_id), &serde_json::to_string(&cfg)?)?;
+    cache.0.lock().unwrap().insert(workspace_id, cfg);
+    Ok(project_resp)
+}
+
+#[tauri::command]
+pub async fn sentry_disconnect(
+    workspace_id: String,
+    cache: State<'_, SentryTokenCache>,
+) -> Result<(), SentryError> {
+    secrets::clear(&credential_key(&workspace_id))?;
+    cache.0.lock().unwrap().remove(&workspace_id);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn sentry_fetch_issues(
+    workspace_id: String,
+    query: Option<String>,
+    cursor: Option<String>,
+    cache: State<'_, SentryTokenCache>,
+) -> Result<SentryIssuesPage, SentryError> {
+    let cfg = read_config(&workspace_id, &cache)?;
+    let url = format!("{}/projects/{}/{}/issues/", BASE_URL, cfg.org, cfg.project);
+    let mut params: Vec<(&str, String)> = vec![
+        ("limit", PAGE_LIMIT.to_string()),
+        ("query", query.unwrap_or_else(|| DEFAULT_QUERY.to_string())),
+    ];
+    if let Some(cursor) = cursor {
+        params.push(("cursor", cursor));
+    }
+    let res = http_client()
+        .get(&url)
+        .bearer_auth(&cfg.token)
+        .query(&params)
+        .send()
+        .await?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(SentryError::Http(format!("status {}: {}", status, body)));
+    }
+    let next_cursor = res
+        .headers()
+        .get(reqwest::header::LINK)
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_next_cursor);
+    let issues: Vec<SentryIssue> = res.json().await?;
+    Ok(SentryIssuesPage {
+        issues,
+        next_cursor,
+    })
+}
+
+#[tauri::command]
+pub async fn sentry_fetch_issue_detail(
+    workspace_id: String,
+    issue_id: String,
+    cache: State<'_, SentryTokenCache>,
+) -> Result<SentryIssueDetail, SentryError> {
+    let cfg = read_config(&workspace_id, &cache)?;
+    let url = format!("{}/issues/{}/events/latest/", BASE_URL, issue_id);
+    let res = http_client().get(&url).bearer_auth(&cfg.token).send().await?;
+    let status = res.status();
+    if !status.is_success() {
+        let body = res.text().await.unwrap_or_default();
+        return Err(SentryError::Http(format!("status {}: {}", status, body)));
+    }
+    let event: serde_json::Value = res.json().await?;
+    let title = event
+        .get("title")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let culprit = event
+        .get("culprit")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    Ok(SentryIssueDetail {
+        title,
+        culprit,
+        frames: extract_frames(&event),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_cursor_extracts_when_results_true() {
+        let link = "<https://sentry.io/api/0/x/?cursor=0:0:1>; rel=\"previous\"; results=\"false\"; cursor=\"0:0:1\", <https://sentry.io/api/0/x/?cursor=0:100:0>; rel=\"next\"; results=\"true\"; cursor=\"0:100:0\"";
+        assert_eq!(parse_next_cursor(link), Some("0:100:0".to_string()));
+    }
+
+    #[test]
+    fn next_cursor_none_when_results_false() {
+        let link = "<https://sentry.io/api/0/x/?cursor=0:100:0>; rel=\"next\"; results=\"false\"; cursor=\"0:100:0\"";
+        assert_eq!(parse_next_cursor(link), None);
+    }
+
+    #[test]
+    fn next_cursor_none_when_no_next_rel() {
+        let link = "<https://sentry.io/api/0/x/?cursor=0:0:1>; rel=\"previous\"; results=\"true\"; cursor=\"0:0:1\"";
+        assert_eq!(parse_next_cursor(link), None);
+    }
+
+    #[test]
+    fn extract_frames_from_exception_entry() {
+        let event = serde_json::json!({
+            "entries": [
+                { "type": "breadcrumbs", "data": {} },
+                {
+                    "type": "exception",
+                    "data": {
+                        "values": [
+                            { "stacktrace": { "frames": [ { "filename": "a.ts", "function": "old", "lineNo": 1, "inApp": false } ] } },
+                            { "stacktrace": { "frames": [ { "filename": "b.ts", "function": "boom", "lineNo": 42, "inApp": true } ] } }
+                        ]
+                    }
+                }
+            ]
+        });
+        let frames = extract_frames(&event);
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].filename.as_deref(), Some("b.ts"));
+        assert_eq!(frames[0].line_no, Some(42));
+        assert!(frames[0].in_app);
+    }
+
+    #[test]
+    fn extract_frames_empty_without_entries() {
+        let event = serde_json::json!({ "title": "x" });
+        assert!(extract_frames(&event).is_empty());
+    }
+}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -25,6 +25,7 @@ import { GitHubStudio } from './features/github/components/GitHubStudio';
 import { GitHubSessionPane } from './features/github/components/GitHubSessionPane';
 import { PlanStudio } from './features/plans/components/PlanStudio';
 import { LinearStudio } from './features/integrations/linear/LinearStudio';
+import { SentryStudio } from './features/integrations/sentry/SentryStudio';
 import { ProviderStudio } from './features/providers/components/ProviderStudio';
 import { BudgetStudio } from './features/budget/components/BudgetStudio';
 import type { BudgetScope } from './features/budget/components/BudgetStudio/lib';
@@ -117,6 +118,8 @@ export const App = () => {
   const [workflowStudioOpen, setWorkflowStudioOpen] = useState(false);
   const [linearStudioOpen, setLinearStudioOpen] = useState(false);
   const [linearStudioFocus, setLinearStudioFocus] = useState<string | null>(null);
+  const [sentryStudioOpen, setSentryStudioOpen] = useState(false);
+  const [sentryStudioFocus, setSentryStudioFocus] = useState<string | null>(null);
   const [providerStudioOpen, setProviderStudioOpen] = useState(false);
   const [providerStudioFocus, setProviderStudioFocus] = useState<ProviderId | null>(null);
   const [providerStudioAction, setProviderStudioAction] = useState<ProviderLifecycleAction | null>(
@@ -345,6 +348,16 @@ export const App = () => {
     };
     window.addEventListener('goodboy:open-linear-studio', handler);
     return () => window.removeEventListener('goodboy:open-linear-studio', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ issueExternalId?: string }>).detail;
+      setSentryStudioFocus(detail?.issueExternalId ?? null);
+      setSentryStudioOpen(true);
+    };
+    window.addEventListener('goodboy:open-sentry-studio', handler);
+    return () => window.removeEventListener('goodboy:open-sentry-studio', handler);
   }, []);
 
   useEffect(() => {
@@ -707,6 +720,10 @@ export const App = () => {
                 setLinearStudioFocus(null);
                 setLinearStudioOpen(true);
               }}
+              onOpenSentry={() => {
+                setSentryStudioFocus(null);
+                setSentryStudioOpen(true);
+              }}
               onOpenProviders={() => {
                 setProviderStudioFocus(null);
                 setProviderStudioAction(null);
@@ -892,6 +909,14 @@ export const App = () => {
           workspaceName={currentWorkspace.name}
           initialIssueId={linearStudioFocus}
           onClose={() => setLinearStudioOpen(false)}
+        />
+      ) : null}
+      {sentryStudioOpen && currentWorkspace ? (
+        <SentryStudio
+          workspaceId={currentWorkspace.id}
+          workspaceName={currentWorkspace.name}
+          initialIssueId={sentryStudioFocus}
+          onClose={() => setSentryStudioOpen(false)}
         />
       ) : null}
       {commitDiff ? (

--- a/apps/desktop/src/__tests__/a11y/smoke.test.tsx
+++ b/apps/desktop/src/__tests__/a11y/smoke.test.tsx
@@ -139,6 +139,7 @@ describe('a11y smoke, WorkspacesSidebar', () => {
         onOpenPalette={vi.fn()}
         onOpenWorkflows={vi.fn()}
         onOpenLinear={vi.fn()}
+        onOpenSentry={vi.fn()}
         onOpenProviders={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenBudget={vi.fn()}

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -210,6 +210,7 @@ describe('snapshot, empty states', () => {
         onOpenPalette={vi.fn()}
         onOpenWorkflows={vi.fn()}
         onOpenLinear={vi.fn()}
+        onOpenSentry={vi.fn()}
         onOpenProviders={vi.fn()}
         onOpenGithub={vi.fn()}
         onOpenBudget={vi.fn()}

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -219,7 +219,8 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
         branchPrefix: sanitizePrefix(branchPrefix).trim() || DEFAULT_BRANCH_PREFIX,
         branchSlug: branchSlug.trim() || undefined,
         ...(adoptBranch ? { existingBranch: adoptBranch } : {}),
-        linearIssue: {
+        externalTask: {
+          provider: 'linear',
           externalId: issue.id,
           identifier: issue.identifier,
           url: issue.url,

--- a/apps/desktop/src/features/integrations/sentry/ConnectSentryDialog.tsx
+++ b/apps/desktop/src/features/integrations/sentry/ConnectSentryDialog.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { LinearIntegrationConfig, WorkspaceId, WorkspaceIntegration } from '@goodboy/types';
+import type { SentryIntegrationConfig, WorkspaceId } from '@goodboy/types';
 import { Button, Dialog, Input } from '@goodboy/ui';
 import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
 import { useAppStore } from '../../../store';
@@ -12,22 +12,24 @@ type Props = {
   onClose: () => void;
 };
 
-export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
+export const ConnectSentryDialog = ({ workspaceId, open, onClose }: Props) => {
   const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
-  const linear =
-    (integrations.find((i) => i.provider === 'linear') as
-      | (WorkspaceIntegration & { config: LinearIntegrationConfig })
-      | undefined) ?? null;
-  const connectLinear = useAppStore((s) => s.connectLinear);
-  const disconnectLinear = useAppStore((s) => s.disconnectLinear);
+  const sentry = integrations.find((i) => i.provider === 'sentry') ?? null;
+  const sentryConfig = (sentry?.config ?? null) as SentryIntegrationConfig | null;
+  const connectSentry = useAppStore((s) => s.connectSentry);
+  const disconnectSentry = useAppStore((s) => s.disconnectSentry);
 
   const [token, setToken] = useState('');
+  const [org, setOrg] = useState('');
+  const [project, setProject] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) {
       setToken('');
+      setOrg('');
+      setProject('');
       setError(null);
       setBusy(false);
     }
@@ -37,8 +39,10 @@ export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
     setBusy(true);
     setError(null);
     try {
-      await connectLinear(workspaceId, token.trim());
+      await connectSentry(workspaceId, token.trim(), org.trim(), project.trim());
       setToken('');
+      setOrg('');
+      setProject('');
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -50,7 +54,7 @@ export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
     setBusy(true);
     setError(null);
     try {
-      await disconnectLinear(workspaceId);
+      await disconnectSentry(workspaceId);
     } catch (err) {
       setError(formatError(err));
     } finally {
@@ -58,20 +62,22 @@ export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
     }
   };
 
+  const canConnect = token.trim().length > 0 && org.trim().length > 0 && project.trim().length > 0;
+
   return (
     <Dialog
       open={open}
       onClose={onClose}
-      title="Connect Linear"
-      description="Personal access token. Stored in your OS keychain."
+      title="Connect Sentry"
+      description="Auth token plus org and project slugs. Stored in your OS keychain."
       size="md"
       footer={
         <div className="flex w-full items-center justify-end gap-2">
           <Button variant="ghost" onClick={onClose} disabled={busy}>
             Close
           </Button>
-          {linear ? null : (
-            <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
+          {sentry ? null : (
+            <Button onClick={() => void onConnect()} disabled={busy || !canConnect}>
               {busy ? (
                 <>
                   <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
@@ -85,17 +91,17 @@ export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
       }
     >
       <div className="flex flex-col gap-5">
-        {linear ? (
+        {sentry && sentryConfig ? (
           <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
             <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
               <CheckCircle2 size={14} aria-hidden className="text-success" />
-              Connected as {linear.config.viewerName}
+              Connected to {sentryConfig.projectName ?? sentryConfig.project}
             </div>
             <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
-              <dt className="text-muted-foreground">workspace</dt>
-              <dd className="font-mono text-foreground">
-                linear.app/{linear.config.workspaceUrlKey}
-              </dd>
+              <dt className="text-muted-foreground">organization</dt>
+              <dd className="font-mono text-foreground">{sentryConfig.org}</dd>
+              <dt className="text-muted-foreground">project</dt>
+              <dd className="font-mono text-foreground">{sentryConfig.project}</dd>
             </dl>
             <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
               <Unplug size={12} aria-hidden className="mr-1.5" />
@@ -105,30 +111,60 @@ export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
         ) : (
           <>
             <div className="flex flex-col gap-2">
-              <label htmlFor="linear-pat" className="text-xs font-semibold text-foreground">
-                Personal access token
+              <label htmlFor="sentry-token" className="text-xs font-semibold text-foreground">
+                Auth token
               </label>
               <Input
-                id="linear-pat"
+                id="sentry-token"
                 type="password"
                 autoFocus
-                placeholder="lin_api_…"
+                placeholder="sntryu_…"
                 value={token}
                 onChange={(e) => setToken(e.target.value)}
                 disabled={busy}
               />
               <a
-                href="https://linear.app/settings/account/security"
+                href="https://sentry.io/settings/account/api/auth-tokens/"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
               >
-                Create a token in Linear settings <ExternalLink size={10} aria-hidden />
+                Create a token in Sentry settings <ExternalLink size={10} aria-hidden />
               </a>
             </div>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="sentry-org" className="text-xs font-semibold text-foreground">
+                Organization slug
+              </label>
+              <Input
+                id="sentry-org"
+                placeholder="my-org"
+                value={org}
+                onChange={(e) => setOrg(e.target.value)}
+                disabled={busy}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label htmlFor="sentry-project" className="text-xs font-semibold text-foreground">
+                Project slug
+              </label>
+              <Input
+                id="sentry-project"
+                placeholder="my-project"
+                value={project}
+                onChange={(e) => setProject(e.target.value)}
+                disabled={busy}
+                autoCapitalize="none"
+                autoCorrect="off"
+                spellCheck={false}
+              />
+            </div>
             <p className="text-2xs leading-relaxed text-muted-foreground">
-              Read-only scope is enough. The token is stored encrypted in your operating system
-              keychain and never leaves this machine.
+              A token with issue read scope is enough. It is stored encrypted in your operating
+              system keychain and never leaves this machine.
             </p>
           </>
         )}

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -1,0 +1,372 @@
+import { useEffect, useRef, useState } from 'react';
+import { Button, Divider, EmptyState, Input, SectionHeader, Textarea, cn } from '@goodboy/ui';
+import {
+  ArrowRight,
+  ExternalLink,
+  GitBranch,
+  Layers,
+  Loader2,
+  MessagesSquare,
+  MousePointerClick,
+  Target,
+} from 'lucide-react';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+import { ScrollFade } from '../../../../shared/components/ScrollFade';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+import { formatError } from '../../../../shared/lib/errors';
+import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
+import { goalFromSentry } from '../goal-from-sentry';
+import { sentryFetchIssueDetail, type SentryIssue, type SentryIssueDetail } from '../client';
+
+type Props = {
+  readonly issue: SentryIssue | null;
+  readonly sessionId: SessionId | null;
+  readonly workspaceId: WorkspaceId;
+  readonly onClose: () => void;
+};
+
+const SLUG_MAX_LEN = 30;
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]+/g, '')
+    .trim()
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .slice(0, SLUG_MAX_LEN)
+    .replace(/-+$/, '');
+}
+
+function sanitizeSlug(input: string): string {
+  return input
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+/, '')
+    .slice(0, SLUG_MAX_LEN);
+}
+
+function sanitizePrefix(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '')
+    .replace(/^-+/, '')
+    .slice(0, 16);
+}
+
+function isValidBranchSlug(slug: string): boolean {
+  const s = slug.trim();
+  if (!s) {
+    return false;
+  }
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(s) && !s.includes('..');
+}
+
+const LEVEL_TONE: Record<string, string> = {
+  fatal: 'border-danger/40 bg-danger/10 text-danger',
+  error: 'border-danger/40 bg-danger/10 text-danger',
+  warning: 'border-warning/40 bg-warning/10 text-warning',
+  info: 'border-info/40 bg-info/10 text-info',
+  debug: 'border-border-soft bg-muted/40 text-muted-foreground',
+};
+
+const levelTone = (level: string | null): string =>
+  LEVEL_TONE[level?.toLowerCase() ?? ''] ?? 'border-border-soft bg-muted/40 text-muted-foreground';
+
+export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
+  const createSession = useAppStore((s) => s.createSession);
+  const loadSetting = useAppStore((s) => s.loadSetting);
+  const { showToast } = useToast();
+
+  const [goal, setGoal] = useState('');
+  const [branchSlug, setBranchSlug] = useState('');
+  const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [detail, setDetail] = useState<SentryIssueDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [setupWorkflow, setSetupWorkflow] = useState(() => {
+    try {
+      return localStorage.getItem('goodboy:new-session-setup-workflow') !== '0';
+    } catch {
+      return true;
+    }
+  });
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lastGenRef = useRef('');
+
+  useEffect(() => {
+    if (!issue) {
+      return;
+    }
+    const initial = goalFromSentry(issue);
+    lastGenRef.current = initial;
+    setGoal(initial);
+    setBranchSlug(slugify(issue.title));
+    setDetail(null);
+    setDetailError(null);
+    setError(null);
+    setBusy(false);
+  }, [issue]);
+
+  useEffect(() => {
+    if (!issue) {
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    setDetailError(null);
+    sentryFetchIssueDetail(workspaceId, issue.id)
+      .then((d) => {
+        if (cancelled) {
+          return;
+        }
+        setDetail(d);
+        const regenerated = goalFromSentry(issue, d);
+        const prevGen = lastGenRef.current;
+        lastGenRef.current = regenerated;
+        setGoal((cur) => (cur === prevGen ? regenerated : cur));
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setDetailError(formatError(err));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setDetailLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [issue, workspaceId]);
+
+  useEffect(() => {
+    void loadSetting(settingBranchPrefix(workspaceId)).then((value) => {
+      setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
+    });
+  }, [workspaceId, loadSetting]);
+
+  if (!issue) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <EmptyState
+          icon={MousePointerClick}
+          title="No issue selected"
+          description="Pick an issue to see its stack trace and launch a session."
+        />
+      </div>
+    );
+  }
+
+  const canLaunch = goal.trim().length > 0 && isValidBranchSlug(branchSlug) && !busy;
+
+  const onLaunch = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      const { session } = await createSession({
+        workspaceId,
+        goal,
+        branchPrefix: sanitizePrefix(branchPrefix).trim() || DEFAULT_BRANCH_PREFIX,
+        branchSlug: branchSlug.trim() || undefined,
+        externalTask: {
+          provider: 'sentry',
+          externalId: issue.id,
+          identifier: issue.shortId ?? issue.id,
+          url: issue.permalink ?? '',
+          title: issue.title,
+        },
+      });
+      showToast('success', `Session created: ${session.goal}`);
+      onClose();
+      if (setupWorkflow) {
+        setTimeout(() => {
+          window.dispatchEvent(
+            new CustomEvent('goodboy:open-workflow-builder', {
+              detail: { sessionId: session.id },
+            }),
+          );
+        }, 0);
+      }
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onToggleSetupWorkflow = (next: boolean) => {
+    setSetupWorkflow(next);
+    try {
+      localStorage.setItem('goodboy:new-session-setup-workflow', next ? '1' : '0');
+    } catch {
+      void 0;
+    }
+  };
+
+  const frames = detail?.frames ?? [];
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              'shrink-0 rounded border px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide',
+              levelTone(issue.level),
+            )}
+          >
+            {issue.level ?? 'error'}
+          </span>
+          {issue.shortId ? (
+            <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+              {issue.shortId}
+            </span>
+          ) : null}
+          <span className="flex-1" />
+          {issue.permalink ? (
+            <a
+              href={issue.permalink}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Open in Sentry <ExternalLink size={11} aria-hidden />
+            </a>
+          ) : null}
+        </div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
+        {issue.culprit ? (
+          <span className="truncate font-mono text-2xs text-muted-foreground">{issue.culprit}</span>
+        ) : null}
+      </div>
+      <Divider />
+
+      <div className="min-h-0 flex-1">
+        <ScrollFade className="mx-auto h-full max-w-3xl px-10 py-8">
+          <div className="flex flex-col gap-8">
+            <section className="flex flex-col gap-3">
+              <SectionHeader
+                label="stack trace"
+                icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
+              />
+              {detailLoading ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground/70">
+                  <Loader2 size={13} className="animate-spin" aria-hidden /> Loading latest event…
+                </div>
+              ) : detailError ? (
+                <p className="text-sm text-danger">{detailError}</p>
+              ) : frames.length > 0 ? (
+                <pre className="overflow-x-auto rounded-lg border border-border-soft bg-subtle/40 p-3 font-mono text-2xs leading-relaxed text-muted-foreground">
+                  {frames
+                    .map(
+                      (f) =>
+                        `${f.in_app ? '› ' : '  '}${f.function ?? '?'} (${f.filename ?? '?'}${
+                          f.line_no != null ? `:${f.line_no}` : ''
+                        })`,
+                    )
+                    .join('\n')}
+                </pre>
+              ) : (
+                <p className="text-sm italic text-muted-foreground/60">No stack trace available.</p>
+              )}
+            </section>
+
+            <section className="flex flex-col gap-3">
+              <SectionHeader label="launch session" />
+              {sessionId ? (
+                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+                    <MessagesSquare size={15} className="text-success" aria-hidden />
+                  </span>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="text-sm font-medium text-foreground">
+                      Session already launched
+                    </span>
+                    <span className="truncate text-2xs text-muted-foreground">
+                      A session is linked to this issue.
+                    </span>
+                  </div>
+                  <OpenSessionButton sessionId={sessionId} onOpened={onClose} />
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+                  <div className="flex flex-col gap-1.5">
+                    <SectionHeader
+                      label="Goal"
+                      icon={<Target size={13} aria-hidden className="text-primary" />}
+                    />
+                    <Textarea
+                      value={goal}
+                      onChange={(e) => setGoal(e.target.value)}
+                      autoGrow
+                      minRows={3}
+                      maxRows={12}
+                      disabled={busy}
+                      aria-label="Session goal"
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1.5">
+                    <SectionHeader
+                      label="Branch"
+                      icon={<GitBranch size={13} aria-hidden className="text-success" />}
+                    />
+                    <div className="flex items-center gap-1.5">
+                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                        {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
+                      </span>
+                      <Input
+                        value={branchSlug}
+                        onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
+                        placeholder="branch-slug"
+                        className="h-8 flex-1 font-mono text-sm"
+                        disabled={busy}
+                        autoCapitalize="off"
+                        autoCorrect="off"
+                        spellCheck={false}
+                        aria-label="Branch slug"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-3 pt-1">
+                    <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+                      <input
+                        type="checkbox"
+                        checked={setupWorkflow}
+                        onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
+                        className="accent-primary"
+                        disabled={busy}
+                      />
+                      Set up workflow next
+                    </label>
+                    <span className="flex-1" />
+                    {error ? <span className="text-xs text-danger">{error}</span> : null}
+                    <Button onClick={() => void onLaunch()} disabled={!canLaunch}>
+                      {busy ? (
+                        <>
+                          <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden />
+                          Launching…
+                        </>
+                      ) : (
+                        <>
+                          Launch session
+                          <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
+        </ScrollFade>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueInbox.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useState } from 'react';
+import { cn, EmptyState } from '@goodboy/ui';
+import { Inbox, Loader2, MessagesSquare, Search, Users } from 'lucide-react';
+import { ScrollFade } from '../../../../shared/components/ScrollFade';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import type { SentryIssue } from '../client';
+import type { SentryIssueRow } from './useSentryIssues';
+
+type Props = {
+  readonly rows: ReadonlyArray<SentryIssueRow>;
+  readonly focusedIssueId: string | null;
+  readonly onSelect: (issue: SentryIssue) => void;
+  readonly onLoadMore: () => void;
+  readonly hasMore: boolean;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+const LEVEL_TONE: Record<string, string> = {
+  fatal: 'border-danger/40 bg-danger/10 text-danger',
+  error: 'border-danger/40 bg-danger/10 text-danger',
+  warning: 'border-warning/40 bg-warning/10 text-warning',
+  info: 'border-info/40 bg-info/10 text-info',
+  debug: 'border-border-soft bg-muted/40 text-muted-foreground',
+};
+
+const levelTone = (level: string | null): string =>
+  LEVEL_TONE[level?.toLowerCase() ?? ''] ?? 'border-border-soft bg-muted/40 text-muted-foreground';
+
+export const IssueInbox = ({
+  rows,
+  focusedIssueId,
+  onSelect,
+  onLoadMore,
+  hasMore,
+  loading,
+  error,
+}: Props) => {
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return rows;
+    }
+    return rows.filter(
+      (r) =>
+        r.issue.title.toLowerCase().includes(q) ||
+        (r.issue.culprit?.toLowerCase().includes(q) ?? false) ||
+        (r.issue.shortId?.toLowerCase().includes(q) ?? false),
+    );
+  }, [rows, query]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-3 pb-2">
+        <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-2.5 focus-within:border-primary">
+          <Search size={13} aria-hidden className="shrink-0 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search issues…"
+            aria-label="Search Sentry issues"
+            autoComplete="off"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
+          />
+        </div>
+      </div>
+
+      {loading && rows.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground/60">
+          <Loader2 size={16} className="animate-spin" aria-hidden />
+        </div>
+      ) : error ? (
+        <div className="px-3 pb-3">
+          <div className="flex items-start gap-2.5 rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={Inbox}
+            title={query.trim() ? 'No matching issues' : 'No issues'}
+            description={
+              query.trim()
+                ? 'Try a different search term.'
+                : 'No unresolved issues in this project.'
+            }
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1">
+          <ul className="flex flex-col gap-0.5 px-3 pb-3">
+            {filtered.map((row) => {
+              const active = row.issue.id === focusedIssueId;
+              const lastSeen = row.issue.lastSeen ? formatRelativeDuration(row.issue.lastSeen) : '';
+              return (
+                <li key={row.issue.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(row.issue)}
+                    title={row.issue.title}
+                    aria-current={active}
+                    className={cn(
+                      'flex w-full flex-col gap-1 rounded-md px-2.5 py-2 text-left transition-colors',
+                      active
+                        ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                        : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          'shrink-0 rounded border px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide',
+                          levelTone(row.issue.level),
+                        )}
+                      >
+                        {row.issue.level ?? 'error'}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                        {row.issue.title}
+                      </span>
+                      {row.sessionId ? (
+                        <MessagesSquare
+                          size={11}
+                          aria-label="session launched"
+                          className="shrink-0 text-success"
+                        />
+                      ) : null}
+                    </div>
+                    {row.issue.culprit ? (
+                      <span className="truncate font-mono text-2xs text-muted-foreground/70">
+                        {row.issue.culprit}
+                      </span>
+                    ) : null}
+                    <div className="flex items-center gap-2.5 text-2xs tabular-nums text-muted-foreground/60">
+                      {row.issue.count ? <span>{row.issue.count} events</span> : null}
+                      {row.issue.userCount != null ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Users size={9} aria-hidden />
+                          {row.issue.userCount}
+                        </span>
+                      ) : null}
+                      {lastSeen ? <span className="ml-auto">{lastSeen}</span> : null}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+          {hasMore ? (
+            <div className="px-3 pb-3">
+              <button
+                type="button"
+                onClick={onLoadMore}
+                disabled={loading}
+                className={cn(
+                  'flex w-full items-center justify-center gap-1.5 rounded-md border border-border-soft py-2',
+                  'text-2xs font-medium text-muted-foreground transition-colors',
+                  'hover:border-border hover:bg-muted/40 hover:text-foreground disabled:opacity-50',
+                )}
+              >
+                {loading ? <Loader2 size={12} className="animate-spin" aria-hidden /> : 'Load more'}
+              </button>
+            </div>
+          ) : null}
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react';
+import { cn, Divider } from '@goodboy/ui';
+import { RefreshCw, X } from 'lucide-react';
+import type { WorkspaceId } from '@goodboy/types';
+import { useStudioOverlay } from '../../../../shared/hooks/useStudioOverlay';
+import { IssueInbox } from './IssueInbox';
+import { IssueDetailPanel } from './IssueDetailPanel';
+import { useSentryIssues } from './useSentryIssues';
+import type { SentryIssue } from '../client';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly workspaceName: string;
+  readonly initialIssueId?: string | null;
+  readonly onClose: () => void;
+};
+
+export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClose }: Props) => {
+  const { rows, loadMore, hasMore, loading, error, refetch } = useSentryIssues(workspaceId);
+  const [focused, setFocused] = useState<SentryIssue | null>(null);
+  const { closing, requestClose } = useStudioOverlay(onClose);
+
+  useEffect(() => {
+    if (focused !== null) {
+      return;
+    }
+    if (initialIssueId) {
+      const match = rows.find((r) => r.issue.id === initialIssueId);
+      if (match) {
+        setFocused(match.issue);
+        return;
+      }
+    }
+    const first = rows[0]?.issue ?? null;
+    if (first) {
+      setFocused(first);
+    }
+  }, [focused, rows, initialIssueId]);
+
+  const focusedRow = useMemo(
+    () => (focused ? (rows.find((r) => r.issue.id === focused.id) ?? null) : null),
+    [focused, rows],
+  );
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-0 z-50 flex flex-col bg-background',
+        closing ? 'motion-safe:animate-studio-out' : 'motion-safe:animate-studio-in',
+      )}
+    >
+      <header className="flex shrink-0 items-center gap-3 px-6 py-3">
+        <span className="flex size-8 items-center justify-center rounded-lg bg-provider-sentry/10">
+          <span className="flex size-4 items-center justify-center rounded-sm bg-provider-sentry text-[9px] font-bold text-white">
+            S
+          </span>
+        </span>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex items-center gap-2">
+            <h1 className="text-sm font-semibold text-foreground">Sentry</h1>
+            <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
+              beta
+            </span>
+          </div>
+          <span className="truncate text-2xs text-muted-foreground">{workspaceName}</span>
+        </div>
+        <div className="flex-1" />
+        <button
+          type="button"
+          onClick={refetch}
+          disabled={loading}
+          title="Refresh issues"
+          aria-label="Refresh issues"
+          className={cn(
+            'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+            'text-muted-foreground transition-colors',
+            'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+          )}
+        >
+          <RefreshCw size={13} aria-hidden className={loading ? 'animate-spin' : undefined} />
+        </button>
+        <button
+          type="button"
+          onClick={requestClose}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5',
+            'text-xs font-semibold text-danger transition-colors',
+            'hover:border-danger/60 hover:bg-danger/15',
+          )}
+          aria-label="close sentry studio"
+        >
+          <X size={13} aria-hidden /> Done
+        </button>
+      </header>
+      <Divider />
+
+      <div className="flex min-h-0 flex-1">
+        <div className="w-72 shrink-0">
+          <IssueInbox
+            rows={rows}
+            focusedIssueId={focused?.id ?? null}
+            onSelect={setFocused}
+            onLoadMore={loadMore}
+            hasMore={hasMore}
+            loading={loading}
+            error={error}
+          />
+        </div>
+        <Divider orientation="vertical" />
+        <div className="min-h-0 flex-1">
+          <IssueDetailPanel
+            issue={focused}
+            sessionId={focusedRow?.sessionId ?? null}
+            workspaceId={workspaceId}
+            onClose={requestClose}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.test.ts
@@ -1,0 +1,176 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import {
+  buildIssueRows,
+  dedupById,
+  resolveSentrySessions,
+  useSentryIssues,
+} from './useSentryIssues';
+import { sentryFetchIssues } from '../client';
+import type { SentryIssue, SentryIssuesPage } from '../client';
+
+const hoisted = vi.hoisted(() => ({
+  externalTasks: {} as Record<string, SessionExternalTask>,
+}));
+
+vi.mock('../client', () => ({ sentryFetchIssues: vi.fn() }));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: (
+    selector: (s: { sessionExternalTasks: Record<string, SessionExternalTask> }) => unknown,
+  ) => selector({ sessionExternalTasks: hoisted.externalTasks }),
+}));
+
+const fetchIssues = vi.mocked(sentryFetchIssues);
+const WS = 'ws-1' as WorkspaceId;
+
+const page = (issues: SentryIssue[], next_cursor: string | null = null): SentryIssuesPage => ({
+  issues,
+  next_cursor,
+});
+
+function makeIssue(overrides: Partial<SentryIssue> = {}): SentryIssue {
+  return {
+    id: 'sentry-1',
+    shortId: 'GOODBOY-1',
+    title: 'Boom',
+    culprit: null,
+    level: 'error',
+    status: 'unresolved',
+    count: '1',
+    userCount: 1,
+    firstSeen: null,
+    lastSeen: null,
+    permalink: null,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+describe('dedupById', () => {
+  it('keeps first occurrence and drops later duplicates', () => {
+    const deduped = dedupById([
+      makeIssue({ id: 'a', title: 'first' }),
+      makeIssue({ id: 'b' }),
+      makeIssue({ id: 'a', title: 'dup' }),
+    ]);
+    expect(deduped.map((i) => i.id)).toEqual(['a', 'b']);
+    expect(deduped[0]?.title).toBe('first');
+  });
+});
+
+describe('resolveSentrySessions', () => {
+  it('links sentry external tasks by external id, ignoring other providers', () => {
+    const tasks: Record<string, SessionExternalTask> = {
+      s1: { provider: 'sentry', externalId: 'sentry-1' } as SessionExternalTask,
+      s2: { provider: 'linear', externalId: 'lin-1' } as SessionExternalTask,
+    };
+    const map = resolveSentrySessions(tasks);
+    expect(map.get('sentry-1')).toBe('s1');
+    expect(map.has('lin-1')).toBe(false);
+  });
+});
+
+describe('buildIssueRows', () => {
+  it('attaches the linked session id when present', () => {
+    const rows = buildIssueRows(
+      [makeIssue({ id: 'sentry-1' }), makeIssue({ id: 'sentry-2' })],
+      new Map<string, SessionId>([['sentry-1', 's1' as SessionId]]),
+    );
+    expect(rows.find((r) => r.issue.id === 'sentry-1')?.sessionId).toBe('s1');
+    expect(rows.find((r) => r.issue.id === 'sentry-2')?.sessionId).toBeNull();
+  });
+});
+
+describe('useSentryIssues', () => {
+  beforeEach(() => {
+    hoisted.externalTasks = {};
+    fetchIssues.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('loads the first page on mount and exposes rows', async () => {
+    fetchIssues.mockResolvedValueOnce(page([makeIssue({ id: 'a' })]));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    expect(result.current.rows[0]?.issue.id).toBe('a');
+    expect(result.current.loading).toBe(false);
+    expect(result.current.hasMore).toBe(false);
+    expect(fetchIssues).toHaveBeenCalledWith(WS, undefined, undefined);
+  });
+
+  it('exposes hasMore and forwards the cursor on loadMore, deduping across pages', async () => {
+    fetchIssues
+      .mockResolvedValueOnce(page([makeIssue({ id: 'a' }), makeIssue({ id: 'b' })], 'cur-1'))
+      .mockResolvedValueOnce(page([makeIssue({ id: 'b' }), makeIssue({ id: 'c' })], null));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(3));
+    expect(result.current.rows.map((r) => r.issue.id)).toEqual(['a', 'b', 'c']);
+    expect(result.current.hasMore).toBe(false);
+    expect(fetchIssues).toHaveBeenNthCalledWith(2, WS, undefined, 'cur-1');
+  });
+
+  it('does not fetch again when loadMore is called without a cursor', async () => {
+    fetchIssues.mockResolvedValueOnce(page([makeIssue({ id: 'a' })], null));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(1));
+    fetchIssues.mockClear();
+    act(() => result.current.loadMore());
+    expect(fetchIssues).not.toHaveBeenCalled();
+  });
+
+  it('captures a fetch error message and stays empty', async () => {
+    fetchIssues.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.error).toBe('boom'));
+    expect(result.current.rows).toHaveLength(0);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    fetchIssues.mockRejectedValueOnce('offline');
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.error).toBe('offline'));
+  });
+
+  it('refetch resets rows and reloads from the first page', async () => {
+    fetchIssues
+      .mockResolvedValueOnce(page([makeIssue({ id: 'a' })], 'cur-1'))
+      .mockResolvedValueOnce(page([makeIssue({ id: 'z' })], null));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.rows.map((r) => r.issue.id)).toEqual(['a']));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.refetch());
+
+    await waitFor(() => expect(result.current.rows.map((r) => r.issue.id)).toEqual(['z']));
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('cross-links rows to sessions from the store', async () => {
+    hoisted.externalTasks = {
+      s9: { provider: 'sentry', externalId: 'a' } as SessionExternalTask,
+    };
+    fetchIssues.mockResolvedValueOnce(page([makeIssue({ id: 'a' }), makeIssue({ id: 'b' })]));
+    const { result } = renderHook(() => useSentryIssues(WS));
+
+    await waitFor(() => expect(result.current.rows).toHaveLength(2));
+    expect(result.current.rows.find((r) => r.issue.id === 'a')?.sessionId).toBe('s9');
+    expect(result.current.rows.find((r) => r.issue.id === 'b')?.sessionId).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.ts
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { sentryFetchIssues, type SentryIssue } from '../client';
+
+export type SentryIssueRow = {
+  readonly issue: SentryIssue;
+  readonly sessionId: SessionId | null;
+};
+
+export const dedupById = (issues: ReadonlyArray<SentryIssue>): SentryIssue[] => {
+  const seen = new Set<string>();
+  const out: SentryIssue[] = [];
+  for (const issue of issues) {
+    if (seen.has(issue.id)) {
+      continue;
+    }
+    seen.add(issue.id);
+    out.push(issue);
+  }
+  return out;
+};
+
+export const resolveSentrySessions = (
+  sessionExternalTasks: Readonly<Record<string, SessionExternalTask>>,
+): Map<string, SessionId> => {
+  const byIssue = new Map<string, SessionId>();
+  for (const [sessionId, task] of Object.entries(sessionExternalTasks)) {
+    if (task && task.provider === 'sentry' && !byIssue.has(task.externalId)) {
+      byIssue.set(task.externalId, sessionId as SessionId);
+    }
+  }
+  return byIssue;
+};
+
+export const buildIssueRows = (
+  issues: ReadonlyArray<SentryIssue>,
+  sessionIdByExternalId: ReadonlyMap<string, SessionId>,
+): SentryIssueRow[] =>
+  issues.map((issue) => ({
+    issue,
+    sessionId: sessionIdByExternalId.get(issue.id) ?? null,
+  }));
+
+export type UseSentryIssues = {
+  readonly rows: ReadonlyArray<SentryIssueRow>;
+  readonly loadMore: () => void;
+  readonly hasMore: boolean;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly refetch: () => void;
+};
+
+export const useSentryIssues = (workspaceId: WorkspaceId): UseSentryIssues => {
+  const sessionExternalTasks = useAppStore((s) => s.sessionExternalTasks);
+  const [issues, setIssues] = useState<ReadonlyArray<SentryIssue>>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (nextCursor: string | null, reset: boolean) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const page = await sentryFetchIssues(workspaceId, undefined, nextCursor ?? undefined);
+        setIssues((prev) => dedupById(reset ? page.issues : [...prev, ...page.issues]));
+        setCursor(page.next_cursor);
+        setHasMore(page.next_cursor != null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [workspaceId],
+  );
+
+  useEffect(() => {
+    setIssues([]);
+    setCursor(null);
+    setHasMore(false);
+    void load(null, true);
+  }, [load]);
+
+  const sessionIdByIssueId = useMemo(
+    () => resolveSentrySessions(sessionExternalTasks),
+    [sessionExternalTasks],
+  );
+
+  const rows = useMemo(
+    () => buildIssueRows(issues, sessionIdByIssueId),
+    [issues, sessionIdByIssueId],
+  );
+
+  const reload = useCallback(() => {
+    setIssues([]);
+    setCursor(null);
+    setHasMore(false);
+    void load(null, true);
+  }, [load]);
+
+  return {
+    rows,
+    loadMore: () => {
+      if (!loading && cursor) {
+        void load(cursor, false);
+      }
+    },
+    hasMore,
+    loading,
+    error,
+    refetch: reload,
+  };
+};

--- a/apps/desktop/src/features/integrations/sentry/client.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+import {
+  sentryConnect,
+  sentryDisconnect,
+  sentryFetchIssueDetail,
+  sentryFetchIssues,
+} from './client';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const WS = 'ws-1' as WorkspaceId;
+const mockInvoke = vi.mocked(invoke);
+
+afterEach(() => {
+  mockInvoke.mockReset();
+});
+
+describe('sentryConnect', () => {
+  it('invokes sentry_connect with token, org and project', async () => {
+    mockInvoke.mockResolvedValue({ slug: 'p', name: 'P', organization: { slug: 'o', name: 'O' } });
+    await sentryConnect(WS, 'tok', 'org', 'proj');
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_connect', {
+      workspaceId: WS,
+      token: 'tok',
+      org: 'org',
+      project: 'proj',
+    });
+  });
+});
+
+describe('sentryDisconnect', () => {
+  it('invokes sentry_disconnect with workspace id', async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    await sentryDisconnect(WS);
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_disconnect', { workspaceId: WS });
+  });
+});
+
+describe('sentryFetchIssues', () => {
+  it('passes null for omitted query and cursor', async () => {
+    mockInvoke.mockResolvedValue({ issues: [], next_cursor: null });
+    await sentryFetchIssues(WS);
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_fetch_issues', {
+      workspaceId: WS,
+      query: null,
+      cursor: null,
+    });
+  });
+
+  it('forwards query and cursor when provided', async () => {
+    mockInvoke.mockResolvedValue({ issues: [], next_cursor: null });
+    await sentryFetchIssues(WS, 'is:unresolved', 'cur-1');
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_fetch_issues', {
+      workspaceId: WS,
+      query: 'is:unresolved',
+      cursor: 'cur-1',
+    });
+  });
+});
+
+describe('sentryFetchIssueDetail', () => {
+  it('invokes sentry_fetch_issue_detail with issue id', async () => {
+    mockInvoke.mockResolvedValue({ title: null, culprit: null, frames: [] });
+    await sentryFetchIssueDetail(WS, 'issue-9');
+    expect(mockInvoke).toHaveBeenCalledWith('sentry_fetch_issue_detail', {
+      workspaceId: WS,
+      issueId: 'issue-9',
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/client.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.ts
@@ -1,0 +1,83 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+
+export type SentryOrganization = {
+  slug: string;
+  name: string;
+};
+
+export type SentryProject = {
+  slug: string;
+  name: string;
+  organization: SentryOrganization;
+};
+
+export type SentryIssueMetadata = {
+  type: string | null;
+  value: string | null;
+};
+
+export type SentryIssue = {
+  id: string;
+  shortId: string | null;
+  title: string;
+  culprit: string | null;
+  level: string | null;
+  status: string | null;
+  count: string | null;
+  userCount: number | null;
+  firstSeen: string | null;
+  lastSeen: string | null;
+  permalink: string | null;
+  metadata: SentryIssueMetadata | null;
+};
+
+export type SentryIssuesPage = {
+  issues: SentryIssue[];
+  next_cursor: string | null;
+};
+
+export type SentryStackFrame = {
+  filename: string | null;
+  function: string | null;
+  line_no: number | null;
+  in_app: boolean;
+};
+
+export type SentryIssueDetail = {
+  title: string | null;
+  culprit: string | null;
+  frames: SentryStackFrame[];
+};
+
+export const sentryConnect = async (
+  workspaceId: WorkspaceId,
+  token: string,
+  org: string,
+  project: string,
+): Promise<SentryProject> => {
+  return invoke<SentryProject>('sentry_connect', { workspaceId, token, org, project });
+};
+
+export const sentryDisconnect = async (workspaceId: WorkspaceId): Promise<void> => {
+  await invoke('sentry_disconnect', { workspaceId });
+};
+
+export const sentryFetchIssues = async (
+  workspaceId: WorkspaceId,
+  query?: string,
+  cursor?: string,
+): Promise<SentryIssuesPage> => {
+  return invoke<SentryIssuesPage>('sentry_fetch_issues', {
+    workspaceId,
+    query: query ?? null,
+    cursor: cursor ?? null,
+  });
+};
+
+export const sentryFetchIssueDetail = async (
+  workspaceId: WorkspaceId,
+  issueId: string,
+): Promise<SentryIssueDetail> => {
+  return invoke<SentryIssueDetail>('sentry_fetch_issue_detail', { workspaceId, issueId });
+};

--- a/apps/desktop/src/features/integrations/sentry/goal-from-sentry.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/goal-from-sentry.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { goalFromSentry } from './goal-from-sentry';
+import type { SentryIssue, SentryIssueDetail, SentryStackFrame } from './client';
+
+function makeIssue(overrides: Partial<SentryIssue> = {}): SentryIssue {
+  return {
+    id: 'sentry-1',
+    shortId: 'GOODBOY-7A',
+    title: 'TypeError: cannot read property foo of undefined',
+    culprit: 'app/handlers/session in createSession',
+    level: 'error',
+    status: 'unresolved',
+    count: '12',
+    userCount: 3,
+    firstSeen: '2026-05-01T10:00:00Z',
+    lastSeen: '2026-05-21T10:00:00Z',
+    permalink: 'https://sentry.io/organizations/goodboy/issues/1/',
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function frame(overrides: Partial<SentryStackFrame> = {}): SentryStackFrame {
+  return {
+    filename: 'src/store/createSession.ts',
+    function: 'createSession',
+    line_no: 88,
+    in_app: true,
+    ...overrides,
+  };
+}
+
+describe('goalFromSentry', () => {
+  it('builds heading + culprit when no detail', () => {
+    expect(goalFromSentry(makeIssue())).toBe(
+      '[GOODBOY-7A] TypeError: cannot read property foo of undefined\n\napp/handlers/session in createSession',
+    );
+  });
+
+  it('falls back to id when shortId is null and heading-only when nothing else', () => {
+    expect(goalFromSentry(makeIssue({ shortId: null, culprit: null }))).toBe(
+      '[sentry-1] TypeError: cannot read property foo of undefined',
+    );
+  });
+
+  it('appends top stack frames from detail', () => {
+    const detail: SentryIssueDetail = {
+      title: null,
+      culprit: 'app/x',
+      frames: [frame(), frame({ function: 'caller', line_no: 12 })],
+    };
+    const goal = goalFromSentry(makeIssue(), detail);
+    expect(goal).toContain('app/x');
+    expect(goal).toContain('  at createSession (src/store/createSession.ts:88)');
+    expect(goal).toContain('  at caller (src/store/createSession.ts:12)');
+  });
+
+  it('prefers in-app frames over library frames', () => {
+    const detail: SentryIssueDetail = {
+      title: null,
+      culprit: null,
+      frames: [
+        frame({ function: 'libCall', in_app: false }),
+        frame({ function: 'appCall', in_app: true }),
+      ],
+    };
+    const goal = goalFromSentry(makeIssue({ culprit: null }), detail);
+    expect(goal).toContain('appCall');
+    expect(goal).not.toContain('libCall');
+  });
+
+  it('caps an overlong body and prefers detail title', () => {
+    const detail: SentryIssueDetail = {
+      title: 'Detail title',
+      culprit: 'x'.repeat(2000),
+      frames: [],
+    };
+    const goal = goalFromSentry(makeIssue(), detail);
+    expect(goal.startsWith('[GOODBOY-7A] Detail title')).toBe(true);
+    expect(goal.endsWith('…')).toBe(true);
+    expect(goal.length).toBeLessThanOrEqual(1300);
+  });
+
+  it('falls back to all frames when none are marked in-app', () => {
+    const detail: SentryIssueDetail = {
+      title: null,
+      culprit: null,
+      frames: [
+        frame({ function: 'libA', in_app: false }),
+        frame({ function: 'libB', in_app: false }),
+      ],
+    };
+    const goal = goalFromSentry(makeIssue({ culprit: null }), detail);
+    expect(goal).toContain('libA');
+    expect(goal).toContain('libB');
+  });
+
+  it('caps the stack at ten frames', () => {
+    const frames = Array.from({ length: 15 }, (_, i) => frame({ function: `fn${i}`, line_no: i }));
+    const goal = goalFromSentry(makeIssue({ culprit: null }), {
+      title: null,
+      culprit: null,
+      frames,
+    });
+    const stackLines = goal.split('\n').filter((l) => l.startsWith('  at '));
+    expect(stackLines).toHaveLength(10);
+    expect(goal).toContain('fn0');
+    expect(goal).toContain('fn9');
+    expect(goal).not.toContain('fn10');
+  });
+
+  it('renders a missing filename and line number as placeholders', () => {
+    const goal = goalFromSentry(makeIssue({ culprit: null }), {
+      title: null,
+      culprit: null,
+      frames: [frame({ function: null, filename: null, line_no: null })],
+    });
+    expect(goal).toContain('  at ? (?)');
+  });
+
+  it('returns heading only when detail has no culprit and no frames', () => {
+    const goal = goalFromSentry(makeIssue({ shortId: 'GB-9', culprit: null }), {
+      title: null,
+      culprit: null,
+      frames: [],
+    });
+    expect(goal).toBe('[GB-9] TypeError: cannot read property foo of undefined');
+  });
+
+  it('trims surrounding whitespace from the title', () => {
+    const goal = goalFromSentry(makeIssue({ title: '  Spacey error  ', culprit: null }));
+    expect(goal).toBe('[GOODBOY-7A] Spacey error');
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/goal-from-sentry.ts
+++ b/apps/desktop/src/features/integrations/sentry/goal-from-sentry.ts
@@ -1,0 +1,39 @@
+import type { SentryIssue, SentryIssueDetail, SentryStackFrame } from './client';
+
+const BODY_CHAR_CAP = 1200;
+const MAX_FRAMES = 10;
+
+const formatFrame = (frame: SentryStackFrame): string => {
+  const location = frame.filename ?? '?';
+  const line = frame.line_no != null ? `:${frame.line_no}` : '';
+  const fn = frame.function ?? '?';
+  return `  at ${fn} (${location}${line})`;
+};
+
+export const goalFromSentry = (issue: SentryIssue, detail?: SentryIssueDetail | null): string => {
+  const label = issue.shortId ?? issue.id;
+  const title = (detail?.title ?? issue.title).trim();
+  const heading = `[${label}] ${title}`;
+
+  const sections: string[] = [];
+  const culprit = (detail?.culprit ?? issue.culprit ?? '').trim();
+  if (culprit) {
+    sections.push(culprit);
+  }
+  const frames = detail?.frames ?? [];
+  if (frames.length > 0) {
+    const inApp = frames.filter((f) => f.in_app);
+    const chosen = (inApp.length > 0 ? inApp : frames).slice(0, MAX_FRAMES);
+    const stack = chosen.map(formatFrame).join('\n');
+    if (stack) {
+      sections.push(stack);
+    }
+  }
+
+  const body = sections.join('\n\n');
+  if (!body) {
+    return heading;
+  }
+  const trimmed = body.length > BODY_CHAR_CAP ? `${body.slice(0, BODY_CHAR_CAP).trimEnd()}…` : body;
+  return `${heading}\n\n${trimmed}`;
+};

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -324,7 +324,8 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
         ...(useExisting ? { existingBranch: existingBranch.trim() } : {}),
         ...(linearIssue
           ? {
-              linearIssue: {
+              externalTask: {
+                provider: 'linear' as const,
                 externalId: linearIssue.id,
                 identifier: linearIssue.identifier,
                 url: linearIssue.url,

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { GhTokenStatus, ProviderId, VerbosityLevel, WorkspaceId } from '@goodboy/types';
+import type {
+  GhTokenStatus,
+  LinearIntegrationConfig,
+  ProviderId,
+  SentryIntegrationConfig,
+  VerbosityLevel,
+  WorkspaceId,
+  WorkspaceIntegration,
+} from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { Button, FieldRow, cn } from '@goodboy/ui';
 import { Check, GitBranch, Loader2, Unplug } from 'lucide-react';
@@ -10,6 +18,7 @@ import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel'
 import { ScriptsPanel } from '../../../../features/scripts';
 import { VerbositySelect } from '../../../../features/session/components/VerbositySelect';
 import { ConnectLinearDialog } from '../../../../features/integrations/linear/ConnectLinearDialog';
+import { ConnectSentryDialog } from '../../../../features/integrations/sentry/ConnectSentryDialog';
 import { ConnectGithubDialog } from '../../../../features/integrations/github/ConnectGithubDialog';
 import { ghStatus } from '../../../../features/github/github';
 import { ToggleSwitch } from '../../../../shared/components/ToggleSwitch';
@@ -236,6 +245,7 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
 
           <div ref={anchor('integrations')} className="py-4 first:pt-0 last:pb-0">
             <LinearRow workspaceId={workspaceId} />
+            <SentryRow workspaceId={workspaceId} />
           </div>
           <GithubRow workspaceId={workspaceId} />
 
@@ -318,7 +328,10 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
 
 function LinearRow({ workspaceId }: { workspaceId: WorkspaceId }) {
   const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
-  const linear = integrations.find((i) => i.provider === 'linear') ?? null;
+  const linear =
+    (integrations.find((i) => i.provider === 'linear') as
+      | (WorkspaceIntegration & { config: LinearIntegrationConfig })
+      | undefined) ?? null;
   const [open, setOpen] = useState(false);
 
   return (
@@ -334,6 +347,31 @@ function LinearRow({ workspaceId }: { workspaceId: WorkspaceId }) {
         {linear ? 'Manage' : 'Connect'}
       </Button>
       <ConnectLinearDialog workspaceId={workspaceId} open={open} onClose={() => setOpen(false)} />
+    </FieldRow>
+  );
+}
+
+function SentryRow({ workspaceId }: { workspaceId: WorkspaceId }) {
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
+  const sentry =
+    (integrations.find((i) => i.provider === 'sentry') as
+      | (WorkspaceIntegration & { config: SentryIntegrationConfig })
+      | undefined) ?? null;
+  const [open, setOpen] = useState(false);
+
+  return (
+    <FieldRow
+      label="Sentry"
+      help={
+        sentry
+          ? `Connected to ${sentry.config.org}/${sentry.config.project}`
+          : 'Pull app issues into session goals.'
+      }
+    >
+      <Button variant={sentry ? 'ghost' : 'secondary'} size="sm" onClick={() => setOpen(true)}>
+        {sentry ? 'Manage' : 'Connect'}
+      </Button>
+      <ConnectSentryDialog workspaceId={workspaceId} open={open} onClose={() => setOpen(false)} />
     </FieldRow>
   );
 }

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -145,14 +145,22 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
             type="button"
             onClick={() =>
               window.dispatchEvent(
-                new CustomEvent('goodboy:open-linear-studio', {
-                  detail: { issueExternalId: externalTask.externalId },
-                }),
+                new CustomEvent(
+                  externalTask.provider === 'sentry'
+                    ? 'goodboy:open-sentry-studio'
+                    : 'goodboy:open-linear-studio',
+                  { detail: { issueExternalId: externalTask.externalId } },
+                ),
               )
             }
             title={`${externalTask.identifier}: ${externalTask.title}`}
-            className="shrink-0 inline-flex items-center gap-1 rounded-md border border-provider-linear/30 bg-provider-linear/5 px-1.5 py-0.5 text-2xs font-medium text-provider-linear transition-colors hover:border-provider-linear/60 hover:bg-provider-linear/10"
-            aria-label={`open ${externalTask.identifier} in linear studio`}
+            className={cn(
+              'shrink-0 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-colors',
+              externalTask.provider === 'sentry'
+                ? 'border-provider-sentry/30 bg-provider-sentry/5 text-provider-sentry hover:border-provider-sentry/60 hover:bg-provider-sentry/10'
+                : 'border-provider-linear/30 bg-provider-linear/5 text-provider-linear hover:border-provider-linear/60 hover:bg-provider-linear/10',
+            )}
+            aria-label={`open ${externalTask.identifier} in ${externalTask.provider} studio`}
           >
             <span className="font-mono">{externalTask.identifier}</span>
           </button>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -126,6 +126,7 @@ type WorkspacesSidebarProps = {
   onOpenPalette: (initialQuery?: string) => void;
   onOpenWorkflows: () => void;
   onOpenLinear: () => void;
+  onOpenSentry: () => void;
   onOpenProviders: () => void;
   onOpenGithub: () => void;
   onOpenBudget: () => void;
@@ -141,6 +142,7 @@ export const WorkspacesSidebar = ({
   onOpenPalette,
   onOpenWorkflows,
   onOpenLinear,
+  onOpenSentry,
   onOpenProviders,
   onOpenGithub,
   onOpenBudget,
@@ -152,6 +154,11 @@ export const WorkspacesSidebar = ({
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
       (i) => i.provider === 'linear',
+    ),
+  );
+  const hasSentry = useAppStore((s) =>
+    (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
+      (i) => i.provider === 'sentry',
     ),
   );
   const currentSession = useCurrentSession();
@@ -304,9 +311,11 @@ export const WorkspacesSidebar = ({
             onOpenPalette={onOpenPalette}
             onOpenWorkflows={onOpenWorkflows}
             onOpenLinear={onOpenLinear}
+            onOpenSentry={onOpenSentry}
             onOpenProviders={onOpenProviders}
             onOpenGithub={onOpenGithub}
             linearEnabled={hasLinear}
+            sentryEnabled={hasSentry}
             skillsEnabled={WORKSPACE_FEATURES.skills}
           />
         </>
@@ -341,17 +350,21 @@ function QuickActionsRow({
   onOpenPalette,
   onOpenWorkflows,
   onOpenLinear,
+  onOpenSentry,
   onOpenProviders,
   onOpenGithub,
   linearEnabled,
+  sentryEnabled,
   skillsEnabled,
 }: {
   onOpenPalette: (initialQuery?: string) => void;
   onOpenWorkflows: () => void;
   onOpenLinear: () => void;
+  onOpenSentry: () => void;
   onOpenProviders: () => void;
   onOpenGithub: () => void;
   linearEnabled: boolean;
+  sentryEnabled: boolean;
   skillsEnabled: boolean;
 }) {
   const noProviderConnected = useAppStore(
@@ -389,6 +402,18 @@ function QuickActionsRow({
           label="Linear"
           title="launch a session from a Linear issue"
           onClick={onOpenLinear}
+        />
+      ) : null}
+      {sentryEnabled ? (
+        <QuickAction
+          icon={
+            <span className="flex size-3 items-center justify-center rounded-[3px] bg-provider-sentry text-[7px] font-bold text-white">
+              S
+            </span>
+          }
+          label="Sentry"
+          title="launch a session from a Sentry issue"
+          onClick={onOpenSentry}
         />
       ) : null}
       <QuickAction

--- a/apps/desktop/src/store/slices/integrations/configFromSentry.ts
+++ b/apps/desktop/src/store/slices/integrations/configFromSentry.ts
@@ -1,0 +1,11 @@
+import type { SentryIntegrationConfig } from '@goodboy/types';
+import type { SentryProject } from '../../../features/integrations/sentry/client';
+
+export const configFromSentry = (project: SentryProject): SentryIntegrationConfig => {
+  return {
+    org: project.organization.slug,
+    project: project.slug,
+    projectName: project.name,
+    orgName: project.organization.name,
+  };
+};

--- a/apps/desktop/src/store/slices/integrations/connectSentry.ts
+++ b/apps/desktop/src/store/slices/integrations/connectSentry.ts
@@ -1,0 +1,45 @@
+import { upsertWorkspaceIntegration } from '@goodboy/db';
+import type {
+  IsoDateTime,
+  WorkspaceId,
+  WorkspaceIntegration,
+  WorkspaceIntegrationId,
+} from '@goodboy/types';
+import { sentryConnect, type SentryProject } from '../../../features/integrations/sentry/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { configFromSentry } from './configFromSentry';
+import type { GetFn, SetFn } from './types';
+
+export const connectSentry = (set: SetFn, get: GetFn) => {
+  return async (
+    workspaceId: WorkspaceId,
+    token: string,
+    org: string,
+    project: string,
+  ): Promise<SentryProject> => {
+    const projectInfo = await sentryConnect(workspaceId, token, org, project);
+    const now = new Date().toISOString() as IsoDateTime;
+    const existing = get().workspaceIntegrations[workspaceId]?.find((i) => i.provider === 'sentry');
+    const integration: WorkspaceIntegration = {
+      id: (existing?.id ?? crypto.randomUUID()) as WorkspaceIntegrationId,
+      workspaceId,
+      provider: 'sentry',
+      config: configFromSentry(projectInfo),
+      credentialKey: `goodboy.workspace.${workspaceId}.sentry`,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    await upsertWorkspaceIntegration(tauriDatabase, integration);
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      const rest = current.filter((i) => i.provider !== 'sentry');
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: [...rest, integration],
+        },
+      };
+    });
+    return projectInfo;
+  };
+};

--- a/apps/desktop/src/store/slices/integrations/disconnectSentry.ts
+++ b/apps/desktop/src/store/slices/integrations/disconnectSentry.ts
@@ -1,0 +1,21 @@
+import { deleteWorkspaceIntegration as deleteIntegrationInDb } from '@goodboy/db';
+import type { WorkspaceId } from '@goodboy/types';
+import { sentryDisconnect } from '../../../features/integrations/sentry/client';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { SetFn } from './types';
+
+export const disconnectSentry = (set: SetFn) => {
+  return async (workspaceId: WorkspaceId) => {
+    await sentryDisconnect(workspaceId);
+    await deleteIntegrationInDb(tauriDatabase, workspaceId, 'sentry');
+    set((state) => {
+      const current = state.workspaceIntegrations[workspaceId] ?? [];
+      return {
+        workspaceIntegrations: {
+          ...state.workspaceIntegrations,
+          [workspaceId]: current.filter((i) => i.provider !== 'sentry'),
+        },
+      };
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/integrations/index.test.ts
+++ b/apps/desktop/src/store/slices/integrations/index.test.ts
@@ -292,6 +292,14 @@ vi.mock('../../../features/integrations/linear/client', () => ({
   linearDisconnect: linearDisconnectSpy,
 }));
 
+const sentryConnectSpy = vi.fn();
+const sentryDisconnectSpy = vi.fn(async () => undefined);
+
+vi.mock('../../../features/integrations/sentry/client', () => ({
+  sentryConnect: sentryConnectSpy,
+  sentryDisconnect: sentryDisconnectSpy,
+}));
+
 const ghStatusSpy: ReturnType<typeof vi.fn> = vi.fn<() => Promise<GhTokenStatus>>(async () => ({
   available: true,
   mode: 'gh-cli',
@@ -563,6 +571,120 @@ describe('store contract', () => {
       store.setState({ workspaceIntegrations: { [WS_ID]: [integ] } });
       await store.getState().disconnectLinear(WS_ID);
       expect(store.getState().workspaceIntegrations[WS_ID]).toEqual([]);
+    });
+
+    it('connectSentry upserts a sentry row, derives config, and caches it', async () => {
+      const store = await getStore();
+      sentryConnectSpy.mockResolvedValueOnce({
+        slug: 'desktop',
+        name: 'Desktop',
+        organization: { slug: 'goodboy', name: 'Goodboy' },
+      });
+      const out = await store.getState().connectSentry(WS_ID, 'tok', 'goodboy', 'desktop');
+      expect(out.slug).toBe('desktop');
+      expect(sentryConnectSpy).toHaveBeenCalledWith(WS_ID, 'tok', 'goodboy', 'desktop');
+      expect(upsertWorkspaceIntegrationSpy).toHaveBeenCalledTimes(1);
+      const cached = store.getState().workspaceIntegrations[WS_ID];
+      const sentry = cached?.find((i) => i.provider === 'sentry');
+      expect(sentry).toBeDefined();
+      expect(sentry?.credentialKey).toBe(`goodboy.workspace.${WS_ID}.sentry`);
+      expect(sentry?.config).toEqual({
+        org: 'goodboy',
+        project: 'desktop',
+        projectName: 'Desktop',
+        orgName: 'Goodboy',
+      });
+    });
+
+    it('connectSentry reuses an existing row id and createdAt on reconnect', async () => {
+      const store = await getStore();
+      const existing: WorkspaceIntegration = {
+        id: 'sentry-old' as WorkspaceIntegrationId,
+        workspaceId: WS_ID,
+        provider: 'sentry',
+        config: { org: 'goodboy', project: 'old', projectName: 'Old' },
+        credentialKey: `goodboy.workspace.${WS_ID}.sentry`,
+        createdAt: '2026-01-01T00:00:00.000Z' as IsoDateTime,
+        updatedAt: '2026-01-01T00:00:00.000Z' as IsoDateTime,
+      };
+      store.setState({ workspaceIntegrations: { [WS_ID]: [existing] } });
+      sentryConnectSpy.mockResolvedValueOnce({
+        slug: 'new',
+        name: 'New',
+        organization: { slug: 'goodboy', name: 'Goodboy' },
+      });
+      await store.getState().connectSentry(WS_ID, 'tok', 'goodboy', 'new');
+      const cached = store.getState().workspaceIntegrations[WS_ID] ?? [];
+      const sentryRows = cached.filter((i) => i.provider === 'sentry');
+      expect(sentryRows).toHaveLength(1);
+      expect(sentryRows[0]?.id).toBe('sentry-old');
+      expect(sentryRows[0]?.createdAt).toBe('2026-01-01T00:00:00.000Z');
+      expect((sentryRows[0]?.config as { project: string }).project).toBe('new');
+    });
+
+    it('connectSentry preserves a coexisting linear row', async () => {
+      const store = await getStore();
+      const linear: WorkspaceIntegration = {
+        id: 'lin-1' as WorkspaceIntegrationId,
+        workspaceId: WS_ID,
+        provider: 'linear',
+        config: { workspaceUrlKey: 'k', viewerUserId: 'u', viewerName: 'n' },
+        credentialKey: 'k',
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      store.setState({ workspaceIntegrations: { [WS_ID]: [linear] } });
+      sentryConnectSpy.mockResolvedValueOnce({
+        slug: 'desktop',
+        name: 'Desktop',
+        organization: { slug: 'goodboy', name: 'Goodboy' },
+      });
+      await store.getState().connectSentry(WS_ID, 'tok', 'goodboy', 'desktop');
+      const providers = (store.getState().workspaceIntegrations[WS_ID] ?? [])
+        .map((i) => i.provider)
+        .sort();
+      expect(providers).toEqual(['linear', 'sentry']);
+    });
+
+    it('connectSentry propagates a backend error and leaves cache untouched', async () => {
+      const store = await getStore();
+      sentryConnectSpy.mockRejectedValueOnce(new Error('invalid token'));
+      await expect(
+        store.getState().connectSentry(WS_ID, 'bad', 'goodboy', 'desktop'),
+      ).rejects.toThrow('invalid token');
+      expect(upsertWorkspaceIntegrationSpy).not.toHaveBeenCalled();
+      expect(store.getState().workspaceIntegrations[WS_ID]).toBeUndefined();
+    });
+
+    it('disconnectSentry calls backend + db and removes only the sentry row', async () => {
+      const store = await getStore();
+      const linear: WorkspaceIntegration = {
+        id: 'lin-1' as WorkspaceIntegrationId,
+        workspaceId: WS_ID,
+        provider: 'linear',
+        config: { workspaceUrlKey: 'k', viewerUserId: 'u', viewerName: 'n' },
+        credentialKey: 'k',
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      const sentry: WorkspaceIntegration = {
+        id: 'sentry-1' as WorkspaceIntegrationId,
+        workspaceId: WS_ID,
+        provider: 'sentry',
+        config: { org: 'goodboy', project: 'desktop' },
+        credentialKey: `goodboy.workspace.${WS_ID}.sentry`,
+        createdAt: NOW,
+        updatedAt: NOW,
+      };
+      store.setState({ workspaceIntegrations: { [WS_ID]: [linear, sentry] } });
+      await store.getState().disconnectSentry(WS_ID);
+      expect(sentryDisconnectSpy).toHaveBeenCalledWith(WS_ID);
+      expect(deleteWorkspaceIntegrationSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        WS_ID,
+        'sentry',
+      );
+      expect(store.getState().workspaceIntegrations[WS_ID]).toEqual([linear]);
     });
   });
 });

--- a/apps/desktop/src/store/slices/integrations/index.ts
+++ b/apps/desktop/src/store/slices/integrations/index.ts
@@ -1,5 +1,7 @@
 import { connectLinear } from './connectLinear';
+import { connectSentry } from './connectSentry';
 import { disconnectLinear } from './disconnectLinear';
+import { disconnectSentry } from './disconnectSentry';
 import { loadIntegrations } from './loadIntegrations';
 import type { GetFn, SetFn } from './types';
 
@@ -8,5 +10,7 @@ export const createIntegrationsSlice = (set: SetFn, get: GetFn) => {
     loadIntegrations: loadIntegrations(set),
     connectLinear: connectLinear(set, get),
     disconnectLinear: disconnectLinear(set),
+    connectSentry: connectSentry(set, get),
+    disconnectSentry: disconnectSentry(set),
   };
 };

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -4,6 +4,7 @@ import type {
   Session,
   SessionId,
   SessionExternalTask,
+  SessionExternalTaskProvider,
   SessionProviderPreference,
   TurnState,
   WorkflowId,
@@ -52,7 +53,8 @@ type Input = {
   autoRun?: boolean;
   firstAgentKind?: AgentKind;
   firstAgentModel?: string;
-  linearIssue?: {
+  externalTask?: {
+    provider: SessionExternalTaskProvider;
     externalId: string;
     identifier: string;
     url: string;
@@ -72,7 +74,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     autoRun,
     firstAgentKind,
     firstAgentModel: requestedModel,
-    linearIssue,
+    externalTask,
   }: Input): Promise<{ session: Session; worktree: CreatedWorktree }> => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) {
@@ -162,21 +164,21 @@ export const createSession = (set: SetFn, get: GetFn) => {
       updatedAt: now,
     };
     await insertSession(tauriDatabase, session);
-    let externalTask: SessionExternalTask | null = null;
-    if (linearIssue) {
-      externalTask = {
+    let externalTaskRow: SessionExternalTask | null = null;
+    if (externalTask) {
+      externalTaskRow = {
         sessionId: session.id,
-        provider: 'linear',
-        externalId: linearIssue.externalId,
-        identifier: linearIssue.identifier,
-        url: linearIssue.url,
-        title: linearIssue.title,
+        provider: externalTask.provider,
+        externalId: externalTask.externalId,
+        identifier: externalTask.identifier,
+        url: externalTask.url,
+        title: externalTask.title,
         createdAt: now,
       };
       try {
-        await setSessionExternalTask(tauriDatabase, externalTask);
+        await setSessionExternalTask(tauriDatabase, externalTaskRow);
       } catch {
-        externalTask = null;
+        externalTaskRow = null;
       }
     }
     await insertSessionWorktree(tauriDatabase, {
@@ -287,8 +289,8 @@ export const createSession = (set: SetFn, get: GetFn) => {
         state.currentWorkspaceId === workspaceId ? [session, ...state.sessions] : state.sessions,
       currentSessionId: session.id,
       sessionSummary: null,
-      sessionExternalTasks: externalTask
-        ? { ...state.sessionExternalTasks, [session.id]: externalTask }
+      sessionExternalTasks: externalTaskRow
+        ? { ...state.sessionExternalTasks, [session.id]: externalTaskRow }
         : state.sessionExternalTasks,
       sessionWorktrees: {
         ...state.sessionWorktrees,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -52,6 +52,7 @@ import type {
   TurnEvent,
   TurnProviderOverride,
   SessionExternalTask,
+  SessionExternalTaskProvider,
   Workspace,
   WorkspaceId,
   WorkspaceIntegration,
@@ -123,6 +124,7 @@ import { createBootSlice } from './slices/boot';
 import { createUpdaterSlice } from './slices/updater';
 import { initialUpdaterState, type UpdaterState } from './slices/updater/state';
 import type { LinearViewer } from '../features/integrations/linear/client';
+import type { SentryProject } from '../features/integrations/sentry/client';
 
 export type BootPhase =
   | 'pending'
@@ -331,6 +333,13 @@ export type AppActions = {
   loadIntegrations(workspaceId: WorkspaceId): Promise<void>;
   connectLinear(workspaceId: WorkspaceId, token: string): Promise<LinearViewer>;
   disconnectLinear(workspaceId: WorkspaceId): Promise<void>;
+  connectSentry(
+    workspaceId: WorkspaceId,
+    token: string,
+    org: string,
+    project: string,
+  ): Promise<SentryProject>;
+  disconnectSentry(workspaceId: WorkspaceId): Promise<void>;
   createSession(input: {
     workspaceId: WorkspaceId;
     goal: string;
@@ -342,7 +351,8 @@ export type AppActions = {
     autoRun?: boolean;
     firstAgentKind?: AgentKind;
     firstAgentModel?: string;
-    linearIssue?: {
+    externalTask?: {
+      provider: SessionExternalTaskProvider;
       externalId: string;
       identifier: string;
       url: string;

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -42,6 +42,7 @@
   --color-provider-codex: oklch(0.72 0.16 150);
   --color-provider-gemini: oklch(0.72 0.16 240);
   --color-provider-linear: oklch(0.57 0.16 277);
+  --color-provider-sentry: oklch(0.55 0.18 320);
 
   --text-2xs: 11px;
   --text-xs: 12px;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -61,6 +61,7 @@ import { m060WorkflowTriggerMode } from './m060-workflow-trigger-mode';
 import { m061DiffCommentLineRange } from './m061-diff-comment-line-range';
 import { m062OpenQuestionsTurnOrdinal } from './m062-open-questions-turn-ordinal';
 import { m063OpenQuestionsRecommendedAnswer } from './m063-open-questions-recommended-answer';
+import { m064SentryProvider } from './m064-sentry-provider';
 
 export type Migration = {
   readonly version: number;
@@ -131,4 +132,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 61, sql: m061DiffCommentLineRange },
   { version: 62, sql: m062OpenQuestionsTurnOrdinal },
   { version: 63, sql: m063OpenQuestionsRecommendedAnswer },
+  { version: 64, sql: m064SentryProvider },
 ];

--- a/packages/db/src/migrations/m064-sentry-provider.ts
+++ b/packages/db/src/migrations/m064-sentry-provider.ts
@@ -1,0 +1,59 @@
+export const m064SentryProvider = /* sql */ `
+-- Widen workspace_integrations.provider and session_external_tasks.provider
+-- CHECK constraints to allow 'sentry'. SQLite can't ALTER a CHECK in place,
+-- so rebuild each table. FKs OFF for the rebuild so DROP TABLE does not
+-- cascade-wipe rows in tables that reference these by FK.
+
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS workspace_integrations_new;
+
+CREATE TABLE workspace_integrations_new (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry')),
+  config TEXT NOT NULL DEFAULT '{}',
+  credential_key TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  UNIQUE (workspace_id, provider),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+INSERT INTO workspace_integrations_new (id, workspace_id, provider, config, credential_key, created_at, updated_at)
+  SELECT id, workspace_id, provider, config, credential_key, created_at, updated_at
+  FROM workspace_integrations;
+
+DROP TABLE workspace_integrations;
+ALTER TABLE workspace_integrations_new RENAME TO workspace_integrations;
+
+DROP INDEX IF EXISTS idx_workspace_integrations_workspace_id;
+CREATE INDEX idx_workspace_integrations_workspace_id ON workspace_integrations(workspace_id);
+
+DROP TABLE IF EXISTS session_external_tasks_new;
+
+CREATE TABLE session_external_tasks_new (
+  session_id TEXT PRIMARY KEY,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry')),
+  external_id TEXT NOT NULL,
+  identifier TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO session_external_tasks_new (session_id, provider, external_id, identifier, url, title, created_at)
+  SELECT session_id, provider, external_id, identifier, url, title, created_at
+  FROM session_external_tasks;
+
+DROP TABLE session_external_tasks;
+ALTER TABLE session_external_tasks_new RENAME TO session_external_tasks;
+
+DROP INDEX IF EXISTS idx_session_external_tasks_provider_external;
+CREATE INDEX idx_session_external_tasks_provider_external
+  ON session_external_tasks(provider, external_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/db/src/queries/session-external-task.test.ts
+++ b/packages/db/src/queries/session-external-task.test.ts
@@ -52,6 +52,30 @@ describe('session_external_tasks queries', () => {
     expect(got!.title).toBe(task.title);
   });
 
+  it('persists a sentry-provider task (widened provider CHECK)', async () => {
+    const db = await seed();
+    const task = makeTask({
+      provider: 'sentry',
+      externalId: 'sentry-issue-42',
+      identifier: 'GOODBOY-7A',
+      url: 'https://sentry.io/organizations/goodboy/issues/42/',
+      title: 'TypeError: undefined is not a function',
+    });
+    await setSessionExternalTask(db, task);
+
+    const got = await getSessionExternalTask(db, sessionId);
+    expect(got!.provider).toBe('sentry');
+    expect(got!.externalId).toBe('sentry-issue-42');
+    expect(got!.identifier).toBe('GOODBOY-7A');
+  });
+
+  it('rejects an unknown provider via the CHECK constraint', async () => {
+    const db = await seed();
+    await expect(
+      setSessionExternalTask(db, makeTask({ provider: 'asana' as never })),
+    ).rejects.toThrow(/CHECK constraint/);
+  });
+
   it('set on conflict replaces fields (1:1 per session)', async () => {
     const db = await seed();
     await setSessionExternalTask(db, makeTask());

--- a/packages/db/src/queries/workspace-integration.test.ts
+++ b/packages/db/src/queries/workspace-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type {
   LinearIntegrationConfig,
+  SentryIntegrationConfig,
   WorkspaceId,
   WorkspaceIntegration,
   WorkspaceIntegrationId,
@@ -48,6 +49,28 @@ function makeIntegration(overrides: Partial<WorkspaceIntegration> = {}): Workspa
   };
 }
 
+function makeSentryIntegration(
+  overrides: Partial<WorkspaceIntegration> = {},
+): WorkspaceIntegration {
+  const config: SentryIntegrationConfig = {
+    org: 'goodboy',
+    project: 'desktop',
+    projectName: 'Desktop',
+    orgName: 'Goodboy',
+  };
+  const ts = new Date('2026-05-21T10:00:00Z').toISOString() as IsoDateTime;
+  return {
+    id: 'wi-sentry' as WorkspaceIntegrationId,
+    workspaceId,
+    provider: 'sentry',
+    config,
+    credentialKey: `goodboy.workspace.${workspaceId}.sentry`,
+    createdAt: ts,
+    updatedAt: ts,
+    ...overrides,
+  };
+}
+
 describe('workspace_integrations queries', () => {
   it('upsert inserts a row, get retrieves it, config round-trips through JSON', async () => {
     const db = await seed();
@@ -57,8 +80,8 @@ describe('workspace_integrations queries', () => {
     const got = await getWorkspaceIntegration(db, workspaceId, 'linear');
     expect(got).not.toBeNull();
     expect(got!.id).toBe(integration.id);
-    expect(got!.config.workspaceUrlKey).toBe('serenis');
-    expect(got!.config.viewerUserId).toBe('u-abc');
+    expect((got!.config as LinearIntegrationConfig).workspaceUrlKey).toBe('serenis');
+    expect((got!.config as LinearIntegrationConfig).viewerUserId).toBe('u-abc');
     expect(got!.credentialKey).toBe(integration.credentialKey);
   });
 
@@ -81,7 +104,7 @@ describe('workspace_integrations queries', () => {
 
     const got = await getWorkspaceIntegration(db, workspaceId, 'linear');
     expect(got!.id).toBe(initial.id);
-    expect(got!.config.viewerName).toBe('Amin Khayam');
+    expect((got!.config as LinearIntegrationConfig).viewerName).toBe('Amin Khayam');
     expect(got!.credentialKey).toBe('rotated-key');
     expect(got!.createdAt).toBe(initial.createdAt);
   });
@@ -113,6 +136,91 @@ describe('workspace_integrations queries', () => {
 
     const got = await getWorkspaceIntegration(db, workspaceId, 'linear');
     expect(got).not.toBeNull();
-    expect(got!.config.viewerUserId).toBe('u-abc');
+    expect((got!.config as LinearIntegrationConfig).viewerUserId).toBe('u-abc');
+  });
+
+  it('round-trips a sentry config union through JSON', async () => {
+    const db = await seed();
+    const integration = makeSentryIntegration();
+    await upsertWorkspaceIntegration(db, integration);
+
+    const got = await getWorkspaceIntegration(db, workspaceId, 'sentry');
+    expect(got).not.toBeNull();
+    expect(got!.provider).toBe('sentry');
+    const config = got!.config as SentryIntegrationConfig;
+    expect(config.org).toBe('goodboy');
+    expect(config.project).toBe('desktop');
+    expect(config.projectName).toBe('Desktop');
+    expect(config.orgName).toBe('Goodboy');
+    expect(got!.credentialKey).toBe(`goodboy.workspace.${workspaceId}.sentry`);
+  });
+
+  it('persists a sentry config with optional name fields omitted', async () => {
+    const db = await seed();
+    await upsertWorkspaceIntegration(
+      db,
+      makeSentryIntegration({ config: { org: 'o', project: 'p' } }),
+    );
+
+    const got = await getWorkspaceIntegration(db, workspaceId, 'sentry');
+    const config = got!.config as SentryIntegrationConfig;
+    expect(config.org).toBe('o');
+    expect(config.project).toBe('p');
+    expect(config.projectName).toBeUndefined();
+    expect(config.orgName).toBeUndefined();
+  });
+
+  it('keeps linear and sentry integrations side by side for one workspace', async () => {
+    const db = await seed();
+    await upsertWorkspaceIntegration(db, makeIntegration());
+    await upsertWorkspaceIntegration(db, makeSentryIntegration());
+
+    const all = await listIntegrationsForWorkspace(db, workspaceId);
+    expect(all.map((i) => i.provider).sort()).toEqual(['linear', 'sentry']);
+
+    const sentry = await getWorkspaceIntegration(db, workspaceId, 'sentry');
+    const linear = await getWorkspaceIntegration(db, workspaceId, 'linear');
+    expect((sentry!.config as SentryIntegrationConfig).project).toBe('desktop');
+    expect((linear!.config as LinearIntegrationConfig).workspaceUrlKey).toBe('serenis');
+  });
+
+  it('delete by provider removes only the targeted integration', async () => {
+    const db = await seed();
+    await upsertWorkspaceIntegration(db, makeIntegration());
+    await upsertWorkspaceIntegration(db, makeSentryIntegration());
+
+    await deleteWorkspaceIntegration(db, workspaceId, 'sentry');
+
+    const remaining = await listIntegrationsForWorkspace(db, workspaceId);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.provider).toBe('linear');
+    expect(await getWorkspaceIntegration(db, workspaceId, 'sentry')).toBeNull();
+  });
+
+  it('upsert on conflict rotates the sentry project without changing id', async () => {
+    const db = await seed();
+    const initial = makeSentryIntegration();
+    await upsertWorkspaceIntegration(db, initial);
+
+    await upsertWorkspaceIntegration(
+      db,
+      makeSentryIntegration({
+        id: 'wi-different' as WorkspaceIntegrationId,
+        config: { org: 'goodboy', project: 'mobile', projectName: 'Mobile' },
+        updatedAt: new Date('2026-05-22T10:00:00Z').toISOString() as IsoDateTime,
+      }),
+    );
+
+    const got = await getWorkspaceIntegration(db, workspaceId, 'sentry');
+    expect(got!.id).toBe(initial.id);
+    expect((got!.config as SentryIntegrationConfig).project).toBe('mobile');
+    expect(got!.createdAt).toBe(initial.createdAt);
+  });
+
+  it('rejects an unknown provider via the widened CHECK constraint', async () => {
+    const db = await seed();
+    await expect(
+      upsertWorkspaceIntegration(db, makeSentryIntegration({ provider: 'jira' as never })),
+    ).rejects.toThrow(/CHECK constraint/);
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ContextSlotHistoryEntry,
   LinearIntegrationConfig,
   Session,
+  SentryIntegrationConfig,
   SessionExternalTask,
   SessionExternalTaskProvider,
   TurnState,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -101,7 +101,7 @@ export type WorkspaceScript = Readonly<{
   updatedAt: IsoDateTime;
 }>;
 
-export type WorkspaceIntegrationProvider = 'linear';
+export type WorkspaceIntegrationProvider = 'linear' | 'sentry';
 
 export type LinearIntegrationConfig = Readonly<{
   workspaceUrlKey: string;
@@ -109,17 +109,24 @@ export type LinearIntegrationConfig = Readonly<{
   viewerName: string;
 }>;
 
+export type SentryIntegrationConfig = Readonly<{
+  org: string;
+  project: string;
+  projectName?: string;
+  orgName?: string;
+}>;
+
 export type WorkspaceIntegration = Readonly<{
   id: WorkspaceIntegrationId;
   workspaceId: WorkspaceId;
   provider: WorkspaceIntegrationProvider;
-  config: LinearIntegrationConfig;
+  config: LinearIntegrationConfig | SentryIntegrationConfig;
   credentialKey: string;
   createdAt: IsoDateTime;
   updatedAt: IsoDateTime;
 }>;
 
-export type SessionExternalTaskProvider = 'linear';
+export type SessionExternalTaskProvider = 'linear' | 'sentry';
 
 export type SessionExternalTask = Readonly<{
   sessionId: SessionId;


### PR DESCRIPTION
## Summary
- Per-workspace Sentry integration: connect a token + org/project, browse the project's issues, and launch a session seeded from an issue's title, culprit, and latest-event stacktrace.
- Mirrors the Linear integration end-to-end: Rust backend (`sentry.rs`, keyring-stored `SentryConfig`, 4 tauri commands, cursor-based pagination), store slices, `SentryStudio` UI, and a sidebar quick-action gated on a connected integration.
- Migration `m064-sentry-provider` widens the `workspace_integrations` and `session_external_tasks` provider CHECK constraints to accept `'sentry'`.

## Notes
- `WorkspaceIntegration.config` widened to a flat union (`LinearIntegrationConfig | SentryIntegrationConfig`); Linear-specific read sites narrow via cast.
- `createSession` input generalized from `linearIssue?` to a provider-agnostic `externalTask?`.
- m064 deliberately sits above main's m061/62/63 (index.ts append-only) after rebase.

## Test plan
- [ ] `cargo test --locked` (5 sentry unit tests: Link-cursor parser, frame extraction)
- [ ] vitest suites for client/goal/hook/store-slices/db round-trip
- [ ] manual: connect a real Sentry token, list issues, load-more, launch a session, disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)