### PR TITLE
fix(desktop): preview window titles use "Goodboy | <workspace>" format

### DIFF
--- a/apps/desktop/src/features/workspace/window.ts
+++ b/apps/desktop/src/features/workspace/window.ts
@@ -18,6 +18,8 @@ function inTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
 
+const brandTitle = (name: string): string => (name ? `Goodboy | ${name}` : 'Goodboy');
+
 export const currentWindowLabel = (): string => {
   if (!inTauri()) {
     return MAIN_WINDOW_LABEL;
@@ -61,7 +63,7 @@ export const spawnWorkspaceWindow = async (id: WorkspaceId, title: string): Prom
   }
   const win = new WebviewWindow(freshWindowLabel(), {
     url: `index.html#${WORKSPACE_HASH_KEY}=${id}`,
-    title,
+    title: brandTitle(title),
     width: 1280,
     height: 860,
     minWidth: 1024,
@@ -78,7 +80,7 @@ export const setWindowTitle = async (title: string): Promise<void> => {
     return;
   }
   await getCurrentWindow()
-    .setTitle(`${title} · Goodboy`)
+    .setTitle(brandTitle(title))
     .catch(() => undefined);
 };
 

--- a/apps/desktop/src/store/slices/presence/index.test.ts
+++ b/apps/desktop/src/store/slices/presence/index.test.ts
@@ -10,6 +10,7 @@ const { focusWindow, spawnWorkspaceWindow } = vi.hoisted(() => ({
 vi.mock('../../../features/workspace/window', () => ({
   currentWindowLabel: () => 'main',
   focusWindow,
+  setWindowTitle: vi.fn(async () => undefined),
   spawnWorkspaceWindow,
 }));
 

--- a/apps/desktop/src/store/slices/presence/openWorkspace.ts
+++ b/apps/desktop/src/store/slices/presence/openWorkspace.ts
@@ -2,6 +2,7 @@ import type { WorkspaceId } from '@goodboy/types';
 import {
   currentWindowLabel,
   focusWindow,
+  setWindowTitle,
   spawnWorkspaceWindow,
 } from '../../../features/workspace/window';
 import type { GetFn } from './types';
@@ -22,6 +23,7 @@ export const openWorkspace = (get: GetFn) => {
     }
     if (get().currentWorkspaceId === null) {
       await get().setCurrentWorkspace(id);
+      void setWindowTitle(title);
       return;
     }
     await spawnWorkspaceWindow(id, title);


### PR DESCRIPTION
## Summary
- preview/workspace window titles now render as `Goodboy | <workspace>` (e.g. `Goodboy | app-web`), replacing the old `<title> · Goodboy` format
- centralized formatting in a `brandTitle` helper in `window.ts`, used by both `spawnWorkspaceWindow` and `setWindowTitle`
- closed the empty-window gap: opening a workspace into the current empty window now sets the title (`openWorkspace` first-window branch)

## Test plan
- [x] `pnpm vitest run src/store/slices/presence/index.test.ts` (5/5 green)
- [ ] manual: open a workspace in a fresh window and via launcher → title shows `Goodboy | <workspace>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)