### PR TITLE
feat(desktop): bulk delete and restore for archived sessions

### DIFF
--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsDialog/index.test.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsDialog/index.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    bulkDeleteTask: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+import { BulkDeleteSessionsDialog } from './index';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+
+function makeSession(id: string, goal: string): Session {
+  return {
+    id: id as SessionId,
+    workspaceId: WS_ID,
+    goal,
+    state: { kind: 'idle', lastActivityAt: '2026-05-28T00:00:00.000Z' },
+    workflowRuns: [],
+  } as unknown as Session;
+}
+
+function renderDialog(overrides: Partial<Parameters<typeof BulkDeleteSessionsDialog>[0]> = {}) {
+  const props = {
+    sessions: [makeSession('s-1', 'alpha'), makeSession('s-2', 'beta')],
+    open: true,
+    onClose: vi.fn(),
+    onConfirmed: vi.fn(),
+    ...overrides,
+  };
+  render(<BulkDeleteSessionsDialog {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  state.bulkDeleteTask.mockReset();
+  state.bulkDeleteTask.mockResolvedValue(undefined);
+});
+
+afterEach(cleanup);
+
+describe('BulkDeleteSessionsDialog', () => {
+  it('titles with the count and lists every session goal plus the undo warning', () => {
+    renderDialog();
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/Delete 2 sessions\?/)).toBeDefined();
+    expect(within(dialog).getByText('alpha')).toBeDefined();
+    expect(within(dialog).getByText('beta')).toBeDefined();
+    expect(within(dialog).getByText(/This cannot be undone/i)).toBeDefined();
+  });
+
+  it('renders nothing when open is false', () => {
+    renderDialog({ open: false });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('confirms by calling bulkDeleteTask with the ids, then onConfirmed and onClose', async () => {
+    const props = renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalledWith(['s-1', 's-2']));
+    await waitFor(() => expect(props.onConfirmed).toHaveBeenCalledTimes(1));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels by calling onClose without deleting', () => {
+    const props = renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Cancel$/ }));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(state.bulkDeleteTask).not.toHaveBeenCalled();
+  });
+
+  it('shows a busy label and disables both buttons while the delete is in flight', async () => {
+    let release: () => void = () => undefined;
+    state.bulkDeleteTask.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          release = () => resolve(undefined);
+        }),
+    );
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Deleting…/ })).toBeDefined());
+    const cancel = screen.getByRole('button', { name: /^Cancel$/ }) as HTMLButtonElement;
+    const confirm = screen.getByRole('button', { name: /Deleting…/ }) as HTMLButtonElement;
+    expect(cancel.disabled).toBe(true);
+    expect(confirm.disabled).toBe(true);
+    release();
+    await waitFor(() => expect(screen.queryByRole('button', { name: /Deleting…/ })).toBeNull());
+  });
+
+  it('surfaces an Error message and keeps the dialog open when the delete throws', async () => {
+    state.bulkDeleteTask.mockRejectedValue(new Error('worktree locked'));
+    const props = renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    await waitFor(() => expect(screen.getByText('worktree locked')).toBeDefined());
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onConfirmed).not.toHaveBeenCalled();
+    const confirm = screen.getByRole('button', { name: /^Delete \(2\)$/ }) as HTMLButtonElement;
+    expect(confirm.disabled).toBe(false);
+  });
+
+  it('unwraps a thrown plain object with a message property', async () => {
+    state.bulkDeleteTask.mockRejectedValue({ message: 'object failure' });
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    await waitFor(() => expect(screen.getByText('object failure')).toBeDefined());
+  });
+
+  it('stringifies a thrown primitive that has no message', async () => {
+    state.bulkDeleteTask.mockRejectedValue('boom');
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    await waitFor(() => expect(screen.getByText('boom')).toBeDefined());
+  });
+
+  it('handles a single-session delete count of one', () => {
+    renderDialog({ sessions: [makeSession('s-1', 'solo')] });
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/Delete 1 sessions\?/)).toBeDefined();
+    expect(within(dialog).getByRole('button', { name: /^Delete \(1\)$/ })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/BulkDeleteSessionsDialog/index.tsx
+++ b/apps/desktop/src/features/session/components/BulkDeleteSessionsDialog/index.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Button, Dialog } from '@goodboy/ui';
+import type { Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+
+function unwrapError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === 'object' && err !== null && 'message' in err) {
+    const { message } = err as Record<string, unknown>;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  return String(err);
+}
+
+type Props = {
+  sessions: ReadonlyArray<Session>;
+  open: boolean;
+  onClose: () => void;
+  onConfirmed?: () => void;
+};
+
+export const BulkDeleteSessionsDialog = ({ sessions, open, onClose, onConfirmed }: Props) => {
+  const bulkDeleteTask = useAppStore((s) => s.bulkDeleteTask);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const count = sessions.length;
+
+  const onConfirmDelete = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await bulkDeleteTask(sessions.map((s) => s.id as SessionId));
+      onConfirmed?.();
+      onClose();
+    } catch (err) {
+      setError(unwrapError(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={`Delete ${count} sessions?`}
+      description="Permanently removes the worktrees and transcripts for these sessions from this device. Branches are preserved for manual merge."
+      size="md"
+      footer={
+        <>
+          {error ? <span className="mr-auto text-xs text-danger">{error}</span> : null}
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => void onConfirmDelete()} disabled={busy}>
+            {busy ? 'Deleting…' : `Delete (${count})`}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded-md border border-border-soft bg-subtle px-3 py-2 text-xs text-muted-foreground">
+          {sessions.map((session) => (
+            <span key={session.id} className="font-mono text-foreground">
+              {session.goal}
+            </span>
+          ))}
+        </div>
+        <p className="text-xs font-medium text-danger">This cannot be undone.</p>
+      </div>
+    </Dialog>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -1,12 +1,15 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { Session, SessionId, WorkspaceId } from '@goodboy/types';
 
 const { state } = vi.hoisted(() => ({
   state: {
     sessionGithub: {} as Record<string, unknown>,
     sessionTelemetry: {} as Record<string, ReadonlyArray<unknown>>,
+    bulkUnarchiveTask: vi.fn(async () => undefined),
+    bulkDeleteTask: vi.fn(async () => undefined),
   },
 }));
 
@@ -14,6 +17,7 @@ vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: [] as readonly never[],
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
   useSessionHasUnread: () => false,
+  useSessionStageInfo: () => ({ stage: 'done' as const, reason: 'idle' }),
   useSessionViewPrefs: () => ({ group: 'none' as const, sort: 'recent' as const }),
   useSortedGroupedSessions: (_w: unknown, sessions: ReadonlyArray<unknown>) => [
     { key: 'all', sessions },
@@ -35,35 +39,202 @@ vi.mock('../../../../features/github/components/PullRequestChip', () => ({
 
 import { SessionActivityBar } from './index';
 
+const WS_ID = 'ws-1' as WorkspaceId;
+
+function makeSession(id: string, goal: string): Session {
+  return {
+    id: id as SessionId,
+    workspaceId: WS_ID,
+    goal,
+    state: { kind: 'idle', lastActivityAt: '2026-05-28T00:00:00.000Z' },
+    workflowRuns: [],
+  } as unknown as Session;
+}
+
+function renderBar(
+  archived: ReadonlyArray<Session>,
+  active: ReadonlyArray<Session> = [],
+  onSelectSession: (id: SessionId) => void = vi.fn(),
+) {
+  return render(
+    <SessionActivityBar
+      workspaceId={WS_ID}
+      sessions={active}
+      archivedSessions={archived}
+      currentSessionId={null}
+      onSelectSession={onSelectSession}
+      onNewSession={vi.fn()}
+    />,
+  );
+}
+
+function toggleArchivedTab() {
+  fireEvent.click(screen.getByRole('button', { name: 'Archived' }));
+}
+
+function checkboxAt(index: number): HTMLElement {
+  const box = screen.getAllByRole('checkbox')[index];
+  if (!box) {
+    throw new Error(`no checkbox at index ${index}`);
+  }
+  return box;
+}
+
+function clickCheckbox(index: number): HTMLElement {
+  const box = checkboxAt(index);
+  fireEvent.click(box);
+  return box;
+}
+
+beforeEach(() => {
+  state.bulkUnarchiveTask.mockClear();
+  state.bulkDeleteTask.mockClear();
+});
+
 afterEach(cleanup);
 
-describe('SessionActivityBar', () => {
+describe('SessionActivityBar, baseline', () => {
   it('renders the Sessions header and the New session button', () => {
-    render(
-      <SessionActivityBar
-        workspaceId={'ws-1' as never}
-        sessions={[]}
-        archivedSessions={[]}
-        currentSessionId={null}
-        onSelectSession={vi.fn()}
-        onNewSession={vi.fn()}
-      />,
-    );
+    renderBar([]);
     expect(screen.getByText(/^Sessions$/)).toBeDefined();
     expect(screen.getByRole('button', { name: /create new session/i })).toBeDefined();
   });
 
   it('renders empty-state copy when no sessions in active tab', () => {
-    render(
-      <SessionActivityBar
-        workspaceId={'ws-1' as never}
-        sessions={[]}
-        archivedSessions={[]}
-        currentSessionId={null}
-        onSelectSession={vi.fn()}
-        onNewSession={vi.fn()}
-      />,
-    );
+    renderBar([]);
     expect(screen.getByText(/no sessions yet/i)).toBeDefined();
+  });
+});
+
+describe('SessionActivityBar, bulk selection', () => {
+  it('hides selection checkboxes in the active tab and shows them in the archived tab', () => {
+    renderBar([makeSession('s-1', 'archived one')], [makeSession('a-1', 'active one')]);
+    expect(screen.queryByRole('checkbox')).toBeNull();
+    toggleArchivedTab();
+    expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+  });
+
+  it('builds a selection from checkbox clicks and surfaces the bulk action bar with a count', () => {
+    renderBar([makeSession('s-1', 'one'), makeSession('s-2', 'two')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    expect(screen.getByText(/1 selected/)).toBeDefined();
+    expect(screen.getByRole('button', { name: /^Restore \(1\)$/ })).toBeDefined();
+  });
+
+  it('calls bulkUnarchiveTask with the selected ids and clears the selection on Restore', async () => {
+    renderBar([makeSession('s-1', 'one'), makeSession('s-2', 'two')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    clickCheckbox(1);
+    fireEvent.click(screen.getByRole('button', { name: /^Restore \(2\)$/ }));
+    expect(state.bulkUnarchiveTask).toHaveBeenCalledWith(['s-1', 's-2']);
+    await waitFor(() => expect(screen.queryByText(/selected/)).toBeNull());
+  });
+
+  it('opens the confirm dialog on Delete and calls bulkDeleteTask once confirmed', async () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText(/Delete 1 sessions\?/)).toBeDefined();
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Delete \(1\)$/ }));
+    await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalledWith(['s-1']));
+  });
+
+  it('clears the selection when switching tabs', () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    expect(screen.getByText(/1 selected/)).toBeDefined();
+    toggleArchivedTab();
+    toggleArchivedTab();
+    expect(screen.queryByText(/selected/)).toBeNull();
+  });
+
+  it('shows no bulk action bar when nothing is selected in the archived tab', () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    expect(screen.queryByText(/selected/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Restore/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^Delete/ })).toBeNull();
+  });
+
+  it('toggles aria-checked and hides the bulk bar when the last selection is removed', () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    expect(checkboxAt(0).getAttribute('aria-checked')).toBe('false');
+    clickCheckbox(0);
+    expect(checkboxAt(0).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByText(/1 selected/)).toBeDefined();
+    clickCheckbox(0);
+    expect(checkboxAt(0).getAttribute('aria-checked')).toBe('false');
+    expect(screen.queryByText(/selected/)).toBeNull();
+  });
+
+  it('reflects the selected count across both bulk actions when several are picked', () => {
+    renderBar([makeSession('s-1', 'one'), makeSession('s-2', 'two'), makeSession('s-3', 'three')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    clickCheckbox(2);
+    expect(screen.getByText(/2 selected/)).toBeDefined();
+    expect(screen.getByRole('button', { name: /^Restore \(2\)$/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /^Delete \(2\)$/ })).toBeDefined();
+  });
+
+  it('clears the selection via the Clear button', () => {
+    renderBar([makeSession('s-1', 'one'), makeSession('s-2', 'two')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    expect(screen.getByText(/1 selected/)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /^Clear$/ }));
+    expect(screen.queryByText(/selected/)).toBeNull();
+    expect(state.bulkUnarchiveTask).not.toHaveBeenCalled();
+    expect(state.bulkDeleteTask).not.toHaveBeenCalled();
+  });
+
+  it('lists the selected session goals in the confirm dialog', () => {
+    renderBar([makeSession('s-1', 'alpha goal'), makeSession('s-2', 'beta goal')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    clickCheckbox(1);
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(2\)$/ }));
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('alpha goal')).toBeDefined();
+    expect(within(dialog).getByText('beta goal')).toBeDefined();
+  });
+
+  it('does not call bulkDeleteTask when the confirm dialog is cancelled', () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Cancel$/ }));
+    expect(state.bulkDeleteTask).not.toHaveBeenCalled();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(screen.getByText(/1 selected/)).toBeDefined();
+  });
+
+  it('opens a session on body click without toggling its selection in the archived tab', () => {
+    const onSelect = vi.fn();
+    renderBar([makeSession('s-1', 'open me')], [], onSelect);
+    toggleArchivedTab();
+    fireEvent.click(screen.getByRole('button', { name: /open me/ }));
+    expect(onSelect).toHaveBeenCalledWith('s-1');
+    expect(checkboxAt(0).getAttribute('aria-checked')).toBe('false');
+    expect(screen.queryByText(/selected/)).toBeNull();
+  });
+
+  it('clears the selection after a confirmed bulk delete', async () => {
+    renderBar([makeSession('s-1', 'one')]);
+    toggleArchivedTab();
+    clickCheckbox(0);
+    fireEvent.click(screen.getByRole('button', { name: /^Delete \(1\)$/ }));
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Delete \(1\)$/ }));
+    await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalled());
+    await waitFor(() => expect(screen.queryByText(/selected/)).toBeNull());
   });
 });

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -1,5 +1,5 @@
-import { Fragment, memo, useMemo, useState } from 'react';
-import { Archive, ChevronRight, Plus } from 'lucide-react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { Archive, Check, ChevronRight, Plus, RotateCcw, Trash2 } from 'lucide-react';
 import { Button, cn, ScrollArea } from '@goodboy/ui';
 import type {
   Session,
@@ -22,6 +22,7 @@ import {
   PullRequestChip,
   pullRequestMeta,
 } from '../../../../features/github/components/PullRequestChip';
+import { BulkDeleteSessionsDialog } from '../../../session/components/BulkDeleteSessionsDialog';
 import { SessionViewMenu } from './SessionViewMenu';
 
 type ActivityTab = 'active' | 'archived';
@@ -70,6 +71,9 @@ export const SessionActivityBar = ({
   const [expandedOverrides, setExpandedOverrides] = useState<ReadonlyMap<string, boolean>>(
     new Map(),
   );
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<SessionId>>(new Set());
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const bulkUnarchiveTask = useAppStore((s) => s.bulkUnarchiveTask);
 
   const prefs = useSessionViewPrefs(workspaceId);
 
@@ -80,6 +84,34 @@ export const SessionActivityBar = ({
   const isGrouped = prefs.group !== 'none';
   const isArchivedView = tab === 'archived';
   const totalVisible = displayGroups.reduce((n, g) => n + g.sessions.length, 0);
+
+  const selectedSessions = useMemo(
+    () => archivedSessions.filter((s) => selectedIds.has(s.id as SessionId)),
+    [archivedSessions, selectedIds],
+  );
+
+  const onToggleSelect = useCallback((id: SessionId) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const onBulkRestore = async () => {
+    await bulkUnarchiveTask(selectedSessions.map((s) => s.id as SessionId));
+    setSelectedIds(new Set());
+  };
+
+  useEffect(() => {
+    if (tab !== 'archived') {
+      setSelectedIds(new Set());
+    }
+  }, [tab]);
 
   const isCollapsed = (key: string): boolean =>
     expandedOverrides.get(key) ?? COLLAPSED_BY_DEFAULT.includes(key);
@@ -160,6 +192,9 @@ export const SessionActivityBar = ({
                       session={session}
                       isActive={session.id === currentSessionId}
                       dimmed={isArchivedView}
+                      selectable={isArchivedView}
+                      selected={selectedIds.has(session.id as SessionId)}
+                      onToggleSelect={onToggleSelect}
                       onClick={() => onSelectSession(session.id as SessionId)}
                     />
                   ))}
@@ -181,6 +216,42 @@ export const SessionActivityBar = ({
       </ScrollArea>
 
       <div className="shrink-0 p-2">
+        {isArchivedView && selectedSessions.length > 0 && (
+          <div className="mb-2 flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1.5">
+            <span className="mr-auto text-xs font-medium text-foreground">
+              {selectedSessions.length} selected
+            </span>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => void onBulkRestore()}
+              title="restore selected sessions"
+              className="gap-1 px-2 text-xs"
+            >
+              <RotateCcw size={11} aria-hidden />
+              Restore ({selectedSessions.length})
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={() => setBulkDeleteOpen(true)}
+              title="delete selected sessions"
+              className="gap-1 px-2 text-xs"
+            >
+              <Trash2 size={11} aria-hidden />
+              Delete ({selectedSessions.length})
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSelectedIds(new Set())}
+              title="clear selection"
+              className="px-2 text-xs"
+            >
+              Clear
+            </Button>
+          </div>
+        )}
         <button
           type="button"
           onClick={() => {
@@ -203,6 +274,15 @@ export const SessionActivityBar = ({
           <span>Archived</span>
         </button>
       </div>
+
+      {bulkDeleteOpen && (
+        <BulkDeleteSessionsDialog
+          sessions={selectedSessions}
+          open
+          onClose={() => setBulkDeleteOpen(false)}
+          onConfirmed={() => setSelectedIds(new Set())}
+        />
+      )}
     </div>
   );
 };
@@ -211,6 +291,9 @@ type SessionActivityItemProps = {
   session: Session;
   isActive: boolean;
   dimmed?: boolean;
+  selectable?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: SessionId) => void;
   onClick: () => void;
 };
 
@@ -218,6 +301,9 @@ const SessionActivityItem = memo(function SessionActivityItem({
   session,
   isActive,
   dimmed,
+  selectable,
+  selected,
+  onToggleSelect,
   onClick,
 }: SessionActivityItemProps) {
   const { stage, reason } = useSessionStageInfo(session);
@@ -243,7 +329,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
     return sum;
   }, [telemetry]);
 
-  return (
+  const body = (
     <button
       type="button"
       onClick={onClick}
@@ -292,5 +378,30 @@ const SessionActivityItem = memo(function SessionActivityItem({
         )}
       </span>
     </button>
+  );
+
+  if (!selectable) {
+    return body;
+  }
+
+  return (
+    <div className="flex w-full items-center gap-1.5">
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked={selected}
+        onClick={() => onToggleSelect?.(session.id as SessionId)}
+        title={selected ? 'deselect session' : 'select session'}
+        className={cn(
+          'flex size-4 shrink-0 items-center justify-center rounded border transition-colors',
+          selected
+            ? 'border-primary bg-primary text-primary-foreground'
+            : 'border-border-soft hover:border-primary/50',
+        )}
+      >
+        {selected && <Check size={11} aria-hidden />}
+      </button>
+      <span className="min-w-0 flex-1">{body}</span>
+    </div>
   );
 });

--- a/apps/desktop/src/store/slices/sessions/bulkDeleteTask.ts
+++ b/apps/desktop/src/store/slices/sessions/bulkDeleteTask.ts
@@ -1,0 +1,22 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+export const bulkDeleteTask = (set: SetFn, get: GetFn) => {
+  return async (ids: ReadonlyArray<SessionId>) => {
+    const failures: SessionId[] = [];
+    for (const id of ids) {
+      try {
+        await get().deleteTask(id);
+      } catch {
+        failures.push(id);
+      }
+    }
+    if (failures.length > 0) {
+      void get().emitNotification(
+        'error',
+        'warning',
+        `failed to delete ${failures.length} of ${ids.length} sessions`,
+      );
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/sessions/bulkUnarchiveTask.ts
+++ b/apps/desktop/src/store/slices/sessions/bulkUnarchiveTask.ts
@@ -1,0 +1,22 @@
+import type { SessionId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+export const bulkUnarchiveTask = (set: SetFn, get: GetFn) => {
+  return async (ids: ReadonlyArray<SessionId>) => {
+    const failures: SessionId[] = [];
+    for (const id of ids) {
+      try {
+        await get().unarchiveTask(id);
+      } catch {
+        failures.push(id);
+      }
+    }
+    if (failures.length > 0) {
+      void get().emitNotification(
+        'error',
+        'warning',
+        `failed to restore ${failures.length} of ${ids.length} sessions`,
+      );
+    }
+  };
+};

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -621,6 +621,155 @@ describe('store contract', () => {
       expect(s.archivedSessions[WS_ID]).toEqual([]);
       expect(s.currentSessionId).toBeNull();
     });
+
+    describe('bulk archived ops', () => {
+      function buildArchived(id: SessionId, goal: string): Session {
+        return {
+          ...buildSession({ id, goal }),
+          archivedAt: NOW,
+        } as Session;
+      }
+
+      it('bulkUnarchiveTask restores every selected session into the active list', async () => {
+        const store = await getStore();
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+        });
+        await store.getState().bulkUnarchiveTask([SESSION_ID, SESSION_ID_2]);
+        const s = store.getState();
+        expect(s.sessions.map((x) => x.id).sort()).toEqual([SESSION_ID, SESSION_ID_2].sort());
+        expect(s.archivedSessions[WS_ID]).toEqual([]);
+      });
+
+      it('bulkUnarchiveTask keeps restoring after one session fails and reports the failure', async () => {
+        const store = await getStore();
+        const { unarchiveSession } = await import('@goodboy/db');
+        (unarchiveSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+          new Error('db down'),
+        );
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'bad'), buildArchived(SESSION_ID_2, 'good')],
+          },
+        });
+        await store.getState().bulkUnarchiveTask([SESSION_ID, SESSION_ID_2]);
+        const s = store.getState();
+        expect(s.sessions.map((x) => x.id)).toEqual([SESSION_ID_2]);
+        expect(s.archivedSessions[WS_ID]?.map((x) => x.id)).toEqual([SESSION_ID]);
+        expect(insertNotificationSpy).toHaveBeenCalled();
+      });
+
+      it('bulkDeleteTask removes every selected session from the archived cache', async () => {
+        const store = await getStore();
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+        });
+        await store.getState().bulkDeleteTask([SESSION_ID, SESSION_ID_2]);
+        expect(store.getState().archivedSessions[WS_ID]).toEqual([]);
+      });
+
+      it('bulkDeleteTask keeps deleting after one session throws', async () => {
+        const store = await getStore();
+        const MISSING = 'session-missing' as SessionId;
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+        });
+        await store.getState().bulkDeleteTask([MISSING, SESSION_ID, SESSION_ID_2]);
+        expect(store.getState().archivedSessions[WS_ID]).toEqual([]);
+      });
+
+      it('bulkDeleteTask reports the exact failed-of-total count when a delete throws', async () => {
+        const store = await getStore();
+        const MISSING = 'session-missing' as SessionId;
+        const emitSpy = vi.fn<(...args: unknown[]) => Promise<undefined>>(async () => undefined);
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+          emitNotification: emitSpy as never,
+        });
+        await store.getState().bulkDeleteTask([MISSING, SESSION_ID]);
+        expect(store.getState().archivedSessions[WS_ID]?.map((x) => x.id)).toEqual([SESSION_ID_2]);
+        const summary = emitSpy.mock.calls.find((c) =>
+          String((c as unknown[])[2]).startsWith('failed to delete'),
+        );
+        expect(summary?.[2]).toBe('failed to delete 1 of 2 sessions');
+      });
+
+      it('bulkDeleteTask deletes sequentially in the given id order', async () => {
+        const store = await getStore();
+        const { deleteSession } = await import('@goodboy/db');
+        const spy = deleteSession as unknown as ReturnType<typeof vi.fn>;
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+        });
+        await store.getState().bulkDeleteTask([SESSION_ID_2, SESSION_ID]);
+        expect(spy.mock.calls.map((c) => c[1])).toEqual([SESSION_ID_2, SESSION_ID]);
+      });
+
+      it('bulkDeleteTask is a no-op and emits no notification for an empty selection', async () => {
+        const store = await getStore();
+        const { deleteSession } = await import('@goodboy/db');
+        await store.getState().bulkDeleteTask([]);
+        expect(deleteSession as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+        expect(insertNotificationSpy).not.toHaveBeenCalled();
+      });
+
+      it('bulkUnarchiveTask is a no-op and emits no notification for an empty selection', async () => {
+        const store = await getStore();
+        const { unarchiveSession } = await import('@goodboy/db');
+        await store.getState().bulkUnarchiveTask([]);
+        expect(unarchiveSession as unknown as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+        expect(insertNotificationSpy).not.toHaveBeenCalled();
+      });
+
+      it('bulkUnarchiveTask reports failed-of-total when every restore fails', async () => {
+        const store = await getStore();
+        const { unarchiveSession } = await import('@goodboy/db');
+        (unarchiveSession as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+          new Error('db down'),
+        );
+        const emitSpy = vi.fn<(...args: unknown[]) => Promise<undefined>>(async () => undefined);
+        store.setState({
+          workspaces: [buildWorkspace()],
+          currentWorkspaceId: WS_ID,
+          archivedSessions: {
+            [WS_ID]: [buildArchived(SESSION_ID, 'one'), buildArchived(SESSION_ID_2, 'two')],
+          },
+          emitNotification: emitSpy as never,
+        });
+        await store.getState().bulkUnarchiveTask([SESSION_ID, SESSION_ID_2]);
+        const s = store.getState();
+        expect(s.sessions).toEqual([]);
+        expect(s.archivedSessions[WS_ID]?.map((x) => x.id).sort()).toEqual(
+          [SESSION_ID, SESSION_ID_2].sort(),
+        );
+        const summary = emitSpy.mock.calls.find((c) =>
+          String((c as unknown[])[2]).startsWith('failed to restore'),
+        );
+        expect(summary?.[2]).toBe('failed to restore 2 of 2 sessions');
+      });
+    });
   });
 
   describe('createSession external task', () => {

--- a/apps/desktop/src/store/slices/sessions/index.ts
+++ b/apps/desktop/src/store/slices/sessions/index.ts
@@ -1,5 +1,7 @@
 import { archiveTask } from './archiveTask';
 import { autoTitleSession } from './autoTitleSession';
+import { bulkDeleteTask } from './bulkDeleteTask';
+import { bulkUnarchiveTask } from './bulkUnarchiveTask';
 import { createSession } from './createSession';
 import { deleteTask } from './deleteTask';
 import { renameTask } from './renameTask';
@@ -22,8 +24,10 @@ export const createSessionsSlice = (set: SetFn, get: GetFn) => {
     setSessionAutoRun: setSessionAutoRun(set, get),
     setAgentVerbosity: setAgentVerbosity(set),
     deleteTask: deleteTask(set, get),
+    bulkDeleteTask: bulkDeleteTask(set, get),
     archiveTask: archiveTask(set, get),
     unarchiveTask: unarchiveTask(set, get),
+    bulkUnarchiveTask: bulkUnarchiveTask(set, get),
     createSession: createSession(set, get),
     setCurrentSession: setCurrentSession(set, get),
   };

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -538,8 +538,10 @@ export type AppActions = {
   renameTask(sessionId: SessionId, goal: string): Promise<void>;
   autoTitleSession(sessionId: SessionId, title: string): Promise<void>;
   deleteTask(sessionId: SessionId): Promise<void>;
+  bulkDeleteTask(ids: ReadonlyArray<SessionId>): Promise<void>;
   archiveTask(sessionId: SessionId): Promise<void>;
   unarchiveTask(sessionId: SessionId): Promise<void>;
+  bulkUnarchiveTask(ids: ReadonlyArray<SessionId>): Promise<void>;
   setSessionConfig(sessionId: SessionId, fields: SessionConfigUpdate): Promise<void>;
   setAgentConfig(sessionId: SessionId, agentId: AgentId, fields: AgentConfigUpdate): Promise<void>;
   setSidebarWorkspaceSearch(query: string): void;


### PR DESCRIPTION
## Summary
- multi-select archived sessions with always-visible checkboxes (Gmail/Finder pattern: body click previews, checkbox toggles selection)
- bulk **delete** with confirmation dialog listing session goals; bulk **restore** (unarchive) immediate, no dialog (reversible)
- bulk store actions `bulkDeleteTask` / `bulkUnarchiveTask` compose existing single-item `deleteTask` / `unarchiveTask` sequentially, reusing hard-wipe + rollback + Zustand cleanup (no logic duplication)
- partial failure = best-effort: batch continues past errors, summary error notification only when >0 failures
- non-archived sessions unchanged (single-action only)

## Test plan
- [ ] typecheck clean
- [ ] 50 tests green (store slice, SessionActivityBar, BulkDeleteSessionsDialog)
- [ ] manual: select multiple archived sessions, bulk delete (confirm dialog), bulk restore
- [ ] manual: partial-failure summary notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)