### PR TITLE
fix(desktop): keep parent agent selected when cluster children start

### DIFF
--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -1,7 +1,39 @@
-import type { PlanWithCount, SessionId, WorkflowRunId } from '@goodboy/types';
-import { describe, expect, it } from 'vitest';
-import { selectClustersPlan, selectFanOutPlan } from './clusterImplementation';
-import type { GetFn } from './types';
+import type {
+  Agent,
+  AgentId,
+  ImplementationCluster,
+  PlanWithCount,
+  SessionId,
+  WorkflowRunId,
+} from '@goodboy/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { GetFn, SetFn } from './types';
+
+const hoisted = vi.hoisted(() => {
+  const insertArgs: Array<Record<string, unknown>> = [];
+  return {
+    insertArgs,
+    invokeAgentInsert: vi.fn(async (args: Record<string, unknown>) => {
+      insertArgs.push(args);
+      return { id: `child-${insertArgs.length}` as AgentId, ...args } as unknown as Agent;
+    }),
+    invokeAgentList: vi.fn(async () => [] as Agent[]),
+    invokeAgentUpdateStatus: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentInsert: hoisted.invokeAgentInsert,
+  invokeAgentList: hoisted.invokeAgentList,
+  invokeAgentUpdateStatus: hoisted.invokeAgentUpdateStatus,
+}));
+
+import {
+  advanceClusterImplementation,
+  fanOutClusters,
+  selectClustersPlan,
+  selectFanOutPlan,
+} from './clusterImplementation';
 
 const plan = (over: Partial<Omit<PlanWithCount, 'id'>> & { id?: string }): PlanWithCount =>
   ({
@@ -107,5 +139,264 @@ describe('selectFanOutPlan', () => {
 
   it('returns null when neither an explicit nor a stored plan qualifies', () => {
     expect(selectFanOutPlan(fakeGet([]), sessionId, {})).toBeNull();
+  });
+});
+
+const SID = 's1' as SessionId;
+const PARENT = 'parent' as AgentId;
+
+const clusters: ReadonlyArray<ImplementationCluster> = [
+  { title: 'c0', instructions: 'do 0' },
+  { title: 'c1', instructions: 'do 1' },
+];
+
+const container = (over: Partial<Agent> = {}): Agent =>
+  ({
+    id: PARENT,
+    sessionId: SID,
+    ordinal: 0,
+    name: 'container',
+    status: 'pending',
+    kind: 'implementer',
+    ...over,
+  }) as Agent;
+
+const childAgent = (over: Omit<Partial<Agent>, 'id'> & { id: string; ordinal: number }): Agent =>
+  ({
+    sessionId: SID,
+    parentAgentId: PARENT,
+    name: over.name ?? `child-${over.ordinal}`,
+    status: 'pending',
+    kind: 'implementer',
+    ...over,
+    id: over.id as AgentId,
+  }) as Agent;
+
+function makeStore(initial: Record<string, unknown>) {
+  const sendTurn = vi.fn(async () => undefined);
+  const emitNotification = vi.fn(async () => undefined);
+  const refreshUnreadWorkspaces = vi.fn(async () => undefined);
+  const maybeAutoAdvanceWorkflow = vi.fn(async () => undefined);
+  const state: Record<string, unknown> = {
+    sessionPhaseRuns: {},
+    sessionPlans: {},
+    transcripts: {},
+    agentTurnState: {},
+    agentKindOverride: {},
+    selectedAgentId: PARENT,
+    sendTurn,
+    emitNotification,
+    refreshUnreadWorkspaces,
+    maybeAutoAdvanceWorkflow,
+    ...initial,
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((u: unknown) => {
+    const patch =
+      typeof u === 'function'
+        ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (u as Record<string, unknown>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return {
+    state,
+    get,
+    set,
+    sendTurn,
+    emitNotification,
+    refreshUnreadWorkspaces,
+    maybeAutoAdvanceWorkflow,
+  };
+}
+
+afterEach(() => {
+  hoisted.insertArgs.length = 0;
+  vi.clearAllMocks();
+  hoisted.invokeAgentList.mockResolvedValue([]);
+});
+
+describe('fanOutClusters', () => {
+  it('flips the container to running and inserts one implementer child per cluster', async () => {
+    const c = container();
+    const { get, set } = makeStore({ sessionPhaseRuns: { [SID]: [c] } });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(PARENT, { status: 'running' });
+    expect(hoisted.insertArgs).toHaveLength(2);
+    for (const args of hoisted.insertArgs) {
+      expect(args.kind).toBe('implementer');
+      expect(args.parentAgentId).toBe(PARENT);
+      expect(args.sessionId).toBe(SID);
+    }
+  });
+
+  it('assigns ordinals continuing past the highest existing run ordinal', async () => {
+    const c = container({ ordinal: 4 });
+    const { get, set } = makeStore({ sessionPhaseRuns: { [SID]: [c] } });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    expect(hoisted.insertArgs[0]?.ordinal).toBe(5);
+    expect(hoisted.insertArgs[1]?.ordinal).toBe(6);
+  });
+
+  it('propagates the container workflowRunId to every child', async () => {
+    const c = container({ workflowRunId: 'wf-1' as WorkflowRunId });
+    const { get, set } = makeStore({ sessionPhaseRuns: { [SID]: [c] } });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    for (const args of hoisted.insertArgs) {
+      expect(args.workflowRunId).toBe('wf-1');
+    }
+  });
+
+  it('omits workflowRunId for an ad-hoc container that has none', async () => {
+    const c = container();
+    const { get, set } = makeStore({ sessionPhaseRuns: { [SID]: [c] } });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    for (const args of hoisted.insertArgs) {
+      expect(args.workflowRunId).toBeUndefined();
+    }
+  });
+
+  it('kicks off only the first child and seeds its turn state to idle', async () => {
+    const c = container();
+    const { get, set, sendTurn, state } = makeStore({ sessionPhaseRuns: { [SID]: [c] } });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    const call = (sendTurn.mock.calls[0]! as unknown[])[0] as { agentId: AgentId; content: string };
+    expect(call.agentId).toBe('child-1');
+    expect(call.content).toContain('1/2');
+    const turnState = state.agentTurnState as Record<string, { kind: string }>;
+    expect(turnState['child-1']?.kind).toBe('idle');
+  });
+
+  it('keeps the parent selected: starting the first child never reassigns selectedAgentId', async () => {
+    const c = container();
+    const { get, set, state } = makeStore({
+      sessionPhaseRuns: { [SID]: [c] },
+      selectedAgentId: PARENT,
+    });
+
+    await fanOutClusters(set, get, SID, c, clusters, 'goal');
+
+    expect(state.selectedAgentId).toBe(PARENT);
+  });
+});
+
+describe('advanceClusterImplementation', () => {
+  const done = (id: string) => `<<cluster-done id="${id}">>`;
+
+  it('no-ops when the agent is not found in the session runs', async () => {
+    const { get, set, sendTurn } = makeStore({ sessionPhaseRuns: { [SID]: [] } });
+    await advanceClusterImplementation(set, get)(SID, 'ghost' as AgentId, done('ghost'));
+    expect(sendTurn).not.toHaveBeenCalled();
+    expect(hoisted.invokeAgentUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when the agent has no parent (not a cluster child)', async () => {
+    const orphan = childAgent({ id: 'orphan', ordinal: 0, parentAgentId: undefined });
+    const { get, set, sendTurn } = makeStore({ sessionPhaseRuns: { [SID]: [orphan] } });
+    await advanceClusterImplementation(set, get)(SID, 'orphan' as AgentId, done('orphan'));
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('re-prompts the same child to continue when no done marker is present', async () => {
+    const child = childAgent({ id: 'cont-a', ordinal: 0 });
+    const p = plan({});
+    const { get, set, sendTurn, state } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+      sessionPlans: { [SID]: [p] },
+    });
+
+    await advanceClusterImplementation(set, get)(SID, 'cont-a' as AgentId, 'still working...');
+
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    const call = (sendTurn.mock.calls[0]! as unknown[])[0] as { agentId: AgentId; content: string };
+    expect(call.agentId).toBe('cont-a');
+    expect(call.content).toContain('stopped before finishing');
+    expect(state.selectedAgentId).toBe(PARENT);
+    expect(hoisted.invokeAgentUpdateStatus).not.toHaveBeenCalled();
+  });
+
+  it('fails the child and notifies after exhausting continue attempts', async () => {
+    const child = childAgent({ id: 'cont-b', ordinal: 0 });
+    const p = plan({});
+    const store = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+      sessionPlans: { [SID]: [p] },
+    });
+    const advance = advanceClusterImplementation(store.set, store.get);
+
+    await advance(SID, 'cont-b' as AgentId, 'no marker 1');
+    await advance(SID, 'cont-b' as AgentId, 'no marker 2');
+    expect(store.sendTurn).toHaveBeenCalledTimes(2);
+    expect(store.emitNotification).not.toHaveBeenCalled();
+
+    await advance(SID, 'cont-b' as AgentId, 'no marker 3');
+    expect(store.sendTurn).toHaveBeenCalledTimes(2);
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith('cont-b', {
+      status: 'failed',
+      completedAt: expect.any(String),
+    });
+    expect(store.emitNotification).toHaveBeenCalled();
+  });
+
+  it('marks the child completed and starts the next child on a done marker', async () => {
+    const c0 = childAgent({ id: 'k0', ordinal: 0 });
+    const c1 = childAgent({ id: 'k1', ordinal: 1 });
+    const p = plan({});
+    const { get, set, sendTurn, state } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), c0, c1] },
+      sessionPlans: { [SID]: [p] },
+    });
+    hoisted.invokeAgentList.mockResolvedValue([
+      container({ status: 'running' }),
+      childAgent({ id: 'k0', ordinal: 0, status: 'completed' }),
+      c1,
+    ]);
+
+    await advanceClusterImplementation(set, get)(SID, 'k0' as AgentId, done('k0'));
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      'k0',
+      expect.objectContaining({ status: 'completed' }),
+    );
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    const call = (sendTurn.mock.calls[0]! as unknown[])[0] as { agentId: AgentId; content: string };
+    expect(call.agentId).toBe('k1');
+    expect(call.content).toContain('2/2');
+    expect(state.selectedAgentId).toBe(PARENT);
+  });
+
+  it('completes the container and auto-advances when the last child finishes', async () => {
+    const c0 = childAgent({ id: 'm0', ordinal: 0, status: 'completed' });
+    const c1 = childAgent({ id: 'm1', ordinal: 1 });
+    const p = plan({});
+    const { get, set, sendTurn, refreshUnreadWorkspaces, maybeAutoAdvanceWorkflow } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), c0, c1] },
+      sessionPlans: { [SID]: [p] },
+    });
+    hoisted.invokeAgentList.mockResolvedValue([
+      container({ status: 'running' }),
+      c0,
+      childAgent({ id: 'm1', ordinal: 1, status: 'completed' }),
+    ]);
+
+    await advanceClusterImplementation(set, get)(SID, 'm1' as AgentId, done('m1'));
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      PARENT,
+      expect.objectContaining({ status: 'completed' }),
+    );
+    expect(sendTurn).not.toHaveBeenCalled();
+    expect(refreshUnreadWorkspaces).toHaveBeenCalledTimes(1);
+    expect(maybeAutoAdvanceWorkflow).toHaveBeenCalledWith(SID);
   });
 });

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -63,7 +63,7 @@ function composeContinuePrompt(
   ].join('\n');
 }
 
