### PR TITLE
fix(desktop): restore summarizer cost pill lost in work-surface refactor

### DIFF
--- a/apps/desktop/src/features/context/components/ContextPanel/lib.ts
+++ b/apps/desktop/src/features/context/components/ContextPanel/lib.ts
@@ -1,7 +1,5 @@
 import type { ContextSlot } from '@goodboy/types';
 
-export type SummarizerStatusKind = 'idle' | 'running' | 'error';
-
 export interface FilesTouchedShape {
   readonly paths: ReadonlyArray<string>;
   readonly count: number;

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -1,16 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
 import { History, RotateCcw } from 'lucide-react';
 import { Dialog, Markdown, Textarea, cn } from '@goodboy/ui';
-import type { ContextSlotHistoryEntry, Session, SessionId, TelemetryRecord } from '@goodboy/types';
+import type { ContextSlotHistoryEntry, Session, SessionId } from '@goodboy/types';
 import {
-  EMPTY_ARRAY,
   useAppStore,
   useSessionLoading,
   useSessionSlots,
   useSlotHistory,
   useSummarizerStatus,
 } from '../../../../../store';
-import { SummarizerBadge } from '../../../../context/components/ContextPanel/parts/SummarizerBadge';
 import { PaneShell } from './PaneShell';
 
 type SlotKey = 'goal' | 'decisions' | 'last_output_summary';
@@ -48,9 +46,6 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
   const loadSlotHistory = useAppStore((s) => s.loadSlotHistory);
   const history = useSlotHistory(sessionId, slotKey);
-  const telemetry = useAppStore(
-    (s) => s.sessionTelemetry[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
-  );
 
   const slot = useMemo(() => slots.find((s) => s.key === slotKey), [slots, slotKey]);
   const value = slot?.value ?? '';
@@ -65,25 +60,6 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
   useEffect(() => {
     if (!editing) setDraft(value);
   }, [value, editing]);
-
-  const summarizerTotals = useMemo(() => {
-    let inputTokens = 0;
-    let outputTokens = 0;
-    let estimatedCostUsd = 0;
-    let count = 0;
-    for (const rec of telemetry) {
-      if (rec.kind !== 'summarizer') continue;
-      inputTokens += rec.inputTokens;
-      outputTokens += rec.outputTokens;
-      estimatedCostUsd += rec.estimatedCostUsd;
-      count += 1;
-    }
-    return { inputTokens, outputTokens, estimatedCostUsd, count };
-  }, [telemetry]);
-
-  const showSummarizer =
-    slotKey === 'last_output_summary' &&
-    (summarizer.status === 'running' || summarizer.status === 'error');
 
   const commit = () => {
     setEditing(false);
@@ -106,16 +82,6 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
       description={SLOT_DESCRIPTION[slotKey]}
       actions={
         <>
-          {showSummarizer ? (
-            <SummarizerBadge
-              sessionId={sessionId}
-              status={summarizer.status}
-              lastUpdate={summarizer.lastUpdate}
-              error={summarizer.error}
-              totals={summarizerTotals}
-              canRetry={summarizer.lastAttempt !== null}
-            />
-          ) : null}
           {history.length > 0 ? (
             <button
               type="button"

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/SummarizerBadge.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/SummarizerBadge.tsx
@@ -1,36 +1,36 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, Loader2, RotateCw } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { SessionId } from '@goodboy/types';
-import { useAppStore } from '../../../../../store';
-import type { SummarizerStatusKind } from '../lib';
+import type { SessionId, TelemetryRecord } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore, useSummarizerStatus } from '../../../../store';
 
-export function SummarizerBadge({
-  sessionId,
-  status,
-  lastUpdate,
-  error,
-  totals,
-  canRetry,
-}: {
-  sessionId: SessionId;
-  status: SummarizerStatusKind;
-  lastUpdate: string | null;
-  error: string | null;
-  totals: {
-    readonly inputTokens: number;
-    readonly outputTokens: number;
-    readonly estimatedCostUsd: number;
-    readonly count: number;
-  };
-  canRetry: boolean;
-}) {
+export const SummarizerBadge = ({ sessionId }: { sessionId: SessionId }) => {
+  const { status, lastUpdate, error, lastAttempt } = useSummarizerStatus(sessionId);
+  const canRetry = lastAttempt !== null;
+  const telemetry = useAppStore(
+    (s) => s.sessionTelemetry[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
+  );
   const retrySummarizer = useAppStore((s) => s.retrySummarizer);
   const [retrying, setRetrying] = useState(false);
 
   useEffect(() => {
     if (status !== 'error') setRetrying(false);
   }, [status]);
+
+  const totals = useMemo(() => {
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let estimatedCostUsd = 0;
+    let count = 0;
+    for (const rec of telemetry) {
+      if (rec.kind !== 'summarizer') continue;
+      inputTokens += rec.inputTokens;
+      outputTokens += rec.outputTokens;
+      estimatedCostUsd += rec.estimatedCostUsd;
+      count += 1;
+    }
+    return { inputTokens, outputTokens, estimatedCostUsd, count };
+  }, [telemetry]);
 
   const costTooltip =
     totals.count === 0
@@ -85,5 +85,7 @@ export function SummarizerBadge({
     );
   }
 
+  if (status === 'idle') return totals.count > 0 ? costPill : null;
+
   return null;
-}
+};

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -16,6 +16,7 @@ import { openInEditor } from '../../../../shared/lib/editor';
 import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/components/OverflowMenu';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
+import { SummarizerBadge } from './SummarizerBadge';
 
 type SessionDetailPanelProps = {
   session: Session;
@@ -360,6 +361,7 @@ export const SessionMetaFooter = ({ session }: SessionMetaFooterProps) => {
       ) : (
         <div className="flex-1" />
       )}
+      <SummarizerBadge sessionId={session.id as SessionId} />
       <SessionCostChip sessionId={session.id as SessionId} />
       <button
         type="button"


### PR DESCRIPTION
## Summary

Audit of the v0.1.16 3-column work-surface refactor surfaced a regression: the **summarizer cost pill** stopped rendering. The badge returned `null` on `idle`, and the `SlotPane` gate excluded `idle` status, so summarizer spend was no longer visible once a run finished.

This restores the tracking and moves it to a clearer home.

## Changes

- **Relocate** `SummarizerBadge` out of the dead `ContextPanel/parts/` into `SessionDetailPanel/`, beside its sole consumer.
- **Self-contained badge**: props reduce to `{ sessionId }`; it reads `useSummarizerStatus` + telemetry internally instead of receiving 6 props.
- **Wire into `SessionMetaFooter`**: the summarizer-only `Σ` chip sits immediately left of the agent-only `SessionCostChip`. The two stay complementary, preserving the agent-vs-summarizer breakdown and the existing "excluding summarizer" tooltip.
- **Idle render fix**: shows the cost pill on `idle` only when `totals.count > 0`, avoiding a noisy `Σ $0.0000` for never-summarized sessions. `running` / `error` always render.
- **Cleanup**: drop telemetry plumbing + `summarizerTotals` from `SlotPane`, remove the orphaned `SummarizerStatusKind` type from `ContextPanel/lib.ts`.

## Test plan

- [ ] Session with completed summarizer runs shows `Σ $<cost>` chip in the top-bar footer
- [ ] Never-summarized session shows no `Σ` chip
- [ ] Running state shows spinner + pill; error state shows retry button
- [ ] `SessionCostChip` still excludes `kind === 'summarizer'` (no double-count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)