### PR TITLE
feat(desktop): cluster progress dashboard cards in chat

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/ClusterProgressDashboard.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/ClusterProgressDashboard.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import { ClusterProgressDashboard } from './ClusterProgressDashboard';
+import type { ClusterDashboardItem } from './clusterDashboard';
+
+const agent = (over: {
+  id: string;
+  name?: string;
+  status?: Agent['status'];
+  outputSummary?: string;
+}): Agent =>
+  ({
+    sessionId: 's1',
+    ordinal: 0,
+    name: over.name ?? over.id,
+    status: over.status ?? 'pending',
+    kind: 'implementer',
+    ...over,
+    id: over.id as AgentId,
+  }) as Agent;
+
+const item = (over: {
+  id: string;
+  index: number;
+  status?: Agent['status'];
+  instructions?: string | null;
+  outputSummary?: string;
+}): ClusterDashboardItem => ({
+  agent: agent({ id: over.id, status: over.status, outputSummary: over.outputSummary }),
+  index: over.index,
+  total: 3,
+  instructions: over.instructions ?? `do ${over.index}`,
+});
+
+const items: ReadonlyArray<ClusterDashboardItem> = [
+  item({ id: 'child0', index: 0, status: 'completed', outputSummary: 'built thing 0' }),
+  item({ id: 'child1', index: 1, status: 'running' }),
+  item({ id: 'child2', index: 2, status: 'pending' }),
+];
+
+afterEach(cleanup);
+
+describe('ClusterProgressDashboard', () => {
+  it('renders one card per item with the header count', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('cluster progress 1/3')).toBeTruthy();
+    expect(screen.getByText('child0')).toBeTruthy();
+    expect(screen.getByText('child1')).toBeTruthy();
+    expect(screen.getByText('child2')).toBeTruthy();
+  });
+
+  it('shows the right status label per status', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('done')).toBeTruthy();
+    expect(screen.getByText('running…')).toBeTruthy();
+    expect(screen.getByText('queued')).toBeTruthy();
+  });
+
+  it('shows outputSummary for completed and instructions otherwise', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('built thing 0')).toBeTruthy();
+    expect(screen.getByText('do 1')).toBeTruthy();
+  });
+
+  it('fires onSelect with the agent id on click', () => {
+    const onSelect = vi.fn();
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByText('child1'));
+    expect(onSelect).toHaveBeenCalledWith('child1');
+  });
+
+  it('applies the selected highlight to the active card', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={'child1' as AgentId}
+        onSelect={vi.fn()}
+      />,
+    );
+    const selected = screen.getByText('child1').closest('button');
+    expect(selected?.className).toContain(MARKER_ACCENT_BG);
+  });
+
+  it('does not highlight cards that are not selected', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={'child1' as AgentId}
+        onSelect={vi.fn()}
+      />,
+    );
+    const other = screen.getByText('child0').closest('button');
+    expect(other?.className).not.toContain(MARKER_ACCENT_BG);
+  });
+
+  it('labels a failed cluster as stalled', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={[item({ id: 'child0', index: 0, status: 'failed' })]}
+        completed={0}
+        total={1}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('stalled')).toBeTruthy();
+  });
+
+  it('renders the ordinal badge as index+1 over total per card', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('1/3')).toBeTruthy();
+    expect(screen.getByText('2/3')).toBeTruthy();
+    expect(screen.getByText('3/3')).toBeTruthy();
+  });
+
+  it('falls back to instructions when a completed cluster has no outputSummary', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={[
+          item({ id: 'child0', index: 0, status: 'completed', instructions: 'fallback body' }),
+        ]}
+        completed={1}
+        total={1}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('fallback body')).toBeTruthy();
+  });
+
+  it('renders no body text when there is neither summary nor instructions', () => {
+    const bodyless: ClusterDashboardItem = {
+      agent: agent({ id: 'lonely', status: 'pending' }),
+      index: 0,
+      total: 1,
+      instructions: null,
+    };
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={[bodyless]}
+        completed={0}
+        total={1}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    const card = screen.getByText('lonely').closest('button');
+    expect(card?.querySelector('.line-clamp-2')).toBeNull();
+  });
+
+  it('renders only the header when there are no items', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={[]}
+        completed={0}
+        total={0}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('cluster progress 0/0')).toBeTruthy();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('tags the container with the session id', () => {
+    render(
+      <ClusterProgressDashboard
+        sessionId={'s1' as SessionId}
+        items={items}
+        completed={1}
+        total={3}
+        selectedAgentId={undefined}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('cluster-progress-dashboard').getAttribute('data-session-id')).toBe(
+      's1',
+    );
+  });
+});
+
+const MARKER_ACCENT_BG = 'bg-merged/10';

