### PR TITLE
feat(desktop): default branch prefix goodboy

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -659,7 +659,7 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
               <span
                 class="shrink-0 text-xs text-muted-foreground font-mono"
               >
-                kay/
+                goodboy/
               </span>
               <input
                 aria-label="Branch slug"
@@ -1739,7 +1739,7 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
               <span
                 class="shrink-0 text-xs text-muted-foreground font-mono"
               >
-                kay/
+                goodboy/
               </span>
               <input
                 aria-label="Branch slug"

--- a/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
+++ b/apps/desktop/src/features/settings/components/GuideDialog/index.tsx
@@ -183,7 +183,7 @@ function SessionsSection() {
             },
             {
               term: 'branch',
-              desc: 'kay/<slug> (or your prefix), derived from the goal. Configurable per workspace.',
+              desc: 'goodboy/<slug> (or your prefix), derived from the goal. Configurable per workspace.',
               icon: <GitBranch size={11} aria-hidden />,
               tone: 'success',
             },

--- a/apps/desktop/src/features/settings/settings.ts
+++ b/apps/desktop/src/features/settings/settings.ts
@@ -6,7 +6,7 @@ export const SETTING_LAST_WORKSPACE_ID = 'last.workspace_id';
 export const SETTING_LAST_SESSION_ID = 'last.session_id';
 export const SETTING_REOPEN_LAST = 'launch.reopen_last';
 export const DEFAULT_EDITOR_BINARY = 'code';
-export const DEFAULT_BRANCH_PREFIX = 'kay';
+export const DEFAULT_BRANCH_PREFIX = 'goodboy';
 
 export const settingBranchPrefix = (workspaceId: WorkspaceId): string =>
   `workspace.${workspaceId}.branch_prefix`;

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -31,7 +31,10 @@ import {
   inferAgentKindFromName,
   type AgentKind,
 } from '../../../features/session/agent-kind';
-import { SETTING_LAST_SESSION_ID } from '../../../features/settings/settings';
+import {
+  SETTING_LAST_SESSION_ID,
+  DEFAULT_BRANCH_PREFIX,
+} from '../../../features/settings/settings';
 import type { GetFn, SetFn } from './types';
 
 const slugifyDir = (raw: string): string =>
@@ -81,7 +84,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       throw new Error(`workspace not found: ${workspaceId}`);
     }
 
-    const prefix = branchPrefix?.trim() || 'kay';
+    const prefix = branchPrefix?.trim() || DEFAULT_BRANCH_PREFIX;
     const slugSeed =
       branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
     const trimmedExisting = existingBranch?.trim();

--- a/packages/core/src/worktree/__tests__/parallel.test.ts
+++ b/packages/core/src/worktree/__tests__/parallel.test.ts
@@ -56,7 +56,7 @@ describe('createParallelWorktrees', () => {
     );
   });
 
-  it('uses "kay" prefix when parentBranch has no slash', async () => {
+  it('uses "goodboy" prefix when parentBranch has no slash', async () => {
     const deps = makeDeps();
     await createParallelWorktrees(deps, {
       sessionId: SESSION_ID,
@@ -67,7 +67,7 @@ describe('createParallelWorktrees', () => {
     });
 
     expect(deps.invokeWorktreeCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ branchPrefix: 'kay', slug: 'my-seed-p0' }),
+      expect.objectContaining({ branchPrefix: 'goodboy', slug: 'my-seed-p0' }),
     );
   });
 

--- a/packages/core/src/worktree/parallel.ts
+++ b/packages/core/src/worktree/parallel.ts
@@ -29,7 +29,7 @@ export type ParallelWorktreeResult = {
 function splitParentBranch(parentBranch: string): { prefix: string; base: string } {
   const slashIdx = parentBranch.indexOf('/');
   if (slashIdx === -1) {
-    return { prefix: 'kay', base: parentBranch };
+    return { prefix: 'goodboy', base: parentBranch };
   }
   return {
     prefix: parentBranch.slice(0, slashIdx),


### PR DESCRIPTION
## Summary
- Change `DEFAULT_BRANCH_PREFIX` from `kay` to `goodboy` (single source in settings.ts)
- Update hardcoded fallbacks: `createSession.ts` now references the constant, `parallel.ts` scout split uses `goodboy`
- Update GuideDialog copy + empty/error-state snapshots
- Update `parallel.test.ts` expectation to `goodboy`

## Test plan
- [ ] CI green (vitest)
- [ ] New session branch defaults to `goodboy/<slug>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)