### PR TITLE
feat(desktop): context-aware goal attachment distribution

### DIFF
--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -582,6 +582,84 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
           class="flex items-start gap-2.5"
         >
           <span
+            class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-paperclip text-primary"
+              fill="none"
+              height="14"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="14"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"
+              />
+            </svg>
+          </span>
+          <div
+            class="flex flex-col gap-0.5"
+          >
+            <h3
+              class="text-sm font-semibold text-foreground"
+            >
+              Attachments
+            </h3>
+            <p
+              class="text-2xs leading-relaxed text-muted-foreground"
+            >
+              Images and files the agents can read on demand. Routed to the agents that benefit from each type.
+            </p>
+          </div>
+        </header>
+        <div>
+          <div
+            class="flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors border-border-soft"
+          >
+            <input
+              accept="image/*,.pdf,.csv,.tsv,.txt,.log,.md,.markdown,.json,.xml,.yaml,.yml,.docx,.xlsx"
+              hidden=""
+              multiple=""
+              type="file"
+            />
+            <button
+              class="inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-paperclip"
+                fill="none"
+                height="13"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="13"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"
+                />
+              </svg>
+               Add files
+            </button>
+          </div>
+        </div>
+      </section>
+      <section
+        class="flex flex-col gap-2.5"
+      >
+        <header
+          class="flex items-start gap-2.5"
+        >
+          <span
             class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-success/10"
           >
             <svg
@@ -1653,6 +1731,84 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
             placeholder="Refactor auth domain to extract token validation into a shared module…"
             style="overflow-y: hidden;"
           />
