### PR TITLE
fix(desktop): restore PR reload CTA in empty state

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -108,7 +108,10 @@ const GithubPrCard = ({ session }: { session: Session }) => {
 
   if (!pr) {
     return (
-      <div className="animate-fade-in flex flex-col items-center gap-5 rounded-2xl border border-border-soft bg-elevated px-8 py-10 text-center">
+      <div className="animate-fade-in relative flex flex-col items-center gap-5 rounded-2xl border border-border-soft bg-elevated px-8 py-10 text-center">
+        <div className="absolute right-3 top-3">
+          <RefreshButton onClick={refresh} loading={loading} error={error} />
+        </div>
         <span
           aria-hidden
           className="flex size-14 items-center justify-center rounded-2xl bg-primary/10 ring-1 ring-primary/15"


### PR DESCRIPTION
## Summary
- Restore the PR reload control lost since v0.1.15. PRs created outside the canonical workflow weren't caught in the reference window, leaving the empty state with no way to fetch them.
- Add the existing `RefreshButton` (absolute top-right) to the PR pane empty state; it calls `refreshSessionPr(sessionId, { force: true })` to bypass `skipUnknownPr` and force a GitHub fetch. The populated state already exposed this button.

## Test plan
- [ ] Open a session whose PR was created outside Goodboy → empty state shows refresh button → click → PR card populates.
- [ ] Spinner shows while loading; error surfaces via tooltip on failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)