### PR TITLE
fix(core): preserve goal language in custom workflows

### DIFF
--- a/packages/core/src/planner/parser.test.ts
+++ b/packages/core/src/planner/parser.test.ts
@@ -128,6 +128,36 @@ describe('parsePlannerOutput', () => {
     }
   });
 
+  it('falls back to custom when role is not a canonical AgentRole', () => {
+    const translated = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'implementatore', promptPrefix: 'p', expectedOutput: 'o' }],
+    });
+    const out = parsePlannerOutput(translated);
+    expect(out.steps[0]!.role).toBe('custom');
+  });
+
+  it('maps the non-canonical "other" role to custom', () => {
+    const other = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'other', promptPrefix: 'p', expectedOutput: 'o' }],
+    });
+    const out = parsePlannerOutput(other);
+    expect(out.steps[0]!.role).toBe('custom');
+  });
+
+  it('preserves a canonical role verbatim', () => {
+    const canonical = JSON.stringify({
+      workflowName: 'X',
+      reasoning: 'x',
+      steps: [{ name: 'X', role: 'reviewer', promptPrefix: 'p', expectedOutput: 'o' }],
+    });
+    const out = parsePlannerOutput(canonical);
+    expect(out.steps[0]!.role).toBe('reviewer');
+  });
+
   it('trims whitespace from workflowName', () => {
     const padded = JSON.stringify({
       workflowName: '  Auth  ',

--- a/packages/core/src/planner/parser.ts
+++ b/packages/core/src/planner/parser.ts
@@ -1,3 +1,4 @@
+import { isAgentRole } from '../roles';
 import type { PlannerOutput, PlannerStep } from './types';
 
 export class PlannerParseError extends Error {
@@ -79,7 +80,8 @@ export const parsePlannerOutput = (raw: string): PlannerOutput => {
     if (typeof expectedOutput !== 'string') {
       throw new PlannerParseError(`planner step at index ${index} missing "expectedOutput"`, raw);
     }
-    steps.push({ name, role, promptPrefix, expectedOutput });
+    const normalizedRole = isAgentRole(role.trim()) ? role.trim() : 'custom';
+    steps.push({ name, role: normalizedRole, promptPrefix, expectedOutput });
   }
 
   return {

--- a/packages/core/src/planner/prompt.ts
+++ b/packages/core/src/planner/prompt.ts
@@ -20,7 +20,7 @@ no code fences. The schema is:
   "steps": [
     {
       "name": "<short imperative title>",
-      "role": "<scout|planner|implementer|reviewer|tester|investigator|product|architect|explorer|other>",
+      "role": "<scout|planner|implementer|reviewer|tester|investigator|product|architect|explorer|custom>",
       "promptPrefix": "<system-style instructions for the step's agent>",
       "expectedOutput": "<one sentence describing what the step should produce>"
     },
@@ -34,11 +34,12 @@ Rules:
 - A step's promptPrefix should make sense without seeing the user's original description;
   the description will be appended automatically as the user message.
 - expectedOutput tells the post-step summarizer what to extract; be specific.
-- Pick roles from the canonical list above. Use "other" only if none fit.
+- Pick roles from the canonical list above. Use "custom" only if none fit.
+- The role value MUST be one of the canonical English keywords above. Never translate or rename it, even when every other field is written in another language.
 - Names should be short (1-3 words), in title case.
 - Do not include preamble, apologies, or explanations outside the JSON object.
-- The user may write in any language. Always respond with JSON regardless of input language.
-  All JSON field values (workflowName, names, reasoning, promptPrefix, expectedOutput) must be in English.`;
+- The user may write in any language. Always respond with the JSON object regardless of input language.
+  Match the language of the user's process description for all JSON field values (workflowName, names, reasoning, promptPrefix, expectedOutput): if the process is written in Italian, write those values in Italian; same for any other language. Keep the JSON structure and role values unchanged.`;
 
 export const buildPlannerUserPrompt = (input: PlannerInput): string => {
   const parts = ['Process:', input.process];

--- a/packages/core/src/summarizer/goal-rewrite.ts
+++ b/packages/core/src/summarizer/goal-rewrite.ts
@@ -6,6 +6,7 @@ const GOAL_REWRITE_SYSTEM_PROMPT = `You clean the "goal" note for an AI coding s
 You receive the current goal text and the ordered list of workflow steps.
 
 Rewrite the goal so that it:
+- matches the language of the CURRENT GOAL exactly. If the current goal is written in Italian, write the rewritten goal in Italian; same for any other language.
 - keeps the concrete objective: what to build, change, or fix, plus domain specifics, constraints, acceptance criteria, and any ticket id.
 - removes every procedural instruction that a workflow step already owns. Examples to strip: "scout" or "explore the code", "write a plan" or "plan it out", "implement it", "review", "write tests", "commit", "push", "open a PR" or "raise a pull request". Each of those is a workflow step's job; if they stay in the goal, the wrong agent performs them too early.
 - stays short: one to three plain sentences. No markdown, no headings, no bullet list of phases, no step numbers.

--- a/packages/core/src/workflows/format.ts
+++ b/packages/core/src/workflows/format.ts
@@ -19,6 +19,7 @@ const WORKFLOW_FORMAT_SYSTEM_PROMPT = `You design multi-step AI coding workflows
 You receive a plain-language description of a desired workflow, plus the current draft steps (if any). Produce a clean, ordered set of steps.
 
 Rules:
+- Match the language of the DESIRED WORKFLOW description for all text fields (name, description, goal, step names, promptPrefix, expectedOutput, suggestions). If the description is written in Italian, write every field in Italian; same for any other language. Keep role values from the canonical list unchanged.
 - 2 to 6 steps. Each step has a single clear responsibility; do not bundle "plan and implement" into one step.
 - name: a short verb or noun (e.g. "Scout", "Plan", "Implement", "Review"). Title case, no numbering.
 - role: one of scout, planner, implementer, reviewer, investigator, product, architect, tester, explorer, custom. Pick the closest fit; use custom only when none apply.

--- a/packages/core/src/workflows/polish.ts
+++ b/packages/core/src/workflows/polish.ts
@@ -6,6 +6,7 @@ const GOAL_POLISH_SYSTEM_PROMPT = `You polish goal statements for AI coding work
 You receive a rough, hand-written goal. Rewrite it as a clear, specific objective for a team of coding agents.
 
 Rules:
+- Match the language of the input goal exactly. If the goal is written in Italian, write the polished goal in Italian; same for any other language.
 - Preserve every concrete detail: file names, paths, feature names, constraints, do-not items.
 - Imperative voice, one to three sentences.
 - Do not invent requirements, scope, or constraints that are not in the input.


### PR DESCRIPTION
## Summary
- Anchor all four workflow-authoring system prompts (`polish`, `format`, `planner`, `goal-rewrite`) to the input language, so a goal written in any language produces a workflow in that same language instead of English.
- Harden the planner parser: normalize each step `role` against the canonical `AgentRole` enum (fallback `custom`), mirroring `format.ts`. Prevents a launch-time crash when the cheap planner model translates a role or emits the non-canonical `other`.
- Align the planner prompt: `other` → `custom`, plus an explicit rule that `role` must stay an English canonical keyword even when every other field is localized.

## Why
The language anchoring is the goal. The parser hardening is required because the new "match the input language" instruction makes a translated `role` likely on the cheap planner tier; `ROLE_TO_KIND[role]` had no fallback at `createSession`/`attachWorkflowToSession`, so a persisted non-canonical role would crash at launch.

## Test plan
- [x] `vitest run` core planner/workflows/summarizer (135 pass, +3 new role-normalization tests)
- [x] `tsc --noEmit` core clean
- [ ] manual: author a goal in Italian → workflow fields come back in Italian, role stays canonical

🤖 Generated with [Claude Code](https://claude.com/claude-code)