### PR TITLE
fix(desktop): cap oversized-goal breadcrumb width

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -179,7 +179,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 </div>
               </div>
               <Divider orientation="vertical" />
-              <div className="min-h-0 flex-1">
+              <div className="min-h-0 min-w-0 flex-1">
                 <ChatView session={session} isActive={isActive && selectedAgentId != null} />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- oversized session goals overflowed the chat breadcrumb (and chat column) because the `ChatView` flex wrapper lacked `min-w-0`, so the column couldn't shrink below its content
- add `min-w-0` to the wrapper → flex chain shrinks → existing `min-w-0 truncate` on the session label ellipsizes correctly

## Test plan
- [ ] open a session with a very long goal, select an agent, confirm breadcrumb truncates with ellipsis and chat no longer overflows
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)