### PR TITLE
feat(desktop): group open questions by spawning agent

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
@@ -1,0 +1,537 @@
+// @vitest-environment happy-dom
+
+let _storeState: Record<string, unknown> = {};
+let _openQuestions: Array<{ status: string; [k: string]: unknown }> = [];
+let _oqDrafts: Record<string, unknown> = {};
+let _oqJustAnswered: string[] = [];
+
+const mockAnswerOpenQuestions = vi.fn().mockResolvedValue(undefined);
+const mockDismissOpenQuestion = vi.fn().mockResolvedValue(undefined);
+const mockFlashAnswered = vi.fn();
+const mockToggleSuggestion = vi.fn();
+const mockSetCustomAnswer = vi.fn();
+const mockToggleCustomField = vi.fn();
+const mockClearJustAnswered = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: vi.fn() }));
+vi.mock('@tauri-apps/plugin-shell', () => ({ Command: { create: vi.fn() } }));
+vi.mock('@tauri-apps/plugin-sql', () => ({
+  default: { load: vi.fn().mockResolvedValue({}) },
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: [] as never[],
+  useAppStore: vi.fn((selector: (s: unknown) => unknown) => selector(_storeState)),
+  useSessionOpenQuestions: vi.fn(() => _openQuestions),
+}));
+
+vi.mock('../../../../context/components/QuestionsTab/useOpenQuestions', () => ({
+  useOpenQuestions: vi.fn((selector: (s: unknown) => unknown) =>
+    selector({
+      drafts: _oqDrafts,
+      justAnswered: _oqJustAnswered,
+      toggleSuggestion: mockToggleSuggestion,
+      setCustomAnswer: mockSetCustomAnswer,
+      toggleCustomField: mockToggleCustomField,
+      flashAnswered: mockFlashAnswered,
+      clearJustAnswered: mockClearJustAnswered,
+    }),
+  ),
+  deriveDraftAnswer: vi.fn(
+    (draft: { selectedSuggestions?: string[]; customAnswer?: string } | undefined) => {
+      if (!draft) return '';
+      const custom = draft.customAnswer?.trim() ?? '';
+      if (custom.length > 0) return custom;
+      return (draft.selectedSuggestions ?? []).join(', ');
+    },
+  ),
+}));
+
+vi.mock('../../../../context/components/QuestionsTab/QuestionCard', () => ({
+  QuestionCard: (props: {
+    question: { id: string; text: string };
+    onDismiss: (id: string) => void;
+  }) => (
+    <div data-testid={`question-card-${props.question.id}`}>
+      <span>{props.question.text}</span>
+      <button onClick={() => props.onDismiss(props.question.id)}>dismiss</button>
+    </div>
+  ),
+}));
+
+vi.mock('./PaneShell', () => ({
+  PaneShell: (props: { title: string; description?: string; children: React.ReactNode }) => (
+    <div data-testid="pane-shell" data-title={props.title} data-description={props.description}>
+      {props.children}
+    </div>
+  ),
+}));
+
+vi.mock('../../SessionOverviewPane/lib', () => ({
+  selectOpenQuestions: (qs: Array<{ status: string }>) => qs.filter((q) => q.status === 'open'),
+}));
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  OpenQuestion,
+  OpenQuestionId,
+  Session,
+  SessionId,
+  Step,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { QuestionsPane } from './QuestionsPane';
+
+const NOW = '2026-05-26T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'sess_1' as SessionId;
+const WS_ID = 'ws_1' as WorkspaceId;
+const WF_A = 'wf_a' as WorkflowId;
+const WF_B = 'wf_b' as WorkflowId;
+
+const BASE_SESSION: Session = {
+  id: SESSION_ID,
+  workspaceId: WS_ID,
+  goal: 'test goal',
+  branchPrefix: 'test',
+  createdAt: NOW,
+  state: { kind: 'idle' },
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+} as Session;
+
+function mkStep(workflowId: WorkflowId, ordinal: number): Step {
+  return {
+    id: `${workflowId}_s${ordinal}` as StepId,
+    workflowId,
+    ordinal,
+    name: `step ${ordinal}`,
+    promptPrefix: '',
+  };
+}
+
+function mkWorkflow(id: WorkflowId, stepCount: number): Workflow {
+  return {
+    id,
+    workspaceId: WS_ID,
+    name: id === WF_A ? 'Workflow A' : 'Workflow B',
+    description: '',
+    steps: Array.from({ length: stepCount }, (_, i) => mkStep(id, i)),
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+function mkAgent(
+  id: string,
+  stepId: StepId | undefined,
+  name: string,
+  extras?: Partial<Agent>,
+): Agent {
+  return {
+    id: id as AgentId,
+    sessionId: SESSION_ID,
+    stepId,
+    ordinal: 0,
+    name,
+    status: 'completed',
+    ...extras,
+  } as Agent;
+}
+
+function mkQuestion(id: string, opts: Partial<OpenQuestion> = {}): OpenQuestion {
+  return {
+    id: id as OpenQuestionId,
+    sessionId: SESSION_ID,
+    text: `question ${id}`,
+    suggestedAnswers: [],
+    userAnswer: null,
+    status: 'open',
+    createdAt: NOW,
+    ...opts,
+  } as OpenQuestion;
+}
+
+function setupStore(overrides: {
+  agents?: Agent[];
+  workflows?: Workflow[];
+  openQuestions?: OpenQuestion[];
+  drafts?: Record<string, unknown>;
+}) {
+  const agents = overrides.agents ?? [];
+  const workflows = overrides.workflows ?? [];
+  const openQuestions = overrides.openQuestions ?? [];
+
+  _openQuestions = openQuestions;
+  _oqDrafts = overrides.drafts ?? {};
+  _oqJustAnswered = [];
+  _storeState = {
+    sessionPhaseRuns: { [SESSION_ID]: agents },
+    phaseTemplates: { [WS_ID]: workflows },
+    sessionOpenQuestions: { [SESSION_ID]: openQuestions },
+    answerOpenQuestions: mockAnswerOpenQuestions,
+    dismissOpenQuestion: mockDismissOpenQuestion,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  _storeState = {};
+  _openQuestions = [];
+  _oqDrafts = {};
+  _oqJustAnswered = [];
+});
+
+describe('QuestionsPane', () => {
+  describe('empty state', () => {
+    it('renders empty state when no open questions', () => {
+      setupStore({ openQuestions: [] });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.getByText('No open questions')).toBeDefined();
+    });
+
+    it('renders empty state when all questions are answered/dismissed', () => {
+      setupStore({
+        openQuestions: [
+          mkQuestion('q1', { status: 'answered' }),
+          mkQuestion('q2', { status: 'dismissed' }),
+        ],
+      });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.getByText('No open questions')).toBeDefined();
+    });
+
+    it('passes correct PaneShell description in empty state', () => {
+      setupStore({ openQuestions: [] });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      const shell = screen.getByTestId('pane-shell');
+      expect(shell.getAttribute('data-title')).toBe('Questions');
+      expect(shell.getAttribute('data-description')).toBe(
+        'Decisions agents need from you to keep going.',
+      );
+    });
+  });
+
+  describe('cluster rendering', () => {
+    it('renders questions grouped by workflow-owner agent with headers', () => {
+      const wfA = mkWorkflow(WF_A, 2);
+      const planner = mkAgent('agent_planner', wfA.steps[0]!.id, 'planner');
+      const implementer = mkAgent('agent_impl', wfA.steps[1]!.id, 'implementer');
+
+      setupStore({
+        agents: [planner, implementer],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q1', { workflowId: WF_A, ownedByStepOrdinal: 0 }),
+          mkQuestion('q2', { workflowId: WF_A, ownedByStepOrdinal: 0 }),
+          mkQuestion('q3', { workflowId: WF_A, ownedByStepOrdinal: 1 }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByText('planner')).toBeDefined();
+      expect(screen.getByText('implementer')).toBeDefined();
+      expect(screen.getByTestId('question-card-q1')).toBeDefined();
+      expect(screen.getByTestId('question-card-q2')).toBeDefined();
+      expect(screen.getByTestId('question-card-q3')).toBeDefined();
+    });
+
+    it('renders ad-hoc clusters by creator agent when no workflow', () => {
+      const scout = mkAgent('agent_scout', undefined, 'scout');
+      const fixer = mkAgent('agent_fixer', undefined, 'fixer');
+
+      setupStore({
+        agents: [scout, fixer],
+        workflows: [],
+        openQuestions: [
+          mkQuestion('q1', { createdByAgentId: scout.id }),
+          mkQuestion('q2', { createdByAgentId: fixer.id }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByText('scout')).toBeDefined();
+      expect(screen.getByText('fixer')).toBeDefined();
+    });
+
+    it('shows "via {creator}" suffix when owner differs from creator', () => {
+      const wfA = mkWorkflow(WF_A, 2);
+      const scout = mkAgent('agent_scout', wfA.steps[0]!.id, 'scout');
+      const planner = mkAgent('agent_planner', wfA.steps[1]!.id, 'planner');
+
+      setupStore({
+        agents: [scout, planner],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q1', {
+            workflowId: WF_A,
+            ownedByStepOrdinal: 1,
+            createdByAgentId: scout.id,
+            createdByStepOrdinal: 0,
+          }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByText('planner')).toBeDefined();
+      expect(screen.getByText('via scout')).toBeDefined();
+    });
+
+    it('does not show "via" suffix when owner == creator', () => {
+      const wfA = mkWorkflow(WF_A, 1);
+      const planner = mkAgent('agent_planner', wfA.steps[0]!.id, 'planner');
+
+      setupStore({
+        agents: [planner],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q1', {
+            workflowId: WF_A,
+            ownedByStepOrdinal: 0,
+            createdByAgentId: planner.id,
+            createdByStepOrdinal: 0,
+          }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByText('planner')).toBeDefined();
+      expect(screen.queryByText(/^via /)).toBeNull();
+    });
+
+    it('no header for orphan questions', () => {
+      setupStore({
+        agents: [],
+        workflows: [],
+        openQuestions: [mkQuestion('q1'), mkQuestion('q2')],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByTestId('question-card-q1')).toBeDefined();
+      expect(screen.getByTestId('question-card-q2')).toBeDefined();
+      expect(screen.queryByText(/^via /)).toBeNull();
+    });
+
+    it('orphan cluster sorts last when mixed with owned clusters', () => {
+      const wfA = mkWorkflow(WF_A, 1);
+      const planner = mkAgent('agent_planner', wfA.steps[0]!.id, 'planner');
+
+      setupStore({
+        agents: [planner],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q_owned', { workflowId: WF_A, ownedByStepOrdinal: 0 }),
+          mkQuestion('q_orphan'),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      const cards = screen.getAllByTestId(/^question-card-/);
+      expect(cards[0]!.getAttribute('data-testid')).toBe('question-card-q_owned');
+      expect(cards[1]!.getAttribute('data-testid')).toBe('question-card-q_orphan');
+    });
+
+    it('separates clusters across different workflows', () => {
+      const wfA = mkWorkflow(WF_A, 1);
+      const wfB = mkWorkflow(WF_B, 1);
+      const agentA = mkAgent('agent_a', wfA.steps[0]!.id, 'agent A');
+      const agentB = mkAgent('agent_b', wfB.steps[0]!.id, 'agent B');
+
+      setupStore({
+        agents: [agentA, agentB],
+        workflows: [wfA, wfB],
+        openQuestions: [
+          mkQuestion('q1', { workflowId: WF_A, ownedByStepOrdinal: 0 }),
+          mkQuestion('q2', { workflowId: WF_B, ownedByStepOrdinal: 0 }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      expect(screen.getByText('agent A')).toBeDefined();
+      expect(screen.getByText('agent B')).toBeDefined();
+    });
+  });
+
+  describe('pane description', () => {
+    it('singular "question" for 1 open question', () => {
+      setupStore({ openQuestions: [mkQuestion('q1')] });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      const shell = screen.getByTestId('pane-shell');
+      expect(shell.getAttribute('data-description')).toBe('1 open question waiting on you.');
+    });
+
+    it('plural "questions" for multiple open questions', () => {
+      setupStore({
+        openQuestions: [mkQuestion('q1'), mkQuestion('q2'), mkQuestion('q3')],
+      });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      const shell = screen.getByTestId('pane-shell');
+      expect(shell.getAttribute('data-description')).toBe('3 open questions waiting on you.');
+    });
+  });
+
+  describe('dismiss callback', () => {
+    it('calls dismissOpenQuestion with session id and question', () => {
+      const question = mkQuestion('q1');
+      setupStore({ openQuestions: [question] });
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      fireEvent.click(screen.getByText('dismiss'));
+      expect(mockDismissOpenQuestion).toHaveBeenCalledWith(SESSION_ID, question);
+    });
+  });
+
+  describe('submit callback per cluster', () => {
+    it('routes answer to cluster ownerAgentId, not global first question creator', () => {
+      const wfA = mkWorkflow(WF_A, 2);
+      const planner = mkAgent('agent_planner', wfA.steps[0]!.id, 'planner');
+      const implementer = mkAgent('agent_impl', wfA.steps[1]!.id, 'implementer');
+
+      setupStore({
+        agents: [planner, implementer],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q1', {
+            workflowId: WF_A,
+            ownedByStepOrdinal: 0,
+            createdByAgentId: 'some_other_agent' as AgentId,
+          }),
+          mkQuestion('q2', {
+            workflowId: WF_A,
+            ownedByStepOrdinal: 1,
+          }),
+        ],
+        drafts: {
+          q2: { selectedSuggestions: ['yes'], customAnswer: '', showCustomField: false },
+        },
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+
+      const submitButtons = screen.getAllByText('send answer');
+      expect(submitButtons.length).toBeGreaterThanOrEqual(1);
+
+      fireEvent.click(submitButtons[submitButtons.length - 1]!);
+
+      expect(mockAnswerOpenQuestions).toHaveBeenCalledWith(
+        SESSION_ID,
+        [{ id: 'q2', text: 'question q2', answer: 'yes' }],
+        implementer.id,
+      );
+    });
+
+    it('does not render submit button when no drafts pending', () => {
+      setupStore({ openQuestions: [mkQuestion('q1')] });
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.queryByText('send answer')).toBeNull();
+      expect(screen.queryByText(/send \d+ answers/)).toBeNull();
+    });
+
+    it('shows "send N answers" when multiple drafts pending in a cluster', () => {
+      const scout = mkAgent('agent_scout', undefined, 'scout');
+
+      setupStore({
+        agents: [scout],
+        workflows: [],
+        openQuestions: [
+          mkQuestion('q1', { createdByAgentId: scout.id }),
+          mkQuestion('q2', { createdByAgentId: scout.id }),
+        ],
+        drafts: {
+          q1: { selectedSuggestions: ['option a'], customAnswer: '', showCustomField: false },
+          q2: { selectedSuggestions: [], customAnswer: 'custom answer', showCustomField: true },
+        },
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.getByText('send 2 answers')).toBeDefined();
+    });
+
+    it('submit with null ownerAgentId for orphan cluster', () => {
+      setupStore({
+        openQuestions: [mkQuestion('q1')],
+        drafts: {
+          q1: { selectedSuggestions: ['ok'], customAnswer: '', showCustomField: false },
+        },
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      fireEvent.click(screen.getByText('send answer'));
+
+      expect(mockAnswerOpenQuestions).toHaveBeenCalledWith(
+        SESSION_ID,
+        [{ id: 'q1', text: 'question q1', answer: 'ok' }],
+        null,
+      );
+    });
+
+    it('calls flashAnswered before answerOpenQuestions', () => {
+      setupStore({
+        openQuestions: [mkQuestion('q1')],
+        drafts: {
+          q1: { selectedSuggestions: ['yes'], customAnswer: '', showCustomField: false },
+        },
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      fireEvent.click(screen.getByText('send answer'));
+
+      expect(mockFlashAnswered).toHaveBeenCalledWith(['q1']);
+      expect(mockAnswerOpenQuestions).toHaveBeenCalled();
+    });
+
+    it('does nothing when pairs list is empty (no pending drafts)', () => {
+      setupStore({
+        openQuestions: [mkQuestion('q1')],
+        drafts: {
+          q1: { selectedSuggestions: [], customAnswer: '   ', showCustomField: false },
+        },
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.queryByText('send answer')).toBeNull();
+    });
+  });
+
+  describe('workflowRunId scoping', () => {
+    it('resolves owner via workflowRunId when present on question and agent', () => {
+      const wfA = mkWorkflow(WF_A, 1);
+      const runId = 'run_1' as WorkflowRunId;
+      const agent1 = mkAgent('agent_1', wfA.steps[0]!.id, 'run1-agent', {
+        workflowRunId: runId,
+      });
+
+      setupStore({
+        agents: [agent1],
+        workflows: [wfA],
+        openQuestions: [
+          mkQuestion('q1', {
+            workflowId: WF_A,
+            workflowRunId: runId,
+            ownedByStepOrdinal: 0,
+          }),
+        ],
+      });
+
+      render(<QuestionsPane session={BASE_SESSION} />);
+      expect(screen.getByText('run1-agent')).toBeDefined();
+    });
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.test.tsx
@@ -107,7 +107,7 @@ const BASE_SESSION: Session = {
   createdAt: NOW,
   state: { kind: 'idle' },
   providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
-} as Session;
+} as unknown as Session;
 
 function mkStep(workflowId: WorkflowId, ordinal: number): Step {
   return {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,9 +1,13 @@
-import { useCallback } from 'react';
-import { ArrowRight, CircleCheck } from 'lucide-react';
+import { useCallback, useMemo } from 'react';
+import { ArrowRight, Bot, CircleCheck } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { Session, SessionId } from '@goodboy/types';
-import { useAppStore, useSessionOpenQuestions } from '../../../../../store';
+import type { AgentId, OpenQuestion, OpenQuestionId, Session, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../../store';
 import { QuestionCard } from '../../../../context/components/QuestionsTab/QuestionCard';
+import {
+  buildQuestionClusters,
+  type QuestionCluster,
+} from '../../../../context/components/QuestionsTab/clusters';
 import {
   deriveDraftAnswer,
   useOpenQuestions,
@@ -11,13 +15,95 @@ import {
 import { selectOpenQuestions } from '../../SessionOverviewPane/lib';
 import { PaneShell } from './PaneShell';
 
+type AnswerPair = { id: OpenQuestionId; text: string; answer: string };
+
 type QuestionsPaneProps = {
   readonly session: Session;
+};
+
+type ClusterSectionProps = {
+  readonly cluster: QuestionCluster;
+  readonly drafts: ReturnType<typeof useOpenQuestions.getState>['drafts'];
+  readonly justAnswered: ReadonlyArray<OpenQuestionId>;
+  readonly onToggleSuggestion: (questionId: OpenQuestionId, suggestion: string) => void;
+  readonly onSetCustomAnswer: (questionId: OpenQuestionId, text: string) => void;
+  readonly onToggleCustomField: (questionId: OpenQuestionId) => void;
+  readonly onClearJustAnswered: (id: OpenQuestionId) => void;
+  readonly onDismiss: (question: OpenQuestion) => void;
+  readonly onSubmit: (pairs: ReadonlyArray<AnswerPair>, ownerAgentId: AgentId | null) => void;
+};
+
+const ClusterSection = ({
+  cluster,
+  drafts,
+  justAnswered,
+  onToggleSuggestion,
+  onSetCustomAnswer,
+  onToggleCustomField,
+  onClearJustAnswered,
+  onDismiss,
+  onSubmit,
+}: ClusterSectionProps) => {
+  const pendingPairs = cluster.questions
+    .map((q) => ({ id: q.id, text: q.text, answer: deriveDraftAnswer(drafts[q.id]) }))
+    .filter((pair) => pair.answer.length > 0);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {cluster.ownerAgentName !== null ? (
+        <div className="flex items-center gap-1.5 px-0.5 text-2xs font-medium">
+          <Bot size={12} aria-hidden className="shrink-0 text-muted-foreground" />
+          <span className="truncate text-foreground/80">{cluster.ownerAgentName}</span>
+          {cluster.creatorAgentName !== null ? (
+            <span className="truncate text-muted-foreground">via {cluster.creatorAgentName}</span>
+          ) : null}
+        </div>
+      ) : null}
+      {cluster.questions.map((q) => (
+        <QuestionCard
+          key={q.id}
+          question={q}
+          selectedSuggestions={drafts[q.id]?.selectedSuggestions ?? []}
+          customAnswer={drafts[q.id]?.customAnswer ?? ''}
+          showCustomField={drafts[q.id]?.showCustomField ?? false}
+          justAnswered={justAnswered.includes(q.id)}
+          onToggleSuggestion={onToggleSuggestion}
+          onSetCustomAnswer={onSetCustomAnswer}
+          onToggleCustomField={onToggleCustomField}
+          onDismiss={() => onDismiss(q)}
+          onClearJustAnswered={onClearJustAnswered}
+        />
+      ))}
+      {pendingPairs.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => onSubmit(pendingPairs, cluster.ownerAgentId)}
+          className={cn(
+            'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
+            'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
+            'hover:brightness-105 active:scale-[0.99]',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          )}
+        >
+          <span>
+            {pendingPairs.length > 1 ? `send ${pendingPairs.length} answers` : 'send answer'}
+          </span>
+          <ArrowRight
+            size={13}
+            aria-hidden
+            className="transition-transform group-hover:translate-x-0.5"
+          />
+        </button>
+      ) : null}
+    </div>
+  );
 };
 
 export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   const sessionId = session.id as SessionId;
   const open = selectOpenQuestions(useSessionOpenQuestions(sessionId));
+  const agents = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const workflows = useAppStore((s) => s.phaseTemplates[session.workspaceId] ?? EMPTY_ARRAY);
   const drafts = useOpenQuestions((s) => s.drafts);
   const justAnswered = useOpenQuestions((s) => s.justAnswered);
   const toggleSuggestion = useOpenQuestions((s) => s.toggleSuggestion);
@@ -28,18 +114,21 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
   const answerOpenQuestions = useAppStore((s) => s.answerOpenQuestions);
   const dismissOpenQuestion = useAppStore((s) => s.dismissOpenQuestion);
 
-  const pendingPairs = open
-    .map((q) => ({ id: q.id, text: q.text, answer: deriveDraftAnswer(drafts[q.id]) }))
-    .filter((pair) => pair.answer.length > 0);
-  const targetAgentId = open[0]?.createdByAgentId ?? null;
+  const clusters = useMemo(
+    () => buildQuestionClusters({ questions: open, agents, workflows }),
+    [open, agents, workflows],
+  );
 
-  const handleSubmit = useCallback(async () => {
-    if (pendingPairs.length === 0) {
-      return;
-    }
-    flashAnswered(pendingPairs.map((pair) => pair.id));
-    await answerOpenQuestions(sessionId, pendingPairs, targetAgentId);
-  }, [pendingPairs, flashAnswered, answerOpenQuestions, sessionId, targetAgentId]);
+  const handleSubmit = useCallback(
+    async (pairs: ReadonlyArray<AnswerPair>, ownerAgentId: AgentId | null) => {
+      if (pairs.length === 0) {
+        return;
+      }
+      flashAnswered(pairs.map((pair) => pair.id));
+      await answerOpenQuestions(sessionId, pairs, ownerAgentId);
+    },
+    [flashAnswered, answerOpenQuestions, sessionId],
+  );
 
   if (open.length === 0) {
     return (
@@ -65,43 +154,21 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
       title="Questions"
       description={`${open.length} open ${open.length === 1 ? 'question' : 'questions'} waiting on you.`}
     >
-      <div className="flex flex-col gap-3">
-        {open.map((q) => (
-          <QuestionCard
-            key={q.id}
-            question={q}
-            selectedSuggestions={drafts[q.id]?.selectedSuggestions ?? []}
-            customAnswer={drafts[q.id]?.customAnswer ?? ''}
-            showCustomField={drafts[q.id]?.showCustomField ?? false}
-            justAnswered={justAnswered.includes(q.id)}
+      <div className="flex flex-col gap-4">
+        {clusters.map((cluster) => (
+          <ClusterSection
+            key={cluster.ownerAgentId ?? '__orphan__'}
+            cluster={cluster}
+            drafts={drafts}
+            justAnswered={justAnswered}
             onToggleSuggestion={toggleSuggestion}
             onSetCustomAnswer={setCustomAnswer}
             onToggleCustomField={toggleCustomField}
-            onDismiss={() => void dismissOpenQuestion(sessionId, q)}
             onClearJustAnswered={clearJustAnswered}
+            onDismiss={(q) => void dismissOpenQuestion(sessionId, q)}
+            onSubmit={(pairs, ownerAgentId) => void handleSubmit(pairs, ownerAgentId)}
           />
         ))}
-        {pendingPairs.length > 0 ? (
-          <button
-            type="button"
-            onClick={() => void handleSubmit()}
-            className={cn(
-              'group flex w-full items-center justify-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold',
-              'bg-primary text-primary-foreground shadow-sm transition-all duration-150',
-              'hover:brightness-105 active:scale-[0.99]',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
-            )}
-          >
-            <span>
-              {pendingPairs.length > 1 ? `send ${pendingPairs.length} answers` : 'send answer'}
-            </span>
-            <ArrowRight
-              size={13}
-              aria-hidden
-              className="transition-transform group-hover:translate-x-0.5"
-            />
-          </button>
-        ) : null}
       </div>
     </PaneShell>
   );


### PR DESCRIPTION
## Summary
- Group open questions in `QuestionsPane` by the agent that spawned them, using `buildQuestionClusters` (workflow-owner grouping with creator fallback).
- Per-cluster section header shows owner agent name + `via {creator}` suffix when creator ≠ owner; no header for orphan questions.
- Per-cluster submit routes answers to `cluster.ownerAgentId` (fixes prior bug routing all answers to `open[0]?.createdByAgentId`).

## Test plan
- [x] 20 new tests in `QuestionsPane.test.tsx` (empty states, cluster rendering, `via` suffix, orphan handling, per-cluster routing, dismiss, pane description singular/plural, workflowRunId scoping)
- [x] full desktop suite green, zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)