-function activateChild(
+function startChild(
   set: SetFn,
   get: GetFn,
   sessionId: SessionId,
@@ -71,7 +71,6 @@ function activateChild(
   content: string,
 ): void {
   set((s) => ({
-    selectedAgentId: { ...s.selectedAgentId, [sessionId]: childId },
     agentTurnState: {
       ...s.agentTurnState,
       [childId]: { kind: 'idle' as const, lastActivityAt: nowIso() },
@@ -126,7 +125,7 @@ export const fanOutClusters = async (
 
   const first = childIds[0];
   if (first) {
-    activateChild(set, get, sessionId, first, composeClusterKickoff(first, goalTitle, clusters, 0));
+    startChild(set, get, sessionId, first, composeClusterKickoff(first, goalTitle, clusters, 0));
   }
 };
 
@@ -190,7 +189,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
       const attempts = continueAttempts.get(childAgentId) ?? 0;
       if (attempts < MAX_CONTINUE) {
         continueAttempts.set(childAgentId, attempts + 1);
-        activateChild(
+        startChild(
           set,
           get,
           sessionId,
@@ -241,7 +240,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
 
     const next = children[completedCount];
     if (next) {
-      activateChild(
+      startChild(
         set,
         get,
         sessionId,


### PR DESCRIPTION
## Summary
- starting a cluster implementation child no longer reassigns `selectedAgentId`, so the parent agent (with `ClusterProgressDashboard`) stays in view instead of jumping to the first running child
- renamed `activateChild` → `startChild` (mutation dropped, only seeds `agentTurnState` + fires `sendTurn`), updated all 3 call sites in `clusterImplementation.ts`
- extended `clusterImplementation.test.ts` (26 tests) asserting parent stays selected across fanOut + advance paths

## Test plan
- [x] `vitest run clusterImplementation.test.ts` → 26 green
- [x] `tsc --noEmit` clean for touched file

🤖 Generated with [Claude Code](https://claude.com/claude-code)