### PR TITLE
feat(desktop): guided onboarding wizard + integration setup

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -409,6 +409,24 @@ export const App = () => {
   }, [currentWorkspace]);
 
   useEffect(() => {
+    const handler = () => {
+      setNewSessionOpen(false);
+      setWorkspaceSettingsOpen(false);
+      setWorkspaceSettingsFocus(undefined);
+      setSessionSettingsOpen(false);
+      setWorkflowBuilderSessionId(null);
+      setPlanStudioSession(null);
+      setPlanStudioPlanId(null);
+      setDiffViewerSession(null);
+      setDiffViewerWorkingDir(null);
+      setGithubSessionPane(null);
+      setGitlabMrPane(null);
+    };
+    window.addEventListener('goodboy:reveal-chat', handler);
+    return () => window.removeEventListener('goodboy:reveal-chat', handler);
+  }, []);
+
+  useEffect(() => {
     const handler = () => setAddWorkspaceOpen(true);
     window.addEventListener('goodboy:add-workspace', handler);
     return () => window.removeEventListener('goodboy:add-workspace', handler);
@@ -669,14 +687,11 @@ export const App = () => {
     );
   }
 
-  if (hasWorkspaces && !currentWorkspace && isMainWindow()) {
+  if (hasWorkspaces && !currentWorkspace && isMainWindow() && !addWorkspaceOpen) {
     return (
       <ToastProvider>
         <NotificationToastBridge />
         <WorkspaceLauncher />
-        {addWorkspaceOpen ? (
-          <WorkspaceLinkDialog open onClose={() => setAddWorkspaceOpen(false)} />
-        ) : null}
         {switcherOpen ? <WorkspaceSwitcher onClose={() => setSwitcherOpen(false)} /> : null}
       </ToastProvider>
     );
@@ -739,7 +754,9 @@ export const App = () => {
             ) : (
               <EmptyState
                 hasWorkspace={Boolean(currentWorkspace)}
+                hasSessions={currentWorkspaceSessions.length > 0}
                 onAddWorkspace={() => setAddWorkspaceOpen(true)}
+                onCreateSession={openNewSession}
               />
             )}
 

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -1,5 +1,440 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`snapshot, empty states > AppEmptyState: workspace with no sessions, create-first CTA 1`] = `
+<div
+  class="relative flex h-full w-full items-center justify-center overflow-hidden px-6"
+>
+  <div
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-0"
+    style="background: radial-gradient(ellipse at center, transparent 0%, transparent 40%, var(--color-background) 100%);"
+  />
+  <div
+    class="relative flex max-w-md flex-col items-center gap-6 text-center"
+  >
+    <div
+      class="relative"
+    >
+      <div
+        class="absolute -inset-6 rounded-full bg-primary/10 blur-2xl"
+      />
+      <div
+        class="relative flex h-24 w-24 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 shadow-lg backdrop-blur-sm"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block shrink-0 text-foreground"
+          style="width: 56px; height: 56px; background-color: currentcolor;"
+        />
+      </div>
+    </div>
+    <div
+      class="flex flex-col gap-2.5"
+    >
+      <h2
+        class="text-2xl font-semibold tracking-tight text-foreground"
+      >
+        Create your first session
+      </h2>
+      <p
+        class="max-w-sm text-sm leading-relaxed text-muted-foreground"
+      >
+        A session spins up its own worktree and branch so your main checkout stays untouched. Set a goal and let an agent run.
+      </p>
+    </div>
+    <button
+      class="inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-primary text-primary-foreground hover:bg-primary/90 h-8 text-sm px-6 py-2.5"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-plus"
+        fill="none"
+        height="16"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M5 12h14"
+        />
+        <path
+          d="M12 5v14"
+        />
+      </svg>
+      New session
+    </button>
+    <div
+      class="mt-2 flex flex-wrap items-center justify-center gap-2 text-2xs text-muted-foreground"
+    >
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          K
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          command palette
+        </span>
+      </span>
+      <span
+        class="text-muted-foreground/30"
+      >
+        ·
+      </span>
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ,
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          settings
+        </span>
+      </span>
+      <span
+        class="text-muted-foreground/30"
+      >
+        ·
+      </span>
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          /
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          shortcuts
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshot, empty states > AppEmptyState: workspace with sessions, pick up where you left off 1`] = `
+<div
+  class="relative flex h-full w-full items-center justify-center overflow-hidden px-6"
+>
+  <div
+    aria-hidden="true"
+    class="pointer-events-none absolute inset-0"
+    style="background: radial-gradient(ellipse at center, transparent 0%, transparent 40%, var(--color-background) 100%);"
+  />
+  <div
+    class="relative flex max-w-md flex-col items-center gap-6 text-center"
+  >
+    <div
+      class="relative"
+    >
+      <div
+        class="absolute -inset-6 rounded-full bg-primary/10 blur-2xl"
+      />
+      <div
+        class="relative flex h-24 w-24 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 shadow-lg backdrop-blur-sm"
+      >
+        <span
+          aria-hidden="true"
+          class="inline-block shrink-0 text-foreground"
+          style="width: 56px; height: 56px; background-color: currentcolor;"
+        />
+      </div>
+    </div>
+    <div
+      class="flex flex-col gap-2.5"
+    >
+      <h2
+        class="text-2xl font-semibold tracking-tight text-foreground"
+      >
+        Pick up where you left off
+      </h2>
+      <p
+        class="max-w-sm text-sm leading-relaxed text-muted-foreground"
+      >
+        Create a new session from the sidebar, or jump back into an existing one. Each session lives in its own worktree.
+      </p>
+    </div>
+    <div
+      class="mt-2 flex flex-wrap items-center justify-center gap-2 text-2xs text-muted-foreground"
+    >
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          K
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          command palette
+        </span>
+      </span>
+      <span
+        class="text-muted-foreground/30"
+      >
+        ·
+      </span>
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ,
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          settings
+        </span>
+      </span>
+      <span
+        class="text-muted-foreground/30"
+      >
+        ·
+      </span>
+      <span
+        class="inline-flex items-center gap-1"
+      >
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          ⌘
+        </kbd>
+        <kbd
+          class="inline-flex h-4 min-w-[1rem] items-center justify-center rounded border border-border-soft bg-subtle/60 px-1 font-mono text-[10px] font-medium text-muted-foreground"
+        >
+          /
+        </kbd>
+        <span
+          class="ml-1"
+        >
+          shortcuts
+        </span>
+      </span>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`snapshot, empty states > ChatEmptyState: fresh session, set-up-a-workflow CTA 1`] = `
+<div
+  class="mx-auto flex w-full max-w-[640px] flex-col items-center justify-center gap-5 px-6 py-16 text-center"
+>
+  <div
+    class="flex items-center justify-center"
+  >
+    <span
+      aria-hidden="true"
+      class="inline-block shrink-0 text-primary"
+      style="width: 128px; height: 128px; background-color: currentcolor;"
+    />
+  </div>
+  <div
+    class="flex flex-col gap-1.5"
+  >
+    <span
+      class="text-2xs font-semibold uppercase tracking-[0.12em] text-muted-foreground/70"
+    >
+      Fresh session · No context yet
+    </span>
+    <h2
+      class="text-base font-semibold text-foreground"
+    >
+      Let's populate the context
+    </h2>
+    <p
+      class="text-sm leading-relaxed text-muted-foreground"
+    >
+      What you type below becomes the shared brief every agent you spawn starts from.
+    </p>
+  </div>
+  <div
+    class="flex flex-wrap items-center justify-center gap-1.5 text-2xs text-muted-foreground/70"
+  >
+    <span
+      class="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-2 py-0.5 text-2xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-sparkles"
+        fill="none"
+        height="10"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+        />
+        <path
+          d="M20 2v4"
+        />
+        <path
+          d="M22 4h-4"
+        />
+        <circle
+          cx="4"
+          cy="20"
+          r="2"
+        />
+      </svg>
+      What are we building
+    </span>
+    <span
+      class="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-2 py-0.5 text-2xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-sparkles"
+        fill="none"
+        height="10"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+        />
+        <path
+          d="M20 2v4"
+        />
+        <path
+          d="M22 4h-4"
+        />
+        <circle
+          cx="4"
+          cy="20"
+          r="2"
+        />
+      </svg>
+      Any constraints or non-goals
+    </span>
+    <span
+      class="inline-flex items-center gap-1 rounded-full border border-border-soft bg-background px-2 py-0.5 text-2xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-sparkles"
+        fill="none"
+        height="10"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="10"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+        />
+        <path
+          d="M20 2v4"
+        />
+        <path
+          d="M22 4h-4"
+        />
+        <circle
+          cx="4"
+          cy="20"
+          r="2"
+        />
+      </svg>
+      Who should the first agent be
+    </span>
+  </div>
+  <button
+    class="inline-flex items-center justify-center gap-1.5 rounded-md border font-medium motion-safe:transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 bg-muted text-foreground hover:bg-muted/70 border-border h-7 px-2.5 text-xs"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-workflow"
+      fill="none"
+      height="13"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="13"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect
+        height="8"
+        rx="2"
+        width="8"
+        x="3"
+        y="3"
+      />
+      <path
+        d="M7 11v4a2 2 0 0 0 2 2h4"
+      />
+      <rect
+        height="8"
+        rx="2"
+        width="8"
+        x="13"
+        y="13"
+      />
+    </svg>
+    Set up a workflow
+  </button>
+</div>
+`;
+
 exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
 <div
   class="flex h-full w-full flex-col bg-background motion-safe:animate-studio-in"
@@ -76,7 +511,7 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
     class="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5"
   >
     <div
-      class="mx-auto flex w-full max-w-2xl flex-col gap-7"
+      class="mx-auto my-auto flex w-full max-w-2xl flex-col gap-7"
     >
       <section
         class="flex flex-col gap-2.5"
@@ -451,9 +886,17 @@ exports[`snapshot, empty states > WorkspacesSidebar: no workspace selected 1`] =
     <button
       aria-label="open onboarding checklist"
       class="inline-flex shrink-0 items-center gap-1 rounded-md border border-border-soft bg-subtle/60 px-1.5 py-1 transition-colors hover:border-border"
-      title="Setup, 0 of 5 done"
+      title="Setup, 0 of 7 done"
       type="button"
     >
+      <span
+        aria-hidden="true"
+        class="size-1.5 rounded-full transition-colors bg-border"
+      />
+      <span
+        aria-hidden="true"
+        class="size-1.5 rounded-full transition-colors bg-border"
+      />
       <span
         aria-hidden="true"
         class="size-1.5 rounded-full transition-colors bg-border"
@@ -1166,7 +1609,7 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
     class="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5"
   >
     <div
-      class="mx-auto flex w-full max-w-2xl flex-col gap-7"
+      class="mx-auto my-auto flex w-full max-w-2xl flex-col gap-7"
     >
       <section
         class="flex flex-col gap-2.5"

--- a/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
+++ b/apps/desktop/src/__tests__/snapshots/empty-error-states.test.tsx
@@ -158,6 +158,8 @@ function mockStore(partial: Partial<AppStore>): void {
     selector({ providerLifecycle: DEFAULT_LIFECYCLE_MAP, ...partial } as AppStore),
   );
 }
+import { EmptyState } from '../../app/components/AppEmptyState';
+import { ChatEmptyState } from '../../features/chat/components/ChatView/ChatEmptyState';
 import { NotificationCenter } from '../../features/notifications/components/NotificationCenter';
 import { BootSplash } from '../../app/components/BootSplash';
 import { NewSessionView } from '../../features/session/components/NewSessionView';
@@ -232,6 +234,40 @@ describe('snapshot, empty states', () => {
 
   it('NotificationCenter: no notifications', () => {
     const { container } = render(<NotificationCenter />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('AppEmptyState: workspace with no sessions, create-first CTA', () => {
+    const { container, getByRole } = render(
+      <EmptyState
+        hasWorkspace
+        hasSessions={false}
+        onAddWorkspace={vi.fn()}
+        onCreateSession={vi.fn()}
+      />,
+    );
+    expect(getByRole('button', { name: /new session/i })).toBeTruthy();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('AppEmptyState: workspace with sessions, pick up where you left off', () => {
+    const { container, queryByRole } = render(
+      <EmptyState hasWorkspace hasSessions onAddWorkspace={vi.fn()} onCreateSession={vi.fn()} />,
+    );
+    expect(queryByRole('button', { name: /new session/i })).toBeNull();
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('ChatEmptyState: fresh session, set-up-a-workflow CTA', () => {
+    const { container, getByRole } = render(
+      <ChatEmptyState
+        sessionId={'sess-1' as SessionId}
+        selectedAgentId={null}
+        phaseRuns={[]}
+        hasWorkflow={false}
+      />,
+    );
+    expect(getByRole('button', { name: /set up a workflow/i })).toBeTruthy();
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/apps/desktop/src/app/components/AppEmptyState/index.tsx
+++ b/apps/desktop/src/app/components/AppEmptyState/index.tsx
@@ -1,13 +1,15 @@
-import { BookOpen, MessageSquare, MessagesSquare } from 'lucide-react';
+import { BookOpen, MessageSquare, MessagesSquare, Plus } from 'lucide-react';
+import { Button } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 
-export function EmptyState({
-  hasWorkspace,
-  onAddWorkspace,
-}: {
-  hasWorkspace: boolean;
-  onAddWorkspace: () => void;
-}) {
+type Props = {
+  readonly hasWorkspace: boolean;
+  readonly hasSessions: boolean;
+  readonly onAddWorkspace: () => void;
+  readonly onCreateSession: () => void;
+};
+
+export function EmptyState({ hasWorkspace, hasSessions, onAddWorkspace, onCreateSession }: Props) {
   if (!hasWorkspace) {
     return <OnboardingScreen onAddWorkspace={onAddWorkspace} />;
   }
@@ -24,15 +26,33 @@ export function EmptyState({
       />
       <div className="relative flex max-w-md flex-col items-center gap-6 text-center">
         <EmptyStateLogo />
-        <div className="flex flex-col gap-2.5">
-          <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-            Pick up where you left off
-          </h2>
-          <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
-            Create a new session from the sidebar, or jump back into an existing one. Each session
-            lives in its own worktree.
-          </p>
-        </div>
+        {hasSessions ? (
+          <div className="flex flex-col gap-2.5">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+              Pick up where you left off
+            </h2>
+            <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+              Create a new session from the sidebar, or jump back into an existing one. Each session
+              lives in its own worktree.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-2.5">
+              <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+                Create your first session
+              </h2>
+              <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+                A session spins up its own worktree and branch so your main checkout stays
+                untouched. Set a goal and let an agent run.
+              </p>
+            </div>
+            <Button size="md" onClick={onCreateSession} className="px-6 py-2.5">
+              <Plus size={16} aria-hidden />
+              New session
+            </Button>
+          </>
+        )}
         <KeyboardHints hasWorkspace />
       </div>
     </div>

--- a/apps/desktop/src/features/chat/components/ChatView/ChatEmptyState.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/ChatEmptyState.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react';
-import { Sparkles } from 'lucide-react';
-import { cn } from '@goodboy/ui';
-import type { AgentId } from '@goodboy/types';
+import { useCallback, useMemo } from 'react';
+import { Sparkles, Workflow } from 'lucide-react';
+import { Button, cn } from '@goodboy/ui';
+import type { AgentId, SessionId } from '@goodboy/types';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import agentDebugger from '../../../../assets/agents/debugger.png';
 import agentDocs from '../../../../assets/agents/docs.png';
@@ -73,12 +73,13 @@ type EmptyCopy = {
 };
 
 type Props = {
+  readonly sessionId: SessionId;
   readonly selectedAgentId: AgentId | null;
   readonly phaseRuns: ReadonlyArray<import('@goodboy/types').Agent>;
   readonly hasWorkflow: boolean;
 };
 
-export const ChatEmptyState = ({ selectedAgentId, phaseRuns, hasWorkflow }: Props) => {
+export const ChatEmptyState = ({ sessionId, selectedAgentId, phaseRuns, hasWorkflow }: Props) => {
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const selectedAgent = useMemo(
     () => (selectedAgentId ? (phaseRuns.find((r) => r.id === selectedAgentId) ?? null) : null),
@@ -111,7 +112,7 @@ export const ChatEmptyState = ({ selectedAgentId, phaseRuns, hasWorkflow }: Prop
         return {
           eyebrow: `${meta.label} agent · fresh transcript`,
           title: `You're talking to a ${meta.label} agent`,
