### PR TITLE
refactor(desktop): move resolve into work, questions into context

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -101,13 +101,6 @@ export const LensColumn = ({
   const hasPr = useAppStore(
     (s) => s.sessionGithub[sessionId]?.pr != null || s.sessionGitlabMr[sessionId]?.mr != null,
   );
-  const resolverTotal = useAppStore((s) => {
-    const runs = s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY;
-    return runs.reduce(
-      (n, r) => n + (isResolverAgent(r, s.agentKindOverride[r.id] ?? null) ? 1 : 0),
-      0,
-    );
-  });
   const openResolvers = useAppStore((s) => {
     const runs = s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY;
     return runs.reduce(
@@ -132,17 +125,13 @@ export const LensColumn = ({
       tone: 'accent',
       dot: hasPr ? 'running' : undefined,
     },
-    ...(resolverTotal > 0
-      ? [
-          {
-            kind: 'resolve' as const,
-            label: 'Resolve',
-            icon: MessageSquareReply,
-            tone: 'success' as const,
-            count: openResolvers,
-          },
-        ]
-      : []),
+    {
+      kind: 'questions',
+      label: 'Questions',
+      icon: CircleHelp,
+      tone: 'warning',
+      count: openCount,
+    },
   ];
 
   const groups: ReadonlyArray<LensGroup> = [
@@ -163,6 +152,13 @@ export const LensColumn = ({
           icon: Bot,
           tone: 'primary',
           dot: attentionLens === 'agents' ? 'attention' : hasRunningAgent ? 'running' : undefined,
+        },
+        {
+          kind: 'resolve',
+          label: 'Resolve',
+          icon: MessageSquareReply,
+          tone: 'success',
+          count: openResolvers,
         },
         { kind: 'files', label: 'Diff', icon: FileDiff, tone: 'info', count: filesCount },
       ],
@@ -187,18 +183,6 @@ export const LensColumn = ({
           icon: SquareTerminal,
           tone: 'neutral',
           dot: terminalOpen ? 'running' : undefined,
-        },
-      ],
-    },
-    {
-      label: 'Attention',
-      rows: [
-        {
-          kind: 'questions',
-          label: 'Questions',
-          icon: CircleHelp,
-          tone: 'warning',
-          count: openCount,
         },
       ],
     },


### PR DESCRIPTION
## Summary
- move the Resolve lens from Context into the Work group, ordered Workflows, Agents, Resolve, Diff
- Resolve is now always present (no longer gated on resolver count); selecting it with no resolvers shows the existing "Nothing to resolve" empty state
- move Questions under Context and drop the now-empty Attention group

## Test plan
- [ ] open a session panel: Work shows Workflows / Agents / Resolve / Diff
- [ ] Resolve row visible with no resolver agents; clicking it shows the empty state
- [ ] Questions appears under Context; Attention group is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)