### PR TITLE
feat(desktop): surface merge-queue state for PRs and MRs

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrActionBar.tsx
@@ -70,6 +70,7 @@ export const PrActionBar = ({
 }: Props) => {
   const isTerminal = pr.state === 'merged' || pr.state === 'closed';
   const isClosed = pr.state === 'closed';
+  const isQueued = pr.state === 'queued';
   const isDraft = pr.isDraft;
   const spin = (k: ActionBusy) => busy === k;
 
@@ -165,7 +166,18 @@ export const PrActionBar = ({
           <RefreshCw size={14} aria-hidden className={cn(detailLoading && 'animate-spin')} />
         </button>
 
-        {!isTerminal && (
+        {!isTerminal && isQueued && (
+          <>
+            <Divider orientation="vertical" className="mx-0.5 h-5" />
+            <span className="inline-flex items-center gap-1.5 rounded-md border border-primary/40 bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
+              <GitMerge size={13} aria-hidden />
+              In merge queue
+              {pr.mergeQueue?.position != null && <span>#{pr.mergeQueue.position}</span>}
+            </span>
+          </>
+        )}
+
+        {!isTerminal && !isQueued && (
           <>
             <Divider orientation="vertical" className="mx-0.5 h-5" />
             {mergeConfirm ? (

--- a/apps/desktop/src/features/github/components/GitHubStudio/useGithubInbox.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/useGithubInbox.ts
@@ -24,6 +24,9 @@ function bucketOf(pr: PullRequestState | null): SessionPrGroup {
   if (pr.state === 'merged') {
     return 'merged';
   }
+  if (pr.state === 'queued') {
+    return 'queued';
+  }
   if (pr.isDraft) {
     return 'draft';
   }
@@ -45,6 +48,7 @@ const GROUP_ORDER: ReadonlyArray<SessionPrGroup> = [
   'draft',
   'reviewable',
   'reviewed',
+  'queued',
   'closed',
   'merged',
 ];
@@ -54,6 +58,7 @@ const GROUP_LABEL: Record<SessionPrGroup, string> = {
   draft: 'Draft',
   reviewable: 'In review',
   reviewed: 'Approved',
+  queued: 'In queue',
   closed: 'Closed',
   merged: 'Merged',
 };

--- a/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
@@ -18,6 +18,11 @@ describe('PullRequestChip', () => {
     expect(screen.getByText('#42')).toBeDefined();
   });
 
+  it('renders the queued state as a badge with label', () => {
+    render(<PullRequestChip state="queued" variant="badge" />);
+    expect(screen.getByText('Queued')).toBeDefined();
+  });
+
   it('renders compact variant with number, no label word', () => {
     render(<PullRequestChip state="draft" variant="compact" number={7} />);
     expect(screen.getByText('#7')).toBeDefined();
@@ -28,6 +33,7 @@ describe('PullRequestChip', () => {
 describe('pullRequestMeta', () => {
   it('exposes a label for every state', () => {
     expect(pullRequestMeta('open').label).toBe('In review');
+    expect(pullRequestMeta('queued').label).toBe('Queued');
     expect(pullRequestMeta('closed').label).toBe('Closed');
   });
 });

--- a/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
@@ -4,6 +4,7 @@ import {
   GitPullRequest,
   GitPullRequestClosed,
   GitPullRequestDraft,
+  ListChecks,
 } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { PullRequestStateKind } from '@goodboy/types';
@@ -33,6 +34,12 @@ const PR_META: Record<PullRequestStateKind, PrStateMeta> = {
     label: 'Approved',
     textClass: 'text-success',
     bgClass: 'bg-success/18',
+  },
+  queued: {
+    icon: ListChecks,
+    label: 'Queued',
+    textClass: 'text-primary',
+    bgClass: 'bg-primary/12',
   },
   merged: {
     icon: GitMerge,

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -17,6 +17,7 @@ import { AGENT_KIND_DEFAULTS } from '../../../session/agent-kind';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
+import { humanizeMergeStatus, type GitlabMergeStatusTone } from '../client';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -28,6 +29,12 @@ const STATE_STYLE: Record<string, string> = {
   merged: 'bg-info/15 text-info',
   closed: 'bg-danger/15 text-danger',
   locked: 'bg-muted text-muted-foreground',
+};
+
+const MERGE_STATUS_STYLE: Record<GitlabMergeStatusTone, string> = {
+  success: 'bg-success/15 text-success',
+  danger: 'bg-danger/15 text-danger',
+  muted: 'bg-muted text-muted-foreground',
 };
 
 export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
@@ -208,11 +215,19 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
 
               {mr.state === 'opened' ? (
                 <div className="flex items-center gap-3">
-                  {mr.mergeStatus ? (
-                    <span className="text-2xs text-muted-foreground">
-                      merge status: {mr.mergeStatus}
-                    </span>
-                  ) : null}
+                  {(() => {
+                    const status = humanizeMergeStatus(mr.mergeStatus);
+                    return status ? (
+                      <span
+                        className={cn(
+                          'rounded px-1.5 py-0.5 text-2xs font-medium',
+                          MERGE_STATUS_STYLE[status.tone],
+                        )}
+                      >
+                        {status.label}
+                      </span>
+                    ) : null;
+                  })()}
                   <span className="flex-1" />
                   <Button
                     onClick={() => void onMerge()}

--- a/apps/desktop/src/features/integrations/gitlab/client.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { issueIdentifier, type GitlabIssue } from './client';
+import { humanizeMergeStatus, issueIdentifier, type GitlabIssue } from './client';
 
 function makeIssue(overrides: Partial<GitlabIssue> = {}): GitlabIssue {
   return {
@@ -30,5 +30,28 @@ describe('issueIdentifier', () => {
     const issue = makeIssue();
     (issue as { references: { full: string | null } }).references.full = null;
     expect(issueIdentifier(issue)).toBe('#7');
+  });
+});
+
+describe('humanizeMergeStatus', () => {
+  it('maps a mergeable status to a success "Can merge" badge', () => {
+    expect(humanizeMergeStatus('can_be_merged')).toEqual({ label: 'Can merge', tone: 'success' });
+  });
+
+  it('maps a blocked status to a danger "Blocked" badge', () => {
+    expect(humanizeMergeStatus('cannot_be_merged')).toEqual({ label: 'Blocked', tone: 'danger' });
+  });
+
+  it('maps pending statuses to a muted "Checking" badge', () => {
+    expect(humanizeMergeStatus('checking')).toEqual({ label: 'Checking', tone: 'muted' });
+    expect(humanizeMergeStatus('unchecked')).toEqual({ label: 'Checking', tone: 'muted' });
+    expect(humanizeMergeStatus('cannot_be_merged_recheck')).toEqual({
+      label: 'Checking',
+      tone: 'muted',
+    });
+  });
+
+  it('returns null when the status is unknown', () => {
+    expect(humanizeMergeStatus(null)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -43,6 +43,14 @@ export const gitlabFetchAssignedIssues = async (
 export const issueIdentifier = (issue: GitlabIssue): string =>
   issue.references.full ?? `#${issue.iid}`;
 
+export type GitlabMergeStatus =
+  | 'unchecked'
+  | 'checking'
+  | 'can_be_merged'
+  | 'cannot_be_merged'
+  | 'cannot_be_merged_recheck'
+  | null;
+
 export type GitlabMergeRequest = {
   id: number;
   iid: number;
@@ -55,7 +63,26 @@ export type GitlabMergeRequest = {
   targetBranch: string;
   draft: boolean;
   hasConflicts: boolean;
-  mergeStatus: string | null;
+  mergeStatus: GitlabMergeStatus;
+};
+
+export type GitlabMergeStatusTone = 'success' | 'danger' | 'muted';
+
+export const humanizeMergeStatus = (
+  status: GitlabMergeStatus,
+): { label: string; tone: GitlabMergeStatusTone } | null => {
+  switch (status) {
+    case 'can_be_merged':
+      return { label: 'Can merge', tone: 'success' };
+    case 'cannot_be_merged':
+      return { label: 'Blocked', tone: 'danger' };
+    case 'checking':
+    case 'unchecked':
+    case 'cannot_be_merged_recheck':
+      return { label: 'Checking', tone: 'muted' };
+    default:
+      return null;
+  }
 };
 
 export const gitlabMrForBranch = async (

--- a/apps/desktop/src/store/slices/session-view/sortAndGroupSessions.ts
+++ b/apps/desktop/src/store/slices/session-view/sortAndGroupSessions.ts
@@ -45,6 +45,9 @@ function prBucket(github: SessionGithubState | undefined): SessionPrGroup {
   if (pr.state === 'merged') {
     return 'merged';
   }
+  if (pr.state === 'queued') {
+    return 'queued';
+  }
   if (pr.isDraft) {
     return 'draft';
   }

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -64,8 +64,9 @@ export const PR_GROUP_ORDER: Record<SessionPrGroup, number> = {
   draft: 1,
   reviewable: 2,
   reviewed: 3,
-  closed: 4,
-  merged: 5,
+  queued: 4,
+  closed: 5,
+  merged: 6,
 };
 
 export type LensHistory = {

--- a/apps/desktop/src/store/store.session-view.test.ts
+++ b/apps/desktop/src/store/store.session-view.test.ts
@@ -42,7 +42,7 @@ function makeSession(
 
 function makePr(
   overrides: Partial<{
-    state: 'draft' | 'open' | 'approved' | 'merged' | 'closed';
+    state: 'draft' | 'open' | 'approved' | 'queued' | 'merged' | 'closed';
     isDraft: boolean;
     reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null;
   }> = {},
@@ -352,6 +352,16 @@ describe('sortAndGroupSessions, pr grouping', () => {
     expect(keys(result)).toEqual(['merged']);
   });
 
+  it('pr.state=queued → queued bucket', () => {
+    const s = makeSession(sid(1));
+    const result = sortAndGroupSessions(
+      [s],
+      prefs,
+      githubWith([{ id: sid(1), pr: makePr({ state: 'queued' }) }]),
+    );
+    expect(keys(result)).toEqual(['queued']);
+  });
+
   it('pr.isDraft=true → draft bucket (before reviewDecision check)', () => {
     const s = makeSession(sid(1));
     const result = sortAndGroupSessions(
@@ -387,15 +397,18 @@ describe('sortAndGroupSessions, pr grouping', () => {
     expect(keys(result)).toEqual(['reviewable']);
   });
 
-  it('all 6 pr buckets present → correct order', () => {
-    const sessions = [sid(1), sid(2), sid(3), sid(4), sid(5), sid(6)].map((id) => makeSession(id));
+  it('all 7 pr buckets present → correct order', () => {
+    const sessions = [sid(1), sid(2), sid(3), sid(4), sid(5), sid(6), sid(7)].map((id) =>
+      makeSession(id),
+    );
     const github = githubWith([
       { id: sid(1), pr: null },
       { id: sid(2), pr: makePr({ isDraft: true }) },
       { id: sid(3), pr: makePr({ isDraft: false, reviewDecision: 'review_required' }) },
       { id: sid(4), pr: makePr({ isDraft: false, reviewDecision: 'approved' }) },
-      { id: sid(5), pr: makePr({ state: 'closed' }) },
-      { id: sid(6), pr: makePr({ state: 'merged' }) },
+      { id: sid(5), pr: makePr({ state: 'queued' }) },
+      { id: sid(6), pr: makePr({ state: 'closed' }) },
+      { id: sid(7), pr: makePr({ state: 'merged' }) },
     ]);
     const result = sortAndGroupSessions(sessions, prefs, github);
     expect(keys(result)).toEqual([
@@ -403,6 +416,7 @@ describe('sortAndGroupSessions, pr grouping', () => {
       'draft',
       'reviewable',
       'reviewed',
+      'queued',
       'closed',
       'merged',
     ]);

--- a/packages/core/src/github/__tests__/resolver.test.ts
+++ b/packages/core/src/github/__tests__/resolver.test.ts
@@ -23,6 +23,7 @@ const BASE_RAW = {
   statusCheckRollup: null as null,
   updatedAt: '2024-01-01T00:00:00Z',
   body: null as null,
+  autoMergeRequest: null as Record<string, unknown> | null,
 };
 
 describe('resolvePrForBranch', () => {
@@ -127,6 +128,67 @@ describe('resolvePrForBranch', () => {
     const runner = makeJsonRunner([pr]);
     const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
     expect(result?.state).toBe('merged');
+  });
+
+  it('maps OPEN + autoMergeRequest object → queued (with mergeQueue)', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      autoMergeRequest: { enabledAt: '2024-01-01T00:00:00Z' },
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('queued');
+    expect(result?.mergeQueue).toEqual({ position: null });
+  });
+
+  it('queued beats approved when autoMergeRequest present', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      reviewDecision: 'APPROVED' as const,
+      autoMergeRequest: {},
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('queued');
+  });
+
+  it('OPEN + autoMergeRequest null → unchanged (mergeQueue null)', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'OPEN' as const };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('open');
+    expect(result?.mergeQueue).toBeNull();
+  });
+
+  it('draft + autoMergeRequest → still draft', async () => {
+    const pr = {
+      ...BASE_RAW,
+      number: 1,
+      state: 'OPEN' as const,
+      isDraft: true,
+      autoMergeRequest: {},
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('draft');
+  });
+
+  it('MERGED + autoMergeRequest → merged (terminal wins)', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'MERGED' as const, autoMergeRequest: {} };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('merged');
+  });
+
+  it('CLOSED + autoMergeRequest → closed (terminal wins)', async () => {
+    const pr = { ...BASE_RAW, number: 1, state: 'CLOSED' as const, autoMergeRequest: {} };
+    const runner = makeJsonRunner([pr]);
+    const result = await resolvePrForBranch(runner, 'org/repo', 'feature');
+    expect(result?.state).toBe('closed');
   });
 
   it('CONFLICTING → mergeable: false', async () => {

--- a/packages/core/src/github/resolver.ts
+++ b/packages/core/src/github/resolver.ts
@@ -15,6 +15,7 @@ const PR_FIELDS = [
   'statusCheckRollup',
   'updatedAt',
   'body',
+  'autoMergeRequest',
 ] as const;
 
 type RawPullRequest = {
@@ -33,6 +34,7 @@ type RawPullRequest = {
   }> | null;
   updatedAt: string;
   body: string | null;
+  autoMergeRequest: Record<string, unknown> | null;
 };
 
 type ClosingIssueRef = {
@@ -50,6 +52,9 @@ function deriveStateKind(raw: RawPullRequest): PullRequestStateKind {
   }
   if (raw.isDraft) {
     return 'draft';
+  }
+  if (raw.autoMergeRequest != null) {
+    return 'queued';
   }
   if (raw.reviewDecision === 'APPROVED') {
     return 'approved';
@@ -109,6 +114,7 @@ function toPullRequestState(raw: RawPullRequest): PullRequestState {
     reviewDecision: raw.reviewDecision ? (reviewMap[raw.reviewDecision] ?? null) : null,
     body: raw.body ?? '',
     updatedAt: raw.updatedAt,
+    mergeQueue: raw.autoMergeRequest != null ? { position: null } : null,
   };
 }
 

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -11,7 +11,7 @@ export type GhTokenStatus = {
   scoped?: boolean;
 };
 
-export type PullRequestStateKind = 'draft' | 'open' | 'approved' | 'merged' | 'closed';
+export type PullRequestStateKind = 'draft' | 'open' | 'approved' | 'queued' | 'merged' | 'closed';
 
 export type PullRequestChecks = 'pending' | 'success' | 'failure' | null;
 
@@ -28,6 +28,7 @@ export type PullRequestState = {
   reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null;
   body: string;
   updatedAt: string;
+  mergeQueue?: { position: number | null } | null;
 };
 
 export type LinkedIssue = {

--- a/packages/types/src/session-view.ts
+++ b/packages/types/src/session-view.ts
@@ -20,4 +20,11 @@ export type SessionStageInfo = Readonly<{
   reason: string;
 }>;
 
-export type SessionPrGroup = 'not-open' | 'draft' | 'reviewable' | 'reviewed' | 'closed' | 'merged';
+export type SessionPrGroup =
+  | 'not-open'
+  | 'draft'
+  | 'reviewable'
+  | 'reviewed'
+  | 'queued'
+  | 'closed'
+  | 'merged';


### PR DESCRIPTION
## Summary
- Detect GitHub PRs enrolled in the merge queue via `autoMergeRequest` (no GraphQL); resolver emits a new `queued` state plus a `mergeQueue: { position }` field.
- Thread the `queued` state through session-view buckets (`PR_GROUP_ORDER` slot 4) and the PR chip / action bar (Merge CTA disabled, inline "In merge queue #position" badge).
- GitLab free-tier parity: type `mergeStatus` as a union, add `humanizeMergeStatus`, render a toned badge in `MrDetailPanel`.

## Notes
- No DB migration (JSON cache is opaque).
- Phase B GraphQL position enrichment and GitLab merge-trains (Premium) deferred.

## Test plan
- [x] `pnpm typecheck` (5/5)
- [x] core resolver tests (29 pass, incl. terminal/draft precedence, queued-beats-approved)
- [x] desktop session-view + PullRequestChip + gitlab client tests (67 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)