### PR TITLE
refactor(desktop): reduce session detail panel initial load

### DIFF
--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.test.tsx
@@ -6,6 +6,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 type MockState = {
   workspaceScripts: Record<string, ReadonlyArray<{ id: string; name: string; body: string }>>;
   scriptRuns: Record<string, Record<string, { status: string; result: unknown }>>;
+  sessionPanelExpanded: Record<string, Partial<Record<string, boolean>>>;
+  setPanelSectionExpanded: ReturnType<typeof vi.fn>;
   loadScripts: ReturnType<typeof vi.fn>;
   runScript: ReturnType<typeof vi.fn>;
   cancelScript: ReturnType<typeof vi.fn>;
@@ -15,6 +17,8 @@ const { state } = vi.hoisted<{ state: MockState }>(() => ({
   state: {
     workspaceScripts: {},
     scriptRuns: {},
+    sessionPanelExpanded: {},
+    setPanelSectionExpanded: vi.fn(),
     loadScripts: vi.fn(async () => undefined),
     runScript: vi.fn(async () => undefined),
     cancelScript: vi.fn(async () => undefined),
@@ -32,6 +36,8 @@ beforeEach(() => {
     'ws-1': [{ id: 'sc-1', name: 'sync env', body: 'cp .env .env.local' }],
   };
   state.scriptRuns = {};
+  state.sessionPanelExpanded = { 'sess-1': { scripts: true } };
+  state.setPanelSectionExpanded = vi.fn();
   state.loadScripts = vi.fn(async () => undefined);
   state.runScript = vi.fn(async () => undefined);
   state.cancelScript = vi.fn(async () => undefined);
@@ -77,6 +83,7 @@ describe('ScriptsSection', () => {
       />,
     );
     expect(screen.getByText('sync env')).toBeDefined();
+    expect(screen.queryByText('cp .env .env.local')).toBeNull();
   });
 
   it('disables the run control when the session has no worktree', () => {
@@ -115,5 +122,31 @@ describe('ScriptsSection', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /stop script/i }));
     expect(state.cancelScript).toHaveBeenCalledWith('sess-1', 'sc-1');
+  });
+
+  it('defaults to collapsed, hiding rows behind a count summary', () => {
+    state.sessionPanelExpanded = {};
+    render(
+      <ScriptsSection
+        sessionId={'sess-1' as never}
+        workspaceId={'ws-1' as never}
+        worktreePath="/wt"
+      />,
+    );
+    expect(screen.queryByText('sync env')).toBeNull();
+    expect(screen.getByText('1 script')).toBeDefined();
+  });
+
+  it('persists the expanded state through the store when toggled', () => {
+    state.sessionPanelExpanded = {};
+    render(
+      <ScriptsSection
+        sessionId={'sess-1' as never}
+        workspaceId={'ws-1' as never}
+        worktreePath="/wt"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /expand scripts/i }));
+    expect(state.setPanelSectionExpanded).toHaveBeenCalledWith('sess-1', 'scripts', true);
   });
 });

