### PR TITLE
fix(desktop): reconcile work-surface foreground for agent nav

### DIFF
--- a/apps/desktop/src/__tests__/overlay-mutual-exclusion.test.ts
+++ b/apps/desktop/src/__tests__/overlay-mutual-exclusion.test.ts
@@ -142,6 +142,90 @@ describe('full-page overlay mutual exclusion', () => {
   });
 });
 
+type SessionForeground = {
+  activeLens: string | null;
+  selectedAgentId: string | null;
+  sessionStudio: SessionStudioKind | null;
+};
+
+function emptyForeground(): SessionForeground {
+  return { activeLens: null, selectedAgentId: null, sessionStudio: null };
+}
+
+function setActiveLens(s: SessionForeground, lens: string | null): SessionForeground {
+  return { ...s, activeLens: lens, selectedAgentId: null, sessionStudio: null };
+}
+
+function selectAgent(s: SessionForeground, agentId: string): SessionForeground {
+  return { ...s, selectedAgentId: agentId, sessionStudio: null };
+}
+
+function setSessionStudio(s: SessionForeground, kind: SessionStudioKind | null): SessionForeground {
+  return kind != null
+    ? { ...s, sessionStudio: kind, selectedAgentId: null }
+    : { ...s, sessionStudio: null };
+}
+
+function foregroundLayer(s: SessionForeground): 'studio' | 'agent' | 'lens' {
+  if (s.sessionStudio !== null) return 'studio';
+  if (s.selectedAgentId !== null) return 'agent';
+  return 'lens';
+}
+
+describe('work-surface foreground triad mutual exclusion', () => {
+  const transitions = [
+    (s: SessionForeground) => setActiveLens(s, 'agents'),
+    (s: SessionForeground) => setActiveLens(s, 'plans'),
+    (s: SessionForeground) => setActiveLens(s, null),
+    (s: SessionForeground) => selectAgent(s, 'agent-1'),
+    (s: SessionForeground) => selectAgent(s, 'agent-2'),
+    (s: SessionForeground) => setSessionStudio(s, 'workflow'),
+    (s: SessionForeground) => setSessionStudio(s, 'github'),
+    (s: SessionForeground) => setSessionStudio(s, null),
+  ];
+
+  it('never shows an agent overlay and a studio at once', () => {
+    for (const first of transitions) {
+      for (const second of transitions) {
+        let s = emptyForeground();
+        s = first(s);
+        s = second(s);
+        const bothExclusive = s.selectedAgentId !== null && s.sessionStudio !== null;
+        expect(bothExclusive).toBe(false);
+        expect(['studio', 'agent', 'lens']).toContain(foregroundLayer(s));
+      }
+    }
+  });
+
+  it('setActiveLens drops both agent overlay and studio', () => {
+    let s = selectAgent(emptyForeground(), 'agent-1');
+    s = setSessionStudio(s, 'workflow');
+    s = setActiveLens(s, 'agents');
+    expect(s.selectedAgentId).toBeNull();
+    expect(s.sessionStudio).toBeNull();
+    expect(s.activeLens).toBe('agents');
+    expect(foregroundLayer(s)).toBe('lens');
+  });
+
+  it('selecting an agent keeps the lens (back-target) but drops the studio', () => {
+    let s = setActiveLens(emptyForeground(), 'agents');
+    s = setSessionStudio(s, 'workflow');
+    s = selectAgent(s, 'agent-1');
+    expect(s.selectedAgentId).toBe('agent-1');
+    expect(s.sessionStudio).toBeNull();
+    expect(s.activeLens).toBe('agents');
+    expect(foregroundLayer(s)).toBe('agent');
+  });
+
+  it('opening a studio drops the agent overlay', () => {
+    let s = selectAgent(emptyForeground(), 'agent-1');
+    s = setSessionStudio(s, 'workflow');
+    expect(s.sessionStudio).toBe('workflow');
+    expect(s.selectedAgentId).toBeNull();
+    expect(foregroundLayer(s)).toBe('studio');
+  });
+});
+
 describe('session studio event dispatch contracts', () => {
   it('goodboy:open-plan-studio event carries sessionId and optional planId', () => {
     let received: CustomEvent | null = null;

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -1,7 +1,19 @@
 import { classifyFirstTurn, type AgentKindLabel, type WorkflowLibraryStep } from '@goodboy/core';
-import type { AgentRole } from '@goodboy/types';
+import type { Agent, AgentRole } from '@goodboy/types';
 
 export type AgentKind = AgentKindLabel;
+
+export type AgentHomeLens = 'agents' | 'resolve' | 'workflows';
+
+export const agentHomeLens = (agent: Agent, kind: AgentKind): AgentHomeLens => {
+  if (agent.workflowRunId != null && agent.stepId != null) {
+    return 'workflows';
+  }
+  if (kind === 'resolver') {
+    return 'resolve';
+  }
+  return 'agents';
+};
 
 export const AGENT_KIND_ORDER: ReadonlyArray<AgentKind> = [
   'planner',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.ts
@@ -1,0 +1,26 @@
+import { useMemo } from 'react';
+import type { SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
+import { agentHomeLens, resolveAgentKind, type AgentHomeLens } from '../../../../agent-kind';
+
+export const useSelectedAgentHome = (sessionId: SessionId): AgentHomeLens | null => {
+  const selectedAgentId = useAppStore((s) => s.selectedAgentId[sessionId] ?? null);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const messages = useAppStore((s) => s.messages[sessionId] ?? EMPTY_ARRAY);
+  const override = useAppStore((s) =>
+    selectedAgentId ? (s.agentKindOverride[selectedAgentId] ?? null) : null,
+  );
+  return useMemo(() => {
+    if (!selectedAgentId) {
+      return null;
+    }
+    const agent = phaseRuns.find((r) => r.id === selectedAgentId);
+    if (!agent) {
+      return null;
+    }
+    const firstUserText =
+      messages.find((m) => m.role === 'user' && m.agentId === selectedAgentId)?.content ?? null;
+    const kind = resolveAgentKind(agent.name, firstUserText, override);
+    return agentHomeLens(agent, kind);
+  }, [selectedAgentId, phaseRuns, messages, override]);
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -19,6 +19,7 @@ import { SlotPane } from './parts/SlotPane';
 import { PrPane } from './parts/PrPane';
 import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
+import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -48,7 +49,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[sessionId] ?? null,
   ) as AgentId | null;
-  const deselectAgent = useAppStore((s) => s.deselectAgent);
+  const agentHome = useSelectedAgentHome(sessionId);
   const workingDir = useAppStore((s) => (s.sessionWorktrees[sessionId] ?? [])[0] ?? null);
   const studio = useAppStore((s) => s.sessionStudio[sessionId] ?? null);
   const setSessionStudio = useAppStore((s) => s.setSessionStudio);
@@ -78,13 +79,15 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
 
   const lens: LensKind | null = activeLens ?? null;
   const onSelectLens = (next: LensKind) => {
-    deselectAgent(sessionId);
     setActiveLens(sessionId, next);
   };
   const onSelectOverview = () => {
-    deselectAgent(sessionId);
     setActiveLens(sessionId, null);
   };
+  const showStudio = studio != null;
+  const showAgentOverlay = selectedAgentId != null && !showStudio;
+  const showLens = selectedAgentId == null && !showStudio;
+  const overlayHome = agentHome ?? 'agents';
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -101,81 +104,83 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
         </div>
         <Divider orientation="vertical" />
         <div className="relative min-w-0 flex-1">
-          {lens === null ? (
-            <SessionOverviewPane
-              session={session}
-              filesTouched={filesTouched}
-              onSelectLens={onSelectLens}
-            />
-          ) : null}
-          {lens === 'questions' ? <QuestionsPane session={session} /> : null}
-          {lens === 'plans' ? (
-            <PlanStudio sessionId={sessionId} initialPlanId={focusedPlanId ?? undefined} />
-          ) : null}
-          {lens === 'workflows' ? (
-            <PaneShell
-              title="Workflows"
-              description="Sequences of agents that drive this session toward its goal."
-              width="3xl"
-            >
-              <AgentsSection task={session} only="workflows" />
-            </PaneShell>
-          ) : null}
-          {lens === 'resolve' ? (
-            <PaneShell
-              title="Resolve"
-              description="Resolver agents spawned from pull request comments and diff selections."
-              width="3xl"
-            >
-              <AgentsSection task={session} only="resolve" />
-            </PaneShell>
-          ) : null}
-          {lens === 'scripts' ? (
-            <PaneShell title="Scripts" width="3xl">
-              <ScriptsPanel
-                workspaceId={session.workspaceId}
-                sessionId={sessionId}
-                worktreePath={workingDir}
-              />
-            </PaneShell>
-          ) : null}
-          {lens === 'goal' || lens === 'decisions' || lens === 'last_output_summary' ? (
-            <SlotPane session={session} slotKey={lens} />
-          ) : null}
-          {lens === 'pr' ? <PrPane session={session} /> : null}
-          {lens === 'files' ? (
-            <FilesPane sessionId={sessionId} workingDir={workingDir} onClose={onSelectOverview} />
+          {showLens ? (
+            <div className="absolute inset-0 z-0">
+              {lens === null ? (
+                <SessionOverviewPane
+                  session={session}
+                  filesTouched={filesTouched}
+                  onSelectLens={onSelectLens}
+                />
+              ) : null}
+              {lens === 'questions' ? <QuestionsPane session={session} /> : null}
+              {lens === 'plans' ? (
+                <PlanStudio sessionId={sessionId} initialPlanId={focusedPlanId ?? undefined} />
+              ) : null}
+              {lens === 'workflows' ? (
+                <PaneShell
+                  title="Workflows"
+                  description="Sequences of agents that drive this session toward its goal."
+                  width="3xl"
+                >
+                  <AgentsSection task={session} only="workflows" />
+                </PaneShell>
+              ) : null}
+              {lens === 'resolve' ? (
+                <PaneShell
+                  title="Resolve"
+                  description="Resolver agents spawned from pull request comments and diff selections."
+                  width="3xl"
+                >
+                  <AgentsSection task={session} only="resolve" />
+                </PaneShell>
+              ) : null}
+              {lens === 'scripts' ? (
+                <PaneShell title="Scripts" width="3xl">
+                  <ScriptsPanel
+                    workspaceId={session.workspaceId}
+                    sessionId={sessionId}
+                    worktreePath={workingDir}
+                  />
+                </PaneShell>
+              ) : null}
+              {lens === 'goal' || lens === 'decisions' || lens === 'last_output_summary' ? (
+                <SlotPane session={session} slotKey={lens} />
+              ) : null}
+              {lens === 'pr' ? <PrPane session={session} /> : null}
+              {lens === 'files' ? (
+                <FilesPane
+                  sessionId={sessionId}
+                  workingDir={workingDir}
+                  onClose={onSelectOverview}
+                />
+              ) : null}
+              <Pane visible={lens === 'agents'}>
+                <PaneShell
+                  title="Agents"
+                  description="Agents you spawn by hand to work this session."
+                  width="3xl"
+                >
+                  <AgentsSection task={session} only="agents" />
+                </PaneShell>
+              </Pane>
+            </div>
           ) : null}
 
-          <Pane visible={lens === 'agents'}>
-            <PaneShell
-              title="Agents"
-              description="Agents you spawn by hand to work this session."
-              width="3xl"
-            >
-              <AgentsSection task={session} only="agents" />
-            </PaneShell>
-          </Pane>
-
-          {selectedAgentId != null ? (
-            <div className="absolute inset-0 flex bg-background">
+          {showAgentOverlay ? (
+            <div className="absolute inset-0 z-20 flex bg-background">
               <div className="flex w-72 shrink-0 flex-col bg-background">
                 <button
                   type="button"
-                  onClick={() => deselectAgent(sessionId)}
+                  onClick={() => setActiveLens(sessionId, overlayHome)}
                   className="flex shrink-0 items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.03] hover:text-foreground"
                 >
                   <ArrowLeft size={14} aria-hidden className="shrink-0" />
-                  <span className="truncate">{lens ? LENS_LABEL[lens] : 'Overview'}</span>
+                  <span className="truncate">{LENS_LABEL[overlayHome]}</span>
                 </button>
                 <Divider />
                 <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
-                  <AgentsSection
-                    task={session}
-                    only={
-                      lens === 'agents' ? 'agents' : lens === 'resolve' ? 'resolve' : 'workflows'
-                    }
-                  />
+                  <AgentsSection task={session} only={overlayHome} />
                 </div>
               </div>
               <Divider orientation="vertical" />
@@ -187,23 +192,25 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
 
           <div
             className={cn(
-              'absolute inset-0 flex flex-col',
-              lens !== 'terminal' && 'invisible pointer-events-none',
+              'absolute inset-0 z-10 flex flex-col',
+              !(lens === 'terminal' && showLens) && 'invisible pointer-events-none',
             )}
           >
             <TerminalDock
               sessionId={sessionId}
-              isActive={isActive && lens === 'terminal'}
+              isActive={isActive && lens === 'terminal' && showLens}
               cwd={workingDir}
             />
           </div>
 
-          {studio && selectedAgentId == null ? (
-            <SessionStudioLayer
-              session={session}
-              studio={studio}
-              onClose={() => setSessionStudio(sessionId, null)}
-            />
+          {studio != null ? (
+            <div className="absolute inset-0 z-30">
+              <SessionStudioLayer
+                session={session}
+                studio={studio}
+                onClose={() => setSessionStudio(sessionId, null)}
+              />
+            </div>
           ) : null}
         </div>
       </div>

--- a/apps/desktop/src/store/slices/agents/selectAgent.ts
+++ b/apps/desktop/src/store/slices/agents/selectAgent.ts
@@ -21,6 +21,8 @@ export const selectAgent = (set: SetFn, get: GetFn) => {
     const stampRuns = (runs: ReadonlyArray<Agent>): ReadonlyArray<Agent> =>
       runs.map((s) => (stampAgents.has(s.id) ? { ...s, lastViewedAt: stampedAt } : s));
 
+    set((state) => ({ sessionStudio: { ...state.sessionStudio, [sessionId]: null } }));
+
     const cached = get().transcripts[agentId];
     if (cached) {
       // eslint-disable-next-line no-console

--- a/apps/desktop/src/store/slices/session-view/index.test.ts
+++ b/apps/desktop/src/store/slices/session-view/index.test.ts
@@ -510,7 +510,6 @@ describe('store contract', () => {
         activeLens: {},
         lensHistory: {},
         workflowExpand: {},
-        focusedAgentId: {},
         focusedPlanId: {},
         sessionStudio: {},
       };
@@ -615,14 +614,52 @@ describe('store contract', () => {
       expect(store.getState().workflowExpand[SESSION_ID]?.['run-a']).toBe(true);
     });
 
-    it('setFocusedAgentId, setFocusedPlanId and setSessionStudio update per-session state', async () => {
+    it('setFocusedPlanId and setSessionStudio update per-session state', async () => {
       const store = await getStore();
-      store.getState().setFocusedAgentId(SESSION_ID, AGENT_ID);
       store.getState().setFocusedPlanId(SESSION_ID, PLAN_ID);
       store.getState().setSessionStudio(SESSION_ID, { kind: 'workflow' });
-      expect(store.getState().focusedAgentId[SESSION_ID]).toBe(AGENT_ID);
       expect(store.getState().focusedPlanId[SESSION_ID]).toBe(PLAN_ID);
       expect(store.getState().sessionStudio[SESSION_ID]).toEqual({ kind: 'workflow' });
+    });
+
+    it('setActiveLens clears the selected agent (foreground reconciliation)', async () => {
+      const store = await getStore();
+      store.setState({ selectedAgentId: { [SESSION_ID]: AGENT_ID } } as never);
+      store.getState().setActiveLens(SESSION_ID, 'agents');
+      expect(store.getState().selectedAgentId[SESSION_ID]).toBeNull();
+    });
+
+    it('setActiveLens clears any open session studio', async () => {
+      const store = await getStore();
+      store.getState().setSessionStudio(SESSION_ID, { kind: 'workflow' });
+      store.getState().setActiveLens(SESSION_ID, 'agents');
+      expect(store.getState().sessionStudio[SESSION_ID]).toBeNull();
+    });
+
+    it('setSessionStudio(non-null) clears the selected agent', async () => {
+      const store = await getStore();
+      store.setState({ selectedAgentId: { [SESSION_ID]: AGENT_ID } } as never);
+      store.getState().setSessionStudio(SESSION_ID, { kind: 'workflow' });
+      expect(store.getState().sessionStudio[SESSION_ID]).toEqual({ kind: 'workflow' });
+      expect(store.getState().selectedAgentId[SESSION_ID]).toBeNull();
+    });
+
+    it('setSessionStudio(null) leaves the selected agent untouched', async () => {
+      const store = await getStore();
+      store.setState({ selectedAgentId: { [SESSION_ID]: AGENT_ID } } as never);
+      store.getState().setSessionStudio(SESSION_ID, null);
+      expect(store.getState().selectedAgentId[SESSION_ID]).toBe(AGENT_ID);
+    });
+
+    it('selectAgent clears any open session studio (foreground reconciliation)', async () => {
+      const store = await getStore();
+      store.setState({
+        transcripts: { [AGENT_ID]: [] },
+        sessionStudio: { [SESSION_ID]: { kind: 'workflow' } },
+      } as never);
+      await store.getState().selectAgent(SESSION_ID, AGENT_ID);
+      expect(store.getState().selectedAgentId[SESSION_ID]).toBe(AGENT_ID);
+      expect(store.getState().sessionStudio[SESSION_ID]).toBeNull();
     });
   });
 });

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -4,7 +4,6 @@ import { setSessionSort } from './setSessionSort';
 import {
   lensGo,
   setActiveLens,
-  setFocusedAgentId,
   setFocusedPlanId,
   setSessionStudio,
   toggleWorkflowExpand,
@@ -23,7 +22,6 @@ export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice
     sessionViewPrefs: {},
     activeLens: {},
     lensHistory: {},
-    focusedAgentId: {},
     focusedPlanId: {},
     sessionStudio: {},
     workflowExpand: {},
@@ -33,7 +31,6 @@ export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice
     setActiveLens: setActiveLens(set),
     lensGo: lensGo(set, get),
     toggleWorkflowExpand: toggleWorkflowExpand(set),
-    setFocusedAgentId: setFocusedAgentId(set),
     setFocusedPlanId: setFocusedPlanId(set),
     setSessionStudio: setSessionStudio(set),
   };

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -1,5 +1,4 @@
 import type {
-  AgentId,
   PlanId,
   Session,
   SessionGroupKey,
@@ -78,7 +77,6 @@ type SessionViewSliceState = {
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
-  readonly focusedAgentId: Readonly<Record<SessionId, AgentId | null>>;
   readonly focusedPlanId: Readonly<Record<SessionId, PlanId | null>>;
   readonly sessionStudio: Readonly<Record<SessionId, SessionStudio | null>>;
   readonly workflowExpand: Readonly<Record<SessionId, Readonly<Record<string, boolean>>>>;
@@ -91,7 +89,6 @@ type SessionViewSliceActions = {
   setActiveLens(sessionId: SessionId, lens: LensKind | null): void;
   lensGo(sessionId: SessionId, delta: number): void;
   toggleWorkflowExpand(sessionId: SessionId, runId: string, defaultExpanded: boolean): void;
-  setFocusedAgentId(sessionId: SessionId, agentId: AgentId | null): void;
   setFocusedPlanId(sessionId: SessionId, planId: PlanId | null): void;
   setSessionStudio(sessionId: SessionId, studio: SessionStudio | null): void;
 };

--- a/apps/desktop/src/store/slices/session-view/workSurface.ts
+++ b/apps/desktop/src/store/slices/session-view/workSurface.ts
@@ -1,4 +1,4 @@
-import type { AgentId, PlanId, SessionId } from '@goodboy/types';
+import type { PlanId, SessionId } from '@goodboy/types';
 import type { GetFn, LensKind, SessionStudio, SetFn } from './types';
 import { writePersistedLens } from './workSurfaceStorage';
 
@@ -13,6 +13,7 @@ export const setActiveLens = (set: SetFn) => {
       return {
         activeLens: { ...s.activeLens, [sessionId]: lens },
         sessionStudio: { ...s.sessionStudio, [sessionId]: null },
+        selectedAgentId: { ...s.selectedAgentId, [sessionId]: null },
         lensHistory: {
           ...s.lensHistory,
           [sessionId]: { entries, index: entries.length - 1 },
@@ -57,12 +58,6 @@ export const toggleWorkflowExpand = (set: SetFn) => {
   };
 };
 
-export const setFocusedAgentId = (set: SetFn) => {
-  return (sessionId: SessionId, agentId: AgentId | null): void => {
-    set((s) => ({ focusedAgentId: { ...s.focusedAgentId, [sessionId]: agentId } }));
-  };
-};
-
 export const setFocusedPlanId = (set: SetFn) => {
   return (sessionId: SessionId, planId: PlanId | null): void => {
     set((s) => ({ focusedPlanId: { ...s.focusedPlanId, [sessionId]: planId } }));
@@ -71,6 +66,13 @@ export const setFocusedPlanId = (set: SetFn) => {
 
 export const setSessionStudio = (set: SetFn) => {
   return (sessionId: SessionId, studio: SessionStudio | null): void => {
-    set((s) => ({ sessionStudio: { ...s.sessionStudio, [sessionId]: studio } }));
+    set((s) =>
+      studio != null
+        ? {
+            sessionStudio: { ...s.sessionStudio, [sessionId]: studio },
+            selectedAgentId: { ...s.selectedAgentId, [sessionId]: null },
+          }
+        : { sessionStudio: { ...s.sessionStudio, [sessionId]: studio } },
+    );
   };
 };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -273,7 +273,6 @@ export type AppState = UpdaterState & {
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
   readonly workflowExpand: Readonly<Record<SessionId, Readonly<Record<string, boolean>>>>;
   readonly sessionStudio: Readonly<Record<SessionId, SessionStudio | null>>;
-  readonly focusedAgentId: Readonly<Record<SessionId, AgentId | null>>;
   readonly focusedPlanId: Readonly<Record<SessionId, PlanId | null>>;
   readonly terminalSessions: Readonly<Record<SessionId, 'open' | 'closed'>>;
   readonly terminalTabs: Readonly<Record<SessionId, readonly TerminalTab[]>>;
@@ -670,7 +669,6 @@ export type AppActions = {
   lensGo(sessionId: SessionId, delta: number): void;
   toggleWorkflowExpand(sessionId: SessionId, runId: string, defaultExpanded: boolean): void;
   setSessionStudio(sessionId: SessionId, studio: SessionStudio | null): void;
-  setFocusedAgentId(sessionId: SessionId, agentId: AgentId | null): void;
   setFocusedPlanId(sessionId: SessionId, planId: PlanId | null): void;
   openTerminal(sessionId: SessionId, cwd: string | null, cols: number, rows: number): Promise<void>;
   closeTerminal(sessionId: SessionId): Promise<void>;
@@ -769,7 +767,6 @@ export const initialState: AppState = {
   lensHistory: {},
   workflowExpand: {},
   sessionStudio: {},
-  focusedAgentId: {},
   focusedPlanId: {},
   terminalSessions: {},
   terminalTabs: {},


### PR DESCRIPTION
## Summary
- Agent overlay, lens panes, and session studio were each toggled independently, so navigation transitions left stale layers stacked on top of each other (inset overlays behaving like modals that blocked navigation).
- Establish a single-foreground invariant: at most one of `{lens-without-agent, agent-overlay, studio}` is visible. `setActiveLens` and `setSessionStudio(non-null)` clear `selectedAgentId`; `selectAgent` clears `sessionStudio`.
- Agent overlay now derives its home lens (back-label + mini-list group) from the selected agent's kind via `agentHomeLens` + `useSelectedAgentHome`, instead of reading a parallel lens atom. `selectAgent` no longer writes `activeLens` (avoids polluting `lensHistory`).
- Explicit visibility guards + z-index layering on each surface; terminal/chat stay mounted (toggle visibility) to preserve PTY/scrollback.
- Remove dead `focusedAgentId` state across store, slice, types, and tests.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 1472/1472 pass
- [x] new store invariants: `setActiveLens`/`setSessionStudio` zero `selectedAgentId`, `selectAgent` clears studio
- [x] `overlay-mutual-exclusion.test.ts` foreground-triad coverage over all transition pairs
- [ ] manual QA: select planning agent → plan opens; resource agent page navigates; overlay back returns to correct home lens

🤖 Generated with [Claude Code](https://claude.com/claude-code)