### PR TITLE
fix(core): subscription-aware cursor model routing

### DIFF
--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Divider, Input, Textarea, cn } from '@goodboy/ui';
 import { AlertTriangle, GitBranch, Loader2, Plus, Target, Wand2 } from 'lucide-react';
 import type { ProviderId, SessionId, WorkspaceId } from '@goodboy/types';
+import { CURSOR_AUTO_MODEL } from '@goodboy/core';
 import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../../../../features/settings/settings';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -77,7 +78,7 @@ function getCheapModel(providerId: ProviderId): string {
     case 'anthropic':
       return 'claude-haiku-4-5';
     case 'cursor':
-      return 'composer-2-fast';
+      return CURSOR_AUTO_MODEL;
     case 'codex':
       return 'gpt-5.4-mini';
     case 'gemini':

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,7 +85,7 @@ export { getModelDescriptor, getModelProvider } from './providers/model-display'
 export { assessTurnWeight, type TurnWeight } from './providers/turn-weight';
 
 export { CURSOR_CHEAP_MODEL, computeCursorCostUsd } from './providers/cursor/cost';
-export { CURSOR_DEFAULT_MODEL, CURSOR_MODELS } from './providers/cursor/models';
+export { CURSOR_AUTO_MODEL, CURSOR_DEFAULT_MODEL, CURSOR_MODELS } from './providers/cursor/models';
 export {
   parseCursorStreamLine,
   type ParseContext as CursorParseContext,

--- a/packages/core/src/providers/auto-model.ts
+++ b/packages/core/src/providers/auto-model.ts
@@ -1,5 +1,6 @@
 import type { ModelCostTier, ProviderId } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES } from './capabilities';
+import { CURSOR_AUTO_MODEL } from './cursor/models';
 import { defaultsForRole } from '../roles';
 
 export type AutoModelChoice = {
@@ -42,5 +43,11 @@ export const autoModelForRole = (
       }
     }
   }
-  return best === null ? null : { provider: best.provider, model: best.model };
+  if (best === null) {
+    return null;
+  }
+  return {
+    provider: best.provider,
+    model: best.provider === 'cursor' ? CURSOR_AUTO_MODEL : best.model,
+  };
 };

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,5 +1,5 @@
 import type { ModelEffort, ProviderId, ProviderRegistryCapabilities } from '@goodboy/types';
-import { CURSOR_MODELS } from './cursor/models';
+import { CURSOR_AUTO_MODEL, CURSOR_MODELS } from './cursor/models';
 import { CODEX_MODELS } from './codex/constants';
 import { GEMINI_MODELS } from './gemini/constants';
 
@@ -123,6 +123,9 @@ export const getCapabilities = (id: ProviderId): ProviderRegistryCapabilities =>
 };
 
 export const getDefaultTurnModel = (id: ProviderId): string => {
+  if (id === 'cursor') {
+    return CURSOR_AUTO_MODEL;
+  }
   const caps = PROVIDER_CAPABILITIES[id];
   return caps.models.find((m) => m.tier === 'turn')?.id ?? caps.models[0]!.id;
 };

--- a/packages/core/src/providers/cursor/models.ts
+++ b/packages/core/src/providers/cursor/models.ts
@@ -3,6 +3,8 @@ import { CURSOR_CHEAP_MODEL } from './cost';
 
 export const CURSOR_DEFAULT_MODEL = 'composer-2';
 
