### PR TITLE
feat(desktop): relocate session meta to overview, guide fresh sessions, polish builder

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: toastMock }),
+}));
+
+import { BranchChip } from './BranchChip';
+
+const writeText = vi.fn(async () => undefined);
+
+beforeEach(() => {
+  toastMock.mockReset();
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+});
+afterEach(cleanup);
+
+describe('BranchChip', () => {
+  it('renders the branch name', () => {
+    render(<BranchChip branch="ak/feat-thing" />);
+    expect(screen.getByText('ak/feat-thing')).toBeDefined();
+  });
+
+  it('copies the branch and toasts success on click', async () => {
+    render(<BranchChip branch="ak/feat-thing" />);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('ak/feat-thing'));
+    expect(toastMock).toHaveBeenCalledWith('success', 'branch copied');
+  });
+
+  it('toasts an error when the clipboard write fails', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'));
+    render(<BranchChip branch="ak/feat-thing" />);
+    fireEvent.click(screen.getByRole('button'));
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith('error', expect.stringMatching(/copy failed/i)),
+    );
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/BranchChip.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { Check, GitBranch } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import { formatError } from '../../../../shared/lib/errors';
+import { useToast } from '../../../../app/components/Toast';
+
+export const BranchChip = ({ branch }: { branch: string }) => {
+  const { showToast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(branch);
+      setCopied(true);
+      showToast('success', 'branch copied');
+      setTimeout(() => setCopied(false), 1200);
+    } catch (err) {
+      showToast('error', `copy failed: ${formatError(err)}`);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={() => void onCopy()}
+      title="click to copy branch name"
+      className={cn(
+        'group inline-flex min-w-0 max-w-full shrink items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-2xs transition-colors',
+        copied
+          ? 'border-success/30 bg-success/10 text-success'
+          : 'border-border-soft bg-muted/30 text-foreground/80 hover:border-border hover:bg-muted/50 hover:text-foreground',
+      )}
+    >
+      {copied ? (
+        <Check size={10} aria-hidden className="shrink-0" />
+      ) : (
+        <GitBranch
+          size={10}
+          aria-hidden
+          className="shrink-0 text-muted-foreground group-hover:text-foreground"
+        />
+      )}
+      <span className="truncate">{branch}</span>
+    </button>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SessionId, TelemetryRecord } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: { sessionTelemetry: {} as Record<string, ReadonlyArray<TelemetryRecord>> },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+}));
+
+import { SessionCostChip } from './SessionCostChip';
+
+const rec = (kind: string, cost: number): TelemetryRecord =>
+  ({ kind, estimatedCostUsd: cost }) as unknown as TelemetryRecord;
+
+const SID = 'sess-1' as SessionId;
+
+beforeEach(() => {
+  state.sessionTelemetry = {};
+});
+afterEach(cleanup);
+
+describe('SessionCostChip', () => {
+  it('shows $0 when there is no telemetry', () => {
+    render(<SessionCostChip sessionId={SID} />);
+    expect(screen.getByRole('button').textContent).toBe('$0');
+  });
+
+  it('sums turn costs and excludes summarizer records', () => {
+    state.sessionTelemetry = {
+      [SID]: [rec('turn', 1.5), rec('summarizer', 9.99), rec('turn', 0.25)],
+    };
+    render(<SessionCostChip sessionId={SID} />);
+    expect(screen.getByRole('button').textContent).toBe('$1.75');
+  });
+
+  it('dispatches the budget-studio event scoped to the session on click', () => {
+    const handler = vi.fn();
+    window.addEventListener('goodboy:open-budget-studio', handler);
+    render(<SessionCostChip sessionId={SID} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(handler).toHaveBeenCalledOnce();
+    const evt = handler.mock.calls[0]![0] as CustomEvent;
+    expect(evt.detail).toEqual({ scope: { kind: 'session', sessionId: SID } });
+    window.removeEventListener('goodboy:open-budget-studio', handler);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SessionCostChip.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@goodboy/ui';
+import type { SessionId, TelemetryRecord } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+
+export const SessionCostChip = ({ sessionId }: { sessionId: SessionId }) => {
+  const telemetry = useAppStore(
+    (s) => s.sessionTelemetry[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
+  );
+  const sessionCost = useMemo(() => {
+    let sum = 0;
+    for (const rec of telemetry) {
+      if (rec.kind === 'summarizer') {
+        continue;
+      }
+      sum += rec.estimatedCostUsd;
+    }
+    return sum;
+  }, [telemetry]);
+  const finalLabel = sessionCost === 0 ? '$0' : `$${sessionCost.toFixed(2)}`;
+
+  const [displayLabel, setDisplayLabel] = useState(finalLabel);
+  const [animating, setAnimating] = useState(false);
+  const prevCostRef = useRef(sessionCost);
+  const prevSessionIdRef = useRef(sessionId);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (prevSessionIdRef.current !== sessionId) {
+      prevSessionIdRef.current = sessionId;
+      prevCostRef.current = sessionCost;
+      setDisplayLabel(finalLabel);
+      setAnimating(false);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      return;
+    }
+    if (prevCostRef.current === sessionCost) {
+      setDisplayLabel(finalLabel);
+      return;
+    }
+    const fromCost = prevCostRef.current;
+    const toCost = sessionCost;
+    prevCostRef.current = toCost;
+
+    if (
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+    ) {
+      setDisplayLabel(finalLabel);
+      setAnimating(false);
+      return;
+    }
+
+    setAnimating(true);
+    const duration = 1100;
+    const start = performance.now();
+
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const t = Math.min(1, elapsed / duration);
+      const eased = 1 - Math.pow(1 - t, 3);
+      const current = fromCost + (toCost - fromCost) * eased;
+      setDisplayLabel(current === 0 ? '$0' : `$${current.toFixed(2)}`);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        rafRef.current = null;
+        setDisplayLabel(finalLabel);
+        setAnimating(false);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [sessionCost, sessionId, finalLabel]);
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        window.dispatchEvent(
+          new CustomEvent('goodboy:open-budget-studio', {
+            detail: { scope: { kind: 'session', sessionId } },
+          }),
+        )
+      }
+      title={`Estimated cost for this session: ${finalLabel} (excluding summarizer), click for budget studio`}
+      className={cn(
+        'inline-flex shrink-0 items-center rounded-md border border-success/20 bg-success/10 px-2 py-1 font-mono text-2xs text-success transition-colors hover:border-success/40 hover:bg-success/15',
+        animating && 'cost-chip-pulse',
+      )}
+    >
+      {displayLabel}
+    </button>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { OpenQuestion, Session, SessionStageInfo, Workspace } from '@goodboy/types';
+import type { FilesTouched } from '../../../../store';
+
+type Store = {
+  sessionBranches: Record<string, string>;
+  spawnAgent: ReturnType<typeof vi.fn>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
+  scriptRuns: Record<string, Record<string, { status: string }>>;
+  sessionGithub: Record<string, { pr?: unknown }>;
+  sessionGitlabMr: Record<string, { mr?: unknown }>;
+};
+
+const { store, hooks } = vi.hoisted(() => ({
+  store: {
+    sessionBranches: {} as Record<string, string>,
+    spawnAgent: vi.fn(async () => undefined),
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    scriptRuns: {} as Record<string, Record<string, { status: string }>>,
+    sessionGithub: {} as Record<string, { pr?: unknown }>,
+    sessionGitlabMr: {} as Record<string, { mr?: unknown }>,
+  } as Store,
+  hooks: {
+    workspace: { name: 'My workspace' } as Workspace | null,
+    openQuestions: [] as ReadonlyArray<OpenQuestion>,
+    plans: [] as ReadonlyArray<{ status: string }>,
+    stage: { stage: 'building', reason: '' } as SessionStageInfo,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (s: Store) => T) => selector(store),
+  useCurrentWorkspace: () => hooks.workspace,
+  useSessionOpenQuestions: () => hooks.openQuestions,
+  useSessionPlans: () => hooks.plans,
+  useSessionStageInfo: () => hooks.stage,
+}));
+
+vi.mock('../../../../shared/components/ScrollFade', () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../../../workspace/components/SessionDetailPanel/SummarizerBadge', () => ({
+  SummarizerBadge: () => <span data-testid="summarizer-badge" />,
+}));
+
+vi.mock('./BranchChip', () => ({
+  BranchChip: ({ branch }: { branch: string }) => <span data-testid="branch-chip">{branch}</span>,
+}));
+
+vi.mock('./SessionCostChip', () => ({
+  SessionCostChip: () => <span data-testid="cost-chip" />,
+}));
+
+import { SessionOverviewPane } from './index';
+
+const standaloneAgent = (status = 'running') => ({
+  parentAgentId: null,
+  workflowRunId: null,
+  stepId: null,
+  status,
+});
+
+const baseSession = (over: Partial<Session> = {}): Session =>
+  ({
+    id: 'sess-1',
+    goal: 'refactor auth',
+    createdAt: '2026-06-22T10:00:00.000Z',
+    workflowRuns: [],
+    ...over,
+  }) as unknown as Session;
+
+const files: FilesTouched = { count: 3 } as unknown as FilesTouched;
+
+const renderPane = (session = baseSession(), onSelectLens = vi.fn(), filesTouched = files) => {
+  render(
+    <SessionOverviewPane
+      session={session}
+      filesTouched={filesTouched}
+      onSelectLens={onSelectLens}
+    />,
+  );
+  return onSelectLens;
+};
+
+beforeEach(() => {
+  store.sessionBranches = {};
+  store.spawnAgent.mockReset();
+  store.spawnAgent.mockResolvedValue(undefined);
+  store.sessionPhaseRuns = {};
+  store.scriptRuns = {};
+  store.sessionGithub = {};
+  store.sessionGitlabMr = {};
+  hooks.workspace = { name: 'My workspace' } as Workspace;
+  hooks.openQuestions = [];
+  hooks.plans = [];
+  hooks.stage = { stage: 'building', reason: '' } as SessionStageInfo;
+});
+afterEach(cleanup);
+
+describe('SessionOverviewPane header meta (cluster A)', () => {
+  it('renders the goal, stage label and workspace name', () => {
+    hooks.stage = { stage: 'building', reason: 'agents are working' } as SessionStageInfo;
+    renderPane();
+    expect(screen.getByRole('heading', { name: /refactor auth/i })).toBeDefined();
+    expect(screen.getByText('Building')).toBeDefined();
+    expect(screen.getByText('agents are working')).toBeDefined();
+    expect(screen.getByText('My workspace')).toBeDefined();
+  });
+
+  it('falls back to Untitled session when the goal is blank', () => {
+    renderPane(baseSession({ goal: '' }));
+    expect(screen.getByRole('heading', { name: /untitled session/i })).toBeDefined();
+  });
+
+  it('shows the branch chip, cost chip, summarizer and session age', () => {
+    store.sessionBranches = { 'sess-1': 'ak/feat-thing' };
+    renderPane();
+    expect(screen.getByTestId('branch-chip').textContent).toBe('ak/feat-thing');
+    expect(screen.getByTestId('cost-chip')).toBeDefined();
+    expect(screen.getByTestId('summarizer-badge')).toBeDefined();
+    expect(screen.getByText(/old$/)).toBeDefined();
+  });
+
+  it('omits the branch chip when no branch is known', () => {
+    renderPane();
+    expect(screen.queryByTestId('branch-chip')).toBeNull();
+  });
+});
+
+describe('SessionOverviewPane guided empty-state (cluster B)', () => {
+  it('shows the get-started CTAs and hides the stats grid when fresh', () => {
+    renderPane();
+    expect(screen.getByText('Get started')).toBeDefined();
+    expect(screen.getByRole('button', { name: /create a workflow/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /spawn an agent/i })).toBeDefined();
+    expect(screen.queryByText('At a glance')).toBeNull();
+  });
+
+  it('dispatches the workflow-builder event scoped to the session', () => {
+    const handler = vi.fn();
+    window.addEventListener('goodboy:open-workflow-builder', handler);
+    renderPane();
+    fireEvent.click(screen.getByRole('button', { name: /create a workflow/i }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect((handler.mock.calls[0]![0] as CustomEvent).detail).toEqual({ sessionId: 'sess-1' });
+    window.removeEventListener('goodboy:open-workflow-builder', handler);
+  });
+
+  it('spawns an agent for the session from the second CTA', () => {
+    renderPane();
+    fireEvent.click(screen.getByRole('button', { name: /spawn an agent/i }));
+    expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', {});
+  });
+
+  it('treats discarded workflow runs as not active for freshness', () => {
+    renderPane(
+      baseSession({
+        workflowRuns: [{ discardedAt: '2026-06-22T11:00:00.000Z' }],
+      } as unknown as Partial<Session>),
+    );
+    expect(screen.getByText('Get started')).toBeDefined();
+  });
+});
+
+describe('SessionOverviewPane stats grid', () => {
+  beforeEach(() => {
+    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
+  });
+
+  it('renders the at-a-glance grid and hides the get-started CTAs once work exists', () => {
+    renderPane();
+    expect(screen.getByText('At a glance')).toBeDefined();
+    expect(screen.queryByText('Get started')).toBeNull();
+  });
+
+  it('reports running agents as a ratio', () => {
+    renderPane();
+    expect(screen.getByText('1/1')).toBeDefined();
+    expect(screen.getByText('agents running')).toBeDefined();
+  });
+
+  it('uses the singular files label for a single change', () => {
+    renderPane(baseSession(), vi.fn(), { count: 1 } as unknown as FilesTouched);
+    expect(screen.getByText('file changed')).toBeDefined();
+  });
+
+  it('selects the lens when a stat card is clicked', () => {
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByText('active workflows'));
+    expect(onSelectLens).toHaveBeenCalledWith('workflows');
+  });
+});
+
+describe('SessionOverviewPane nudges', () => {
+  it('surfaces open questions with the first line as detail', () => {
+    hooks.openQuestions = [
+      { status: 'open', text: 'why this approach?\nmore detail' },
+    ] as unknown as ReadonlyArray<OpenQuestion>;
+    const onSelectLens = renderPane();
+    expect(screen.getByText('1 open question')).toBeDefined();
+    expect(screen.getByText('why this approach?')).toBeDefined();
+    fireEvent.click(screen.getByText('1 open question'));
+    expect(onSelectLens).toHaveBeenCalledWith('questions');
+  });
+
+  it('shows the calm fallback when nothing needs the user', () => {
+    renderPane();
+    expect(screen.getByText(/nothing needs you right now/i)).toBeDefined();
+  });
+
+  it('raises an attention nudge for a pull request', () => {
+    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
+    hooks.stage = { stage: 'attention', reason: 'PR needs review' } as SessionStageInfo;
+    renderPane();
+    expect(screen.getByText(/pull request needs you/i)).toBeDefined();
+  });
+});
+
+describe('SessionOverviewPane jump-to links', () => {
+  it('selects the goal lens from the jump-to row', () => {
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByRole('button', { name: /^goal$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('goal');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -12,19 +12,26 @@ import {
   SquareTerminal,
   Target,
   Terminal,
+  Workflow,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { FolderGit2 } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { Session, SessionStage } from '@goodboy/types';
+import type { Session, SessionId, SessionStage } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
   useAppStore,
+  useCurrentWorkspace,
   useSessionOpenQuestions,
   useSessionPlans,
   useSessionStageInfo,
 } from '../../../../store';
 import type { FilesTouched, LensKind } from '../../../../store';
 import { ScrollFade } from '../../../../shared/components/ScrollFade';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import { SummarizerBadge } from '../../../workspace/components/SessionDetailPanel/SummarizerBadge';
+import { BranchChip } from './BranchChip';
+import { SessionCostChip } from './SessionCostChip';
 import {
   resolveAttentionLens,
   selectAttention,
@@ -99,6 +106,9 @@ export const SessionOverviewPane = ({
   onSelectLens,
 }: SessionOverviewPaneProps) => {
   const stage = useSessionStageInfo(session);
+  const workspace = useCurrentWorkspace();
+  const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
   const attention = selectAttention(stage);
   const openQuestions = selectOpenQuestions(useSessionOpenQuestions(session.id));
   const agents = selectStandaloneAgents(
@@ -119,6 +129,15 @@ export const SessionOverviewPane = ({
 
   const openCount = openQuestions.length;
   const activeWorkflows = session.workflowRuns.filter((r) => r.discardedAt == null).length;
+  const isFresh = activeWorkflows === 0 && agents.length === 0;
+
+  const openWorkflowBuilder = () => {
+    window.dispatchEvent(
+      new CustomEvent('goodboy:open-workflow-builder', {
+        detail: { sessionId: session.id as SessionId },
+      }),
+    );
+  };
 
   const nudges: Nudge[] = [];
   if (openCount > 0) {
@@ -225,6 +244,20 @@ export const SessionOverviewPane = ({
           {stage.reason ? (
             <p className="text-sm leading-relaxed text-muted-foreground">{stage.reason}</p>
           ) : null}
+          <div className="flex flex-wrap items-center gap-2">
+            {workspace ? (
+              <span className="inline-flex min-w-0 shrink items-center gap-1.5 rounded-md border border-border-soft bg-muted/30 px-2 py-1 text-2xs text-foreground/80">
+                <FolderGit2 size={10} aria-hidden className="shrink-0 text-muted-foreground" />
+                <span className="truncate">{workspace.name}</span>
+              </span>
+            ) : null}
+            {branch ? <BranchChip branch={branch} /> : null}
+            <SessionCostChip sessionId={session.id as SessionId} />
+            <SummarizerBadge sessionId={session.id as SessionId} />
+            <span className="text-2xs text-muted-foreground/70">
+              {formatRelativeDuration(session.createdAt)} old
+            </span>
+          </div>
         </div>
 
         {nudges.length > 0 ? (
@@ -267,38 +300,33 @@ export const SessionOverviewPane = ({
           </div>
         )}
 
-        <div className="flex flex-col gap-2">
-          <span className="px-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">
-            At a glance
-          </span>
-          <div className="grid grid-cols-2 gap-2">
-            {stats.map((stat) => (
+        {isFresh ? (
+          <div className="flex flex-col gap-2">
+            <span className="px-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">
+              Get started
+            </span>
+            <div className="grid grid-cols-2 gap-2">
               <button
-                key={stat.kind}
                 type="button"
-                onClick={() => onSelectLens(stat.kind)}
-                className={cn(
-                  'group flex items-center gap-3 rounded-xl border bg-elevated px-3.5 py-3 text-left shadow-sm transition-all',
-                  'hover:-translate-y-px hover:shadow-md',
-                  stat.alert
-                    ? 'border-warning/40 hover:border-warning/60'
-                    : 'border-border-soft hover:border-border',
-                )}
+                onClick={openWorkflowBuilder}
+                className="group flex items-center gap-3 rounded-xl border border-border-soft bg-elevated px-3.5 py-3 text-left shadow-sm transition-all hover:-translate-y-px hover:border-border hover:shadow-md"
               >
                 <span
                   aria-hidden
                   className={cn(
                     'flex size-9 shrink-0 items-center justify-center rounded-lg ring-1',
-                    TONE[stat.tone].chip,
+                    TONE.accent.chip,
                   )}
                 >
-                  <stat.icon size={16} aria-hidden className={TONE[stat.tone].icon} />
+                  <Workflow size={16} aria-hidden className={TONE.accent.icon} />
                 </span>
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="text-lg font-semibold leading-none text-foreground tabular-nums">
-                    {stat.value}
+                  <span className="text-sm font-semibold leading-tight text-foreground">
+                    Create a workflow
                   </span>
-                  <span className="truncate text-xs text-muted-foreground">{stat.label}</span>
+                  <span className="truncate text-xs text-muted-foreground">
+                    Chain agents into steps
+                  </span>
                 </span>
                 <ArrowRight
                   size={14}
@@ -306,9 +334,82 @@ export const SessionOverviewPane = ({
                   className="shrink-0 text-muted-foreground/30 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
                 />
               </button>
-            ))}
+              <button
+                type="button"
+                onClick={() => {
+                  void spawnAgent(session.id as SessionId, {});
+                }}
+                className="group flex items-center gap-3 rounded-xl border border-border-soft bg-elevated px-3.5 py-3 text-left shadow-sm transition-all hover:-translate-y-px hover:border-border hover:shadow-md"
+              >
+                <span
+                  aria-hidden
+                  className={cn(
+                    'flex size-9 shrink-0 items-center justify-center rounded-lg ring-1',
+                    TONE.primary.chip,
+                  )}
+                >
+                  <Bot size={16} aria-hidden className={TONE.primary.icon} />
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="text-sm font-semibold leading-tight text-foreground">
+                    Spawn an agent
+                  </span>
+                  <span className="truncate text-xs text-muted-foreground">
+                    Start a one-off session
+                  </span>
+                </span>
+                <ArrowRight
+                  size={14}
+                  aria-hidden
+                  className="shrink-0 text-muted-foreground/30 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+                />
+              </button>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <span className="px-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">
+              At a glance
+            </span>
+            <div className="grid grid-cols-2 gap-2">
+              {stats.map((stat) => (
+                <button
+                  key={stat.kind}
+                  type="button"
+                  onClick={() => onSelectLens(stat.kind)}
+                  className={cn(
+                    'group flex items-center gap-3 rounded-xl border bg-elevated px-3.5 py-3 text-left shadow-sm transition-all',
+                    'hover:-translate-y-px hover:shadow-md',
+                    stat.alert
+                      ? 'border-warning/40 hover:border-warning/60'
+                      : 'border-border-soft hover:border-border',
+                  )}
+                >
+                  <span
+                    aria-hidden
+                    className={cn(
+                      'flex size-9 shrink-0 items-center justify-center rounded-lg ring-1',
+                      TONE[stat.tone].chip,
+                    )}
+                  >
+                    <stat.icon size={16} aria-hidden className={TONE[stat.tone].icon} />
+                  </span>
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-lg font-semibold leading-none text-foreground tabular-nums">
+                      {stat.value}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">{stat.label}</span>
+                  </span>
+                  <ArrowRight
+                    size={14}
+                    aria-hidden
+                    className="shrink-0 text-muted-foreground/30 transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="flex flex-col gap-2">
           <span className="px-0.5 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent, OpenQuestion, SessionStageInfo } from '@goodboy/types';
+import {
+  isStandaloneAgent,
+  resolveAttentionLens,
+  selectAttention,
+  selectOpenQuestions,
+  selectStandaloneAgents,
+} from './lib';
+
+const agent = (over: Partial<Agent>): Agent =>
+  ({ parentAgentId: null, workflowRunId: null, stepId: null, ...over }) as unknown as Agent;
+
+const stage = (over: Partial<SessionStageInfo>): SessionStageInfo =>
+  ({ stage: 'building', reason: '', ...over }) as SessionStageInfo;
+
+const question = (over: Partial<OpenQuestion>): OpenQuestion =>
+  ({ status: 'open', text: 'q', ...over }) as unknown as OpenQuestion;
+
+describe('isStandaloneAgent', () => {
+  it('treats a top-level agent with no workflow binding as standalone', () => {
+    expect(isStandaloneAgent(agent({}))).toBe(true);
+  });
+
+  it('rejects a child agent', () => {
+    expect(isStandaloneAgent(agent({ parentAgentId: 'a1' as Agent['parentAgentId'] }))).toBe(false);
+  });
+
+  it('rejects an agent bound to a workflow step', () => {
+    expect(
+      isStandaloneAgent(
+        agent({
+          workflowRunId: 'run1' as Agent['workflowRunId'],
+          stepId: 'step1' as Agent['stepId'],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps an agent that has a workflowRunId but no stepId', () => {
+    expect(isStandaloneAgent(agent({ workflowRunId: 'run1' as Agent['workflowRunId'] }))).toBe(
+      true,
+    );
+  });
+});
+
+describe('selectStandaloneAgents', () => {
+  it('filters out child and workflow-bound agents', () => {
+    const list = [
+      agent({}),
+      agent({ parentAgentId: 'p' as Agent['parentAgentId'] }),
+      agent({
+        workflowRunId: 'r' as Agent['workflowRunId'],
+        stepId: 's' as Agent['stepId'],
+      }),
+    ];
+    expect(selectStandaloneAgents(list)).toHaveLength(1);
+  });
+
+  it('returns an empty array when given none', () => {
+    expect(selectStandaloneAgents([])).toEqual([]);
+  });
+});
+
+describe('selectAttention', () => {
+  it('flags active when the stage is attention and carries the reason', () => {
+    expect(selectAttention(stage({ stage: 'attention', reason: 'needs you' }))).toEqual({
+      active: true,
+      reason: 'needs you',
+    });
+  });
+
+  it('is inactive for any other stage', () => {
+    expect(selectAttention(stage({ stage: 'running', reason: 'x' })).active).toBe(false);
+  });
+});
+
+describe('resolveAttentionLens', () => {
+  const ctx = { hasStandalone: false, hasWorkflow: false };
+
+  it('returns null when not in the attention stage', () => {
+    expect(resolveAttentionLens(stage({ stage: 'running' }), ctx)).toBeNull();
+  });
+
+  it('routes a PR reason to the pr lens', () => {
+    expect(
+      resolveAttentionLens(stage({ stage: 'attention', reason: 'PR needs review' }), ctx),
+    ).toBe('pr');
+  });
+
+  it('routes a question reason to the questions lens', () => {
+    expect(
+      resolveAttentionLens(stage({ stage: 'attention', reason: 'an open question' }), ctx),
+    ).toBe('questions');
+  });
+
+  it('prefers standalone agents over workflows', () => {
+    expect(
+      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
+        hasStandalone: true,
+        hasWorkflow: true,
+      }),
+    ).toBe('agents');
+  });
+
+  it('falls back to workflows when only a workflow is present', () => {
+    expect(
+      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
+        hasStandalone: false,
+        hasWorkflow: true,
+      }),
+    ).toBe('workflows');
+  });
+
+  it('defaults to agents when nothing else matches', () => {
+    expect(resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), ctx)).toBe('agents');
+  });
+});
+
+describe('selectOpenQuestions', () => {
+  it('keeps only open questions', () => {
+    const list = [
+      question({ status: 'open' }),
+      question({ status: 'answered' as OpenQuestion['status'] }),
+      question({ status: 'open' }),
+    ];
+    expect(selectOpenQuestions(list)).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
@@ -1,10 +1,7 @@
 import { Divider } from '@goodboy/ui';
 import type { Session } from '@goodboy/types';
 import { useSessionStageInfo } from '../../../../../store';
-import {
-  SessionDetailPanel,
-  SessionMetaFooter,
-} from '../../../../workspace/components/SessionDetailPanel';
+import { SessionDetailPanel } from '../../../../workspace/components/SessionDetailPanel';
 
 type SessionTopBarProps = {
   readonly session: Session;
@@ -28,7 +25,6 @@ export const SessionTopBar = ({ session }: SessionTopBarProps) => {
             {reason}
           </span>
         ) : null}
-        <SessionMetaFooter session={session} />
       </div>
       <Divider />
     </>

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -44,7 +44,8 @@ vi.mock('../../../../store', () => {
     { getState },
   );
   const useSessionSlots = () => [{ key: 'goal', value: 'do a thing' }];
-  return { EMPTY_ARRAY: Object.freeze([]), useAppStore, useSessionSlots };
+  const useCurrentWorkspace = () => ({ name: 'Test workspace' });
+  return { EMPTY_ARRAY: Object.freeze([]), useAppStore, useCurrentWorkspace, useSessionSlots };
 });
 
 vi.mock('../../../../app/components/Toast', () => ({
@@ -141,6 +142,14 @@ async function draftPlan() {
   fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
   await waitFor(() => screen.getByText('Workflow ready'));
 }
+
+describe('WorkflowBuilderView (studio chrome)', () => {
+  it('renders the studio header with the title and workspace name', () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: /start a workflow/i })).toBeDefined();
+    expect(screen.getByText('Test workspace')).toBeDefined();
+  });
+});
 
 describe('WorkflowBuilderView (custom mode, no presets)', () => {
   it('enables start only after a plan is drafted', async () => {
@@ -248,7 +257,7 @@ describe('WorkflowBuilderView (preset mode)', () => {
     storeState.phaseTemplates = { 'ws-1': [presetWorkflow('wf-preset-1', 'Ship It')] };
     const onClose = vi.fn();
     render(<WorkflowBuilderView session={session} onClose={onClose} />);
-    expect(screen.getByText(/pick the preset/i)).toBeDefined();
+    expect(screen.getByText(/pick a preset\./i)).toBeDefined();
     const start = screen.getByRole('button', { name: /start workflow/i }) as HTMLButtonElement;
     expect(start.disabled).toBe(true);
 

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -16,6 +16,7 @@ import {
   Target,
   Undo2,
   Wand2,
+  type LucideIcon,
 } from 'lucide-react';
 import { Button, Divider, Input, Textarea, cn } from '@goodboy/ui';
 import {
@@ -40,7 +41,7 @@ import type {
   WorkflowRunId,
   WorkflowTriggerMode,
 } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore, useSessionSlots } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore, useCurrentWorkspace, useSessionSlots } from '../../../../store';
 import type {
   Mode,
   StepEdit,
@@ -65,7 +66,7 @@ import {
 import { formatError } from '../../../../shared/lib/errors';
 import { ToggleSwitch } from '../../../../shared/components/ToggleSwitch';
 import { useToast } from '../../../../app/components/Toast';
-import { OverlayHeader } from '../../../../shared/components/OverlayHeader';
+import { StudioShell } from '../../../../shared/components/StudioShell';
 import { useClickOutside } from '../../../../shared/hooks/useClickOutside';
 import { useDropdownDirection } from '../../../../shared/hooks/useDropdownDirection';
 import { POPUP_BASE, POPUP_DOWN, POPUP_UP } from '../dropdown-utils';
@@ -253,18 +254,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   };
   const sessionGoal = (sessionSlots.find((s) => s.key === 'goal')?.value ?? '').trim();
   const selectedPreset = presets.find((t) => t.id === selectedPresetId) ?? null;
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && !blocked) {
-        e.preventDefault();
-        handleClose();
-      }
-    };
-    window.addEventListener('keydown', onKey, { capture: true });
-    return () => window.removeEventListener('keydown', onKey, { capture: true });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [blocked]);
+  const workspaceName = useCurrentWorkspace()?.name ?? '';
 
   const replaceGoal = (next: string) => {
     setGoalHistory((h) => [...h, goalText]);
@@ -425,16 +415,15 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const onStart = mode === 'preset' ? onStartPreset : onStartCustom;
 
   return (
-    <div className="flex h-full w-full flex-col bg-background motion-safe:animate-studio-in">
-      <OverlayHeader
-        icon={Sparkles}
-        title="Start a workflow"
-        subtitle={`for: ${session.goal}`}
-        onClose={handleClose}
-        closeLabel="cancel workflow builder"
-        closeDisabled={blocked}
-      >
-        {!draftEmpty ? (
+    <StudioShell
+      icon={Sparkles}
+      title="Start a workflow"
+      workspaceName={workspaceName}
+      closeLabel="cancel workflow builder"
+      onClose={handleClose}
+      variant="slot"
+      headerAccessory={
+        !draftEmpty ? (
           <button
             type="button"
             onClick={resetDraft}
@@ -448,487 +437,518 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
           >
             <RotateCcw size={11} aria-hidden /> Reset
           </button>
-        ) : null}
-      </OverlayHeader>
-      <Divider />
+        ) : null
+      }
+    >
+      {() => (
+        <div className="flex min-h-0 w-full flex-1 flex-col">
+          <div className="flex min-h-0 flex-1">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-6 py-6">
+              <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+                <section className="flex flex-col gap-2">
+                  <SectionHeader icon={Target} label="Goal" htmlFor="workflow-goal">
+                    {goalHistory.length > 0 ? (
+                      <button
+                        type="button"
+                        onClick={onUndoGoal}
+                        disabled={blocked || polishing}
+                        aria-label="undo goal change"
+                        className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        <Undo2 size={10} aria-hidden /> Undo
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => void onPolishGoal()}
+                      disabled={blocked || polishing || goalText.trim().length === 0}
+                      aria-label="polish goal"
+                      className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      {polishing ? (
+                        <Loader2 size={10} className="animate-spin" aria-hidden />
+                      ) : (
+                        <Wand2 size={10} aria-hidden />
+                      )}
+                      Polish
+                    </button>
+                    {sessionGoal.length > 0 ? (
+                      <button
+                        type="button"
+                        onClick={onUseSessionGoal}
+                        disabled={blocked || polishing || goalText === sessionGoal}
+                        className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/5 px-2 py-0.5 text-2xs text-primary transition-colors hover:border-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Use session goal
+                      </button>
+                    ) : null}
+                  </SectionHeader>
+                  <Textarea
+                    id="workflow-goal"
+                    value={goalText}
+                    onChange={(e) => setGoalText(e.target.value)}
+                    placeholder="what should this workflow accomplish? same as the session, or a specific sub-objective (e.g. just the auth module)…"
+                    autoGrow
+                    minRows={2}
+                    maxRows={4}
+                    disabled={busy || polishing}
+                    className="resize-none rounded-lg bg-subtle/80 px-4 py-3 text-sm ring-1 ring-border-soft focus-visible:ring-foreground/15"
+                  />
+                  <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
+                    Every step works toward this goal.
+                  </p>
+                </section>
 
-      <div className="flex min-h-0 flex-1">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto px-6 py-5">
-          <div className="mx-auto my-auto flex w-full max-w-2xl flex-col gap-4">
-            <div className="flex flex-col gap-1.5">
-              <div className="flex items-center gap-2">
-                <label
-                  htmlFor="workflow-goal"
-                  className="inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70"
-                >
-                  <Target size={11} aria-hidden /> Goal
-                </label>
-                <div className="flex-1" />
-                {goalHistory.length > 0 ? (
-                  <button
-                    type="button"
-                    onClick={onUndoGoal}
-                    disabled={blocked || polishing}
-                    aria-label="undo goal change"
-                    className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    <Undo2 size={10} aria-hidden /> Undo
-                  </button>
-                ) : null}
-                <button
-                  type="button"
-                  onClick={() => void onPolishGoal()}
-                  disabled={blocked || polishing || goalText.trim().length === 0}
-                  aria-label="polish goal"
-                  className="inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {polishing ? (
-                    <Loader2 size={10} className="animate-spin" aria-hidden />
-                  ) : (
-                    <Wand2 size={10} aria-hidden />
-                  )}
-                  Polish
-                </button>
-                {sessionGoal.length > 0 ? (
-                  <button
-                    type="button"
-                    onClick={onUseSessionGoal}
-                    disabled={blocked || polishing || goalText === sessionGoal}
-                    className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/5 px-2 py-0.5 text-2xs text-primary transition-colors hover:border-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    Use session goal
-                  </button>
-                ) : null}
-              </div>
-              <Textarea
-                id="workflow-goal"
-                value={goalText}
-                onChange={(e) => setGoalText(e.target.value)}
-                placeholder="what should this workflow accomplish? same as the session, or a specific sub-objective (e.g. just the auth module)…"
-                autoGrow
-                minRows={2}
-                maxRows={4}
-                disabled={busy || polishing}
-                className="resize-none rounded-lg bg-subtle/80 px-4 py-3 text-sm ring-1 ring-border-soft focus-visible:ring-foreground/15"
-              />
-              <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
-                Every step of the workflow works toward this goal.
-              </p>
-            </div>
+                <Divider />
 
-            <div className="flex flex-col gap-1.5">
-              <span className="inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
-                <Paperclip size={11} aria-hidden /> Attachments
-              </span>
-              <div
-                ref={composerRef}
-                className={cn(
-                  'flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors',
-                  isDragging ? 'border-primary bg-primary/5' : 'border-border-soft',
-                )}
-              >
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept={ATTACHMENT_ACCEPT}
-                  multiple
-                  hidden
-                  onChange={onFileInputChange}
-                />
-                {attachments.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {attachments.map((a) => (
-                      <AttachmentChip
-                        key={a.id}
-                        attachment={a}
-                        onRemove={() => removeAttachment(a.id)}
-                      />
-                    ))}
+                <section className="flex flex-col gap-2">
+                  <SectionHeader icon={Paperclip} label="Attachments" />
+                  <div
+                    ref={composerRef}
+                    className={cn(
+                      'flex flex-col gap-2.5 rounded-lg border border-dashed px-3 py-3 transition-colors',
+                      isDragging ? 'border-primary bg-primary/5' : 'border-border-soft',
+                    )}
+                  >
+                    <input
+                      ref={fileInputRef}
+                      type="file"
+                      accept={ATTACHMENT_ACCEPT}
+                      multiple
+                      hidden
+                      onChange={onFileInputChange}
+                    />
+                    {attachments.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {attachments.map((a) => (
+                          <AttachmentChip
+                            key={a.id}
+                            attachment={a}
+                            onRemove={() => removeAttachment(a.id)}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={blocked}
+                      className={cn(
+                        'inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors',
+                        blocked
+                          ? 'cursor-not-allowed text-muted-foreground/40'
+                          : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                      )}
+                    >
+                      <Paperclip size={13} aria-hidden /> Add files
+                    </button>
                   </div>
-                ) : null}
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={blocked}
-                  className={cn(
-                    'inline-flex w-fit items-center gap-1.5 rounded-md border border-border px-2.5 py-1 text-xs transition-colors',
-                    blocked
-                      ? 'cursor-not-allowed text-muted-foreground/40'
-                      : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                  )}
-                >
-                  <Paperclip size={13} aria-hidden /> Add files
-                </button>
-              </div>
-              <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
-                Routed to the agents that benefit from each type, on top of the session goal
-                attachments.
-              </p>
-            </div>
+                  <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
+                    Routed to the agents that need them.
+                  </p>
+                </section>
 
-            <div className="flex w-fit items-center gap-0.5 rounded-lg bg-subtle/80 p-0.5 ring-1 ring-border-soft">
-              <button
-                type="button"
-                onClick={() => setMode('preset')}
-                disabled={blocked}
-                aria-pressed={mode === 'preset'}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
-                  mode === 'preset'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                <ListChecks size={12} aria-hidden /> Preset
-              </button>
-              <button
-                type="button"
-                onClick={() => setMode('custom')}
-                disabled={blocked}
-                aria-pressed={mode === 'custom'}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
-                  mode === 'custom'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground',
-                )}
-              >
-                <Sparkles size={12} aria-hidden /> Custom
-                <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-                  beta
-                </span>
-              </button>
-            </div>
+                <Divider />
 
-            {mode === 'preset' ? (
-              <div className="flex flex-col gap-2">
-                <p className="text-xs leading-relaxed text-muted-foreground">
-                  Pick the preset to run toward this goal. Its steps show on the right.
-                </p>
-                {presets.length === 0 ? (
-                  <div className="flex flex-col items-start gap-2 rounded-lg border border-dashed border-border-soft px-4 py-5">
-                    <p className="text-xs text-muted-foreground">
-                      No presets in this workspace yet.
-                    </p>
+                <section className="flex flex-col gap-3">
+                  <SectionHeader icon={Layers} label="Approach" />
+                  <div className="flex w-fit items-center gap-0.5 rounded-lg bg-subtle/80 p-0.5 ring-1 ring-border-soft">
+                    <button
+                      type="button"
+                      onClick={() => setMode('preset')}
+                      disabled={blocked}
+                      aria-pressed={mode === 'preset'}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
+                        mode === 'preset'
+                          ? 'bg-background text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
+                    >
+                      <ListChecks size={12} aria-hidden /> Preset
+                    </button>
                     <button
                       type="button"
                       onClick={() => setMode('custom')}
-                      className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2.5 py-1 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/10"
+                      disabled={blocked}
+                      aria-pressed={mode === 'custom'}
+                      className={cn(
+                        'inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
+                        mode === 'custom'
+                          ? 'bg-background text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground',
+                      )}
                     >
-                      <Sparkles size={12} aria-hidden /> Describe your own
+                      <Sparkles size={12} aria-hidden /> Custom
                     </button>
                   </div>
+
+                  {mode === 'preset' ? (
+                    <div className="flex flex-col gap-2">
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        Pick a preset. Its steps show on the right.
+                      </p>
+                      {presets.length === 0 ? (
+                        <div className="flex flex-col items-start gap-2 rounded-lg border border-dashed border-border-soft px-4 py-5">
+                          <p className="text-xs text-muted-foreground">
+                            No presets in this workspace yet.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => setMode('custom')}
+                            className="inline-flex items-center gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2.5 py-1 text-xs text-primary transition-colors hover:border-primary hover:bg-primary/10"
+                          >
+                            <Sparkles size={12} aria-hidden /> Describe your own
+                          </button>
+                        </div>
+                      ) : (
+                        <div className="flex flex-col gap-2" role="radiogroup" aria-label="presets">
+                          {presets.map((t) => {
+                            const steps = sortedSteps(t);
+                            const kinds = steps.map(templateStepKind);
+                            const shown = kinds.slice(0, 5);
+                            const selected = t.id === selectedPresetId;
+                            return (
+                              <button
+                                key={t.id}
+                                type="button"
+                                role="radio"
+                                aria-checked={selected}
+                                onClick={() => setSelectedPresetId(t.id)}
+                                disabled={busy}
+                                className={cn(
+                                  'flex flex-col gap-1.5 rounded-lg border px-3 py-2.5 text-left transition-colors',
+                                  selected
+                                    ? 'border-primary bg-primary/5'
+                                    : 'border-border-soft hover:border-border hover:bg-muted/40',
+                                  busy && 'cursor-not-allowed opacity-60',
+                                )}
+                              >
+                                <span className="flex items-center gap-2">
+                                  <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                                    {t.name}
+                                  </span>
+                                  {selected ? (
+                                    <Check
+                                      size={13}
+                                      className="shrink-0 text-primary"
+                                      aria-hidden
+                                    />
+                                  ) : (
+                                    <span className="shrink-0 text-[10px] text-muted-foreground/50">
+                                      {steps.length} step{steps.length === 1 ? '' : 's'}
+                                    </span>
+                                  )}
+                                </span>
+                                {t.description || t.goal ? (
+                                  <span className="truncate text-[10px] leading-snug text-muted-foreground/70">
+                                    {t.description || t.goal}
+                                  </span>
+                                ) : null}
+                                <span className="flex items-center gap-1">
+                                  {shown.map((k, i) => (
+                                    <AgentAvatar key={`${k}-${i}`} kind={k} size="xs" />
+                                  ))}
+                                  {kinds.length > shown.length ? (
+                                    <span className="text-[10px] text-muted-foreground/40">
+                                      +{kinds.length - shown.length}
+                                    </span>
+                                  ) : null}
+                                </span>
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex flex-col gap-2">
+                      <p className="text-xs leading-relaxed text-muted-foreground">
+                        Describe the flow. The planner drafts ordered steps you can tune before
+                        starting.
+                      </p>
+                      <div
+                        ref={promptRef}
+                        className="rounded-lg bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15"
+                      >
+                        <div className="relative">
+                          <Textarea
+                            value={processText}
+                            onChange={(e) => setProcessText(e.target.value)}
+                            placeholder="describe the process you expect (e.g. read the existing github integration, study how it works, then plan the gitlab equivalent, then implement)…"
+                            autoGrow
+                            minRows={5}
+                            maxRows={10}
+                            className="min-h-24 resize-none border-0 bg-transparent px-4 pt-3 pb-12 text-sm shadow-none focus-visible:ring-0"
+                          />
+                          <div className="absolute bottom-2.5 right-2.5">
+                            <Button
+                              size="sm"
+                              onClick={() => void onPlan()}
+                              disabled={blocked || processText.trim().length === 0}
+                              className="min-w-[6.5rem]"
+                            >
+                              {planning ? (
+                                <Loader2 size={15} className="animate-spin" aria-label="planning" />
+                              ) : plan ? (
+                                'Re-plan'
+                              ) : (
+                                'Generate plan'
+                              )}
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex justify-end px-1">
+                        <span className="text-2xs text-muted-foreground/60">
+                          cheap-tier · {providerId}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </section>
+
+                <Divider />
+
+                <section className="flex flex-col gap-2">
+                  <SectionHeader icon={Play} label="When to start" />
+                  <div className="flex flex-wrap items-center gap-2">
+                    <div className="flex w-fit items-center gap-0.5 rounded-lg bg-subtle/80 p-0.5 ring-1 ring-border-soft">
+                      <TriggerButton
+                        active={triggerMode === 'immediate'}
+                        disabled={blocked}
+                        onClick={() => setTriggerMode('immediate')}
+                        icon={<Play size={12} aria-hidden />}
+                        label="Start now"
+                      />
+                      <TriggerButton
+                        active={triggerMode === 'manual'}
+                        disabled={blocked}
+                        onClick={() => setTriggerMode('manual')}
+                        icon={<Hand size={12} aria-hidden />}
+                        label="Start manually"
+                      />
+                      {activeRuns.length > 0 ? (
+                        <TriggerButton
+                          active={triggerMode === 'after_run'}
+                          disabled={blocked}
+                          onClick={() => {
+                            setTriggerMode('after_run');
+                            if (chainAfterId === null) {
+                              setChainAfterId(latestActiveRunId);
+                            }
+                          }}
+                          icon={<Link2 size={12} aria-hidden />}
+                          label="Run after"
+                        />
+                      ) : null}
+                    </div>
+                    {triggerMode === 'after_run' && activeRuns.length > 1 ? (
+                      <ChainAfterSelect
+                        runs={activeRuns}
+                        value={resolvedChainId}
+                        disabled={blocked}
+                        onChange={setChainAfterId}
+                      />
+                    ) : null}
+                  </div>
+                  <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
+                    {triggerMode === 'immediate'
+                      ? 'Runs as soon as you start it.'
+                      : triggerMode === 'manual'
+                        ? 'Stays queued until you start it from the sidebar.'
+                        : `Starts after ${
+                            activeRuns.find((e) => e.run.id === resolvedChainId)?.template.name ??
+                            'the selected workflow'
+                          } completes.`}
+                  </p>
+                </section>
+              </div>
+            </div>
+
+            <div className="hidden w-96 shrink-0 flex-col overflow-y-auto border-l border-border-soft bg-subtle/40 px-4 py-6 lg:flex">
+              {mode === 'preset' ? (
+                selectedPreset ? (
+                  <div className="flex flex-col gap-2.5">
+                    <div className="flex items-center gap-2">
+                      <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
+                        <Check size={10} className="text-success" aria-hidden />
+                      </span>
+                      <span className="text-xs font-medium text-foreground">Preset ready</span>
+                      <span className="text-2xs text-muted-foreground/60">
+                        {selectedPreset.steps.length} step
+                        {selectedPreset.steps.length === 1 ? '' : 's'}
+                      </span>
+                    </div>
+                    <div className="truncate text-xs font-semibold text-foreground">
+                      {selectedPreset.name}
+                    </div>
+                    <ol className="flex flex-col divide-y divide-border-soft/50">
+                      {sortedSteps(selectedPreset).map((s, i) => (
+                        <ReadOnlyStepCard
+                          key={s.id}
+                          ordinal={i}
+                          kind={templateStepKind(s)}
+                          name={s.name}
+                          role={s.role ?? 'custom'}
+                          model={s.modelOverride}
+                          effort={s.effort}
+                          promptPrefix={s.promptPrefix}
+                        />
+                      ))}
+                    </ol>
+                  </div>
                 ) : (
-                  <div
-                    className="flex flex-col divide-y divide-border-soft/50"
-                    role="radiogroup"
-                    aria-label="presets"
-                  >
-                    {presets.map((t) => {
-                      const steps = sortedSteps(t);
-                      const kinds = steps.map(templateStepKind);
-                      const shown = kinds.slice(0, 5);
-                      const selected = t.id === selectedPresetId;
+                  <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+                    <Layers size={22} className="text-muted-foreground/30" aria-hidden />
+                    <p className="text-xs font-medium text-foreground">Step preview</p>
+                    <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
+                      Pick a preset and its ordered steps show here.
+                    </p>
+                  </div>
+                )
+              ) : plan ? (
+                <div className="flex flex-col gap-2.5">
+                  <div className="flex items-center gap-2">
+                    <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
+                      <Check size={10} className="text-success" aria-hidden />
+                    </span>
+                    <span className="text-xs font-medium text-foreground">Workflow ready</span>
+                    <span className="text-2xs text-muted-foreground/60">
+                      {plan.steps.length} step{plan.steps.length === 1 ? '' : 's'}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={onRedesign}
+                      disabled={blocked}
+                      className="ml-auto inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      <Sparkles size={10} aria-hidden /> Re-design
+                    </button>
+                  </div>
+                  <div className="truncate text-xs font-semibold text-foreground">
+                    {plan.workflowName}
+                  </div>
+                  <ol className="flex flex-col divide-y divide-border-soft/50">
+                    {plan.steps.map((s, i) => {
+                      const role = s.role as AgentRole;
+                      const edit = stepEdits[i];
                       return (
-                        <button
-                          key={t.id}
-                          type="button"
-                          role="radio"
-                          aria-checked={selected}
-                          onClick={() => setSelectedPresetId(t.id)}
+                        <EditableStepCard
+                          key={`${i}-${s.name}`}
+                          ordinal={i}
+                          kind={planStepKind(s)}
+                          provider={providerId}
+                          name={edit?.name ?? s.name}
+                          promptPrefix={edit?.promptPrefix ?? s.promptPrefix}
+                          model={edit?.model ?? ''}
+                          effort={(edit?.effort ?? defaultsForRole(role).effort) as EffortLevel}
+                          effortModel={effortModelFor(i, role)}
                           disabled={busy}
-                          className={cn(
-                            'flex flex-col gap-1.5 px-2.5 py-2.5 text-left transition-colors first:rounded-t-md last:rounded-b-md',
-                            selected ? 'bg-primary/5' : 'hover:bg-muted/40',
-                            busy && 'cursor-not-allowed opacity-60',
-                          )}
-                        >
-                          <span className="flex items-center gap-2">
-                            <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-                              {t.name}
-                            </span>
-                            {selected ? (
-                              <Check size={13} className="shrink-0 text-primary" aria-hidden />
-                            ) : (
-                              <span className="shrink-0 text-[10px] text-muted-foreground/50">
-                                {steps.length} step{steps.length === 1 ? '' : 's'}
-                              </span>
-                            )}
-                          </span>
-                          {t.description || t.goal ? (
-                            <span className="truncate text-[10px] leading-snug text-muted-foreground/70">
-                              {t.description || t.goal}
-                            </span>
-                          ) : null}
-                          <span className="flex items-center gap-1">
-                            {shown.map((k, i) => (
-                              <AgentAvatar key={`${k}-${i}`} kind={k} size="xs" />
-                            ))}
-                            {kinds.length > shown.length ? (
-                              <span className="text-[10px] text-muted-foreground/40">
-                                +{kinds.length - shown.length}
-                              </span>
-                            ) : null}
-                          </span>
-                        </button>
+                          onName={(v) => patchStep(i, { name: v })}
+                          onPrompt={(v) => patchStep(i, { promptPrefix: v })}
+                          onModel={(v) => patchStep(i, { model: v })}
+                          onEffort={(v) => patchStep(i, { effort: v })}
+                        />
                       );
                     })}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <div className="flex flex-col gap-2">
-                <p className="text-xs leading-relaxed text-muted-foreground">
-                  Describe the flow you would like: should it commit or not, open a PR, get reviewed
-                  first. The planner drafts the steps, each one spawns its own agent in order, and
-                  you can tune the model per step before starting.
-                </p>
-                <div
-                  ref={promptRef}
-                  className="rounded-lg bg-subtle/80 ring-1 ring-border-soft transition-shadow focus-within:ring-foreground/15"
-                >
-                  <div className="relative">
-                    <Textarea
-                      value={processText}
-                      onChange={(e) => setProcessText(e.target.value)}
-                      placeholder="describe the process you expect (e.g. read the existing github integration, study how it works, then plan the gitlab equivalent, then implement)…"
-                      autoGrow
-                      minRows={5}
-                      maxRows={10}
-                      className="min-h-24 resize-none border-0 bg-transparent px-4 pt-3 pb-12 text-sm shadow-none focus-visible:ring-0"
-                    />
-                    <div className="absolute bottom-2.5 right-2.5">
-                      <Button
-                        size="sm"
-                        onClick={() => void onPlan()}
-                        disabled={blocked || processText.trim().length === 0}
-                        className="min-w-[6.5rem]"
-                      >
-                        {planning ? (
-                          <Loader2 size={15} className="animate-spin" aria-label="planning" />
-                        ) : plan ? (
-                          'Re-plan'
-                        ) : (
-                          'Generate plan'
-                        )}
-                      </Button>
-                    </div>
-                  </div>
+                  </ol>
                 </div>
-                <div className="flex justify-end px-1">
-                  <span className="text-2xs text-muted-foreground/60">
-                    cheap-tier · {providerId}
-                  </span>
+              ) : planning ? (
+                <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+                  <Loader2
+                    size={22}
+                    className="animate-spin text-muted-foreground/40"
+                    aria-hidden
+                  />
+                  <p className="text-xs font-medium text-foreground">Drafting plan</p>
+                  <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
+                    The planner is breaking your process into ordered steps.
+                  </p>
                 </div>
-              </div>
-            )}
-
-            <div className="flex flex-col gap-1.5">
-              <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
-                When to start
-              </span>
-              <div className="flex flex-wrap items-center gap-2">
-                <div className="flex w-fit items-center gap-0.5 rounded-lg bg-subtle/80 p-0.5 ring-1 ring-border-soft">
-                  <TriggerButton
-                    active={triggerMode === 'immediate'}
-                    disabled={blocked}
-                    onClick={() => setTriggerMode('immediate')}
-                    icon={<Play size={12} aria-hidden />}
-                    label="Start now"
-                  />
-                  <TriggerButton
-                    active={triggerMode === 'manual'}
-                    disabled={blocked}
-                    onClick={() => setTriggerMode('manual')}
-                    icon={<Hand size={12} aria-hidden />}
-                    label="Start manually"
-                  />
-                  {activeRuns.length > 0 ? (
-                    <TriggerButton
-                      active={triggerMode === 'after_run'}
-                      disabled={blocked}
-                      onClick={() => {
-                        setTriggerMode('after_run');
-                        if (chainAfterId === null) {
-                          setChainAfterId(latestActiveRunId);
-                        }
-                      }}
-                      icon={<Link2 size={12} aria-hidden />}
-                      label="Run after"
-                    />
-                  ) : null}
+              ) : (
+                <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
+                  <Layers size={22} className="text-muted-foreground/30" aria-hidden />
+                  <p className="text-xs font-medium text-foreground">Step preview</p>
+                  <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
+                    Once the planner drafts a workflow, the ordered steps show here with a model
+                    pick per step.
+                  </p>
                 </div>
-                {triggerMode === 'after_run' && activeRuns.length > 1 ? (
-                  <ChainAfterSelect
-                    runs={activeRuns}
-                    value={resolvedChainId}
-                    disabled={blocked}
-                    onChange={setChainAfterId}
-                  />
-                ) : null}
-              </div>
-              <p className="px-1 text-2xs leading-relaxed text-muted-foreground/60">
-                {triggerMode === 'immediate'
-                  ? 'Runs as soon as you start it.'
-                  : triggerMode === 'manual'
-                    ? 'Stays queued until you start it from the sidebar.'
-                    : `Starts after ${
-                        activeRuns.find((e) => e.run.id === resolvedChainId)?.template.name ??
-                        'the selected workflow'
-                      } completes.`}
-              </p>
+              )}
             </div>
           </div>
-        </div>
 
-        <div className="hidden w-96 shrink-0 flex-col overflow-y-auto border-l border-border-soft bg-subtle/40 px-4 py-5 lg:flex">
-          {mode === 'preset' ? (
-            selectedPreset ? (
-              <div className="flex flex-col gap-2.5">
-                <div className="flex items-center gap-2">
-                  <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
-                    <Check size={10} className="text-success" aria-hidden />
-                  </span>
-                  <span className="text-xs font-medium text-foreground">Preset ready</span>
-                  <span className="text-2xs text-muted-foreground/60">
-                    {selectedPreset.steps.length} step{selectedPreset.steps.length === 1 ? '' : 's'}
-                  </span>
-                </div>
-                <div className="truncate text-xs font-semibold text-foreground">
-                  {selectedPreset.name}
-                </div>
-                <ol className="flex flex-col divide-y divide-border-soft/50">
-                  {sortedSteps(selectedPreset).map((s, i) => (
-                    <ReadOnlyStepCard
-                      key={s.id}
-                      ordinal={i}
-                      kind={templateStepKind(s)}
-                      name={s.name}
-                      role={s.role ?? 'custom'}
-                      model={s.modelOverride}
-                      effort={s.effort}
-                      promptPrefix={s.promptPrefix}
-                    />
-                  ))}
-                </ol>
-              </div>
-            ) : (
-              <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
-                <Layers size={22} className="text-muted-foreground/30" aria-hidden />
-                <p className="text-xs font-medium text-foreground">Step preview</p>
-                <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
-                  Pick a preset and its ordered steps show here.
-                </p>
-              </div>
-            )
-          ) : plan ? (
-            <div className="flex flex-col gap-2.5">
-              <div className="flex items-center gap-2">
-                <span className="flex size-4 items-center justify-center rounded-full bg-success/15">
-                  <Check size={10} className="text-success" aria-hidden />
-                </span>
-                <span className="text-xs font-medium text-foreground">Workflow ready</span>
-                <span className="text-2xs text-muted-foreground/60">
-                  {plan.steps.length} step{plan.steps.length === 1 ? '' : 's'}
-                </span>
-                <button
-                  type="button"
-                  onClick={onRedesign}
-                  disabled={blocked}
-                  className="ml-auto inline-flex items-center gap-1 rounded-md border border-border-soft px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  <Sparkles size={10} aria-hidden /> Re-design
-                </button>
-              </div>
-              <div className="truncate text-xs font-semibold text-foreground">
-                {plan.workflowName}
-              </div>
-              <ol className="flex flex-col divide-y divide-border-soft/50">
-                {plan.steps.map((s, i) => {
-                  const role = s.role as AgentRole;
-                  const edit = stepEdits[i];
-                  return (
-                    <EditableStepCard
-                      key={`${i}-${s.name}`}
-                      ordinal={i}
-                      kind={planStepKind(s)}
-                      provider={providerId}
-                      name={edit?.name ?? s.name}
-                      promptPrefix={edit?.promptPrefix ?? s.promptPrefix}
-                      model={edit?.model ?? ''}
-                      effort={(edit?.effort ?? defaultsForRole(role).effort) as EffortLevel}
-                      effortModel={effortModelFor(i, role)}
-                      disabled={busy}
-                      onName={(v) => patchStep(i, { name: v })}
-                      onPrompt={(v) => patchStep(i, { promptPrefix: v })}
-                      onModel={(v) => patchStep(i, { model: v })}
-                      onEffort={(v) => patchStep(i, { effort: v })}
-                    />
-                  );
-                })}
-              </ol>
-            </div>
-          ) : planning ? (
-            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
-              <Loader2 size={22} className="animate-spin text-muted-foreground/40" aria-hidden />
-              <p className="text-xs font-medium text-foreground">Drafting plan</p>
-              <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
-                The planner is breaking your process into ordered steps.
-              </p>
-            </div>
-          ) : (
-            <div className="flex flex-1 flex-col items-center justify-center gap-2 text-center">
-              <Layers size={22} className="text-muted-foreground/30" aria-hidden />
-              <p className="text-xs font-medium text-foreground">Step preview</p>
-              <p className="max-w-[15rem] text-2xs leading-relaxed text-muted-foreground">
-                Once the planner drafts a workflow, the ordered steps show here with a model pick
-                per step.
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
-      <Divider />
+          <Divider />
 
-      <footer className="flex shrink-0 items-center gap-3 px-6 py-3">
-        <div className="flex-1">
-          {error ? (
-            <span role="alert" className="inline-flex items-center gap-1 text-xs text-danger">
-              <AlertTriangle size={12} aria-hidden />
-              {error}
-            </span>
-          ) : null}
+          <footer className="flex shrink-0 items-center gap-3 px-6 py-4">
+            <div className="flex-1">
+              {error ? (
+                <span role="alert" className="inline-flex items-center gap-1 text-xs text-danger">
+                  <AlertTriangle size={12} aria-hidden />
+                  {error}
+                </span>
+              ) : null}
+            </div>
+            {mode === 'custom' ? (
+              <ToggleSwitch
+                label="Save as preset"
+                checked={saveAsPreset}
+                onChange={setSaveAsPreset}
+                disabled={busy}
+              />
+            ) : null}
+            <ToggleSwitch
+              label="Auto-run"
+              beta
+              checked={autoRun}
+              onChange={setAutoRun}
+              disabled={busy}
+            />
+            <span className="h-5 w-px bg-border-soft" aria-hidden />
+            <Button variant="ghost" onClick={handleClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button onClick={() => void onStart()} disabled={startDisabled}>
+              {busy ? (
+                <Loader2 size={15} className="animate-spin" aria-label="starting" />
+              ) : (
+                'Start workflow'
+              )}
+            </Button>
+          </footer>
         </div>
-        {mode === 'custom' ? (
-          <ToggleSwitch
-            label="Save as preset"
-            checked={saveAsPreset}
-            onChange={setSaveAsPreset}
-            disabled={busy}
-          />
-        ) : null}
-        <ToggleSwitch
-          label="Auto-run"
-          beta
-          checked={autoRun}
-          onChange={setAutoRun}
-          disabled={busy}
-        />
-        <span className="h-5 w-px bg-border-soft" aria-hidden />
-        <Button variant="ghost" onClick={handleClose} disabled={busy}>
-          Cancel
-        </Button>
-        <Button onClick={() => void onStart()} disabled={startDisabled}>
-          {busy ? (
-            <Loader2 size={15} className="animate-spin" aria-label="starting" />
-          ) : (
-            'Start workflow'
-          )}
-        </Button>
-      </footer>
-    </div>
+      )}
+    </StudioShell>
   );
 };
+
+type SectionHeaderProps = {
+  readonly icon: LucideIcon;
+  readonly label: string;
+  readonly htmlFor?: string;
+  readonly children?: ReactNode;
+};
+
+const SECTION_LABEL_CLS =
+  'inline-flex items-center gap-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70';
+
+const SectionHeader = ({ icon: Icon, label, htmlFor, children }: SectionHeaderProps) => (
+  <div className="flex items-center gap-2">
+    {htmlFor ? (
+      <label htmlFor={htmlFor} className={SECTION_LABEL_CLS}>
+        <Icon size={11} aria-hidden /> {label}
+      </label>
+    ) : (
+      <span className={SECTION_LABEL_CLS}>
+        <Icon size={11} aria-hidden /> {label}
+      </span>
+    )}
+    {children ? (
+      <div className="flex flex-1 flex-wrap items-center justify-end gap-1.5">{children}</div>
+    ) : null}
+  </div>
+);
 
 type TriggerButtonProps = {
   readonly active: boolean;

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.test.tsx
@@ -9,16 +9,14 @@ const { state, toastMock } = vi.hoisted(() => ({
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
     renameTask: vi.fn(async () => undefined),
     loadDetectedEditors: vi.fn(async () => undefined),
+    unarchiveTask: vi.fn(async () => undefined),
     sessionExternalTasks: {} as Record<string, unknown>,
     detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
-    sessionBranches: {} as Record<string, string | null>,
-    sessionTelemetry: {} as Record<string, ReadonlyArray<unknown>>,
   },
   toastMock: vi.fn(),
 }));
 
 vi.mock('../../../../store', () => ({
-  EMPTY_ARRAY: [] as readonly never[],
   useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
 }));
 
@@ -55,8 +53,6 @@ beforeEach(() => {
   state.sessionWorktrees = {};
   state.sessionExternalTasks = {};
   state.detectedEditors = [];
-  state.sessionBranches = {};
-  state.sessionTelemetry = {};
   toastMock.mockReset();
 });
 afterEach(cleanup);
@@ -74,9 +70,9 @@ describe('SessionDetailPanel', () => {
     expect(onOpenSessionSettings).toHaveBeenCalledOnce();
   });
 
-  it('renders the editor menu trigger', () => {
+  it('renders the session actions menu trigger', () => {
     render(<SessionDetailPanel session={session} onOpenSessionSettings={vi.fn()} />);
-    expect(screen.getByRole('button', { name: /open in editor/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /session actions/i })).toBeDefined();
   });
 
   it('does not render an external task chip when none is mapped', () => {

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -1,23 +1,14 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  Archive,
-  ArchiveRestore,
-  Check,
-  FolderOpen,
-  GitBranch,
-  Settings2,
-  Trash2,
-} from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Archive, ArchiveRestore, FolderOpen, Settings2, Trash2 } from 'lucide-react';
 import { cn } from '@goodboy/ui';
-import type { Session, SessionId, TelemetryRecord } from '@goodboy/types';
-import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import type { Session, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
 import { SessionStageBadge } from '../../../session/components/SessionStageBadge';
 import { openInEditor } from '../../../../shared/lib/editor';
 import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/components/OverflowMenu';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
-import { SummarizerBadge } from './SummarizerBadge';
 
 type SessionDetailPanelProps = {
   session: Session;
@@ -32,7 +23,9 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
   );
   const detectedEditors = useAppStore((s) => s.detectedEditors);
   const loadDetectedEditors = useAppStore((s) => s.loadDetectedEditors);
+  const unarchiveTask = useAppStore((s) => s.unarchiveTask);
   const { showToast } = useToast();
+  const archived = Boolean(session.archivedAt);
 
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState('');
@@ -53,6 +46,16 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
     } catch (err) {
       showToast('error', `couldn't open editor: ${formatError(err)}`);
     }
+  };
+
+  const onToggleArchive = () => {
+    if (archived) {
+      unarchiveTask(session.id as SessionId).catch((err: unknown) => {
+        showToast('error', `couldn't unarchive: ${formatError(err)}`);
+      });
+      return;
+    }
+    window.dispatchEvent(new CustomEvent('goodboy:archive-session'));
   };
 
   const actionItems = useMemo<ReadonlyArray<OverflowMenuItem>>(() => {
@@ -81,9 +84,29 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
       }
     }
 
+    items.push({ kind: 'separator', key: 'session-sep' });
+    items.push({ kind: 'header', key: 'session-header', label: 'Session' });
+    items.push({
+      kind: 'item',
+      key: 'archive',
+      label: archived ? 'Unarchive' : 'Archive',
+      icon: archived ? ArchiveRestore : Archive,
+      onClick: onToggleArchive,
+      hint: archived ? undefined : '⌘⇧A',
+    });
+    items.push({
+      kind: 'item',
+      key: 'delete',
+      label: 'Delete',
+      icon: Trash2,
+      destructive: true,
+      hint: '⌘.',
+      onClick: () => window.dispatchEvent(new CustomEvent('goodboy:delete-session')),
+    });
+
     return items;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [detectedEditors, worktreePath]);
+  }, [detectedEditors, worktreePath, archived]);
 
   const startRename = () => {
     setRenameDraft(session.goal);
@@ -152,210 +175,8 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
         >
           <Settings2 size={13} aria-hidden />
         </button>
-        <OverflowMenu
-          items={actionItems}
-          label="open in editor"
-          trigger={<FolderOpen size={13} aria-hidden />}
-        />
+        <OverflowMenu items={actionItems} label="session actions" />
       </div>
-    </div>
-  );
-};
-
-function BranchChip({ branch }: { branch: string }) {
-  const { showToast } = useToast();
-  const [copied, setCopied] = useState(false);
-
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(branch);
-      setCopied(true);
-      showToast('success', 'branch copied');
-      setTimeout(() => setCopied(false), 1200);
-    } catch (err) {
-      showToast('error', `copy failed: ${formatError(err)}`);
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={() => void onCopy()}
-      title="click to copy branch name"
-      className={cn(
-        'group inline-flex min-w-0 max-w-full shrink items-center gap-1.5 rounded-md border px-2 py-1 font-mono text-2xs transition-colors',
-        copied
-          ? 'border-success/30 bg-success/10 text-success'
-          : 'border-border-soft bg-muted/30 text-foreground/80 hover:border-border hover:bg-muted/50 hover:text-foreground',
-      )}
-    >
-      {copied ? (
-        <Check size={10} aria-hidden className="shrink-0" />
-      ) : (
-        <GitBranch
-          size={10}
-          aria-hidden
-          className="shrink-0 text-muted-foreground group-hover:text-foreground"
-        />
-      )}
-      <span className="truncate">{branch}</span>
-    </button>
-  );
-}
-
-function SessionCostChip({ sessionId }: { sessionId: SessionId }) {
-  const telemetry = useAppStore(
-    (s) => s.sessionTelemetry[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<TelemetryRecord>),
-  );
-  const sessionCost = useMemo(() => {
-    let sum = 0;
-    for (const rec of telemetry) {
-      if (rec.kind === 'summarizer') {
-        continue;
-      }
-      sum += rec.estimatedCostUsd;
-    }
-    return sum;
-  }, [telemetry]);
-  const finalLabel = sessionCost === 0 ? '$0' : `$${sessionCost.toFixed(2)}`;
-
-  const [displayLabel, setDisplayLabel] = useState(finalLabel);
-  const [animating, setAnimating] = useState(false);
-  const prevCostRef = useRef(sessionCost);
-  const prevSessionIdRef = useRef(sessionId);
-  const rafRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (prevSessionIdRef.current !== sessionId) {
-      prevSessionIdRef.current = sessionId;
-      prevCostRef.current = sessionCost;
-      setDisplayLabel(finalLabel);
-      setAnimating(false);
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-      return;
-    }
-    if (prevCostRef.current === sessionCost) {
-      setDisplayLabel(finalLabel);
-      return;
-    }
-    const fromCost = prevCostRef.current;
-    const toCost = sessionCost;
-    prevCostRef.current = toCost;
-
-    if (
-      typeof window !== 'undefined' &&
-      window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-    ) {
-      setDisplayLabel(finalLabel);
-      setAnimating(false);
-      return;
-    }
-
-    setAnimating(true);
-    const duration = 1100;
-    const start = performance.now();
-
-    const tick = (now: number) => {
-      const elapsed = now - start;
-      const t = Math.min(1, elapsed / duration);
-      const eased = 1 - Math.pow(1 - t, 3);
-      const current = fromCost + (toCost - fromCost) * eased;
-      setDisplayLabel(current === 0 ? '$0' : `$${current.toFixed(2)}`);
-      if (t < 1) {
-        rafRef.current = requestAnimationFrame(tick);
-      } else {
-        rafRef.current = null;
-        setDisplayLabel(finalLabel);
-        setAnimating(false);
-      }
-    };
-    rafRef.current = requestAnimationFrame(tick);
-
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [sessionCost, sessionId, finalLabel]);
-
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() =>
-          window.dispatchEvent(
-            new CustomEvent('goodboy:open-budget-studio', {
-              detail: { scope: { kind: 'session', sessionId } },
-            }),
-          )
-        }
-        title={`Estimated cost for this session: ${finalLabel} (excluding summarizer), click for budget studio`}
-        className={cn(
-          'inline-flex shrink-0 items-center rounded-md border border-success/20 bg-success/10 px-2 py-1 font-mono text-2xs text-success transition-colors hover:border-success/40 hover:bg-success/15',
-          animating && 'cost-chip-pulse',
-        )}
-      >
-        {displayLabel}
-      </button>
-    </>
-  );
-}
-
-type SessionMetaFooterProps = {
-  session: Session;
-};
-
-export const SessionMetaFooter = ({ session }: SessionMetaFooterProps) => {
-  const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
-  const unarchiveTask = useAppStore((s) => s.unarchiveTask);
-  const { showToast } = useToast();
-  const archived = Boolean(session.archivedAt);
-
-  const onToggleArchive = () => {
-    if (archived) {
-      unarchiveTask(session.id as SessionId).catch((err: unknown) => {
-        showToast('error', `couldn't unarchive: ${formatError(err)}`);
-      });
-      return;
-    }
-    window.dispatchEvent(new CustomEvent('goodboy:archive-session'));
-  };
-
-  return (
-    <div className="flex shrink-0 items-center gap-2 px-2 pb-2.5 pt-2">
-      {branch ? (
-        <div className="min-w-0 flex-1">
-          <BranchChip branch={branch} />
-        </div>
-      ) : (
-        <div className="flex-1" />
-      )}
-      <SummarizerBadge sessionId={session.id as SessionId} />
-      <SessionCostChip sessionId={session.id as SessionId} />
-      <button
-        type="button"
-        onClick={onToggleArchive}
-        title={archived ? 'Unarchive session' : 'Archive session (⌘⇧A)'}
-        aria-label={archived ? 'unarchive session' : 'archive session'}
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border-soft bg-muted/30 px-2 py-1 text-2xs font-medium text-foreground/80 transition-colors hover:border-border hover:bg-muted/60 hover:text-foreground"
-      >
-        {archived ? <ArchiveRestore size={12} aria-hidden /> : <Archive size={12} aria-hidden />}
-        {archived ? 'Unarchive' : 'Archive'}
-      </button>
-      <button
-        type="button"
-        onClick={() => window.dispatchEvent(new CustomEvent('goodboy:delete-session'))}
-        title="Delete session (⌘.)"
-        aria-label="delete session"
-        className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-danger/30 bg-danger/10 px-2 py-1 text-2xs font-medium text-danger transition-colors hover:border-danger/50 hover:bg-danger/15"
-      >
-        <Trash2 size={12} aria-hidden />
-        Delete
-      </button>
     </div>
   );
 };

--- a/apps/desktop/src/shared/components/StudioShell/index.tsx
+++ b/apps/desktop/src/shared/components/StudioShell/index.tsx
@@ -46,7 +46,9 @@ export const StudioShell = ({
           beta
           onClose={requestClose}
           closeLabel={closeLabel}
-        />
+        >
+          {headerAccessory}
+        </OverlayHeader>
       ) : (
         <header className="flex shrink-0 items-center gap-3 px-6 py-3">
           {glyph ??


### PR DESCRIPTION
## Summary
- Relocate session header meta (branch, cost, duration, summarizer, files-touched count, workspace name) from the top bar into the overview pane. Top bar retains stage dot, editable goal, external task badge, settings gear, editor menu.
- Add guided empty-state CTA cards so fresh sessions prompt users to create a workflow or spawn an agent (prominent hero cards, `EmptyState` bordered variant).
- Refactor the workflow builder onto the `StudioShell` slot pattern (full-screen studio) to align with PlanStudio/BudgetStudio, plus layout polish (`gap`, `rounded-lg`/`rounded-xl`, `ScrollFade`, `Divider`).

All presentational — no store/schema changes.

New components extracted: `BranchChip`, `SessionCostChip` (with tests + `lib.test.ts`, `index.test.tsx`).

## Test plan
- [x] full suite green: 1672 tests / 213 files
- [x] 37 new tests for `SessionOverviewPane` (lib + index + chips)
- [x] no production regressions
- [ ] visual QA of overview relocation + fresh-session CTAs + workflow builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)