--- a/apps/desktop/src/features/chat/components/ChatView/ClusterProgressDashboard.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/ClusterProgressDashboard.tsx
@@ -1,0 +1,96 @@
+import type { AgentId, SessionId } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { Check, Clock, Layers, Loader2 } from 'lucide-react';
+import { MARKER_ACCENT } from '../marker-accents';
+import type { ClusterDashboardItem } from './clusterDashboard';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly items: ReadonlyArray<ClusterDashboardItem>;
+  readonly completed: number;
+  readonly total: number;
+  readonly selectedAgentId: AgentId | undefined;
+  readonly onSelect: (agentId: AgentId) => void;
+};
+
+const accent = MARKER_ACCENT.clusters;
+
+const statusIcon = (status: ClusterDashboardItem['agent']['status']) =>
+  status === 'running' ? (
+    <Loader2 size={14} className="animate-spin text-info" aria-hidden />
+  ) : status === 'completed' ? (
+    <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
+      <Check size={10} className="text-success" aria-hidden />
+    </span>
+  ) : status === 'failed' ? (
+    <span className="size-2 rounded-full bg-danger" aria-hidden />
+  ) : (
+    <Clock size={14} className="text-muted-foreground/60" aria-hidden />
+  );
+
+const statusLabel = (status: ClusterDashboardItem['agent']['status']): string =>
+  status === 'running'
+    ? 'running…'
+    : status === 'completed'
+      ? 'done'
+      : status === 'failed'
+        ? 'stalled'
+        : 'queued';
+
+export const ClusterProgressDashboard = ({
+  sessionId,
+  items,
+  completed,
+  total,
+  selectedAgentId,
+  onSelect,
+}: Props) => (
+  <div
+    className="mx-auto flex w-full max-w-[640px] flex-col gap-3 py-10"
+    data-session-id={sessionId}
+    data-testid="cluster-progress-dashboard"
+  >
+    <div className={cn('flex items-center gap-1.5 text-sm font-medium', accent.text)}>
+      <Layers size={14} aria-hidden />
+      <span>
+        cluster progress {completed}/{total}
+      </span>
+    </div>
+    {items.map(({ agent, index, instructions }) => {
+      const isSelected = agent.id === selectedAgentId;
+      const body =
+        agent.status === 'completed' ? (agent.outputSummary ?? instructions) : instructions;
+      return (
+        <button
+          key={agent.id}
+          type="button"
+          onClick={() => onSelect(agent.id)}
+          className={cn(
+            'flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
+            isSelected
+              ? cn(accent.border, accent.bg)
+              : 'border-border hover:border-merged/40 hover:bg-merged/5',
+          )}
+        >
+          <span className="mt-0.5 shrink-0 tabular-nums text-xs text-muted-foreground/60">
+            {index + 1}/{total}
+          </span>
+          <span className="mt-0.5 shrink-0">{statusIcon(agent.status)}</span>
+          <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="flex items-center justify-between gap-2">
+              <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                {agent.name}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground/70">
+                {statusLabel(agent.status)}
+              </span>
+            </span>
+            {body ? (
+              <span className="line-clamp-2 text-xs text-muted-foreground">{body}</span>
+            ) : null}
+          </span>
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.test.ts
@@ -1,0 +1,170 @@
+import type { Agent, AgentId, PlanWithCount, WorkflowRunId } from '@goodboy/types';
+import { describe, expect, it } from 'vitest';
+import { selectClusterDashboard } from './clusterDashboard';
+
+const agent = (over: {
+  id: string;
+  ordinal?: number;
+  parentAgentId?: string;
+  status?: Agent['status'];
+  kind?: string;
+  workflowRunId?: WorkflowRunId;
+}): Agent =>
+  ({
+    sessionId: 's1',
+    ordinal: 0,
+    name: over.id,
+    status: 'pending',
+    kind: 'implementer',
+    ...over,
+    id: over.id as AgentId,
+    parentAgentId: over.parentAgentId as AgentId | undefined,
+  }) as Agent;
+
+const plan = (over: Partial<PlanWithCount>): PlanWithCount =>
+  ({
+    id: 'p1',
+    sessionId: 's1',
+    agentId: 'a',
+    title: 'goal',
+    bodyMd: '',
+    status: 'active',
+    consumptionCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    clusters: [
+      { title: 'c0', instructions: 'do 0' },
+      { title: 'c1', instructions: 'do 1' },
+    ],
+    ...over,
+  }) as PlanWithCount;
+
+const runs: ReadonlyArray<Agent> = [
+  agent({ id: 'container', ordinal: 0 }),
+  agent({ id: 'child0', parentAgentId: 'container', ordinal: 1, status: 'completed' }),
+  agent({ id: 'child1', parentAgentId: 'container', ordinal: 2, status: 'running' }),
+];
+
+describe('selectClusterDashboard', () => {
+  it('resolves dashboard when the container is selected', () => {
+    const d = selectClusterDashboard(runs, 'container' as AgentId, [plan({})]);
+    expect(d?.containerId).toBe('container');
+    expect(d?.total).toBe(2);
+    expect(d?.completed).toBe(1);
+    expect(d?.items.map((i) => i.agent.id)).toEqual(['child0', 'child1']);
+  });
+
+  it('resolves dashboard when a child is selected (via parentAgentId)', () => {
+    const d = selectClusterDashboard(runs, 'child1' as AgentId, [plan({})]);
+    expect(d?.containerId).toBe('container');
+    expect(d?.items).toHaveLength(2);
+  });
+
+  it('maps child index to plan cluster instructions', () => {
+    const d = selectClusterDashboard(runs, 'container' as AgentId, [plan({})]);
+    expect(d?.items[0]?.instructions).toBe('do 0');
+    expect(d?.items[1]?.instructions).toBe('do 1');
+  });
+
+  it('returns null when children are not implementers (scout fan-out)', () => {
+    const scoutRuns: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'c0', parentAgentId: 'container', ordinal: 1, kind: 'scout' }),
+      agent({ id: 'c1', parentAgentId: 'container', ordinal: 2, kind: 'scout' }),
+    ];
+    expect(selectClusterDashboard(scoutRuns, 'container' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('returns null when no matching clusters plan exists', () => {
+    expect(selectClusterDashboard(runs, 'container' as AgentId, [])).toBeNull();
+  });
+
+  it('returns null when the selected agent has no cluster siblings', () => {
+    const lone: ReadonlyArray<Agent> = [agent({ id: 'solo', ordinal: 0 })];
+    expect(selectClusterDashboard(lone, 'solo' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('matches plans by workflowRunId', () => {
+    const wfRuns: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0, workflowRunId: 'wf1' as WorkflowRunId }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1 }),
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2 }),
+    ];
+    const wfPlan = plan({ workflowRunId: 'wf1' as WorkflowRunId });
+    expect(selectClusterDashboard(wfRuns, 'container' as AgentId, [wfPlan])?.total).toBe(2);
+    expect(selectClusterDashboard(wfRuns, 'container' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('returns null when no agent is selected', () => {
+    expect(selectClusterDashboard(runs, undefined, [plan({})])).toBeNull();
+  });
+
+  it('returns null when the selected agent is not in the run list', () => {
+    expect(selectClusterDashboard(runs, 'ghost' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('returns null when only some children are implementers', () => {
+    const mixed: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1 }),
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2, kind: 'scout' }),
+    ];
+    expect(selectClusterDashboard(mixed, 'container' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('returns null when the container has a single child (below the cluster threshold)', () => {
+    const single: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1 }),
+    ];
+    expect(selectClusterDashboard(single, 'child0' as AgentId, [plan({})])).toBeNull();
+  });
+
+  it('yields null instructions for children beyond the plan cluster count', () => {
+    const wider: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1 }),
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2 }),
+      agent({ id: 'child2', parentAgentId: 'container', ordinal: 3 }),
+    ];
+    const d = selectClusterDashboard(wider, 'container' as AgentId, [plan({})]);
+    expect(d?.total).toBe(3);
+    expect(d?.items[2]?.instructions).toBeNull();
+  });
+
+  it('reports completed as 0 when no child has completed', () => {
+    const pending: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1, status: 'pending' }),
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2, status: 'running' }),
+    ];
+    expect(selectClusterDashboard(pending, 'container' as AgentId, [plan({})])?.completed).toBe(0);
+  });
+
+  it('reports completed equal to total when every child is completed', () => {
+    const done: ReadonlyArray<Agent> = [
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1, status: 'completed' }),
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2, status: 'completed' }),
+    ];
+    const d = selectClusterDashboard(done, 'container' as AgentId, [plan({})]);
+    expect(d?.completed).toBe(2);
+    expect(d?.total).toBe(2);
+  });
+
+  it('orders items by ordinal regardless of run array order', () => {
+    const shuffled: ReadonlyArray<Agent> = [
+      agent({ id: 'child1', parentAgentId: 'container', ordinal: 2 }),
+      agent({ id: 'container', ordinal: 0 }),
+      agent({ id: 'child0', parentAgentId: 'container', ordinal: 1 }),
+    ];
+    const d = selectClusterDashboard(shuffled, 'container' as AgentId, [plan({})]);
+    expect(d?.items.map((i) => i.agent.id)).toEqual(['child0', 'child1']);
+  });
+
+  it('tags each item with its zero-based index and the shared total', () => {
+    const d = selectClusterDashboard(runs, 'container' as AgentId, [plan({})]);
+    expect(d?.items.map((i) => i.index)).toEqual([0, 1]);
+    expect(d?.items.every((i) => i.total === 2)).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.ts
+++ b/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.ts
@@ -1,0 +1,69 @@
+import type { Agent, AgentId, PlanWithCount } from '@goodboy/types';
+import { selectClustersPlan } from '../../../../store/slices/workflows/clusterImplementation';
+
+export type ClusterDashboardItem = Readonly<{
+  agent: Agent;
+  index: number;
+  total: number;
+  instructions: string | null;
+}>;
+
+export type ClusterDashboard = Readonly<{
+  containerId: AgentId;
+  completed: number;
+  total: number;
+  items: ReadonlyArray<ClusterDashboardItem>;
+}>;
+
+const childrenOf = (runs: ReadonlyArray<Agent>, containerId: AgentId): ReadonlyArray<Agent> =>
+  runs.filter((r) => r.parentAgentId === containerId).sort((a, b) => a.ordinal - b.ordinal);
+
+export const selectClusterDashboard = (
+  phaseRuns: ReadonlyArray<Agent>,
+  selectedAgentId: AgentId | undefined,
+  plans: ReadonlyArray<PlanWithCount>,
+): ClusterDashboard | null => {
+  if (!selectedAgentId) {
+    return null;
+  }
+  const selected = phaseRuns.find((r) => r.id === selectedAgentId);
+  if (!selected) {
+    return null;
+  }
+
+  let containerId: AgentId | null = null;
+  if (childrenOf(phaseRuns, selected.id).length >= 2) {
+    containerId = selected.id;
+  } else if (selected.parentAgentId && childrenOf(phaseRuns, selected.parentAgentId).length >= 2) {
+    containerId = selected.parentAgentId;
+  }
+  if (!containerId) {
+    return null;
+  }
+
+  const container = phaseRuns.find((r) => r.id === containerId);
+  if (!container) {
+    return null;
+  }
+
+  const children = childrenOf(phaseRuns, containerId);
+  if (!children.every((c) => c.kind === 'implementer')) {
+    return null;
+  }
+
+  const plan = selectClustersPlan(plans, container.workflowRunId);
+  if (!plan) {
+    return null;
+  }
+
+  const total = children.length;
+  const items: ReadonlyArray<ClusterDashboardItem> = children.map((agent, index) => ({
+    agent,
+    index,
+    total,
+    instructions: plan.clusters?.[index]?.instructions ?? null,
+  }));
+  const completed = children.filter((c) => c.status === 'completed').length;
+
+  return { containerId, completed, total, items };
+};

--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
 const { state, openQuestions, answeredQuestions, transcriptItems } = vi.hoisted(() => ({
@@ -14,6 +14,7 @@ const { state, openQuestions, answeredQuestions, transcriptItems } = vi.hoisted(
     selectAgent: vi.fn(async () => undefined),
     markAgentViewed: vi.fn(async () => undefined),
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionPlans: {} as Record<string, ReadonlyArray<unknown>>,
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
     authResults: {} as Record<string, unknown>,
     refreshProviders: vi.fn(async () => undefined),
@@ -204,5 +205,99 @@ describe('ChatView', () => {
 
     const clusters = screen.getAllByTestId('cluster');
     expect(clusters.map((c) => c.textContent)).toEqual(['q-turn0', 'q-turn1']);
+  });
+});
+
+const clusterRuns = [
+  { id: 'container', ordinal: 0, kind: 'implementer', status: 'running', name: 'container' },
+  {
+    id: 'child0',
+    parentAgentId: 'container',
+    ordinal: 1,
+    kind: 'implementer',
+    status: 'completed',
+    name: 'cluster A',
+  },
+  {
+    id: 'child1',
+    parentAgentId: 'container',
+    ordinal: 2,
+    kind: 'implementer',
+    status: 'pending',
+    name: 'cluster B',
+  },
+];
+
+const clusterPlan = {
+  id: 'p1',
+  sessionId: 'sess-1',
+  agentId: 'a',
+  title: 'goal',
+  bodyMd: '',
+  status: 'active',
+  consumptionCount: 0,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  clusters: [
+    { title: 'cluster A', instructions: 'do A' },
+    { title: 'cluster B', instructions: 'do B' },
+  ],
+};
+
+describe('ChatView cluster dashboard', () => {
+  it('renders the cluster progress dashboard in place of the empty state', () => {
+    state.selectedAgentId = { 'sess-1': 'container' };
+    state.sessionPhaseRuns = { 'sess-1': clusterRuns };
+    state.sessionPlans = { 'sess-1': [clusterPlan] };
+
+    render(<ChatView session={session} />);
+
+    expect(screen.getByTestId('cluster-progress-dashboard')).toBeTruthy();
+    expect(screen.getByText('cluster progress 1/2')).toBeTruthy();
+    expect(screen.getByText('cluster A')).toBeTruthy();
+    expect(screen.getByText('cluster B')).toBeTruthy();
+  });
+
+  it('folds running turn-state onto a pending cluster child', () => {
+    state.selectedAgentId = { 'sess-1': 'container' };
+    state.sessionPhaseRuns = { 'sess-1': clusterRuns };
+    state.sessionPlans = { 'sess-1': [clusterPlan] };
+    state.agentTurnState = { child1: { kind: 'running' } };
+
+    render(<ChatView session={session} />);
+
+    expect(screen.getByText('running…')).toBeTruthy();
+  });
+
+  it('selects the agent when a cluster card is clicked', () => {
+    state.selectedAgentId = { 'sess-1': 'container' };
+    state.sessionPhaseRuns = { 'sess-1': clusterRuns };
+    state.sessionPlans = { 'sess-1': [clusterPlan] };
+
+    render(<ChatView session={session} />);
+
+    fireEvent.click(screen.getByText('cluster B'));
+    expect(state.selectAgent).toHaveBeenCalledWith('sess-1', 'child1');
+  });
+
+  it('shows the empty state when no cluster plan matches', () => {
+    state.selectedAgentId = { 'sess-1': 'container' };
+    state.sessionPhaseRuns = { 'sess-1': clusterRuns };
+    state.sessionPlans = { 'sess-1': [] };
+
+    render(<ChatView session={session} />);
+
+    expect(screen.queryByTestId('cluster-progress-dashboard')).toBeNull();
+  });
+
+  it('prefers the disconnected callout over the dashboard', () => {
+    state.selectedAgentId = { 'sess-1': 'container' };
+    state.sessionPhaseRuns = { 'sess-1': clusterRuns };
+    state.sessionPlans = { 'sess-1': [clusterPlan] };
+    state.authResults = { anthropic: { state: 'disconnected' } };
+
+    render(<ChatView session={session} />);
+
+    expect(screen.queryByTestId('cluster-progress-dashboard')).toBeNull();
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { ArrowDown } from 'lucide-react';
 import type { AgentId, OpenQuestion, ProviderRunId, Session } from '@goodboy/types';
 import { cn, Divider } from '@goodboy/ui';
@@ -29,6 +30,8 @@ import { DiffViewerDialog } from '../../../../features/permissions/components/Di
 import { worktreeDiff } from '../../../../features/worktree/worktree';
 import { OpenQuestionCluster } from './OpenQuestionCluster';
 import { ChatEmptyState } from './ChatEmptyState';
+import { ClusterProgressDashboard } from './ClusterProgressDashboard';
+import { selectClusterDashboard } from './clusterDashboard';
 import { ParallelColumn } from './ParallelColumn';
 import { useScrollPin } from './useScrollPin';
 import { dayKey, formatDayLabel } from './lib';
@@ -130,7 +133,22 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
   );
 
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY);
+  const sessionPlans = useAppStore((s) => s.sessionPlans[session.id] ?? EMPTY_ARRAY);
+  const agentTurnState = useAppStore(useShallow((s) => s.agentTurnState));
   const sessionWorkflows = useAppStore((s) => s.sessionWorkflows[session.id] ?? EMPTY_ARRAY);
+
+  const clusterDashboard = useMemo(() => {
+    const base = selectClusterDashboard(phaseRuns, selectedAgentId ?? undefined, sessionPlans);
+    if (!base) {
+      return null;
+    }
+    const items = base.items.map((item) =>
+      agentTurnState[item.agent.id]?.kind === 'running' && item.agent.status !== 'running'
+        ? { ...item, agent: { ...item.agent, status: 'running' as const } }
+        : item,
+    );
+    return { ...base, items };
+  }, [phaseRuns, selectedAgentId, sessionPlans, agentTurnState]);
   const rawMergeConflicts = useAppStore((s) => s.sessionMergeConflicts[session.id] ?? EMPTY_ARRAY);
   const resolveMergeConflicts = useAppStore((s) => s.resolveMergeConflicts);
 
@@ -386,6 +404,15 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
                   />
                 </div>
               </div>
+            ) : clusterDashboard ? (
+              <ClusterProgressDashboard
+                sessionId={session.id}
+                items={clusterDashboard.items}
+                completed={clusterDashboard.completed}
+                total={clusterDashboard.total}
+                selectedAgentId={selectedAgentId ?? undefined}
+                onSelect={(id) => void selectAgent(session.id, id)}
+              />
             ) : (
               <div className="flex h-full items-center justify-center">
                 <ChatEmptyState

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -1,0 +1,111 @@
+import type { PlanWithCount, SessionId, WorkflowRunId } from '@goodboy/types';
+import { describe, expect, it } from 'vitest';
+import { selectClustersPlan, selectFanOutPlan } from './clusterImplementation';
+import type { GetFn } from './types';
+
+const plan = (over: Partial<Omit<PlanWithCount, 'id'>> & { id?: string }): PlanWithCount =>
+  ({
+    id: 'p1',
+    sessionId: 's1',
+    agentId: 'a',
+    title: 'goal',
+    bodyMd: '',
+    status: 'active',
+    consumptionCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    clusters: [
+      { title: 'c0', instructions: 'do 0' },
+      { title: 'c1', instructions: 'do 1' },
+    ],
+    ...over,
+  }) as PlanWithCount;
+
+describe('selectClustersPlan', () => {
+  it('returns null for an empty plan list', () => {
+    expect(selectClustersPlan([])).toBeNull();
+  });
+
+  it('returns null when the only plan has fewer than 2 clusters', () => {
+    expect(
+      selectClustersPlan([plan({ clusters: [{ title: 'c0', instructions: 'x' }] })]),
+    ).toBeNull();
+  });
+
+  it('returns null when the plan has no clusters field', () => {
+    expect(selectClustersPlan([plan({ clusters: undefined })])).toBeNull();
+  });
+
+  it('matches an ad-hoc plan (no workflowRunId) when no target is given', () => {
+    const p = plan({ id: 'ad-hoc' });
+    expect(selectClustersPlan([p])?.id).toBe('ad-hoc');
+  });
+
+  it('does not match an ad-hoc plan against a workflowRunId target', () => {
+    expect(selectClustersPlan([plan({})], 'wf1' as WorkflowRunId)).toBeNull();
+  });
+
+  it('matches a plan by workflowRunId', () => {
+    const p = plan({ id: 'wf-plan', workflowRunId: 'wf1' as WorkflowRunId });
+    expect(selectClustersPlan([p], 'wf1' as WorkflowRunId)?.id).toBe('wf-plan');
+  });
+
+  it('does not match a workflow plan when the target is undefined (ad-hoc lookup)', () => {
+    const p = plan({ workflowRunId: 'wf1' as WorkflowRunId });
+    expect(selectClustersPlan([p])).toBeNull();
+  });
+
+  it('returns the most recent matching plan (reverse iteration, last wins)', () => {
+    const first = plan({ id: 'first' });
+    const second = plan({ id: 'second' });
+    expect(selectClustersPlan([first, second])?.id).toBe('second');
+  });
+
+  it('skips a trailing invalid plan and returns the earlier valid one', () => {
+    const valid = plan({ id: 'valid' });
+    const short = plan({ id: 'short', clusters: [{ title: 'only', instructions: 'x' }] });
+    expect(selectClustersPlan([valid, short])?.id).toBe('valid');
+  });
+
+  it('isolates plans across workflow runs', () => {
+    const wf1 = plan({ id: 'p-wf1', workflowRunId: 'wf1' as WorkflowRunId });
+    const wf2 = plan({ id: 'p-wf2', workflowRunId: 'wf2' as WorkflowRunId });
+    expect(selectClustersPlan([wf1, wf2], 'wf1' as WorkflowRunId)?.id).toBe('p-wf1');
+    expect(selectClustersPlan([wf1, wf2], 'wf2' as WorkflowRunId)?.id).toBe('p-wf2');
+  });
+});
+
+const fakeGet = (plans: ReadonlyArray<PlanWithCount>): GetFn =>
+  (() => ({ sessionPlans: { s1: plans } })) as unknown as GetFn;
+
+describe('selectFanOutPlan', () => {
+  const sessionId = 's1' as SessionId;
+
+  it('returns the explicit plan directly when it has 2+ clusters', () => {
+    const explicit = plan({ id: 'explicit' });
+    const result = selectFanOutPlan(fakeGet([plan({ id: 'store' })]), sessionId, {
+      explicitPlan: explicit,
+    });
+    expect(result?.id).toBe('explicit');
+  });
+
+  it('falls back to the store lookup when the explicit plan has too few clusters', () => {
+    const explicit = plan({ id: 'explicit', clusters: [{ title: 'c0', instructions: 'x' }] });
+    const result = selectFanOutPlan(fakeGet([plan({ id: 'store' })]), sessionId, {
+      explicitPlan: explicit,
+    });
+    expect(result?.id).toBe('store');
+  });
+
+  it('delegates to the store lookup by workflowRunId when no explicit plan is given', () => {
+    const stored = plan({ id: 'wf-store', workflowRunId: 'wf1' as WorkflowRunId });
+    const result = selectFanOutPlan(fakeGet([stored]), sessionId, {
+      workflowRunId: 'wf1' as WorkflowRunId,
+    });
+    expect(result?.id).toBe('wf-store');
+  });
+
+  it('returns null when neither an explicit nor a stored plan qualifies', () => {
+    expect(selectFanOutPlan(fakeGet([]), sessionId, {})).toBeNull();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -130,12 +130,10 @@ export const fanOutClusters = async (
   }
 };
 
-function findClustersPlan(
-  get: GetFn,
-  sessionId: SessionId,
-  workflowRunId: WorkflowRunId | undefined,
-) {
-  const plans = get().sessionPlans[sessionId] ?? [];
+export const selectClustersPlan = (
+  plans: ReadonlyArray<PlanWithCount>,
+  workflowRunId?: WorkflowRunId | undefined,
+): PlanWithCount | null => {
   const target = workflowRunId ?? undefined;
   for (let i = plans.length - 1; i >= 0; i--) {
     const p = plans[i];
@@ -148,6 +146,14 @@ function findClustersPlan(
     return p;
   }
   return null;
+};
+
+function findClustersPlan(
+  get: GetFn,
+  sessionId: SessionId,
+  workflowRunId: WorkflowRunId | undefined,
+) {
+  return selectClustersPlan(get().sessionPlans[sessionId] ?? [], workflowRunId);
 }
 
 export const selectFanOutPlan = (


### PR DESCRIPTION
## Summary
- When a gen-ed plan with clusters is executing, render a per-cluster progress dashboard (one card per cluster: status badge, title, current action) instead of the chat empty state, keeping the chat input active.
- Pure helper `selectClusterDashboard(phaseRuns, selectedAgentId, sessionPlans)` joins agent hierarchy with `sessionPlans` to derive cards; gated on `selectClustersPlan` match so scout fan-outs are excluded.
- Extract shared `selectClustersPlan` in `clusterImplementation.ts` as the single source of truth so dashboard and runtime fan-out never drift.

## Test plan
- [x] 52 tests across the 4 touched files green (clusterDashboard, ClusterProgressDashboard, ChatView wiring, clusterImplementation)
- [x] full desktop suite: 203 files / 1510 tests / 0 regressions
- [x] typecheck clean
- [x] knip clean (only pre-existing config hints)
- [ ] visual/browser verification of styling + focus behavior (not covered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)