-          body: `${meta.hint}. It already knows the session brief on the right: goal, decisions, open questions. No need to re-explain. Say what you want next.`,
+          body: 'It already knows the session brief on the right, so just say what you want next.',
           hints: [
             selectedKind === 'scout' ? 'Try: "find where X is defined"' : null,
             selectedKind === 'planner' ? 'Try: "plan how to add X to Y"' : null,
@@ -128,22 +129,22 @@ export const ChatEmptyState = ({ selectedAgentId, phaseRuns, hasWorkflow }: Prop
         return {
           eyebrow: `${phaseRuns.length === 1 ? 'agent' : 'agents'} in this session`,
           title: 'Pick an agent on the left',
-          body: 'Agents share the session context on the right. Every new one starts already knowing the goal, decisions and open questions. Only the chat history is per-agent. Pick one to keep talking, or spawn a new one: it will hit the ground running.',
+          body: 'Agents share the session context, so pick one to keep talking or spawn a new one.',
           hints: ['Select an agent to see its transcript', 'Spawn fresh, context travels with it'],
         };
       case 'workflow_no_agent':
         return {
           eyebrow: 'Workflow ready · No agents yet',
           title: 'Start the first step',
-          body: 'No agents have run yet. Write here to shape the session brief on the right: goal, constraints, anything important. The first agent, and every one after, will start already knowing it.',
-          hints: ['Describe the goal in 1–2 lines', 'Lands in the shared context'],
+          body: 'Type your goal below to shape the shared brief before the first agent runs.',
+          hints: ['Describe the goal in 1-2 lines', 'Lands in the shared context'],
         };
       case 'fresh':
       default:
         return {
           eyebrow: 'Fresh session · No context yet',
           title: "Let's populate the context",
-          body: "Whatever you write here feeds the shared session brief on the right: goal, decisions, open questions. Every agent you spawn from now on starts already knowing the essentials, so you don't repeat yourself.",
+          body: 'What you type below becomes the shared brief every agent you spawn starts from.',
           hints: [
             'What are we building',
             'Any constraints or non-goals',
@@ -154,6 +155,13 @@ export const ChatEmptyState = ({ selectedAgentId, phaseRuns, hasWorkflow }: Prop
   }, [scenario, selectedKind, phaseRuns.length]);
 
   const agentVisual = scenario === 'agent_focus' && selectedKind ? KIND_ICON[selectedKind] : null;
+
+  const showWorkflowCta = scenario === 'fresh' || scenario === 'workflow_no_agent';
+  const openWorkflowBuilder = useCallback(() => {
+    window.dispatchEvent(
+      new CustomEvent('goodboy:open-workflow-builder', { detail: { sessionId } }),
+    );
+  }, [sessionId]);
 
   return (
     <div className="mx-auto flex w-full max-w-[640px] flex-col items-center justify-center gap-5 px-6 py-16 text-center">
@@ -186,6 +194,12 @@ export const ChatEmptyState = ({ selectedAgentId, phaseRuns, hasWorkflow }: Prop
           </span>
         ))}
       </div>
+      {showWorkflowCta ? (
+        <Button variant="secondary" size="sm" onClick={openWorkflowBuilder}>
+          <Workflow size={13} aria-hidden />
+          Set up a workflow
+        </Button>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -389,6 +389,7 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
             ) : (
               <div className="flex h-full items-center justify-center">
                 <ChatEmptyState
+                  sessionId={session.id}
                   selectedAgentId={selectedAgentId}
                   phaseRuns={phaseRuns}
                   hasWorkflow={session.workflowRuns.length > 0}

--- a/apps/desktop/src/features/integrations/github/ConnectGithubDialog.tsx
+++ b/apps/desktop/src/features/integrations/github/ConnectGithubDialog.tsx
@@ -1,12 +1,6 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import { Button, Dialog, Input } from '@goodboy/ui';
-import { CheckCircle2, Loader2, Unplug } from 'lucide-react';
-import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
-import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
-import { useAppStore } from '../../../store';
-import { formatError } from '../../../shared/lib/errors';
-import { CreateTokenLink } from './CreateTokenLink';
+import type { WorkspaceId } from '@goodboy/types';
+import { Button, Dialog } from '@goodboy/ui';
+import { GithubFormBody } from './GithubFormBody';
 
 type Props = {
   workspaceId: WorkspaceId;
@@ -14,158 +8,19 @@ type Props = {
   onClose: () => void;
 };
 
-export const ConnectGithubDialog = ({ workspaceId, open, onClose }: Props) => {
-  const [status, setStatus] = useState<GhTokenStatus | null>(null);
-  const [token, setToken] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const gitlabConnected = useAppStore(
-    useShallow((s) =>
-      (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab'),
-    ),
-  );
-  const disconnectGitlab = useAppStore((s) => s.disconnectGitlab);
-
-  const refresh = useCallback(async () => {
-    try {
-      setStatus(await ghStatus(workspaceId));
-    } catch {
-      setStatus(null);
+export const ConnectGithubDialog = ({ workspaceId, open, onClose }: Props) => (
+  <Dialog
+    open={open}
+    onClose={onClose}
+    title="Connect GitHub"
+    description="Per-workspace token (classic, scope repo). Stored in your OS keychain."
+    size="md"
+    footer={
+      <Button variant="ghost" onClick={onClose}>
+        Close
+      </Button>
     }
-  }, [workspaceId]);
-
-  useEffect(() => {
-    if (open) {
-      void refresh();
-    }
-  }, [open, refresh]);
-
-  useEffect(() => {
-    if (!open) {
-      setToken('');
-      setError(null);
-      setBusy(false);
-    }
-  }, [open]);
-
-  const onConnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await ghSetToken(token.trim(), workspaceId);
-      setToken('');
-      await refresh();
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDisconnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await ghClearToken(workspaceId);
-      await refresh();
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const scoped = status?.scoped ?? false;
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      title="Connect GitHub"
-      description="Per-workspace token (classic, scope repo). Stored in your OS keychain."
-      size="md"
-      footer={
-        <div className="flex w-full items-center justify-end gap-2">
-          <Button variant="ghost" onClick={onClose} disabled={busy}>
-            Close
-          </Button>
-          {scoped || gitlabConnected ? null : (
-            <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          )}
-        </div>
-      }
-    >
-      <div className="flex flex-col gap-5">
-        {scoped ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-              <CheckCircle2 size={14} aria-hidden className="text-success" />
-              Connected as {status?.user ?? '(unknown user)'}
-            </div>
-            <p className="text-2xs leading-relaxed text-muted-foreground">
-              This workspace uses its own token for every gh call.
-            </p>
-            <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              {busy ? 'Disconnecting…' : 'Disconnect'}
-            </Button>
-          </div>
-        ) : gitlabConnected ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              GitLab is connected for this workspace. Disconnect GitLab to use a GitHub token.
-            </p>
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={() => void disconnectGitlab(workspaceId)}
-              disabled={busy}
-            >
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              Disconnect GitLab
-            </Button>
-          </div>
-        ) : (
-          <>
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              {status?.user
-                ? `This workspace falls back to your system gh (connected as ${status.user}). Connect a token to override it, e.g. one authorized for this repo's org via SSO.`
-                : 'Connect a personal access token so Goodboy can resolve PRs for this workspace.'}
-            </p>
-            <div className="flex flex-col gap-2">
-              <Input
-                type="password"
-                autoFocus
-                placeholder="ghp_…"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                disabled={busy}
-                aria-label="GitHub personal access token"
-              />
-              <CreateTokenLink />
-            </div>
-            <p className="text-2xs leading-relaxed text-muted-foreground">
-              The token is stored encrypted in your operating system keychain and never leaves this
-              machine.
-            </p>
-          </>
-        )}
-
-        {error ? (
-          <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
-        ) : null}
-      </div>
-    </Dialog>
-  );
-};
+  >
+    {open ? <GithubFormBody workspaceId={workspaceId} /> : null}
+  </Dialog>
+);

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+
+const { state, ghStatusMock, ghSetTokenMock, ghClearTokenMock } = vi.hoisted(() => ({
+  state: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    disconnectGitlab: vi.fn(async () => undefined),
+  },
+  ghStatusMock: vi.fn(async () => ({ scoped: false, user: null }) as unknown),
+  ghSetTokenMock: vi.fn(async () => ({ scoped: true }) as unknown),
+  ghClearTokenMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../github/github', () => ({
+  ghStatus: ghStatusMock,
+  ghSetToken: ghSetTokenMock,
+  ghClearToken: ghClearTokenMock,
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+const gitlabIntegration: GitlabWorkspaceIntegration = {
+  id: 'wi-1' as never,
+  workspaceId: WS_ID,
+  provider: 'gitlab',
+  credentialKey: 'cred-1',
+  config: { userName: 'octo', userId: '42', host: 'https://gitlab.com' },
+  createdAt: '2026-01-01T00:00:00.000Z' as never,
+  updatedAt: '2026-01-01T00:00:00.000Z' as never,
+};
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+  state.disconnectGitlab = vi.fn(async () => undefined);
+  ghStatusMock.mockResolvedValue({ scoped: false, user: null });
+  ghSetTokenMock.mockResolvedValue({ scoped: true });
+  ghClearTokenMock.mockResolvedValue(undefined);
+});
+afterEach(cleanup);
+
+import { GithubFormBody } from './GithubFormBody';
+
+describe('GithubFormBody', () => {
+  describe('token form (happy path)', () => {
+    it('queries gh status for the workspace on mount', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      await waitFor(() => expect(ghStatusMock).toHaveBeenCalledWith(WS_ID));
+    });
+
+    it('disables Connect until a non-empty token is entered', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      const btn = (await screen.findByRole('button', { name: /^connect$/i })) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/GitHub personal access token/i), {
+        target: { value: 'ghp_abc' },
+      });
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('keeps Connect disabled for a whitespace-only token', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      await screen.findByLabelText(/GitHub personal access token/i);
+      fireEvent.change(screen.getByLabelText(/GitHub personal access token/i), {
+        target: { value: '   ' },
+      });
+      expect(
+        (screen.getByRole('button', { name: /^connect$/i }) as HTMLButtonElement).disabled,
+      ).toBe(true);
+    });
+
+    it('sets the trimmed token and fires onConnected on a successful connect', async () => {
+      const onConnected = vi.fn();
+      render(<GithubFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(await screen.findByLabelText(/GitHub personal access token/i), {
+        target: { value: '  ghp_abc  ' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() => expect(ghSetTokenMock).toHaveBeenCalledWith('ghp_abc', WS_ID));
+      await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+    });
+
+    it('shows the formatted error and skips onConnected when the connect fails', async () => {
+      const onConnected = vi.fn();
+      ghSetTokenMock.mockRejectedValueOnce(new Error('bad credentials'));
+      render(<GithubFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(await screen.findByLabelText(/GitHub personal access token/i), {
+        target: { value: 'ghp_bad' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      expect(await screen.findByText(/bad credentials/i)).toBeDefined();
+      expect(onConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when a scoped token is already connected', () => {
+    beforeEach(() => {
+      ghStatusMock.mockResolvedValue({ scoped: true, user: 'octocat' });
+    });
+
+    it('renders the connected state with the gh user', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      expect(await screen.findByText(/Connected as octocat/i)).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('clears the token for the workspace on Disconnect', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      await waitFor(() => expect(ghClearTokenMock).toHaveBeenCalledWith(WS_ID));
+    });
+  });
+
+  describe('when GitLab is connected (mutual exclusivity)', () => {
+    beforeEach(() => {
+      state.workspaceIntegrations = { [WS_ID]: [gitlabIntegration] };
+    });
+
+    it('shows the mutex banner and no token form', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      expect(await screen.findByText(/Disconnect GitLab to use a GitHub token/i)).toBeDefined();
+      expect(screen.queryByLabelText(/GitHub personal access token/i)).toBeNull();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('disconnects GitLab when the banner action is clicked', async () => {
+      render(<GithubFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /disconnect gitlab/i }));
+      expect(state.disconnectGitlab).toHaveBeenCalledWith(WS_ID);
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
+++ b/apps/desktop/src/features/integrations/github/GithubFormBody.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { Button, Input } from '@goodboy/ui';
+import { CheckCircle2, Loader2, Unplug } from 'lucide-react';
+import type { GhTokenStatus, WorkspaceId } from '@goodboy/types';
+import { ghClearToken, ghSetToken, ghStatus } from '../../github/github';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
+import { CreateTokenLink } from './CreateTokenLink';
+
+type Props = {
+  workspaceId: WorkspaceId;
+  onConnected?: () => void;
+};
+
+export const GithubFormBody = ({ workspaceId, onConnected }: Props) => {
+  const [status, setStatus] = useState<GhTokenStatus | null>(null);
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const gitlabConnected = useAppStore(
+    useShallow((s) =>
+      (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab'),
+    ),
+  );
+  const disconnectGitlab = useAppStore((s) => s.disconnectGitlab);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await ghStatus(workspaceId));
+    } catch {
+      setStatus(null);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const onConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await ghSetToken(token.trim(), workspaceId);
+      setToken('');
+      await refresh();
+      onConnected?.();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await ghClearToken(workspaceId);
+      await refresh();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const scoped = status?.scoped ?? false;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {scoped ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CheckCircle2 size={14} aria-hidden className="text-success" />
+            Connected as {status?.user ?? '(unknown user)'}
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            This workspace uses its own token for every gh call.
+          </p>
+          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            {busy ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      ) : gitlabConnected ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            GitLab is connected for this workspace. Disconnect GitLab to use a GitHub token.
+          </p>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => void disconnectGitlab(workspaceId)}
+            disabled={busy}
+          >
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            Disconnect GitLab
+          </Button>
+        </div>
+      ) : (
+        <>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {status?.user
+              ? `This workspace falls back to your system gh (connected as ${status.user}). Connect a token to override it, e.g. one authorized for this repo's org via SSO.`
+              : 'Connect a personal access token so Goodboy can resolve PRs for this workspace.'}
+          </p>
+          <div className="flex flex-col gap-2">
+            <Input
+              type="password"
+              autoFocus
+              placeholder="ghp_…"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              disabled={busy}
+              aria-label="GitHub personal access token"
+            />
+            <CreateTokenLink />
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            The token is stored encrypted in your operating system keychain and never leaves this
+            machine.
+          </p>
+        </>
+      )}
+
+      {error ? (
+        <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {scoped || gitlabConnected ? null : (
+        <div className="flex justify-end">
+          <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
+            {busy ? (
+              <>
+                <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/ConnectGitlabDialog.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/ConnectGitlabDialog.tsx
@@ -1,11 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
-import { Button, Dialog, Input } from '@goodboy/ui';
-import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
-import { useAppStore } from '../../../store';
-import { ghClearToken, ghStatus } from '../../github/github';
-import { formatError } from '../../../shared/lib/errors';
+import type { WorkspaceId } from '@goodboy/types';
+import { Button, Dialog } from '@goodboy/ui';
+import { GitlabFormBody } from './GitlabFormBody';
 
 type Props = {
   workspaceId: WorkspaceId;
@@ -13,207 +8,19 @@ type Props = {
   onClose: () => void;
 };
 
-const DEFAULT_HOST = 'https://gitlab.com';
-
-function normalizeHost(input: string): string {
-  const trimmed = input.trim().replace(/\/+$/, '');
-  if (trimmed === '') {
-    return DEFAULT_HOST;
-  }
-  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
-  try {
-    const url = new URL(withScheme);
-    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-      return DEFAULT_HOST;
+export const ConnectGitlabDialog = ({ workspaceId, open, onClose }: Props) => (
+  <Dialog
+    open={open}
+    onClose={onClose}
+    title="Connect GitLab"
+    description="Personal access token. Stored in your OS keychain."
+    size="md"
+    footer={
+      <Button variant="ghost" onClick={onClose}>
+        Close
+      </Button>
     }
-    return `${url.protocol}//${url.host}`;
-  } catch {
-    return DEFAULT_HOST;
-  }
-}
-
-export const ConnectGitlabDialog = ({ workspaceId, open, onClose }: Props) => {
-  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
-  const gitlab =
-    integrations.find((i): i is GitlabWorkspaceIntegration => i.provider === 'gitlab') ?? null;
-  const config = gitlab ? gitlab.config : null;
-  const connectGitlab = useAppStore((s) => s.connectGitlab);
-  const disconnectGitlab = useAppStore((s) => s.disconnectGitlab);
-
-  const [host, setHost] = useState(DEFAULT_HOST);
-  const [token, setToken] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [githubScoped, setGithubScoped] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      void ghStatus(workspaceId)
-        .then((status) => setGithubScoped(status.scoped ?? false))
-        .catch(() => setGithubScoped(false));
-    }
-  }, [open, workspaceId]);
-
-  useEffect(() => {
-    if (!open) {
-      setHost(DEFAULT_HOST);
-      setToken('');
-      setError(null);
-      setBusy(false);
-      setGithubScoped(false);
-    }
-  }, [open]);
-
-  const onConnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await connectGitlab(workspaceId, normalizeHost(host), token.trim());
-      setToken('');
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDisconnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await disconnectGitlab(workspaceId);
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDisconnectGithub = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await ghClearToken(workspaceId);
-      setGithubScoped(false);
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const tokenUrl = `${normalizeHost(host)}/-/profile/personal_access_tokens`;
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      title="Connect GitLab"
-      description="Personal access token. Stored in your OS keychain."
-      size="md"
-      footer={
-        <div className="flex w-full items-center justify-end gap-2">
-          <Button variant="ghost" onClick={onClose} disabled={busy}>
-            Close
-          </Button>
-          {gitlab || githubScoped ? null : (
-            <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          )}
-        </div>
-      }
-    >
-      <div className="flex flex-col gap-5">
-        {gitlab && config ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-              <CheckCircle2 size={14} aria-hidden className="text-success" />
-              Connected as {config.userName}
-            </div>
-            <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
-              <dt className="text-muted-foreground">host</dt>
-              <dd className="font-mono text-foreground">{config.host}</dd>
-            </dl>
-            <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              {busy ? 'Disconnecting…' : 'Disconnect'}
-            </Button>
-          </div>
-        ) : githubScoped ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              A GitHub token is connected for this workspace. Disconnect GitHub to use GitLab.
-            </p>
-            <Button
-              variant="danger"
-              size="sm"
-              onClick={() => void onDisconnectGithub()}
-              disabled={busy}
-            >
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              {busy ? 'Disconnecting…' : 'Disconnect GitHub'}
-            </Button>
-          </div>
-        ) : (
-          <>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="gitlab-host" className="text-xs font-semibold text-foreground">
-                Host
-              </label>
-              <Input
-                id="gitlab-host"
-                type="text"
-                placeholder={DEFAULT_HOST}
-                value={host}
-                onChange={(e) => setHost(e.target.value)}
-                disabled={busy}
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="gitlab-pat" className="text-xs font-semibold text-foreground">
-                Personal access token
-              </label>
-              <Input
-                id="gitlab-pat"
-                type="password"
-                autoFocus
-                placeholder="glpat-…"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                disabled={busy}
-              />
-              <a
-                href={tokenUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
-              >
-                Create a token (scope read_api) <ExternalLink size={10} aria-hidden />
-              </a>
-            </div>
-            <p className="text-2xs leading-relaxed text-muted-foreground">
-              The read_api scope is enough. The token is stored encrypted in your operating system
-              keychain and never leaves this machine.
-            </p>
-          </>
-        )}
-
-        {error ? (
-          <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
-        ) : null}
-      </div>
-    </Dialog>
-  );
-};
+  >
+    {open ? <GitlabFormBody workspaceId={workspaceId} /> : null}
+  </Dialog>
+);

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+
+const { state, ghStatusMock, ghClearTokenMock } = vi.hoisted(() => ({
+  state: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    connectGitlab: vi.fn(async () => undefined),
+    disconnectGitlab: vi.fn(async () => undefined),
+  },
+  ghStatusMock: vi.fn(async () => ({ scoped: false }) as unknown),
+  ghClearTokenMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../github/github', () => ({
+  ghStatus: ghStatusMock,
+  ghClearToken: ghClearTokenMock,
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+const gitlabIntegration: GitlabWorkspaceIntegration = {
+  id: 'wi-1' as never,
+  workspaceId: WS_ID,
+  provider: 'gitlab',
+  credentialKey: 'cred-1',
+  config: { userName: 'octo', userId: '42', host: 'https://gitlab.example.com' },
+  createdAt: '2026-01-01T00:00:00.000Z' as never,
+  updatedAt: '2026-01-01T00:00:00.000Z' as never,
+};
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+  state.connectGitlab = vi.fn(async () => undefined);
+  state.disconnectGitlab = vi.fn(async () => undefined);
+  ghStatusMock.mockResolvedValue({ scoped: false });
+  ghClearTokenMock.mockResolvedValue(undefined);
+});
+afterEach(cleanup);
+
+import { GitlabFormBody } from './GitlabFormBody';
+
+describe('GitlabFormBody', () => {
+  describe('connect form (happy path)', () => {
+    it('disables Connect until a non-empty token is entered', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      const btn = (await screen.findByRole('button', { name: /^connect$/i })) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: 'glpat-x' },
+      });
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('connects with the default host and fires onConnected', async () => {
+      const onConnected = vi.fn();
+      render(<GitlabFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(await screen.findByLabelText(/personal access token/i), {
+        target: { value: '  glpat-x  ' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() =>
+        expect(state.connectGitlab).toHaveBeenCalledWith(WS_ID, 'https://gitlab.com', 'glpat-x'),
+      );
+      await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+    });
+
+    it('normalizes a scheme-less host and strips trailing slashes before connecting', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      fireEvent.change(await screen.findByLabelText(/^host$/i), {
+        target: { value: 'gitlab.example.com/' },
+      });
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: 'glpat-x' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() =>
+        expect(state.connectGitlab).toHaveBeenCalledWith(
+          WS_ID,
+          'https://gitlab.example.com',
+          'glpat-x',
+        ),
+      );
+    });
+
+    it('falls back to the default host when a non-http(s) scheme is supplied', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      fireEvent.change(await screen.findByLabelText(/^host$/i), {
+        target: { value: 'javascript://evil.example.com' },
+      });
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: 'glpat-x' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() =>
+        expect(state.connectGitlab).toHaveBeenCalledWith(WS_ID, 'https://gitlab.com', 'glpat-x'),
+      );
+    });
+
+    it('shows the formatted error and skips onConnected when the connect fails', async () => {
+      const onConnected = vi.fn();
+      state.connectGitlab = vi.fn(async () => {
+        throw new Error('invalid token');
+      });
+      render(<GitlabFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(await screen.findByLabelText(/personal access token/i), {
+        target: { value: 'glpat-bad' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      expect(await screen.findByText(/invalid token/i)).toBeDefined();
+      expect(onConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when GitLab is already connected', () => {
+    beforeEach(() => {
+      state.workspaceIntegrations = { [WS_ID]: [gitlabIntegration] };
+    });
+
+    it('renders the connected state with user and host', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      expect(await screen.findByText(/Connected as octo/i)).toBeDefined();
+      expect(screen.getByText('https://gitlab.example.com')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('disconnects GitLab for the workspace', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /^disconnect$/i }));
+      expect(state.disconnectGitlab).toHaveBeenCalledWith(WS_ID);
+    });
+  });
+
+  describe('when a scoped GitHub token exists (mutual exclusivity)', () => {
+    beforeEach(() => {
+      ghStatusMock.mockResolvedValue({ scoped: true });
+    });
+
+    it('shows the mutex banner and no connect form', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      expect(await screen.findByText(/Disconnect GitHub to use GitLab/i)).toBeDefined();
+      expect(screen.queryByLabelText(/personal access token/i)).toBeNull();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('clears the GitHub token when the banner action is clicked', async () => {
+      render(<GitlabFormBody workspaceId={WS_ID} />);
+      fireEvent.click(await screen.findByRole('button', { name: /disconnect github/i }));
+      await waitFor(() => expect(ghClearTokenMock).toHaveBeenCalledWith(WS_ID));
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabFormBody.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { Button, Input } from '@goodboy/ui';
+import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
+import { useAppStore } from '../../../store';
+import { ghClearToken, ghStatus } from '../../github/github';
+import { formatError } from '../../../shared/lib/errors';
+
+type Props = {
+  workspaceId: WorkspaceId;
+  onConnected?: () => void;
+};
+
+const DEFAULT_HOST = 'https://gitlab.com';
+
+function normalizeHost(input: string): string {
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (trimmed === '') {
+    return DEFAULT_HOST;
+  }
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const url = new URL(withScheme);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return DEFAULT_HOST;
+    }
+    return `${url.protocol}//${url.host}`;
+  } catch {
+    return DEFAULT_HOST;
+  }
+}
+
+export const GitlabFormBody = ({ workspaceId, onConnected }: Props) => {
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
+  const gitlab =
+    integrations.find((i): i is GitlabWorkspaceIntegration => i.provider === 'gitlab') ?? null;
+  const config = gitlab ? gitlab.config : null;
+  const connectGitlab = useAppStore((s) => s.connectGitlab);
+  const disconnectGitlab = useAppStore((s) => s.disconnectGitlab);
+
+  const [host, setHost] = useState(DEFAULT_HOST);
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [githubScoped, setGithubScoped] = useState(false);
+
+  useEffect(() => {
+    void ghStatus(workspaceId)
+      .then((status) => setGithubScoped(status.scoped ?? false))
+      .catch(() => setGithubScoped(false));
+  }, [workspaceId]);
+
+  const onConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectGitlab(workspaceId, normalizeHost(host), token.trim());
+      setToken('');
+      onConnected?.();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectGitlab(workspaceId);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnectGithub = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await ghClearToken(workspaceId);
+      setGithubScoped(false);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const tokenUrl = `${normalizeHost(host)}/-/profile/personal_access_tokens`;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {gitlab && config ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CheckCircle2 size={14} aria-hidden className="text-success" />
+            Connected as {config.userName}
+          </div>
+          <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
+            <dt className="text-muted-foreground">host</dt>
+            <dd className="font-mono text-foreground">{config.host}</dd>
+          </dl>
+          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            {busy ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      ) : githubScoped ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            A GitHub token is connected for this workspace. Disconnect GitHub to use GitLab.
+          </p>
+          <Button
+            variant="danger"
+            size="sm"
+            onClick={() => void onDisconnectGithub()}
+            disabled={busy}
+          >
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            {busy ? 'Disconnecting…' : 'Disconnect GitHub'}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="gitlab-host" className="text-xs font-semibold text-foreground">
+              Host
+            </label>
+            <Input
+              id="gitlab-host"
+              type="text"
+              placeholder={DEFAULT_HOST}
+              value={host}
+              onChange={(e) => setHost(e.target.value)}
+              disabled={busy}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="gitlab-pat" className="text-xs font-semibold text-foreground">
+              Personal access token
+            </label>
+            <Input
+              id="gitlab-pat"
+              type="password"
+              autoFocus
+              placeholder="glpat-…"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              disabled={busy}
+            />
+            <a
+              href={tokenUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
+            >
+              Create a token (scope read_api) <ExternalLink size={10} aria-hidden />
+            </a>
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            The read_api scope is enough. The token is stored encrypted in your operating system
+            keychain and never leaves this machine.
+          </p>
+        </>
+      )}
+
+      {error ? (
+        <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {gitlab || githubScoped ? null : (
+        <div className="flex justify-end">
+          <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
+            {busy ? (
+              <>
+                <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
+++ b/apps/desktop/src/features/integrations/linear/ConnectLinearDialog.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import type { LinearIntegrationConfig, WorkspaceId } from '@goodboy/types';
-import { Button, Dialog, Input } from '@goodboy/ui';
-import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
-import { useAppStore } from '../../../store';
-import { formatError } from '../../../shared/lib/errors';
+import type { WorkspaceId } from '@goodboy/types';
+import { Button, Dialog } from '@goodboy/ui';
+import { LinearFormBody } from './LinearFormBody';
 
 type Props = {
   workspaceId: WorkspaceId;
@@ -12,131 +8,19 @@ type Props = {
   onClose: () => void;
 };
 
-export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => {
-  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
-  const linear = integrations.find((i) => i.provider === 'linear') ?? null;
-  const linearConfig = linear ? (linear.config as LinearIntegrationConfig) : null;
-  const connectLinear = useAppStore((s) => s.connectLinear);
-  const disconnectLinear = useAppStore((s) => s.disconnectLinear);
-
-  const [token, setToken] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!open) {
-      setToken('');
-      setError(null);
-      setBusy(false);
+export const ConnectLinearDialog = ({ workspaceId, open, onClose }: Props) => (
+  <Dialog
+    open={open}
+    onClose={onClose}
+    title="Connect Linear"
+    description="Personal access token. Stored in your OS keychain."
+    size="md"
+    footer={
+      <Button variant="ghost" onClick={onClose}>
+        Close
+      </Button>
     }
-  }, [open]);
-
-  const onConnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await connectLinear(workspaceId, token.trim());
-      setToken('');
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDisconnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await disconnectLinear(workspaceId);
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      title="Connect Linear"
-      description="Personal access token. Stored in your OS keychain."
-      size="md"
-      footer={
-        <div className="flex w-full items-center justify-end gap-2">
-          <Button variant="ghost" onClick={onClose} disabled={busy}>
-            Close
-          </Button>
-          {linear ? null : (
-            <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          )}
-        </div>
-      }
-    >
-      <div className="flex flex-col gap-5">
-        {linear ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-              <CheckCircle2 size={14} aria-hidden className="text-success" />
-              Connected as {linearConfig?.viewerName}
-            </div>
-            <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
-              <dt className="text-muted-foreground">workspace</dt>
-              <dd className="font-mono text-foreground">
-                linear.app/{linearConfig?.workspaceUrlKey}
-              </dd>
-            </dl>
-            <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              {busy ? 'Disconnecting…' : 'Disconnect'}
-            </Button>
-          </div>
-        ) : (
-          <>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="linear-pat" className="text-xs font-semibold text-foreground">
-                Personal access token
-              </label>
-              <Input
-                id="linear-pat"
-                type="password"
-                autoFocus
-                placeholder="lin_api_…"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                disabled={busy}
-              />
-              <a
-                href="https://linear.app/settings/account/security"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
-              >
-                Create a token in Linear settings <ExternalLink size={10} aria-hidden />
-              </a>
-            </div>
-            <p className="text-2xs leading-relaxed text-muted-foreground">
-              Read-only scope is enough. The token is stored encrypted in your operating system
-              keychain and never leaves this machine.
-            </p>
-          </>
-        )}
-
-        {error ? (
-          <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
-        ) : null}
-      </div>
-    </Dialog>
-  );
-};
+  >
+    {open ? <LinearFormBody workspaceId={workspaceId} /> : null}
+  </Dialog>
+);

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    connectLinear: vi.fn(async () => undefined),
+    disconnectLinear: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+const linearIntegration = {
+  id: 'wi-1',
+  workspaceId: WS_ID,
+  provider: 'linear' as const,
+  credentialKey: 'cred-1',
+  config: { viewerName: 'Ada Lovelace', workspaceUrlKey: 'acme' },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+  state.connectLinear = vi.fn(async () => undefined);
+  state.disconnectLinear = vi.fn(async () => undefined);
+});
+afterEach(cleanup);
+
+import { LinearFormBody } from './LinearFormBody';
+
+describe('LinearFormBody', () => {
+  describe('connect form (happy path)', () => {
+    it('disables Connect until a non-empty token is entered', () => {
+      render(<LinearFormBody workspaceId={WS_ID} />);
+      const btn = screen.getByRole('button', { name: /^connect$/i }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: 'lin_api_x' },
+      });
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('connects with the trimmed token and fires onConnected', async () => {
+      const onConnected = vi.fn();
+      render(<LinearFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: '  lin_api_x  ' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() => expect(state.connectLinear).toHaveBeenCalledWith(WS_ID, 'lin_api_x'));
+      await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+    });
+
+    it('shows the formatted error and skips onConnected when the connect fails', async () => {
+      const onConnected = vi.fn();
+      state.connectLinear = vi.fn(async () => {
+        throw new Error('unauthorized');
+      });
+      render(<LinearFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fireEvent.change(screen.getByLabelText(/personal access token/i), {
+        target: { value: 'lin_api_bad' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      expect(await screen.findByText(/unauthorized/i)).toBeDefined();
+      expect(onConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when Linear is already connected', () => {
+    beforeEach(() => {
+      state.workspaceIntegrations = { [WS_ID]: [linearIntegration] };
+    });
+
+    it('renders the connected state with viewer and workspace', () => {
+      render(<LinearFormBody workspaceId={WS_ID} />);
+      expect(screen.getByText(/Connected as Ada Lovelace/i)).toBeDefined();
+      expect(screen.getByText('linear.app/acme')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('disconnects Linear for the workspace', () => {
+      render(<LinearFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(state.disconnectLinear).toHaveBeenCalledWith(WS_ID);
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearFormBody.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { LinearIntegrationConfig, WorkspaceId } from '@goodboy/types';
+import { Button, Input } from '@goodboy/ui';
+import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
+
+type Props = {
+  workspaceId: WorkspaceId;
+  onConnected?: () => void;
+};
+
+export const LinearFormBody = ({ workspaceId, onConnected }: Props) => {
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
+  const linear = integrations.find((i) => i.provider === 'linear') ?? null;
+  const linearConfig = linear ? (linear.config as LinearIntegrationConfig) : null;
+  const connectLinear = useAppStore((s) => s.connectLinear);
+  const disconnectLinear = useAppStore((s) => s.disconnectLinear);
+
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectLinear(workspaceId, token.trim());
+      setToken('');
+      onConnected?.();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectLinear(workspaceId);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      {linear ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CheckCircle2 size={14} aria-hidden className="text-success" />
+            Connected as {linearConfig?.viewerName}
+          </div>
+          <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
+            <dt className="text-muted-foreground">workspace</dt>
+            <dd className="font-mono text-foreground">
+              linear.app/{linearConfig?.workspaceUrlKey}
+            </dd>
+          </dl>
+          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            {busy ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="linear-pat" className="text-xs font-semibold text-foreground">
+              Personal access token
+            </label>
+            <Input
+              id="linear-pat"
+              type="password"
+              autoFocus
+              placeholder="lin_api_…"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              disabled={busy}
+            />
+            <a
+              href="https://linear.app/settings/account/security"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
+            >
+              Create a token in Linear settings <ExternalLink size={10} aria-hidden />
+            </a>
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            Read-only scope is enough. The token is stored encrypted in your operating system
+            keychain and never leaves this machine.
+          </p>
+        </>
+      )}
+
+      {error ? (
+        <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {linear ? null : (
+        <div className="flex justify-end">
+          <Button onClick={() => void onConnect()} disabled={busy || token.trim().length === 0}>
+            {busy ? (
+              <>
+                <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/ConnectSentryDialog.tsx
+++ b/apps/desktop/src/features/integrations/sentry/ConnectSentryDialog.tsx
@@ -1,10 +1,6 @@
-import { useEffect, useState } from 'react';
-import { useShallow } from 'zustand/react/shallow';
-import type { SentryIntegrationConfig, WorkspaceId } from '@goodboy/types';
-import { Button, Dialog, Input } from '@goodboy/ui';
-import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
-import { useAppStore } from '../../../store';
-import { formatError } from '../../../shared/lib/errors';
+import type { WorkspaceId } from '@goodboy/types';
+import { Button, Dialog } from '@goodboy/ui';
+import { SentryFormBody } from './SentryFormBody';
 
 type Props = {
   workspaceId: WorkspaceId;
@@ -12,169 +8,19 @@ type Props = {
   onClose: () => void;
 };
 
-export const ConnectSentryDialog = ({ workspaceId, open, onClose }: Props) => {
-  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
-  const sentry = integrations.find((i) => i.provider === 'sentry') ?? null;
-  const sentryConfig = (sentry?.config ?? null) as SentryIntegrationConfig | null;
-  const connectSentry = useAppStore((s) => s.connectSentry);
-  const disconnectSentry = useAppStore((s) => s.disconnectSentry);
-
-  const [token, setToken] = useState('');
-  const [org, setOrg] = useState('');
-  const [project, setProject] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!open) {
-      setToken('');
-      setOrg('');
-      setProject('');
-      setError(null);
-      setBusy(false);
+export const ConnectSentryDialog = ({ workspaceId, open, onClose }: Props) => (
+  <Dialog
+    open={open}
+    onClose={onClose}
+    title="Connect Sentry"
+    description="Auth token plus org and project slugs. Stored in your OS keychain."
+    size="md"
+    footer={
+      <Button variant="ghost" onClick={onClose}>
+        Close
+      </Button>
     }
-  }, [open]);
-
-  const onConnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await connectSentry(workspaceId, token.trim(), org.trim(), project.trim());
-      setToken('');
-      setOrg('');
-      setProject('');
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const onDisconnect = async () => {
-    setBusy(true);
-    setError(null);
-    try {
-      await disconnectSentry(workspaceId);
-    } catch (err) {
-      setError(formatError(err));
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const canConnect = token.trim().length > 0 && org.trim().length > 0 && project.trim().length > 0;
-
-  return (
-    <Dialog
-      open={open}
-      onClose={onClose}
-      title="Connect Sentry"
-      description="Auth token plus org and project slugs. Stored in your OS keychain."
-      size="md"
-      footer={
-        <div className="flex w-full items-center justify-end gap-2">
-          <Button variant="ghost" onClick={onClose} disabled={busy}>
-            Close
-          </Button>
-          {sentry ? null : (
-            <Button onClick={() => void onConnect()} disabled={busy || !canConnect}>
-              {busy ? (
-                <>
-                  <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
-                </>
-              ) : (
-                'Connect'
-              )}
-            </Button>
-          )}
-        </div>
-      }
-    >
-      <div className="flex flex-col gap-5">
-        {sentry && sentryConfig ? (
-          <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
-            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-              <CheckCircle2 size={14} aria-hidden className="text-success" />
-              Connected to {sentryConfig.projectName ?? sentryConfig.project}
-            </div>
-            <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
-              <dt className="text-muted-foreground">organization</dt>
-              <dd className="font-mono text-foreground">{sentryConfig.org}</dd>
-              <dt className="text-muted-foreground">project</dt>
-              <dd className="font-mono text-foreground">{sentryConfig.project}</dd>
-            </dl>
-            <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
-              <Unplug size={12} aria-hidden className="mr-1.5" />
-              {busy ? 'Disconnecting…' : 'Disconnect'}
-            </Button>
-          </div>
-        ) : (
-          <>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="sentry-token" className="text-xs font-semibold text-foreground">
-                Auth token
-              </label>
-              <Input
-                id="sentry-token"
-                type="password"
-                autoFocus
-                placeholder="sntryu_…"
-                value={token}
-                onChange={(e) => setToken(e.target.value)}
-                disabled={busy}
-              />
-              <a
-                href="https://sentry.io/settings/account/api/auth-tokens/"
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
-              >
-                Create a token in Sentry settings <ExternalLink size={10} aria-hidden />
-              </a>
-            </div>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="sentry-org" className="text-xs font-semibold text-foreground">
-                Organization slug
-              </label>
-              <Input
-                id="sentry-org"
-                placeholder="my-org"
-                value={org}
-                onChange={(e) => setOrg(e.target.value)}
-                disabled={busy}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-            </div>
-            <div className="flex flex-col gap-2">
-              <label htmlFor="sentry-project" className="text-xs font-semibold text-foreground">
-                Project slug
-              </label>
-              <Input
-                id="sentry-project"
-                placeholder="my-project"
-                value={project}
-                onChange={(e) => setProject(e.target.value)}
-                disabled={busy}
-                autoCapitalize="none"
-                autoCorrect="off"
-                spellCheck={false}
-              />
-            </div>
-            <p className="text-2xs leading-relaxed text-muted-foreground">
-              A token with issue read scope is enough. It is stored encrypted in your operating
-              system keychain and never leaves this machine.
-            </p>
-          </>
-        )}
-
-        {error ? (
-          <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
-            {error}
-          </div>
-        ) : null}
-      </div>
-    </Dialog>
-  );
-};
+  >
+    {open ? <SentryFormBody workspaceId={workspaceId} /> : null}
+  </Dialog>
+);

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
+    connectSentry: vi.fn(async () => undefined),
+    disconnectSentry: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+const sentryIntegration = {
+  id: 'wi-1',
+  workspaceId: WS_ID,
+  provider: 'sentry' as const,
+  credentialKey: 'cred-1',
+  config: { org: 'my-org', project: 'my-proj', projectName: 'My Project' },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const fillForm = ({ token, org, project }: { token: string; org: string; project: string }) => {
+  fireEvent.change(screen.getByLabelText(/auth token/i), { target: { value: token } });
+  fireEvent.change(screen.getByLabelText(/organization slug/i), { target: { value: org } });
+  fireEvent.change(screen.getByLabelText(/project slug/i), { target: { value: project } });
+};
+
+beforeEach(() => {
+  state.workspaceIntegrations = {};
+  state.connectSentry = vi.fn(async () => undefined);
+  state.disconnectSentry = vi.fn(async () => undefined);
+});
+afterEach(cleanup);
+
+import { SentryFormBody } from './SentryFormBody';
+
+describe('SentryFormBody', () => {
+  describe('connect form (happy path)', () => {
+    it('keeps Connect disabled until token, org and project are all filled', () => {
+      render(<SentryFormBody workspaceId={WS_ID} />);
+      const btn = screen.getByRole('button', { name: /^connect$/i }) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/auth token/i), { target: { value: 'sntryu_x' } });
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/organization slug/i), { target: { value: 'org' } });
+      expect(btn.disabled).toBe(true);
+      fireEvent.change(screen.getByLabelText(/project slug/i), { target: { value: 'proj' } });
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('connects with all trimmed fields and fires onConnected', async () => {
+      const onConnected = vi.fn();
+      render(<SentryFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fillForm({ token: '  sntryu_x  ', org: '  my-org  ', project: '  my-proj  ' });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      await waitFor(() =>
+        expect(state.connectSentry).toHaveBeenCalledWith(WS_ID, 'sntryu_x', 'my-org', 'my-proj'),
+      );
+      await waitFor(() => expect(onConnected).toHaveBeenCalledOnce());
+    });
+
+    it('shows the formatted error and skips onConnected when the connect fails', async () => {
+      const onConnected = vi.fn();
+      state.connectSentry = vi.fn(async () => {
+        throw new Error('project not found');
+      });
+      render(<SentryFormBody workspaceId={WS_ID} onConnected={onConnected} />);
+      fillForm({ token: 'sntryu_x', org: 'org', project: 'proj' });
+      fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+      expect(await screen.findByText(/project not found/i)).toBeDefined();
+      expect(onConnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when Sentry is already connected', () => {
+    beforeEach(() => {
+      state.workspaceIntegrations = { [WS_ID]: [sentryIntegration] };
+    });
+
+    it('renders the connected state with project name, org and project', () => {
+      render(<SentryFormBody workspaceId={WS_ID} />);
+      expect(screen.getByText(/Connected to My Project/i)).toBeDefined();
+      expect(screen.getByText('my-org')).toBeDefined();
+      expect(screen.getByText('my-proj')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^connect$/i })).toBeNull();
+    });
+
+    it('disconnects Sentry for the workspace', () => {
+      render(<SentryFormBody workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+      expect(state.disconnectSentry).toHaveBeenCalledWith(WS_ID);
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryFormBody.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { SentryIntegrationConfig, WorkspaceId } from '@goodboy/types';
+import { Button, Input } from '@goodboy/ui';
+import { CheckCircle2, ExternalLink, Loader2, Unplug } from 'lucide-react';
+import { useAppStore } from '../../../store';
+import { formatError } from '../../../shared/lib/errors';
+
+type Props = {
+  workspaceId: WorkspaceId;
+  onConnected?: () => void;
+};
+
+export const SentryFormBody = ({ workspaceId, onConnected }: Props) => {
+  const integrations = useAppStore(useShallow((s) => s.workspaceIntegrations[workspaceId] ?? []));
+  const sentry = integrations.find((i) => i.provider === 'sentry') ?? null;
+  const sentryConfig = (sentry?.config ?? null) as SentryIntegrationConfig | null;
+  const connectSentry = useAppStore((s) => s.connectSentry);
+  const disconnectSentry = useAppStore((s) => s.disconnectSentry);
+
+  const [token, setToken] = useState('');
+  const [org, setOrg] = useState('');
+  const [project, setProject] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await connectSentry(workspaceId, token.trim(), org.trim(), project.trim());
+      setToken('');
+      setOrg('');
+      setProject('');
+      onConnected?.();
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onDisconnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await disconnectSentry(workspaceId);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const canConnect = token.trim().length > 0 && org.trim().length > 0 && project.trim().length > 0;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {sentry && sentryConfig ? (
+        <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-subtle/40 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CheckCircle2 size={14} aria-hidden className="text-success" />
+            Connected to {sentryConfig.projectName ?? sentryConfig.project}
+          </div>
+          <dl className="grid grid-cols-[8rem_1fr] gap-y-1 text-xs">
+            <dt className="text-muted-foreground">organization</dt>
+            <dd className="font-mono text-foreground">{sentryConfig.org}</dd>
+            <dt className="text-muted-foreground">project</dt>
+            <dd className="font-mono text-foreground">{sentryConfig.project}</dd>
+          </dl>
+          <Button variant="danger" size="sm" onClick={() => void onDisconnect()} disabled={busy}>
+            <Unplug size={12} aria-hidden className="mr-1.5" />
+            {busy ? 'Disconnecting…' : 'Disconnect'}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="sentry-token" className="text-xs font-semibold text-foreground">
+              Auth token
+            </label>
+            <Input
+              id="sentry-token"
+              type="password"
+              autoFocus
+              placeholder="sntryu_…"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              disabled={busy}
+            />
+            <a
+              href="https://sentry.io/settings/account/api/auth-tokens/"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground hover:text-foreground"
+            >
+              Create a token in Sentry settings <ExternalLink size={10} aria-hidden />
+            </a>
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="sentry-org" className="text-xs font-semibold text-foreground">
+              Organization slug
+            </label>
+            <Input
+              id="sentry-org"
+              placeholder="my-org"
+              value={org}
+              onChange={(e) => setOrg(e.target.value)}
+              disabled={busy}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="sentry-project" className="text-xs font-semibold text-foreground">
+              Project slug
+            </label>
+            <Input
+              id="sentry-project"
+              placeholder="my-project"
+              value={project}
+              onChange={(e) => setProject(e.target.value)}
+              disabled={busy}
+              autoCapitalize="none"
+              autoCorrect="off"
+              spellCheck={false}
+            />
+          </div>
+          <p className="text-2xs leading-relaxed text-muted-foreground">
+            A token with issue read scope is enough. It is stored encrypted in your operating system
+            keychain and never leaves this machine.
+          </p>
+        </>
+      )}
+
+      {error ? (
+        <div className="rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {sentry ? null : (
+        <div className="flex justify-end">
+          <Button onClick={() => void onConnect()} disabled={busy || !canConnect}>
+            {busy ? (
+              <>
+                <Loader2 size={13} className="mr-1.5 animate-spin" aria-hidden /> Verifying…
+              </>
+            ) : (
+              'Connect'
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingCard/index.tsx
@@ -5,9 +5,17 @@ import {
   collapse,
   finish,
   reopen,
+  type OnboardingGroup,
   type OnboardingStepId,
 } from '../onboarding-store';
 import { useOnboardingProgress, type OnboardingProgress } from '../hooks/useOnboardingProgress';
+
+const GROUP_LABEL: Record<OnboardingGroup, string> = {
+  setup: 'Setup',
+  build: 'First steps',
+};
+
+const GROUP_ORDER: ReadonlyArray<OnboardingGroup> = ['setup', 'build'];
 
 export const OnboardingCard = () => {
   const progress = useOnboardingProgress();
@@ -45,17 +53,32 @@ function ChecklistBody({ progress }: { progress: OnboardingProgress }) {
           <X size={11} aria-hidden />
         </button>
       </div>
-      <ul className="flex flex-col gap-1">
-        {ONBOARDING_STEPS.map((step) => (
-          <StepRow
-            key={step.id}
-            id={step.id}
-            title={step.title}
-            why={step.why}
-            done={progress.completed.has(step.id)}
-          />
-        ))}
-      </ul>
+      <div className="flex flex-col gap-2.5">
+        {GROUP_ORDER.map((group) => {
+          const steps = ONBOARDING_STEPS.filter((s) => s.group === group);
+          if (steps.length === 0) {
+            return null;
+          }
+          return (
+            <div key={group} className="flex flex-col gap-1">
+              <span className="px-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground/50">
+                {GROUP_LABEL[group]}
+              </span>
+              <ul className="flex flex-col gap-1">
+                {steps.map((step) => (
+                  <StepRow
+                    key={step.id}
+                    id={step.id}
+                    title={step.title}
+                    why={step.why}
+                    done={progress.completed.has(step.id)}
+                  />
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
       <p className="text-[10px] leading-snug text-muted-foreground/60">
         {progress.completedCount} of {progress.totalCount} steps done
       </p>
@@ -84,13 +107,6 @@ function CompletedBody() {
       <p className="text-[11px] leading-snug text-muted-foreground/80">
         Nice, you've got the hang of Goodboy. That was the last step.
       </p>
-      <button
-        type="button"
-        onClick={() => finish()}
-        className="self-start rounded-md bg-primary px-2 py-1 text-2xs font-semibold text-primary-foreground transition-colors hover:brightness-110"
-      >
-        Done
-      </button>
     </>
   );
 }

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/Segmented.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/Segmented.tsx
@@ -1,0 +1,72 @@
+import type { LucideIcon } from 'lucide-react';
+import { Check } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+
+export type SegmentedOption<T extends string> = {
+  readonly value: T;
+  readonly label: string;
+  readonly icon: LucideIcon;
+  readonly color?: string;
+  readonly disabled?: boolean;
+  readonly badge?: string;
+  readonly connected?: boolean;
+};
+
+type Props<T extends string> = {
+  readonly options: ReadonlyArray<SegmentedOption<T>>;
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+  readonly ariaLabel: string;
+};
+
+export const Segmented = <T extends string>({ options, value, onChange, ariaLabel }: Props<T>) => {
+  return (
+    <div
+      role="tablist"
+      aria-label={ariaLabel}
+      className="grid w-full gap-1.5 rounded-xl border border-border-soft/60 bg-subtle/30 p-1.5"
+      style={{ gridTemplateColumns: `repeat(${options.length}, minmax(0, 1fr))` }}
+    >
+      {options.map((opt) => {
+        const active = opt.value === value;
+        const Icon = opt.icon;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={opt.disabled}
+            onClick={() => onChange(opt.value)}
+            style={active && opt.color ? { color: opt.color, borderColor: opt.color } : undefined}
+            className={cn(
+              'group relative flex items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-semibold motion-safe:transition-all',
+              active
+                ? 'border-transparent bg-background shadow-sm'
+                : 'border-transparent text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+              opt.disabled && 'cursor-not-allowed opacity-50 hover:bg-transparent',
+            )}
+          >
+            <span
+              className="flex size-6 shrink-0 items-center justify-center rounded-md motion-safe:transition-colors"
+              style={
+                active && opt.color
+                  ? { backgroundColor: `color-mix(in oklch, ${opt.color} 16%, transparent)` }
+                  : undefined
+              }
+            >
+              <Icon size={15} aria-hidden />
+            </span>
+            <span className="truncate">{opt.label}</span>
+            {opt.badge ? (
+              <span className="rounded bg-foreground/10 px-1.5 py-0.5 text-2xs font-bold uppercase tracking-wide text-muted-foreground">
+                {opt.badge}
+              </span>
+            ) : null}
+            {opt.connected ? <Check size={13} aria-hidden className="text-success" /> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { OnboardingWizardState } from './useOnboardingWizard';
+
+const { hookState, finishWizard } = vi.hoisted(() => ({
+  hookState: {} as OnboardingWizardState,
+  finishWizard: vi.fn(),
+}));
+
+vi.mock('./useOnboardingWizard', () => ({
+  useOnboardingWizard: () => hookState,
+}));
+
+vi.mock('../onboarding-store', () => ({
+  finishWizard,
+}));
+
+vi.mock('./Stepper', () => ({
+  Stepper: ({ current, total }: { current: number; total: number }) => (
+    <div data-testid="stepper">{`${current}/${total}`}</div>
+  ),
+}));
+
+vi.mock('./steps/WelcomeStep', () => ({ WelcomeStep: () => <div data-testid="WelcomeStep" /> }));
+vi.mock('./steps/ProvidersStep', () => ({
+  ProvidersStep: () => <div data-testid="ProvidersStep" />,
+}));
+vi.mock('./steps/WorkspaceStep', () => ({
+  WorkspaceStep: () => <div data-testid="WorkspaceStep" />,
+}));
+vi.mock('./steps/PreferencesStep', () => ({
+  PreferencesStep: () => <div data-testid="PreferencesStep" />,
+}));
+vi.mock('./steps/CodeHostStep', () => ({ CodeHostStep: () => <div data-testid="CodeHostStep" /> }));
+vi.mock('./steps/TrackerStep', () => ({ TrackerStep: () => <div data-testid="TrackerStep" /> }));
+vi.mock('./steps/SentryStep', () => ({ SentryStep: () => <div data-testid="SentryStep" /> }));
+vi.mock('./steps/ReadyStep', () => ({ ReadyStep: () => <div data-testid="ReadyStep" /> }));
+
+const baseState: OnboardingWizardState = {
+  open: true,
+  mode: 'full',
+  providersConnected: 0,
+  hasWorkspace: false,
+  workspaceId: null,
+  githubConnected: false,
+  gitlabConnected: false,
+  hasCodeHost: false,
+  hasLinear: false,
+  hasSentry: false,
+  refreshGithubStatus: vi.fn(),
+};
+
+const setHook = (partial: Partial<OnboardingWizardState>) =>
+  Object.assign(hookState, baseState, partial);
+
+beforeEach(() => {
+  finishWizard.mockClear();
+  Object.assign(hookState, baseState);
+});
+afterEach(cleanup);
+
+import { OnboardingWizard } from './index';
+
+const advance = (label: RegExp, times: number) => {
+  for (let i = 0; i < times; i += 1) {
+    fireEvent.click(screen.getByRole('button', { name: label }));
+  }
+};
+
+describe('OnboardingWizard', () => {
+  it('renders nothing when closed', () => {
+    setHook({ open: false });
+    const { container } = render(<OnboardingWizard />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('opens on the welcome step with no stepper, back, or skip', () => {
+    setHook({ hasWorkspace: false });
+    render(<OnboardingWizard />);
+    expect(screen.getByTestId('WelcomeStep')).toBeDefined();
+    expect(screen.getByRole('button', { name: /get started/i })).toBeDefined();
+    expect(screen.queryByTestId('stepper')).toBeNull();
+    expect(screen.queryByRole('button', { name: /^back$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /skip setup/i })).toBeNull();
+  });
+
+  describe('mandatory gates', () => {
+    it('keeps Continue disabled on the providers step until one is connected', () => {
+      setHook({ providersConnected: 0, hasWorkspace: true });
+      render(<OnboardingWizard />);
+      fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+      expect(screen.getByTestId('ProvidersStep')).toBeDefined();
+      expect(
+        (screen.getByRole('button', { name: /continue/i }) as HTMLButtonElement).disabled,
+      ).toBe(true);
+    });
+
+    it('enables Continue on the providers step once one is connected', () => {
+      setHook({ providersConnected: 1, hasWorkspace: true });
+      render(<OnboardingWizard />);
+      fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+      expect(
+        (screen.getByRole('button', { name: /continue/i }) as HTMLButtonElement).disabled,
+      ).toBe(false);
+    });
+
+    it('keeps Continue disabled on the workspace step until a workspace exists', () => {
+      setHook({ providersConnected: 1, hasWorkspace: false });
+      render(<OnboardingWizard />);
+      fireEvent.click(screen.getByRole('button', { name: /get started/i }));
+      fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+      expect(screen.getByTestId('WorkspaceStep')).toBeDefined();
+      expect(
+        (screen.getByRole('button', { name: /continue/i }) as HTMLButtonElement).disabled,
+      ).toBe(true);
+    });
+  });
+
+  describe('optional steps', () => {
+    it('offers Skip for now on the code host step when none is connected', () => {
+      setHook({ providersConnected: 1, hasWorkspace: true, hasCodeHost: false });
+      render(<OnboardingWizard />);
+      advance(/get started/i, 1);
+      advance(/continue/i, 3);
+      expect(screen.getByTestId('CodeHostStep')).toBeDefined();
+      expect(screen.getByRole('button', { name: /skip for now/i })).toBeDefined();
+    });
+
+    it('offers Continue on the code host step once connected', () => {
+      setHook({ providersConnected: 1, hasWorkspace: true, hasCodeHost: true });
+      render(<OnboardingWizard />);
+      advance(/get started/i, 1);
+      advance(/continue/i, 3);
+      expect(screen.getByTestId('CodeHostStep')).toBeDefined();
+      expect(screen.getByRole('button', { name: /continue/i })).toBeDefined();
+    });
+  });
+
+  describe('setup mode', () => {
+    it('starts at the preferences step with no back button', () => {
+      setHook({ mode: 'setup', hasWorkspace: true });
+      render(<OnboardingWizard />);
+      expect(screen.getByTestId('PreferencesStep')).toBeDefined();
+      expect(screen.queryByRole('button', { name: /^back$/i })).toBeNull();
+      expect(screen.queryByTestId('stepper')).toBeNull();
+    });
+  });
+
+  describe('exit', () => {
+    it('shows Skip setup once a workspace exists and finishes the wizard', async () => {
+      setHook({ hasWorkspace: true });
+      render(<OnboardingWizard />);
+      fireEvent.click(screen.getByRole('button', { name: /skip setup/i }));
+      await waitFor(() => expect(finishWizard).toHaveBeenCalledOnce());
+    });
+
+    it('finishes the wizard from the ready step', async () => {
+      setHook({
+        providersConnected: 1,
+        hasWorkspace: true,
+        hasCodeHost: true,
+        hasLinear: true,
+        hasSentry: true,
+      });
+      render(<OnboardingWizard />);
+      advance(/get started/i, 1);
+      advance(/continue/i, 6);
+      expect(screen.getByTestId('ReadyStep')).toBeDefined();
+      fireEvent.click(screen.getByRole('button', { name: /start building/i }));
+      await waitFor(() => expect(finishWizard).toHaveBeenCalledOnce());
+    });
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/index.tsx
@@ -6,39 +6,60 @@ import { Stepper } from './Stepper';
 import { WelcomeStep } from './steps/WelcomeStep';
 import { ProvidersStep } from './steps/ProvidersStep';
 import { WorkspaceStep } from './steps/WorkspaceStep';
+import { PreferencesStep } from './steps/PreferencesStep';
+import { CodeHostStep } from './steps/CodeHostStep';
+import { TrackerStep } from './steps/TrackerStep';
+import { SentryStep } from './steps/SentryStep';
 import { ReadyStep } from './steps/ReadyStep';
 
-const STEP_COUNT = 4;
+const STEP_COUNT = 8;
+const SETUP_START_STEP = 3;
 const EXIT_MS = 200;
 
 type Cta = {
   readonly label: string;
   readonly onClick: () => void;
   readonly variant: ButtonVariant;
+  readonly disabled?: boolean;
 };
 
 export const OnboardingWizard = () => {
-  const { open, providersConnected, hasWorkspace } = useOnboardingWizard();
+  const {
+    open,
+    mode,
+    providersConnected,
+    hasWorkspace,
+    workspaceId,
+    githubConnected,
+    gitlabConnected,
+    hasCodeHost,
+    hasLinear,
+    hasSentry,
+    refreshGithubStatus,
+  } = useOnboardingWizard();
   const [step, setStep] = useState(0);
   const [closing, setClosing] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const minStep = mode === 'setup' ? SETUP_START_STEP : 0;
+  const last = STEP_COUNT - 1;
 
   useEffect(() => {
     if (!open) {
       return;
     }
-    setStep(0);
+    setStep(minStep);
     setClosing(false);
     containerRef.current?.focus();
-  }, [open]);
+  }, [open, minStep]);
 
   if (!open) {
     return null;
   }
 
-  const last = STEP_COUNT - 1;
   const goNext = () => setStep((s) => Math.min(s + 1, last));
-  const goBack = () => setStep((s) => Math.max(s - 1, 0));
+  const goBack = () => setStep((s) => Math.max(s - 1, minStep));
+  const canSkipSetup = hasWorkspace;
   const dismiss = () => {
     setClosing(true);
     window.setTimeout(finishWizard, EXIT_MS);
@@ -49,18 +70,43 @@ export const OnboardingWizard = () => {
 
   if (step === 1) {
     body = <ProvidersStep />;
-    cta =
-      providersConnected > 0
-        ? { label: 'Continue', onClick: goNext, variant: 'primary' }
-        : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
+    cta = {
+      label: 'Continue',
+      onClick: goNext,
+      variant: 'primary',
+      disabled: providersConnected === 0,
+    };
   } else if (step === 2) {
     body = <WorkspaceStep hasWorkspace={hasWorkspace} />;
-    cta = hasWorkspace
+    cta = { label: 'Continue', onClick: goNext, variant: 'primary', disabled: !hasWorkspace };
+  } else if (step === 3) {
+    body = <PreferencesStep workspaceId={workspaceId} />;
+    cta = { label: 'Continue', onClick: goNext, variant: 'primary' };
+  } else if (step === 4) {
+    body = (
+      <CodeHostStep
+        workspaceId={workspaceId}
+        githubConnected={githubConnected}
+        gitlabConnected={gitlabConnected}
+        onConnected={refreshGithubStatus}
+      />
+    );
+    cta = hasCodeHost
       ? { label: 'Continue', onClick: goNext, variant: 'primary' }
       : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
-  } else if (step === 3) {
+  } else if (step === 5) {
+    body = <TrackerStep workspaceId={workspaceId} linearConnected={hasLinear} />;
+    cta = hasLinear
+      ? { label: 'Continue', onClick: goNext, variant: 'primary' }
+      : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
+  } else if (step === 6) {
+    body = <SentryStep workspaceId={workspaceId} />;
+    cta = hasSentry
+      ? { label: 'Continue', onClick: goNext, variant: 'primary' }
+      : { label: 'Skip for now', onClick: goNext, variant: 'secondary' };
+  } else if (step === 7) {
     body = <ReadyStep />;
-    cta = { label: 'Start using Goodboy', onClick: dismiss, variant: 'primary' };
+    cta = { label: 'Start building', onClick: dismiss, variant: 'primary' };
   }
 
   return (
@@ -84,37 +130,42 @@ export const OnboardingWizard = () => {
         aria-hidden
       />
 
-      <header className="relative flex shrink-0 items-center justify-end px-6 pt-5">
-        {step < last && (
-          <button
-            type="button"
-            onClick={dismiss}
-            className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-          >
-            Skip setup
-          </button>
-        )}
+      <header className="relative grid min-h-[3.25rem] shrink-0 grid-cols-3 items-center px-6 pt-5">
+        <span aria-hidden />
+        <div className="flex justify-center">
+          {step > minStep && <Stepper current={step - minStep} total={last - minStep} />}
+        </div>
+        <div className="flex justify-end">
+          {step < last && canSkipSetup && (
+            <button
+              type="button"
+              onClick={dismiss}
+              className="rounded-md px-2 py-1 text-xs font-medium text-muted-foreground/70 transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            >
+              Skip setup
+            </button>
+          )}
+        </div>
       </header>
 
       <main className="relative min-h-0 flex-1 overflow-y-auto">
         <div className="flex min-h-full items-center justify-center px-6 py-10">
           <div className="flex w-full max-w-xl flex-col gap-8">
-            {step > 0 && <Stepper current={step} total={last} />}
             <div key={step} className="motion-safe:animate-fade-in">
               {body}
             </div>
             <div
               className={cn(
                 'flex items-center pt-2',
-                step > 0 ? 'justify-between' : 'justify-center',
+                step > minStep ? 'justify-between' : 'justify-center',
               )}
             >
-              {step > 0 && (
+              {step > minStep && (
                 <Button variant="ghost" size="sm" onClick={goBack}>
                   Back
                 </Button>
               )}
-              <Button variant={cta.variant} onClick={cta.onClick}>
+              <Button variant={cta.variant} onClick={cta.onClick} disabled={cta.disabled}>
                 {cta.label}
               </Button>
             </div>

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+vi.mock('../../../integrations/github/GithubFormBody', () => ({
+  GithubFormBody: ({ workspaceId }: { workspaceId: WorkspaceId }) => (
+    <div data-testid="github-form">{workspaceId}</div>
+  ),
+}));
+
+vi.mock('../../../integrations/gitlab/GitlabFormBody', () => ({
+  GitlabFormBody: ({ workspaceId }: { workspaceId: WorkspaceId }) => (
+    <div data-testid="gitlab-form">{workspaceId}</div>
+  ),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+afterEach(cleanup);
+
+import { CodeHostStep } from './CodeHostStep';
+
+describe('CodeHostStep', () => {
+  it('renders the heading', () => {
+    render(
+      <CodeHostStep
+        workspaceId={WS_ID}
+        githubConnected={false}
+        gitlabConnected={false}
+        onConnected={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('heading', { name: /connect a code host/i })).toBeDefined();
+  });
+
+  describe('with a workspace', () => {
+    it('renders only the GitHub form by default', () => {
+      render(
+        <CodeHostStep
+          workspaceId={WS_ID}
+          githubConnected={false}
+          gitlabConnected={false}
+          onConnected={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('github-form').textContent).toBe(WS_ID);
+      expect(screen.queryByTestId('gitlab-form')).toBeNull();
+      expect(screen.queryByText(/Add a workspace first/i)).toBeNull();
+    });
+
+    it('swaps to the GitLab form when its segment is selected', () => {
+      render(
+        <CodeHostStep
+          workspaceId={WS_ID}
+          githubConnected={false}
+          gitlabConnected={false}
+          onConnected={vi.fn()}
+        />,
+      );
+      fireEvent.click(screen.getByRole('tab', { name: /gitlab/i }));
+      expect(screen.getByTestId('gitlab-form').textContent).toBe(WS_ID);
+      expect(screen.queryByTestId('github-form')).toBeNull();
+    });
+
+    it('defaults to GitLab when only GitLab is connected', () => {
+      render(
+        <CodeHostStep
+          workspaceId={WS_ID}
+          githubConnected={false}
+          gitlabConnected
+          onConnected={vi.fn()}
+        />,
+      );
+      expect(screen.getByTestId('gitlab-form').textContent).toBe(WS_ID);
+      expect(screen.queryByTestId('github-form')).toBeNull();
+    });
+  });
+
+  describe('without a workspace', () => {
+    beforeEach(() => {
+      render(
+        <CodeHostStep
+          workspaceId={null}
+          githubConnected={false}
+          gitlabConnected={false}
+          onConnected={vi.fn()}
+        />,
+      );
+    });
+
+    it('shows the add-workspace empty state instead of the forms', () => {
+      expect(screen.getByText(/Add a workspace first to connect a code host/i)).toBeDefined();
+      expect(screen.queryByTestId('github-form')).toBeNull();
+      expect(screen.queryByTestId('gitlab-form')).toBeNull();
+    });
+
+    it('dispatches goodboy:add-workspace when the Add workspace button is clicked', () => {
+      const spy = vi.fn();
+      window.addEventListener('goodboy:add-workspace', spy);
+      fireEvent.click(screen.getByRole('button', { name: /add workspace/i }));
+      expect(spy).toHaveBeenCalledOnce();
+      window.removeEventListener('goodboy:add-workspace', spy);
+    });
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+import { FolderGit2, GitBranch, GitFork } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { GithubFormBody } from '../../../integrations/github/GithubFormBody';
+import { GitlabFormBody } from '../../../integrations/gitlab/GitlabFormBody';
+import { Segmented, type SegmentedOption } from '../Segmented';
+
+type Host = 'github' | 'gitlab';
+
+type Props = {
+  readonly workspaceId: WorkspaceId | null;
+  readonly githubConnected: boolean;
+  readonly gitlabConnected: boolean;
+  readonly onConnected: () => void;
+};
+
+export const CodeHostStep = ({
+  workspaceId,
+  githubConnected,
+  gitlabConnected,
+  onConnected,
+}: Props) => {
+  const [host, setHost] = useState<Host>(gitlabConnected && !githubConnected ? 'gitlab' : 'github');
+
+  const options: ReadonlyArray<SegmentedOption<Host>> = [
+    { value: 'github', label: 'GitHub', icon: GitBranch, connected: githubConnected },
+    {
+      value: 'gitlab',
+      label: 'GitLab',
+      icon: GitFork,
+      color: 'var(--color-provider-gitlab)',
+      connected: gitlabConnected,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-foreground">
+        <GitBranch size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Connect a code host
+        </h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Link GitHub or GitLab so Goodboy can review and resolve pull requests for this workspace.
+          You can only use one at a time.
+        </p>
+      </div>
+
+      {workspaceId === null ? (
+        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
+          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
+            <FolderGit2 size={18} aria-hidden />
+          </span>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Add a workspace first to connect a code host.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+          >
+            <FolderGit2 size={14} aria-hidden /> Add workspace
+          </Button>
+        </div>
+      ) : (
+        <div className="flex w-full flex-col gap-4 text-left">
+          <Segmented ariaLabel="code host" options={options} value={host} onChange={setHost} />
+          <div className="rounded-lg border border-border-soft/40 bg-subtle/20 p-4">
+            {host === 'github' ? (
+              <GithubFormBody workspaceId={workspaceId} onConnected={onConnected} />
+            ) : (
+              <GitlabFormBody workspaceId={workspaceId} onConnected={onConnected} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ProviderId, WorkspaceId } from '@goodboy/types';
+import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    loadSetting: vi.fn(async (_key: string): Promise<string | null> => null),
+    saveSetting: vi.fn(async () => undefined),
+    setWorkspaceOverrides: vi.fn(async () => undefined),
+    workspaceOverrides: {} as Record<string, unknown>,
+    providers: [] as ReadonlyArray<{ id: ProviderId; connection: string }>,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: <T,>(selector: T) => selector,
+}));
+
+vi.mock('../../../session/components/VerbositySelect', () => ({
+  VerbositySelect: ({ onChange }: { onChange: (v: string) => void }) => (
+    <button type="button" data-testid="verbosity" onClick={() => onChange('terse')}>
+      verbosity
+    </button>
+  ),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+beforeEach(() => {
+  state.loadSetting = vi.fn(async () => null);
+  state.saveSetting = vi.fn(async () => undefined);
+  state.setWorkspaceOverrides = vi.fn(async () => undefined);
+  state.workspaceOverrides = {};
+  state.providers = [
+    { id: 'anthropic', connection: 'connected' },
+    { id: 'cursor', connection: 'connected' },
+    { id: 'codex', connection: 'disconnected' },
+    { id: 'gemini', connection: 'disconnected' },
+  ];
+});
+afterEach(cleanup);
+
+import { PreferencesStep } from './PreferencesStep';
+
+describe('PreferencesStep', () => {
+  it('renders the heading', () => {
+    render(<PreferencesStep workspaceId={WS_ID} />);
+    expect(screen.getByRole('heading', { name: /set your defaults/i })).toBeDefined();
+  });
+
+  describe('without a workspace', () => {
+    beforeEach(() => render(<PreferencesStep workspaceId={null} />));
+
+    it('shows the add-workspace empty state instead of the form', () => {
+      expect(screen.getByText(/Add a workspace first to set its defaults/i)).toBeDefined();
+      expect(screen.queryByLabelText(/branch prefix/i)).toBeNull();
+    });
+
+    it('dispatches goodboy:add-workspace when the button is clicked', () => {
+      const spy = vi.fn();
+      window.addEventListener('goodboy:add-workspace', spy);
+      fireEvent.click(screen.getByRole('button', { name: /add workspace/i }));
+      expect(spy).toHaveBeenCalledOnce();
+      window.removeEventListener('goodboy:add-workspace', spy);
+    });
+  });
+
+  describe('default provider picker', () => {
+    it('disables offline providers and marks them as offline', () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      const codex = screen.getByRole('button', { name: /codex/i }) as HTMLButtonElement;
+      const gemini = screen.getByRole('button', { name: /gemini/i }) as HTMLButtonElement;
+      expect(codex.disabled).toBe(true);
+      expect(gemini.disabled).toBe(true);
+      expect(screen.getAllByText(/offline/i).length).toBe(2);
+    });
+
+    it('leaves connected providers enabled', () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      const cursor = screen.getByRole('button', { name: /cursor/i }) as HTMLButtonElement;
+      expect(cursor.disabled).toBe(false);
+    });
+
+    it('persists the picked provider through setWorkspaceOverrides', async () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('button', { name: /cursor/i }));
+      await waitFor(() =>
+        expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+          WS_ID,
+          expect.objectContaining({ defaultProviderId: 'cursor' }),
+        ),
+      );
+    });
+  });
+
+  describe('branch prefix', () => {
+    it('sanitizes the typed value to lowercase alphanumerics', () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      const input = screen.getByLabelText(/branch prefix/i) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'AB 12!#cd' } });
+      expect(input.value).toBe('ab12cd');
+    });
+
+    it('commits the sanitized prefix on blur', async () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      const input = screen.getByLabelText(/branch prefix/i) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'feat' } });
+      fireEvent.blur(input);
+      await waitFor(() =>
+        expect(state.saveSetting).toHaveBeenCalledWith(settingBranchPrefix(WS_ID), 'feat'),
+      );
+    });
+
+    it('falls back to the default when emptied', async () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      const input = screen.getByLabelText(/branch prefix/i) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: 'feat' } });
+      fireEvent.blur(input);
+      await waitFor(() => expect(state.saveSetting).toHaveBeenCalled());
+      state.saveSetting = vi.fn(async () => undefined);
+      fireEvent.change(input, { target: { value: '' } });
+      fireEvent.blur(input);
+      await waitFor(() => expect(input.value).toBe(DEFAULT_BRANCH_PREFIX));
+    });
+  });
+
+  describe('parallel scouts toggle', () => {
+    it('persists scoutFanout when switched on', async () => {
+      render(<PreferencesStep workspaceId={WS_ID} />);
+      fireEvent.click(screen.getByRole('switch'));
+      await waitFor(() =>
+        expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+          WS_ID,
+          expect.objectContaining({ scoutFanout: true }),
+        ),
+      );
+    });
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { OverrideSettings, ProviderId, VerbosityLevel, WorkspaceId } from '@goodboy/types';
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
+import { Button, FieldRow, cn } from '@goodboy/ui';
+import { FolderGit2, GitBranch, SlidersHorizontal, Sparkles } from 'lucide-react';
+import { ProviderChip } from '../../../providers/components/ProviderChip';
+import { ToggleSwitch } from '../../../../shared/components/ToggleSwitch';
+import { VerbositySelect } from '../../../session/components/VerbositySelect';
+import { formatError } from '../../../../shared/lib/errors';
+import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
+import { useAppStore } from '../../../../store';
+
+type Props = {
+  readonly workspaceId: WorkspaceId | null;
+};
+
+const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
+
+const sanitizePrefix = (input: string): string =>
+  input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '')
+    .replace(/^-+/, '')
+    .slice(0, 16);
+
+export const PreferencesStep = ({ workspaceId }: Props) => {
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-primary">
+        <SlidersHorizontal size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">Set your defaults</h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          A few preferences for this workspace. Every new session inherits them, and you can change
+          any of it later in settings.
+        </p>
+      </div>
+
+      {workspaceId === null ? <EmptyState /> : <PreferencesForm workspaceId={workspaceId} />}
+    </div>
+  );
+};
+
+const EmptyState = () => (
+  <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
+    <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
+      <FolderGit2 size={18} aria-hidden />
+    </span>
+    <p className="text-xs leading-relaxed text-muted-foreground">
+      Add a workspace first to set its defaults.
+    </p>
+    <Button
+      variant="secondary"
+      size="sm"
+      onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+    >
+      <FolderGit2 size={14} aria-hidden /> Add workspace
+    </Button>
+  </div>
+);
+
+const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
+  const loadSetting = useAppStore((s) => s.loadSetting);
+  const saveSetting = useAppStore((s) => s.saveSetting);
+  const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
+  const setWorkspaceOverrides = useAppStore((s) => s.setWorkspaceOverrides);
+  const connectedProviderIds = useAppStore(
+    useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
+  );
+
+  const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [savedBranchPrefix, setSavedBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const verbosity = wsOverrides?.defaultVerbosity ?? 'normal';
+  const defaultProvider =
+    wsOverrides?.defaultProviderId ?? DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider;
+  const scoutFanout = wsOverrides?.scoutFanout ?? false;
+
+  useEffect(() => {
+    void loadSetting(settingBranchPrefix(workspaceId)).then((v) => {
+      const value = v ?? DEFAULT_BRANCH_PREFIX;
+      setBranchPrefix(value);
+      setSavedBranchPrefix(value);
+    });
+  }, [workspaceId, loadSetting]);
+
+  const persistOverrides = async (
+    partial: Partial<
+      Pick<OverrideSettings, 'defaultProviderId' | 'defaultVerbosity' | 'scoutFanout'>
+    >,
+  ) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await setWorkspaceOverrides(workspaceId, {
+        defaultProviderId: wsOverrides?.defaultProviderId ?? null,
+        defaultWorkflowId: wsOverrides?.defaultWorkflowId ?? null,
+        defaultBranchPrefix: wsOverrides?.defaultBranchPrefix ?? null,
+        parallelEnabled: wsOverrides?.parallelEnabled ?? null,
+        defaultVerbosity: verbosity,
+        providerBindings: wsOverrides?.providerBindings ?? null,
+        scoutFanout,
+        ...partial,
+      });
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const commitBranchPrefix = async () => {
+    const next = branchPrefix.trim() || DEFAULT_BRANCH_PREFIX;
+    setBranchPrefix(next);
+    if (next === savedBranchPrefix) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await saveSetting(settingBranchPrefix(workspaceId), next);
+      setSavedBranchPrefix(next);
+    } catch (err) {
+      setError(formatError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-4 text-left">
+      <div className="flex flex-col divide-y divide-border-soft/50 rounded-lg border border-border-soft/40 bg-subtle/20 px-4">
+        <FieldRow
+          label="Branch prefix"
+          help="Prefixes every new session branch, e.g. your initials."
+        >
+          <div className="flex items-center gap-1.5">
+            <GitBranch size={13} aria-hidden className="shrink-0 text-muted-foreground" />
+            <input
+              type="text"
+              value={branchPrefix}
+              onChange={(e) => setBranchPrefix(sanitizePrefix(e.target.value))}
+              onBlur={() => void commitBranchPrefix()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  void commitBranchPrefix();
+                }
+              }}
+              placeholder={DEFAULT_BRANCH_PREFIX}
+              disabled={busy}
+              maxLength={16}
+              size={12}
+              aria-label="branch prefix"
+              className={cn(
+                'h-8 rounded-md border border-border bg-background px-2 font-mono text-sm text-foreground motion-safe:transition-colors',
+                'placeholder:text-muted-foreground/40',
+                'hover:border-border-strong focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary',
+                busy && 'cursor-not-allowed opacity-50',
+              )}
+            />
+            <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
+          </div>
+        </FieldRow>
+
+        <FieldRow
+          label="Default provider"
+          help="New sessions start on it and can override it."
+          layout="stacked"
+        >
+          <div className="flex flex-col gap-2.5">
+            <div className="flex flex-wrap gap-1.5">
+              {PROVIDER_OPTIONS.map((id) => (
+                <ProviderChip
+                  key={id}
+                  id={id}
+                  selected={defaultProvider === id}
+                  disabled={busy || !connectedProviderIds.includes(id)}
+                  onClick={() => void persistOverrides({ defaultProviderId: id })}
+                  trailing={
+                    connectedProviderIds.includes(id) ? null : (
+                      <span className="text-[9px] uppercase tracking-wide text-warning">
+                        offline
+                      </span>
+                    )
+                  }
+                />
+              ))}
+            </div>
+            <p className="flex items-start gap-1.5 text-2xs leading-relaxed text-muted-foreground">
+              <Sparkles
+                size={12}
+                aria-hidden
+                className="mt-0.5 shrink-0"
+                style={{ color: 'var(--color-provider-anthropic)' }}
+              />
+              Goodboy runs best on Claude today. The other providers work and are catching up fast.
+            </p>
+          </div>
+        </FieldRow>
+
+        <FieldRow label="Output verbosity" help="How much agents say in their replies.">
+          <div className="w-40">
+            <VerbositySelect
+              value={verbosity as VerbosityLevel}
+              onChange={(v) => void persistOverrides({ defaultVerbosity: v })}
+              disabled={busy}
+            />
+          </div>
+        </FieldRow>
+
+        <FieldRow
+          label="Parallel scouts"
+          help="Split broad searches across parallel sub-scouts. Much faster on large codebases."
+        >
+          <ToggleSwitch
+            label={scoutFanout ? 'On' : 'Off'}
+            checked={scoutFanout}
+            disabled={busy}
+            onChange={(next) => void persistOverrides({ scoutFanout: next })}
+          />
+        </FieldRow>
+      </div>
+
+      {error ? <p className="text-xs text-danger">{error}</p> : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ProvidersStep.tsx
@@ -28,8 +28,8 @@ export const ProvidersStep = () => {
           Connect a provider
         </h2>
         <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
-          Goodboy runs your agents through these CLIs. Connect at least one to start; add the others
-          whenever.
+          Goodboy runs every agent through a provider CLI, so you need at least one to continue. You
+          can add more, or connect API-key providers, later in settings.
         </p>
       </div>
 

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ReadyStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/ReadyStep.tsx
@@ -1,11 +1,6 @@
 import { CheckCircle2 } from 'lucide-react';
 import { KbdPill } from '@goodboy/ui';
 
-const TIPS: ReadonlyArray<{ readonly combo: ReadonlyArray<string>; readonly label: string }> = [
-  { combo: ['⌘', 'K'], label: 'command palette' },
-  { combo: ['⌘', 'N'], label: 'new session' },
-];
-
 export const ReadyStep = () => {
   return (
     <div className="flex flex-col items-center gap-6 text-center">
@@ -16,26 +11,27 @@ export const ReadyStep = () => {
       <div className="flex flex-col gap-2">
         <h2 className="text-2xl font-semibold tracking-tight text-foreground">You are all set</h2>
         <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
-          Create a session from the sidebar to get going. The checklist in the corner covers the
-          rest.
+          Jump in and start your first session from the workspace, or explore from the sidebar. The
+          checklist in the corner covers whatever is left.
         </p>
       </div>
 
-      <ul className="flex w-full max-w-sm flex-col gap-2">
-        {TIPS.map((tip) => (
-          <li
-            key={tip.label}
-            className="flex items-center justify-between rounded-lg border border-border-soft/40 bg-subtle/20 px-3.5 py-2.5"
-          >
-            <span className="text-xs text-foreground">{tip.label}</span>
-            <span className="flex items-center gap-0.5">
-              {tip.combo.map((k) => (
-                <KbdPill key={k}>{k}</KbdPill>
-              ))}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <p className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground/70">
+        <span className="inline-flex items-center gap-1.5">
+          <span className="inline-flex items-center gap-0.5">
+            <KbdPill>⌘</KbdPill>
+            <KbdPill>K</KbdPill>
+          </span>
+          command palette
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="inline-flex items-center gap-0.5">
+            <KbdPill>⌘</KbdPill>
+            <KbdPill>N</KbdPill>
+          </span>
+          new session
+        </span>
+      </p>
     </div>
   );
 };

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+vi.mock('../../../integrations/sentry/SentryFormBody', () => ({
+  SentryFormBody: ({ workspaceId }: { workspaceId: WorkspaceId }) => (
+    <div data-testid="sentry-form">{workspaceId}</div>
+  ),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+afterEach(cleanup);
+
+import { SentryStep } from './SentryStep';
+
+describe('SentryStep', () => {
+  it('renders the heading', () => {
+    render(<SentryStep workspaceId={WS_ID} />);
+    expect(screen.getByRole('heading', { name: /triage errors with sentry/i })).toBeDefined();
+  });
+
+  describe('with a workspace', () => {
+    it('renders the Sentry form scoped to the workspace', () => {
+      render(<SentryStep workspaceId={WS_ID} />);
+      expect(screen.getByTestId('sentry-form').textContent).toBe(WS_ID);
+      expect(screen.queryByText(/Add a workspace first/i)).toBeNull();
+    });
+  });
+
+  describe('without a workspace', () => {
+    beforeEach(() => {
+      render(<SentryStep workspaceId={null} />);
+    });
+
+    it('shows the add-workspace empty state instead of the form', () => {
+      expect(screen.getByText(/Add a workspace first to connect Sentry/i)).toBeDefined();
+      expect(screen.queryByTestId('sentry-form')).toBeNull();
+    });
+
+    it('dispatches goodboy:add-workspace when the Add workspace button is clicked', () => {
+      const spy = vi.fn();
+      window.addEventListener('goodboy:add-workspace', spy);
+      fireEvent.click(screen.getByRole('button', { name: /add workspace/i }));
+      expect(spy).toHaveBeenCalledOnce();
+      window.removeEventListener('goodboy:add-workspace', spy);
+    });
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
@@ -1,0 +1,55 @@
+import { Bug, FolderGit2 } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { SentryFormBody } from '../../../integrations/sentry/SentryFormBody';
+
+type Props = {
+  readonly workspaceId: WorkspaceId | null;
+};
+
+export const SentryStep = ({ workspaceId }: Props) => {
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span
+        className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40"
+        style={{ color: 'var(--color-provider-sentry)' }}
+      >
+        <Bug size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Triage errors with Sentry
+        </h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Link Sentry so agents can pull stack traces and triage production errors for this
+          workspace. Optional, and you can connect it later.
+        </p>
+      </div>
+
+      {workspaceId === null ? (
+        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
+          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
+            <FolderGit2 size={18} aria-hidden />
+          </span>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Add a workspace first to connect Sentry.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+          >
+            <FolderGit2 size={14} aria-hidden /> Add workspace
+          </Button>
+        </div>
+      ) : (
+        <div className="flex w-full flex-col gap-4 text-left">
+          <div className="rounded-lg border border-border-soft/40 bg-subtle/20 p-4">
+            <SentryFormBody workspaceId={workspaceId} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.test.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+vi.mock('../../../integrations/linear/LinearFormBody', () => ({
+  LinearFormBody: ({ workspaceId }: { workspaceId: WorkspaceId }) => (
+    <div data-testid="linear-form">{workspaceId}</div>
+  ),
+}));
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+afterEach(cleanup);
+
+import { TrackerStep } from './TrackerStep';
+
+describe('TrackerStep', () => {
+  it('renders the heading', () => {
+    render(<TrackerStep workspaceId={WS_ID} linearConnected={false} />);
+    expect(screen.getByRole('heading', { name: /connect your issue tracker/i })).toBeDefined();
+  });
+
+  describe('with a workspace', () => {
+    beforeEach(() => {
+      render(<TrackerStep workspaceId={WS_ID} linearConnected={false} />);
+    });
+
+    it('renders the Linear form scoped to the workspace', () => {
+      expect(screen.getByTestId('linear-form').textContent).toBe(WS_ID);
+      expect(screen.queryByText(/Add a workspace first/i)).toBeNull();
+    });
+
+    it('keeps the Jira segment disabled', () => {
+      const jira = screen.getByRole('tab', { name: /jira/i });
+      expect(jira.hasAttribute('disabled')).toBe(true);
+    });
+  });
+
+  describe('without a workspace', () => {
+    beforeEach(() => {
+      render(<TrackerStep workspaceId={null} linearConnected={false} />);
+    });
+
+    it('shows the add-workspace empty state instead of the form', () => {
+      expect(screen.getByText(/Add a workspace first to connect your tracker/i)).toBeDefined();
+      expect(screen.queryByTestId('linear-form')).toBeNull();
+    });
+
+    it('dispatches goodboy:add-workspace when the Add workspace button is clicked', () => {
+      const spy = vi.fn();
+      window.addEventListener('goodboy:add-workspace', spy);
+      fireEvent.click(screen.getByRole('button', { name: /add workspace/i }));
+      expect(spy).toHaveBeenCalledOnce();
+      window.removeEventListener('goodboy:add-workspace', spy);
+    });
+  });
+});

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { FolderGit2, Layers, ListChecks } from 'lucide-react';
+import { Button } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { LinearFormBody } from '../../../integrations/linear/LinearFormBody';
+import { Segmented, type SegmentedOption } from '../Segmented';
+
+type Tracker = 'linear' | 'jira';
+
+type Props = {
+  readonly workspaceId: WorkspaceId | null;
+  readonly linearConnected: boolean;
+};
+
+export const TrackerStep = ({ workspaceId, linearConnected }: Props) => {
+  const [tracker, setTracker] = useState<Tracker>('linear');
+
+  const options: ReadonlyArray<SegmentedOption<Tracker>> = [
+    {
+      value: 'linear',
+      label: 'Linear',
+      icon: ListChecks,
+      color: 'var(--color-provider-linear)',
+      connected: linearConnected,
+    },
+    { value: 'jira', label: 'Jira', icon: Layers, badge: 'soon', disabled: true },
+  ];
+
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <span
+        className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40"
+        style={{ color: 'var(--color-provider-linear)' }}
+      >
+        <ListChecks size={26} aria-hidden />
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+          Connect your issue tracker
+        </h2>
+        <p className="mx-auto max-w-md text-sm leading-relaxed text-muted-foreground">
+          Link Linear so agents can pull issue context and ship against real tickets. Jira support
+          is on the way.
+        </p>
+      </div>
+
+      {workspaceId === null ? (
+        <div className="flex w-full max-w-sm flex-col items-center gap-3 rounded-lg border border-border-soft/40 bg-subtle/20 px-4 py-6 text-center">
+          <span className="flex size-10 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40 text-muted-foreground">
+            <FolderGit2 size={18} aria-hidden />
+          </span>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Add a workspace first to connect your tracker.
+          </p>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:add-workspace'))}
+          >
+            <FolderGit2 size={14} aria-hidden /> Add workspace
+          </Button>
+        </div>
+      ) : (
+        <div className="flex w-full flex-col gap-4 text-left">
+          <Segmented
+            ariaLabel="issue tracker"
+            options={options}
+            value={tracker}
+            onChange={setTracker}
+          />
+          <div className="rounded-lg border border-border-soft/40 bg-subtle/20 p-4">
+            <LinearFormBody workspaceId={workspaceId} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderConnectionState } from '@goodboy/types';
 import { OPEN_WIZARD_EVENT } from '../../onboarding-store';
@@ -8,15 +8,29 @@ let wizardDone = false;
 let hydrated = true;
 const providers: Array<{ connection: ProviderConnectionState }> = [];
 const workspaces: Array<{ id: string }> = [];
+let workspaceIntegrations: Record<string, Array<{ provider: string }>> = {};
+
+const { ghStatusMock } = vi.hoisted(() => ({
+  ghStatusMock: vi.fn(async () => ({ scoped: false }) as unknown),
+}));
 
 vi.mock('../../onboarding-store', () => ({
   OPEN_WIZARD_EVENT: 'goodboy:open-onboarding-wizard',
   isWizardDone: () => wizardDone,
 }));
 
+vi.mock('../../../github/github', () => ({
+  ghStatus: ghStatusMock,
+}));
+
 vi.mock('../../../../store', () => ({
-  useAppStore: (selector: (s: { providers: typeof providers; hydrated: boolean }) => unknown) =>
-    selector({ providers, hydrated }),
+  useAppStore: (
+    selector: (s: {
+      providers: typeof providers;
+      hydrated: boolean;
+      workspaceIntegrations: typeof workspaceIntegrations;
+    }) => unknown,
+  ) => selector({ providers, hydrated, workspaceIntegrations }),
   useWorkspaces: () => workspaces,
 }));
 
@@ -25,95 +39,234 @@ function reset() {
   hydrated = true;
   providers.length = 0;
   workspaces.length = 0;
+  workspaceIntegrations = {};
+  ghStatusMock.mockReset();
+  ghStatusMock.mockResolvedValue({ scoped: false });
 }
 
 describe('useOnboardingWizard', () => {
   beforeEach(reset);
   afterEach(reset);
 
-  it('opens on a genuine first run with nothing connected', () => {
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(true);
-  });
-
-  it('stays closed when a workspace already exists', () => {
-    workspaces.push({ id: 'w1' });
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-  });
-
-  it('still opens when a provider is connected but no workspace exists yet', () => {
-    providers.push({ connection: 'connected' });
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(true);
-    expect(result.current.providersConnected).toBe(1);
-  });
-
-  it('stays closed once the wizard was finished', () => {
-    wizardDone = true;
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-  });
-
-  it('stays closed before the store hydrates, even with no workspace', () => {
-    hydrated = false;
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-  });
-
-  it('does not open once a workspace arrives during hydration', () => {
-    hydrated = false;
-    const { result, rerender } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-    workspaces.push({ id: 'w1' });
-    hydrated = true;
-    rerender();
-    expect(result.current.open).toBe(false);
-  });
-
-  it('reopens on the open-wizard event even after being done', () => {
-    wizardDone = true;
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-    act(() => {
-      window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+  describe('open/close decision', () => {
+    it('opens on a genuine first run with nothing connected', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(true);
     });
-    expect(result.current.open).toBe(true);
-  });
 
-  it('opens once hydration completes on a genuine first run', () => {
-    hydrated = false;
-    const { result, rerender } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-    hydrated = true;
-    rerender();
-    expect(result.current.open).toBe(true);
-  });
-
-  it('does not reopen after a workspace is created post-decision', () => {
-    const { result, rerender } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(true);
-    workspaces.push({ id: 'w1' });
-    rerender();
-    expect(result.current.open).toBe(true);
-  });
-
-  it('opens if the last workspace is removed after hydration (guard latches only on open)', () => {
-    workspaces.push({ id: 'w1' });
-    const { result, rerender } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-    workspaces.length = 0;
-    rerender();
-    expect(result.current.open).toBe(true);
-  });
-
-  it('keeps the wizard open through an explicit event even after a workspace exists', () => {
-    workspaces.push({ id: 'w1' });
-    const { result } = renderHook(() => useOnboardingWizard());
-    expect(result.current.open).toBe(false);
-    act(() => {
-      window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+    it('stays closed when a workspace already exists', () => {
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
     });
-    expect(result.current.open).toBe(true);
+
+    it('still opens when a provider is connected but no workspace exists yet', () => {
+      providers.push({ connection: 'connected' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(true);
+      expect(result.current.providersConnected).toBe(1);
+    });
+
+    it('stays closed once the wizard was finished', () => {
+      wizardDone = true;
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+    });
+
+    it('stays closed before the store hydrates, even with no workspace', () => {
+      hydrated = false;
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+    });
+
+    it('does not open once a workspace arrives during hydration', () => {
+      hydrated = false;
+      const { result, rerender } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      workspaces.push({ id: 'w1' });
+      hydrated = true;
+      rerender();
+      expect(result.current.open).toBe(false);
+    });
+
+    it('reopens on the open-wizard event even after being done', () => {
+      wizardDone = true;
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      act(() => {
+        window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+      });
+      expect(result.current.open).toBe(true);
+    });
+
+    it('opens once hydration completes on a genuine first run', () => {
+      hydrated = false;
+      const { result, rerender } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      hydrated = true;
+      rerender();
+      expect(result.current.open).toBe(true);
+    });
+
+    it('does not reopen after a workspace is created post-decision', () => {
+      const { result, rerender } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(true);
+      workspaces.push({ id: 'w1' });
+      rerender();
+      expect(result.current.open).toBe(true);
+    });
+
+    it('opens if the last workspace is removed after hydration (guard latches only on open)', () => {
+      workspaces.push({ id: 'w1' });
+      const { result, rerender } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      workspaces.length = 0;
+      rerender();
+      expect(result.current.open).toBe(true);
+    });
+
+    it('keeps the wizard open through an explicit event even after a workspace exists', () => {
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      act(() => {
+        window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+      });
+      expect(result.current.open).toBe(true);
+    });
+  });
+
+  describe('mode', () => {
+    it('defaults to full on a first-run open', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(true);
+      expect(result.current.mode).toBe('full');
+    });
+
+    it('enters setup mode when the open event requests it', () => {
+      wizardDone = true;
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(false);
+      act(() => {
+        window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT, { detail: { mode: 'setup' } }));
+      });
+      expect(result.current.open).toBe(true);
+      expect(result.current.mode).toBe('setup');
+    });
+
+    it('ignores a setup request while the wizard is already open', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.open).toBe(true);
+      expect(result.current.mode).toBe('full');
+      act(() => {
+        window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT, { detail: { mode: 'setup' } }));
+      });
+      expect(result.current.mode).toBe('full');
+      expect(result.current.open).toBe(true);
+    });
+
+    it('reopens in full mode when the event omits a mode', () => {
+      wizardDone = true;
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      act(() => {
+        window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+      });
+      expect(result.current.mode).toBe('full');
+    });
+  });
+
+  describe('workspaceId', () => {
+    it('is null when no workspace exists', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.workspaceId).toBeNull();
+    });
+
+    it('resolves to the first workspace id', () => {
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.workspaceId).toBe('w1');
+    });
+  });
+
+  describe('hasCodeHost', () => {
+    it('is false without a workspace and never queries gh status', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasCodeHost).toBe(false);
+      expect(ghStatusMock).not.toHaveBeenCalled();
+    });
+
+    it('is true when GitLab is connected for the workspace', () => {
+      workspaces.push({ id: 'w1' });
+      workspaceIntegrations = { w1: [{ provider: 'gitlab' }] };
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasCodeHost).toBe(true);
+      expect(result.current.gitlabConnected).toBe(true);
+      expect(result.current.githubConnected).toBe(false);
+    });
+
+    it('becomes true once gh status reports a scoped token', async () => {
+      workspaces.push({ id: 'w1' });
+      ghStatusMock.mockResolvedValue({ scoped: true });
+      const { result } = renderHook(() => useOnboardingWizard());
+      await waitFor(() => expect(result.current.hasCodeHost).toBe(true));
+      expect(result.current.githubConnected).toBe(true);
+      expect(ghStatusMock).toHaveBeenCalledWith('w1');
+    });
+
+    it('stays false when gh status check rejects', async () => {
+      workspaces.push({ id: 'w1' });
+      ghStatusMock.mockRejectedValue(new Error('offline'));
+      const { result } = renderHook(() => useOnboardingWizard());
+      await waitFor(() => expect(ghStatusMock).toHaveBeenCalledWith('w1'));
+      expect(result.current.hasCodeHost).toBe(false);
+    });
+  });
+
+  describe('hasLinear / hasSentry', () => {
+    it('are both false without a workspace', () => {
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasLinear).toBe(false);
+      expect(result.current.hasSentry).toBe(false);
+    });
+
+    it('flags Linear independently of Sentry', () => {
+      workspaces.push({ id: 'w1' });
+      workspaceIntegrations = { w1: [{ provider: 'linear' }] };
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasLinear).toBe(true);
+      expect(result.current.hasSentry).toBe(false);
+    });
+
+    it('flags Sentry independently of Linear', () => {
+      workspaces.push({ id: 'w1' });
+      workspaceIntegrations = { w1: [{ provider: 'sentry' }] };
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasSentry).toBe(true);
+      expect(result.current.hasLinear).toBe(false);
+    });
+
+    it('leaves both false when only a code host is connected', () => {
+      workspaces.push({ id: 'w1' });
+      workspaceIntegrations = { w1: [{ provider: 'gitlab' }] };
+      const { result } = renderHook(() => useOnboardingWizard());
+      expect(result.current.hasLinear).toBe(false);
+      expect(result.current.hasSentry).toBe(false);
+    });
+  });
+
+  describe('refreshGithubStatus', () => {
+    it('re-queries gh status and flips hasCodeHost after a fresh connect', async () => {
+      workspaces.push({ id: 'w1' });
+      const { result } = renderHook(() => useOnboardingWizard());
+      await waitFor(() => expect(ghStatusMock).toHaveBeenCalledWith('w1'));
+      expect(result.current.hasCodeHost).toBe(false);
+      ghStatusMock.mockResolvedValue({ scoped: true });
+      act(() => {
+        result.current.refreshGithubStatus();
+      });
+      await waitFor(() => expect(result.current.hasCodeHost).toBe(true));
+    });
   });
 });

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/useOnboardingWizard/index.ts
@@ -1,31 +1,84 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
 import { useAppStore, useWorkspaces } from '../../../../store';
-import { isWizardDone, OPEN_WIZARD_EVENT } from '../../onboarding-store';
+import { ghStatus } from '../../../github/github';
+import { isWizardDone, OPEN_WIZARD_EVENT, type WizardMode } from '../../onboarding-store';
 
 export type OnboardingWizardState = {
   readonly open: boolean;
+  readonly mode: WizardMode;
   readonly providersConnected: number;
   readonly hasWorkspace: boolean;
+  readonly workspaceId: WorkspaceId | null;
+  readonly githubConnected: boolean;
+  readonly gitlabConnected: boolean;
+  readonly hasCodeHost: boolean;
+  readonly hasLinear: boolean;
+  readonly hasSentry: boolean;
+  readonly refreshGithubStatus: () => void;
 };
 
 export const useOnboardingWizard = (): OnboardingWizardState => {
   const providersConnected = useAppStore(
     (s) => s.providers.filter((p) => p.connection === 'connected').length,
   );
+  const workspaceId = useWorkspaces()[0]?.id ?? null;
   const hasWorkspace = useWorkspaces().length > 0;
   const hydrated = useAppStore((s) => s.hydrated);
 
-  const [open, setOpen] = useState(false);
-  const decided = useRef(false);
+  const gitlabConnected = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab')
+      : false,
+  );
+  const hasLinear = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'linear')
+      : false,
+  );
+  const hasSentry = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'sentry')
+      : false,
+  );
+
+  const [githubScoped, setGithubScoped] = useState(false);
+  const refreshGithubStatus = useCallback(() => {
+    if (!workspaceId) {
+      setGithubScoped(false);
+      return;
+    }
+    void ghStatus(workspaceId)
+      .then((status) => setGithubScoped(status.scoped ?? false))
+      .catch(() => setGithubScoped(false));
+  }, [workspaceId]);
 
   useEffect(() => {
-    const onOpen = () => {
+    refreshGithubStatus();
+  }, [refreshGithubStatus]);
+
+  const hasCodeHost = githubScoped || gitlabConnected;
+
+  const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<WizardMode>('full');
+  const decided = useRef(false);
+  const openRef = useRef(false);
+
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const requested = (e as CustomEvent<{ mode?: WizardMode }>).detail?.mode ?? 'full';
+      if (requested === 'setup' && openRef.current) {
+        return;
+      }
       decided.current = true;
+      openRef.current = true;
+      setMode(requested);
       setOpen(true);
     };
     const onProgress = () => {
       if (isWizardDone()) {
         decided.current = true;
+        openRef.current = false;
         setOpen(false);
       }
     };
@@ -43,9 +96,22 @@ export const useOnboardingWizard = (): OnboardingWizardState => {
     }
     if (!isWizardDone() && !hasWorkspace) {
       decided.current = true;
+      openRef.current = true;
       setOpen(true);
     }
   }, [hydrated, hasWorkspace]);
 
-  return { open, providersConnected, hasWorkspace };
+  return {
+    open,
+    mode,
+    providersConnected,
+    hasWorkspace,
+    workspaceId,
+    githubConnected: githubScoped,
+    gitlabConnected,
+    hasCodeHost,
+    hasLinear,
+    hasSentry,
+    refreshGithubStatus,
+  };
 };

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.test.ts
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OnboardingStepId } from '../../onboarding-store';
+
+let completed: Array<OnboardingStepId> = [];
+const workspaces: Array<{ id: string }> = [];
+let workspaceIntegrations: Record<string, Array<{ provider: string }>> = {};
+let sessions: Array<unknown> = [];
+
+const { markStepCompleteMock, ghStatusMock } = vi.hoisted(() => ({
+  markStepCompleteMock: vi.fn(),
+  ghStatusMock: vi.fn(async () => ({ scoped: false }) as unknown),
+}));
+
+vi.mock('../../onboarding-store', () => ({
+  ONBOARDING_STEPS: new Array(7).fill({ id: 'x', title: 'x', why: 'x' }),
+  getCompleted: () => completed,
+  isCollapsed: () => false,
+  isFinished: () => false,
+  markStepComplete: markStepCompleteMock,
+}));
+
+vi.mock('../../../github/github', () => ({
+  ghStatus: ghStatusMock,
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: (
+    selector: (s: {
+      sessions: typeof sessions;
+      sessionPhaseRuns: Record<string, unknown[]>;
+      sessionPlans: Record<string, unknown[]>;
+      workspaceIntegrations: typeof workspaceIntegrations;
+    }) => unknown,
+  ) =>
+    selector({
+      sessions,
+      sessionPhaseRuns: {},
+      sessionPlans: {},
+      workspaceIntegrations,
+    }),
+  useCurrentSession: () => null,
+  useWorkspaces: () => workspaces,
+}));
+
+function reset() {
+  completed = [];
+  workspaces.length = 0;
+  workspaceIntegrations = {};
+  sessions = [];
+  markStepCompleteMock.mockReset();
+  ghStatusMock.mockReset();
+  ghStatusMock.mockResolvedValue({ scoped: false });
+}
+
+import { useOnboardingProgress } from './index';
+
+describe('useOnboardingProgress auto-mark', () => {
+  beforeEach(reset);
+  afterEach(reset);
+
+  it('marks codeHost when GitLab is connected for the workspace', () => {
+    workspaces.push({ id: 'w1' });
+    workspaceIntegrations = { w1: [{ provider: 'gitlab' }] };
+    renderHook(() => useOnboardingProgress());
+    expect(markStepCompleteMock).toHaveBeenCalledWith('codeHost');
+  });
+
+  it('marks codeHost once gh status reports a scoped token', async () => {
+    workspaces.push({ id: 'w1' });
+    ghStatusMock.mockResolvedValue({ scoped: true });
+    renderHook(() => useOnboardingProgress());
+    await waitFor(() => expect(markStepCompleteMock).toHaveBeenCalledWith('codeHost'));
+  });
+
+  it('marks tools when Linear is connected for the workspace', () => {
+    workspaces.push({ id: 'w1' });
+    workspaceIntegrations = { w1: [{ provider: 'linear' }] };
+    renderHook(() => useOnboardingProgress());
+    expect(markStepCompleteMock).toHaveBeenCalledWith('tools');
+  });
+
+  it('marks tools when Sentry is connected for the workspace', () => {
+    workspaces.push({ id: 'w1' });
+    workspaceIntegrations = { w1: [{ provider: 'sentry' }] };
+    renderHook(() => useOnboardingProgress());
+    expect(markStepCompleteMock).toHaveBeenCalledWith('tools');
+  });
+
+  it('does not mark codeHost or tools when no workspace exists', () => {
+    workspaceIntegrations = { w1: [{ provider: 'gitlab' }, { provider: 'linear' }] };
+    renderHook(() => useOnboardingProgress());
+    expect(markStepCompleteMock).not.toHaveBeenCalledWith('codeHost');
+    expect(markStepCompleteMock).not.toHaveBeenCalledWith('tools');
+  });
+
+  it('skips already-completed steps and never re-queries gh status', () => {
+    completed = ['workspace', 'codeHost', 'tools'];
+    workspaces.push({ id: 'w1' });
+    workspaceIntegrations = { w1: [{ provider: 'gitlab' }, { provider: 'linear' }] };
+    renderHook(() => useOnboardingProgress());
+    expect(markStepCompleteMock).not.toHaveBeenCalled();
+    expect(ghStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('reports completed count and total from the store', () => {
+    completed = ['workspace', 'codeHost'];
+    const { result } = renderHook(() => useOnboardingProgress());
+    expect(result.current.completedCount).toBe(2);
+    expect(result.current.totalCount).toBe(7);
+    expect(result.current.isDone).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
+++ b/apps/desktop/src/features/onboarding/hooks/useOnboardingProgress/index.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useAppStore, useCurrentSession, useWorkspaces } from '../../../../store';
+import { ghStatus } from '../../../github/github';
 import {
   ONBOARDING_STEPS,
   getCompleted,
@@ -58,9 +59,44 @@ export const useOnboardingProgress = (): OnboardingProgress => {
   });
   const currentSession = useCurrentSession();
 
+  const workspaceId = workspaces[0]?.id ?? null;
+  const needsCodeHostDetect = !persistedCompleted.has('codeHost');
+  const needsToolsDetect = !persistedCompleted.has('tools');
+  const gitlabConnected = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some((i) => i.provider === 'gitlab')
+      : false,
+  );
+  const hasTools = useAppStore((s) =>
+    workspaceId
+      ? (s.workspaceIntegrations[workspaceId] ?? []).some(
+          (i) => i.provider === 'linear' || i.provider === 'sentry',
+        )
+      : false,
+  );
+
+  const [githubScoped, setGithubScoped] = useState(false);
+  const refreshGithubStatus = useCallback(() => {
+    if (!workspaceId || !needsCodeHostDetect) {
+      return;
+    }
+    void ghStatus(workspaceId)
+      .then((status) => setGithubScoped(status.scoped ?? false))
+      .catch(() => setGithubScoped(false));
+  }, [workspaceId, needsCodeHostDetect]);
+  useEffect(() => {
+    refreshGithubStatus();
+  }, [refreshGithubStatus]);
+
   useEffect(() => {
     if (workspaces.length > 0 && !persistedCompleted.has('workspace')) {
       markStepComplete('workspace');
+    }
+    if ((gitlabConnected || githubScoped) && !persistedCompleted.has('codeHost')) {
+      markStepComplete('codeHost');
+    }
+    if (hasTools && !persistedCompleted.has('tools')) {
+      markStepComplete('tools');
     }
     if (sessionCount > 0 && !persistedCompleted.has('session')) {
       markStepComplete('session');
@@ -71,7 +107,17 @@ export const useOnboardingProgress = (): OnboardingProgress => {
     if (anyPlan && !persistedCompleted.has('plan')) {
       markStepComplete('plan');
     }
-  }, [workspaces.length, sessionCount, anyAgent, anyPlan, persistedCompleted, currentSession]);
+  }, [
+    workspaces.length,
+    sessionCount,
+    anyAgent,
+    anyPlan,
+    gitlabConnected,
+    githubScoped,
+    hasTools,
+    persistedCompleted,
+    currentSession,
+  ]);
 
   const totalCount = ONBOARDING_STEPS.length;
   const completedCount = persistedCompleted.size;

--- a/apps/desktop/src/features/onboarding/onboarding-store.test.ts
+++ b/apps/desktop/src/features/onboarding/onboarding-store.test.ts
@@ -88,4 +88,26 @@ describe('onboarding-store wizard flag', () => {
     expect(spy).toHaveBeenCalledOnce();
     window.removeEventListener(OPEN_WIZARD_EVENT, spy);
   });
+
+  it('reopenWizard defaults to full mode in the event detail', () => {
+    let detail: unknown;
+    const spy = (e: Event) => {
+      detail = (e as CustomEvent).detail;
+    };
+    window.addEventListener(OPEN_WIZARD_EVENT, spy);
+    reopenWizard();
+    window.removeEventListener(OPEN_WIZARD_EVENT, spy);
+    expect(detail).toEqual({ mode: 'full' });
+  });
+
+  it('reopenWizard forwards the requested setup mode in the event detail', () => {
+    let detail: unknown;
+    const spy = (e: Event) => {
+      detail = (e as CustomEvent).detail;
+    };
+    window.addEventListener(OPEN_WIZARD_EVENT, spy);
+    reopenWizard('setup');
+    window.removeEventListener(OPEN_WIZARD_EVENT, spy);
+    expect(detail).toEqual({ mode: 'setup' });
+  });
 });

--- a/apps/desktop/src/features/onboarding/onboarding-store.ts
+++ b/apps/desktop/src/features/onboarding/onboarding-store.ts
@@ -1,37 +1,64 @@
 import { getSetting, setSetting } from '@goodboy/db';
 import { tauriDatabase } from '../../shared/lib/db';
 
-export type OnboardingStepId = 'workspace' | 'session' | 'agent' | 'plan' | 'palette';
+export type OnboardingStepId =
+  | 'workspace'
+  | 'codeHost'
+  | 'tools'
+  | 'session'
+  | 'agent'
+  | 'plan'
+  | 'palette';
+
+export type OnboardingGroup = 'setup' | 'build';
 
 export const ONBOARDING_STEPS: ReadonlyArray<{
   readonly id: OnboardingStepId;
   readonly title: string;
   readonly why: string;
+  readonly group: OnboardingGroup;
 }> = [
   {
     id: 'workspace',
     title: 'Connect a workspace',
     why: 'Point Goodboy at a git repo, every session worktree lives off it.',
+    group: 'setup',
+  },
+  {
+    id: 'codeHost',
+    title: 'Connect a code host',
+    why: 'Link GitHub or GitLab so agents can read PRs, branches, and reviews.',
+    group: 'setup',
+  },
+  {
+    id: 'tools',
+    title: 'Connect your tools',
+    why: 'Wire Linear or Sentry to pull issues and errors into context.',
+    group: 'setup',
   },
   {
     id: 'session',
     title: 'Create your first session',
     why: 'A session = one goal on its own worktree + branch. Pick something concrete.',
+    group: 'build',
   },
   {
     id: 'agent',
     title: 'Create your first agent',
     why: 'Sessions host agents (planner, scout, implementer…). Create the one that fits the work.',
+    group: 'build',
   },
   {
     id: 'plan',
     title: 'Make your first plan',
     why: 'Spawn a planner, it emits a structured plan you can hand off to an implementer.',
+    group: 'build',
   },
   {
     id: 'palette',
     title: 'Open the command palette',
     why: '⌘K. Navigate workspaces, sessions, and agents, everything from one input.',
+    group: 'build',
   },
 ];
 
@@ -42,13 +69,9 @@ const SETTING_WIZARD = 'onboarding.wizard';
 
 export const OPEN_WIZARD_EVENT = 'goodboy:open-onboarding-wizard';
 
-const STEP_IDS: ReadonlyArray<OnboardingStepId> = [
-  'workspace',
-  'session',
-  'agent',
-  'plan',
-  'palette',
-];
+export type WizardMode = 'full' | 'setup';
+
+const STEP_IDS: ReadonlyArray<OnboardingStepId> = ONBOARDING_STEPS.map((s) => s.id);
 
 type OnboardingCache = {
   completed: ReadonlyArray<OnboardingStepId>;
@@ -169,10 +192,10 @@ export const finishWizard = (): void => {
   window.dispatchEvent(new CustomEvent('goodboy:onboarding-progress'));
 };
 
-export const reopenWizard = (): void => {
+export const reopenWizard = (mode: WizardMode = 'full'): void => {
   if (cache.wizardDone) {
     cache.wizardDone = false;
     void setSetting(tauriDatabase, SETTING_WIZARD, '');
   }
-  window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT));
+  window.dispatchEvent(new CustomEvent(OPEN_WIZARD_EVENT, { detail: { mode } }));
 };

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -376,7 +376,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       <Divider />
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-6 py-5">
-        <div className="mx-auto flex w-full max-w-2xl flex-col gap-7">
+        <div className="mx-auto my-auto flex w-full max-w-2xl flex-col gap-7">
           {noProviderConnected ? (
             <div className="flex items-start gap-3 rounded-md border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs">
               <span className="mt-0.5 text-warning">⚠</span>

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -439,7 +439,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-6 py-5">
-          <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+          <div className="mx-auto my-auto flex w-full max-w-2xl flex-col gap-4">
             <div className="flex flex-col gap-1.5">
               <div className="flex items-center gap-2">
                 <label

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
@@ -96,6 +96,7 @@ describe('WorkspaceScopePanel', () => {
   });
 
   it('persists a provider pick from a brand chip', () => {
+    state.providers = [{ id: 'cursor', connection: 'connected' }];
     render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: /cursor/i }));
     expect(state.setWorkspaceOverrides).toHaveBeenCalledOnce();

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -195,7 +195,7 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
                   key={id}
                   id={id}
                   selected={defaultProvider === id}
-                  disabled={busy}
+                  disabled={busy || !connectedProviderIds.includes(id)}
                   onClick={() =>
                     void persistOverrides(
                       { defaultProviderId: id },

--- a/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspaceLinkDialog/index.tsx
@@ -6,6 +6,7 @@ import { Boxes, Check, FolderGit2, FolderPlus, Loader2 } from 'lucide-react';
 import { useAppStore, useWorkspaces } from '../../../../store';
 import { formatError } from '../../../../shared/lib/errors';
 import { validateGitRepo } from '../../../../shared/lib/repo';
+import { reopenWizard } from '../../../onboarding/onboarding-store';
 
 type Props = {
   open: boolean;
@@ -163,6 +164,7 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
       const ws = await addWorkspace({ rootPath: path });
       await setCurrentWorkspace(ws.id);
       onClose();
+      reopenWizard('setup');
     } catch (err) {
       setSubmitError(formatError(err));
     } finally {
@@ -185,6 +187,7 @@ export const WorkspaceLinkDialog = ({ open, onClose }: Props) => {
       });
       await setCurrentWorkspace(ws.id);
       onClose();
+      reopenWizard('setup');
     } catch (err) {
       setSubmitError(formatError(err));
     } finally {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -425,13 +425,16 @@ export function AgentsSection({ task }: AgentsSectionProps) {
 
   const onPickAgent = (sid: AgentId) => {
     if (sid === selectedAgentId) {
+      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
       return;
     }
     void selectAgent(task.id, sid);
+    window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
   };
 
   const onStartStepAgent = async (agent: Agent, model?: string) => {
     setSpawnError(null);
+    window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
     try {
       if (agent.status === 'pending') {
         await activateWorkflowAgent(task.id, agent.id);
@@ -721,7 +724,7 @@ export function AgentsSection({ task }: AgentsSectionProps) {
             </div>
           ) : (
             <p className="pb-1 pl-3 text-2xs text-muted-foreground/60">
-              no agents yet for this workflow.
+              No agents yet for this workflow.
             </p>
           )
         ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
@@ -117,6 +117,7 @@ export function SpawnAgentControl({ sessionId }: SpawnAgentControlProps) {
                     onClick={() => {
                       setOpen(false);
                       void spawnAgent(sessionId, { kindOverride: kind });
+                      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
                     }}
                     className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left transition-colors hover:bg-muted"
                   >


### PR DESCRIPTION
## Summary
- 8-step guided onboarding wizard: welcome → providers (mandatory) → workspace (mandatory) → preferences → code host → tracker → sentry → ready
- Extract GitHub/GitLab/Linear/Sentry connect logic into reusable `*FormBody` primitives; the four `Connect*Dialog`s and the new wizard steps share them
- New `Segmented` control for GitHub|GitLab and Linear|Jira pickers
- `PreferencesStep`: branch prefix, default provider (filtered to connected only, offline chips disabled), output verbosity, parallel scouts
- Onboarding card auto-marks setup/build steps from the same state the wizard writes
- `goodboy:reveal-chat` event clears overlay studios so spawning/picking an agent surfaces the chat

## Test plan
- [x] typecheck
- [x] knip (files/duplicates/unlisted)
- [x] full desktop test suite (1484 tests)
- [x] build
- [ ] manual smoke: first-run wizard, mandatory gates, skip flows, add-workspace from inside app shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)