### PR TITLE
fix(desktop): correct archived session deletion

### DIFF
--- a/apps/desktop/src/features/session/components/DeleteSessionDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/DeleteSessionDialog/index.tsx
@@ -68,10 +68,12 @@ export const DeleteSessionDialog = ({ session, open, onClose }: Props) => {
           <Button variant="ghost" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button variant="secondary" onClick={() => void onArchiveInstead()} disabled={busy}>
-            <Archive size={13} aria-hidden className="mr-1.5" />
-            {busy ? 'Working…' : 'Archive'}
-          </Button>
+          {!session.archivedAt && (
+            <Button variant="secondary" onClick={() => void onArchiveInstead()} disabled={busy}>
+              <Archive size={13} aria-hidden className="mr-1.5" />
+              {busy ? 'Working…' : 'Archive'}
+            </Button>
+          )}
           <Button variant="danger" onClick={() => void onConfirmDelete()} disabled={busy}>
             {busy ? 'Deleting…' : 'Delete'}
           </Button>

--- a/apps/desktop/src/store/slices/sessions/deleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/deleteTask.ts
@@ -1,5 +1,5 @@
 import type { ProviderRunId, SessionId } from '@goodboy/types';
-import { deleteSession as deleteSessionFromDb } from '@goodboy/db';
+import { deleteSession as deleteSessionFromDb, listWorktreesForSession } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
 import { removeWorktree } from '../../../features/worktree/worktree';
@@ -22,9 +22,18 @@ export const deleteTask = (set: SetFn, get: GetFn) => {
       );
     }
     const worktreePaths = get().sessionWorktrees[sessionId] ?? [];
+    let paths = worktreePaths;
+    if (paths.length === 0) {
+      try {
+        const rows = await listWorktreesForSession(tauriDatabase, sessionId);
+        paths = rows.map((r) => r.worktreePath);
+      } catch {
+        paths = [];
+      }
+    }
     const workspace = get().workspaces.find((w) => w.id === session.workspaceId);
     if (workspace) {
-      for (const worktreePath of worktreePaths) {
+      for (const worktreePath of paths) {
         try {
           await removeWorktree(workspace.rootPath, worktreePath);
         } catch {


### PR DESCRIPTION
## Summary
- Hide the Archive button in `DeleteSessionDialog` when the session is already archived (`session.archivedAt` truthy), so archived sessions can only be deleted.
- In `deleteTask`, fall back to a DB lookup (`listWorktreesForSession`) when the in-memory `sessionWorktrees` cache is empty, ensuring the worktree dir is removed from disk (`git worktree remove --force`) even for archived/reloaded sessions.
- Worktree removal stays wrapped in try/catch, so a missing folder never blocks the logical deletion (DB cascade + in-memory cleanup).

## Test plan
- [ ] Delete an active session → worktree dir removed from disk, session gone.
- [ ] Archive a session, then delete it → no Archive button shown, worktree dir removed from disk, session gone.
- [ ] Delete a session whose worktree folder was already removed manually → deletion still completes without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)