### PR TITLE
feat(desktop): surface external task provider in session preview

### DIFF
--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SessionExternalTask, SessionExternalTaskProvider } from '@goodboy/types';
+import { ExternalTaskChip } from './index';
+
+afterEach(cleanup);
+
+function makeTask(overrides: Partial<SessionExternalTask> = {}): SessionExternalTask {
+  return {
+    sessionId: 'sess-1',
+    provider: 'linear',
+    externalId: 'ext-abc',
+    identifier: 'GB-123',
+    url: 'https://linear.app/goodboy/issue/GB-123',
+    title: 'Improve preview metadata',
+    createdAt: '2026-06-22T00:00:00.000Z',
+    ...overrides,
+  } as SessionExternalTask;
+}
+
+describe('ExternalTaskChip, full variant', () => {
+  it('renders identifier and title text', () => {
+    render(<ExternalTaskChip task={makeTask()} />);
+    expect(screen.getByText('GB-123')).toBeDefined();
+    expect(screen.getByText('Improve preview metadata')).toBeDefined();
+  });
+
+  it('exposes an aria-label naming the identifier and provider', () => {
+    render(<ExternalTaskChip task={makeTask()} />);
+    expect(screen.getByRole('button', { name: /open GB-123 in Linear studio/i })).toBeDefined();
+  });
+
+  it('sets the tooltip to "identifier: title"', () => {
+    render(<ExternalTaskChip task={makeTask()} />);
+    const btn = screen.getByRole('button');
+    expect(btn.getAttribute('title')).toBe('GB-123: Improve preview metadata');
+  });
+});
+
+describe('ExternalTaskChip, icon variant', () => {
+  it('renders the provider glyph but omits identifier and title text', () => {
+    render(<ExternalTaskChip task={makeTask()} variant="icon" />);
+    expect(screen.getByText('L')).toBeDefined();
+    expect(screen.queryByText('GB-123')).toBeNull();
+    expect(screen.queryByText('Improve preview metadata')).toBeNull();
+  });
+
+  it('is display-only with an accessible label and tooltip', () => {
+    render(<ExternalTaskChip task={makeTask()} variant="icon" />);
+    expect(screen.queryByRole('button')).toBeNull();
+    const badge = screen.getByLabelText(/GB-123 from Linear/i);
+    expect(badge.getAttribute('title')).toBe('GB-123: Improve preview metadata');
+  });
+});
+
+describe('ExternalTaskChip, provider mapping', () => {
+  const cases: ReadonlyArray<{
+    provider: SessionExternalTaskProvider;
+    glyph: string;
+    label: RegExp;
+    event: string;
+  }> = [
+    { provider: 'linear', glyph: 'L', label: /Linear/i, event: 'goodboy:open-linear-studio' },
+    { provider: 'sentry', glyph: 'S', label: /Sentry/i, event: 'goodboy:open-sentry-studio' },
+    { provider: 'gitlab', glyph: 'G', label: /GitLab/i, event: 'goodboy:open-gitlab-studio' },
+  ];
+
+  for (const { provider, glyph, label, event } of cases) {
+    it(`renders the ${provider} glyph and label`, () => {
+      render(<ExternalTaskChip task={makeTask({ provider, identifier: 'X-1' })} />);
+      expect(screen.getByText(glyph)).toBeDefined();
+      expect(screen.getByRole('button', { name: label })).toBeDefined();
+    });
+
+    it(`dispatches ${event} with the externalId on click`, () => {
+      const listener = vi.fn();
+      window.addEventListener(event, listener);
+      render(<ExternalTaskChip task={makeTask({ provider, externalId: `${provider}-id` })} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(listener).toHaveBeenCalledOnce();
+      const evt = listener.mock.calls[0]?.[0] as CustomEvent;
+      expect(evt.detail).toEqual({ issueExternalId: `${provider}-id` });
+      window.removeEventListener(event, listener);
+    });
+  }
+});
+
+describe('ExternalTaskChip, click behavior', () => {
+  it('invokes a custom onClick instead of dispatching a studio event', () => {
+    const onClick = vi.fn();
+    const studioListener = vi.fn();
+    window.addEventListener('goodboy:open-linear-studio', studioListener);
+    render(<ExternalTaskChip task={makeTask()} onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(studioListener).not.toHaveBeenCalled();
+    window.removeEventListener('goodboy:open-linear-studio', studioListener);
+  });
+
+  it('does not dispatch a studio event from the display-only icon variant', () => {
+    const listener = vi.fn();
+    window.addEventListener('goodboy:open-sentry-studio', listener);
+    render(<ExternalTaskChip task={makeTask({ provider: 'sentry' })} variant="icon" />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener('goodboy:open-sentry-studio', listener);
+  });
+});

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -1,0 +1,95 @@
+import { cn } from '@goodboy/ui';
+import type { SessionExternalTask, SessionExternalTaskProvider } from '@goodboy/types';
+
+type ExternalTaskChipProps = {
+  task: SessionExternalTask;
+  variant?: 'full' | 'icon';
+  onClick?: () => void;
+};
+
+type ProviderMeta = {
+  label: string;
+  glyph: string;
+  glyphClasses: string;
+  colorClasses: string;
+  studioEvent: string;
+};
+
+const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
+  linear: {
+    label: 'Linear',
+    glyph: 'L',
+    glyphClasses: 'bg-provider-linear text-white',
+    colorClasses:
+      'border-provider-linear/30 bg-provider-linear/5 text-provider-linear hover:border-provider-linear/60 hover:bg-provider-linear/10',
+    studioEvent: 'goodboy:open-linear-studio',
+  },
+  sentry: {
+    label: 'Sentry',
+    glyph: 'S',
+    glyphClasses: 'bg-provider-sentry text-white',
+    colorClasses:
+      'border-provider-sentry/30 bg-provider-sentry/5 text-provider-sentry hover:border-provider-sentry/60 hover:bg-provider-sentry/10',
+    studioEvent: 'goodboy:open-sentry-studio',
+  },
+  gitlab: {
+    label: 'GitLab',
+    glyph: 'G',
+    glyphClasses: 'bg-provider-gitlab text-white',
+    colorClasses:
+      'border-provider-gitlab/30 bg-provider-gitlab/5 text-provider-gitlab hover:border-provider-gitlab/60 hover:bg-provider-gitlab/10',
+    studioEvent: 'goodboy:open-gitlab-studio',
+  },
+};
+
+export const ExternalTaskChip = ({ task, variant = 'full', onClick }: ExternalTaskChipProps) => {
+  const meta = PROVIDER_META[task.provider];
+  const tooltip = `${task.identifier}: ${task.title}`;
+
+  const glyph = (
+    <span
+      className={cn(
+        'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-[9px] font-bold',
+        meta.glyphClasses,
+      )}
+    >
+      {meta.glyph}
+    </span>
+  );
+
+  if (variant === 'icon') {
+    return (
+      <span
+        title={tooltip}
+        aria-label={`${task.identifier} from ${meta.label}`}
+        className="inline-flex shrink-0 items-center"
+      >
+        {glyph}
+      </span>
+    );
+  }
+
+  const handleClick =
+    onClick ??
+    (() =>
+      window.dispatchEvent(
+        new CustomEvent(meta.studioEvent, { detail: { issueExternalId: task.externalId } }),
+      ));
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={tooltip}
+      aria-label={`open ${task.identifier} in ${meta.label} studio`}
+      className={cn(
+        'inline-flex min-w-0 shrink-0 items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-colors',
+        meta.colorClasses,
+      )}
+    >
+      {glyph}
+      <span className="shrink-0 font-mono">{task.identifier}</span>
+      <span className="truncate">{task.title}</span>
+    </button>
+  );
+};

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -8,6 +8,7 @@ const { state } = vi.hoisted(() => ({
   state: {
     sessionGithub: {} as Record<string, unknown>,
     sessionTelemetry: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionExternalTasks: {} as Record<string, unknown>,
     bulkUnarchiveTask: vi.fn(async () => undefined),
     bulkDeleteTask: vi.fn(async () => undefined),
   },
@@ -89,6 +90,7 @@ function clickCheckbox(index: number): HTMLElement {
 beforeEach(() => {
   state.bulkUnarchiveTask.mockClear();
   state.bulkDeleteTask.mockClear();
+  state.sessionExternalTasks = {};
 });
 
 afterEach(cleanup);
@@ -236,5 +238,47 @@ describe('SessionActivityBar, bulk selection', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: /^Delete \(1\)$/ }));
     await waitFor(() => expect(state.bulkDeleteTask).toHaveBeenCalled());
     await waitFor(() => expect(screen.queryByText(/selected/)).toBeNull());
+  });
+});
+
+describe('SessionActivityBar, external task chip', () => {
+  it('renders no external task chip when the session has no mapped task', () => {
+    renderBar([], [makeSession('a-1', 'plain session')]);
+    expect(screen.queryByRole('button', { name: /studio/i })).toBeNull();
+  });
+
+  it('renders the icon-variant chip and appends the identifier to the item title', () => {
+    state.sessionExternalTasks = {
+      'a-1': {
+        sessionId: 'a-1',
+        provider: 'linear',
+        externalId: 'ext-1',
+        identifier: 'GB-7',
+        url: 'https://linear.app/x',
+        title: 'mapped task',
+        createdAt: '2026-06-22T00:00:00.000Z',
+      },
+    };
+    renderBar([], [makeSession('a-1', 'active one')]);
+    expect(screen.getByLabelText(/GB-7 from Linear/i)).toBeDefined();
+    expect(screen.getByText('L')).toBeDefined();
+    expect(screen.getByTitle(/active one · idle · GB-7/)).toBeDefined();
+  });
+
+  it('renders the matching glyph for a non-linear provider', () => {
+    state.sessionExternalTasks = {
+      'a-1': {
+        sessionId: 'a-1',
+        provider: 'sentry',
+        externalId: 'ext-2',
+        identifier: 'SENTRY-9',
+        url: 'https://sentry.io/x',
+        title: 'crash',
+        createdAt: '2026-06-22T00:00:00.000Z',
+      },
+    };
+    renderBar([], [makeSession('a-1', 'crashy')]);
+    expect(screen.getByText('S')).toBeDefined();
+    expect(screen.getByLabelText(/SENTRY-9 from Sentry/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -22,6 +22,7 @@ import {
   PullRequestChip,
   pullRequestMeta,
 } from '../../../../features/github/components/PullRequestChip';
+import { ExternalTaskChip } from '../../../../features/integrations/components/ExternalTaskChip';
 import { BulkDeleteSessionsDialog } from '../../../session/components/BulkDeleteSessionsDialog';
 import { SessionViewMenu } from './SessionViewMenu';
 
@@ -312,6 +313,9 @@ const SessionActivityItem = memo(function SessionActivityItem({
     stage === 'running' && session.workflowRuns.some((r) => r.autoRun && !r.discardedAt);
   const prState = useAppStore((s) => s.sessionGithub[session.id as SessionId]?.pr?.state ?? null);
   const prMeta = prState ? pullRequestMeta(prState) : null;
+  const externalTask = useAppStore(
+    (s) => s.sessionExternalTasks?.[session.id as SessionId] ?? null,
+  );
 
   const telemetry = useAppStore(
     (s) =>
@@ -333,7 +337,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
     <button
       type="button"
       onClick={onClick}
-      title={`${session.goal} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}`}
+      title={`${session.goal} · ${reason}${prMeta ? ` · PR ${prMeta.label}` : ''}${externalTask ? ` · ${externalTask.identifier}` : ''}`}
       className={cn(
         'flex w-full flex-col items-start gap-1.5 rounded-lg border px-2.5 py-2.5 text-left transition-colors',
         isActive
@@ -363,6 +367,7 @@ const SessionActivityItem = memo(function SessionActivityItem({
         <span className="line-clamp-2 min-w-0 flex-1 text-[13px] font-medium leading-snug">
           {session.goal}
         </span>
+        {externalTask && <ExternalTaskChip task={externalTask} variant="icon" />}
         {prState && <PullRequestChip state={prState} variant="icon" iconSize={11} />}
       </span>
       <span className="flex w-full items-center gap-1.5 pl-[14px]">

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
@@ -78,4 +78,27 @@ describe('SessionDetailPanel', () => {
     render(<SessionDetailPanel session={session} onOpenSessionSettings={vi.fn()} />);
     expect(screen.getByRole('button', { name: /open in editor/i })).toBeDefined();
   });
+
+  it('does not render an external task chip when none is mapped', () => {
+    render(<SessionDetailPanel session={session} onOpenSessionSettings={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /studio/i })).toBeNull();
+  });
+
+  it('renders the external task chip (full variant) when a task is mapped', () => {
+    state.sessionExternalTasks = {
+      'sess-1': {
+        sessionId: 'sess-1',
+        provider: 'linear',
+        externalId: 'ext-1',
+        identifier: 'GB-9',
+        url: 'https://linear.app/x',
+        title: 'wire metadata',
+        createdAt: '2026-06-22T00:00:00.000Z',
+      },
+    };
+    render(<SessionDetailPanel session={session} onOpenSessionSettings={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /open GB-9 in Linear studio/i })).toBeDefined();
+    expect(screen.getByText('GB-9')).toBeDefined();
+    expect(screen.getByText('wire metadata')).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -16,6 +16,7 @@ import { openInEditor } from '../../../../shared/lib/editor';
 import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/components/OverflowMenu';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
+import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
 import { SummarizerBadge } from './SummarizerBadge';
 
 type SessionDetailPanelProps = {
@@ -141,35 +142,7 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
             </span>
           )}
         </div>
-        {externalTask ? (
-          <button
-            type="button"
-            onClick={() =>
-              window.dispatchEvent(
-                new CustomEvent(
-                  externalTask.provider === 'sentry'
-                    ? 'goodboy:open-sentry-studio'
-                    : externalTask.provider === 'gitlab'
-                      ? 'goodboy:open-gitlab-studio'
-                      : 'goodboy:open-linear-studio',
-                  { detail: { issueExternalId: externalTask.externalId } },
-                ),
-              )
-            }
-            title={`${externalTask.identifier}: ${externalTask.title}`}
-            className={cn(
-              'shrink-0 inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-colors',
-              externalTask.provider === 'sentry'
-                ? 'border-provider-sentry/30 bg-provider-sentry/5 text-provider-sentry hover:border-provider-sentry/60 hover:bg-provider-sentry/10'
-                : externalTask.provider === 'gitlab'
-                  ? 'border-provider-gitlab/30 bg-provider-gitlab/5 text-provider-gitlab hover:border-provider-gitlab/60 hover:bg-provider-gitlab/10'
-                  : 'border-provider-linear/30 bg-provider-linear/5 text-provider-linear hover:border-provider-linear/60 hover:bg-provider-linear/10',
-            )}
-            aria-label={`open ${externalTask.identifier} in ${externalTask.provider} studio`}
-          >
-            <span className="font-mono">{externalTask.identifier}</span>
-          </button>
-        ) : null}
+        {externalTask ? <ExternalTaskChip task={externalTask} variant="full" /> : null}
         <button
           type="button"
           onClick={onOpenSessionSettings}


### PR DESCRIPTION
## Summary
- Add shared `ExternalTaskChip` (provider glyph L/S/G + color token, `full`/`icon` variants) centralizing provider styling in one `PROVIDER_META` map.
- `SessionDetailPanel` now uses the full clickable chip, removing the inlined provider ternaries (dispatches existing `goodboy:open-{linear,sentry,gitlab}-studio` events).
- `SessionActivityBar` renders a display-only icon badge on the session row (provenance indicator), and appends the task identifier to the row tooltip.

Phase 1, visibility-only: no DB migration, no status field. Persistent status display deferred to Phase 2.

Notable: the sidebar icon variant is intentionally a non-interactive `<span>` (matching `PullRequestChip`), avoiding a nested interactive control inside the session-row button and the double-action (open session + open studio) it would cause.

## Test plan
- [x] `pnpm --filter desktop typecheck` green
- [x] `ExternalTaskChip` unit tests (full + icon variants, provider glyphs, studio-event dispatch, custom onClick)
- [x] `SessionDetailPanel` / `SessionActivityBar` extended tests (mapped/unmapped, icon badge)
- [x] Full desktop suite green, no nested-button warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)