### PR TITLE
feat(desktop): mobile companion bridge (spawn workflow + file diffs)

### DIFF
--- a/apps/desktop/src-tauri/src/bridge/commands.rs
+++ b/apps/desktop/src-tauri/src/bridge/commands.rs
@@ -37,6 +37,11 @@ pub enum MobileAction {
     ResolveComment,
     SetContextSlot,
     QueryProviders,
+    MergePr,
+    QueryIssues,
+    CreateSessionFromIssue,
+    SpawnWorkflow,
+    QueryFileDiff,
 }
 
 impl MobileAction {
@@ -48,6 +53,11 @@ impl MobileAction {
             0x86 => Some(Self::ResolveComment),
             0x87 => Some(Self::QueryProviders),
             0x88 => Some(Self::SetContextSlot),
+            0x8A => Some(Self::MergePr),
+            0x8B => Some(Self::QueryIssues),
+            0x8C => Some(Self::CreateSessionFromIssue),
+            0x8D => Some(Self::SpawnWorkflow),
+            0x8E => Some(Self::QueryFileDiff),
             _ => None,
         }
     }
@@ -61,13 +71,21 @@ impl MobileAction {
             Self::ResolveComment => "resolveComment",
             Self::SetContextSlot => "setContextSlot",
             Self::QueryProviders => "queryProviders",
+            Self::MergePr => "mergePr",
+            Self::QueryIssues => "queryIssues",
+            Self::CreateSessionFromIssue => "createSessionFromIssue",
+            Self::SpawnWorkflow => "spawnWorkflow",
+            Self::QueryFileDiff => "queryFileDiff",
         }
     }
 
     /// Read-only queries get their result frame (OP_QUERY_RESULT) instead of a
     /// write ACK; the phone routes the response to a data continuation.
     pub fn is_query(self) -> bool {
-        matches!(self, Self::QueryProviders)
+        matches!(
+            self,
+            Self::QueryProviders | Self::QueryIssues | Self::QueryFileDiff
+        )
     }
 }
 