+export const CURSOR_AUTO_MODEL = 'auto';
+
 export const CURSOR_MODELS: ReadonlyArray<ModelTier> = [
   {
     id: 'composer-2',
@@ -29,7 +31,7 @@ export const CURSOR_MODELS: ReadonlyArray<ModelTier> = [
     effort: null,
   },
   {
-    id: 'auto',
+    id: CURSOR_AUTO_MODEL,
     tier: 'cheap',
     contextWindow: 200_000,
     family: 'cursor-auto',

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -3,6 +3,7 @@ import type { ContextSlot, ProviderId } from '@goodboy/types';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
+import { CURSOR_AUTO_MODEL } from '../providers/cursor/models';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
 
 type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
@@ -97,6 +98,9 @@ Only include slots that actually change. Omit slots that stay the same. Never in
 If nothing should change, return { "upserts": [] }.`;
 
 function getCheapModel(providerId: ProviderId): string {
+  if (providerId === 'cursor') {
+    return CURSOR_AUTO_MODEL;
+  }
   const caps = PROVIDER_CAPABILITIES[providerId];
   return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
 }

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -89,7 +89,7 @@ describe('Summarizer (CLI-based)', () => {
     expect(binary).toBe('cursor-agent');
     expect(args).toContain('-p');
     expect(args).toContain('--model');
-    expect(args).toContain('composer-2-fast');
+    expect(args).toContain('auto');
     expect(args).toContain('--force');
   });
 

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,10 +1,14 @@
 import type { ContextSlot, ProviderId } from '@goodboy/types';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
+import { CURSOR_AUTO_MODEL } from '../providers/cursor/models';
 import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
 
 export const getCheapModel = (providerId: ProviderId): string => {
+  if (providerId === 'cursor') {
+    return CURSOR_AUTO_MODEL;
+  }
   const caps = PROVIDER_CAPABILITIES[providerId];
   return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
 };

--- a/packages/core/src/workflows/seeder.test.ts
+++ b/packages/core/src/workflows/seeder.test.ts
@@ -4,6 +4,7 @@ import type { IsoDateTime, WorkspaceId } from '@goodboy/types';
 import { migrate, listWorkflows, insertWorkspace, type Database as DbInterface } from '@goodboy/db';
 import { WORKFLOW_LIBRARY } from './library';
 import { seedWorkflowLibrary } from './seeder';
+import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 
 const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
@@ -91,5 +92,34 @@ describe('seedWorkflowLibrary', () => {
       expect(wf.createdAt).toBe(fixed);
       expect(wf.updatedAt).toBe(fixed);
     }
+  });
+
+  describe('provider routing (regression for cursor/codex sessions)', () => {
+    it('does not hardcode providerOverride on seeded steps', async () => {
+      const { db, workspaceId } = await setup();
+      await seedWorkflowLibrary({ db }, workspaceId);
+
+      const workflows = await listWorkflows(db, workspaceId);
+      const steps = workflows.flatMap((w) => w.steps);
+
+      expect(steps.length).toBeGreaterThan(0);
+      expect(steps.every((s) => s.providerOverride === undefined)).toBe(true);
+    });
+
+    it('does not pin anthropic model IDs on seeded steps', async () => {
+      const { db, workspaceId } = await setup();
+      await seedWorkflowLibrary({ db }, workspaceId);
+
+      const workflows = await listWorkflows(db, workspaceId);
+      const steps = workflows.flatMap((w) => w.steps);
+
+      const anthropicModelIds = new Set(PROVIDER_CAPABILITIES.anthropic.models.map((m) => m.id));
+
+      const stepsWithAnthropicModelId = steps.filter(
+        (s) => s.modelOverride !== undefined && anthropicModelIds.has(s.modelOverride),
+      );
+
+      expect(stepsWithAnthropicModelId).toHaveLength(0);
+    });
   });
 });

--- a/packages/core/src/workflows/seeder.ts
+++ b/packages/core/src/workflows/seeder.ts
@@ -10,7 +10,6 @@ import type {
 } from '@goodboy/types';
 import { upsertWorkflow, type Database } from '@goodboy/db';
 import { WORKFLOW_LIBRARY } from './library';
-import { defaultsForRole } from '../roles';
 
 const SEEDED_ROLES = new Set<AgentRole>([
   'scout',
@@ -58,7 +57,6 @@ export const seedWorkflowLibrary = async (
   for (const entry of WORKFLOW_LIBRARY) {
     const workflowId = makeWorkflowId(entry.slug, workspaceId);
     const steps: ReadonlyArray<Step> = entry.steps.map((s, ordinal) => {
-      const roleDefaults = defaultsForRole(s.role);
       const libraryStepId = libraryStepIdForRole(s.role);
       return {
         id: makeStepId(entry.slug, s.name, workspaceId),
@@ -68,8 +66,6 @@ export const seedWorkflowLibrary = async (
         ordinal,
         name: s.name,
         promptPrefix: s.promptPrefix,
-        providerOverride: roleDefaults.provider,
-        modelOverride: roleDefaults.model,
       };
     });
 


### PR DESCRIPTION
## Summary
- seeded workflow steps no longer hardcode the anthropic provider/model; they inherit the session provider at runtime via `autoModelForRole`, so cursor/codex sessions receive provider-local models instead of unrunnable anthropic ids
- cursor system tasks (summarizer, workflow generation, turn defaults) now route to the `auto` model, which cursor resolves server-side per subscription and is always available, instead of the static `composer-2-fast` slug that may be invalid or outside the user's plan
- `composer-2-fast` stays selectable and priced, just no longer auto-picked

## Why
cursor/codex sessions broke on summarizer and custom workflow generation because the model selection layer reads a static capability table and never accounts for subscription-based availability. only anthropic worked reliably.

## Test plan
- [x] `pnpm typecheck` (5/5 packages)
- [x] `pnpm test` (all packages green)
- [x] `pnpm format:check`
- [ ] manual: on a cursor-default session, run summarizer + a custom workflow and confirm no model errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)