### PR TITLE
chore(repo): bump version to 0.1.15

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.14"
+version = "0.1.15"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump version `0.1.14` → `0.1.15` across all release-source files: `package.json`, `apps/desktop/package.json`, `apps/desktop/src-tauri/tauri.conf.json`, `apps/desktop/src-tauri/Cargo.toml` (+ `Cargo.lock`)
- step 1 of the release runbook (`docs/release.md`); the git tag is the source of truth, version must match

## Context
regression audit of `v0.1.14..origin/main` (14 commits: gitlab integration, sentry studio, github PR inline panel, #819 god-file split) found no regressions; CI green on main.

## Test plan
- [ ] CI green (lint + typecheck + test + build, fmt + clippy + test)
- [ ] after merge: dry-run `v0.1.15-rc.1` tag → verify signed/notarized dmg → delete rc → tag `v0.1.15` → publish draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)