@@ -122,13 +140,27 @@ mod tests {
         assert!(matches!(MobileAction::from_opcode(0x86), Some(MobileAction::ResolveComment)));
         assert!(matches!(MobileAction::from_opcode(0x87), Some(MobileAction::QueryProviders)));
         assert!(matches!(MobileAction::from_opcode(0x88), Some(MobileAction::SetContextSlot)));
+        assert!(matches!(MobileAction::from_opcode(0x8A), Some(MobileAction::MergePr)));
+        assert!(matches!(MobileAction::from_opcode(0x8B), Some(MobileAction::QueryIssues)));
+        assert!(matches!(
+            MobileAction::from_opcode(0x8C),
+            Some(MobileAction::CreateSessionFromIssue)
+        ));
+        assert!(matches!(
+            MobileAction::from_opcode(0x8D),
+            Some(MobileAction::SpawnWorkflow)
+        ));
+        assert!(matches!(
+            MobileAction::from_opcode(0x8E),
+            Some(MobileAction::QueryFileDiff)
+        ));
     }
 
     #[test]
     fn rejects_read_server_and_unknown_opcodes() {
         // Server->client (0x01-0x09) and client read opcodes (0x80-0x82) are not
         // mobile actions and must never resolve to one.
-        for op in [0x00u8, 0x01, 0x05, 0x07, 0x08, 0x09, 0x80, 0x81, 0x82, 0x89, 0xFF] {
+        for op in [0x00u8, 0x01, 0x05, 0x07, 0x08, 0x09, 0x80, 0x81, 0x82, 0x89, 0x8F, 0xFF] {
             assert!(
                 MobileAction::from_opcode(op).is_none(),
                 "opcode {op:#x} must not map to a mobile action",
@@ -145,12 +177,24 @@ mod tests {
         assert_eq!(MobileAction::ResolveComment.kind(), "resolveComment");
         assert_eq!(MobileAction::SetContextSlot.kind(), "setContextSlot");
         assert_eq!(MobileAction::QueryProviders.kind(), "queryProviders");
+        assert_eq!(MobileAction::MergePr.kind(), "mergePr");
+        assert_eq!(MobileAction::QueryIssues.kind(), "queryIssues");
+        assert_eq!(
+            MobileAction::CreateSessionFromIssue.kind(),
+            "createSessionFromIssue"
+        );
+        assert_eq!(MobileAction::SpawnWorkflow.kind(), "spawnWorkflow");
+        assert_eq!(MobileAction::QueryFileDiff.kind(), "queryFileDiff");
     }
 
     #[test]
     fn only_query_actions_report_as_queries() {
+        // Read-only queries return data frames; everything else is a write ACK.
         assert!(MobileAction::QueryProviders.is_query());
-        for op in [0x83u8, 0x84, 0x85, 0x86, 0x88] {
+        assert!(MobileAction::QueryIssues.is_query());
+        assert!(MobileAction::QueryFileDiff.is_query());
+        // createSessionFromIssue (0x8C) and spawnWorkflow (0x8D) are WRITEs — they ACK.
+        for op in [0x83u8, 0x84, 0x85, 0x86, 0x88, 0x8A, 0x8C, 0x8D] {
             let action = MobileAction::from_opcode(op).expect("opcode is a write command");
             assert!(!action.is_query(), "{} must be a write, not a query", action.kind());
             assert!(!action.kind().is_empty());

--- a/apps/desktop/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop/src-tauri/src/bridge/snapshot.rs
@@ -229,6 +229,15 @@ pub fn build() -> Result<Snapshot, BridgeError> {
         )?,
         "pr_json",
     );
+    // External provider task linked to a session (Linear/Sentry/GitLab issue).
+    // Read-only mirror of session_external_tasks (m044, widened to sentry/gitlab
+    // by m064/m065). The phone renders an external-task chip that opens `url`.
+    // The desktop table has no per-issue state column, so `state` is omitted here
+    // and decodes to nil on the phone.
+    let session_external_tasks = rows(
+        &conn,
+        "SELECT session_id, provider, identifier, title, url FROM session_external_tasks",
+    )?;
     // Per-session budget rollup for the mobile CostRing: aggregate spend from
     // telemetry_records and the optional soft cap from session_budgets. Read-only
     // mirror; the desktop owns budget enforcement. cap_usd is NULL when no budget
@@ -269,6 +278,7 @@ pub fn build() -> Result<Snapshot, BridgeError> {
             "session_worktrees": session_worktrees,
             "github_pr_cache": github_pr_cache,
             "session_costs": session_costs,
+            "session_external_tasks": session_external_tasks,
         }
     });
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -118,6 +118,7 @@ pub fn run() {
       worktree::worktree_remote_url,
       worktree::worktree_exists,
       worktree::worktree_diff,
+      worktree::worktree_diff_file,
       worktree::worktree_changed_files,
       worktree::worktree_commits,
       worktree::worktree_diff_commit,

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -369,11 +369,106 @@ pub fn worktree_diff(
     Ok(format!("{tracked}{}", untracked_new_file_diffs(p)))
 }
 
+/// Unified diff for a SINGLE file `rel_path` inside the worktree, against the
+/// same merge-base `worktree_diff` uses. The path is taken as worktree-relative
+/// and confined to the worktree: any `..` traversal or path that resolves
+/// outside the worktree root is refused. Untracked files fall back to the same
+/// synthetic new-file diff `worktree_diff` emits.
+#[tauri::command]
+pub fn worktree_diff_file(
+    worktree_path: String,
+    base: Option<String>,
+    path: String,
+) -> Result<String, WorktreeError> {
+    let p = Path::new(&worktree_path);
+    if !p.exists() {
+        return Err(WorktreeError::RepoNotFound(worktree_path));
+    }
+    let rel = confine_rel_path(p, &path)?;
+    let user_base = base.unwrap_or_else(|| "main".to_string());
+    // Same merge-base resolution as `worktree_diff` so the single-file diff lines
+    // up with the whole-worktree diff and the numstat slot.
+    let candidates = [format!("origin/{user_base}"), user_base.clone()];
+    let resolved = candidates
+        .iter()
+        .find_map(|cand| git(p, &["merge-base", "HEAD", cand]).ok())
+        .map(|s| s.trim().to_string())
+        .ok_or_else(|| WorktreeError::Git {
+            message: format!("cannot resolve merge-base against origin/{user_base} or {user_base}"),
+        })?;
+    // `-- <path>` scopes the diff to the one file. Pathspec is anchored at the
+    // worktree root (already confined above), so no traversal is possible.
+    let tracked = git(p, &["diff", &resolved, "--", &rel])?;
+    if !tracked.is_empty() {
+        return Ok(tracked);
+    }
+    // No tracked diff: the file may be untracked (new). Emit the synthetic
+    // new-file diff for just this path, mirroring `untracked_new_file_diffs`.
+    Ok(untracked_new_file_diff_for(p, &rel))
+}
+
+/// Resolve `path` as a worktree-relative path and verify it stays inside the
+/// worktree root. Returns the normalized relative path (forward-slashed) for use
+/// as a git pathspec. Refuses absolute paths and any `..` escape.
+fn confine_rel_path(worktree: &Path, path: &str) -> Result<String, WorktreeError> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err(WorktreeError::Git {
+            message: "diff path is empty".to_string(),
+        });
+    }
+    let candidate = Path::new(trimmed);
+    let abs = if candidate.is_absolute() {
+        candidate.to_path_buf()
+    } else {
+        worktree.join(candidate)
+    };
+    // Reject any `..` component up front (cheap, no fs access) so we never even
+    // canonicalize a traversal attempt.
+    if abs
+        .components()
+        .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(WorktreeError::Git {
+            message: "diff path escapes the worktree".to_string(),
+        });
+    }
+    let root = worktree
+        .canonicalize()
+        .unwrap_or_else(|_| worktree.to_path_buf());
+    // Canonicalize when the file exists (resolves symlinks); fall back to the
+    // lexical join for not-yet-existing (e.g. untracked-but-deleted) paths.
+    let resolved = abs.canonicalize().unwrap_or(abs);
+    if !resolved.starts_with(&root) {
+        return Err(WorktreeError::Git {
+            message: "diff path escapes the worktree".to_string(),
+        });
+    }
+    let rel = resolved
+        .strip_prefix(&root)
+        .unwrap_or(&resolved)
+        .to_string_lossy()
+        .replace('\\', "/");
+    if rel.is_empty() {
+        return Err(WorktreeError::Git {
+            message: "diff path resolves to the worktree root".to_string(),
+        });
+    }
+    Ok(rel)
+}
+
 #[derive(Debug, Serialize)]
 pub struct ChangedFilesSummary {
     pub paths: Vec<String>,
     pub additions: u32,
     pub deletions: u32,
+    /// Raw per-file numstat lines for the SAME change set as `paths` —
+    /// "<adds>\t<dels>\t<path>" (binary files: "-\t-\t<path>"), one per line,
+    /// INCLUDING untracked files (counted as additions, deletions 0). This is the
+    /// source of truth mirrored to the mobile `files_touched_numstat` context
+    /// slot, so the phone gets both the file list and the +/- counts from one
+    /// value computed against the same merge-base the desktop's own view uses.
+    pub numstat: String,
 }
 
 /// Distinct file paths that differ between the worktree (including uncommitted
@@ -411,11 +506,14 @@ pub fn worktree_changed_files(
         .ok_or_else(|| WorktreeError::Git {
             message: format!("cannot resolve merge-base against origin/{user_base} or {user_base}"),
         })?;
-    let numstat = git(p, &["diff", "--numstat", &resolved]).unwrap_or_default();
+    let tracked_numstat = git(p, &["diff", "--numstat", &resolved]).unwrap_or_default();
     let mut additions: u32 = 0;
     let mut deletions: u32 = 0;
     let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
-    for line in numstat.lines() {
+    // Collect the per-file numstat lines so we can mirror them verbatim into the
+    // `files_touched_numstat` context slot (same merge-base as above).
+    let mut numstat_lines: Vec<String> = Vec::new();
+    for line in tracked_numstat.lines() {
         // numstat format: "<adds>\t<dels>\t<path>" — binary files show "-\t-\t<path>"
         let mut parts = line.splitn(3, '\t');
         let add_s = parts.next().unwrap_or("");
@@ -431,8 +529,12 @@ pub fn worktree_changed_files(
             deletions = deletions.saturating_add(d);
         }
         set.insert(path.to_string());
+        // Preserve git's exact line (including "-\t-\t" for binary).
+        numstat_lines.push(format!("{add_s}\t{del_s}\t{path}"));
     }
-    // Untracked files: contribute their content as additions.
+    // Untracked files: contribute their content as additions. `git diff` doesn't
+    // see them, so synthesize a numstat line ("<lines>\t0\t<path>") to keep the
+    // slot's file list complete and the +/- counts consistent with `additions`.
     let untracked = git(p, &["ls-files", "--others", "--exclude-standard"]).unwrap_or_default();
     for line in untracked.lines() {
         let rel = line.trim();
@@ -440,14 +542,26 @@ pub fn worktree_changed_files(
             continue;
         }
         set.insert(rel.to_string());
-        if let Ok(content) = std::fs::read_to_string(p.join(rel)) {
-            additions = additions.saturating_add(content.lines().count() as u32);
+        match std::fs::read(p.join(rel)) {
+            Ok(bytes) if bytes.contains(&0) => {
+                // Binary untracked file — mirror git's "-\t-\t<path>" form.
+                numstat_lines.push(format!("-\t-\t{rel}"));
+            }
+            Ok(bytes) => {
+                let n = String::from_utf8_lossy(&bytes).lines().count() as u32;
+                additions = additions.saturating_add(n);
+                numstat_lines.push(format!("{n}\t0\t{rel}"));
+            }
+            Err(_) => {
+                numstat_lines.push(format!("0\t0\t{rel}"));
+            }
         }
     }
     Ok(ChangedFilesSummary {
         paths: set.into_iter().collect(),
         additions,
         deletions,
+        numstat: numstat_lines.join("\n"),
     })
 }
 
@@ -788,45 +902,61 @@ fn untracked_new_file_diffs(p: &Path) -> String {
         if rel.is_empty() {
             continue;
         }
-        out.push_str(&format!("diff --git a/{rel} b/{rel}\n"));
-        out.push_str("new file mode 100644\n");
-        let bytes = match std::fs::read(p.join(rel)) {
-            Ok(b) => b,
-            Err(_) => {
-                out.push_str("--- /dev/null\n");
-                out.push_str(&format!("+++ b/{rel}\n"));
-                continue;
-            }
-        };
-        if bytes.contains(&0) {
+        out.push_str(&untracked_new_file_diff_for(p, rel));
+    }
+    out
+}
+
+/// Synthetic new-file unified diff for a single untracked `rel` path. Returns an
+/// empty string when the file isn't actually untracked (git lists nothing), so a
+/// caller can treat "" as "no diff for this path".
+fn untracked_new_file_diff_for(p: &Path, rel: &str) -> String {
+    // Only emit if git agrees this path is untracked — keeps the single-file
+    // diff honest (a tracked-but-unchanged file produces nothing).
+    let listed = git(p, &["ls-files", "--others", "--exclude-standard", "--", rel])
+        .unwrap_or_default();
+    if listed.lines().map(str::trim).all(|l| l != rel) {
+        return String::new();
+    }
+    let mut out = String::new();
+    out.push_str(&format!("diff --git a/{rel} b/{rel}\n"));
+    out.push_str("new file mode 100644\n");
+    let bytes = match std::fs::read(p.join(rel)) {
+        Ok(b) => b,
+        Err(_) => {
+            out.push_str("--- /dev/null\n");
+            out.push_str(&format!("+++ b/{rel}\n"));
+            return out;
+        }
+    };
+    if bytes.contains(&0) {
+        out.push_str(&format!("Binary files /dev/null and b/{rel} differ\n"));
+        return out;
+    }
+    let content = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => {
             out.push_str(&format!("Binary files /dev/null and b/{rel} differ\n"));
-            continue;
+            return out;
         }
-        let content = match String::from_utf8(bytes) {
-            Ok(s) => s,
-            Err(_) => {
-                out.push_str(&format!("Binary files /dev/null and b/{rel} differ\n"));
-                continue;
-            }
-        };
-        out.push_str("--- /dev/null\n");
-        out.push_str(&format!("+++ b/{rel}\n"));
-        if content.is_empty() {
-            continue;
-        }
-        let ends_with_nl = content.ends_with('\n');
-        let lines: Vec<&str> = if ends_with_nl {
-            content.split_terminator('\n').collect()
-        } else {
-            content.split('\n').collect()
-        };
-        let n = lines.len();
-        out.push_str(&format!("@@ -0,0 +1,{n} @@\n"));
-        for (i, l) in lines.iter().enumerate() {
-            out.push_str(&format!("+{l}\n"));
-            if !ends_with_nl && i == n - 1 {
-                out.push_str("\\ No newline at end of file\n");
-            }
+    };
+    out.push_str("--- /dev/null\n");
+    out.push_str(&format!("+++ b/{rel}\n"));
+    if content.is_empty() {
+        return out;
+    }
+    let ends_with_nl = content.ends_with('\n');
+    let lines: Vec<&str> = if ends_with_nl {
+        content.split_terminator('\n').collect()
+    } else {
+        content.split('\n').collect()
+    };
+    let n = lines.len();
+    out.push_str(&format!("@@ -0,0 +1,{n} @@\n"));
+    for (i, l) in lines.iter().enumerate() {
+        out.push_str(&format!("+{l}\n"));
+        if !ends_with_nl && i == n - 1 {
+            out.push_str("\\ No newline at end of file\n");
         }
     }
     out

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -13,6 +13,11 @@ const h = vi.hoisted(() => ({
   activateWorkflowAgent: vi.fn(() => Promise.resolve()),
   activateNextResolver: vi.fn(() => Promise.resolve()),
   upsertSessionSlot: vi.fn(() => Promise.resolve()),
+  mergePr: vi.fn(() => Promise.resolve()),
+  createSession: vi.fn(
+    async (input: { workspaceId: string; goal: string }) =>
+      ({ session: { id: 'new-session-1', goal: input.goal }, worktree: {} }) as unknown,
+  ),
   state: { value: null as unknown },
 }));
 
@@ -58,21 +63,99 @@ vi.mock('../workspace/window', () => ({ isMainWindow: () => true }));
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
 
+// Integration clients + goal derivation: the executor fetches issues + resolves
+// them through these. Stub with faithful shapes so queryIssues normalization and
+// createSessionFromIssue resolution are exercised without any real network.
+const integ = vi.hoisted(() => ({
+  linearFetch: vi.fn(
+    async () =>
+      [
+        {
+          id: 'lin-uuid-1',
+          identifier: 'ENG-1',
+          title: 'Fix the thing',
+          description: 'desc',
+          url: 'https://linear.app/x/issue/ENG-1',
+          state: { name: 'In Progress', type: 'started' },
+          team: { key: 'ENG' },
+          updatedAt: '2026-06-22T00:00:00Z',
+        },
+      ] as unknown[],
+  ),
+  gitlabFetch: vi.fn(async () => [] as unknown[]),
+  sentryFetch: vi.fn(async () => ({ issues: [], next_cursor: null })),
+}));
+
+vi.mock('../integrations/linear/client', () => ({
+  linearFetchAssignedIssues: integ.linearFetch,
+}));
+vi.mock('../integrations/linear/goal-from-issue', () => ({
+  goalFromIssue: (i: { identifier: string; title: string }) => `[${i.identifier}] ${i.title}`,
+}));
+vi.mock('../integrations/sentry/client', () => ({
+  sentryFetchIssues: integ.sentryFetch,
+  sentryFetchIssueDetail: vi.fn(async () => null),
+}));
+vi.mock('../integrations/sentry/goal-from-sentry', () => ({
+  goalFromSentry: (i: { title: string }) => i.title,
+}));
+vi.mock('../integrations/gitlab/client', () => ({
+  gitlabFetchAssignedIssues: integ.gitlabFetch,
+  issueIdentifier: (i: { references?: { full?: string }; iid: number }) =>
+    i.references?.full ?? `#${i.iid}`,
+}));
+vi.mock('../integrations/gitlab/goal-from-issue', () => ({
+  goalFromIssue: (i: { title: string }) => i.title,
+}));
+
 import { executeBridgeCommand } from './commandExecutor';
-import { clearMobileSharedSessions, isSessionMobileShared } from './mobileConfinement';
+import { invoke } from '@tauri-apps/api/core';
+import {
+  clearMobileCreateRateState,
+  clearMobileSharedSessions,
+  isSessionMobileShared,
+} from './mobileConfinement';
 import type { SessionId } from '@goodboy/types';
+
+const invokeMock = vi.mocked(invoke);
 
 function makeStore(over: Record<string, unknown> = {}) {
   return {
     sessions: [{ id: 's1', workspaceId: 'w1', workflowRuns: [] }],
+    workspaces: [{ id: 'w1' }, { id: 'w2' }],
+    workspaceIntegrations: {
+      w1: [{ provider: 'linear', config: { host: 'gitlab.com' } }],
+    },
     providers: [],
     phaseTemplates: {},
     sessionPhaseRuns: {},
+    sessionGithub: {},
     sendTurn: h.sendTurn,
     spawnAgent: h.spawnAgent,
     activateWorkflowAgent: h.activateWorkflowAgent,
     activateNextResolver: h.activateNextResolver,
     upsertSessionSlot: h.upsertSessionSlot,
+    mergePr: h.mergePr,
+    createSession: h.createSession,
+    ...over,
+  };
+}
+
+// A fully-eligible PR for the session under test (approved + green + open).
+function eligiblePr(over: Record<string, unknown> = {}) {
+  return {
+    number: 7,
+    title: 't',
+    url: 'https://github.com/x/y/pull/7',
+    state: 'approved',
+    mergeable: true,
+    checks: 'success',
+    baseBranch: 'main',
+    headBranch: 'feat/x',
+    isDraft: false,
+    reviewDecision: 'approved',
+    body: '',
+    updatedAt: '2026-06-22T00:00:00Z',
     ...over,
   };
 }
@@ -86,6 +169,13 @@ const lastCall = (spy: ReturnType<typeof vi.fn>) => spy.mock.calls[spy.mock.call
 beforeEach(() => {
   vi.clearAllMocks();
   clearMobileSharedSessions();
+  clearMobileCreateRateState();
+  // clearAllMocks resets call data but NOT implementations; restore the default
+  // resolving createSession so a sibling test's custom impl doesn't leak.
+  h.createSession.mockImplementation(
+    async (input: { workspaceId: string; goal: string }) =>
+      ({ session: { id: 'new-session-1', goal: input.goal }, worktree: {} }) as unknown,
+  );
   h.state.value = makeStore();
 });
 
@@ -366,5 +456,489 @@ describe('resolveComment thread metadata', () => {
       's1',
       expect.objectContaining({ kindOverride: 'resolver', sourceThreadId: 'T42' }),
     );
+  });
+});
+
+describe('mergePr (write path, security-gated)', () => {
+  it('merges with the server-known PR number when the PR is eligible', async () => {
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr() } } });
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'squash' }));
+    expect(res.ok).toBe(true);
+    // The server PR number (7) is used, not anything the phone supplied.
+    expect(h.mergePr).toHaveBeenCalledWith('s1', 7, 'squash');
+    expect(isSessionMobileShared('s1' as SessionId)).toBe(true);
+  });
+
+  it('passes the merge|rebase method through to the store', async () => {
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr() } } });
+    await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'rebase' }));
+    expect(lastCall(h.mergePr)).toEqual(['s1', 7, 'rebase']);
+  });
+
+  it('defaults to squash when the phone omits a method', async () => {
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr() } } });
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1' }));
+    expect(res.ok).toBe(true);
+    expect(lastCall(h.mergePr)).toEqual(['s1', 7, 'squash']);
+  });
+
+  it('re-validates server-side: refuses when the PR is not approved', async () => {
+    h.state.value = makeStore({
+      sessionGithub: { s1: { pr: eligiblePr({ reviewDecision: 'changes_requested' }) } },
+    });
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'squash' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/merge refused/i);
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+
+  it('refuses when CI checks are not green even if the phone claims otherwise', async () => {
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr({ checks: 'failure' }) } } });
+    // Phone-supplied fields are ignored; only the server PR state decides.
+    const res = await executeBridgeCommand(
+      cmd('mergePr', { sessionId: 's1', method: 'squash', approved: true, checks: 'success' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the session has no PR', async () => {
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'squash' }));
+    expect(res.ok).toBe(false);
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unsupported merge method on an otherwise-eligible PR', async () => {
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr() } } });
+    const res = await executeBridgeCommand(
+      cmd('mergePr', { sessionId: 's1', method: 'fast-forward' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+
+  it('refuses a merge for an unknown session before touching the PR gate', async () => {
+    const res = await executeBridgeCommand(
+      cmd('mergePr', { sessionId: 'ghost', method: 'squash' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown session/i);
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+});
+
+// The single sanitization boundary in executeBridgeCommand: BridgeSafeError
+// messages (our own friendly validation) cross the bridge verbatim; ANY other
+// error (raw `gh pr merge` stderr re-thrown by store.mergePr, an internal
+// store Error.message from an await'd action) is logged desktop-side and
+// replaced with a fixed per-kind generic before it reaches the phone.
+describe('bridge error sanitization gate', () => {
+  it('masks a raw `gh pr merge` stderr (with a secret) to a generic phone message, logging the real error', async () => {
+    // A realistic raw stderr from `gh pr merge` carrying a token + remote URL.
+    const rawStderr =
+      'failed to run git: remote: https://x-access-token:ghp_LIVESECRET123@github.com/acme/private.git\n' +
+      'fatal: Authentication failed for internal-host:9418';
+    h.state.value = makeStore({ sessionGithub: { s1: { pr: eligiblePr() } } });
+    h.mergePr.mockRejectedValueOnce(new Error(rawStderr));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'squash' }));
+
+    expect(res.ok).toBe(false);
+    // Phone sees only the fixed per-kind generic — no stderr body at all.
+    expect(res.error).toBe('merge failed');
+    // No secret / remote URL / internal host leaks in the ACK-error.
+    expect(JSON.stringify(res)).not.toMatch(/ghp_|LIVESECRET|x-access-token|internal-host/i);
+    // The real stderr IS logged desktop-side for debugging (with kind + sessionId).
+    expect(errSpy).toHaveBeenCalled();
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+    expect(logged).toMatch(/LIVESECRET/);
+    expect(logged).toMatch(/kind=mergePr/);
+    expect(logged).toMatch(/sessionId=s1/);
+    errSpy.mockRestore();
+  });
+
+  it("masks a raw internal error from an await'd store action (setContextSlot)", async () => {
+    const rawInternal = 'TypeError: cannot read /Users/ak/.config/secret.json: ENOENT';
+    h.upsertSessionSlot.mockRejectedValueOnce(new Error(rawInternal));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(
+      cmd('setContextSlot', { sessionId: 's1', key: 'goal', value: 'x' }),
+    );
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('could not update context');
+    expect(JSON.stringify(res)).not.toMatch(/ENOENT|Users\/ak|secret\.json/i);
+    expect(errSpy).toHaveBeenCalled();
+    expect(errSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n')).toMatch(/ENOENT/);
+    errSpy.mockRestore();
+  });
+
+  it('masks a raw internal error from spawnAgent', async () => {
+    const rawInternal = 'Error: provider key invalid: sk-ant-INTERNAL-LEAK';
+    h.spawnAgent.mockRejectedValueOnce(new Error(rawInternal));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(cmd('spawnAgent', { sessionId: 's1', kind: 'scout' }));
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('could not spawn agent');
+    expect(JSON.stringify(res)).not.toMatch(/sk-ant|INTERNAL-LEAK/i);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('lets a friendly validation throw (unknown session) reach the phone verbatim', async () => {
+    // BridgeSafeError must pass the gate unchanged — this is our own safe message.
+    const res = await executeBridgeCommand(
+      cmd('mergePr', { sessionId: 'ghost', method: 'squash' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown session: ghost/);
+    // It is NOT the generic mask.
+    expect(res.error).not.toBe('merge failed');
+    expect(h.mergePr).not.toHaveBeenCalled();
+  });
+
+  it('lets the friendly "merge refused" precondition reach the phone verbatim', async () => {
+    h.state.value = makeStore({
+      sessionGithub: { s1: { pr: eligiblePr({ reviewDecision: 'changes_requested' }) } },
+    });
+    const res = await executeBridgeCommand(cmd('mergePr', { sessionId: 's1', method: 'squash' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/merge refused/i);
+    expect(res.error).not.toBe('merge failed');
+  });
+});
+
+describe('queryIssues (read-only issue inbox RPC)', () => {
+  it('returns normalized issues for connected workspaces — no tokens, provider object flattened', async () => {
+    const res = await executeBridgeCommand(cmd('queryIssues', {}));
+    expect(res.ok).toBe(true);
+    const issues = (res.data as { issues: Array<Record<string, unknown>> }).issues;
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toEqual({
+      provider: 'linear',
+      identifier: 'ENG-1',
+      title: 'Fix the thing',
+      url: 'https://linear.app/x/issue/ENG-1',
+      state: 'In Progress', // flattened from { name, type }
+      description: 'desc',
+    });
+    // Only the workspace with a connected provider was fetched (w1, not w2).
+    expect(integ.linearFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors an optional provider filter (skips unconnected providers entirely)', async () => {
+    const res = await executeBridgeCommand(cmd('queryIssues', { provider: 'sentry' }));
+    expect(res.ok).toBe(true);
+    // No workspace has sentry connected, so no fetch happens and the list is empty.
+    expect((res.data as { issues: unknown[] }).issues).toEqual([]);
+    expect(integ.sentryFetch).not.toHaveBeenCalled();
+    expect(integ.linearFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not need a session and never leaks a provider token', async () => {
+    const res = await executeBridgeCommand(cmd('queryIssues', {}));
+    expect(JSON.stringify(res)).not.toMatch(/token|credential|secret/i);
+  });
+
+  // FINDING 1 (don't leak across queryIssues): a provider fetch that throws a raw
+  // remote body must be swallowed per-integration (logged desktop-side), never
+  // surfaced to the phone — the inbox just omits that provider's issues.
+  it('swallows a raw provider fetch error without leaking the body to the phone', async () => {
+    const secret = 'HTTP 500 {"token":"sk-live-LEAK","detail":"/srv/internal"}';
+    integ.linearFetch.mockRejectedValueOnce(new Error(secret));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(cmd('queryIssues', {}));
+
+    expect(res.ok).toBe(true); // one bad integration never blanks/errors the inbox
+    expect((res.data as { issues: unknown[] }).issues).toEqual([]);
+    expect(JSON.stringify(res)).not.toMatch(/sk-live|LEAK|internal|token/i);
+    expect(errSpy).toHaveBeenCalled(); // real error logged desktop-side
+    errSpy.mockRestore();
+  });
+});
+
+describe('queryFileDiff (read-only single-file diff RPC)', () => {
+  it('returns the unified diff text for one file in the session worktree', async () => {
+    h.state.value = makeStore({ sessionWorktrees: { s1: ['/wt/s1'] } });
+    invokeMock.mockResolvedValueOnce('diff --git a/x.ts b/x.ts\n+added');
+
+    const res = await executeBridgeCommand(cmd('queryFileDiff', { sessionId: 's1', path: 'x.ts' }));
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual({ diff: 'diff --git a/x.ts b/x.ts\n+added' });
+    // Path traversal is enforced server-side: the worktree path comes from the
+    // store (never the phone) and only the file name is forwarded.
+    expect(invokeMock).toHaveBeenCalledWith('worktree_diff_file', {
+      worktreePath: '/wt/s1',
+      base: null,
+      path: 'x.ts',
+    });
+  });
+
+  it('rejects an unknown session', async () => {
+    const res = await executeBridgeCommand(
+      cmd('queryFileDiff', { sessionId: 'nope', path: 'x.ts' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown session/i);
+  });
+
+  it('requires a path', async () => {
+    h.state.value = makeStore({ sessionWorktrees: { s1: ['/wt/s1'] } });
+    const res = await executeBridgeCommand(cmd('queryFileDiff', { sessionId: 's1' }));
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/path/i);
+  });
+
+  it('masks a raw worktree error before it reaches the phone', async () => {
+    h.state.value = makeStore({ sessionWorktrees: { s1: ['/wt/s1'] } });
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    invokeMock.mockRejectedValueOnce({
+      kind: 'git',
+      message: 'git diff failed: /srv/internal/path leaked',
+    });
+
+    const res = await executeBridgeCommand(cmd('queryFileDiff', { sessionId: 's1', path: 'x.ts' }));
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('could not load file diff');
+    expect(JSON.stringify(res)).not.toMatch(/srv|internal|leaked/i);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe('createSessionFromIssue (security-gated write)', () => {
+  it('resolves the issue server-side, creates the session, and confines it', async () => {
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'linear',
+        issueIdentifier: 'ENG-1',
+        setupWorkflow: false,
+      }),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.data).toEqual({ sessionId: 'new-session-1' });
+    // Goal + externalTask are derived from the resolved issue, not the phone.
+    expect(h.createSession).toHaveBeenCalledWith({
+      workspaceId: 'w1',
+      goal: '[ENG-1] Fix the thing',
+      externalTask: {
+        provider: 'linear',
+        externalId: 'lin-uuid-1',
+        identifier: 'ENG-1',
+        url: 'https://linear.app/x/issue/ENG-1',
+        title: 'Fix the thing',
+      },
+      // Origin marker: confines the new session before any kickoff turn.
+      mobileShared: true,
+    });
+    // The new session is mobile-shared so its turns clamp at sendTurn.
+    expect(isSessionMobileShared('new-session-1' as SessionId)).toBe(true);
+  });
+
+  // FINDING 2 (ordering): the executor MUST pass mobileShared so createSession
+  // registers the confinement synchronously before its own kickoff turn can
+  // dispatch. (The mark-before-kickoff ordering itself is proven against the real
+  // createSession slice in store.workflow-stepper.test.ts.)
+  it('passes mobileShared:true so createSession confines before any kickoff turn', async () => {
+    await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'linear',
+        issueIdentifier: 'ENG-1',
+      }),
+    );
+    expect(h.createSession).toHaveBeenCalledWith(expect.objectContaining({ mobileShared: true }));
+  });
+
+  // FINDING 1 (info disclosure): a raw provider/client failure while resolving
+  // the issue must NOT cross the bridge verbatim — its body can carry tokens/PII/
+  // internal detail. The phone gets a generic "could not resolve issue <id>"
+  // reason; the real error is logged desktop-side only.
+  it('masks a raw provider error when resolving the issue (no body leaks to phone)', async () => {
+    const secret = 'HTTP 401 {"token":"sk-live-DEADBEEF","trace":"/Users/ak/secret"}';
+    integ.linearFetch.mockRejectedValueOnce(new Error(secret));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'linear',
+        issueIdentifier: 'ENG-1',
+      }),
+    );
+
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('could not resolve issue ENG-1');
+    // The raw body never reaches the phone.
+    expect(res.error).not.toMatch(/token|sk-live|trace|401|Users/i);
+    expect(JSON.stringify(res)).not.toMatch(/sk-live|DEADBEEF|secret/i);
+    // But the real error IS logged desktop-side for diagnosis.
+    expect(errSpy).toHaveBeenCalled();
+    const logged = errSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+    expect(logged).toMatch(/DEADBEEF/);
+    // A masked resolve failure must not burn a rate slot or create a session.
+    expect(h.createSession).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  // The friendly issue-not-found message (our own validation, no remote body) is
+  // SAFE and must still reach the phone unchanged — only raw remote/client bodies
+  // are masked.
+  it('preserves the friendly issue-not-found message (safe validation reason)', async () => {
+    integ.linearFetch.mockResolvedValueOnce([]); // no matching issue
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'linear',
+        issueIdentifier: 'ENG-404',
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/linear issue not found: ENG-404/);
+    expect(h.createSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing issueIdentifier', async () => {
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', { workspaceId: 'w1', provider: 'linear' }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/issueIdentifier/i);
+    expect(h.createSession).not.toHaveBeenCalled();
+  });
+
+  // ADVERSARIAL: forge a workspaceId the desktop doesn't have. Must be refused
+  // BEFORE any issue fetch or session create.
+  it('refuses a forged/disallowed workspaceId and never touches createSession', async () => {
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w-evil',
+        provider: 'linear',
+        issueIdentifier: 'ENG-1',
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/unknown workspace/i);
+    expect(integ.linearFetch).not.toHaveBeenCalled();
+    expect(h.createSession).not.toHaveBeenCalled();
+  });
+
+  // ADVERSARIAL: target a real workspace but a provider that isn't connected
+  // there — refused before resolving, so no credential is ever used.
+  it('refuses a disconnected provider for the target workspace', async () => {
+    const res = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1', // only linear connected on w1
+        provider: 'sentry',
+        issueIdentifier: 'SENTRY-1',
+      }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res.error).toMatch(/not connected/i);
+    expect(integ.sentryFetch).not.toHaveBeenCalled();
+    expect(h.createSession).not.toHaveBeenCalled();
+  });
+
+  // SECURITY (TOCTOU): a pipelined burst of concurrent createSessionFromIssue
+  // commands — arriving before any create resolves — must NOT all pass the rate
+  // gate. The gate reserves a slot synchronously, so even with createSession held
+  // open the cap (5/window) holds end-to-end. Without the reservation fix every
+  // command would pass the empty window and spin up a worktree.
+  it('does not let a concurrent burst bypass the create rate cap (TOCTOU)', async () => {
+    // Make createSession a long, controllable op so all gates run before any
+    // create resolves — the exact race the fix closes.
+    let released = 0;
+    const release: Array<() => void> = [];
+    h.createSession.mockImplementation(
+      (input: { workspaceId: string; goal: string }) =>
+        new Promise((resolve) => {
+          const n = released;
+          released += 1;
+          release.push(() =>
+            resolve({ session: { id: `burst-${n}`, goal: input.goal }, worktree: {} }),
+          );
+        }),
+    );
+
+    // Fire 8 concurrent commands (cap is 5). None resolve yet.
+    const inflight = Array.from({ length: 8 }, () =>
+      executeBridgeCommand(
+        cmd('createSessionFromIssue', {
+          workspaceId: 'w1',
+          provider: 'linear',
+          issueIdentifier: 'ENG-1',
+        }),
+      ),
+    );
+    // Let the synchronous gate decisions + the awaited resolveIssueForSession
+    // microtasks settle so every command has reached (and reserved or been
+    // refused at) the gate before any createSession resolves. Flush several
+    // microtask ticks (the masked-resolve wrapper adds a tick) — none of the
+    // controllable createSession promises resolve during this loop, so this only
+    // drains the resolve chain, never the held creates.
+    for (let i = 0; i < 8; i += 1) {
+      await Promise.resolve();
+    }
+
+    // At most 5 should have reached createSession; the rest are gate-refused.
+    expect(h.createSession.mock.calls.length).toBeLessThanOrEqual(5);
+
+    // Release the in-flight creates so the promises settle.
+    for (const r of release) r();
+    const results = await Promise.all(inflight);
+    const ok = results.filter((r) => r.ok).length;
+    const refused = results.filter((r) => !r.ok).length;
+    expect(ok).toBe(5);
+    expect(refused).toBe(3);
+    for (const r of results) {
+      if (!r.ok) expect(r.error).toMatch(/too many|slow down/i);
+    }
+  });
+
+  // A failed create must RELEASE its reserved slot, not burn it: the window
+  // should still admit a full subsequent burst.
+  it('releases the reserved rate slot when createSession throws', async () => {
+    // Restore the default resolving impl (a sibling test installs a controllable
+    // never-resolving one; clearAllMocks resets calls, not implementations).
+    h.createSession.mockImplementation(
+      async (input: { workspaceId: string; goal: string }) =>
+        ({ session: { id: 'new-session-1', goal: input.goal }, worktree: {} }) as unknown,
+    );
+    h.createSession.mockRejectedValueOnce(new Error('worktree boom'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const failed = await executeBridgeCommand(
+      cmd('createSessionFromIssue', {
+        workspaceId: 'w1',
+        provider: 'linear',
+        issueIdentifier: 'ENG-1',
+      }),
+    );
+    expect(failed.ok).toBe(false);
+    // An internal store error (not a BridgeSafeError) is masked at the gate; the
+    // raw message never crosses the bridge, but the slot must still be released.
+    expect(failed.error).toBe('could not create session');
+    expect(failed.error).not.toMatch(/worktree boom/i);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+
+    // The failed attempt freed its slot: five fresh creates still succeed.
+    for (let i = 0; i < 5; i += 1) {
+      const res = await executeBridgeCommand(
+        cmd('createSessionFromIssue', {
+          workspaceId: 'w1',
+          provider: 'linear',
+          issueIdentifier: 'ENG-1',
+        }),
+      );
+      expect(res.ok).toBe(true);
+    }
   });
 });

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -17,8 +17,34 @@ import type {
 import { useAppStore } from '../../store/store';
 import { PROVIDER_LABEL_LOWER } from '../providers/providers';
 import { isMainWindow } from '../workspace/window';
-import { markSessionMobileShared } from './mobileConfinement';
+import { worktreeDiffFile } from '../worktree/worktree';
+import {
+  evaluateMobileCreateSession,
+  evaluateMobileMerge,
+  evaluateMobileSpawnWorkflow,
+  isMergeMethod,
+  markSessionMobileShared,
+} from './mobileConfinement';
 import type { AgentKind } from '../session/agent-kind';
+import type {
+  SessionExternalTaskProvider,
+  WorkspaceId,
+  WorkspaceIntegrationProvider,
+} from '@goodboy/types';
+import { linearFetchAssignedIssues, type LinearIssue } from '../integrations/linear/client';
+import { goalFromIssue as linearGoalFromIssue } from '../integrations/linear/goal-from-issue';
+import {
+  sentryFetchIssues,
+  sentryFetchIssueDetail,
+  type SentryIssue,
+} from '../integrations/sentry/client';
+import { goalFromSentry } from '../integrations/sentry/goal-from-sentry';
+import {
+  gitlabFetchAssignedIssues,
+  issueIdentifier as gitlabIssueIdentifier,
+  type GitlabIssue,
+} from '../integrations/gitlab/client';
+import { goalFromIssue as gitlabGoalFromIssue } from '../integrations/gitlab/goal-from-issue';
 
 const PROVIDER_IDS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
@@ -58,6 +84,19 @@ function inTauri(): boolean {
   return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
 }
 
+// Errors whose message is SAFE to forward to the phone verbatim: our own
+// friendly validation/precondition messages (unknown workspace, disconnected
+// provider, rate limited, issue-not-found, host-not-configured, merge refused).
+// Anything NOT a BridgeSafeError is treated as a raw provider/client failure and
+// masked before crossing the bridge — raw remote HTTP bodies can carry tokens,
+// PII, or internal detail and must never reach the phone.
+class BridgeSafeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BridgeSafeError';
+  }
+}
+
 function asRecord(v: unknown): Record<string, unknown> {
   return v !== null && typeof v === 'object' ? (v as Record<string, unknown>) : {};
 }
@@ -69,11 +108,11 @@ function asString(v: unknown): string | undefined {
 function requireSession(data: Record<string, unknown>): SessionId {
   const id = asString(data.sessionId);
   if (!id) {
-    throw new Error('missing sessionId');
+    throw new BridgeSafeError('missing sessionId');
   }
   const known = useAppStore.getState().sessions.some((s) => s.id === id);
   if (!known) {
-    throw new Error(`unknown session: ${id}`);
+    throw new BridgeSafeError(`unknown session: ${id}`);
   }
   return id as SessionId;
 }
@@ -140,6 +179,223 @@ function buildProviderMenu(): {
   return { providers };
 }
 
+// ---------------------------------------------------------------------------
+// External issue inbox (read) + launch-from-issue (write).
+//
+// SECURITY: issues are fetched live by the DESKTOP using the workspace's own
+// stored credential (the Rust `*_fetch_*` commands read the credential server-
+// side). The phone only ever receives the NORMALIZED issue fields below — never
+// a token, credential key, or raw provider payload. createSessionFromIssue also
+// re-resolves the issue desktop-side; the phone supplies only an identifier.
+// ---------------------------------------------------------------------------
+
+// The phone-facing issue shape. Deliberately minimal: no tokens/secrets, no raw
+// provider objects — only what the mobile inbox renders. Mirrors `ExternalIssue`
+// (Protocol/Models.swift).
+type NormalizedIssue = {
+  readonly provider: WorkspaceIntegrationProvider;
+  readonly identifier: string;
+  readonly title: string;
+  readonly url: string;
+  readonly state: string | null;
+  readonly description: string | null;
+};
+
+const ALL_ISSUE_PROVIDERS: ReadonlyArray<WorkspaceIntegrationProvider> = [
+  'linear',
+  'sentry',
+  'gitlab',
+];
+
+const normalizeLinear = (i: LinearIssue): NormalizedIssue => ({
+  provider: 'linear',
+  identifier: i.identifier,
+  title: i.title,
+  url: i.url,
+  state: i.state?.name ?? null,
+  description: i.description ?? null,
+});
+
+const normalizeSentry = (i: SentryIssue): NormalizedIssue => ({
+  provider: 'sentry',
+  identifier: i.shortId ?? i.id,
+  title: i.title,
+  url: i.permalink ?? '',
+  state: i.status ?? null,
+  description: i.culprit ?? null,
+});
+
+const normalizeGitlab = (i: GitlabIssue): NormalizedIssue => ({
+  provider: 'gitlab',
+  identifier: gitlabIssueIdentifier(i),
+  title: i.title,
+  url: i.webUrl,
+  state: i.state ?? null,
+  description: i.description ?? null,
+});
+
+// Find the host for a workspace's gitlab integration (the fetch needs it). Read
+// from the trusted store config, never the phone.
+function gitlabHostFor(workspaceId: WorkspaceId): string | undefined {
+  const rows = useAppStore.getState().workspaceIntegrations[workspaceId] ?? [];
+  const row = rows.find((r) => r.provider === 'gitlab');
+  return row && row.provider === 'gitlab' ? row.config.host : undefined;
+}
+
+// Which providers are connected for a workspace, per the trusted store.
+function connectedProviders(workspaceId: WorkspaceId): ReadonlySet<WorkspaceIntegrationProvider> {
+  const rows = useAppStore.getState().workspaceIntegrations[workspaceId] ?? [];
+  return new Set(rows.map((r) => r.provider));
+}
+
+// Fetch + normalize issues for one workspace+provider. Errors per integration are
+// swallowed (logged) so one mis-configured provider doesn't blank the whole inbox.
+async function fetchIssuesFor(
+  workspaceId: WorkspaceId,
+  provider: WorkspaceIntegrationProvider,
+): Promise<NormalizedIssue[]> {
+  try {
+    if (provider === 'linear') {
+      return (await linearFetchAssignedIssues(workspaceId)).map(normalizeLinear);
+    }
+    if (provider === 'sentry') {
+      const page = await sentryFetchIssues(workspaceId);
+      return page.issues.map(normalizeSentry);
+    }
+    const host = gitlabHostFor(workspaceId);
+    if (!host) {
+      return [];
+    }
+    return (await gitlabFetchAssignedIssues(workspaceId, host)).map(normalizeGitlab);
+  } catch (e) {
+    console.error(`[bridge] queryIssues ${provider} fetch failed`, e);
+    return [];
+  }
+}
+
+// queryIssues: gather connected-integration issues across every workspace the
+// phone can see (the snapshot already mirrors all non-deleted workspaces). An
+// optional provider filter narrows the set. Returns only normalized issues — no
+// tokens ever leave the desktop.
+async function queryIssuesForMobile(filter?: WorkspaceIntegrationProvider): Promise<{
+  issues: ReadonlyArray<NormalizedIssue>;
+}> {
+  const store = useAppStore.getState();
+  const wanted = filter ? [filter] : ALL_ISSUE_PROVIDERS;
+  const jobs: Array<Promise<NormalizedIssue[]>> = [];
+  for (const ws of store.workspaces) {
+    const connected = connectedProviders(ws.id);
+    for (const provider of wanted) {
+      if (connected.has(provider)) {
+        jobs.push(fetchIssuesFor(ws.id, provider));
+      }
+    }
+  }
+  const settled = await Promise.all(jobs);
+  return { issues: settled.flat() };
+}
+
+// Re-resolve one issue desktop-side by identifier, deriving the session goal with
+// the provider's own `goalFromIssue`. The phone names the issue; the desktop
+// fetches it with its stored credential and computes the goal — provider tokens
+// never reach the phone, and the phone can't smuggle a forged goal/url/title.
+async function resolveIssueForSession(
+  workspaceId: WorkspaceId,
+  provider: WorkspaceIntegrationProvider,
+  identifier: string,
+): Promise<{
+  goal: string;
+  externalTask: {
+    provider: SessionExternalTaskProvider;
+    externalId: string;
+    identifier: string;
+    url: string;
+    title: string;
+  };
+}> {
+  if (provider === 'linear') {
+    const issue = (await linearFetchAssignedIssues(workspaceId)).find(
+      (i) => i.identifier === identifier,
+    );
+    if (!issue) {
+      throw new BridgeSafeError(`linear issue not found: ${identifier}`);
+    }
+    return {
+      goal: linearGoalFromIssue(issue),
+      externalTask: {
+        provider: 'linear',
+        externalId: issue.id,
+        identifier: issue.identifier,
+        url: issue.url,
+        title: issue.title,
+      },
+    };
+  }
+  if (provider === 'sentry') {
+    const page = await sentryFetchIssues(workspaceId);
+    const issue = page.issues.find((i) => (i.shortId ?? i.id) === identifier);
+    if (!issue) {
+      throw new BridgeSafeError(`sentry issue not found: ${identifier}`);
+    }
+    const detail = await sentryFetchIssueDetail(workspaceId, issue.id).catch(() => null);
+    return {
+      goal: goalFromSentry(issue, detail),
+      externalTask: {
+        provider: 'sentry',
+        externalId: issue.id,
+        identifier: issue.shortId ?? issue.id,
+        url: issue.permalink ?? '',
+        title: issue.title,
+      },
+    };
+  }
+  const host = gitlabHostFor(workspaceId);
+  if (!host) {
+    throw new BridgeSafeError('gitlab host not configured for this workspace');
+  }
+  const issue = (await gitlabFetchAssignedIssues(workspaceId, host)).find(
+    (i) => gitlabIssueIdentifier(i) === identifier,
+  );
+  if (!issue) {
+    throw new BridgeSafeError(`gitlab issue not found: ${identifier}`);
+  }
+  return {
+    goal: gitlabGoalFromIssue(issue),
+    externalTask: {
+      provider: 'gitlab',
+      externalId: String(issue.id),
+      identifier: gitlabIssueIdentifier(issue),
+      url: issue.webUrl,
+      title: issue.title,
+    },
+  };
+}
+
+// Resolve an issue for a mobile-launched session, MASKING any raw provider/
+// client failure before it can cross the bridge. Our own friendly validation
+// throws (issue-not-found, host-not-configured — BridgeSafeError) pass through
+// unchanged; anything else (a remote HTTP error whose body may carry tokens/PII/
+// internal detail, a network failure, a parser blowup) is logged desktop-side
+// with the real error and re-thrown as a generic, phone-safe BridgeSafeError.
+async function resolveIssueForSessionSafe(
+  workspaceId: WorkspaceId,
+  provider: WorkspaceIntegrationProvider,
+  identifier: string,
+): Promise<Awaited<ReturnType<typeof resolveIssueForSession>>> {
+  try {
+    return await resolveIssueForSession(workspaceId, provider, identifier);
+  } catch (e) {
+    if (e instanceof BridgeSafeError) {
+      throw e;
+    }
+    console.error(
+      `[bridge] resolveIssueForSession failed (provider=${provider}, identifier=${identifier})`,
+      e,
+    );
+    throw new BridgeSafeError(`could not resolve issue ${identifier}`);
+  }
+}
+
 // advanceStep: activate the next pending workflow agent whose predecessors are
 // all done. Mirrors `maybeAutoAdvanceWorkflow`'s eligibility check, but here the
 // human on the phone is explicitly advancing, so the autoRun gate doesn't apply.
@@ -147,7 +403,7 @@ async function advanceNextWorkflowStep(sessionId: SessionId): Promise<void> {
   const store = useAppStore.getState();
   const session = store.sessions.find((s) => s.id === sessionId);
   if (!session || session.workflowRuns.length === 0) {
-    throw new Error('session has no workflow to advance');
+    throw new BridgeSafeError('session has no workflow to advance');
   }
   const templates = store.phaseTemplates[session.workspaceId] ?? [];
   const runs = store.sessionPhaseRuns[sessionId] ?? [];
@@ -180,7 +436,7 @@ async function advanceNextWorkflowStep(sessionId: SessionId): Promise<void> {
       break; // earliest pending step blocks the run until its predecessors finish
     }
   }
-  throw new Error('no workflow step is ready to advance');
+  throw new BridgeSafeError('no workflow step is ready to advance');
 }
 
 // Dispatches a mobile-origin command onto the same store actions the desktop UI
@@ -194,6 +450,110 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
     case 'queryProviders':
       return buildProviderMenu();
 
+    case 'queryIssues': {
+      // Read-only: optional provider filter, normalized issues, no tokens.
+      const rawProvider = asString(data.provider);
+      const filter =
+        rawProvider && ALL_ISSUE_PROVIDERS.includes(rawProvider as WorkspaceIntegrationProvider)
+          ? (rawProvider as WorkspaceIntegrationProvider)
+          : undefined;
+      return queryIssuesForMobile(filter);
+    }
+
+    case 'queryFileDiff': {
+      // Read-only: the unified git diff TEXT for ONE file in the session's own
+      // worktree. The phone names sessionId + path; the desktop validates the
+      // session against its OWN list and resolves the worktree path itself (the
+      // phone never supplies a path/cwd outside the file name). Path traversal is
+      // refused SERVER-SIDE in `worktree_diff_file` (confine_rel_path), which
+      // anchors the pathspec at the worktree root — a `..` or absolute path that
+      // escapes the worktree is rejected. Same merge-base/ref as the desktop's
+      // own file-changes view (worktree_diff), so the diff matches the numstat.
+      const sessionId = requireSession(data);
+      const path = asString(data.path);
+      if (!path) {
+        throw new BridgeSafeError('queryFileDiff requires a path');
+      }
+      const worktreePath = (store.sessionWorktrees[sessionId] ?? [])[0] ?? null;
+      if (!worktreePath) {
+        throw new BridgeSafeError('session worktree is not available');
+      }
+      const diff = await worktreeDiffFile(worktreePath, path);
+      return { diff };
+    }
+
+    case 'createSessionFromIssue': {
+      // SECURITY-GATED write. The phone names workspaceId + provider + issue
+      // identifier; the desktop re-validates the workspace and provider against
+      // its OWN state, resolves the issue + goal server-side (tokens never leave
+      // the desktop), then creates the session through the same store action the
+      // desktop UI uses. The new session is marked mobile-shared so every kickoff
+      // turn is clamped via sendTurn's existing choke point.
+      const workspaceId = asString(data.workspaceId);
+      const provider = asString(data.provider);
+      const identifier = asString(data.issueIdentifier);
+      const setupWorkflow = data.setupWorkflow === true;
+      if (!identifier) {
+        throw new BridgeSafeError('createSessionFromIssue requires an issueIdentifier');
+      }
+      const gate = evaluateMobileCreateSession({
+        workspaceId,
+        provider,
+        workspaces: store.workspaces,
+        integrations: workspaceId
+          ? (store.workspaceIntegrations[workspaceId as WorkspaceId] ?? [])
+          : [],
+      });
+      if (!gate.ok) {
+        throw new BridgeSafeError(`create session refused: ${gate.reason}`);
+      }
+      // The gate already reserved a rate slot (counted against the cap up front
+      // so a concurrent burst can't bypass it). Commit it once the session lands;
+      // release it if resolve/create throws, so a failed attempt doesn't burn the
+      // window. No await sits between the gate decision and the reservation.
+      let session;
+      try {
+        const resolved = await resolveIssueForSessionSafe(
+          gate.workspaceId,
+          gate.provider,
+          identifier,
+        );
+        // Pass mobileShared so createSession registers the confinement
+        // SYNCHRONOUSLY (before its own kickoff turn / workflow prespawn can
+        // dispatch). Marking here, after createSession resolved, would race a
+        // kickoff turn fired during creation — the ordering fix lives in
+        // createSession itself now.
+        ({ session } = await store.createSession({
+          workspaceId: gate.workspaceId,
+          goal: resolved.goal,
+          externalTask: resolved.externalTask,
+          mobileShared: true,
+        }));
+      } catch (e) {
+        gate.reservation.release();
+        throw e;
+      }
+      gate.reservation.commit();
+      // Idempotent reassert (createSession already marked it before any kickoff).
+      markSessionMobileShared(session.id);
+      if (setupWorkflow) {
+        // Mirror NewSessionView: surface the workflow builder on the desktop.
+        // Harmless when no window is listening (e.g. headless bridge).
+        try {
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(
+              new CustomEvent('goodboy:open-workflow-builder', {
+                detail: { sessionId: session.id },
+              }),
+            );
+          }
+        } catch {
+          // best-effort UI hint; never fail the create over it
+        }
+      }
+      return { sessionId: session.id };
+    }
+
     case 'advanceStep': {
       const sessionId = requireSession(data);
       markSessionMobileShared(sessionId);
@@ -206,7 +566,7 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       const content = asString(data.content) ?? '';
       const attachments = coerceAttachments(data.attachments);
       if (content.trim().length === 0 && attachments.length === 0) {
-        throw new Error('send requires content or attachments');
+        throw new BridgeSafeError('send requires content or attachments');
       }
       markSessionMobileShared(sessionId);
       const agentId = asString(data.agentId) as AgentId | undefined;
@@ -245,12 +605,12 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       const sessionId = requireSession(data);
       const rawKey = asString(data.key);
       if (!rawKey || !isSlotKey(rawKey) || !MOBILE_EDITABLE_SLOTS.has(rawKey)) {
-        throw new Error(`slot not editable from mobile: ${rawKey ?? '(missing)'}`);
+        throw new BridgeSafeError(`slot not editable from mobile: ${rawKey ?? '(missing)'}`);
       }
       // Absent value is rejected; an explicit empty string clears the slot.
       const value = typeof data.value === 'string' ? data.value : undefined;
       if (value === undefined) {
-        throw new Error('setContextSlot requires a string value');
+        throw new BridgeSafeError('setContextSlot requires a string value');
       }
       markSessionMobileShared(sessionId);
       await store.upsertSessionSlot(sessionId, rawKey, value);
@@ -261,7 +621,7 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       const sessionId = requireSession(data);
       const prompt = asString(data.prompt);
       if (!prompt) {
-        throw new Error('resolveComment requires a prompt describing the comment');
+        throw new BridgeSafeError('resolveComment requires a prompt describing the comment');
       }
       markSessionMobileShared(sessionId);
       const sourceCommentUrl = asString(data.commentUrl);
@@ -277,8 +637,86 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       return undefined;
     }
 
+    case 'mergePr': {
+      const sessionId = requireSession(data);
+      // Re-validate the merge precondition against the desktop's OWN PR state,
+      // never the phone's claim: the phone supplies only the method. A PR that
+      // isn't approved + green (or is draft/merged/closed) is refused here, so a
+      // lying or stale client can't land code on the default branch.
+      const method = asString(data.method) ?? 'squash';
+      const pr = store.sessionGithub[sessionId]?.pr ?? null;
+      const gate = evaluateMobileMerge(pr, method);
+      if (!gate.ok) {
+        throw new BridgeSafeError(`merge refused: ${gate.reason}`);
+      }
+      // gate.ok guarantees the method is valid; this narrows it for the store.
+      if (!isMergeMethod(method)) {
+        throw new BridgeSafeError(`unsupported merge method: ${method}`);
+      }
+      markSessionMobileShared(sessionId);
+      // Reuse the exact desktop merge path (gh pr merge --{method}); pass the
+      // server-known PR number so the phone can't redirect the merge elsewhere.
+      await store.mergePr(sessionId, pr?.number, method);
+      return undefined;
+    }
+
+    case 'spawnWorkflow': {
+      // SECURITY-GATED write. The phone names sessionId + workflowId; the desktop
+      // re-validates the session against its OWN list and that the workflow
+      // belongs to THAT session's workspace (never the phone's claim), then
+      // ATTACHES the workflow without auto-running — autoRun:false + manual
+      // trigger leave the first step pending for the human to Start via
+      // advanceStep (0x83), exactly like a desktop manual-trigger attach.
+      const workflowId = asString(data.workflowId);
+      const session = store.sessions.find((s) => s.id === asString(data.sessionId));
+      const gate = evaluateMobileSpawnWorkflow({
+        sessionId: data.sessionId,
+        workflowId,
+        sessions: store.sessions,
+        workflowsForWorkspace: session ? (store.phaseTemplates[session.workspaceId] ?? []) : [],
+      });
+      if (!gate.ok) {
+        throw new BridgeSafeError(`spawn workflow refused: ${gate.reason}`);
+      }
+      markSessionMobileShared(gate.sessionId);
+      await store.attachWorkflowToSession(gate.sessionId, gate.workflowId, {
+        autoRun: false,
+        triggerMode: 'manual',
+      });
+      return undefined;
+    }
+
     default:
-      throw new Error(`unsupported mobile command: ${cmd.kind}`);
+      throw new BridgeSafeError(`unsupported mobile command: ${cmd.kind}`);
+  }
+}
+
+// Per-kind generic phone-facing mask used when an UNSAFE error escapes a command
+// (anything that is not a BridgeSafeError — a raw `gh pr merge` stderr, an
+// internal store Error.message, a network/parser blowup). The real error is
+// logged desktop-side; the phone only ever sees one of these fixed strings, so
+// no token / remote body / internal path can ride out on an ACK.
+function genericMaskFor(kind: string): string {
+  switch (kind) {
+    case 'mergePr':
+      return 'merge failed';
+    case 'spawnAgent':
+    case 'resolveComment':
+      return 'could not spawn agent';
+    case 'setContextSlot':
+      return 'could not update context';
+    case 'advanceStep':
+      return 'could not advance workflow';
+    case 'spawnWorkflow':
+      return 'could not attach workflow';
+    case 'send':
+      return 'send failed';
+    case 'createSessionFromIssue':
+      return 'could not create session';
+    case 'queryFileDiff':
+      return 'could not load file diff';
+    default:
+      return 'command failed';
   }
 }
 
@@ -289,12 +727,28 @@ export async function executeBridgeCommand(
     if (cmd.origin !== 'mobile') {
       // Only mobile-origin commands travel this channel today. A non-mobile
       // origin means a protocol mismatch — refuse rather than guess.
-      throw new Error(`unexpected command origin: ${cmd.origin}`);
+      throw new BridgeSafeError(`unexpected command origin: ${cmd.origin}`);
     }
     const data = await dispatchMobile(cmd);
     return data !== undefined ? { ok: true, data } : { ok: true };
   } catch (err) {
-    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    // SINGLE sanitization boundary for the whole bridge. Our own friendly
+    // validation/precondition messages are thrown as BridgeSafeError and forwarded
+    // verbatim (unknown session, merge refused, issue not found, …). EVERYTHING
+    // else — a raw `gh pr merge` stderr re-thrown by store.mergePr, an internal
+    // Error.message from any await'd store action (spawnAgent, resolveComment,
+    // setContextSlot, advanceStep), a network/parser failure — is logged
+    // desktop-side and replaced with a fixed per-kind generic before it can cross
+    // the bridge. This closes mergePr + all await'd store actions at one gate.
+    if (err instanceof BridgeSafeError) {
+      return { ok: false, error: err.message };
+    }
+    const data = asRecord(cmd.data);
+    console.error(
+      `[bridge] command failed (kind=${cmd.kind}, sessionId=${asString(data.sessionId) ?? '(none)'})`,
+      err,
+    );
+    return { ok: false, error: genericMaskFor(cmd.kind) };
   }
 }
 

--- a/apps/desktop/src/features/companion/mobileConfinement.test.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.test.ts
@@ -1,13 +1,42 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import type { ClaudePermissionMode, SessionId } from '@goodboy/types';
+import type {
+  ClaudePermissionMode,
+  PullRequestState,
+  SessionId,
+  WorkflowId,
+  WorkspaceId,
+} from '@goodboy/types';
 import {
   clampMobilePermissionMode,
+  clearMobileCreateRateState,
   clearMobileSharedSessions,
+  evaluateMobileCreateSession,
+  evaluateMobileMerge,
+  evaluateMobileSpawnWorkflow,
+  isMergeMethod,
   isSessionMobileShared,
   markSessionMobileShared,
 } from './mobileConfinement';
 
 const sid = (s: string): SessionId => s as SessionId;
+
+// A fully-eligible PR (approved + green + open + non-draft + mergeable). Tests
+// override one field at a time to assert each gate independently.
+const eligiblePr = (over: Partial<PullRequestState> = {}): PullRequestState => ({
+  number: 7,
+  title: 'feat: thing',
+  url: 'https://github.com/x/y/pull/7',
+  state: 'approved',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'feat/thing',
+  isDraft: false,
+  reviewDecision: 'approved',
+  body: '',
+  updatedAt: '2026-06-22T00:00:00Z',
+  ...over,
+});
 
 afterEach(() => clearMobileSharedSessions());
 
@@ -61,5 +90,325 @@ describe('mobile shared-session registry', () => {
     markSessionMobileShared(sid('s1'));
     expect(isSessionMobileShared(sid('s1'))).toBe(true);
     expect(isSessionMobileShared(sid('s2'))).toBe(false);
+  });
+});
+
+describe('isMergeMethod', () => {
+  it('accepts only the closed squash|merge|rebase set', () => {
+    for (const m of ['squash', 'merge', 'rebase']) {
+      expect(isMergeMethod(m)).toBe(true);
+    }
+    for (const m of ['', 'SQUASH', 'fast-forward', 'delete', 42, null, undefined, {}]) {
+      expect(isMergeMethod(m)).toBe(false);
+    }
+  });
+});
+
+describe('evaluateMobileMerge (server-side gate)', () => {
+  it('permits a merge only when approved + green + open + mergeable', () => {
+    expect(evaluateMobileMerge(eligiblePr(), 'squash')).toEqual({ ok: true });
+    expect(evaluateMobileMerge(eligiblePr({ state: 'open' }), 'merge')).toEqual({ ok: true });
+    expect(evaluateMobileMerge(eligiblePr(), 'rebase')).toEqual({ ok: true });
+  });
+
+  it('refuses an unsupported method even when the PR is eligible', () => {
+    const gate = evaluateMobileMerge(eligiblePr(), 'fast-forward');
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/method/i);
+  });
+
+  it('refuses when there is no PR for the session', () => {
+    expect(evaluateMobileMerge(null, 'squash').ok).toBe(false);
+    expect(evaluateMobileMerge(undefined, 'squash').ok).toBe(false);
+  });
+
+  it('refuses a draft PR', () => {
+    const gate = evaluateMobileMerge(eligiblePr({ isDraft: true }), 'squash');
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/draft/i);
+  });
+
+  it('refuses an already-merged or closed PR', () => {
+    expect(evaluateMobileMerge(eligiblePr({ state: 'merged' }), 'squash').ok).toBe(false);
+    expect(evaluateMobileMerge(eligiblePr({ state: 'closed' }), 'squash').ok).toBe(false);
+  });
+
+  it('refuses a PR already in the merge queue', () => {
+    const gate = evaluateMobileMerge(eligiblePr({ state: 'queued' }), 'squash');
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/queue/i);
+  });
+
+  it('refuses when review is not approved (never trusts a stale/lying client)', () => {
+    for (const decision of ['changes_requested', 'review_required', null] as const) {
+      const gate = evaluateMobileMerge(eligiblePr({ reviewDecision: decision }), 'squash');
+      expect(gate.ok).toBe(false);
+      if (!gate.ok) expect(gate.reason).toMatch(/approv/i);
+    }
+  });
+
+  it('refuses when CI checks are not green', () => {
+    const failing = evaluateMobileMerge(eligiblePr({ checks: 'failure' }), 'squash');
+    expect(failing.ok).toBe(false);
+    if (!failing.ok) expect(failing.reason).toMatch(/fail/i);
+
+    const pending = evaluateMobileMerge(eligiblePr({ checks: 'pending' }), 'squash');
+    expect(pending.ok).toBe(false);
+
+    const missing = evaluateMobileMerge(eligiblePr({ checks: null }), 'squash');
+    expect(missing.ok).toBe(false);
+  });
+
+  it('refuses a known-unmergeable PR (conflicts) even when approved + green', () => {
+    const gate = evaluateMobileMerge(eligiblePr({ mergeable: false }), 'squash');
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/conflict/i);
+  });
+});
+
+describe('evaluateMobileCreateSession', () => {
+  // Trusted server-side state the gate validates against. The phone's claims
+  // (workspaceId/provider) are tested against THESE, never trusted directly.
+  const workspaces = [{ id: 'w1' as WorkspaceId }, { id: 'w2' as WorkspaceId }];
+  const linearOnW1 = [{ provider: 'linear' as const }];
+
+  afterEach(() => clearMobileCreateRateState());
+
+  it('accepts a known workspace with the provider connected', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'linear',
+      workspaces,
+      integrations: linearOnW1,
+    });
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.workspaceId).toBe('w1');
+      expect(gate.provider).toBe('linear');
+    }
+  });
+
+  it('refuses a missing workspaceId', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: undefined,
+      provider: 'linear',
+      workspaces,
+      integrations: linearOnW1,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/workspaceId/i);
+  });
+
+  it('refuses an unsupported provider', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'github',
+      workspaces,
+      integrations: linearOnW1,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/provider/i);
+  });
+
+  // ADVERSARIAL: a lying phone claims a workspaceId the desktop does not have.
+  it('refuses a forged/disallowed workspaceId (not in the trusted list)', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w-evil',
+      provider: 'linear',
+      workspaces, // only w1, w2 are real
+      integrations: linearOnW1,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/unknown workspace/i);
+  });
+
+  // ADVERSARIAL: target a real workspace but a provider that isn't connected
+  // there — the desktop has no credential to resolve the issue, so refuse.
+  it('refuses a provider that is not connected for the target workspace', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'sentry', // only linear is connected on w1
+      workspaces,
+      integrations: linearOnW1,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/not connected/i);
+  });
+
+  // ADVERSARIAL: w2 exists but has no integrations at all — can't launch from it.
+  it('refuses a workspace with no integrations connected', () => {
+    const gate = evaluateMobileCreateSession({
+      workspaceId: 'w2',
+      provider: 'linear',
+      workspaces,
+      integrations: [], // w2 has nothing wired up
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/not connected/i);
+  });
+
+  it('rate-limits a burst of launches (abuse guard)', () => {
+    const ok = () => {
+      const g = evaluateMobileCreateSession({
+        workspaceId: 'w1',
+        provider: 'linear',
+        workspaces,
+        integrations: linearOnW1,
+        now: 1_000,
+      });
+      // The gate reserves the slot up front; committing turns it into a counted
+      // launch (matches the executor's commit-on-success path).
+      if (g.ok) g.reservation.commit(1_000);
+      return g.ok;
+    };
+    // First five within the window pass; the sixth is throttled.
+    for (let i = 0; i < 5; i += 1) {
+      expect(ok()).toBe(true);
+    }
+    const sixth = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'linear',
+      workspaces,
+      integrations: linearOnW1,
+      now: 1_000,
+    });
+    expect(sixth.ok).toBe(false);
+    if (!sixth.ok) expect(sixth.reason).toMatch(/too many|slow down/i);
+
+    // After the window slides, launches are allowed again.
+    const later = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'linear',
+      workspaces,
+      integrations: linearOnW1,
+      now: 1_000 + 61_000,
+    });
+    expect(later.ok).toBe(true);
+  });
+
+  // SECURITY (TOCTOU): a pipelined burst arriving in the same tick must NOT all
+  // pass the gate. The reservation is counted against the cap synchronously, so
+  // even with NO create having resolved yet, the 6th concurrent gate is refused.
+  it('counts in-flight reservations against the cap (no concurrent bypass)', () => {
+    const gate = () =>
+      evaluateMobileCreateSession({
+        workspaceId: 'w1',
+        provider: 'linear',
+        workspaces,
+        integrations: linearOnW1,
+        now: 2_000,
+      });
+    // Five concurrent gates pass and HOLD their reservations (no commit yet —
+    // simulating five long createSession ops still in flight).
+    const held = [];
+    for (let i = 0; i < 5; i += 1) {
+      const g = gate();
+      expect(g.ok).toBe(true);
+      if (g.ok) held.push(g.reservation);
+    }
+    // Sixth concurrent gate is refused purely on pending reservations, even
+    // though zero creates have completed (mobileCreateTimestamps is empty).
+    const sixth = gate();
+    expect(sixth.ok).toBe(false);
+    if (!sixth.ok) expect(sixth.reason).toMatch(/too many|slow down/i);
+
+    // Releasing one reservation (a failed create) frees a slot for a retry.
+    held[0]!.release();
+    const retry = gate();
+    expect(retry.ok).toBe(true);
+  });
+
+  // A released reservation must not consume a slot OR throw on double-settle.
+  it('releases a reserved slot without recording a launch; settle is idempotent', () => {
+    const g = evaluateMobileCreateSession({
+      workspaceId: 'w1',
+      provider: 'linear',
+      workspaces,
+      integrations: linearOnW1,
+      now: 3_000,
+    });
+    expect(g.ok).toBe(true);
+    if (!g.ok) return;
+    g.reservation.release();
+    // Double-settle is a no-op (commit after release does nothing).
+    g.reservation.commit(3_000);
+    // Slot was freed: a full burst of five fresh launches still fits.
+    for (let i = 0; i < 5; i += 1) {
+      const next = evaluateMobileCreateSession({
+        workspaceId: 'w1',
+        provider: 'linear',
+        workspaces,
+        integrations: linearOnW1,
+        now: 3_000,
+      });
+      expect(next.ok).toBe(true);
+      if (next.ok) next.reservation.commit(3_000);
+    }
+  });
+});
+
+describe('evaluateMobileSpawnWorkflow (server-side gate)', () => {
+  const sessions = [
+    { id: sid('s1'), workspaceId: 'w1' as WorkspaceId },
+    { id: sid('s2'), workspaceId: 'w2' as WorkspaceId },
+  ];
+  const w1Workflows = [{ id: 'wf-a' as WorkflowId }, { id: 'wf-b' as WorkflowId }];
+
+  it('passes for a known session + a workflow in that session workspace', () => {
+    const gate = evaluateMobileSpawnWorkflow({
+      sessionId: 's1',
+      workflowId: 'wf-a',
+      sessions,
+      workflowsForWorkspace: w1Workflows,
+    });
+    expect(gate.ok).toBe(true);
+    if (gate.ok) {
+      expect(gate.sessionId).toBe('s1');
+      expect(gate.workflowId).toBe('wf-a');
+    }
+  });
+
+  it('refuses a missing sessionId', () => {
+    const gate = evaluateMobileSpawnWorkflow({
+      sessionId: '',
+      workflowId: 'wf-a',
+      sessions,
+      workflowsForWorkspace: w1Workflows,
+    });
+    expect(gate).toMatchObject({ ok: false });
+  });
+
+  it('refuses a missing workflowId', () => {
+    const gate = evaluateMobileSpawnWorkflow({
+      sessionId: 's1',
+      workflowId: undefined,
+      sessions,
+      workflowsForWorkspace: w1Workflows,
+    });
+    expect(gate).toMatchObject({ ok: false });
+  });
+
+  it('refuses an unknown (forged) session id', () => {
+    const gate = evaluateMobileSpawnWorkflow({
+      sessionId: 'nope',
+      workflowId: 'wf-a',
+      sessions,
+      workflowsForWorkspace: w1Workflows,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/unknown session/);
+  });
+
+  it('refuses a workflow that is not in the session workspace', () => {
+    // caller passes only the session's own workspace templates; a cross-workspace
+    // workflow id is therefore absent and refused.
+    const gate = evaluateMobileSpawnWorkflow({
+      sessionId: 's1',
+      workflowId: 'wf-from-w2',
+      sessions,
+      workflowsForWorkspace: w1Workflows,
+    });
+    expect(gate.ok).toBe(false);
+    if (!gate.ok) expect(gate.reason).toMatch(/unknown workflow/);
   });
 });

--- a/apps/desktop/src/features/companion/mobileConfinement.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.ts
@@ -1,4 +1,15 @@
-import type { ClaudePermissionMode, SessionId } from '@goodboy/types';
+import type {
+  ClaudePermissionMode,
+  PrMergeMethod,
+  PullRequestState,
+  SessionId,
+  Workflow,
+  WorkflowId,
+  Workspace,
+  WorkspaceId,
+  WorkspaceIntegration,
+  WorkspaceIntegrationProvider,
+} from '@goodboy/types';
 
 // Sessions a paired phone is currently driving. Every turn a mobile command
 // triggers — kickoffs, fan-out children, scout/resolver chains — funnels
@@ -36,3 +47,319 @@ export const clearMobileSharedSessions = (): void => {
 // interim guard.
 export const clampMobilePermissionMode = (mode: ClaudePermissionMode): ClaudePermissionMode =>
   mode === 'plan' ? 'plan' : 'default';
+
+// ---------------------------------------------------------------------------
+// Mobile merge-PR gate (write path).
+//
+// SECURITY: merging a PR is irreversible and lands code on the default branch,
+// so a mobile-origin merge is the most consequential write the phone can ask
+// for. We re-validate the merge precondition SERVER-SIDE against the desktop's
+// own PR cache — never the phone's claim. The phone supplies only the merge
+// method; the desktop decides whether the PR is mergeable. A phone that lies
+// about approval/checks (or replays a stale state) is refused here.
+// ---------------------------------------------------------------------------
+
+/** The merge methods the phone may name. The closed set the bridge accepts. */
+const MERGE_METHODS: ReadonlySet<string> = new Set<PrMergeMethod>(['squash', 'merge', 'rebase']);
+
+export const isMergeMethod = (v: unknown): v is PrMergeMethod =>
+  typeof v === 'string' && MERGE_METHODS.has(v);
+
+export type MergeGate = { readonly ok: true } | { readonly ok: false; readonly reason: string };
+
+/**
+ * Decide whether a mobile client may merge `pr` with `method`, using only the
+ * trusted server-side PR state. A merge is permitted ONLY when:
+ *   - the PR exists and is in an open, non-draft state (open | approved),
+ *   - review has been approved (`reviewDecision === 'approved'`),
+ *   - CI checks are green (`checks === 'success'`),
+ *   - and the method is one of the closed set (squash | merge | rebase).
+ * Anything else — null PR, draft, merged/closed, changes requested, pending or
+ * failing checks — is refused with a human-readable reason for the phone to show.
+ */
+export const evaluateMobileMerge = (
+  pr: PullRequestState | null | undefined,
+  method: string,
+): MergeGate => {
+  if (!isMergeMethod(method)) {
+    return { ok: false, reason: `unsupported merge method: ${String(method)}` };
+  }
+  if (!pr) {
+    return { ok: false, reason: 'no PR is associated with this session' };
+  }
+  if (pr.isDraft) {
+    return { ok: false, reason: 'PR is a draft — mark it ready before merging' };
+  }
+  if (pr.state === 'merged' || pr.state === 'closed') {
+    return { ok: false, reason: `PR is already ${pr.state}` };
+  }
+  if (pr.state === 'queued') {
+    return { ok: false, reason: 'PR is already in the merge queue' };
+  }
+  if (pr.reviewDecision !== 'approved') {
+    return { ok: false, reason: 'PR is not approved' };
+  }
+  if (pr.checks !== 'success') {
+    return {
+      ok: false,
+      reason: pr.checks === 'failure' ? 'CI checks are failing' : 'CI checks are not green yet',
+    };
+  }
+  if (pr.mergeable === false) {
+    return { ok: false, reason: 'PR has conflicts — resolve them first' };
+  }
+  return { ok: true };
+};
+
+// ---------------------------------------------------------------------------
+// Mobile create-session-from-issue gate (write path).
+//
+// SECURITY: createSession is a genuinely NEW write class — unlike send/merge it
+// has no pre-existing object (session/PR) to authorize against, so the gate is
+// built from scratch around the desktop's own trusted state:
+//   1. workspaceId must be a real, known workspace (validated against the live
+//      store, NEVER the phone's claim) the phone is allowed to target;
+//   2. the named provider must actually be CONNECTED for that workspace (the
+//      desktop resolves the issue with that workspace's credential — a phone
+//      can't point at a workspace where the integration isn't wired up);
+//   3. a basic rate/abuse guard — session creation spins up a worktree + agents,
+//      so an unbounded mobile loop could exhaust disk/compute. We cap the rate.
+// The new session's permission mode is clamped exactly like sendTurn (the same
+// `clampMobilePermissionMode` choke point), so a mobile-launched session can
+// never auto-approve escaping writes.
+// ---------------------------------------------------------------------------
+
+/** Providers a phone may launch a session from. The closed set the bridge accepts. */
+const CREATE_SESSION_PROVIDERS: ReadonlySet<string> = new Set<WorkspaceIntegrationProvider>([
+  'linear',
+  'sentry',
+  'gitlab',
+]);
+
+export const isCreateSessionProvider = (v: unknown): v is WorkspaceIntegrationProvider =>
+  typeof v === 'string' && CREATE_SESSION_PROVIDERS.has(v);
+
+export type CreateSessionGate =
+  | {
+      readonly ok: true;
+      readonly workspaceId: WorkspaceId;
+      readonly provider: WorkspaceIntegrationProvider;
+      // The reserved rate slot. The caller MUST `commit()` once the create lands
+      // or `release()` if it fails/aborts. The slot is already counted against
+      // the cap, so concurrent commands in the same tick can't bypass the limit.
+      readonly reservation: MobileCreateReservation;
+    }
+  | { readonly ok: false; readonly reason: string };
+
+// Rate guard: a sliding window over recent mobile-origin session launches.
+// Sticky module state (same rationale as `mobileSharedSessions`) so it can't be
+// reset by the phone. Cheap, in-memory; the human revoking the bridge clears it.
+//
+// SECURITY (TOCTOU): createSession is a long async op (worktree + git + agents),
+// and `listenBridgeCommands` fires each command fire-and-forget with no
+// serialization. A naive guard that only records a launch AFTER the create
+// resolves leaves the window empty for the whole duration of the create, so a
+// pipelined burst arriving in the same tick all passes the gate before any of
+// them records — the cap collapses to ~unbounded. To close this, the gate
+// reserves a slot SYNCHRONOUSLY (no await between check and reserve): we track
+// in-flight reservations in `mobileCreatePending` and count them toward the cap
+// alongside the completed-launch timestamps. The reservation is later either
+// committed (becomes a timestamp) or released (e.g. the create failed), via the
+// caller's synchronous commit/release call.
+const MOBILE_CREATE_WINDOW_MS = 60_000;
+const MOBILE_CREATE_MAX_IN_WINDOW = 5;
+const mobileCreateTimestamps: number[] = [];
+// In-flight reservations: count of creates that passed the gate but haven't yet
+// resolved. Counted toward the cap so concurrent commands can't all slip through
+// the same empty window.
+let mobileCreatePending = 0;
+
+export const clearMobileCreateRateState = (): void => {
+  mobileCreateTimestamps.length = 0;
+  mobileCreatePending = 0;
+};
+
+/**
+ * A reservation handed back by the gate when it passes. The caller MUST call
+ * exactly one of `commit` (the create landed) or `release` (the create failed or
+ * was abandoned) — `commit` turns the reservation into a counted launch;
+ * `release` frees the slot. Both are idempotent and safe to call once.
+ */
+export type MobileCreateReservation = {
+  /** Convert this reservation into a completed launch within the window. */
+  readonly commit: (now?: number) => void;
+  /** Release the reservation without recording a launch (create failed/abandoned). */
+  readonly release: () => void;
+};
+
+const pruneExpired = (now: number): void => {
+  const cutoff = now - MOBILE_CREATE_WINDOW_MS;
+  // Drop expired entries so the window slides and memory stays bounded.
+  let head = mobileCreateTimestamps[0];
+  while (head !== undefined && head < cutoff) {
+    mobileCreateTimestamps.shift();
+    head = mobileCreateTimestamps[0];
+  }
+};
+
+/**
+ * Record an accepted launch directly (no reservation). Retained for callers that
+ * commit synchronously without holding a reservation across an await.
+ *
+ * Prefer `reserveMobileSessionSlot` for the create path: it counts the in-flight
+ * window so concurrent commands can't bypass the cap.
+ */
+export const noteMobileSessionCreated = (now: number = Date.now()): void => {
+  mobileCreateTimestamps.push(now);
+};
+
+const isRateLimited = (now: number): boolean => {
+  pruneExpired(now);
+  // Count both completed launches AND in-flight reservations against the cap, so
+  // a burst of concurrent creates can't all pass before any of them records.
+  return mobileCreateTimestamps.length + mobileCreatePending >= MOBILE_CREATE_MAX_IN_WINDOW;
+};
+
+/**
+ * Atomically (relative to the event loop) reserve a rate slot. Returns a
+ * reservation when under the cap, or null when rate-limited. Callers MUST invoke
+ * this with NO await between the gate decision and this call — the reservation
+ * is what makes the check-and-record atomic across concurrent commands.
+ */
+const reserveSlot = (): MobileCreateReservation | null => {
+  mobileCreatePending += 1;
+  let settled = false;
+  return {
+    commit: (now: number = Date.now()) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      mobileCreatePending = Math.max(0, mobileCreatePending - 1);
+      mobileCreateTimestamps.push(now);
+    },
+    release: () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      mobileCreatePending = Math.max(0, mobileCreatePending - 1);
+    },
+  };
+};
+
+/**
+ * Decide whether a mobile client may create a session in `workspaceId` from a
+ * `provider` issue, using ONLY trusted server-side state:
+ *   - `workspaces`: the live workspace list (the phone's claimed id must match a
+ *     real, non-deleted workspace),
+ *   - `integrations`: that workspace's connected integrations (the provider must
+ *     be present — i.e. actually connected for this workspace).
+ * The phone supplies the ids; the desktop decides if they're legitimate. Forged
+ * or disallowed workspace ids, and disconnected providers, are refused here with
+ * a human-readable reason. Also enforces the create rate limit.
+ */
+export const evaluateMobileCreateSession = (args: {
+  readonly workspaceId: unknown;
+  readonly provider: unknown;
+  readonly workspaces: ReadonlyArray<Pick<Workspace, 'id'>>;
+  readonly integrations: ReadonlyArray<Pick<WorkspaceIntegration, 'provider'>>;
+  readonly now?: number;
+}): CreateSessionGate => {
+  const { workspaceId, provider, workspaces, integrations } = args;
+  const now = args.now ?? Date.now();
+
+  if (typeof workspaceId !== 'string' || workspaceId.length === 0) {
+    return { ok: false, reason: 'missing workspaceId' };
+  }
+  if (!isCreateSessionProvider(provider)) {
+    return { ok: false, reason: `unsupported provider: ${String(provider)}` };
+  }
+  // (1) Validate the workspace against the desktop's OWN list — never the claim.
+  const known = workspaces.some((w) => w.id === workspaceId);
+  if (!known) {
+    return { ok: false, reason: `unknown workspace: ${workspaceId}` };
+  }
+  // (2) The provider must be connected FOR THIS WORKSPACE (caller passes only
+  // that workspace's integration rows). A phone can't launch from an integration
+  // that isn't wired up — the desktop has no credential to resolve the issue.
+  const connected = integrations.some((i) => i.provider === provider);
+  if (!connected) {
+    return { ok: false, reason: `${provider} is not connected for this workspace` };
+  }
+  // (3) Abuse guard. Check AND reserve atomically — no await between the
+  // isRateLimited() read and reserveSlot() — so a pipelined burst of creates
+  // arriving in the same tick can't all pass the (empty) window. The reservation
+  // is counted against the cap immediately; the caller commits/releases it.
+  if (isRateLimited(now)) {
+    return { ok: false, reason: 'too many session launches — slow down and retry shortly' };
+  }
+  const reservation = reserveSlot();
+  if (!reservation) {
+    return { ok: false, reason: 'too many session launches — slow down and retry shortly' };
+  }
+  return { ok: true, workspaceId: workspaceId as WorkspaceId, provider, reservation };
+};
+
+// ---------------------------------------------------------------------------
+// Mobile spawn-workflow gate (write path).
+//
+// SECURITY: attaching a workflow to a session queues real agents/turns, so the
+// phone must not be able to point a session at an arbitrary (or another
+// workspace's) workflow. We re-validate SERVER-SIDE against the desktop's OWN
+// state — never the phone's claim:
+//   1. the named session must be a real, known session (its workspace is the
+//      trusted scope — taken from the session, not the phone);
+//   2. the named workflow must exist among that workspace's templates (the phone
+//      can't attach a workflow that doesn't belong to the session's workspace).
+// The attach itself is done WITHOUT auto-running (autoRun:false / manual trigger)
+// so the first step is left pending for the human to Start via advanceStep.
+// ---------------------------------------------------------------------------
+
+export type SpawnWorkflowGate =
+  | {
+      readonly ok: true;
+      readonly sessionId: SessionId;
+      readonly workflowId: WorkflowId;
+    }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * Decide whether a mobile client may attach `workflowId` to `sessionId`, using
+ * ONLY trusted server-side state:
+ *   - `sessions`: the live session list (the phone's claimed id must match a
+ *     real session; that session's `workspaceId` is the trusted scope),
+ *   - `workflowsForWorkspace`: the workflow templates for the SESSION'S
+ *     workspace (the workflow must be one of these — a phone can't attach a
+ *     workflow from a workspace the session doesn't belong to).
+ * The phone supplies the ids; the desktop decides if they're legitimate. Forged
+ * session ids and cross-workspace workflow ids are refused here with a
+ * human-readable reason.
+ */
+export const evaluateMobileSpawnWorkflow = (args: {
+  readonly sessionId: unknown;
+  readonly workflowId: unknown;
+  readonly sessions: ReadonlyArray<{ readonly id: SessionId; readonly workspaceId: WorkspaceId }>;
+  readonly workflowsForWorkspace: ReadonlyArray<Pick<Workflow, 'id'>>;
+}): SpawnWorkflowGate => {
+  const { sessionId, workflowId, sessions, workflowsForWorkspace } = args;
+
+  if (typeof sessionId !== 'string' || sessionId.length === 0) {
+    return { ok: false, reason: 'missing sessionId' };
+  }
+  if (typeof workflowId !== 'string' || workflowId.length === 0) {
+    return { ok: false, reason: 'missing workflowId' };
+  }
+  // (1) Validate the session against the desktop's OWN list — never the claim.
+  const session = sessions.find((s) => s.id === sessionId);
+  if (!session) {
+    return { ok: false, reason: `unknown session: ${sessionId}` };
+  }
+  // (2) The workflow must belong to the SESSION'S workspace (caller passes only
+  // that workspace's templates). A phone can't attach a foreign workflow.
+  const known = workflowsForWorkspace.some((w) => w.id === workflowId);
+  if (!known) {
+    return { ok: false, reason: `unknown workflow for this session: ${workflowId}` };
+  }
+  return { ok: true, sessionId: sessionId as SessionId, workflowId: workflowId as WorkflowId };
+};

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -41,6 +41,14 @@ export const worktreeDiff = async (worktreePath: string, base?: string): Promise
   return invoke<string>('worktree_diff', { worktreePath, base: base ?? null });
 };
 
+export const worktreeDiffFile = async (
+  worktreePath: string,
+  path: string,
+  base?: string,
+): Promise<string> => {
+  return invoke<string>('worktree_diff_file', { worktreePath, base: base ?? null, path });
+};
+
 export const worktreeRemoteUrl = async (repoPath: string): Promise<string | null> => {
   return invoke<string | null>('worktree_remote_url', { repoPath });
 };
@@ -49,6 +57,10 @@ export type ChangedFilesSummary = {
   readonly paths: ReadonlyArray<string>;
   readonly additions: number;
   readonly deletions: number;
+  // Raw per-file numstat lines ("<adds>\t<dels>\t<path>", binary: "-\t-\t<path>")
+  // for the same change set, including untracked files. Mirrored to the
+  // `files_touched_numstat` context slot.
+  readonly numstat: string;
 };
 
 export const worktreeChangedFiles = async (

--- a/apps/desktop/src/store/slices/github/mergePr.ts
+++ b/apps/desktop/src/store/slices/github/mergePr.ts
@@ -1,9 +1,17 @@
-import type { SessionId } from '@goodboy/types';
+import type { PrMergeMethod, SessionId } from '@goodboy/types';
 import { tauriGhRunner } from '../../../features/github/github';
 import type { GetFn, SetFn } from './types';
 
+// `gh pr merge` takes exactly one strategy flag. Squash is the desktop default
+// (unchanged from before the method param existed).
+const MERGE_FLAG: Record<PrMergeMethod, string> = {
+  squash: '--squash',
+  merge: '--merge',
+  rebase: '--rebase',
+};
+
 export const mergePr = (_set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, prNumber?: number) => {
+  return async (sessionId: SessionId, prNumber?: number, method: PrMergeMethod = 'squash') => {
     const num = prNumber ?? get().sessionGithub[sessionId]?.pr?.number;
     const session = get().sessions.find((s) => s.id === sessionId);
     if (num == null || !session) {
@@ -13,7 +21,7 @@ export const mergePr = (_set: SetFn, get: GetFn) => {
     if (!workspace) {
       return;
     }
-    const res = await tauriGhRunner.run(['pr', 'merge', String(num), '--squash'], {
+    const res = await tauriGhRunner.run(['pr', 'merge', String(num), MERGE_FLAG[method]], {
       cwd: workspace.rootPath,
       workspaceId: session.workspaceId,
     });

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -36,6 +36,10 @@ import {
   SETTING_LAST_SESSION_ID,
   DEFAULT_BRANCH_PREFIX,
 } from '../../../features/settings/settings';
+import {
+  clampMobilePermissionMode,
+  markSessionMobileShared,
+} from '../../../features/companion/mobileConfinement';
 import type { GetFn, SetFn } from './types';
 
 const slugifyDir = (raw: string): string =>
@@ -65,6 +69,13 @@ type Input = {
     title: string;
   };
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
+  // Origin marker. When true, this session was launched by a paired phone: it is
+  // registered mobile-shared SYNCHRONOUSLY (before any kickoff turn is
+  // dispatched) and its stored permission mode is clamped at creation, so the
+  // confinement is intrinsic and order-independent — a kickoff turn fired during
+  // creation can never run before the mark lands. Default false → desktop
+  // behavior is unchanged (full `bypassPermissions`, no mark).
+  mobileShared?: boolean;
 };
 
 export const createSession = (set: SetFn, get: GetFn) => {
@@ -81,6 +92,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     firstAgentModel: requestedModel,
     externalTask,
     attachmentInputs,
+    mobileShared = false,
   }: Input): Promise<{ session: Session; worktree: CreatedWorktree }> => {
     const workspace = (await listWorkspaces(tauriDatabase)).find((w) => w.id === workspaceId);
     if (!workspace) {
@@ -92,6 +104,16 @@ export const createSession = (set: SetFn, get: GetFn) => {
       branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
     const trimmedExisting = existingBranch?.trim();
     const sessionId = crypto.randomUUID() as SessionId;
+    // SECURITY (ordering): register the confinement BEFORE anything async that
+    // could dispatch a turn for this session (worktree setup, workflow prespawn,
+    // the kickoff sendTurn at the end of this fn). markSessionMobileShared is
+    // synchronous and module-scoped, so once this line runs every sendTurn for
+    // sessionId — including a kickoff fired during creation — clamps at the
+    // sendTurn choke point. Doing it here (not after createSession resolves in
+    // the executor) closes the race where a kickoff could outrun the mark.
+    if (mobileShared) {
+      markSessionMobileShared(sessionId);
+    }
     const isComposite = workspace.kind === 'composite';
     const members = isComposite ? (workspace.members ?? []) : [];
     if (isComposite && members.length < 2) {
@@ -150,7 +172,12 @@ export const createSession = (set: SetFn, get: GetFn) => {
       state: initialState,
       contextSlots: [],
       providerPreference: providerPreference ?? inheritedPreference,
-      permissionMode: 'bypassPermissions',
+      // Desktop sessions run at full power; a mobile-launched session stores a
+      // clamped mode so the ceiling is intrinsic to the session (not only
+      // applied at sendTurn). Belt-and-suspenders with the sendTurn clamp.
+      permissionMode: mobileShared
+        ? clampMobilePermissionMode('bypassPermissions')
+        : 'bypassPermissions',
       workflowRuns:
         workflowId !== undefined && workflowRunId !== undefined
           ? [

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -19,6 +19,7 @@ import {
   updateProviderRunStatus,
   updateSessionState,
   updateSessionWorkflowStep,
+  upsertContextSlot,
 } from '@goodboy/db';
 import type {
   Agent,
@@ -49,6 +50,7 @@ import {
   invokeAgentUpdateStatus,
 } from '../../../features/workflows/workflows';
 import { resolveProviderForTurn } from '../../../features/providers/routing';
+import { worktreeChangedFiles } from '../../../features/worktree/worktree';
 import {
   encodeAuthRequiredMessage,
   isAuthErrorMessage,
@@ -97,6 +99,12 @@ type Input = {
   override?: TurnProviderOverride;
   onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
 };
+
+// Machine-derived context slot carrying `git diff --numstat` lines for the
+// session's changed files (vs the same merge-base as the desktop file-changes
+// view). Deliberately NOT a SLOT_KEY: it's desktop state mirrored to mobile
+// through the snapshot, not an agent-visible or user-editable slot.
+const FILES_TOUCHED_NUMSTAT_SLOT = 'files_touched_numstat';
 
 const EFFORT_FLAG: Readonly<Record<string, string>> = {
   minimal: 'minimal',
@@ -838,6 +846,30 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         }
         if (result.openQuestionsChanged) {
           await get().loadSessionOpenQuestions(sessionId);
+        }
+        // Mirror the session's git file-change numstat into a context slot so the
+        // mobile client gets BOTH the changed-file list and per-file +/- counts
+        // from one value, computed against the SAME merge-base as the desktop's
+        // own file-changes view (worktree_changed_files). This is desktop-machine
+        // state (not in SLOT_KEYS / the desktop context UI), written directly so
+        // it mirrors generically through the snapshot's context_slots projection.
+        // The existing `files_touched` slot is left untouched (mobile falls back
+        // to it, paths-only, when this slot is absent). Best-effort: a git failure
+        // must not fail the turn.
+        try {
+          const changed = await worktreeChangedFiles(workingDir);
+          await upsertContextSlot(
+            tauriDatabase,
+            sessionId,
+            { key: FILES_TOUCHED_NUMSTAT_SLOT, value: changed.numstat, enabled: true },
+            'summarizer',
+          );
+          const refreshedSlots = await listContextSlotsForSession(tauriDatabase, sessionId);
+          set((state) => ({
+            sessionSlots: { ...state.sessionSlots, [sessionId]: refreshedSlots },
+          }));
+        } catch (e) {
+          console.error('files_touched_numstat slot write failed', e);
         }
       } catch (e) {
         console.error('autoPopulateContext failed', e);

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -62,6 +62,7 @@ import type {
   WorkspaceScriptId,
   GhTokenStatus,
   PullRequestState,
+  PrMergeMethod,
   LinkedIssue,
   PrDetail,
   PendingResolution,
@@ -385,6 +386,7 @@ export type AppActions = {
       url: string;
       title: string;
     };
+    mobileShared?: boolean;
   }): Promise<{ session: Session; worktree: CreatedWorktree }>;
   changeSessionBranch(
     sessionId: SessionId,
@@ -588,7 +590,7 @@ export type AppActions = {
   ): Promise<void>;
   markPrReady(sessionId: SessionId, prNumber?: number): Promise<void>;
   convertPrToDraft(sessionId: SessionId, prNumber?: number): Promise<void>;
-  mergePr(sessionId: SessionId, prNumber?: number): Promise<void>;
+  mergePr(sessionId: SessionId, prNumber?: number, method?: PrMergeMethod): Promise<void>;
   refreshSessionMr(
     sessionId: SessionId,
     opts?: { force?: boolean; silent?: boolean },

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -640,3 +640,89 @@ describe('createSession, step.role drives agent kind over name inference (#793)'
     expect(insertArgs['kind']).toBe('scout');
   });
 });
+
+// FINDING 2 (ordering): a mobile-launched session must be confined from its FIRST
+// turn. createSession fires a kickoff turn DURING creation (the workflow's first
+// step promptPrefix → sendTurn), so the confinement must be registered
+// synchronously before that kickoff dispatches — never after createSession
+// resolves. We verify by inspecting the permissionMode that reaches runTurn on
+// that kickoff: a mobile-shared session is clamped (bypassPermissions → default)
+// the instant it runs; a desktop session keeps full bypassPermissions.
+describe('createSession mobile confinement is ordered (#A2 finding 2)', () => {
+  beforeEach(async () => {
+    wirePhaseSpies();
+    runTurnSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+    const { clearMobileSharedSessions } = await import('../features/companion/mobileConfinement');
+    clearMobileSharedSessions();
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-opus-4-5',
+      reason: 'preference',
+    });
+  });
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    const { clearMobileSharedSessions } = await import('../features/companion/mobileConfinement');
+    clearMobileSharedSessions();
+  });
+
+  it('clamps the FIRST kickoff turn of a mobile-launched session (mark precedes kickoff)', async () => {
+    const { useAppStore } = await import('./store');
+    const { isSessionMobileShared } = await import('../features/companion/mobileConfinement');
+    useAppStore.setState({
+      currentWorkspaceId: WS_ID,
+      // Prefixed steps → createSession fires the first-step kickoff turn DURING
+      // creation, which is exactly the moment that could outrun the mark.
+      phaseTemplates: { [WS_ID]: [makeRefactorWorkflowWithPrefixes()] },
+    });
+
+    const { session } = await useAppStore.getState().createSession({
+      workspaceId: WS_ID,
+      goal: 'mobile launch',
+      branchPrefix: 'kay',
+      workflowId: WORKFLOW_ID,
+      mobileShared: true,
+    });
+
+    // The kickoff turn must have already run, and at the moment it reached runTurn
+    // the permission mode was clamped — proving the mark landed before kickoff.
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    const callArgs = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs['permissionMode']).toBe('default'); // clamped, not bypassPermissions
+    expect(isSessionMobileShared(session.id)).toBe(true);
+    // And the stored mode is clamped intrinsically, not left at bypass.
+    expect(useAppStore.getState().sessions.find((s) => s.id === session.id)?.permissionMode).toBe(
+      'default',
+    );
+  });
+
+  it('leaves a desktop (non-mobile) session at full bypassPermissions on its first turn', async () => {
+    const { useAppStore } = await import('./store');
+    const { isSessionMobileShared } = await import('../features/companion/mobileConfinement');
+    useAppStore.setState({
+      currentWorkspaceId: WS_ID,
+      phaseTemplates: { [WS_ID]: [makeRefactorWorkflowWithPrefixes()] },
+    });
+
+    const { session } = await useAppStore.getState().createSession({
+      workspaceId: WS_ID,
+      goal: 'desktop launch',
+      branchPrefix: 'kay',
+      workflowId: WORKFLOW_ID,
+      // mobileShared omitted → default false → desktop behavior unchanged.
+    });
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    const callArgs = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(callArgs['permissionMode']).toBe('bypassPermissions'); // unclamped
+    expect(isSessionMobileShared(session.id)).toBe(false);
+    expect(useAppStore.getState().sessions.find((s) => s.id === session.id)?.permissionMode).toBe(
+      'bypassPermissions',
+    );
+  });
+});

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -15,6 +15,9 @@ export type PullRequestStateKind = 'draft' | 'open' | 'approved' | 'queued' | 'm
 
 export type PullRequestChecks = 'pending' | 'success' | 'failure' | null;
 
+/** How a PR is integrated when merged. Maps to `gh pr merge --{method}`. */
+export type PrMergeMethod = 'squash' | 'merge' | 'rebase';
+
 export type PullRequestState = {
   number: number;
   title: string;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -184,6 +184,7 @@ export type {
   PrCheckRun,
   PrComment,
   PrDetail,
+  PrMergeMethod,
   PrReview,
   PrReviewRequest,
   PrReviewState,


### PR DESCRIPTION
Desktop side of the mobile companion, paired with **mobile v0.1.1**.

## What
- **spawnWorkflow (0x8D)** — attach a workflow to a session with `autoRun:false` / manual trigger, so the first step is left pending for the user to Start (via advanceStep).
- **queryFileDiff (0x8E)** + **`files_touched_numstat`** context slot — powers the mobile file-change cards (+/− counts) and on-demand per-file diffs. Worktree-confined, path-traversal guarded.
- Mobile **merge gate** + **issue inbox** (createSessionFromIssue) + external-task snapshot projection.
- Security gates: `evaluateMobileSpawnWorkflow`, mobile-shared session marking.

## Tests
Bridge opcode tests, mobileConfinement gates, commandExecutor cases, workflow stepper — all green (cargo + vitest); tsc + cargo check clean.

## Notes
- Version stays **0.1.19** (no bump) — the v0.1.20 release will be cut separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)