+        </div>
+      </section>
+      <section
+        class="flex flex-col gap-2.5"
+      >
+        <header
+          class="flex items-start gap-2.5"
+        >
+          <span
+            class="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-paperclip text-primary"
+              fill="none"
+              height="14"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="14"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"
+              />
+            </svg>
+          </span>
+          <div
+            class="flex flex-col gap-0.5"
+          >
+            <h3
+              class="text-sm font-semibold text-foreground"
+            >
+              Attachments
+            </h3>
+            <p
+              class="text-2xs leading-relaxed text-muted-foreground"
+            >
+              Images and files the agents can read on demand. Routed to the agents that benefit from each type.
+            </p>
+          </div>
+        </header>
+        <div>
+          <div
+            class="flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors border-border-soft"
+          >
+            <input
+              accept="image/*,.pdf,.csv,.tsv,.txt,.log,.md,.markdown,.json,.xml,.yaml,.yml,.docx,.xlsx"
+              hidden=""
+              multiple=""
+              type="file"
+            />
+            <button
+              class="inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors text-muted-foreground hover:bg-muted hover:text-foreground"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-paperclip"
+                fill="none"
+                height="13"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="13"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m16 6-8.414 8.586a2 2 0 0 0 2.829 2.829l8.414-8.586a4 4 0 1 0-5.657-5.657l-8.379 8.551a6 6 0 1 0 8.485 8.485l8.379-8.551"
+                />
+              </svg>
+               Add files
+            </button>
+          </div>
         </div>
       </section>
       <section

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useAttachments.ts
@@ -1,31 +1,11 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ChangeEvent as ReactChangeEvent,
-  type ClipboardEvent as ReactClipboardEvent,
-} from 'react';
-import { getCurrentWebview } from '@tauri-apps/api/webview';
+import { useCallback, useEffect, useRef } from 'react';
 import type { AgentId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../../store';
 import type { DraftAttachment } from '../../../../../store/slices/agents/setAgentAttachments';
-import {
-  deleteAttachment,
-  readAttachment,
-  readDroppedAttachment,
-  writeAttachment,
-} from '../../../turn';
-import { isAllowedAttachment, resolveAttachmentMime } from '../../../attachment-kinds';
+import { deleteAttachment, readAttachment, writeAttachment } from '../../../turn';
 import type { ToastKind } from '../../../../../app/components/Toast';
-import {
-  ATTACHMENT_LIMIT,
-  MAX_ATTACHMENT_BYTES,
-  dataUrlToBase64,
-  extFromMime,
-  readFileAsDataUrl,
-  type PendingAttachment,
-} from '../lib';
+import { dataUrlToBase64, type PendingAttachment } from '../lib';
+import { usePendingAttachments } from './usePendingAttachments';
 
 interface UseAttachmentsArgs {
   readonly sessionId: SessionId;
@@ -42,11 +22,6 @@ export function useAttachments({
   providerDisconnected,
   showToast,
 }: UseAttachmentsArgs) {
-  const [attachments, setAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
-  const [isDragging, setIsDragging] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const composerRef = useRef<HTMLDivElement>(null);
-
   const setAgentAttachments = useAppStore((s) => s.setAgentAttachments);
 
   const sessionWorktreeRef = useRef(sessionWorktree);
@@ -78,185 +53,20 @@ export function useAttachments({
     [],
   );
 
-  const addFiles = useCallback(
-    async (files: ReadonlyArray<File>) => {
-      const allowed = files.filter(isAllowedAttachment);
-      const skipped = files.length - allowed.length;
-      if (skipped > 0) {
-        showToast(
-          'warning',
-          `${skipped} file${skipped === 1 ? '' : 's'} skipped, unsupported type`,
-        );
-      }
-      if (allowed.length === 0) {
-        return;
-      }
-      const accepted: PendingAttachment[] = [];
-      for (const file of allowed) {
-        if (file.size > MAX_ATTACHMENT_BYTES) {
-          showToast('error', `${file.name || 'file'} is over 15MB`);
-          continue;
-        }
-        try {
-          const dataUrl = await readFileAsDataUrl(file);
-          const mimeType = resolveAttachmentMime(file);
-          const id = crypto.randomUUID();
-          const fileName = file.name || `pasted-file.${extFromMime(mimeType)}`;
-          const relPath = await persistAttachmentToDisk({ id, fileName, dataUrl });
-          accepted.push({ id, fileName, mimeType, dataUrl, relPath });
-        } catch {
-          showToast('error', `could not read ${file.name || 'file'}`);
-        }
-      }
-      if (accepted.length === 0) {
-        return;
-      }
-      setAttachments((prev) => {
-        const room = ATTACHMENT_LIMIT - prev.length;
-        if (room <= 0) {
-          showToast('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
-          return prev;
-        }
-        if (accepted.length > room) {
-          showToast('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
-        }
-        return [...prev, ...accepted.slice(0, room)];
-      });
-    },
-    [showToast, persistAttachmentToDisk],
-  );
-
-  const removeAttachment = useCallback((id: string) => {
-    setAttachments((prev) => prev.filter((a) => a.id !== id));
-  }, []);
-
-  const onPaste = useCallback(
-    (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
-      const files = Array.from(event.clipboardData.files).filter(isAllowedAttachment);
-      if (files.length > 0) {
-        event.preventDefault();
-        void addFiles(files);
-      }
-    },
-    [addFiles],
-  );
-
-  const onFileInputChange = (event: ReactChangeEvent<HTMLInputElement>) => {
-    const files = event.target.files ? Array.from(event.target.files) : [];
-    if (files.length > 0) {
-      void addFiles(files);
-    }
-    event.target.value = '';
-  };
-
-  const providerDisconnectedRef = useRef(providerDisconnected);
-  providerDisconnectedRef.current = providerDisconnected;
-  const showToastRef = useRef(showToast);
-  showToastRef.current = showToast;
-  const persistAttachmentToDiskRef = useRef(persistAttachmentToDisk);
-  persistAttachmentToDiskRef.current = persistAttachmentToDisk;
-
-  useEffect(() => {
-    let cancelled = false;
-    let unlisten: (() => void) | null = null;
-
-    const isInsideComposer = (px: number, py: number): boolean => {
-      const el = composerRef.current;
-      if (!el) {
-        return false;
-      }
-      const rect = el.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      const candidates: ReadonlyArray<readonly [number, number]> = [
-        [px / dpr, py / dpr],
-        [px, py],
-      ];
-      return candidates.some(
-        ([x, y]) => x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom,
-      );
-    };
-
-    const ingestDroppedPaths = async (paths: ReadonlyArray<string>) => {
-      const dropped: PendingAttachment[] = [];
-      for (const path of paths) {
-        try {
-          const r = await readDroppedAttachment(path);
-          const id = crypto.randomUUID();
-          const dataUrl = `data:${r.mimeType};base64,${r.dataBase64}`;
-          const relPath = await persistAttachmentToDiskRef.current({
-            id,
-            fileName: r.fileName,
-            dataUrl,
-          });
-          dropped.push({
-            id,
-            fileName: r.fileName,
-            mimeType: r.mimeType,
-            dataUrl,
-            relPath,
-          });
-        } catch {
-          // Unsupported / oversize drops are silently skipped: otherwise a
-          // folder drop would spam a toast per child.
-        }
-      }
-      if (dropped.length === 0) {
-        return;
-      }
-      setAttachments((prev) => {
-        const room = ATTACHMENT_LIMIT - prev.length;
-        if (room <= 0) {
-          showToastRef.current('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
-          return prev;
-        }
-        if (dropped.length > room) {
-          showToastRef.current('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
-        }
-        return [...prev, ...dropped.slice(0, room)];
-      });
-    };
-
-    void (async () => {
-      try {
-        const off = await getCurrentWebview().onDragDropEvent((event) => {
-          const p = event.payload;
-          if (providerDisconnectedRef.current) {
-            setIsDragging(false);
-            return;
-          }
-          switch (p.type) {
-            case 'enter':
-            case 'over':
-              setIsDragging(true);
-              break;
-            case 'leave':
-              setIsDragging(false);
-              break;
-            case 'drop': {
-              setIsDragging(false);
-              if (!isInsideComposer(p.position.x, p.position.y)) {
-                return;
-              }
-              void ingestDroppedPaths(p.paths);
-              break;
-            }
-          }
-        });
-        if (cancelled) {
-          off();
-        } else {
-          unlisten = off;
-        }
-      } catch (err) {
-        console.warn('drag-drop listener registration failed:', err);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, []);
+  const {
+    attachments,
+    setAttachments,
+    isDragging,
+    composerRef,
+    fileInputRef,
+    onPaste,
+    onFileInputChange,
+    removeAttachment,
+  } = usePendingAttachments({
+    showToast,
+    enabled: !providerDisconnected,
+    persistToDisk: persistAttachmentToDisk,
+  });
 
   const restoreAttachments = useCallback(
     async (draftAttachments: ReadonlyArray<DraftAttachment>, agentId: AgentId) => {

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
@@ -1,0 +1,241 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent as ReactChangeEvent,
+  type ClipboardEvent as ReactClipboardEvent,
+} from 'react';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import { isAllowedAttachment, resolveAttachmentMime } from '../../../attachment-kinds';
+import { readDroppedAttachment } from '../../../turn';
+import type { ToastKind } from '../../../../../app/components/Toast';
+import {
+  ATTACHMENT_LIMIT,
+  MAX_ATTACHMENT_BYTES,
+  extFromMime,
+  readFileAsDataUrl,
+  type PendingAttachment,
+} from '../lib';
+
+type PersistArgs = {
+  readonly id: string;
+  readonly fileName: string;
+  readonly dataUrl: string;
+};
+
+interface UsePendingAttachmentsArgs {
+  readonly showToast: (kind: ToastKind, message: string) => void;
+  readonly enabled?: boolean;
+  readonly persistToDisk?: (att: PersistArgs) => Promise<string | null>;
+}
+
+export function usePendingAttachments({
+  showToast,
+  enabled = true,
+  persistToDisk,
+}: UsePendingAttachmentsArgs) {
+  const [attachments, setAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const composerRef = useRef<HTMLDivElement>(null);
+
+  const persist = useCallback(
+    async (att: PersistArgs): Promise<string | null> => {
+      if (!persistToDisk) {
+        return null;
+      }
+      return persistToDisk(att);
+    },
+    [persistToDisk],
+  );
+
+  const addFiles = useCallback(
+    async (files: ReadonlyArray<File>) => {
+      const allowed = files.filter(isAllowedAttachment);
+      const skipped = files.length - allowed.length;
+      if (skipped > 0) {
+        showToast(
+          'warning',
+          `${skipped} file${skipped === 1 ? '' : 's'} skipped, unsupported type`,
+        );
+      }
+      if (allowed.length === 0) {
+        return;
+      }
+      const accepted: PendingAttachment[] = [];
+      for (const file of allowed) {
+        if (file.size > MAX_ATTACHMENT_BYTES) {
+          showToast('error', `${file.name || 'file'} is over 15MB`);
+          continue;
+        }
+        try {
+          const dataUrl = await readFileAsDataUrl(file);
+          const mimeType = resolveAttachmentMime(file);
+          const id = crypto.randomUUID();
+          const fileName = file.name || `pasted-file.${extFromMime(mimeType)}`;
+          const relPath = await persist({ id, fileName, dataUrl });
+          accepted.push({ id, fileName, mimeType, dataUrl, relPath });
+        } catch {
+          showToast('error', `could not read ${file.name || 'file'}`);
+        }
+      }
+      if (accepted.length === 0) {
+        return;
+      }
+      setAttachments((prev) => {
+        const room = ATTACHMENT_LIMIT - prev.length;
+        if (room <= 0) {
+          showToast('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
+          return prev;
+        }
+        if (accepted.length > room) {
+          showToast('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
+        }
+        return [...prev, ...accepted.slice(0, room)];
+      });
+    },
+    [showToast, persist],
+  );
+
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  const onPaste = useCallback(
+    (event: ReactClipboardEvent<HTMLTextAreaElement>) => {
+      const files = Array.from(event.clipboardData.files).filter(isAllowedAttachment);
+      if (files.length > 0) {
+        event.preventDefault();
+        void addFiles(files);
+      }
+    },
+    [addFiles],
+  );
+
+  const onFileInputChange = (event: ReactChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files ? Array.from(event.target.files) : [];
+    if (files.length > 0) {
+      void addFiles(files);
+    }
+    event.target.value = '';
+  };
+
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const showToastRef = useRef(showToast);
+  showToastRef.current = showToast;
+  const persistRef = useRef(persist);
+  persistRef.current = persist;
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+
+    const isInsideComposer = (px: number, py: number): boolean => {
+      const el = composerRef.current;
+      if (!el) {
+        return false;
+      }
+      const rect = el.getBoundingClientRect();
+      const dpr = window.devicePixelRatio || 1;
+      const candidates: ReadonlyArray<readonly [number, number]> = [
+        [px / dpr, py / dpr],
+        [px, py],
+      ];
+      return candidates.some(
+        ([x, y]) => x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom,
+      );
+    };
+
+    const ingestDroppedPaths = async (paths: ReadonlyArray<string>) => {
+      const dropped: PendingAttachment[] = [];
+      for (const path of paths) {
+        try {
+          const r = await readDroppedAttachment(path);
+          const id = crypto.randomUUID();
+          const dataUrl = `data:${r.mimeType};base64,${r.dataBase64}`;
+          const relPath = await persistRef.current({
+            id,
+            fileName: r.fileName,
+            dataUrl,
+          });
+          dropped.push({
+            id,
+            fileName: r.fileName,
+            mimeType: r.mimeType,
+            dataUrl,
+            relPath,
+          });
+        } catch {}
+      }
+      if (dropped.length === 0) {
+        return;
+      }
+      setAttachments((prev) => {
+        const room = ATTACHMENT_LIMIT - prev.length;
+        if (room <= 0) {
+          showToastRef.current('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
+          return prev;
+        }
+        if (dropped.length > room) {
+          showToastRef.current('warning', `attachment limit is ${ATTACHMENT_LIMIT}`);
+        }
+        return [...prev, ...dropped.slice(0, room)];
+      });
+    };
+
+    void (async () => {
+      try {
+        const off = await getCurrentWebview().onDragDropEvent((event) => {
+          const p = event.payload;
+          if (!enabledRef.current) {
+            setIsDragging(false);
+            return;
+          }
+          switch (p.type) {
+            case 'enter':
+            case 'over':
+              setIsDragging(true);
+              break;
+            case 'leave':
+              setIsDragging(false);
+              break;
+            case 'drop': {
+              setIsDragging(false);
+              if (!isInsideComposer(p.position.x, p.position.y)) {
+                return;
+              }
+              void ingestDroppedPaths(p.paths);
+              break;
+            }
+          }
+        });
+        if (cancelled) {
+          off();
+        } else {
+          unlisten = off;
+        }
+      } catch (err) {
+        console.warn('drag-drop listener registration failed:', err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  return {
+    attachments,
+    setAttachments,
+    isDragging,
+    composerRef,
+    fileInputRef,
+    addFiles,
+    removeAttachment,
+    onPaste,
+    onFileInputChange,
+  };
+}

--- a/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
+++ b/apps/desktop/src/features/context/components/ContextPanel/strips/GoalAttachmentsStrip.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { ImageOff, Paperclip, X } from 'lucide-react';
+import type { GoalAttachment, GoalAttachmentOwner, SessionId, WorkflowRunId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { fileIconFor } from '../../../../chat/attachment-kinds';
+import { readAttachment } from '../../../../chat/turn';
+import { ImageLightbox } from '../../../../chat/components/ImageLightbox';
+import { ATTACHMENT_KIND_ROUTING } from '../../../../providers/attachment-routing';
+
+export function GoalAttachmentsStrip({ owner }: { readonly owner: GoalAttachmentOwner }) {
+  const loadGoalAttachments = useAppStore((s) => s.loadGoalAttachments);
+  const removeGoalAttachment = useAppStore((s) => s.removeGoalAttachment);
+  const attachments = useAppStore((s) =>
+    owner.type === 'session'
+      ? (s.sessionAttachments[owner.id as SessionId] ?? EMPTY_ARRAY)
+      : (s.workflowRunAttachments[owner.id as WorkflowRunId] ?? EMPTY_ARRAY),
+  );
+  const workingDir = useAppStore((s) => {
+    const sessionId = owner.type === 'session' ? (owner.id as SessionId) : s.currentSessionId;
+    return sessionId ? ((s.sessionWorktrees[sessionId] ?? EMPTY_ARRAY)[0] ?? null) : null;
+  });
+
+  const ownerType = owner.type;
+  const ownerId = owner.id;
+  useEffect(() => {
+    void loadGoalAttachments({ type: ownerType, id: ownerId });
+  }, [ownerType, ownerId, loadGoalAttachments]);
+
+  if (attachments.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-1.5 text-2xs font-medium uppercase tracking-[0.12em] text-muted-foreground/60">
+        <Paperclip size={11} aria-hidden />
+        <span>Attachments</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {attachments.map((att) => (
+          <AttachmentChip
+            key={att.id}
+            attachment={att}
+            workingDir={workingDir}
+            onRemove={() => void removeGoalAttachment(owner, att.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AttachmentChip({
+  attachment,
+  workingDir,
+  onRemove,
+}: {
+  readonly attachment: GoalAttachment;
+  readonly workingDir: string | null;
+  readonly onRemove: () => void;
+}) {
+  const readers = ATTACHMENT_KIND_ROUTING[attachment.kind].join(', ');
+  const title = `${attachment.fileName}\nread by: ${readers}`;
+  const removeButton = (
+    <button
+      type="button"
+      onClick={onRemove}
+      title={`remove ${attachment.fileName}`}
+      aria-label={`remove ${attachment.fileName}`}
+      className="absolute right-0.5 top-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-foreground/70 text-background opacity-0 transition-opacity hover:bg-foreground group-hover:opacity-100"
+    >
+      <X size={10} aria-hidden />
+    </button>
+  );
+
+  if (attachment.kind === 'image') {
+    return (
+      <div
+        className="group relative h-16 w-16 overflow-hidden rounded-md ring-1 ring-border-soft"
+        title={title}
+      >
+        <ImageThumb attachment={attachment} workingDir={workingDir} />
+        {removeButton}
+      </div>
+    );
+  }
+
+  const Icon = fileIconFor(attachment.mimeType);
+  return (
+    <div
+      className="group relative flex h-16 max-w-[12rem] items-center gap-2 rounded-md bg-background/60 py-2 pl-2.5 pr-6 ring-1 ring-border-soft"
+      title={title}
+    >
+      <Icon size={18} aria-hidden className="shrink-0 text-muted-foreground" />
+      <span className="truncate text-xs text-foreground/80">{attachment.fileName}</span>
+      {removeButton}
+    </div>
+  );
+}
+
+function ImageThumb({
+  attachment,
+  workingDir,
+}: {
+  readonly attachment: GoalAttachment;
+  readonly workingDir: string | null;
+}) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  useEffect(() => {
+    if (!workingDir) {
+      setFailed(true);
+      return;
+    }
+    let alive = true;
+    setFailed(false);
+    setSrc(null);
+    readAttachment(workingDir, attachment.relPath)
+      .then((dataUrl) => {
+        if (alive) setSrc(dataUrl);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [workingDir, attachment.relPath]);
+
+  if (failed) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-1 bg-foreground/5 text-muted-foreground">
+        <ImageOff size={14} aria-hidden />
+      </div>
+    );
+  }
+
+  if (src === null) {
+    return <div className="h-full w-full animate-pulse bg-foreground/10" />;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setPreviewOpen(true)}
+        title={`preview ${attachment.fileName}`}
+        aria-label={`preview ${attachment.fileName}`}
+        className="block h-full w-full cursor-zoom-in"
+      >
+        <img src={src} alt={attachment.fileName} className="h-full w-full object-cover" />
+      </button>
+      {previewOpen ? (
+        <ImageLightbox src={src} alt={attachment.fileName} onClose={() => setPreviewOpen(false)} />
+      ) : null}
+    </>
+  );
+}

--- a/apps/desktop/src/features/providers/attachment-routing.ts
+++ b/apps/desktop/src/features/providers/attachment-routing.ts
@@ -1,0 +1,11 @@
+import type { GoalAttachment } from '@goodboy/types';
+import type { AgentKind } from '../../features/session/agent-kind';
+
+export const ATTACHMENT_KIND_ROUTING: Record<'image' | 'file', ReadonlyArray<AgentKind>> = {
+  image: ['planner', 'debugger', 'reviewer', 'generic'],
+  file: ['planner', 'implementer', 'debugger', 'generic'],
+};
+
+export const kindReadsAttachment = (att: GoalAttachment, kind: AgentKind): boolean => {
+  return ATTACHMENT_KIND_ROUTING[att.kind].includes(kind);
+};

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -1,9 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
 import { useEffect, useState, type ReactNode } from 'react';
 import { Button, Divider, Input, Textarea, cn } from '@goodboy/ui';
-import { AlertTriangle, GitBranch, Loader2, Plus, Target, Wand2 } from 'lucide-react';
+import { AlertTriangle, GitBranch, Loader2, Paperclip, Plus, Target, Wand2 } from 'lucide-react';
 import type { ProviderId, SessionId, WorkspaceId } from '@goodboy/types';
 import { CURSOR_AUTO_MODEL } from '@goodboy/core';
+import { AttachmentChip } from '../../../chat/components/ChatInput/parts/AttachmentChip';
+import { toAttachmentInput } from '../../../chat/components/ChatInput/lib';
+import { usePendingAttachments } from '../../../chat/components/ChatInput/hooks/usePendingAttachments';
+import { ATTACHMENT_ACCEPT } from '../../../chat/attachment-kinds';
 import { settingBranchPrefix, DEFAULT_BRANCH_PREFIX } from '../../../../features/settings/settings';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -214,6 +218,15 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
     }
   });
 
+  const {
+    attachments,
+    isDragging,
+    composerRef,
+    fileInputRef,
+    onFileInputChange,
+    removeAttachment,
+  } = usePendingAttachments({ showToast });
+
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[workspaceId] ?? []).some((i) => i.provider === 'linear'),
   );
@@ -336,6 +349,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
               },
             }
           : {}),
+        ...(attachments.length > 0 ? { attachmentInputs: attachments.map(toAttachmentInput) } : {}),
       });
       showToast('success', `session created: ${session.goal}`);
       onClose();
@@ -438,6 +452,54 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
               autoFocus
               disabled={busy}
             />
+          </Section>
+
+          <Section
+            icon={<Paperclip size={14} aria-hidden className="text-primary" />}
+            tone="primary"
+            title="Attachments"
+            subtitle="Images and files the agents can read on demand. Routed to the agents that benefit from each type."
+          >
+            <div
+              ref={composerRef}
+              className={cn(
+                'flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors',
+                isDragging ? 'border-primary bg-primary/5' : 'border-border-soft',
+              )}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={ATTACHMENT_ACCEPT}
+                multiple
+                hidden
+                onChange={onFileInputChange}
+              />
+              {attachments.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {attachments.map((a) => (
+                    <AttachmentChip
+                      key={a.id}
+                      attachment={a}
+                      onRemove={() => removeAttachment(a.id)}
+                    />
+                  ))}
+                </div>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={busy}
+                className={cn(
+                  'inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors',
+                  busy
+                    ? 'cursor-not-allowed text-muted-foreground/40'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                )}
+              >
+                <Paperclip size={13} aria-hidden /> Add files
+              </button>
+            </div>
           </Section>
 
           <Section

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -9,6 +9,7 @@ import {
   useSlotHistory,
   useSummarizerStatus,
 } from '../../../../../store';
+import { GoalAttachmentsStrip } from '../../../../context/components/ContextPanel/strips/GoalAttachmentsStrip';
 import { PaneShell } from './PaneShell';
 
 type SlotKey = 'goal' | 'decisions' | 'last_output_summary';
@@ -168,6 +169,10 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
             {value}
           </button>
         )}
+
+        {slotKey === 'goal' ? (
+          <GoalAttachmentsStrip owner={{ type: 'session', id: sessionId }} />
+        ) : null}
 
         <SlotHistoryDialog
           label={SLOT_TITLE[slotKey]}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -9,6 +9,7 @@ import {
   Link2,
   ListChecks,
   Loader2,
+  Paperclip,
   Play,
   RotateCcw,
   Sparkles,
@@ -68,6 +69,10 @@ import { OverlayHeader } from '../../../../shared/components/OverlayHeader';
 import { useClickOutside } from '../../../../shared/hooks/useClickOutside';
 import { useDropdownDirection } from '../../../../shared/hooks/useDropdownDirection';
 import { POPUP_BASE, POPUP_DOWN, POPUP_UP } from '../dropdown-utils';
+import { AttachmentChip } from '../../../chat/components/ChatInput/parts/AttachmentChip';
+import { toAttachmentInput } from '../../../chat/components/ChatInput/lib';
+import { usePendingAttachments } from '../../../chat/components/ChatInput/hooks/usePendingAttachments';
+import { ATTACHMENT_ACCEPT } from '../../../chat/attachment-kinds';
 
 type Props = {
   readonly session: Session;
@@ -116,6 +121,15 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const sessionSlots = useSessionSlots(session.id);
   const { showToast } = useToast();
+
+  const {
+    attachments,
+    isDragging,
+    composerRef,
+    fileInputRef,
+    onFileInputChange,
+    removeAttachment,
+  } = usePendingAttachments({ showToast });
 
   const presets = phaseTemplates.filter((t) => t.isPreset !== false && !t.deletedAt);
 
@@ -301,6 +315,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       ...(goal.length > 0 && { goal }),
       ...(triggerMode !== 'immediate' && { triggerMode }),
       ...(triggerMode === 'after_run' && after && { chainAfterId: after }),
+      ...(attachments.length > 0 && { attachmentInputs: attachments.map(toAttachmentInput) }),
     };
   };
 
@@ -498,6 +513,56 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
               />
               <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
                 Every step of the workflow works toward this goal.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <span className="inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+                <Paperclip size={11} aria-hidden /> Attachments
+              </span>
+              <div
+                ref={composerRef}
+                className={cn(
+                  'flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors',
+                  isDragging ? 'border-primary bg-primary/5' : 'border-border-soft',
+                )}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={ATTACHMENT_ACCEPT}
+                  multiple
+                  hidden
+                  onChange={onFileInputChange}
+                />
+                {attachments.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {attachments.map((a) => (
+                      <AttachmentChip
+                        key={a.id}
+                        attachment={a}
+                        onRemove={() => removeAttachment(a.id)}
+                      />
+                    ))}
+                  </div>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={blocked}
+                  className={cn(
+                    'inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors',
+                    blocked
+                      ? 'cursor-not-allowed text-muted-foreground/40'
+                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                  )}
+                >
+                  <Paperclip size={13} aria-hidden /> Add files
+                </button>
+              </div>
+              <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
+                Routed to the agents that benefit from each type, on top of the session goal
+                attachments.
               </p>
             </div>
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../../../../store';
 import { pickNextWorkflowStep } from '../../../../../features/workflows/components/WorkflowNextStepCta';
 import { workflowRunHasOpenQuestions } from '../../../../../features/context/openQuestionsGate';
+import { GoalAttachmentsStrip } from '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip';
 import { computeLatestTelemetryByAgentId } from '../../../../../features/session/agent-row-format';
 import {
   AGENT_KIND_DEFAULTS,
@@ -753,6 +754,11 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
               No agents yet for this workflow.
             </p>
           )
+        ) : null}
+        {expanded ? (
+          <div className="pb-1 pl-3">
+            <GoalAttachmentsStrip owner={{ type: 'workflow_run', id: run.id }} />
+          </div>
         ) : null}
       </div>
     );

--- a/apps/desktop/src/store/slices/attachments/addGoalAttachments.ts
+++ b/apps/desktop/src/store/slices/attachments/addGoalAttachments.ts
@@ -1,0 +1,62 @@
+import {
+  insertGoalAttachment,
+  listGoalAttachmentsForRun,
+  listGoalAttachmentsForSession,
+} from '@goodboy/db';
+import type {
+  AttachmentInput,
+  GoalAttachmentOwner,
+  SessionId,
+  WorkflowRunId,
+} from '@goodboy/types';
+import { writeAttachment } from '../../../features/chat/turn';
+import { attachmentKindFor } from '../../../features/chat/attachment-kinds';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { GetFn, SetFn } from './types';
+
+export const addGoalAttachments = (set: SetFn, get: GetFn) => {
+  return async (
+    owner: GoalAttachmentOwner,
+    inputs: ReadonlyArray<AttachmentInput>,
+  ): Promise<void> => {
+    if (inputs.length === 0) {
+      return;
+    }
+    const sessionId = owner.type === 'session' ? (owner.id as SessionId) : get().currentSessionId;
+    const worktreeDir = sessionId ? (get().sessionWorktrees[sessionId] ?? [])[0] : undefined;
+    if (!worktreeDir) {
+      throw new Error('cannot add goal attachments: session worktree not available');
+    }
+
+    for (const input of inputs) {
+      const relPath = await writeAttachment({
+        worktreeDir,
+        attachmentId: input.id,
+        fileName: input.fileName,
+        dataBase64: input.dataBase64,
+      });
+      await insertGoalAttachment(tauriDatabase, {
+        id: input.id,
+        owner,
+        relPath,
+        kind: attachmentKindFor(input.mimeType),
+        fileName: input.fileName,
+        mimeType: input.mimeType,
+      });
+    }
+
+    if (owner.type === 'session') {
+      const sid = owner.id as SessionId;
+      const attachments = await listGoalAttachmentsForSession(tauriDatabase, sid);
+      set((state) => ({
+        sessionAttachments: { ...state.sessionAttachments, [sid]: attachments },
+      }));
+      return;
+    }
+    const runId = owner.id as WorkflowRunId;
+    const attachments = await listGoalAttachmentsForRun(tauriDatabase, runId);
+    set((state) => ({
+      workflowRunAttachments: { ...state.workflowRunAttachments, [runId]: attachments },
+    }));
+  };
+};

--- a/apps/desktop/src/store/slices/attachments/index.ts
+++ b/apps/desktop/src/store/slices/attachments/index.ts
@@ -1,0 +1,12 @@
+import { addGoalAttachments } from './addGoalAttachments';
+import { loadGoalAttachments } from './loadGoalAttachments';
+import { removeGoalAttachment } from './removeGoalAttachment';
+import type { GetFn, SetFn } from './types';
+
+export const createAttachmentsSlice = (set: SetFn, get: GetFn) => {
+  return {
+    loadGoalAttachments: loadGoalAttachments(set, get),
+    addGoalAttachments: addGoalAttachments(set, get),
+    removeGoalAttachment: removeGoalAttachment(set, get),
+  };
+};

--- a/apps/desktop/src/store/slices/attachments/loadGoalAttachments.ts
+++ b/apps/desktop/src/store/slices/attachments/loadGoalAttachments.ts
@@ -1,0 +1,28 @@
+import { listGoalAttachmentsForRun, listGoalAttachmentsForSession } from '@goodboy/db';
+import type { GoalAttachmentOwner, SessionId, WorkflowRunId } from '@goodboy/types';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { GetFn, SetFn } from './types';
+
+export const loadGoalAttachments = (set: SetFn, get: GetFn) => {
+  return async (owner: GoalAttachmentOwner): Promise<void> => {
+    if (owner.type === 'session') {
+      const sessionId = owner.id as SessionId;
+      if (get().sessionAttachments[sessionId] !== undefined) {
+        return;
+      }
+      const attachments = await listGoalAttachmentsForSession(tauriDatabase, sessionId);
+      set((state) => ({
+        sessionAttachments: { ...state.sessionAttachments, [sessionId]: attachments },
+      }));
+      return;
+    }
+    const runId = owner.id as WorkflowRunId;
+    if (get().workflowRunAttachments[runId] !== undefined) {
+      return;
+    }
+    const attachments = await listGoalAttachmentsForRun(tauriDatabase, runId);
+    set((state) => ({
+      workflowRunAttachments: { ...state.workflowRunAttachments, [runId]: attachments },
+    }));
+  };
+};

--- a/apps/desktop/src/store/slices/attachments/removeGoalAttachment.ts
+++ b/apps/desktop/src/store/slices/attachments/removeGoalAttachment.ts
@@ -1,0 +1,41 @@
+import { deleteGoalAttachment } from '@goodboy/db';
+import type { GoalAttachmentOwner, SessionId, WorkflowRunId } from '@goodboy/types';
+import { deleteAttachment } from '../../../features/chat/turn';
+import { tauriDatabase } from '../../../shared/lib/db';
+import type { GetFn, SetFn } from './types';
+
+export const removeGoalAttachment = (set: SetFn, get: GetFn) => {
+  return async (owner: GoalAttachmentOwner, id: string): Promise<void> => {
+    const state = get();
+    const list =
+      owner.type === 'session'
+        ? state.sessionAttachments[owner.id as SessionId]
+        : state.workflowRunAttachments[owner.id as WorkflowRunId];
+    const target = list?.find((a) => a.id === id);
+
+    const sessionId = owner.type === 'session' ? (owner.id as SessionId) : state.currentSessionId;
+    const worktreeDir = sessionId ? (state.sessionWorktrees[sessionId] ?? [])[0] : undefined;
+    if (target && worktreeDir) {
+      await deleteAttachment(worktreeDir, target.relPath).catch(() => {});
+    }
+    await deleteGoalAttachment(tauriDatabase, id);
+
+    if (owner.type === 'session') {
+      const sid = owner.id as SessionId;
+      set((s) => ({
+        sessionAttachments: {
+          ...s.sessionAttachments,
+          [sid]: (s.sessionAttachments[sid] ?? []).filter((a) => a.id !== id),
+        },
+      }));
+      return;
+    }
+    const runId = owner.id as WorkflowRunId;
+    set((s) => ({
+      workflowRunAttachments: {
+        ...s.workflowRunAttachments,
+        [runId]: (s.workflowRunAttachments[runId] ?? []).filter((a) => a.id !== id),
+      },
+    }));
+  };
+};

--- a/apps/desktop/src/store/slices/attachments/types.ts
+++ b/apps/desktop/src/store/slices/attachments/types.ts
@@ -1,0 +1,1 @@
+export type { SetFn, GetFn } from '../../slice-types';

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -1,5 +1,6 @@
 import type {
   Agent,
+  AttachmentInput,
   IsoDateTime,
   Session,
   SessionId,
@@ -63,6 +64,7 @@ type Input = {
     url: string;
     title: string;
   };
+  attachmentInputs?: ReadonlyArray<AttachmentInput>;
 };
 
 export const createSession = (set: SetFn, get: GetFn) => {
@@ -78,6 +80,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     firstAgentKind,
     firstAgentModel: requestedModel,
     externalTask,
+    attachmentInputs,
   }: Input): Promise<{ session: Session; worktree: CreatedWorktree }> => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) {
@@ -331,6 +334,10 @@ export const createSession = (set: SetFn, get: GetFn) => {
       agentKindOverride: { ...get().agentKindOverride, ...agentKindOverrides },
     }));
     await dbSetSetting(tauriDatabase, SETTING_LAST_SESSION_ID, session.id);
+
+    if (attachmentInputs && attachmentInputs.length > 0) {
+      await get().addGoalAttachments({ type: 'session', id: session.id }, attachmentInputs);
+    }
 
     if (workflowId) {
       void get().reprocessGoalForWorkflow(session.id);

--- a/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
+++ b/apps/desktop/src/store/slices/sessions/setCurrentSession.ts
@@ -135,6 +135,8 @@ export const setCurrentSession = (set: SetFn, get: GetFn) => {
         });
     }
 
+    void get().loadGoalAttachments({ type: 'session', id });
+
     void listOpenQuestionsForSession(tauriDatabase, id, 'open')
       .then((qs) => {
         set((state) => ({

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -72,6 +72,7 @@ import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } fro
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import {
   applyHeuristicTitle,
+  buildGoalAttachmentsBlock,
   capturePlanFromTurn,
   emitTurnNudges,
   enqueueSummarizer,
@@ -514,6 +515,22 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const contextPreamble = buildContextPreamble(sharedSlots, slotFilter);
     if (contextPreamble.length > 0) {
       resolvedPrompt = `${contextPreamble}\n\n${resolvedPrompt}`;
+    }
+
+    const isKickoff =
+      agentRowEarly?.providerSessionId === undefined &&
+      (get().transcripts[activeAgentId] ?? []).length === 0;
+    const goalAttachments = [
+      ...(get().sessionAttachments[sessionId] ?? []),
+      ...(agentRowEarly?.workflowRunId
+        ? (get().workflowRunAttachments[agentRowEarly.workflowRunId] ?? [])
+        : []),
+    ];
+    const goalAttachmentsBlock = buildGoalAttachmentsBlock(earlyAgentKind, goalAttachments, {
+      isKickoff,
+    });
+    if (goalAttachmentsBlock.length > 0) {
+      resolvedPrompt = `${goalAttachmentsBlock}\n\n${resolvedPrompt}`;
     }
 
     const needsTextHistory = provider === 'cursor' || provider === 'codex' || provider === 'gemini';

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -1,5 +1,6 @@
 import type {
   Agent,
+  AttachmentInput,
   IsoDateTime,
   SessionId,
   WorkflowId,
@@ -23,6 +24,7 @@ type Options = {
   goal?: string;
   triggerMode?: WorkflowTriggerMode;
   chainAfterId?: WorkflowRunId;
+  attachmentInputs?: ReadonlyArray<AttachmentInput>;
 };
 
 export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
@@ -144,6 +146,11 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       agentModelOverride: { ...state.agentModelOverride, ...agentModelOverrides },
       agentKindOverride: { ...state.agentKindOverride, ...agentKindOverrides },
     }));
+
+    const attachmentInputs = options?.attachmentInputs;
+    if (attachmentInputs && attachmentInputs.length > 0) {
+      await get().addGoalAttachments({ type: 'workflow_run', id: workflowRunId }, attachmentInputs);
+    }
 
     void get().reprocessGoalForWorkflow(sessionId);
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -18,6 +18,8 @@ import type {
   ContextSlotHistoryEntry,
   DiffComment,
   AttachmentInput,
+  GoalAttachment,
+  GoalAttachmentOwner,
   GlobalSettings,
   IsoDateTime,
   Message,
@@ -91,6 +93,7 @@ import { createOpenQuestionsSlice } from './slices/open-questions';
 import { createBudgetSlice } from './slices/budget';
 import { createSkillsSlice } from './slices/skills';
 import { createDiffCommentsSlice } from './slices/diff-comments';
+import { createAttachmentsSlice } from './slices/attachments';
 import { createGithubSlice } from './slices/github';
 import { createGitlabMrSlice } from './slices/gitlab-mr';
 import type { GitlabMergeRequest } from '../features/integrations/gitlab/client';
@@ -257,6 +260,8 @@ export type AppState = UpdaterState & {
   readonly workflowDrafts: Readonly<Record<SessionId, WorkflowBuilderDraft | undefined>>;
   readonly agentAttachments: Readonly<Record<AgentId, ReadonlyArray<DraftAttachment>>>;
   readonly diffComments: Readonly<Record<string, ReadonlyArray<DiffComment>>>;
+  readonly sessionAttachments: Readonly<Record<SessionId, ReadonlyArray<GoalAttachment>>>;
+  readonly workflowRunAttachments: Readonly<Record<WorkflowRunId, ReadonlyArray<GoalAttachment>>>;
   readonly notifications: ReadonlyArray<Notification>;
   readonly sessionPlans: Readonly<Record<SessionId, ReadonlyArray<PlanWithCount>>>;
   readonly planConsumptions: Readonly<Record<PlanId, ReadonlyArray<PlanConsumption>>>;
@@ -628,6 +633,12 @@ export type AppActions = {
   ): Promise<void>;
   reopenDiffComment(sessionId: SessionId, commentId: string): Promise<void>;
   deleteDiffComment(sessionId: SessionId, commentId: string): Promise<void>;
+  loadGoalAttachments(owner: GoalAttachmentOwner): Promise<void>;
+  addGoalAttachments(
+    owner: GoalAttachmentOwner,
+    inputs: ReadonlyArray<AttachmentInput>,
+  ): Promise<void>;
+  removeGoalAttachment(owner: GoalAttachmentOwner, id: string): Promise<void>;
   loadNotifications(): Promise<void>;
   emitNotification(
     kind: NotificationKind,
@@ -756,6 +767,8 @@ export const initialState: AppState = {
   workflowDrafts: {},
   agentAttachments: {},
   diffComments: {},
+  sessionAttachments: {},
+  workflowRunAttachments: {},
   notifications: [],
   sessionPlans: {},
   sessionNudges: {},
@@ -787,6 +800,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createBudgetSlice(set, get),
   ...createSkillsSlice(set, get),
   ...createDiffCommentsSlice(set, get),
+  ...createAttachmentsSlice(set, get),
   ...createGithubSlice(set, get),
   ...createGitlabMrSlice(set, get),
   ...createIntegrationsSlice(set, get),

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -27,6 +27,7 @@ import {
 import type {
   AgentId,
   ContextSlot,
+  GoalAttachment,
   IsoDateTime,
   MessageAttachment,
   PlanId,
@@ -38,6 +39,8 @@ import type {
   WorkflowRunId,
 } from '@goodboy/types';
 import { tauriDatabase } from '../shared/lib/db';
+import type { AgentKind } from '../features/session/agent-kind';
+import { kindReadsAttachment } from '../features/providers/attachment-routing';
 import { invokeBudgetRuleList } from '../features/budget/budget';
 import {
   listPlansForSession as invokeListPlansForSession,
@@ -57,6 +60,27 @@ export const buildAttachmentPromptBlock = (refs: ReadonlyArray<MessageAttachment
     'Inspect each path below before answering. Images and PDFs render with your Read tool; for spreadsheets or other binary formats, read or parse the file with the appropriate tool:',
     list,
     '[/attached-files]',
+  ].join('\n');
+};
+
+export const buildGoalAttachmentsBlock = (
+  kind: AgentKind,
+  attachments: ReadonlyArray<GoalAttachment>,
+  { isKickoff }: { isKickoff: boolean },
+): string => {
+  if (!isKickoff) {
+    return '';
+  }
+  const relevant = attachments.filter((att) => kindReadsAttachment(att, kind));
+  if (relevant.length === 0) {
+    return '';
+  }
+  const list = relevant.map((a) => `- ${a.relPath}`).join('\n');
+  return [
+    '## attachments',
+    `The user attached ${relevant.length} file${relevant.length === 1 ? '' : 's'} to the goal of this session.`,
+    'Read only those relevant to your role; ignore the rest. Inspect each path below with your Read tool before relying on it:',
+    list,
   ].join('\n');
 };
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -59,6 +59,12 @@ export {
 } from './queries/session-workflow';
 export { insertMessage, listMessagesForAgent, listMessagesForSession } from './queries/message';
 export {
+  insertGoalAttachment,
+  listGoalAttachmentsForSession,
+  listGoalAttachmentsForRun,
+  deleteGoalAttachment,
+} from './queries/attachment';
+export {
   insertTurnEvent,
   insertTurnEventsBatch,
   listTurnEventsForAgent,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -63,6 +63,7 @@ import { m062OpenQuestionsTurnOrdinal } from './m062-open-questions-turn-ordinal
 import { m063OpenQuestionsRecommendedAnswer } from './m063-open-questions-recommended-answer';
 import { m064SentryProvider } from './m064-sentry-provider';
 import { m065IntegrationGitlabProvider } from './m065-integration-gitlab-provider';
+import { m066GoalAttachments } from './m066-goal-attachments';
 
 export type Migration = {
   readonly version: number;
@@ -135,4 +136,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 63, sql: m063OpenQuestionsRecommendedAnswer },
   { version: 64, sql: m064SentryProvider },
   { version: 65, sql: m065IntegrationGitlabProvider },
+  { version: 66, sql: m066GoalAttachments },
 ];

--- a/packages/db/src/migrations/m066-goal-attachments.ts
+++ b/packages/db/src/migrations/m066-goal-attachments.ts
@@ -1,0 +1,15 @@
+export const m066GoalAttachments = /* sql */ `
+CREATE TABLE IF NOT EXISTS goal_attachments (
+  id TEXT PRIMARY KEY,
+  owner_type TEXT NOT NULL,
+  owner_id TEXT NOT NULL,
+  rel_path TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  file_name TEXT NOT NULL,
+  mime_type TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_goal_attachments_owner
+  ON goal_attachments(owner_type, owner_id);
+`;

--- a/packages/db/src/queries/attachment.ts
+++ b/packages/db/src/queries/attachment.ts
@@ -1,0 +1,92 @@
+import type {
+  GoalAttachment,
+  GoalAttachmentOwner,
+  GoalAttachmentOwnerType,
+  IsoDateTime,
+  SessionId,
+  WorkflowRunId,
+} from '@goodboy/types';
+import type { Database } from '../client';
+
+type GoalAttachmentRow = {
+  id: string;
+  owner_type: string;
+  owner_id: string;
+  rel_path: string;
+  kind: string;
+  file_name: string;
+  mime_type: string;
+  created_at: number;
+};
+
+function toDomain(row: GoalAttachmentRow): GoalAttachment {
+  return {
+    id: row.id,
+    ownerType: row.owner_type as GoalAttachmentOwnerType,
+    ownerId: row.owner_id,
+    relPath: row.rel_path,
+    kind: row.kind as 'image' | 'file',
+    fileName: row.file_name,
+    mimeType: row.mime_type,
+    createdAt: new Date(row.created_at).toISOString() as IsoDateTime,
+  };
+}
+
+const SELECT_COLUMNS = `id, owner_type, owner_id, rel_path, kind, file_name, mime_type, created_at`;
+
+export const insertGoalAttachment = async (
+  db: Database,
+  attachment: {
+    readonly id: string;
+    readonly owner: GoalAttachmentOwner;
+    readonly relPath: string;
+    readonly kind: 'image' | 'file';
+    readonly fileName: string;
+    readonly mimeType: string;
+  },
+): Promise<void> => {
+  await db.execute(
+    `INSERT INTO goal_attachments
+       (id, owner_type, owner_id, rel_path, kind, file_name, mime_type, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      attachment.id,
+      attachment.owner.type,
+      attachment.owner.id,
+      attachment.relPath,
+      attachment.kind,
+      attachment.fileName,
+      attachment.mimeType,
+      Date.now(),
+    ],
+  );
+};
+
+const listForOwner = async (
+  db: Database,
+  ownerType: GoalAttachmentOwnerType,
+  ownerId: string,
+): Promise<ReadonlyArray<GoalAttachment>> => {
+  const rows = await db.select<GoalAttachmentRow>(
+    `SELECT ${SELECT_COLUMNS}
+     FROM goal_attachments
+     WHERE owner_type = ? AND owner_id = ?
+     ORDER BY created_at ASC`,
+    [ownerType, ownerId],
+  );
+  return rows.map(toDomain);
+};
+
+export const listGoalAttachmentsForSession = (
+  db: Database,
+  sessionId: SessionId,
+): Promise<ReadonlyArray<GoalAttachment>> => listForOwner(db, 'session', sessionId);
+
+export const listGoalAttachmentsForRun = (
+  db: Database,
+  runId: WorkflowRunId,
+): Promise<ReadonlyArray<GoalAttachment>> => listForOwner(db, 'workflow_run', runId);
+
+export const deleteGoalAttachment = async (db: Database, id: string): Promise<void> => {
+  await db.execute(`DELETE FROM goal_attachments WHERE id = ?`, [id]);
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,7 +44,15 @@ export type {
   WorkspaceIntegrationProvider,
   WorkspaceScript,
 } from './workspace';
-export type { AttachmentInput, Message, MessageAttachment, MessageRole } from './message';
+export type {
+  AttachmentInput,
+  GoalAttachment,
+  GoalAttachmentOwner,
+  GoalAttachmentOwnerType,
+  Message,
+  MessageAttachment,
+  MessageRole,
+} from './message';
 export type { ProviderName, ProviderRun, ProviderRunStatus } from './provider';
 export type {
   DetectResult,

--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -18,6 +18,24 @@ export type AttachmentInput = Readonly<{
   dataBase64: string;
 }>;
 
+export type GoalAttachmentOwnerType = 'session' | 'workflow_run';
+
+export type GoalAttachmentOwner = Readonly<{
+  type: GoalAttachmentOwnerType;
+  id: string;
+}>;
+
+export type GoalAttachment = Readonly<{
+  id: string;
+  ownerType: GoalAttachmentOwnerType;
+  ownerId: string;
+  relPath: string;
+  kind: 'image' | 'file';
+  fileName: string;
+  mimeType: string;
+  createdAt: IsoDateTime;
+}>;
+
 export type Message = Readonly<{
   id: MessageId;
   sessionId: SessionId;


### PR DESCRIPTION
## Summary
- Attach files at session/workflow creation; persisted owner-scoped (session | workflow_run), written to the session worktree, injected into the goal context.
- Per-agent-kind routing via a deny-by-default policy (`ATTACHMENT_KIND_ROUTING`): images to planning agents, files to implementers; reuses existing attachment infra (Rust write/read/delete, whitelist, `attachmentKindFor`).
- Inject only paths at kickoff (agents read on-demand via Read tool) — frugal on tokens, provider-agnostic. First turn only; never re-injected on resume.
- ContextPanel `GoalAttachmentsStrip` for view/remove; per-chip routing badge shows which agent kinds read it.

## Notes
- New DB migration `m066-goal-attachments` (owner-scoped table).
- No per-attachment override UI in v1; reusable workflow templates excluded (would need workspace-level storage).

## Test plan
- [x] typecheck green (5 packages)
- [x] full test suite green (1463 tests); NewSessionView snapshots updated for the new attachments UI
- [ ] manual: attach at session + workflow creation, routing-badge visibility, second-turn non-mention, remove wipes file + DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)