--- a/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsSection/index.tsx
@@ -27,7 +27,8 @@ type LogTarget = {
 };
 
 export const ScriptsSection = ({ sessionId, workspaceId, worktreePath }: ScriptsSectionProps) => {
-  const [expanded, setExpanded] = useState(true);
+  const expanded = useAppStore((s) => s.sessionPanelExpanded[sessionId]?.scripts ?? false);
+  const setPanelSectionExpanded = useAppStore((s) => s.setPanelSectionExpanded);
   const [log, setLog] = useState<LogTarget | null>(null);
   const scripts = useAppStore((s) => s.workspaceScripts[workspaceId]);
   const runs = useAppStore((s) => s.scriptRuns[sessionId]);
@@ -79,7 +80,7 @@ export const ScriptsSection = ({ sessionId, workspaceId, worktreePath }: Scripts
         action={
           <button
             type="button"
-            onClick={() => setExpanded((v) => !v)}
+            onClick={() => setPanelSectionExpanded(sessionId, 'scripts', !expanded)}
             aria-expanded={expanded}
             aria-label={`${expanded ? 'collapse' : 'expand'} scripts`}
             className="flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:bg-foreground/10 hover:text-foreground"
@@ -161,7 +162,6 @@ function ScriptRow({
   const status: ScriptRunStatus = run?.status ?? 'idle';
   const result = run?.result ?? null;
   const isPending = status === 'pending';
-  const preview = script.body.trim().split('\n')[0] ?? '';
   const hasOutput = result !== null;
   const logRef = useRef<HTMLButtonElement>(null);
 
@@ -174,10 +174,9 @@ function ScriptRow({
       )}
     >
       <StatusDot status={status} />
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-xs font-medium text-foreground">{script.name}</span>
-        <span className="truncate font-mono text-2xs text-muted-foreground/80">{preview}</span>
-      </div>
+      <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+        {script.name}
+      </span>
       {hasOutput ? (
         <button
           ref={logRef}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+const h = vi.hoisted(() => {
+  const state: Record<string, unknown> = {};
+  const setPanelSectionExpanded = vi.fn((sessionId: string, section: string, expanded: boolean) => {
+    const prev = (state.sessionPanelExpanded ?? {}) as Record<string, Record<string, boolean>>;
+    state.sessionPanelExpanded = {
+      ...prev,
+      [sessionId]: { ...prev[sessionId], [section]: expanded },
+    };
+  });
+  return { state, setPanelSectionExpanded };
+});
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof h.state) => T) => selector(h.state),
+  useSessionLoading: () => ({ agents: false, transcript: false }),
+  useSessionOpenQuestions: () => [],
+  useSessionPlans: () => [],
+  EMPTY_ARRAY: [] as never[],
+}));
+
+vi.mock('@goodboy/ui', () => ({
+  SectionHeader: ({ label, action }: { label: string; action?: unknown }) => (
+    <div data-testid={`header-${label}`}>
+      {label}
+      {action as never}
+    </div>
+  ),
+  cn: (...a: unknown[]) => a.filter(Boolean).join(' '),
+}));
+
+vi.mock('./SectionToggle', () => ({
+  SectionToggle: ({
+    expanded,
+    label,
+    onToggle,
+  }: {
+    expanded: boolean;
+    label: string;
+    onToggle: () => void;
+  }) => (
+    <button data-testid={`toggle-${label}`} onClick={onToggle}>
+      {expanded ? 'expanded' : 'collapsed'}
+    </button>
+  ),
+}));
+
+vi.mock('./PlanReadySuggestion', () => ({
+  PlanReadySuggestion: () => <div data-testid="plan-ready" />,
+}));
+vi.mock('./SpawnAgentControl', () => ({ SpawnAgentControl: () => <div data-testid="spawn" /> }));
+vi.mock('./CollapsedSummary', () => ({
+  CollapsedSummary: ({ text }: { text: string }) => <div data-testid="collapsed">{text}</div>,
+}));
+vi.mock('./AgentRow', () => ({
+  AgentRow: ({ run }: { run: Agent }) => <li data-testid="agent-row">{run.name}</li>,
+}));
+vi.mock('./WorkflowStartButton', () => ({
+  WorkflowStartButton: () => <div data-testid="wf-start" />,
+}));
+vi.mock('./WorkflowStepRow', () => ({ WorkflowStepRow: () => null }));
+vi.mock('./ResolveCluster', () => ({ ResolveCluster: () => null }));
+vi.mock('./ScoutSubtree', () => ({ ScoutSubtree: () => null }));
+vi.mock('./ClusterChildRow', () => ({ ClusterChildRow: () => null }));
+vi.mock('./WorkflowKillButton', () => ({ WorkflowKillButton: () => null }));
+vi.mock('../../../../scripts/components/ScriptsSection', () => ({
+  ScriptsSection: () => <div data-testid="scripts" />,
+}));
+vi.mock('../../../../../shared/components/DogMascot', () => ({ DogMascot: () => null }));
+
+vi.mock('../../../../../features/workflows/components/WorkflowNextStepCta', () => ({
+  pickNextWorkflowStep: () => null,
+}));
+vi.mock('../../../../../features/context/openQuestionsGate', () => ({
+  workflowRunHasOpenQuestions: () => false,
+}));
+vi.mock('../../../../../features/session/agent-row-format', () => ({
+  computeLatestTelemetryByAgentId: () => new Map(),
+}));
+vi.mock('../../../../../features/session/agent-kind', () => ({
+  AGENT_KIND_DEFAULTS: new Proxy({}, { get: () => ({ model: 'm' }) }),
+  inferAgentKindFromName: () => 'implementer',
+  resolveAgentKind: () => 'implementer',
+}));
+vi.mock('../../../../../shared/lib/errors', () => ({ formatError: (e: unknown) => String(e) }));
+
+import { AgentsSection } from './AgentsSection';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const SESSION_ID = 'session-1' as SessionId;
+const NOW = '2026-06-16T00:00:00.000Z' as IsoDateTime;
+
+function buildSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: SESSION_ID,
+    workspaceId: WS_ID,
+    goal: 'do a thing',
+    state: { kind: 'idle', lastActivityAt: NOW },
+    contextSlots: [],
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+    permissionMode: 'bypassPermissions',
+    autoRun: false,
+    titleUserEdited: false,
+    workflowRuns: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
+  return {
+    sessionId: SESSION_ID,
+    ordinal: 0,
+    name: 'agent one',
+    status: 'pending',
+    ...overrides,
+  };
+}
+
+function reset() {
+  Object.keys(h.state).forEach((k) => delete h.state[k]);
+  Object.assign(h.state, {
+    currentSessionId: null,
+    sessionPhaseRuns: {},
+    sessionTelemetry: {},
+    messages: {},
+    agentRunHistory: {},
+    agentKindOverride: {},
+    agentModelOverride: {},
+    selectedAgentId: {},
+    sessionWorktrees: {},
+    sessionGithub: {},
+    sessionPendingResolutions: {},
+    resolverState: {},
+    selectAgent: vi.fn(),
+    activateNextResolver: vi.fn(),
+    spawnAgent: vi.fn(),
+    activateWorkflowAgent: vi.fn(),
+    renameAgent: vi.fn(),
+    deleteAgent: vi.fn(),
+    phaseTemplates: {},
+    sessionWorkflows: {},
+    discardWorkflow: vi.fn(),
+    reorderSessionWorkflows: vi.fn(),
+    setWorkflowRunAutoRun: vi.fn(),
+    startWorkflowRun: vi.fn(),
+    summarizerStatus: {},
+    setPanelSectionExpanded: h.setPanelSectionExpanded,
+    sessionPanelExpanded: {},
+  });
+}
+
+describe('AgentsSection collapse defaults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('empty session: workflow expanded, agents collapsed with no-agents summary', () => {
+    render(<AgentsSection task={buildSession()} />);
+
+    expect(screen.getByTestId('toggle-workflow').textContent).toBe('expanded');
+    expect(screen.queryByTestId('wf-start')).not.toBeNull();
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
+    expect(screen.getByTestId('collapsed').textContent).toBe('No agents yet');
+    expect(screen.queryByTestId('spawn')).toBeNull();
+  });
+
+  it('renders PlanReadySuggestion even when agents collapsed', () => {
+    render(<AgentsSection task={buildSession()} />);
+
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
+    expect(screen.queryByTestId('plan-ready')).not.toBeNull();
+  });
+
+  it('with agents present, agents section defaults expanded', () => {
+    h.state.sessionPhaseRuns = { [SESSION_ID]: [buildAgent({ id: 'agent-1' as AgentId })] };
+    render(<AgentsSection task={buildSession()} />);
+
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('expanded');
+    expect(screen.getByTestId('agent-row').textContent).toBe('agent one');
+    expect(screen.queryByTestId('spawn')).not.toBeNull();
+  });
+
+  it('agent count excludes workflow-step and child agents', () => {
+    h.state.sessionPanelExpanded = { [SESSION_ID]: { agents: false } };
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'agent-1' as AgentId }),
+        buildAgent({
+          id: 'wf-1' as AgentId,
+          workflowRunId: 'run-1' as WorkflowRunId,
+          stepId: 'step-1' as StepId,
+        }),
+        buildAgent({ id: 'child-1' as AgentId, parentAgentId: 'agent-1' as AgentId }),
+      ],
+    };
+    render(<AgentsSection task={buildSession()} />);
+
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
+    expect(screen.getByTestId('collapsed').textContent).toBe('1 agent');
+  });
+
+  it('agents toggle persists across remount', () => {
+    const { unmount } = render(<AgentsSection task={buildSession()} />);
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
+
+    fireEvent.click(screen.getByTestId('toggle-agents'));
+    expect(h.setPanelSectionExpanded).toHaveBeenCalledWith(SESSION_ID, 'agents', true);
+
+    unmount();
+    render(<AgentsSection task={buildSession()} />);
+
+    expect(screen.getByTestId('toggle-agents').textContent).toBe('expanded');
+    expect(screen.queryByTestId('spawn')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -198,8 +198,8 @@ export function AgentsSection({ task }: AgentsSectionProps) {
     });
   }, []);
   const [resolveExpanded, setResolveExpanded] = useState(true);
