### PR TITLE
feat(desktop): companion bridge for goodboy mobile pairing + commands

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +212,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -435,6 +479,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +512,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -556,6 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -597,6 +677,41 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "darling"
@@ -693,6 +808,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -926,6 +1042,12 @@ checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "field-offset"
@@ -1255,6 +1377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,12 +1493,15 @@ dependencies = [
  "log",
  "objc2",
  "portable-pty",
+ "qrcode",
+ "rand 0.8.6",
  "regex",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
  "sha2",
+ "snow",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -1779,6 +1914,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2460,6 +2604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2644,6 +2794,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-pty"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2958,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quick-xml"
@@ -3719,6 +3898,22 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "rustc_version",
+ "sha2",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -4760,6 +4955,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -34,7 +34,10 @@ tauri-plugin-process = "2"
 libc = "0.2"
 portable-pty = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "sync", "time"] }
+snow = "0.9"
+qrcode = { version = "0.14", default-features = false, features = ["svg"] }
+rand = "0.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/apps/desktop/src-tauri/src/bridge/commands.rs
+++ b/apps/desktop/src-tauri/src/bridge/commands.rs
@@ -1,0 +1,159 @@
+//! Mobile write-command plumbing.
+//!
+//! Security model (see PROTOCOL.md / companion design): the phone may request
+//! only a CLOSED set of actions. It never supplies an origin, a path, a working
+//! dir, or tool/permission flags — just the action's data. The bridge stamps
+//! `origin = Mobile` server-side (unforgeable) and forwards the command to the
+//! trusted desktop frontend, which validates scope and executes through the same
+//! store actions the desktop UI uses. There is intentionally no raw/exec variant.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::sync::{oneshot, Mutex};
+
+/// Who originated a command. Assigned by the trusted server from the channel it
+/// arrived on — NEVER read from client input. The phone cannot forge `Desktop`.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Origin {
+    #[allow(dead_code)]
+    Desktop,
+    Mobile,
+}
+
+/// Closed set of actions a mobile client may request. No raw/exec/path variant
+/// exists, so the phone cannot express anything outside these. `QueryProviders`
+/// is read-only: it returns the desktop's provider/model menu so the phone's
+/// composer can offer a picker, without the phone hardcoding the registry.
+#[derive(Debug, Clone, Copy)]
+pub enum MobileAction {
+    AdvanceStep,
+    Send,
+    SpawnAgent,
+    ResolveComment,
+    SetContextSlot,
+    QueryProviders,
+}
+
+impl MobileAction {
+    pub fn from_opcode(op: u8) -> Option<Self> {
+        match op {
+            0x83 => Some(Self::AdvanceStep),
+            0x84 => Some(Self::Send),
+            0x85 => Some(Self::SpawnAgent),
+            0x86 => Some(Self::ResolveComment),
+            0x87 => Some(Self::QueryProviders),
+            0x88 => Some(Self::SetContextSlot),
+            _ => None,
+        }
+    }
+
+    /// Stable string the frontend dispatcher switches on.
+    pub fn kind(self) -> &'static str {
+        match self {
+            Self::AdvanceStep => "advanceStep",
+            Self::Send => "send",
+            Self::SpawnAgent => "spawnAgent",
+            Self::ResolveComment => "resolveComment",
+            Self::SetContextSlot => "setContextSlot",
+            Self::QueryProviders => "queryProviders",
+        }
+    }
+
+    /// Read-only queries get their result frame (OP_QUERY_RESULT) instead of a
+    /// write ACK; the phone routes the response to a data continuation.
+    pub fn is_query(self) -> bool {
+        matches!(self, Self::QueryProviders)
+    }
+}
+
+/// Payload forwarded to the frontend executor over the `bridge://command` event.
+/// `origin` and `kind` are server-set; `data` is the phone's raw fields (only
+/// known keys are ever read downstream).
+#[derive(Debug, Serialize)]
+pub struct CommandEvent {
+    pub id: String,
+    pub kind: &'static str,
+    pub origin: Origin,
+    pub data: Value,
+}
+
+/// What the frontend reports back via `bridge_command_result`. `data` is only
+/// populated for read-only queries (e.g. the provider menu); write commands
+/// leave it `None` and the phone ignores it.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CmdResult {
+    pub ok: bool,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub data: Option<Value>,
+}
+
+/// In-flight commands awaiting a frontend result, keyed by command id.
+pub type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<CmdResult>>>>;
+
+/// How long the bridge waits for the frontend to acknowledge a command before
+/// giving up and telling the phone it failed.
+pub const ACK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Fallback command id when the phone omits one (it normally supplies its own
+/// correlation id so it can match the ACK).
+pub fn random_id() -> String {
+    use rand::RngCore;
+    let mut b = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut b);
+    b.iter().map(|x| format!("{x:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_the_command_opcodes() {
+        assert!(matches!(MobileAction::from_opcode(0x83), Some(MobileAction::AdvanceStep)));
+        assert!(matches!(MobileAction::from_opcode(0x84), Some(MobileAction::Send)));
+        assert!(matches!(MobileAction::from_opcode(0x85), Some(MobileAction::SpawnAgent)));
+        assert!(matches!(MobileAction::from_opcode(0x86), Some(MobileAction::ResolveComment)));
+        assert!(matches!(MobileAction::from_opcode(0x87), Some(MobileAction::QueryProviders)));
+        assert!(matches!(MobileAction::from_opcode(0x88), Some(MobileAction::SetContextSlot)));
+    }
+
+    #[test]
+    fn rejects_read_server_and_unknown_opcodes() {
+        // Server->client (0x01-0x09) and client read opcodes (0x80-0x82) are not
+        // mobile actions and must never resolve to one.
+        for op in [0x00u8, 0x01, 0x05, 0x07, 0x08, 0x09, 0x80, 0x81, 0x82, 0x89, 0xFF] {
+            assert!(
+                MobileAction::from_opcode(op).is_none(),
+                "opcode {op:#x} must not map to a mobile action",
+            );
+        }
+    }
+
+    #[test]
+    fn kind_strings_match_the_frontend_dispatcher() {
+        // These literals are switched on in commandExecutor.ts — keep them in sync.
+        assert_eq!(MobileAction::AdvanceStep.kind(), "advanceStep");
+        assert_eq!(MobileAction::Send.kind(), "send");
+        assert_eq!(MobileAction::SpawnAgent.kind(), "spawnAgent");
+        assert_eq!(MobileAction::ResolveComment.kind(), "resolveComment");
+        assert_eq!(MobileAction::SetContextSlot.kind(), "setContextSlot");
+        assert_eq!(MobileAction::QueryProviders.kind(), "queryProviders");
+    }
+
+    #[test]
+    fn only_query_actions_report_as_queries() {
+        assert!(MobileAction::QueryProviders.is_query());
+        for op in [0x83u8, 0x84, 0x85, 0x86, 0x88] {
+            let action = MobileAction::from_opcode(op).expect("opcode is a write command");
+            assert!(!action.is_query(), "{} must be a write, not a query", action.kind());
+            assert!(!action.kind().is_empty());
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/bridge/frame.rs
+++ b/apps/desktop/src-tauri/src/bridge/frame.rs
@@ -1,0 +1,39 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+use super::BridgeError;
+
+/// Noise transport cap: a single ciphertext must fit 65535 bytes.
+pub const NOISE_MAX: usize = 65535;
+
+/// Reads one on-wire frame: `u32 big-endian length || bytes[length]`.
+/// The length counts only the ciphertext bytes that follow.
+pub async fn read_frame(stream: &mut TcpStream) -> Result<Vec<u8>, BridgeError> {
+    let mut len_buf = [0u8; 4];
+    stream
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(BridgeError::Io)?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > NOISE_MAX {
+        return Err(BridgeError::Protocol(format!("bad frame length {len}")));
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body).await.map_err(BridgeError::Io)?;
+    Ok(body)
+}
+
+/// Writes one on-wire frame with the u32 big-endian length prefix.
+pub async fn write_frame(stream: &mut TcpStream, body: &[u8]) -> Result<(), BridgeError> {
+    if body.len() > NOISE_MAX {
+        return Err(BridgeError::Protocol(format!(
+            "frame too large: {}",
+            body.len()
+        )));
+    }
+    let len = (body.len() as u32).to_be_bytes();
+    stream.write_all(&len).await.map_err(BridgeError::Io)?;
+    stream.write_all(body).await.map_err(BridgeError::Io)?;
+    stream.flush().await.map_err(BridgeError::Io)?;
+    Ok(())
+}

--- a/apps/desktop/src-tauri/src/bridge/identity.rs
+++ b/apps/desktop/src-tauri/src/bridge/identity.rs
@@ -1,0 +1,105 @@
+use std::path::PathBuf;
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+
+use super::noise_params;
+use super::BridgeError;
+
+const IDENTITY_FILE: &str = "companion.json";
+
+/// Persisted pairing identity: the desktop's long-term Noise static key plus the
+/// allow-list of enrolled phone static public keys (TOFU). Lives next to the DB
+/// under `~/.goodboy/` and never leaves the machine.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Identity {
+    /// X25519 static private key, base64 (raw 32 bytes).
+    pub static_priv_b64: String,
+    /// X25519 static public key, base64 (raw 32 bytes) — the QR `staticPub`.
+    pub static_pub_b64: String,
+    /// Enrolled phone static public keys, base64. Re-dial authorizes by membership.
+    #[serde(default)]
+    pub allow_list: Vec<String>,
+}
+
+fn b64() -> base64::engine::GeneralPurpose {
+    base64::engine::general_purpose::STANDARD
+}
+
+fn identity_path() -> Result<PathBuf, BridgeError> {
+    let home = dirs::home_dir().ok_or(BridgeError::NoHomeDir)?;
+    Ok(home.join(".goodboy").join(IDENTITY_FILE))
+}
+
+impl Identity {
+    /// Loads the persisted identity, generating (and writing) a fresh static
+    /// keypair on first use.
+    pub fn load_or_create() -> Result<Self, BridgeError> {
+        let path = identity_path()?;
+        if let Ok(bytes) = std::fs::read(&path) {
+            if let Ok(id) = serde_json::from_slice::<Identity>(&bytes) {
+                return Ok(id);
+            }
+        }
+        let keypair = snow::Builder::new(noise_params())
+            .generate_keypair()
+            .map_err(|e| BridgeError::Noise(e.to_string()))?;
+        let id = Identity {
+            static_priv_b64: b64().encode(keypair.private),
+            static_pub_b64: b64().encode(keypair.public),
+            allow_list: Vec::new(),
+        };
+        id.persist()?;
+        Ok(id)
+    }
+
+    pub fn static_priv(&self) -> Result<Vec<u8>, BridgeError> {
+        b64()
+            .decode(self.static_priv_b64.as_bytes())
+            .map_err(|e| BridgeError::Decode(e.to_string()))
+    }
+
+    pub fn is_enrolled(&self, phone_static_pub: &[u8]) -> bool {
+        let enc = b64().encode(phone_static_pub);
+        self.allow_list.iter().any(|k| k == &enc)
+    }
+
+    pub fn enroll(&mut self, phone_static_pub: &[u8]) -> Result<(), BridgeError> {
+        let enc = b64().encode(phone_static_pub);
+        if !self.allow_list.contains(&enc) {
+            self.allow_list.push(enc);
+            self.persist()?;
+        }
+        Ok(())
+    }
+
+    /// Forgets every enrolled phone (desktop-initiated disconnect). Afterwards a
+    /// re-dial fails the `is_enrolled` check, so a phone must scan a fresh QR to
+    /// reconnect — restoring pairing is a deliberate human act on the desktop,
+    /// never something the phone can do on its own.
+    pub fn revoke_all(&mut self) -> Result<(), BridgeError> {
+        if self.allow_list.is_empty() {
+            return Ok(());
+        }
+        self.allow_list.clear();
+        self.persist()
+    }
+
+    fn persist(&self) -> Result<(), BridgeError> {
+        let path = identity_path()?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(BridgeError::Io)?;
+        }
+        let json = serde_json::to_vec_pretty(self).map_err(BridgeError::Json)?;
+        std::fs::write(&path, json).map_err(BridgeError::Io)?;
+        // The file holds the desktop's long-term Noise static private key; keep it
+        // owner-only so other local accounts can't read it and impersonate us.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .map_err(BridgeError::Io)?;
+        }
+        Ok(())
+    }
+}

--- a/apps/desktop/src-tauri/src/bridge/mod.rs
+++ b/apps/desktop/src-tauri/src/bridge/mod.rs
@@ -1,0 +1,305 @@
+//! Companion bridge: the desktop-side responder for Goodboy Mobile.
+//!
+//! Implements the FROZEN wire/crypto contract in `goodboy-mobile/PROTOCOL.md`
+//! (Noise_XK_25519_ChaChaPoly_SHA256 + length-prefixed app frames). Read-only by
+//! construction: there is no client opcode that mutates the desktop. The phone
+//! observes; the desktop stays the sole writer of `~/.goodboy/data.db`.
+//!
+//! There is intentionally NO visible "connect your phone" surface. The bridge is
+//! reached only via a hidden frontend shortcut that calls `bridge_start`.
+
+mod commands;
+mod frame;
+mod identity;
+mod server;
+mod snapshot;
+mod tokens;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use base64::Engine as _;
+use serde::Serialize;
+use snow::params::NoiseParams;
+use tauri::async_runtime::JoinHandle;
+use tauri::{AppHandle, State};
+use thiserror::Error;
+use tokio::net::TcpListener;
+use tokio::sync::{watch, Mutex};
+
+use commands::{CmdResult, PendingMap};
+use identity::Identity;
+use server::{serve, ServerCtx};
+use tokens::TokenStore;
+
+const PROTOCOL_NAME: &str = "Noise_XK_25519_ChaChaPoly_SHA256";
+const SERVICE_NAME: &str = "_goodboy._tcp";
+
+pub(crate) fn noise_params() -> NoiseParams {
+    PROTOCOL_NAME
+        .parse()
+        .expect("static Noise protocol name is valid")
+}
+
+#[derive(Debug, Error)]
+pub enum BridgeError {
+    #[error("home directory not available")]
+    NoHomeDir,
+    #[error("noise error: {0}")]
+    Noise(String),
+    #[error("decode error: {0}")]
+    Decode(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("db error: {0}")]
+    Db(String),
+    #[error("protocol error: {0}")]
+    Protocol(String),
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
+}
+
+impl Serialize for BridgeError {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+/// Tauri-managed state. Holds the persisted identity, the live token store, and
+/// the running server task (if any).
+pub struct BridgeState {
+    static_pub_b64: String,
+    identity: Arc<Mutex<Identity>>,
+    tokens: Arc<TokenStore>,
+    /// In-flight mobile commands awaiting a frontend result, keyed by command id.
+    pending: PendingMap,
+    inner: Mutex<Inner>,
+}
+
+#[derive(Default)]
+struct Inner {
+    port: Option<u16>,
+    task: Option<JoinHandle<()>>,
+    /// Signals live connections to tear down on stop/revoke.
+    shutdown: Option<watch::Sender<bool>>,
+}
+
+impl BridgeState {
+    pub fn new() -> Result<Self, BridgeError> {
+        let identity = Identity::load_or_create()?;
+        Ok(Self {
+            static_pub_b64: identity.static_pub_b64.clone(),
+            identity: Arc::new(Mutex::new(identity)),
+            tokens: Arc::new(TokenStore::new()),
+            pending: Arc::new(Mutex::new(HashMap::new())),
+            inner: Mutex::new(Inner::default()),
+        })
+    }
+
+    /// Binds the listener and spawns the accept loop once; returns the bound port.
+    async fn ensure_running(&self, app: AppHandle) -> Result<u16, BridgeError> {
+        let mut inner = self.inner.lock().await;
+        if let Some(port) = inner.port {
+            return Ok(port);
+        }
+        let listener = TcpListener::bind(("0.0.0.0", 0)).await?;
+        let port = listener.local_addr()?.port();
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let ctx = Arc::new(ServerCtx {
+            identity: self.identity.clone(),
+            tokens: self.tokens.clone(),
+            device_name: device_name(),
+            app,
+            pending: self.pending.clone(),
+            shutdown: shutdown_rx,
+        });
+        let task = tauri::async_runtime::spawn(async move {
+            serve(listener, ctx).await;
+        });
+        inner.port = Some(port);
+        inner.task = Some(task);
+        inner.shutdown = Some(shutdown_tx);
+        Ok(port)
+    }
+
+    async fn stop(&self) {
+        let mut inner = self.inner.lock().await;
+        // Trip live connections first so a connected phone is dropped at once,
+        // then abort the accept loop so no new ones get in.
+        if let Some(shutdown) = inner.shutdown.take() {
+            let _ = shutdown.send(true);
+        }
+        if let Some(task) = inner.task.take() {
+            task.abort();
+        }
+        inner.port = None;
+    }
+}
+
+#[derive(Serialize)]
+pub struct Endpoint {
+    host: String,
+    port: u16,
+}
+
+/// The compact JSON encoded into the QR (PROTOCOL §4).
+#[derive(Serialize)]
+struct QrPayload {
+    v: u8,
+    #[serde(rename = "deviceName")]
+    device_name: String,
+    #[serde(rename = "staticPub")]
+    static_pub: String,
+    token: String,
+    endpoints: Vec<Endpoint>,
+    #[serde(rename = "serviceName")]
+    service_name: String,
+}
+
+/// What the hidden modal renders: the QR (as inline SVG) plus diagnostics.
+#[derive(Serialize)]
+pub struct QrInfo {
+    /// Compact JSON payload that the SVG encodes (also handy for debugging).
+    payload: String,
+    /// Inline SVG markup of the QR code.
+    svg: String,
+    #[serde(rename = "deviceName")]
+    device_name: String,
+    port: u16,
+    #[serde(rename = "expiresInSecs")]
+    expires_in_secs: u16,
+}
+
+#[derive(Serialize)]
+pub struct BridgeStatus {
+    running: bool,
+    port: Option<u16>,
+    #[serde(rename = "enrolledCount")]
+    enrolled_count: usize,
+}
+
+/// Starts the bridge (idempotent) and mints a fresh one-time pairing token,
+/// returning the QR the phone must scan. Invoked only by the hidden shortcut.
+#[tauri::command]
+pub async fn bridge_start(
+    app: AppHandle,
+    state: State<'_, BridgeState>,
+) -> Result<QrInfo, BridgeError> {
+    let port = state.ensure_running(app).await?;
+    let token = state.tokens.mint();
+    let device_name = device_name();
+
+    let payload = QrPayload {
+        v: 1,
+        device_name: device_name.clone(),
+        static_pub: state.static_pub_b64.clone(),
+        token: base64::engine::general_purpose::STANDARD.encode(&token),
+        endpoints: endpoints(port),
+        service_name: SERVICE_NAME.to_string(),
+    };
+    let json = serde_json::to_string(&payload)?;
+    let svg = render_qr_svg(&json)?;
+
+    Ok(QrInfo {
+        payload: json,
+        svg,
+        device_name,
+        port,
+        expires_in_secs: 60,
+    })
+}
+
+#[tauri::command]
+pub async fn bridge_stop(state: State<'_, BridgeState>) -> Result<(), BridgeError> {
+    state.stop().await;
+    Ok(())
+}
+
+/// Desktop-initiated disconnect ("forget device"): clears the enrolled-phone
+/// allow-list and tears the bridge down, dropping any live connection. The phone
+/// must scan a fresh QR to reconnect — re-pairing is a deliberate act here on the
+/// desktop, never something a phone can trigger. This is the desktop-side twin of
+/// the phone's own "Forget device".
+#[tauri::command]
+pub async fn bridge_revoke(state: State<'_, BridgeState>) -> Result<(), BridgeError> {
+    state.identity.lock().await.revoke_all()?;
+    state.stop().await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn bridge_status(state: State<'_, BridgeState>) -> Result<BridgeStatus, BridgeError> {
+    let inner = state.inner.lock().await;
+    let enrolled_count = state.identity.lock().await.allow_list.len();
+    Ok(BridgeStatus {
+        running: inner.port.is_some(),
+        port: inner.port,
+        enrolled_count,
+    })
+}
+
+/// The trusted frontend executor reports a mobile command's outcome here; this
+/// wakes the connection task waiting in `run_command` so it can ACK the phone.
+/// Unknown ids are ignored (already timed out / never existed).
+#[tauri::command]
+pub async fn bridge_command_result(
+    state: State<'_, BridgeState>,
+    id: String,
+    ok: bool,
+    error: Option<String>,
+    data: Option<serde_json::Value>,
+) -> Result<(), BridgeError> {
+    if let Some(tx) = state.pending.lock().await.remove(&id) {
+        let _ = tx.send(CmdResult { ok, error, data });
+    }
+    Ok(())
+}
+
+fn render_qr_svg(data: &str) -> Result<String, BridgeError> {
+    use qrcode::render::svg;
+    use qrcode::QrCode;
+    let code = QrCode::new(data.as_bytes()).map_err(|e| BridgeError::Protocol(e.to_string()))?;
+    Ok(code
+        .render::<svg::Color>()
+        .min_dimensions(240, 240)
+        .quiet_zone(true)
+        .build())
+}
+
+fn endpoints(port: u16) -> Vec<Endpoint> {
+    let mut out = Vec::new();
+    if let Some(ip) = primary_ipv4() {
+        out.push(Endpoint { host: ip, port });
+    }
+    out
+}
+
+/// Primary LAN IPv4 via the connected-UDP trick (no packets sent).
+fn primary_ipv4() -> Option<String> {
+    use std::net::UdpSocket;
+    let sock = UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("8.8.8.8:80").ok()?;
+    let ip = sock.local_addr().ok()?.ip();
+    if ip.is_loopback() || ip.is_unspecified() {
+        None
+    } else {
+        Some(ip.to_string())
+    }
+}
+
+fn device_name() -> String {
+    let mut buf = [0u8; 256];
+    let rc = unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
+    if rc == 0 {
+        let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        if let Ok(name) = std::str::from_utf8(&buf[..end]) {
+            let trimmed = name.trim_end_matches(".local").trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_string();
+            }
+        }
+    }
+    "Goodboy Desktop".to_string()
+}

--- a/apps/desktop/src-tauri/src/bridge/server.rs
+++ b/apps/desktop/src-tauri/src/bridge/server.rs
@@ -1,0 +1,332 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Emitter};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{oneshot, watch, Mutex};
+
+use super::commands::{CmdResult, CommandEvent, MobileAction, Origin, PendingMap, ACK_TIMEOUT};
+use super::frame::{read_frame, write_frame, NOISE_MAX};
+use super::identity::Identity;
+use super::snapshot::{self, Snapshot};
+use super::tokens::TokenStore;
+use super::{noise_params, BridgeError};
+
+// Server -> client opcodes.
+const OP_HELLO: u8 = 0x01;
+const OP_SNAPSHOT_BEGIN: u8 = 0x02;
+const OP_SNAPSHOT_CHUNK: u8 = 0x03;
+const OP_SNAPSHOT_END: u8 = 0x04;
+const OP_PING: u8 = 0x07;
+const OP_ACK: u8 = 0x08;
+/// Result of a read-only mobile query (e.g. the provider/model menu). Distinct
+/// from OP_ACK so the phone routes it to a data continuation, not the
+/// write-command ACK handler.
+const OP_QUERY_RESULT: u8 = 0x0A;
+// Client -> server opcodes.
+const OP_PONG: u8 = 0x80;
+const OP_SUBSCRIBE: u8 = 0x81;
+const OP_RESNAPSHOT: u8 = 0x82;
+// Client -> server WRITE opcodes (0x83..=0x86) are decoded via
+// `MobileAction::from_opcode`; the closed set lives in `commands.rs`.
+
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+/// How often the bridge checks the DB for changes to auto-push to the phone.
+/// Doubles as a debounce: at most one snapshot push per interval even under a
+/// burst of writes (e.g. streaming turn events).
+const SYNC_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Shared handles the per-connection task needs.
+pub struct ServerCtx {
+    pub identity: Arc<Mutex<Identity>>,
+    pub tokens: Arc<TokenStore>,
+    pub device_name: String,
+    /// Used to forward mobile commands to the trusted frontend executor.
+    pub app: AppHandle,
+    /// In-flight mobile commands awaiting a frontend result.
+    pub pending: PendingMap,
+    /// Tripped (or dropped) when the bridge stops or revokes; every live
+    /// connection bails at once so a forgotten phone cannot keep observing or
+    /// sending commands.
+    pub shutdown: watch::Receiver<bool>,
+}
+
+/// Accepts connections until `listener` is dropped (bridge stop drops the task).
+pub async fn serve(listener: TcpListener, ctx: Arc<ServerCtx>) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, _peer)) => {
+                let ctx = ctx.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = handle_conn(stream, ctx).await {
+                        log::warn!("[bridge] connection ended: {e}");
+                    }
+                });
+            }
+            Err(e) => {
+                log::warn!("[bridge] accept failed: {e}");
+                return;
+            }
+        }
+    }
+}
+
+async fn handle_conn(mut stream: TcpStream, ctx: Arc<ServerCtx>) -> Result<(), BridgeError> {
+    // ---- Noise_XK responder handshake ----
+    let static_priv = { ctx.identity.lock().await.static_priv()? };
+    let mut hs = snow::Builder::new(noise_params())
+        .local_private_key(&static_priv)
+        .build_responder()
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+
+    let mut scratch = vec![0u8; NOISE_MAX];
+
+    // msg1: -> e, es  (payload = enrollment token, or empty for re-dial)
+    let msg1 = read_frame(&mut stream).await?;
+    let n = hs
+        .read_message(&msg1, &mut scratch)
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+    let msg1_payload = scratch[..n].to_vec();
+
+    let enrolling = match msg1_payload.len() {
+        0 => false,
+        32 => {
+            if !ctx.tokens.consume(&msg1_payload) {
+                return Err(BridgeError::Unauthorized("invalid or expired token".into()));
+            }
+            true
+        }
+        other => {
+            return Err(BridgeError::Protocol(format!(
+                "msg1 payload must be 0 or 32 bytes, got {other}"
+            )))
+        }
+    };
+
+    // msg2: <- e, ee
+    let len = hs
+        .write_message(&[], &mut scratch)
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+    write_frame(&mut stream, &scratch[..len]).await?;
+
+    // msg3: -> s, se  (phone reveals its static)
+    let msg3 = read_frame(&mut stream).await?;
+    hs.read_message(&msg3, &mut scratch)
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+    let phone_static = hs
+        .get_remote_static()
+        .ok_or_else(|| BridgeError::Protocol("missing phone static after msg3".into()))?
+        .to_vec();
+
+    // Authorize: enrollment adds to allow-list; re-dial requires membership.
+    {
+        let mut id = ctx.identity.lock().await;
+        if enrolling {
+            id.enroll(&phone_static)?;
+        } else if !id.is_enrolled(&phone_static) {
+            return Err(BridgeError::Unauthorized("phone not enrolled".into()));
+        }
+    }
+
+    let mut transport = hs
+        .into_transport_mode()
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+
+    // ---- App layer: HELLO then the initial snapshot ----
+    let snap = snapshot::build()?;
+    send_app(
+        &mut stream,
+        &mut transport,
+        OP_HELLO,
+        &json!({
+            "protocol": 1,
+            "deviceName": ctx.device_name,
+            "headMigration": snap.head_migration,
+            "serverTime": now_iso(),
+        }),
+    )
+    .await?;
+    stream_snapshot(&mut stream, &mut transport, &snap).await?;
+    log::info!("[bridge] phone synced; head {}", snap.head_migration);
+
+    // A desktop stop/revoke trips this; the live loop bails at once. Catch the
+    // already-shut-down case before entering the loop, then race it below.
+    let mut shutdown = ctx.shutdown.clone();
+    if *shutdown.borrow() {
+        return Ok(());
+    }
+
+    // Live loop: PING heartbeat + DB-change auto-sync + handle client frames.
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    // Auto-sync: poll the DB's data_version and push a fresh snapshot when the
+    // desktop writes, so the phone stays current without manual pull-to-refresh.
+    // If the probe can't open (rare), we degrade to RESNAPSHOT-only behavior.
+    let mut probe = snapshot::ChangeProbe::new().ok();
+    let mut sync = tokio::time::interval(SYNC_POLL_INTERVAL);
+    sync.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                log::info!("[bridge] connection closed by desktop");
+                return Ok(());
+            }
+            _ = ping.tick() => {
+                send_app(&mut stream, &mut transport, OP_PING, &json!({ "at": now_iso() })).await?;
+            }
+            _ = sync.tick() => {
+                if probe.as_mut().is_some_and(snapshot::ChangeProbe::changed) {
+                    send_snapshot(&mut stream, &mut transport).await?;
+                }
+            }
+            frame = read_frame(&mut stream) => {
+                let frame = frame?;
+                let mut buf = vec![0u8; NOISE_MAX];
+                let n = transport
+                    .read_message(&frame, &mut buf)
+                    .map_err(|e| BridgeError::Noise(e.to_string()))?;
+                if n == 0 { continue; }
+                let opcode = buf[0];
+                match opcode {
+                    OP_PONG | OP_SUBSCRIBE => { /* read-only: liveness / filter only */ }
+                    OP_RESNAPSHOT => {
+                        send_snapshot(&mut stream, &mut transport).await?;
+                    }
+                    op => match MobileAction::from_opcode(op) {
+                        // Mobile action: stamp origin server-side, forward to the
+                        // trusted frontend, then reply. Writes get an ACK; read-only
+                        // queries get their result frame carrying `data`.
+                        Some(action) => {
+                            let data: Value = if n > 1 {
+                                serde_json::from_slice(&buf[1..n]).unwrap_or(Value::Null)
+                            } else {
+                                Value::Null
+                            };
+                            let reply_op = if action.is_query() { OP_QUERY_RESULT } else { OP_ACK };
+                            let result = run_command(&ctx, action, data).await;
+                            send_app(&mut stream, &mut transport, reply_op, &result).await?;
+                        }
+                        None => log::warn!("[bridge] unexpected client opcode {op:#04x}"),
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Forwards a mobile-originated command to the trusted frontend executor and
+/// awaits its result. `origin` is stamped `Mobile` here — server-side and
+/// unforgeable — so the frontend guard applies the locked-down profile. The
+/// phone only ever supplies `data` (and an optional correlation id).
+async fn run_command(ctx: &Arc<ServerCtx>, action: MobileAction, data: Value) -> Value {
+    // The phone may supply a correlation id so it can match this ACK; otherwise
+    // mint one. This is the only phone-controlled field we read here.
+    let id = data
+        .get("cmdId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(super::commands::random_id);
+
+    let (tx, rx) = oneshot::channel::<CmdResult>();
+    ctx.pending.lock().await.insert(id.clone(), tx);
+
+    let event = CommandEvent {
+        id: id.clone(),
+        kind: action.kind(),
+        origin: Origin::Mobile,
+        data,
+    };
+
+    if let Err(e) = ctx.app.emit("bridge://command", &event) {
+        ctx.pending.lock().await.remove(&id);
+        return json!({ "cmdId": id, "ok": false, "error": format!("forward failed: {e}") });
+    }
+
+    match tokio::time::timeout(ACK_TIMEOUT, rx).await {
+        Ok(Ok(res)) => json!({ "cmdId": id, "ok": res.ok, "error": res.error, "data": res.data }),
+        Ok(Err(_)) => {
+            json!({ "cmdId": id, "ok": false, "error": "executor dropped before responding" })
+        }
+        Err(_) => {
+            ctx.pending.lock().await.remove(&id);
+            json!({ "cmdId": id, "ok": false, "error": "timed out waiting for desktop" })
+        }
+    }
+}
+
+/// Encrypts `[opcode || json]` and writes it as one framed Noise message.
+async fn send_app(
+    stream: &mut TcpStream,
+    transport: &mut snow::TransportState,
+    opcode: u8,
+    payload: &serde_json::Value,
+) -> Result<(), BridgeError> {
+    let mut plain = Vec::with_capacity(256);
+    plain.push(opcode);
+    serde_json::to_writer(&mut plain, payload).map_err(BridgeError::Json)?;
+    let mut ct = vec![0u8; plain.len() + 16];
+    let len = transport
+        .write_message(&plain, &mut ct)
+        .map_err(|e| BridgeError::Noise(e.to_string()))?;
+    write_frame(stream, &ct[..len]).await
+}
+
+/// Builds a fresh snapshot and streams it (used for RESNAPSHOT).
+async fn send_snapshot(
+    stream: &mut TcpStream,
+    transport: &mut snow::TransportState,
+) -> Result<(), BridgeError> {
+    let snap = snapshot::build()?;
+    stream_snapshot(stream, transport, &snap).await
+}
+
+/// BEGIN -> CHUNK* -> END for an already-built snapshot.
+async fn stream_snapshot(
+    stream: &mut TcpStream,
+    transport: &mut snow::TransportState,
+    snap: &Snapshot,
+) -> Result<(), BridgeError> {
+    let total = snap.total_chunks();
+
+    send_app(
+        stream,
+        transport,
+        OP_SNAPSHOT_BEGIN,
+        &json!({
+            "snapshotId": snap.snapshot_id,
+            "headMigration": snap.head_migration,
+            "totalChunks": total,
+            "transcriptWindow": { "perSessionMaxEvents": 500, "maxAgeHours": 24 },
+        }),
+    )
+    .await?;
+
+    for index in 0..total {
+        send_app(
+            stream,
+            transport,
+            OP_SNAPSHOT_CHUNK,
+            &json!({
+                "snapshotId": snap.snapshot_id,
+                "index": index,
+                "bytesB64": snap.chunk_b64(index),
+            }),
+        )
+        .await?;
+    }
+
+    send_app(
+        stream,
+        transport,
+        OP_SNAPSHOT_END,
+        &json!({ "snapshotId": snap.snapshot_id, "sha256": snap.sha256_hex }),
+    )
+    .await?;
+
+    Ok(())
+}
+
+fn now_iso() -> String {
+    snapshot::iso_now()
+}

--- a/apps/desktop/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop/src-tauri/src/bridge/snapshot.rs
@@ -1,0 +1,445 @@
+use base64::Engine as _;
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+
+use super::frame::NOISE_MAX;
+use super::BridgeError;
+use crate::db;
+
+/// Snapshot transcript window (PROTOCOL §7): last ~500 events/session or 24 h.
+const TRANSCRIPT_MAX_EVENTS: usize = 500;
+const TRANSCRIPT_MAX_AGE_HOURS: i64 = 24;
+
+/// Raw-byte chunk size before base64. base64 grows ~1.33x and we add the JSON
+/// envelope + AEAD tag, so 32 KiB raw stays comfortably under the 65535 cap.
+const CHUNK_RAW_BYTES: usize = 32 * 1024;
+
+/// A serialized snapshot ready to stream: the canonical body bytes plus the
+/// metadata the BEGIN/END frames carry.
+pub struct Snapshot {
+    pub snapshot_id: String,
+    pub head_migration: String,
+    pub body: Vec<u8>,
+    pub sha256_hex: String,
+}
+
+impl Snapshot {
+    pub fn total_chunks(&self) -> usize {
+        if self.body.is_empty() {
+            0
+        } else {
+            (self.body.len() + CHUNK_RAW_BYTES - 1) / CHUNK_RAW_BYTES
+        }
+    }
+
+    /// base64 of chunk `index` (a raw-byte slice of the canonical body).
+    pub fn chunk_b64(&self, index: usize) -> String {
+        let start = index * CHUNK_RAW_BYTES;
+        let end = (start + CHUNK_RAW_BYTES).min(self.body.len());
+        base64::engine::general_purpose::STANDARD.encode(&self.body[start..end])
+    }
+}
+
+/// Cheap change detector for live sync. Holds one persistent read-only
+/// connection and watches SQLite's `data_version`, which bumps whenever ANOTHER
+/// connection (the desktop app's writer) commits. Lets the bridge push a fresh
+/// snapshot only when the DB actually changed, instead of polling full rebuilds.
+pub struct ChangeProbe {
+    conn: Connection,
+    last: i64,
+}
+
+impl ChangeProbe {
+    pub fn new() -> Result<Self, BridgeError> {
+        let conn = open_ro()?;
+        let last = read_data_version(&conn);
+        Ok(Self { conn, last })
+    }
+
+    /// True once per committed change by the writer connection since last call.
+    pub fn changed(&mut self) -> bool {
+        let v = read_data_version(&self.conn);
+        if v != self.last {
+            self.last = v;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn read_data_version(conn: &Connection) -> i64 {
+    conn.query_row("PRAGMA data_version", [], |r| r.get(0)).unwrap_or(0)
+}
+
+fn open_ro() -> Result<Connection, BridgeError> {
+    let path = db::resolve_db_path().map_err(|e| BridgeError::Db(e.to_string()))?;
+    Connection::open_with_flags(
+        &path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| BridgeError::Db(e.to_string()))
+}
+
+/// Runs a SELECT and maps each row to a JSON object using the statement's
+/// column names, preserving SQLite types via `db::value_to_json`.
+fn rows(conn: &Connection, sql: &str) -> Result<Vec<Value>, BridgeError> {
+    let mut stmt = conn.prepare(sql).map_err(|e| BridgeError::Db(e.to_string()))?;
+    let names: Vec<String> = stmt.column_names().into_iter().map(String::from).collect();
+    let mut q = stmt.query([]).map_err(|e| BridgeError::Db(e.to_string()))?;
+    let mut out = Vec::new();
+    while let Some(row) = q.next().map_err(|e| BridgeError::Db(e.to_string()))? {
+        let mut rec = Map::new();
+        for (i, name) in names.iter().enumerate() {
+            let rv = row
+                .get_ref(i)
+                .map_err(|e| BridgeError::Db(e.to_string()))?;
+            rec.insert(name.clone(), db::value_to_json(rv));
+        }
+        out.push(Value::Object(rec));
+    }
+    Ok(out)
+}
+
+fn head_migration(conn: &Connection) -> String {
+    let v: Option<i64> = conn
+        .query_row("SELECT MAX(version) FROM schema_version", [], |r| r.get(0))
+        .ok()
+        .flatten();
+    match v {
+        Some(n) => format!("m{n:03}"),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Some columns store JSON as TEXT; embed the named column as a parsed value so
+/// the client receives a structured object instead of an escaped string.
+fn embed_json_column(mut rows: Vec<Value>, key: &str) -> Vec<Value> {
+    for row in &mut rows {
+        if let Some(obj) = row.as_object_mut() {
+            if let Some(Value::String(s)) = obj.get(key) {
+                if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                    obj.insert(key.to_string(), parsed);
+                }
+            }
+        }
+    }
+    rows
+}
+
+/// turn_events.payload is stored as JSON TEXT; embed it as a parsed object so
+/// the client receives a structured TurnEvent (PROTOCOL §6), not a string.
+fn parse_turn_events(events: Vec<Value>) -> Vec<Value> {
+    embed_json_column(events, "payload")
+}
+
+/// Caps transcript events at TRANSCRIPT_MAX_EVENTS per session (rows arrive
+/// ordered newest-first, so we keep the newest then restore chronological order).
+fn cap_per_session(events: Vec<Value>) -> Vec<Value> {
+    use std::collections::HashMap;
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    let mut kept: Vec<Value> = Vec::new();
+    for ev in events {
+        let sid = ev
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let c = counts.entry(sid).or_insert(0);
+        if *c < TRANSCRIPT_MAX_EVENTS {
+            *c += 1;
+            kept.push(ev);
+        }
+    }
+    kept.reverse();
+    kept
+}
+
+pub fn build() -> Result<Snapshot, BridgeError> {
+    let conn = open_ro()?;
+    let head = head_migration(&conn);
+
+    let workspaces = rows(
+        &conn,
+        "SELECT id, name, root_path, kind, disconnected_at, last_accessed_at, created_at, updated_at \
+         FROM workspaces WHERE deleted_at IS NULL",
+    )?;
+    let sessions = rows(
+        &conn,
+        "SELECT id, workspace_id, goal, state_kind, user_status, workflow_id, current_step_ordinal, \
+         provider_allow_override, permission_mode, \
+         archived_at, deleted_at, created_at, updated_at \
+         FROM sessions WHERE deleted_at IS NULL AND archived_at IS NULL",
+    )?;
+    let agents = rows(
+        &conn,
+        "SELECT id, session_id, step_id, ordinal, name, kind, status, provider_run_id, output_summary, \
+         group_id, parallel_index, parent_agent_id, workflow_run_id, started_at, completed_at, deleted_at \
+         FROM agents WHERE deleted_at IS NULL",
+    )?;
+    let messages = rows(
+        &conn,
+        "SELECT id, session_id, agent_id, role, content, created_at FROM messages ORDER BY created_at ASC",
+    )?;
+    let cutoff_ms = chrono_now_ms() - TRANSCRIPT_MAX_AGE_HOURS * 3_600_000;
+    let turn_events_raw = rows(
+        &conn,
+        &format!(
+            "SELECT id, session_id, agent_id, created_at, payload FROM turn_events \
+             WHERE created_at >= {cutoff_ms} ORDER BY created_at DESC"
+        ),
+    )?;
+    let turn_events = parse_turn_events(cap_per_session(turn_events_raw));
+    let context_slots = rows(
+        &conn,
+        "SELECT session_id, key, value, enabled FROM context_slots",
+    )?;
+    let session_plans = rows(
+        &conn,
+        "SELECT id, session_id, agent_id, title, body_md, status, clusters_json, workflow_run_id, \
+         created_at, updated_at FROM session_plans",
+    )?;
+    let workflows = rows(
+        &conn,
+        "SELECT id, workspace_id, name, description, goal, is_preset, deleted_at, created_at, updated_at \
+         FROM workflows WHERE deleted_at IS NULL",
+    )?;
+    let steps = rows(
+        &conn,
+        "SELECT id, workflow_id, ordinal, name, role, parallel_group, deleted_at \
+         FROM steps WHERE deleted_at IS NULL",
+    )?;
+    let session_workflows = rows(
+        &conn,
+        "SELECT workflow_run_id, session_id, workflow_id, ordinal, current_step_ordinal, goal, \
+         trigger_mode, discarded_at, created_at FROM session_workflows WHERE discarded_at IS NULL",
+    )?;
+    // PR status: the per-session branch (session_worktrees) joined on the phone
+    // to the desktop's cached PR (github_pr_cache.pr_json, parsed inline). The
+    // cache is read-only here — mobile mirrors what the desktop last fetched.
+    let session_worktrees = rows(
+        &conn,
+        "SELECT session_id, branch, parallel_index FROM session_worktrees",
+    )?;
+    let github_pr_cache = embed_json_column(
+        rows(
+            &conn,
+            "SELECT branch, repo_slug, pr_json, fetched_at FROM github_pr_cache",
+        )?,
+        "pr_json",
+    );
+    // Per-session budget rollup for the mobile CostRing: aggregate spend from
+    // telemetry_records and the optional soft cap from session_budgets. Read-only
+    // mirror; the desktop owns budget enforcement. cap_usd is NULL when no budget
+    // is set (the phone renders spend without a ring).
+    let session_costs = rows(
+        &conn,
+        "SELECT s.id AS session_id, \
+                COALESCE(c.spent_usd, 0) AS spent_usd, \
+                b.soft_cap_usd AS cap_usd \
+         FROM sessions s \
+         LEFT JOIN (SELECT session_id, SUM(estimated_cost_usd) AS spent_usd \
+                    FROM telemetry_records GROUP BY session_id) c ON c.session_id = s.id \
+         LEFT JOIN session_budgets b ON b.session_id = s.id \
+         WHERE s.deleted_at IS NULL AND s.archived_at IS NULL",
+    )?;
+
+    let snapshot_id = format!("snap_{}", random_id());
+    let body_value = json!({
+        "schemaVersion": 1,
+        "snapshotId": snapshot_id.clone(),
+        "headMigration": head.clone(),
+        "generatedAt": iso_now(),
+        "transcriptWindow": {
+            "perSessionMaxEvents": TRANSCRIPT_MAX_EVENTS,
+            "maxAgeHours": TRANSCRIPT_MAX_AGE_HOURS,
+        },
+        "entities": {
+            "workspaces": workspaces,
+            "sessions": sessions,
+            "agents": agents,
+            "messages": messages,
+            "turn_events": turn_events,
+            "context_slots": context_slots,
+            "session_plans": session_plans,
+            "workflows": workflows,
+            "steps": steps,
+            "session_workflows": session_workflows,
+            "session_worktrees": session_worktrees,
+            "github_pr_cache": github_pr_cache,
+            "session_costs": session_costs,
+        }
+    });
+
+    let body = serde_json::to_vec(&body_value).map_err(BridgeError::Json)?;
+    let sha256_hex = {
+        let mut h = Sha256::new();
+        h.update(&body);
+        format!("{:x}", h.finalize())
+    };
+
+    debug_assert!(CHUNK_RAW_BYTES < NOISE_MAX);
+    Ok(Snapshot {
+        snapshot_id,
+        head_migration: head,
+        body,
+        sha256_hex,
+    })
+}
+
+fn chrono_now_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+pub fn iso_now() -> String {
+    // Minimal RFC3339 UTC formatter (no chrono dep). Precision: seconds + .000Z.
+    let ms = chrono_now_ms();
+    let secs = ms / 1000;
+    let days = secs / 86400;
+    let tod = secs % 86400;
+    let (h, m, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let (y, mo, d) = civil_from_days(days);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}.000Z")
+}
+
+/// Howard Hinnant's days->civil date algorithm.
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+fn random_id() -> String {
+    use rand::Rng;
+    const ALPHABET: &[u8] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+    let mut rng = rand::thread_rng();
+    (0..12)
+        .map(|_| ALPHABET[rng.gen_range(0..ALPHABET.len())] as char)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(session: &str, n: i64) -> Value {
+        json!({ "session_id": session, "n": n })
+    }
+
+    fn snap(body: Vec<u8>) -> Snapshot {
+        Snapshot {
+            snapshot_id: "s".into(),
+            head_migration: "m001".into(),
+            body,
+            sha256_hex: "x".into(),
+        }
+    }
+
+    #[test]
+    fn cap_per_session_restores_chronological_order() {
+        // Rows arrive newest-first (created_at DESC); the cap keeps that order
+        // then reverses, so the client receives oldest-first within the window.
+        let newest_first = vec![ev("s1", 3), ev("s1", 2), ev("s1", 1)];
+        let ns: Vec<i64> = cap_per_session(newest_first)
+            .iter()
+            .map(|e| e["n"].as_i64().unwrap())
+            .collect();
+        assert_eq!(ns, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn cap_per_session_keeps_newest_window_and_drops_oldest() {
+        // 502 events newest-first: n = 502 (newest) .. 1 (oldest).
+        let newest_first: Vec<Value> = (1..=502).rev().map(|n| ev("s1", n)).collect();
+        let kept = cap_per_session(newest_first);
+        assert_eq!(kept.len(), TRANSCRIPT_MAX_EVENTS);
+        let ns: Vec<i64> = kept.iter().map(|e| e["n"].as_i64().unwrap()).collect();
+        // Oldest two (n=1,2) dropped; window is n=3..=502, chronological.
+        assert_eq!(*ns.first().unwrap(), 3);
+        assert_eq!(*ns.last().unwrap(), 502);
+    }
+
+    #[test]
+    fn cap_per_session_counts_each_session_independently() {
+        let mut input: Vec<Value> = (1..=600).rev().map(|n| ev("s1", n)).collect();
+        input.push(ev("s2", 1));
+        let kept = cap_per_session(input);
+        let s1 = kept.iter().filter(|e| e["session_id"] == "s1").count();
+        let s2 = kept.iter().filter(|e| e["session_id"] == "s2").count();
+        assert_eq!(s1, TRANSCRIPT_MAX_EVENTS);
+        assert_eq!(s2, 1);
+    }
+
+    #[test]
+    fn embed_json_column_parses_text_into_structured_value() {
+        let rows = vec![json!({ "branch": "main", "pr_json": "{\"number\":7,\"state\":\"open\"}" })];
+        let out = embed_json_column(rows, "pr_json");
+        assert_eq!(out[0]["pr_json"]["number"], json!(7));
+        assert_eq!(out[0]["pr_json"]["state"], json!("open"));
+    }
+
+    #[test]
+    fn embed_json_column_leaves_non_json_and_missing_untouched() {
+        let rows = vec![json!({ "pr_json": "not json at all" }), json!({ "other": 1 })];
+        let out = embed_json_column(rows, "pr_json");
+        assert_eq!(out[0]["pr_json"], json!("not json at all"));
+        assert!(out[1].get("pr_json").is_none());
+    }
+
+    #[test]
+    fn parse_turn_events_embeds_payload() {
+        let events = vec![json!({ "id": "e1", "payload": "{\"kind\":\"delta\"}" })];
+        let out = parse_turn_events(events);
+        assert_eq!(out[0]["payload"]["kind"], json!("delta"));
+    }
+
+    #[test]
+    fn total_chunks_handles_empty_exact_and_overflow_boundaries() {
+        assert_eq!(snap(vec![]).total_chunks(), 0);
+        assert_eq!(snap(vec![0u8; CHUNK_RAW_BYTES]).total_chunks(), 1);
+        assert_eq!(snap(vec![0u8; CHUNK_RAW_BYTES + 1]).total_chunks(), 2);
+    }
+
+    #[test]
+    fn chunk_b64_roundtrips_the_whole_body() {
+        let body: Vec<u8> = (0..(CHUNK_RAW_BYTES * 2 + 123)).map(|i| (i % 256) as u8).collect();
+        let s = snap(body.clone());
+        let mut reassembled = Vec::new();
+        for i in 0..s.total_chunks() {
+            let decoded = base64::engine::general_purpose::STANDARD
+                .decode(s.chunk_b64(i))
+                .expect("valid base64");
+            reassembled.extend(decoded);
+        }
+        assert_eq!(reassembled, body);
+    }
+
+    #[test]
+    fn civil_from_days_matches_known_dates() {
+        // Cross-checked against Unix epoch-day arithmetic (ts / 86400).
+        assert_eq!(civil_from_days(0), (1970, 1, 1));
+        assert_eq!(civil_from_days(10957), (2000, 1, 1));
+        assert_eq!(civil_from_days(18321), (2020, 2, 29)); // leap day
+    }
+
+    #[test]
+    fn iso_now_is_well_formed_rfc3339() {
+        let s = iso_now();
+        assert_eq!(s.len(), 24, "unexpected format: {s}");
+        assert!(s.ends_with(".000Z"), "missing millis/zulu: {s}");
+        let year: i64 = s[0..4].parse().expect("year");
+        assert!(year >= 2025, "year looks wrong: {s}");
+    }
+}

--- a/apps/desktop/src-tauri/src/bridge/tokens.rs
+++ b/apps/desktop/src-tauri/src/bridge/tokens.rs
@@ -1,0 +1,60 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// One-time pairing tokens. Minted at QR display, validated once at handshake
+/// msg1, then burned. TTL mirrors PROTOCOL.md (~60 s from QR generation).
+pub struct TokenStore {
+    entries: Mutex<Vec<Entry>>,
+    ttl: Duration,
+}
+
+struct Entry {
+    token: Vec<u8>,
+    expires_at: Instant,
+}
+
+impl TokenStore {
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(Vec::new()),
+            ttl: Duration::from_secs(60),
+        }
+    }
+
+    /// Mints a fresh 256-bit single-use token and stores it with a TTL.
+    pub fn mint(&self) -> Vec<u8> {
+        use rand::RngCore;
+        let mut token = vec![0u8; 32];
+        rand::thread_rng().fill_bytes(&mut token);
+        let mut guard = self.entries.lock().unwrap();
+        guard.retain(|e| e.expires_at > Instant::now());
+        guard.push(Entry {
+            token: token.clone(),
+            expires_at: Instant::now() + self.ttl,
+        });
+        token
+    }
+
+    /// Validates and burns a token: true iff present and unexpired. Single-use —
+    /// a matching entry is removed so it can never be replayed.
+    pub fn consume(&self, token: &[u8]) -> bool {
+        let mut guard = self.entries.lock().unwrap();
+        let now = Instant::now();
+        guard.retain(|e| e.expires_at > now);
+        if let Some(pos) = guard
+            .iter()
+            .position(|e| e.token.len() == token.len() && e.token == token)
+        {
+            guard.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl Default for TokenStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -68,7 +68,7 @@ pub fn open() -> Result<Db, DbError> {
 ///   3. Release builds (the shipped app) -> `data.db`, the production file.
 /// Splitting on `debug_assertions` keeps local experiments off the prod DB
 /// automatically, with no env setup required.
-fn resolve_db_path() -> Result<PathBuf, DbError> {
+pub fn resolve_db_path() -> Result<PathBuf, DbError> {
     let home = dirs::home_dir().ok_or(DbError::NoHomeDir)?;
     let dir = home.join(APP_DIR);
 
@@ -182,7 +182,7 @@ pub fn db_select(
     Ok(out)
 }
 
-fn value_to_json(value: ValueRef<'_>) -> serde_json::Value {
+pub fn value_to_json(value: ValueRef<'_>) -> serde_json::Value {
     match value {
         ValueRef::Null => serde_json::Value::Null,
         ValueRef::Integer(n) => serde_json::Value::Number(Number::from(n)),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod attachment;
+mod bridge;
 mod budget;
 mod config_export;
 mod db;
@@ -50,6 +51,7 @@ pub fn run() {
     #[cfg(target_os = "macos")]
     suppress_webkit_media_remote();
   let database = db::open().expect("failed to open Goodboy database");
+  let bridge_state = bridge::BridgeState::new().expect("failed to init companion bridge");
   let provider_state = providers::ProviderState(Mutex::new(providers::detect_claude()));
   let cursor_state = providers::CursorState(Mutex::new(providers::detect_cursor()));
   let codex_state = providers::CodexState(Mutex::new(providers::detect_codex()));
@@ -66,6 +68,7 @@ pub fn run() {
     .plugin(tauri_plugin_dialog::init())
     .plugin(tauri_plugin_process::init())
     .manage(database)
+    .manage(bridge_state)
     .manage(provider_state)
     .manage(cursor_state)
     .manage(codex_state)
@@ -104,6 +107,11 @@ pub fn run() {
       db::db_execute,
       db::db_select,
       db::db_wipe,
+      bridge::bridge_start,
+      bridge::bridge_stop,
+      bridge::bridge_status,
+      bridge::bridge_command_result,
+      bridge::bridge_revoke,
       worktree::worktree_create,
       worktree::worktree_remove,
       worktree::worktree_list,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -33,6 +33,8 @@ import { ghCommitDiff } from './features/github/github';
 import { worktreeDiffCommit } from './features/worktree/worktree';
 import { OnboardingCard } from './features/onboarding/OnboardingCard';
 import { OnboardingWizard } from './features/onboarding/OnboardingWizard';
+import { CompanionStudio } from './features/companion/CompanionStudio';
+import { listenBridgeCommands } from './features/companion/commandExecutor';
 import { markStepComplete } from './features/onboarding/onboarding-store';
 import { useKeyboardShortcut } from './shared/hooks/useKeyboardShortcut';
 import { useProviderRefreshOnFocus } from './shared/hooks/useProviderRefreshOnFocus';
@@ -63,6 +65,7 @@ export const App = () => {
   const hasWorkspaces = workspaces.length > 0;
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
+  const [companionOpen, setCompanionOpen] = useState(false);
   const [appSettingsOpen, setAppSettingsOpen] = useState(false);
   const [appSettingsFocus, setAppSettingsFocus] = useState<string | undefined>(undefined);
   const [workspaceSettingsOpen, setWorkspaceSettingsOpen] = useState(false);
@@ -372,6 +375,22 @@ export const App = () => {
   }, []);
 
   useEffect(() => {
+    let off: (() => void) | undefined;
+    let cancelled = false;
+    void listenBridgeCommands().then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      off = fn;
+    });
+    return () => {
+      cancelled = true;
+      off?.();
+    };
+  }, []);
+
+  useEffect(() => {
     const handler = () => setSwitcherOpen(true);
     window.addEventListener('goodboy:open-workspace-switcher', handler);
     return () => window.removeEventListener('goodboy:open-workspace-switcher', handler);
@@ -564,6 +583,16 @@ export const App = () => {
   useKeyboardShortcut('cmd+7', () => selectWorkspaceByIndex(6), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+8', () => selectWorkspaceByIndex(7), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+9', () => selectWorkspaceByIndex(8), { ignoreInInputs: false });
+  // Hidden pairing surface — undocumented on purpose, no menu/help entry.
+  useKeyboardShortcut('cmd+ctrl+shift+m', () => setCompanionOpen((v) => !v), {
+    ignoreInInputs: false,
+  });
+
+  useEffect(() => {
+    const handler = () => setCompanionOpen(true);
+    window.addEventListener('goodboy:open-pair-device', handler);
+    return () => window.removeEventListener('goodboy:open-pair-device', handler);
+  }, []);
 
   const renderedSessionIds = useMemo<ReadonlyArray<SessionId>>(() => {
     const cid = currentSession?.id ?? null;
@@ -799,6 +828,8 @@ export const App = () => {
         <ArchiveSessionDialog session={currentSession} open onClose={() => setArchiveOpen(false)} />
       ) : null}
       {switcherOpen ? <WorkspaceSwitcher onClose={() => setSwitcherOpen(false)} /> : null}
+
+      {companionOpen ? <CompanionStudio onClose={() => setCompanionOpen(false)} /> : null}
 
       <OnboardingWizard />
     </ToastProvider>

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -1,6 +1,9 @@
+import { useEffect, useState } from 'react';
+import { Smartphone } from 'lucide-react';
 import { Divider } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 import { UpdateIndicator } from '../../../features/updater/components/UpdateIndicator';
+import { bridgeStatus } from '../../../features/companion/bridge';
 
 export const AppTopBar = () => (
   <>
@@ -13,10 +16,64 @@ export const AppTopBar = () => (
         <span className="text-xs font-semibold tracking-tight text-foreground">Goodboy</span>
         <UpdateIndicator variant="pip" />
       </div>
-      <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary ring-1 ring-primary/15">
-        Beta
-      </span>
+      <div className="flex items-center gap-2">
+        <PairDeviceCta />
+        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary ring-1 ring-primary/15">
+          Beta
+        </span>
+      </div>
     </div>
     <Divider />
   </>
 );
+
+// App-header pairing entry-point, beside the Beta chip — twin of the hidden
+// cmd+ctrl+shift+m shortcut. Polls bridge status to surface a presence dot.
+function PairDeviceCta() {
+  const [linked, setLinked] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    const refresh = () => {
+      bridgeStatus()
+        .then((s) => {
+          if (active) setLinked(s.running && s.enrolledCount > 0);
+        })
+        .catch(() => {});
+    };
+    refresh();
+    const id = window.setInterval(refresh, 5000);
+    const onChanged = () => refresh();
+    window.addEventListener('goodboy:bridge-paired-changed', onChanged);
+    return () => {
+      active = false;
+      window.clearInterval(id);
+      window.removeEventListener('goodboy:bridge-paired-changed', onChanged);
+    };
+  }, []);
+
+  const label = linked ? 'iPhone linked — manage' : 'Pair your iPhone';
+
+  return (
+    <button
+      type="button"
+      onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-pair-device'))}
+      title={label}
+      aria-label={label}
+      className="group/pair relative inline-flex shrink-0 items-center gap-1 rounded-full border border-border-soft/70 bg-gradient-to-b from-muted/40 to-muted/10 px-2 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm transition-all hover:border-primary/40 hover:from-primary/15 hover:to-primary/5 hover:text-primary hover:shadow-md"
+    >
+      <Smartphone
+        size={11}
+        aria-hidden
+        className="transition-transform duration-200 group-hover/pair:-rotate-6 group-hover/pair:scale-110"
+      />
+      <span>Pair</span>
+      {linked ? (
+        <span aria-hidden className="relative ml-0.5 flex size-1.5">
+          <span className="absolute inline-flex size-full animate-ping rounded-full bg-success opacity-75" />
+          <span className="relative inline-flex size-1.5 rounded-full bg-success" />
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/apps/desktop/src/features/companion/CompanionStudio.tsx
+++ b/apps/desktop/src/features/companion/CompanionStudio.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FlaskConical, Loader2, RefreshCw, Smartphone, Unplug } from 'lucide-react';
+import { StudioShell } from '../../shared/components/StudioShell';
+import { bridgeRevoke, bridgeStart, bridgeStatus, type BridgeStatus, type QrInfo } from './bridge';
+import { clearMobileSharedSessions } from './mobileConfinement';
+
+type Props = {
+  readonly onClose: () => void;
+};
+
+function barColor(remaining: number, total: number): string {
+  const ratio = total > 0 ? remaining / total : 0;
+  if (ratio <= 0.15) return 'var(--color-danger, #ef4444)';
+  if (ratio <= 0.35) return 'var(--color-warning, #f59e0b)';
+  return 'var(--color-success, #22c55e)';
+}
+
+/**
+ * Full-page pairing surface for Goodboy Mobile, rendered like the Settings
+ * studio (StudioShell). Starts the companion bridge, shows a single-use QR with
+ * an auto-reminting countdown bar, and lets the human disconnect a paired phone.
+ */
+export const CompanionStudio = ({ onClose }: Props) => {
+  const [info, setInfo] = useState<QrInfo | null>(null);
+  const [status, setStatus] = useState<BridgeStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [revoking, setRevoking] = useState(false);
+  const [remaining, setRemaining] = useState(0);
+  const totalRef = useRef(0);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      setStatus(await bridgeStatus());
+    } catch {
+      setStatus(null);
+    }
+  }, []);
+
+  const mint = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const next = await bridgeStart();
+      totalRef.current = next.expiresInSecs;
+      setRemaining(next.expiresInSecs);
+      setInfo(next);
+      await refreshStatus();
+    } catch (e) {
+      setError(String(e));
+      setInfo(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [refreshStatus]);
+
+  const revoke = useCallback(async () => {
+    setRevoking(true);
+    setError(null);
+    try {
+      await bridgeRevoke();
+      clearMobileSharedSessions();
+      window.dispatchEvent(new CustomEvent('goodboy:bridge-paired-changed'));
+      await mint();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setRevoking(false);
+    }
+  }, [mint]);
+
+  useEffect(() => {
+    void mint();
+  }, [mint]);
+
+  useEffect(() => {
+    if (!info) return;
+    const id = setInterval(() => setRemaining((r) => Math.max(0, r - 1)), 1000);
+    return () => clearInterval(id);
+  }, [info]);
+
+  useEffect(() => {
+    if (info && remaining === 0 && !loading) {
+      void mint();
+    }
+  }, [remaining, info, loading, mint]);
+
+  const enrolled = status?.enrolledCount ?? 0;
+  const total = totalRef.current || 1;
+
+  return (
+    <StudioShell
+      icon={Smartphone}
+      title="Pair device"
+      workspaceName="Connect Goodboy Mobile"
+      closeLabel="Close pairing"
+      onClose={onClose}
+    >
+      {() => (
+        <div className="flex h-full min-h-0 w-full items-center justify-center overflow-y-auto">
+          <div className="mx-auto flex w-full max-w-md flex-col items-center gap-7 px-8 py-10">
+            <div className="flex flex-col items-center gap-1.5 text-center">
+              <h2 className="text-lg font-semibold tracking-tight text-foreground">Scan to pair</h2>
+              <p className="max-w-[18rem] text-2xs text-muted-foreground">
+                Open Goodboy on your iPhone and point the camera at this code.
+              </p>
+            </div>
+
+            <div className="flex max-w-[20rem] items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-left">
+              <FlaskConical size={13} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+              <p className="text-2xs leading-relaxed text-warning">
+                This feature is currently in testing. Contact the developer to get access before
+                trying it out.
+              </p>
+            </div>
+
+            {loading && !info ? (
+              <div className="grid size-[300px] place-items-center">
+                <Loader2 size={28} aria-hidden className="animate-spin text-muted-foreground" />
+              </div>
+            ) : error ? (
+              <div className="flex size-[300px] flex-col items-center justify-center gap-3">
+                <p className="text-center text-xs text-danger">{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void mint()}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/50"
+                >
+                  <RefreshCw size={13} aria-hidden /> Retry
+                </button>
+              </div>
+            ) : info ? (
+              <>
+                <div className="flex flex-col items-center gap-3.5">
+                  <div
+                    className="size-[244px] rounded-2xl border border-border-soft bg-white p-3.5 shadow-[0_8px_30px_rgba(0,0,0,0.12)] [&>svg]:h-full [&>svg]:w-full"
+                    // QR SVG is generated server-side from a value we control (the
+                    // pairing payload), never from untrusted input.
+                    dangerouslySetInnerHTML={{ __html: info.svg }}
+                  />
+                  <div className="flex w-[244px] flex-col items-center gap-1.5">
+                    <div
+                      className="h-1.5 w-full overflow-hidden rounded-full bg-border-soft/60"
+                      role="progressbar"
+                      aria-valuenow={remaining}
+                      aria-valuemin={0}
+                      aria-valuemax={total}
+                    >
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${(Math.min(remaining, total) / total) * 100}%`,
+                          backgroundColor: barColor(remaining, total),
+                          transition: 'width 1s linear, background-color 0.4s ease',
+                        }}
+                      />
+                    </div>
+                    <span className="text-2xs font-semibold tabular-nums text-muted-foreground">
+                      Expires in {remaining}s
+                    </span>
+                  </div>
+                </div>
+
+                <div className="flex flex-col items-center gap-2.5">
+                  <button
+                    type="button"
+                    onClick={() => void mint()}
+                    className="inline-flex items-center gap-1.5 rounded-md border border-border-soft px-3 py-1.5 text-xs font-medium text-foreground transition-colors hover:bg-muted/50"
+                  >
+                    <RefreshCw size={13} aria-hidden /> New code
+                  </button>
+                  <p className="max-w-[18rem] text-center text-2xs text-muted-foreground">
+                    A new code is minted automatically when this one expires. Only one device can be
+                    linked at a time.
+                  </p>
+                </div>
+
+                {enrolled > 0 ? (
+                  <div className="flex w-full flex-col items-center gap-2.5 border-t border-border-soft/60 pt-5">
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-success/15 px-2.5 py-0.5 text-2xs font-semibold text-success">
+                      <span aria-hidden className="size-1.5 rounded-full bg-success" />
+                      {enrolled} paired {enrolled === 1 ? 'device' : 'devices'}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={revoking}
+                      onClick={() => void revoke()}
+                      className="inline-flex items-center gap-1.5 rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5 text-xs font-semibold text-danger transition-colors hover:border-danger/60 hover:bg-danger/15 disabled:opacity-50"
+                    >
+                      <Unplug size={13} aria-hidden />
+                      {revoking ? 'Disconnecting…' : 'Disconnect phone'}
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </StudioShell>
+  );
+};

--- a/apps/desktop/src/features/companion/bridge.ts
+++ b/apps/desktop/src/features/companion/bridge.ts
@@ -1,0 +1,30 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export type QrInfo = {
+  payload: string;
+  svg: string;
+  deviceName: string;
+  port: number;
+  expiresInSecs: number;
+};
+
+export type BridgeStatus = {
+  running: boolean;
+  port: number | null;
+  enrolledCount: number;
+};
+
+/** Starts the companion bridge (idempotent) and mints a fresh pairing QR. */
+export const bridgeStart = (): Promise<QrInfo> => invoke<QrInfo>('bridge_start');
+
+/** Stops the companion bridge and drops the accept loop. */
+export const bridgeStop = (): Promise<void> => invoke<void>('bridge_stop');
+
+/**
+ * Desktop-initiated disconnect: forgets every paired phone and tears the bridge
+ * down (any live connection is dropped). The phone must re-scan a QR to pair
+ * again — the desktop-side twin of the phone's own "Forget device".
+ */
+export const bridgeRevoke = (): Promise<void> => invoke<void>('bridge_revoke');
+
+export const bridgeStatus = (): Promise<BridgeStatus> => invoke<BridgeStatus>('bridge_status');

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -40,7 +40,7 @@ const core = vi.hoisted(() => {
     isSlotKey: (k: string) => SLOT_KEY_SET.has(k),
     PROVIDER_CAPABILITIES,
     getDefaultTurnModel: (id: string) => {
-      const caps = PROVIDER_CAPABILITIES[id];
+      const caps = PROVIDER_CAPABILITIES[id]!;
       return caps.models.find((m) => m.tier === 'turn')?.id ?? caps.models[0]!.id;
     },
     // Real implementation from packages/core/src/workflows/sequencer.ts.
@@ -81,7 +81,7 @@ function cmd(kind: string, data: unknown, origin: 'desktop' | 'mobile' = 'mobile
   return { id: 'c1', kind, origin, data };
 }
 
-const lastCall = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls[spy.mock.calls.length - 1];
+const lastCall = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls[spy.mock.calls.length - 1]!;
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -1,0 +1,370 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BridgeCommand } from './commandExecutor';
+
+// Hermetic mocks, mirroring commandExecutor.test.ts. This file exercises the
+// command kinds the sibling suite leaves untested: queryProviders, advanceStep,
+// setContextSlot, the provider-override coercion, and the full spawnAgent option
+// mapping. The `@goodboy/core` stubs reproduce the *real* behaviour the guard
+// relies on — the genuine SLOT_KEYS set (so the editable allow-list is tested
+// against the same keys production uses) and a faithful runsForWorkflowRun.
+const h = vi.hoisted(() => ({
+  sendTurn: vi.fn(() => Promise.resolve()),
+  spawnAgent: vi.fn(() => Promise.resolve()),
+  activateWorkflowAgent: vi.fn(() => Promise.resolve()),
+  activateNextResolver: vi.fn(() => Promise.resolve()),
+  upsertSessionSlot: vi.fn(() => Promise.resolve()),
+  state: { value: null as unknown },
+}));
+
+const core = vi.hoisted(() => {
+  // Mirrors packages/core/src/context/slots.ts exactly.
+  const SLOT_KEY_SET = new Set([
+    'goal',
+    'files_touched',
+    'decisions',
+    'open_questions',
+    'last_output_summary',
+  ]);
+  const PROVIDER_CAPABILITIES = {
+    anthropic: {
+      models: [
+        { id: 'claude-opus-4-8', label: 'Opus 4.8', tier: 'turn' },
+        { id: 'claude-haiku', label: 'Haiku', tier: 'utility' },
+      ],
+    },
+    cursor: { models: [{ id: 'cursor-fast', label: 'Cursor Fast', tier: 'turn' }] },
+    codex: { models: [{ id: 'gpt-5-codex', label: 'Codex', tier: 'turn' }] },
+    gemini: { models: [{ id: 'gemini-2-pro', label: 'Gemini Pro', tier: 'turn' }] },
+  } as Record<string, { models: Array<{ id: string; label: string; tier: string }> }>;
+  return {
+    isSlotKey: (k: string) => SLOT_KEY_SET.has(k),
+    PROVIDER_CAPABILITIES,
+    getDefaultTurnModel: (id: string) => {
+      const caps = PROVIDER_CAPABILITIES[id];
+      return caps.models.find((m) => m.tier === 'turn')?.id ?? caps.models[0]!.id;
+    },
+    // Real implementation from packages/core/src/workflows/sequencer.ts.
+    runsForWorkflowRun: (runs: ReadonlyArray<{ workflowRunId?: string }>, id: string) =>
+      runs.filter((r) => r.workflowRunId === id),
+  };
+});
+
+vi.mock('../../store/store', () => ({ useAppStore: { getState: () => h.state.value } }));
+vi.mock('@goodboy/core', () => core);
+vi.mock('../providers/providers', () => ({
+  PROVIDER_LABEL_LOWER: { anthropic: 'claude', cursor: 'cursor', codex: 'codex', gemini: 'gemini' },
+}));
+vi.mock('../workspace/window', () => ({ isMainWindow: () => true }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+import { executeBridgeCommand } from './commandExecutor';
+import { clearMobileSharedSessions, isSessionMobileShared } from './mobileConfinement';
+import type { SessionId } from '@goodboy/types';
+
+function makeStore(over: Record<string, unknown> = {}) {
+  return {
+    sessions: [{ id: 's1', workspaceId: 'w1', workflowRuns: [] }],
+    providers: [],
+    phaseTemplates: {},
+    sessionPhaseRuns: {},
+    sendTurn: h.sendTurn,
+    spawnAgent: h.spawnAgent,
+    activateWorkflowAgent: h.activateWorkflowAgent,
+    activateNextResolver: h.activateNextResolver,
+    upsertSessionSlot: h.upsertSessionSlot,
+    ...over,
+  };
+}
+
+function cmd(kind: string, data: unknown, origin: 'desktop' | 'mobile' = 'mobile'): BridgeCommand {
+  return { id: 'c1', kind, origin, data };
+}
+
+const lastCall = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls[spy.mock.calls.length - 1];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearMobileSharedSessions();
+  h.state.value = makeStore();
+});
+
+describe('queryProviders (read-only menu RPC)', () => {
+  it('returns the full closed provider set without needing a session', async () => {
+    const res = await executeBridgeCommand(cmd('queryProviders', {}));
+    expect(res.ok).toBe(true);
+    const providers = (res.data as { providers: Array<{ id: string }> }).providers;
+    expect(providers.map((p) => p.id)).toEqual(['anthropic', 'cursor', 'codex', 'gemini']);
+  });
+
+  it('reflects live connection state from the store and lists models per provider', async () => {
+    h.state.value = makeStore({
+      providers: [{ id: 'anthropic', label: 'claude', connection: 'connected' }],
+    });
+    const res = await executeBridgeCommand(cmd('queryProviders', {}));
+    const providers = (
+      res.data as {
+        providers: Array<{
+          id: string;
+          connection: string;
+          defaultModel: string;
+          models: unknown[];
+        }>;
+      }
+    ).providers;
+    const anthropic = providers.find((p) => p.id === 'anthropic')!;
+    const codex = providers.find((p) => p.id === 'codex')!;
+    expect(anthropic.connection).toBe('connected');
+    expect(anthropic.defaultModel).toBe('claude-opus-4-8');
+    expect(codex.connection).toBe('missing'); // not in store → falls back
+    expect(anthropic.models.length).toBeGreaterThan(0);
+  });
+
+  it('does not mark any session shared (read-only)', async () => {
+    await executeBridgeCommand(cmd('queryProviders', {}));
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(false);
+  });
+});
+
+describe('setContextSlot editable allow-list', () => {
+  it('writes an editable slot and confines the session', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'goal', value: 'ship the bridge' }),
+    );
+    expect(res.ok).toBe(true);
+    expect(h.upsertSessionSlot).toHaveBeenCalledWith('s1', 'goal', 'ship the bridge');
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
+  });
+
+  it.each(['goal', 'decisions', 'open_questions', 'last_output_summary'])(
+    'accepts editable slot %s',
+    async (key) => {
+      const res = await executeBridgeCommand(
+        cmd('setContextSlot', { sessionId: 's1', key, value: 'x' }),
+      );
+      expect(res.ok).toBe(true);
+      expect(h.upsertSessionSlot).toHaveBeenCalledWith('s1', key, 'x');
+    },
+  );
+
+  it('rejects files_touched even though it is a valid slot key (machine-derived)', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'files_touched', value: '/etc/passwd' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not editable from mobile/i);
+    expect(h.upsertSessionSlot).not.toHaveBeenCalled();
+  });
+
+  it('rejects a key that is not a slot key at all', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'secrets', value: 'x' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not editable from mobile/i);
+    expect(h.upsertSessionSlot).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing key', async () => {
+    const res = await executeBridgeCommand(cmd('setContextSlot', { sessionId: 's1', value: 'x' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not editable from mobile/i);
+  });
+
+  it('rejects an absent value (only string values are allowed)', async () => {
+    const res = await executeBridgeCommand(cmd('setContextSlot', { sessionId: 's1', key: 'goal' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/requires a string value/i);
+    expect(h.upsertSessionSlot).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-string value', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'goal', value: 42 }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/requires a string value/i);
+  });
+
+  it('allows an explicit empty string to clear a slot', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'decisions', value: '' }),
+    );
+    expect(res.ok).toBe(true);
+    expect(h.upsertSessionSlot).toHaveBeenCalledWith('s1', 'decisions', '');
+  });
+
+  it('still enforces session scoping', async () => {
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 'ghost', key: 'goal', value: 'x' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown session/i);
+  });
+});
+
+describe('provider/model override coercion', () => {
+  it('forwards a whitelisted provider + model on send', async () => {
+    await executeBridgeCommand(
+      cmd('send', { sessionId: 's1', content: 'go', providerId: 'codex', model: 'gpt-5-codex' }),
+    );
+    expect(h.sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ override: { providerId: 'codex', model: 'gpt-5-codex' } }),
+    );
+  });
+
+  it('drops an override whose provider is outside the closed set', async () => {
+    await executeBridgeCommand(
+      cmd('send', { sessionId: 's1', content: 'go', providerId: 'openai', model: 'gpt-4' }),
+    );
+    const arg = lastCall(h.sendTurn)[0] as Record<string, unknown>;
+    expect(arg.override).toBeUndefined();
+  });
+
+  it('forwards a provider with no model (provider-only override)', async () => {
+    await executeBridgeCommand(
+      cmd('send', { sessionId: 's1', content: 'go', providerId: 'gemini' }),
+    );
+    expect(h.sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ override: { providerId: 'gemini' } }),
+    );
+  });
+});
+
+describe('spawnAgent option mapping', () => {
+  it('maps name, prompt, whitelisted kind and override into store options', async () => {
+    const res = await executeBridgeCommand(
+      cmd('spawnAgent', {
+        sessionId: 's1',
+        name: 'Scout A',
+        prompt: 'investigate the flake',
+        kind: 'scout',
+        providerId: 'codex',
+        model: 'gpt-5-codex',
+      }),
+    );
+    expect(res.ok).toBe(true);
+    expect(h.spawnAgent).toHaveBeenCalledWith('s1', {
+      name: 'Scout A',
+      initialPrompt: 'investigate the flake',
+      kindOverride: 'scout',
+      provider: 'codex',
+      model: 'gpt-5-codex',
+    });
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
+  });
+
+  it('spawns with no options (plan-approval affordance: desktop auto-selects)', async () => {
+    const res = await executeBridgeCommand(cmd('spawnAgent', { sessionId: 's1' }));
+    expect(res.ok).toBe(true);
+    expect(h.spawnAgent).toHaveBeenCalledWith('s1', {});
+  });
+});
+
+describe('advanceStep workflow advancement', () => {
+  function workflowStore(
+    over: { runs?: unknown[]; phaseRuns?: unknown[]; discardedAt?: string | null } = {},
+  ) {
+    const discardedAt = over.discardedAt ?? null;
+    return makeStore({
+      sessions: [
+        {
+          id: 's1',
+          workspaceId: 'w1',
+          workflowRuns: over.runs ?? [{ id: 'run1', workflowId: 'wf1', discardedAt }],
+        },
+      ],
+      phaseTemplates: {
+        w1: [
+          {
+            id: 'wf1',
+            steps: [
+              { id: 'step1', ordinal: 0 },
+              { id: 'step2', ordinal: 1 },
+            ],
+          },
+        ],
+      },
+      sessionPhaseRuns: { s1: over.phaseRuns ?? [] },
+    });
+  }
+
+  it('activates the next pending step whose predecessors are complete', async () => {
+    h.state.value = workflowStore({
+      phaseRuns: [
+        { id: 'ag1', workflowRunId: 'run1', stepId: 'step1', status: 'completed' },
+        { id: 'ag2', workflowRunId: 'run1', stepId: 'step2', status: 'pending' },
+      ],
+    });
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+    expect(res.ok).toBe(true);
+    expect(h.activateWorkflowAgent).toHaveBeenCalledWith('s1', 'ag2');
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
+  });
+
+  it('activates the first step when nothing has run yet (no predecessors)', async () => {
+    h.state.value = workflowStore({
+      phaseRuns: [{ id: 'ag1', workflowRunId: 'run1', stepId: 'step1', status: 'pending' }],
+    });
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+    expect(res.ok).toBe(true);
+    expect(h.activateWorkflowAgent).toHaveBeenCalledWith('s1', 'ag1');
+  });
+
+  it('refuses to skip ahead when an earlier step is still running', async () => {
+    h.state.value = workflowStore({
+      phaseRuns: [
+        { id: 'ag1', workflowRunId: 'run1', stepId: 'step1', status: 'running' },
+        { id: 'ag2', workflowRunId: 'run1', stepId: 'step2', status: 'pending' },
+      ],
+    });
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/no workflow step is ready/i);
+    expect(h.activateWorkflowAgent).not.toHaveBeenCalled();
+  });
+
+  it('errors when the session has no workflow at all', async () => {
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/no workflow to advance/i);
+  });
+
+  it('treats a discarded run as having no advanceable step', async () => {
+    h.state.value = workflowStore({
+      discardedAt: '2026-01-01T00:00:00Z',
+      phaseRuns: [{ id: 'ag1', workflowRunId: 'run1', stepId: 'step1', status: 'pending' }],
+    });
+    const res = await executeBridgeCommand(cmd('advanceStep', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/no workflow step is ready/i);
+    expect(h.activateWorkflowAgent).not.toHaveBeenCalled();
+  });
+});
+
+describe('send attachments-only happy path', () => {
+  it('accepts a turn with no text but a well-formed attachment', async () => {
+    const res = await executeBridgeCommand(
+      cmd('send', {
+        sessionId: 's1',
+        content: '',
+        attachments: [{ id: 'a', fileName: 'a.jpg', mimeType: 'image/jpeg', dataBase64: 'AAA' }],
+      }),
+    );
+    expect(res.ok).toBe(true);
+    const arg = lastCall(h.sendTurn)[0] as { attachments?: unknown[] };
+    expect(arg.attachments).toHaveLength(1);
+  });
+});
+
+describe('resolveComment thread metadata', () => {
+  it('forwards threadId as sourceThreadId', async () => {
+    await executeBridgeCommand(
+      cmd('resolveComment', { sessionId: 's1', prompt: 'address bob', threadId: 'T42' }),
+    );
+    expect(h.spawnAgent).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ kindOverride: 'resolver', sourceThreadId: 'T42' }),
+    );
+  });
+});

--- a/apps/desktop/src/features/companion/commandExecutor.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.test.ts
@@ -6,10 +6,10 @@ import type { BridgeCommand } from './commandExecutor';
 // helper and the tauri event/core bridges at module load. The guard logic we
 // test here touches none of that machinery directly, so stub it all out.
 const h = vi.hoisted(() => ({
-  sendTurn: vi.fn(() => Promise.resolve()),
-  spawnAgent: vi.fn(() => Promise.resolve()),
-  activateWorkflowAgent: vi.fn(() => Promise.resolve()),
-  activateNextResolver: vi.fn(() => Promise.resolve()),
+  sendTurn: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  spawnAgent: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  activateWorkflowAgent: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  activateNextResolver: vi.fn((..._args: unknown[]) => Promise.resolve()),
   state: { value: null as unknown },
 }));
 
@@ -110,7 +110,7 @@ describe('send', () => {
         ],
       }),
     );
-    const arg = h.sendTurn.mock.calls[0][0] as { attachments?: unknown[] };
+    const arg = h.sendTurn.mock.calls[0]![0] as { attachments?: unknown[] };
     expect(arg.attachments).toHaveLength(1);
   });
 });
@@ -130,7 +130,7 @@ describe('spawnAgent kind allow-list', () => {
   it('drops a kind that is not on the allow-list (no override → safe default)', async () => {
     const res = await executeBridgeCommand(cmd('spawnAgent', { sessionId: 's1', kind: 'root' }));
     expect(res.ok).toBe(true);
-    const opts = h.spawnAgent.mock.calls[0][1] as Record<string, unknown>;
+    const opts = h.spawnAgent.mock.calls[0]![1] as Record<string, unknown>;
     expect(opts.kindOverride).toBeUndefined();
   });
 });

--- a/apps/desktop/src/features/companion/commandExecutor.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+import type { BridgeCommand } from './commandExecutor';
+
+// Hermetic mocks: the executor pulls the whole app store, core, the window
+// helper and the tauri event/core bridges at module load. The guard logic we
+// test here touches none of that machinery directly, so stub it all out.
+const h = vi.hoisted(() => ({
+  sendTurn: vi.fn(() => Promise.resolve()),
+  spawnAgent: vi.fn(() => Promise.resolve()),
+  activateWorkflowAgent: vi.fn(() => Promise.resolve()),
+  activateNextResolver: vi.fn(() => Promise.resolve()),
+  state: { value: null as unknown },
+}));
+
+vi.mock('../../store/store', () => ({ useAppStore: { getState: () => h.state.value } }));
+vi.mock('@goodboy/core', () => ({ runsForWorkflowRun: () => [] }));
+vi.mock('../workspace/window', () => ({ isMainWindow: () => true }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+import { executeBridgeCommand } from './commandExecutor';
+import { clearMobileSharedSessions, isSessionMobileShared } from './mobileConfinement';
+
+function makeStore(over: Record<string, unknown> = {}) {
+  return {
+    sessions: [{ id: 's1', workspaceId: 'w1', workflowRuns: [] }],
+    phaseTemplates: {},
+    sessionPhaseRuns: {},
+    sendTurn: h.sendTurn,
+    spawnAgent: h.spawnAgent,
+    activateWorkflowAgent: h.activateWorkflowAgent,
+    activateNextResolver: h.activateNextResolver,
+    ...over,
+  };
+}
+
+function cmd(kind: string, data: unknown, origin: 'desktop' | 'mobile' = 'mobile'): BridgeCommand {
+  return { id: 'c1', kind, origin, data };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearMobileSharedSessions();
+  h.state.value = makeStore();
+});
+
+describe('origin enforcement', () => {
+  it('refuses a non-mobile origin instead of guessing', async () => {
+    const res = await executeBridgeCommand(
+      cmd('send', { sessionId: 's1', content: 'hi' }, 'desktop'),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/origin/i);
+    expect(h.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unknown command kind', async () => {
+    const res = await executeBridgeCommand(cmd('rmrf', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unsupported/i);
+  });
+});
+
+describe('session scoping', () => {
+  it('rejects a command for a session the desktop does not know', async () => {
+    const res = await executeBridgeCommand(cmd('send', { sessionId: 'ghost', content: 'hi' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown session/i);
+    expect(h.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('rejects a command with no sessionId', async () => {
+    const res = await executeBridgeCommand(cmd('send', { content: 'hi' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/missing sessionId/i);
+  });
+});
+
+describe('send', () => {
+  it('rejects an empty turn (no content, no attachments)', async () => {
+    const res = await executeBridgeCommand(cmd('send', { sessionId: 's1', content: '   ' }));
+    expect(res.ok).toBe(false);
+    expect(h.sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a valid turn and confines the session', async () => {
+    const res = await executeBridgeCommand(cmd('send', { sessionId: 's1', content: 'ship it' }));
+    expect(res.ok).toBe(true);
+    expect(h.sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 's1', content: 'ship it' }),
+    );
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
+  });
+
+  it('forwards an agentId when answering a specific agent', async () => {
+    await executeBridgeCommand(cmd('send', { sessionId: 's1', agentId: 'a9', content: 'yes' }));
+    expect(h.sendTurn).toHaveBeenCalledWith(expect.objectContaining({ agentId: 'a9' }));
+  });
+
+  it('keeps only well-formed attachments and drops malformed ones', async () => {
+    await executeBridgeCommand(
+      cmd('send', {
+        sessionId: 's1',
+        content: '',
+        attachments: [
+          { id: 'a', fileName: 'a.jpg', mimeType: 'image/jpeg', dataBase64: 'AAA' },
+          { id: 'b', fileName: 'b.jpg' }, // missing mimeType/data → dropped
+          'not-an-object',
+        ],
+      }),
+    );
+    const arg = h.sendTurn.mock.calls[0][0] as { attachments?: unknown[] };
+    expect(arg.attachments).toHaveLength(1);
+  });
+});
+
+describe('spawnAgent kind allow-list', () => {
+  it('passes a whitelisted kind through as an override', async () => {
+    const res = await executeBridgeCommand(
+      cmd('spawnAgent', { sessionId: 's1', kind: 'reviewer' }),
+    );
+    expect(res.ok).toBe(true);
+    expect(h.spawnAgent).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({ kindOverride: 'reviewer' }),
+    );
+  });
+
+  it('drops a kind that is not on the allow-list (no override → safe default)', async () => {
+    const res = await executeBridgeCommand(cmd('spawnAgent', { sessionId: 's1', kind: 'root' }));
+    expect(res.ok).toBe(true);
+    const opts = h.spawnAgent.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.kindOverride).toBeUndefined();
+  });
+});
+
+describe('resolveComment', () => {
+  it('requires a prompt describing the comment', async () => {
+    const res = await executeBridgeCommand(cmd('resolveComment', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(h.spawnAgent).not.toHaveBeenCalled();
+  });
+
+  it('spawns a resolver and activates it', async () => {
+    const res = await executeBridgeCommand(
+      cmd('resolveComment', {
+        sessionId: 's1',
+        prompt: 'address alice',
+        commentUrl: 'https://x/1',
+      }),
+    );
+    expect(res.ok).toBe(true);
+    expect(h.spawnAgent).toHaveBeenCalledWith(
+      's1',
+      expect.objectContaining({
+        kindOverride: 'resolver',
+        deferKickoff: true,
+        sourceCommentUrl: 'https://x/1',
+      }),
+    );
+    expect(h.activateNextResolver).toHaveBeenCalledWith('s1');
+  });
+});

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -1,0 +1,322 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  PROVIDER_CAPABILITIES,
+  getDefaultTurnModel,
+  isSlotKey,
+  runsForWorkflowRun,
+  type SlotKey,
+} from '@goodboy/core';
+import type {
+  AgentId,
+  AttachmentInput,
+  ProviderId,
+  SessionId,
+  TurnProviderOverride,
+} from '@goodboy/types';
+import { useAppStore } from '../../store/store';
+import { PROVIDER_LABEL_LOWER } from '../providers/providers';
+import { isMainWindow } from '../workspace/window';
+import { markSessionMobileShared } from './mobileConfinement';
+import type { AgentKind } from '../session/agent-kind';
+
+const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
+
+// Context slots a phone may edit. `files_touched` is machine-derived (the turn
+// loop owns it), so it's intentionally excluded from the writable set.
+const MOBILE_EDITABLE_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>([
+  'goal',
+  'decisions',
+  'open_questions',
+  'last_output_summary',
+]);
+
+const COMMAND_EVENT = 'bridge://command';
+
+// Mirrors the Rust `CommandEvent` (bridge/commands.rs). `origin` is stamped
+// server-side and is unforgeable; `data` is the phone's raw JSON — we read only
+// the known keys below and never a path, cwd, provider, binary or flag.
+type Origin = 'desktop' | 'mobile';
+export type BridgeCommand = {
+  readonly id: string;
+  readonly kind: string;
+  readonly origin: Origin;
+  readonly data: unknown;
+};
+
+const MOBILE_AGENT_KINDS: ReadonlySet<string> = new Set([
+  'planner',
+  'implementer',
+  'reviewer',
+  'tester',
+  'debugger',
+  'scout',
+  'resolver',
+]);
+
+function inTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v !== null && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function requireSession(data: Record<string, unknown>): SessionId {
+  const id = asString(data.sessionId);
+  if (!id) {
+    throw new Error('missing sessionId');
+  }
+  const known = useAppStore.getState().sessions.some((s) => s.id === id);
+  if (!known) {
+    throw new Error(`unknown session: ${id}`);
+  }
+  return id as SessionId;
+}
+
+// Phone-supplied attachments: keep only well-formed entries. Bytes land inside
+// the worktree via `persistAttachments` (server-controlled path), never an
+// arbitrary location the phone chooses.
+function coerceAttachments(v: unknown): ReadonlyArray<AttachmentInput> {
+  if (!Array.isArray(v)) {
+    return [];
+  }
+  const out: AttachmentInput[] = [];
+  for (const item of v) {
+    const r = asRecord(item);
+    const id = asString(r.id);
+    const fileName = asString(r.fileName);
+    const mimeType = asString(r.mimeType);
+    const dataBase64 = asString(r.dataBase64);
+    if (id && fileName && mimeType && dataBase64) {
+      out.push({ id, fileName, mimeType, dataBase64 });
+    }
+  }
+  return out;
+}
+
+// A phone-supplied provider/model pick. Validated against the closed provider
+// set; an unknown id is dropped (the desktop falls back to its own routing).
+function coerceOverride(data: Record<string, unknown>): TurnProviderOverride | undefined {
+  const providerId = asString(data.providerId);
+  if (!providerId || !PROVIDER_IDS.includes(providerId as ProviderId)) {
+    return undefined;
+  }
+  const model = asString(data.model);
+  return { providerId: providerId as ProviderId, ...(model ? { model } : {}) };
+}
+
+// The provider/model menu the phone's composer offers. Connection state comes
+// from the live store (so the phone can grey out unavailable providers); the
+// model list is the static registry, so the phone never hardcodes it.
+function buildProviderMenu(): {
+  providers: ReadonlyArray<{
+    id: ProviderId;
+    label: string;
+    connection: string;
+    defaultModel: string;
+    models: ReadonlyArray<{ id: string; label: string; tier: string }>;
+  }>;
+} {
+  const known = useAppStore.getState().providers;
+  const providers = PROVIDER_IDS.map((id) => {
+    const info = known.find((p) => p.id === id);
+    return {
+      id,
+      label: info?.label ?? PROVIDER_LABEL_LOWER[id],
+      connection: info?.connection ?? 'missing',
+      defaultModel: getDefaultTurnModel(id),
+      models: PROVIDER_CAPABILITIES[id].models.map((m) => ({
+        id: m.id,
+        label: m.label,
+        tier: m.tier,
+      })),
+    };
+  });
+  return { providers };
+}
+
+// advanceStep: activate the next pending workflow agent whose predecessors are
+// all done. Mirrors `maybeAutoAdvanceWorkflow`'s eligibility check, but here the
+// human on the phone is explicitly advancing, so the autoRun gate doesn't apply.
+async function advanceNextWorkflowStep(sessionId: SessionId): Promise<void> {
+  const store = useAppStore.getState();
+  const session = store.sessions.find((s) => s.id === sessionId);
+  if (!session || session.workflowRuns.length === 0) {
+    throw new Error('session has no workflow to advance');
+  }
+  const templates = store.phaseTemplates[session.workspaceId] ?? [];
+  const runs = store.sessionPhaseRuns[sessionId] ?? [];
+  for (const run of session.workflowRuns) {
+    if (run.discardedAt) {
+      continue;
+    }
+    const template = templates.find((t) => t.id === run.workflowId);
+    if (!template) {
+      continue;
+    }
+    const runAgents = runsForWorkflowRun(runs, run.id);
+    const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+    for (const step of sortedSteps) {
+      const agent = runAgents.find((r) => r.stepId === step.id);
+      if (!agent || agent.status !== 'pending') {
+        continue;
+      }
+      const allPrevDone = sortedSteps
+        .filter((s) => s.ordinal < step.ordinal)
+        .every((s) =>
+          runAgents.some(
+            (r) => r.stepId === s.id && (r.status === 'completed' || r.status === 'skipped'),
+          ),
+        );
+      if (allPrevDone) {
+        await store.activateWorkflowAgent(sessionId, agent.id);
+        return;
+      }
+      break; // earliest pending step blocks the run until its predecessors finish
+    }
+  }
+  throw new Error('no workflow step is ready to advance');
+}
+
+// Dispatches a mobile-origin command onto the same store actions the desktop UI
+// uses. Long-running turns are fired-and-forgotten: the ACK only confirms the
+// command was accepted; turn output reaches the phone through the snapshot.
+async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
+  const store = useAppStore.getState();
+  const data = asRecord(cmd.data);
+
+  switch (cmd.kind) {
+    case 'queryProviders':
+      return buildProviderMenu();
+
+    case 'advanceStep': {
+      const sessionId = requireSession(data);
+      markSessionMobileShared(sessionId);
+      await advanceNextWorkflowStep(sessionId);
+      return undefined;
+    }
+
+    case 'send': {
+      const sessionId = requireSession(data);
+      const content = asString(data.content) ?? '';
+      const attachments = coerceAttachments(data.attachments);
+      if (content.trim().length === 0 && attachments.length === 0) {
+        throw new Error('send requires content or attachments');
+      }
+      markSessionMobileShared(sessionId);
+      const agentId = asString(data.agentId) as AgentId | undefined;
+      const override = coerceOverride(data);
+      void store
+        .sendTurn({
+          sessionId,
+          ...(agentId ? { agentId } : {}),
+          content,
+          ...(attachments.length > 0 ? { attachments } : {}),
+          ...(override ? { override } : {}),
+        })
+        .catch((e) => console.error('[bridge] mobile send failed', e));
+      return undefined;
+    }
+
+    case 'spawnAgent': {
+      const sessionId = requireSession(data);
+      markSessionMobileShared(sessionId);
+      const name = asString(data.name);
+      const prompt = asString(data.prompt);
+      const rawKind = asString(data.kind);
+      const kind = rawKind && MOBILE_AGENT_KINDS.has(rawKind) ? (rawKind as AgentKind) : undefined;
+      const override = coerceOverride(data);
+      await store.spawnAgent(sessionId, {
+        ...(name ? { name } : {}),
+        ...(prompt ? { initialPrompt: prompt } : {}),
+        ...(kind ? { kindOverride: kind } : {}),
+        ...(override ? { provider: override.providerId } : {}),
+        ...(override?.model ? { model: override.model } : {}),
+      });
+      return undefined;
+    }
+
+    case 'setContextSlot': {
+      const sessionId = requireSession(data);
+      const rawKey = asString(data.key);
+      if (!rawKey || !isSlotKey(rawKey) || !MOBILE_EDITABLE_SLOTS.has(rawKey)) {
+        throw new Error(`slot not editable from mobile: ${rawKey ?? '(missing)'}`);
+      }
+      // Absent value is rejected; an explicit empty string clears the slot.
+      const value = typeof data.value === 'string' ? data.value : undefined;
+      if (value === undefined) {
+        throw new Error('setContextSlot requires a string value');
+      }
+      markSessionMobileShared(sessionId);
+      await store.upsertSessionSlot(sessionId, rawKey, value);
+      return undefined;
+    }
+
+    case 'resolveComment': {
+      const sessionId = requireSession(data);
+      const prompt = asString(data.prompt);
+      if (!prompt) {
+        throw new Error('resolveComment requires a prompt describing the comment');
+      }
+      markSessionMobileShared(sessionId);
+      const sourceCommentUrl = asString(data.commentUrl);
+      const sourceThreadId = asString(data.threadId);
+      await store.spawnAgent(sessionId, {
+        kindOverride: 'resolver',
+        deferKickoff: true,
+        initialPrompt: prompt,
+        ...(sourceCommentUrl ? { sourceCommentUrl } : {}),
+        ...(sourceThreadId ? { sourceThreadId } : {}),
+      });
+      await store.activateNextResolver(sessionId);
+      return undefined;
+    }
+
+    default:
+      throw new Error(`unsupported mobile command: ${cmd.kind}`);
+  }
+}
+
+export async function executeBridgeCommand(
+  cmd: BridgeCommand,
+): Promise<{ ok: boolean; error?: string; data?: unknown }> {
+  try {
+    if (cmd.origin !== 'mobile') {
+      // Only mobile-origin commands travel this channel today. A non-mobile
+      // origin means a protocol mismatch — refuse rather than guess.
+      throw new Error(`unexpected command origin: ${cmd.origin}`);
+    }
+    const data = await dispatchMobile(cmd);
+    return data !== undefined ? { ok: true, data } : { ok: true };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/// Subscribes the main window to mobile commands forwarded by the Rust bridge,
+/// executing each through the security guard and reporting the outcome back so
+/// the bridge can ACK the phone. No-op off the main window (the event is
+/// broadcast to every window; only one may execute) or outside Tauri.
+export const listenBridgeCommands = async (): Promise<UnlistenFn> => {
+  if (!inTauri() || !isMainWindow()) {
+    return () => undefined;
+  }
+  return listen<BridgeCommand>(COMMAND_EVENT, (event) => {
+    const cmd = event.payload;
+    void executeBridgeCommand(cmd)
+      .then((result) =>
+        invoke('bridge_command_result', {
+          id: cmd.id,
+          ok: result.ok,
+          error: result.error ?? null,
+          data: result.data ?? null,
+        }),
+      )
+      .catch((e) => console.error('[bridge] command result dispatch failed', e));
+  });
+};

--- a/apps/desktop/src/features/companion/mobileConfinement.test.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ClaudePermissionMode, SessionId } from '@goodboy/types';
+import {
+  clampMobilePermissionMode,
+  clearMobileSharedSessions,
+  isSessionMobileShared,
+  markSessionMobileShared,
+} from './mobileConfinement';
+
+const sid = (s: string): SessionId => s as SessionId;
+
+afterEach(() => clearMobileSharedSessions());
+
+describe('clampMobilePermissionMode', () => {
+  it('preserves read-only plan mode', () => {
+    expect(clampMobilePermissionMode('plan')).toBe('plan');
+  });
+
+  it('caps every writable mode at default so the phone cannot auto-approve writes', () => {
+    const writable: ClaudePermissionMode[] = [
+      'default',
+      'acceptEdits',
+      'bypassPermissions',
+      'dontAsk',
+    ];
+    for (const mode of writable) {
+      expect(clampMobilePermissionMode(mode)).toBe('default');
+    }
+  });
+
+  it('never yields a mode more permissive than default', () => {
+    const all: ClaudePermissionMode[] = [
+      'plan',
+      'default',
+      'acceptEdits',
+      'bypassPermissions',
+      'dontAsk',
+    ];
+    for (const mode of all) {
+      expect(['plan', 'default']).toContain(clampMobilePermissionMode(mode));
+    }
+  });
+});
+
+describe('mobile shared-session registry', () => {
+  it('starts empty and marks a session shared', () => {
+    expect(isSessionMobileShared(sid('s1'))).toBe(false);
+    markSessionMobileShared(sid('s1'));
+    expect(isSessionMobileShared(sid('s1'))).toBe(true);
+  });
+
+  it('is sticky and idempotent until explicitly cleared (desktop revoke)', () => {
+    markSessionMobileShared(sid('s1'));
+    markSessionMobileShared(sid('s1'));
+    expect(isSessionMobileShared(sid('s1'))).toBe(true);
+    clearMobileSharedSessions();
+    expect(isSessionMobileShared(sid('s1'))).toBe(false);
+  });
+
+  it('confines each session independently', () => {
+    markSessionMobileShared(sid('s1'));
+    expect(isSessionMobileShared(sid('s1'))).toBe(true);
+    expect(isSessionMobileShared(sid('s2'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/features/companion/mobileConfinement.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.ts
@@ -1,0 +1,38 @@
+import type { ClaudePermissionMode, SessionId } from '@goodboy/types';
+
+// Sessions a paired phone is currently driving. Every turn a mobile command
+// triggers — kickoffs, fan-out children, scout/resolver chains — funnels
+// through `sendTurn`, which consults this set and clamps the permission mode.
+// Tracking it here (module scope, not React state) makes the choke point
+// impossible to bypass: any present or future internal `sendTurn` caller is
+// covered without having to thread a flag through every path.
+//
+// Sticky by design: a session stays confined until the desktop revokes mobile
+// access (bridge stop / device revoke). The human, not the phone, decides when
+// full power returns — so a mobile client can never quietly lift the ceiling.
+const mobileSharedSessions = new Set<SessionId>();
+
+export const markSessionMobileShared = (sessionId: SessionId): void => {
+  mobileSharedSessions.add(sessionId);
+};
+
+export const isSessionMobileShared = (sessionId: SessionId): boolean =>
+  mobileSharedSessions.has(sessionId);
+
+export const clearMobileSharedSessions = (): void => {
+  mobileSharedSessions.clear();
+};
+
+// A mobile-driven turn may never run more permissively than `default`: every
+// edit/Bash that isn't covered by a desktop-set allow-rule then requires
+// explicit desktop approval, so the phone cannot auto-approve writes that
+// escape the worktree. `plan` (read-only) is preserved when already in effect.
+//
+// TODO (@ak): the clamp gates tool *approval*, not the process. A desktop
+// allow-rule that broadly permits Bash would still let a mobile-initiated agent
+// run absolute-path commands outside the worktree (cwd doesn't constrain Bash).
+// Hard confinement needs an OS sandbox (sandbox-exec/seccomp) on mobile-origin
+// spawns — tracked as a follow-up; the clamp + worktree-scope prompt are the
+// interim guard.
+export const clampMobilePermissionMode = (mode: ClaudePermissionMode): ClaudePermissionMode =>
+  mode === 'plan' ? 'plan' : 'default';

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -58,6 +58,10 @@ import { clampEffort, type EffortLevel } from '../../../features/chat/utils/chat
 import { verbosityDirective } from '../../../features/settings/verbosity';
 import { detectDrift } from '../../../features/session/drift-detection';
 import {
+  clampMobilePermissionMode,
+  isSessionMobileShared,
+} from '../../../features/companion/mobileConfinement';
+import {
   AGENT_KIND_DEFAULTS,
   inferAgentKindFromName,
   type AgentKind,
@@ -451,6 +455,12 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
 
     const providerInfo = get().providers.find((p) => p.id === provider);
 
+    // Mobile-driven sessions run gated: never more permissive than `default`,
+    // so phone-initiated edits/Bash outside desktop allow-rules need approval.
+    const effectivePermissionMode = isSessionMobileShared(sessionId)
+      ? clampMobilePermissionMode(session.permissionMode)
+      : session.permissionMode;
+
     let claudeFlags: Partial<ClaudeFlagSet> = {};
     let effectiveRules: ReadonlyArray<PermissionRule> = [];
     if (provider === 'anthropic') {
@@ -464,7 +474,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const flags = buildClaudeFlags({
           rules: effectiveRules,
           scope: { workspaceId: session.workspaceId, sessionId },
-          permissionMode: session.permissionMode,
+          permissionMode: effectivePermissionMode,
         });
         claudeFlags = {
           allowedTools: flags.allowedTools,
@@ -479,7 +489,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         claudeFlags = {
           allowedTools: [],
           disallowedTools: [],
-          permissionMode: session.permissionMode,
+          permissionMode: effectivePermissionMode,
         };
       }
     }


### PR DESCRIPTION
## Summary
- Desktop-side **Noise_XK responder** that pairs a phone via a single-use QR token, streams a read-only DB snapshot, and forwards a **closed set** of mobile-origin write commands through a trusted frontend guard.
- Pairing UI: full-page `CompanionStudio` (StudioShell) + a CTA pill in `AppTopBar` next to the Beta chip → dispatches `goodboy:open-pair-device`. Linear countdown bar (auto-remints), "in testing" notice.
- Desktop-only change set. Mobile (goodboy-mobile) is a separate repo and is **not** part of this PR.

## Security posture
- `origin = Mobile` stamped **server-side** (unforgeable); no raw/exec/path opcode exists.
- Frontend guard validates session existence, slot allow-list (`files_touched` excluded), provider allow-list, agent-kind allow-list, attachment shape; attachment bytes land via server-controlled path.
- Mobile-driven sessions clamped to `default` permission mode at the single `sendTurn` choke point (sticky until desktop revoke).
- Snapshot is a column allow-list over a **read-only** SQLite connection — no credentials/secrets streamed; SQL is static (no injection).
- Enrollment token: 256-bit, single-use, 60s TTL, burned on consume. Revoke/stop trips every live connection.
- Private-key identity file restricted to `0600`.

### Known residual (tracked, non-blocking)
- Permission clamp gates tool *approval*, not the OS process: a pre-existing broad `Bash` allow-rule could let a mobile-initiated agent run outside the worktree. Proper fix = OS sandbox on mobile-origin spawns (TODO @ak in `mobileConfinement.ts`).

## Test plan
- [ ] `cargo test` (bridge unit tests: opcode closure, token burn, snapshot chunking/cap)
- [ ] vitest (commandExecutor + mobileConfinement guards)
- [ ] desktop build (`tauri`) compiles with new deps (snow, qrcode, rand)
- [ ] manual: scan QR → pair → send turn → confirm permission clamp → desktop revoke drops link

🤖 Generated with [Claude Code](https://claude.com/claude-code)