-  const [workflowExpanded, setWorkflowExpanded] = useState(true);
-  const [agentsExpanded, setAgentsExpanded] = useState(true);
+  const setPanelSectionExpanded = useAppStore((s) => s.setPanelSectionExpanded);
+  const workflowExpanded = useAppStore((s) => s.sessionPanelExpanded[task.id]?.workflow ?? true);
   const [clusterExpand, setClusterExpand] = useState<ReadonlyMap<string, boolean>>(new Map());
   const toggleClusterExpand = useCallback((id: string) => {
     setClusterExpand((prev) => {
@@ -349,6 +349,13 @@ export function AgentsSection({ task }: AgentsSectionProps) {
     [sorted, firstUserTextByAgentId, agentKindOverride],
   );
   const resolverIds = useMemo(() => new Set(resolverAgents.map((r) => r.id)), [resolverAgents]);
+  const standaloneAgentCount = useMemo(
+    () => adHocAgents.filter((r) => !resolverIds.has(r.id)).length,
+    [adHocAgents, resolverIds],
+  );
+  const agentsExpanded = useAppStore(
+    (s) => s.sessionPanelExpanded[task.id]?.agents ?? standaloneAgentCount > 0,
+  );
 
   const aggregatesByAgentId = useMemo(() => {
     const map = new Map<
@@ -739,7 +746,7 @@ export function AgentsSection({ task }: AgentsSectionProps) {
           <SectionToggle
             expanded={workflowExpanded}
             label="workflow"
-            onToggle={() => setWorkflowExpanded((v) => !v)}
+            onToggle={() => setPanelSectionExpanded(task.id, 'workflow', !workflowExpanded)}
           />
         }
       />
@@ -766,7 +773,7 @@ export function AgentsSection({ task }: AgentsSectionProps) {
           <SectionToggle
             expanded={agentsExpanded}
             label="agents"
-            onToggle={() => setAgentsExpanded((v) => !v)}
+            onToggle={() => setPanelSectionExpanded(task.id, 'agents', !agentsExpanded)}
           />
         }
       />
@@ -798,20 +805,17 @@ export function AgentsSection({ task }: AgentsSectionProps) {
               {sorted.filter((r) => !resolverIds.has(r.id)).map(renderAdHocRow)}
             </ul>
           )}
-          <div className="flex flex-col gap-1">
-            <PlanReadySuggestion task={task} />
-            <SpawnAgentControl sessionId={task.id} />
-          </div>
+          <SpawnAgentControl sessionId={task.id} />
           {spawnError ? <p className="mt-1 px-2 text-2xs text-danger">{spawnError}</p> : null}
         </>
       ) : (
         <CollapsedSummary
-          text={(() => {
-            const count = sorted.filter((r) => !resolverIds.has(r.id)).length;
-            return count === 0 ? 'No agents yet' : pluralize(count, 'agent');
-          })()}
+          text={
+            standaloneAgentCount === 0 ? 'No agents yet' : pluralize(standaloneAgentCount, 'agent')
+          }
         />
       )}
+      <PlanReadySuggestion task={task} />
 
       <ScriptsSection
         sessionId={task.id}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -4,7 +4,6 @@ import { AlertTriangle, ArrowRight, Check, Clock, Loader2, Play } from 'lucide-r
 import type { Agent, TelemetryRecord } from '@goodboy/types';
 import { getModelProvider } from '@goodboy/core';
 import { agentHasUnread } from '../../../../../store';
-import { formatCost } from '../../../../../features/session/agent-row-format';
 import type { AgentKind } from '../../../../../features/session/agent-kind';
 import { AgentKindChip } from '../../../../../features/session/components/AgentKindChip';
 import {
@@ -60,7 +59,6 @@ export function WorkflowStepRow({
   const isPendingFuture = run.status === 'pending' && !isActionable;
   const modelLabel = resolvedModel.split('-').slice(1, 3).join('-');
   const isStartable = isActionable && !isBlocked;
-  const stepCost = aggregate?.estimatedCostUsd ?? telemetry?.estimatedCostUsd ?? 0;
 
   const [draft, setDraft] = useState(run.name);
   const [pendingConfirm, setPendingConfirm] = useState(false);
@@ -239,14 +237,6 @@ export function WorkflowStepRow({
               {modelLabel}
             </span>
           </span>
-          {stepCost > 0 && (
-            <span
-              className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground/60"
-              title={`estimated cost: ${formatCost(stepCost)}`}
-            >
-              {formatCost(stepCost)}
-            </span>
-          )}
         </div>
         <div
           className={cn(

--- a/apps/desktop/src/store/slices/sidebar/index.test.ts
+++ b/apps/desktop/src/store/slices/sidebar/index.test.ts
@@ -543,6 +543,23 @@ describe('store contract', () => {
       expect(store.getState().sidebarProviderFilter).toEqual(['anthropic']);
     });
 
+    it('setPanelSectionExpanded merges per-session without clobbering siblings', async () => {
+      const store = await getStore();
+      store.getState().setPanelSectionExpanded(SESSION_ID, 'workflow', true);
+      store.getState().setPanelSectionExpanded(SESSION_ID, 'agents', false);
+      store.getState().setPanelSectionExpanded(SESSION_ID_2, 'scripts', true);
+      const state = store.getState().sessionPanelExpanded;
+      expect(state[SESSION_ID]).toEqual({ workflow: true, agents: false });
+      expect(state[SESSION_ID_2]).toEqual({ scripts: true });
+    });
+
+    it('setPanelSectionExpanded leaves absent values to fall back', async () => {
+      const store = await getStore();
+      store.getState().setPanelSectionExpanded(SESSION_ID, 'workflow', true);
+      const state = store.getState().sessionPanelExpanded;
+      expect(state[SESSION_ID]?.scripts ?? 'fallback').toBe('fallback');
+    });
+
     it('refreshUnreadWorkspaces stores the set returned by the invoker', async () => {
       const store = await getStore();
       invokeWorkspacesWithUnreadSpy.mockResolvedValueOnce([WS_ID, WS_ID_2]);

--- a/apps/desktop/src/store/slices/sidebar/index.ts
+++ b/apps/desktop/src/store/slices/sidebar/index.ts
@@ -1,16 +1,18 @@
 import { refreshUnreadWorkspaces } from './refreshUnreadWorkspaces';
+import { setPanelSectionExpanded } from './setPanelSectionExpanded';
 import { setSidebarProviderFilter } from './setSidebarProviderFilter';
 import { setSidebarSessionSearch } from './setSidebarSessionSearch';
 import { setSidebarStateFilter } from './setSidebarStateFilter';
 import { setSidebarWorkspaceSearch } from './setSidebarWorkspaceSearch';
 import type { GetFn, SetFn } from './types';
 
-export const createSidebarSlice = (set: SetFn, _get: GetFn) => {
+export const createSidebarSlice = (set: SetFn, get: GetFn) => {
   return {
     setSidebarWorkspaceSearch: setSidebarWorkspaceSearch(set),
     setSidebarSessionSearch: setSidebarSessionSearch(set),
     refreshUnreadWorkspaces: refreshUnreadWorkspaces(set),
     setSidebarStateFilter: setSidebarStateFilter(set),
     setSidebarProviderFilter: setSidebarProviderFilter(set),
+    setPanelSectionExpanded: setPanelSectionExpanded(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/sidebar/setPanelSectionExpanded.ts
+++ b/apps/desktop/src/store/slices/sidebar/setPanelSectionExpanded.ts
@@ -1,0 +1,14 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn, PanelSection, SetFn } from './types';
+
+export const setPanelSectionExpanded = (set: SetFn, get: GetFn) => {
+  return (sessionId: SessionId, section: PanelSection, expanded: boolean) => {
+    const prev = get().sessionPanelExpanded;
+    set({
+      sessionPanelExpanded: {
+        ...prev,
+        [sessionId]: { ...prev[sessionId], [section]: expanded },
+      },
+    });
+  };
+};

--- a/apps/desktop/src/store/slices/sidebar/types.ts
+++ b/apps/desktop/src/store/slices/sidebar/types.ts
@@ -1,1 +1,3 @@
 export type { SetFn, GetFn } from '../../slice-types';
+
+export type PanelSection = 'workflow' | 'agents' | 'scripts';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -96,6 +96,7 @@ import { createGitlabMrSlice } from './slices/gitlab-mr';
 import type { GitlabMergeRequest } from '../features/integrations/gitlab/client';
 import { createIntegrationsSlice } from './slices/integrations';
 import { createSidebarSlice } from './slices/sidebar';
+import type { PanelSection } from './slices/sidebar/types';
 import { createSessionViewSlice } from './slices/session-view';
 import { createTerminalSlice } from './slices/terminal';
 import { createScriptsSlice } from './slices/scripts';
@@ -238,6 +239,9 @@ export type AppState = UpdaterState & {
   readonly unreadWorkspaceIds: ReadonlySet<WorkspaceId>;
   readonly sidebarStateFilter: ReadonlyArray<TurnState['kind']>;
   readonly sidebarProviderFilter: ReadonlyArray<ProviderId>;
+  readonly sessionPanelExpanded: Readonly<
+    Record<SessionId, Partial<Record<PanelSection, boolean>>>
+  >;
   readonly githubStatus: GhTokenStatus | null;
   readonly sessionGithub: Readonly<Record<SessionId, SessionGithubState>>;
   readonly sessionGitlabMr: Readonly<Record<SessionId, SessionGitlabMrState>>;
@@ -536,6 +540,7 @@ export type AppActions = {
   refreshUnreadWorkspaces(): Promise<void>;
   setSidebarStateFilter(states: ReadonlyArray<TurnState['kind']>): void;
   setSidebarProviderFilter(providers: ReadonlyArray<ProviderId>): void;
+  setPanelSectionExpanded(sessionId: SessionId, section: PanelSection, expanded: boolean): void;
   exportConfig(): Promise<string | null>;
   importConfig(): Promise<import('@goodboy/types').ConfigBundleImportResult | null>;
   refreshGithubStatus(): Promise<void>;
@@ -724,6 +729,7 @@ export const initialState: AppState = {
   unreadWorkspaceIds: new Set<WorkspaceId>(),
   sidebarStateFilter: [],
   sidebarProviderFilter: [],
+  sessionPanelExpanded: {},
   githubStatus: null,
   sessionGithub: {},
   sessionGitlabMr: {},


### PR DESCRIPTION
## Summary
- Persist per-session panel section expand state in the sidebar slice (in-memory, no SQLite migration) so sections don't reset to all-expanded on every mount
- Default fallbacks: Workflow expanded, Agents auto-expand only when standalone (non-resolver) agents exist, Scripts collapsed
- Trim per-row chrome: drop ScriptRow body preview and WorkflowStepRow per-step cost chip
- Fix Agents counter: count only standalone agents, excluding workflow/scout/cluster children that previously inflated the number

## Test plan
- [ ] New session opens with lean panel (Workflow expanded, Agents/Scripts collapsed unless agents exist)
- [ ] Toggling a section persists across session switches
- [ ] Agents counter matches the listed standalone agents
- [x] Unit tests: sidebar slice, AgentsSection, ScriptsSection (20/20), full suite 1402 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)