### PR TITLE
fix(desktop): correct unread feedback for cluster and scout child agents

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -1090,6 +1090,7 @@ pub fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, Phase
          FROM agents a
          JOIN sessions t ON a.session_id = t.id
          WHERE a.last_finished_at IS NOT NULL
+           AND a.status != 'skipped'
            AND (a.last_viewed_at IS NULL OR a.last_finished_at > a.last_viewed_at)
            AND t.archived_at IS NULL
            AND t.deleted_at IS NULL",

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -31,6 +31,12 @@ vi.mock('../../../../../store', () => ({
   useSessionOpenQuestions: () => [],
   useSessionPlans: () => [],
   EMPTY_ARRAY: [] as never[],
+  agentHasUnread: (agent: Agent, isCurrentlyViewed: boolean): boolean => {
+    if (isCurrentlyViewed || agent.status === 'skipped' || !agent.lastFinishedAt) {
+      return false;
+    }
+    return !agent.lastViewedAt || agent.lastFinishedAt > agent.lastViewedAt;
+  },
 }));
 
 vi.mock('@goodboy/ui', () => ({
@@ -84,6 +90,10 @@ vi.mock('./WorkflowKillButton', () => ({ WorkflowKillButton: () => null }));
 vi.mock('../../../../scripts/components/ScriptsSection', () => ({
   ScriptsSection: () => <div data-testid="scripts" />,
 }));
+vi.mock(
+  '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip',
+  () => ({ GoalAttachmentsStrip: () => null }),
+);
 vi.mock('../../../../../shared/components/DogMascot', () => ({ DogMascot: () => null }));
 
 vi.mock('../../../../../features/workflows/components/WorkflowNextStepCta', () => ({
@@ -224,6 +234,145 @@ describe('AgentsSection collapse defaults', () => {
 
     expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
     expect(screen.getByTestId('collapsed').textContent).toBe('1 agent');
+  });
+
+  it('workflow unread badge counts step agents and their cluster children', () => {
+    const RUN_ID = 'run-1' as WorkflowRunId;
+    const workflow = {
+      id: 'wf-def-1',
+      workspaceId: WS_ID,
+      name: 'review',
+      steps: [{ id: 'step-1' as StepId, name: 'implement' }],
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    h.state.sessionWorkflows = { [SESSION_ID]: [workflow] };
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({
+          id: 'wf-1' as AgentId,
+          workflowRunId: RUN_ID,
+          stepId: 'step-1' as StepId,
+          status: 'completed',
+          lastFinishedAt: NOW,
+        }),
+        buildAgent({
+          id: 'child-1' as AgentId,
+          parentAgentId: 'wf-1' as AgentId,
+          status: 'completed',
+          lastFinishedAt: NOW,
+        }),
+      ],
+    };
+    render(
+      <AgentsSection
+        task={buildSession({
+          workflowRuns: [
+            {
+              id: RUN_ID,
+              workflowId: 'wf-def-1',
+              ordinal: 0,
+              triggerMode: 'manual',
+              autoRun: false,
+            } as never,
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByTitle('2 agent replies to review').textContent).toContain('2');
+  });
+
+  function renderWorkflowWith(children: ReadonlyArray<Agent>) {
+    const RUN_ID = 'run-1' as WorkflowRunId;
+    h.state.sessionWorkflows = {
+      [SESSION_ID]: [
+        {
+          id: 'wf-def-1',
+          workspaceId: WS_ID,
+          name: 'review',
+          steps: [{ id: 'step-1' as StepId, name: 'implement' }],
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+    };
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({
+          id: 'wf-1' as AgentId,
+          workflowRunId: RUN_ID,
+          stepId: 'step-1' as StepId,
+          status: 'completed',
+          lastFinishedAt: NOW,
+        }),
+        ...children,
+      ],
+    };
+    render(
+      <AgentsSection
+        task={buildSession({
+          workflowRuns: [
+            {
+              id: RUN_ID,
+              workflowId: 'wf-def-1',
+              ordinal: 0,
+              triggerMode: 'manual',
+              autoRun: false,
+            } as never,
+          ],
+        })}
+      />,
+    );
+  }
+
+  it('workflow unread badge excludes skipped children', () => {
+    renderWorkflowWith([
+      buildAgent({
+        id: 'child-1' as AgentId,
+        parentAgentId: 'wf-1' as AgentId,
+        status: 'skipped',
+        lastFinishedAt: NOW,
+      }),
+    ]);
+
+    expect(screen.queryByTitle('1 agent reply to review')).not.toBeNull();
+    expect(screen.queryByTitle('2 agent replies to review')).toBeNull();
+  });
+
+  it('workflow unread badge excludes the currently-viewed selected child', () => {
+    h.state.currentSessionId = SESSION_ID;
+    h.state.selectedAgentId = { [SESSION_ID]: 'child-1' as AgentId };
+    renderWorkflowWith([
+      buildAgent({
+        id: 'child-1' as AgentId,
+        parentAgentId: 'wf-1' as AgentId,
+        status: 'completed',
+        lastFinishedAt: NOW,
+      }),
+    ]);
+
+    expect(screen.queryByTitle('1 agent reply to review')).not.toBeNull();
+    expect(screen.queryByTitle('2 agent replies to review')).toBeNull();
+  });
+
+  it('workflow unread badge counts nested grandchildren', () => {
+    renderWorkflowWith([
+      buildAgent({
+        id: 'child-1' as AgentId,
+        parentAgentId: 'wf-1' as AgentId,
+        status: 'completed',
+        lastFinishedAt: NOW,
+      }),
+      buildAgent({
+        id: 'grandchild-1' as AgentId,
+        parentAgentId: 'child-1' as AgentId,
+        status: 'completed',
+        lastFinishedAt: NOW,
+      }),
+    ]);
+
+    expect(screen.getByTitle('3 agent replies to review').textContent).toContain('3');
   });
 
   it('picking an agent selects it and reveals the chat (full-width swap trigger)', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -243,6 +243,24 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
       ),
     [sorted],
   );
+  const countUnread = useCallback(
+    (agentsList: ReadonlyArray<Agent>): number => {
+      let n = 0;
+      const visit = (a: Agent) => {
+        if (agentHasUnread(a, a.id === selectedAgentId && isTaskActive)) {
+          n += 1;
+        }
+        for (const c of childrenByParentId.get(a.id) ?? EMPTY_ARRAY) {
+          visit(c);
+        }
+      };
+      for (const a of agentsList) {
+        visit(a);
+      }
+      return n;
+    },
+    [childrenByParentId, selectedAgentId, isTaskActive],
+  );
   const actionableStepIdByRunId = useMemo(() => {
     const map = new Map<string, string | null>();
     for (const { run, workflow } of attachedRuns) {
@@ -510,6 +528,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
               childrenByParentId={childrenByParentId}
               aggregatesByAgentId={aggregatesByAgentId}
               selectedAgentId={selectedAgentId}
+              isTaskActive={isTaskActive}
               expandState={clusterExpand}
               onToggle={toggleClusterExpand}
               onSelect={onPickAgent}
@@ -535,9 +554,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
     const total = workflow.steps.length;
     const done = wfAgents.filter((a) => a.status === 'completed' || a.status === 'skipped').length;
     const isCompleted = !isDiscarded && total > 0 && done >= total;
-    const unreadCount = wfAgents.filter((a) =>
-      agentHasUnread(a, a.id === selectedAgentId && isTaskActive),
-    ).length;
+    const unreadCount = countUnread(wfAgents);
     const expanded =
       workflowExpand?.[run.id] ?? (!isDiscarded && (!isCompleted || unreadCount > 0));
     const hasStarted = wfAgents.length > 0;
@@ -677,6 +694,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
                   AGENT_KIND_DEFAULTS[kind].model;
                 const clusterChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
                 const clustersExpanded = clusterExpand.get(run.id) ?? false;
+                const clusterUnread = countUnread(clusterChildren);
                 return (
                   <Fragment key={run.id}>
                     <WorkflowStepRow
@@ -706,6 +724,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
                         childrenByParentId={childrenByParentId}
                         aggregatesByAgentId={aggregatesByAgentId}
                         selectedAgentId={selectedAgentId}
+                        isTaskActive={isTaskActive}
                         expandState={clusterExpand}
                         onToggle={toggleClusterExpand}
                         onSelect={onPickAgent}
@@ -729,6 +748,15 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
                             {clusterChildren.filter((c) => c.status === 'completed').length}/
                             {clusterChildren.length}
                           </span>
+                          {!clustersExpanded && clusterUnread > 0 ? (
+                            <span
+                              className="inline-flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1 py-0.5 text-[9px] font-medium text-warning"
+                              title={`${clusterUnread} cluster ${clusterUnread === 1 ? 'reply' : 'replies'} to review`}
+                            >
+                              <span aria-hidden className="size-1 rounded-full bg-warning" />
+                              {clusterUnread}
+                            </span>
+                          ) : null}
                         </button>
                         {clustersExpanded
                           ? clusterChildren.map((child, ci) => (
@@ -739,6 +767,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
                                 total={clusterChildren.length}
                                 costUsd={aggregatesByAgentId.get(child.id)?.estimatedCostUsd ?? 0}
                                 isSelected={child.id === selectedAgentId}
+                                isTaskActive={isTaskActive}
                                 onSelect={() => onPickAgent(child.id)}
                               />
                             ))

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+
+vi.mock('@goodboy/ui', () => ({
+  cn: (...a: unknown[]) => a.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../../../store', () => ({
+  agentHasUnread: (agent: Agent, isCurrentlyViewed: boolean): boolean => {
+    if (isCurrentlyViewed || agent.status === 'skipped' || !agent.lastFinishedAt) {
+      return false;
+    }
+    return !agent.lastViewedAt || agent.lastFinishedAt > agent.lastViewedAt;
+  },
+}));
+
+import { ClusterChildRow } from './ClusterChildRow';
+
+const SESSION_ID = 'session-1' as SessionId;
+const NOW = '2026-06-16T00:00:00.000Z' as IsoDateTime;
+
+function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
+  return {
+    sessionId: SESSION_ID,
+    ordinal: 0,
+    name: 'child agent',
+    status: 'completed',
+    ...overrides,
+  };
+}
+
+function renderRow(child: Agent, opts: { isSelected?: boolean; isTaskActive?: boolean } = {}) {
+  const onSelect = vi.fn();
+  render(
+    <ClusterChildRow
+      child={child}
+      index={0}
+      total={3}
+      costUsd={0}
+      isSelected={opts.isSelected ?? false}
+      isTaskActive={opts.isTaskActive ?? true}
+      onSelect={onSelect}
+    />,
+  );
+  return { onSelect, button: screen.getByRole('button') };
+}
+
+describe('ClusterChildRow unread border', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows the warning border for a finished, never-viewed child that is not selected', () => {
+    const { button } = renderRow(buildAgent({ id: 'c1' as AgentId, lastFinishedAt: NOW }), {
+      isSelected: false,
+    });
+    expect(button.className).toContain('border-warning/70');
+    expect(button.className).toContain('bg-warning/5');
+  });
+
+  it('hides the warning border when the child is selected (currently viewed)', () => {
+    const { button } = renderRow(buildAgent({ id: 'c1' as AgentId, lastFinishedAt: NOW }), {
+      isSelected: true,
+      isTaskActive: true,
+    });
+    expect(button.className).not.toContain('border-warning/70');
+  });
+
+  it('hides the warning border when finished work was already viewed', () => {
+    const { button } = renderRow(
+      buildAgent({ id: 'c1' as AgentId, lastFinishedAt: NOW, lastViewedAt: NOW }),
+    );
+    expect(button.className).not.toContain('border-warning/70');
+  });
+
+  it('hides the warning border for a skipped child', () => {
+    const { button } = renderRow(
+      buildAgent({ id: 'c1' as AgentId, status: 'skipped', lastFinishedAt: NOW }),
+    );
+    expect(button.className).not.toContain('border-warning/70');
+  });
+
+  it('hides the warning border for a child that has not finished', () => {
+    const { button } = renderRow(buildAgent({ id: 'c1' as AgentId, status: 'running' }));
+    expect(button.className).not.toContain('border-warning/70');
+  });
+
+  it('selected wins over unread even when the task is inactive', () => {
+    const { button } = renderRow(buildAgent({ id: 'c1' as AgentId, lastFinishedAt: NOW }), {
+      isSelected: true,
+      isTaskActive: false,
+    });
+    expect(button.className).not.toContain('border-warning/70');
+  });
+
+  it('invokes onSelect when clicked', () => {
+    const { onSelect, button } = renderRow(buildAgent({ id: 'c1' as AgentId }));
+    fireEvent.click(button);
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ClusterChildRow.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@goodboy/ui';
 import { Check, Clock, Loader2 } from 'lucide-react';
 import type { Agent } from '@goodboy/types';
+import { agentHasUnread } from '../../../../../store';
 
 type ClusterChildRowProps = {
   readonly child: Agent;
@@ -8,6 +9,7 @@ type ClusterChildRowProps = {
   readonly total: number;
   readonly costUsd: number;
   readonly isSelected: boolean;
+  readonly isTaskActive: boolean;
   readonly onSelect: () => void;
 };
 
@@ -17,8 +19,10 @@ export function ClusterChildRow({
   total,
   costUsd,
   isSelected,
+  isTaskActive,
   onSelect,
 }: ClusterChildRowProps) {
+  const hasUnread = agentHasUnread(child, isSelected && isTaskActive);
   const icon =
     child.status === 'running' ? (
       <Loader2 size={10} className="animate-spin text-info" aria-hidden />
@@ -36,7 +40,8 @@ export function ClusterChildRow({
       type="button"
       onClick={onSelect}
       className={cn(
-        'flex w-full items-center gap-2 rounded px-2 py-1 text-2xs font-medium transition-colors',
+        'flex w-full items-center gap-2 rounded border-l-2 border-transparent px-2 py-1 text-2xs font-medium transition-colors',
+        hasUnread && !isSelected && 'border-warning/70 bg-warning/5',
         isSelected
           ? 'bg-elevated text-foreground'
           : 'text-foreground/70 hover:bg-muted/60 hover:text-foreground',

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: [] as never[],
+  agentHasUnread: (agent: Agent, isCurrentlyViewed: boolean): boolean => {
+    if (isCurrentlyViewed || agent.status === 'skipped' || !agent.lastFinishedAt) {
+      return false;
+    }
+    return !agent.lastViewedAt || agent.lastFinishedAt > agent.lastViewedAt;
+  },
+}));
+
+vi.mock('./ClusterChildRow', () => ({
+  ClusterChildRow: ({ child }: { child: Agent }) => (
+    <div data-testid="cluster-child-row">{child.name}</div>
+  ),
+}));
+
+import { ScoutSubtree } from './ScoutSubtree';
+
+const SESSION_ID = 'session-1' as SessionId;
+const NOW = '2026-06-16T00:00:00.000Z' as IsoDateTime;
+const CONTAINER = 'container' as AgentId;
+
+function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
+  return {
+    sessionId: SESSION_ID,
+    ordinal: 0,
+    name: overrides.id,
+    status: 'completed',
+    kind: 'scout',
+    ...overrides,
+  };
+}
+
+function renderTree(
+  childrenByParentId: Map<string, Agent[]>,
+  opts: {
+    expanded?: boolean;
+    selectedAgentId?: AgentId | null;
+    isTaskActive?: boolean;
+  } = {},
+) {
+  const expandState = new Map<string, boolean>([[CONTAINER, opts.expanded ?? false]]);
+  render(
+    <ScoutSubtree
+      containerId={CONTAINER}
+      depth={0}
+      childrenByParentId={childrenByParentId}
+      aggregatesByAgentId={new Map()}
+      selectedAgentId={opts.selectedAgentId ?? null}
+      isTaskActive={opts.isTaskActive ?? true}
+      expandState={expandState}
+      onToggle={vi.fn()}
+      onSelect={vi.fn()}
+    />,
+  );
+}
+
+describe('ScoutSubtree unread badge', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when the container has no children', () => {
+    const { container } = render(
+      <ScoutSubtree
+        containerId={CONTAINER}
+        depth={0}
+        childrenByParentId={new Map()}
+        aggregatesByAgentId={new Map()}
+        selectedAgentId={null}
+        isTaskActive
+        expandState={new Map()}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows a badge counting unread direct children when collapsed', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW }),
+          buildAgent({ id: 's2' as AgentId, lastFinishedAt: NOW }),
+        ],
+      ],
+    ]);
+    renderTree(map, { expanded: false });
+    expect(screen.getByTitle('2 scout replies to review').textContent).toContain('2');
+  });
+
+  it('counts nested grandchildren in the badge total', () => {
+    const map = new Map<string, Agent[]>([
+      [CONTAINER, [buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW })]],
+      [
+        's1',
+        [
+          buildAgent({ id: 'g1' as AgentId, parentAgentId: 's1' as AgentId, lastFinishedAt: NOW }),
+          buildAgent({ id: 'g2' as AgentId, parentAgentId: 's1' as AgentId, lastFinishedAt: NOW }),
+        ],
+      ],
+    ]);
+    renderTree(map, { expanded: false });
+    expect(screen.getByTitle('3 scout replies to review').textContent).toContain('3');
+  });
+
+  it('uses singular wording for a single unread scout', () => {
+    const map = new Map<string, Agent[]>([
+      [CONTAINER, [buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW })]],
+    ]);
+    renderTree(map, { expanded: false });
+    expect(screen.queryByTitle('1 scout reply to review')).not.toBeNull();
+  });
+
+  it('excludes skipped descendants from the count', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW }),
+          buildAgent({ id: 's2' as AgentId, status: 'skipped', lastFinishedAt: NOW }),
+        ],
+      ],
+    ]);
+    renderTree(map, { expanded: false });
+    expect(screen.queryByTitle('1 scout reply to review')).not.toBeNull();
+    expect(screen.queryByTitle('2 scout replies to review')).toBeNull();
+  });
+
+  it('excludes the currently-viewed selected child from the count', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW }),
+          buildAgent({ id: 's2' as AgentId, lastFinishedAt: NOW }),
+        ],
+      ],
+    ]);
+    renderTree(map, { expanded: false, selectedAgentId: 's1' as AgentId, isTaskActive: true });
+    expect(screen.queryByTitle('1 scout reply to review')).not.toBeNull();
+  });
+
+  it('hides the badge and renders child rows when expanded', () => {
+    const map = new Map<string, Agent[]>([
+      [
+        CONTAINER,
+        [
+          buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW }),
+          buildAgent({ id: 's2' as AgentId, lastFinishedAt: NOW }),
+        ],
+      ],
+    ]);
+    renderTree(map, { expanded: true });
+    expect(screen.queryByTitle('2 scout replies to review')).toBeNull();
+    expect(screen.getAllByTestId('cluster-child-row')).toHaveLength(2);
+  });
+
+  it('shows no badge when every finished child was already viewed', () => {
+    const map = new Map<string, Agent[]>([
+      [CONTAINER, [buildAgent({ id: 's1' as AgentId, lastFinishedAt: NOW, lastViewedAt: NOW })]],
+    ]);
+    renderTree(map, { expanded: false });
+    expect(screen.queryByTitle(/scout repl/)).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ScoutSubtree.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { Agent, AgentId } from '@goodboy/types';
-import { EMPTY_ARRAY } from '../../../../../store';
+import { EMPTY_ARRAY, agentHasUnread } from '../../../../../store';
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetricsBlock';
 import { ClusterChildRow } from './ClusterChildRow';
 
@@ -11,6 +11,7 @@ type ScoutSubtreeProps = {
   readonly childrenByParentId: ReadonlyMap<string, Agent[]>;
   readonly aggregatesByAgentId: ReadonlyMap<string, AgentAggregate>;
   readonly selectedAgentId: AgentId | null;
+  readonly isTaskActive: boolean;
   readonly expandState: ReadonlyMap<string, boolean>;
   readonly onToggle: (id: string) => void;
   readonly onSelect: (id: AgentId) => void;
@@ -22,6 +23,7 @@ export function ScoutSubtree({
   childrenByParentId,
   aggregatesByAgentId,
   selectedAgentId,
+  isTaskActive,
   expandState,
   onToggle,
   onSelect,
@@ -34,6 +36,19 @@ export function ScoutSubtree({
   const doneCount = children.filter(
     (c) => c.status === 'completed' || c.status === 'skipped',
   ).length;
+  const unreadCount = (() => {
+    let n = 0;
+    const visit = (id: AgentId) => {
+      for (const c of childrenByParentId.get(id) ?? EMPTY_ARRAY) {
+        if (agentHasUnread(c, c.id === selectedAgentId && isTaskActive)) {
+          n += 1;
+        }
+        visit(c.id);
+      }
+    };
+    visit(containerId);
+    return n;
+  })();
   return (
     <div className="ml-3 flex flex-col gap-0.5 border-l border-border-soft/60 pl-2">
       <button
@@ -49,6 +64,15 @@ export function ScoutSubtree({
           <ChevronRight size={10} aria-hidden className="shrink-0" />
         )}
         scouts {doneCount}/{children.length}
+        {!expanded && unreadCount > 0 ? (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1 py-0.5 text-[9px] font-medium text-warning"
+            title={`${unreadCount} scout ${unreadCount === 1 ? 'reply' : 'replies'} to review`}
+          >
+            <span aria-hidden className="size-1 rounded-full bg-warning" />
+            {unreadCount}
+          </span>
+        ) : null}
       </button>
       {expanded
         ? children.map((child, ci) => (
@@ -59,6 +83,7 @@ export function ScoutSubtree({
                 total={children.length}
                 costUsd={aggregatesByAgentId.get(child.id)?.estimatedCostUsd ?? 0}
                 isSelected={child.id === selectedAgentId}
+                isTaskActive={isTaskActive}
                 onSelect={() => onSelect(child.id)}
               />
               <ScoutSubtree
@@ -67,6 +92,7 @@ export function ScoutSubtree({
                 childrenByParentId={childrenByParentId}
                 aggregatesByAgentId={aggregatesByAgentId}
                 selectedAgentId={selectedAgentId}
+                isTaskActive={isTaskActive}
                 expandState={expandState}
                 onToggle={onToggle}
                 onSelect={onSelect}

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -310,6 +310,9 @@ export const agentHasUnread = (agent: Agent, isCurrentlyViewed: boolean): boolea
   if (isCurrentlyViewed) {
     return false;
   }
+  if (agent.status === 'skipped') {
+    return false;
+  }
   if (!agent.lastFinishedAt) {
     return false;
   }

--- a/apps/desktop/src/store/slices/agents/selectAgent.ts
+++ b/apps/desktop/src/store/slices/agents/selectAgent.ts
@@ -14,9 +14,30 @@ export const selectAgent = (set: SetFn, get: GetFn) => {
       stampAgents.add(prevAgentId);
     }
 
-    for (const id of stampAgents) {
-      void invokeAgentMarkViewed(id, stampedAt).catch(() => undefined);
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const childrenByParentId = new Map<AgentId, AgentId[]>();
+    for (const run of runs) {
+      if (run.parentAgentId) {
+        const list = childrenByParentId.get(run.parentAgentId) ?? [];
+        list.push(run.id);
+        childrenByParentId.set(run.parentAgentId, list);
+      }
     }
+    const queue: AgentId[] = [agentId];
+    while (queue.length > 0) {
+      const current = queue.shift() as AgentId;
+      for (const childId of childrenByParentId.get(current) ?? []) {
+        if (!stampAgents.has(childId)) {
+          stampAgents.add(childId);
+          queue.push(childId);
+        }
+      }
+    }
+
+    const markViewed = (): Promise<void> =>
+      Promise.all(
+        [...stampAgents].map((id) => invokeAgentMarkViewed(id, stampedAt).catch(() => undefined)),
+      ).then(() => undefined);
 
     const stampRuns = (runs: ReadonlyArray<Agent>): ReadonlyArray<Agent> =>
       runs.map((s) => (stampAgents.has(s.id) ? { ...s, lastViewedAt: stampedAt } : s));
@@ -41,6 +62,7 @@ export const selectAgent = (set: SetFn, get: GetFn) => {
           },
         };
       });
+      await markViewed();
       void get().refreshUnreadWorkspaces();
       return;
     }
@@ -80,6 +102,7 @@ export const selectAgent = (set: SetFn, get: GetFn) => {
           },
         };
       });
+      await markViewed();
       void get().refreshUnreadWorkspaces();
       if (events.length === INITIAL_LIMIT) {
         const tFull = performance.now();

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -346,13 +346,14 @@ describe('advanceClusterImplementation', () => {
       completedAt: expect.any(String),
     });
     expect(store.emitNotification).toHaveBeenCalled();
+    expect(store.refreshUnreadWorkspaces).toHaveBeenCalled();
   });
 
   it('marks the child completed and starts the next child on a done marker', async () => {
     const c0 = childAgent({ id: 'k0', ordinal: 0 });
     const c1 = childAgent({ id: 'k1', ordinal: 1 });
     const p = plan({});
-    const { get, set, sendTurn, state } = makeStore({
+    const { get, set, sendTurn, state, refreshUnreadWorkspaces } = makeStore({
       sessionPhaseRuns: { [SID]: [container({ status: 'running' }), c0, c1] },
       sessionPlans: { [SID]: [p] },
     });
@@ -373,6 +374,7 @@ describe('advanceClusterImplementation', () => {
     expect(call.agentId).toBe('k1');
     expect(call.content).toContain('2/2');
     expect(state.selectedAgentId).toBe(PARENT);
+    expect(refreshUnreadWorkspaces).toHaveBeenCalled();
   });
 
   it('completes the container and auto-advances when the last child finishes', async () => {

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -201,6 +201,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
         await invokeAgentUpdateStatus(childAgentId, { status: 'failed', completedAt: nowIso() });
         const stalled = await invokeAgentList(sessionId);
         set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: stalled } }));
+        void get().refreshUnreadWorkspaces();
         void get().emitNotification(
           'error',
           'warning',
@@ -238,6 +239,7 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
       return;
     }
 
+    void get().refreshUnreadWorkspaces();
     const next = children[completedCount];
     if (next) {
       startChild(

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -224,7 +224,6 @@ async function maybeSynthesizeParent(
   const child = runs.find((r) => r.id === childId);
   const parentId = child?.parentAgentId;
   if (!parentId) {
-    void get().refreshUnreadWorkspaces();
     return;
   }
 
@@ -265,6 +264,7 @@ async function settleScout(
   });
   const refreshed = await invokeAgentList(sessionId);
   set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed } }));
+  void get().refreshUnreadWorkspaces();
   await maybeSynthesizeParent(set, get, sessionId, agentId);
 }
 

--- a/apps/desktop/src/store/store.viewed-stamping.test.ts
+++ b/apps/desktop/src/store/store.viewed-stamping.test.ts
@@ -2,7 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Agent, AgentId, IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
 import { agentHasUnread } from './selectors';
 
-const markViewedSpy = vi.fn();
+const callOrder: string[] = [];
+const markViewedSpy = vi.fn((id: string) => {
+  callOrder.push(`mark:${id}`);
+});
+const unreadSpy = vi.fn(async () => {
+  callOrder.push('refresh');
+  return [] as string[];
+});
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: vi.fn(),
@@ -109,8 +116,9 @@ vi.mock('../features/workflows/workflows', () => ({
   invokeAgentList: vi.fn(async () => []),
   invokeAgentInsert: vi.fn(),
   invokeAgentUpdateStatus: vi.fn(),
-  invokeAgentMarkViewed: (...args: unknown[]) => Promise.resolve(markViewedSpy(...args)),
-  invokeWorkspacesWithUnread: vi.fn(async () => []),
+  invokeAgentMarkViewed: (...args: unknown[]) =>
+    Promise.resolve(markViewedSpy(...(args as [string]))),
+  invokeWorkspacesWithUnread: (...args: unknown[]) => unreadSpy(...(args as [])),
 }));
 
 vi.mock('../features/worktree/worktree', () => ({
@@ -236,6 +244,129 @@ describe('markAgentViewed', () => {
     const updated = runs.find((r) => r.id === AGENT_ID);
     expect(updated?.lastViewedAt).toBeUndefined();
     expect(markViewedSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('agentHasUnread skipped guard', () => {
+  it('returns false for a skipped agent even when finished and never viewed', () => {
+    const agent = buildAgent({ status: 'skipped', lastFinishedAt: T2 });
+    expect(agentHasUnread(agent, false)).toBe(false);
+  });
+});
+
+describe('selectAgent cascades lastViewedAt to descendants', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    callOrder.length = 0;
+  });
+
+  it('stamps the selected parent and every descendant in its parentAgentId subtree', async () => {
+    const PARENT = 'agent-parent' as AgentId;
+    const CHILD = 'agent-child' as AgentId;
+    const GRANDCHILD = 'agent-grandchild' as AgentId;
+    const useAppStore = await importStore();
+
+    const parent = buildAgent({ id: PARENT, lastFinishedAt: T2 });
+    const child = buildAgent({ id: CHILD, parentAgentId: PARENT, lastFinishedAt: T2 });
+    const grandchild = buildAgent({ id: GRANDCHILD, parentAgentId: CHILD, lastFinishedAt: T2 });
+
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: { [SESSION_ID]: [parent, child, grandchild] },
+      selectedAgentId: {},
+    });
+
+    await useAppStore.getState().selectAgent(SESSION_ID, PARENT);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    for (const id of [PARENT, CHILD, GRANDCHILD]) {
+      expect(runs.find((r) => r.id === id)?.lastViewedAt).toBeDefined();
+    }
+    const stamped = markViewedSpy.mock.calls.map((c) => c[0]);
+    expect(stamped).toContain(PARENT);
+    expect(stamped).toContain(CHILD);
+    expect(stamped).toContain(GRANDCHILD);
+  });
+
+  it('awaits every mark-viewed write before refreshing unread workspaces', async () => {
+    const PARENT = 'agent-parent' as AgentId;
+    const CHILD = 'agent-child' as AgentId;
+    const useAppStore = await importStore();
+
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: {
+        [SESSION_ID]: [
+          buildAgent({ id: PARENT, lastFinishedAt: T2 }),
+          buildAgent({ id: CHILD, parentAgentId: PARENT, lastFinishedAt: T2 }),
+        ],
+      },
+      selectedAgentId: {},
+    });
+
+    await useAppStore.getState().selectAgent(SESSION_ID, PARENT);
+    await Promise.resolve();
+
+    const refreshIndex = callOrder.indexOf('refresh');
+    expect(refreshIndex).toBeGreaterThan(-1);
+    const marksBeforeRefresh = callOrder
+      .slice(0, refreshIndex)
+      .filter((c) => c.startsWith('mark:'));
+    expect(marksBeforeRefresh).toEqual(expect.arrayContaining([`mark:${PARENT}`, `mark:${CHILD}`]));
+  });
+
+  it('does not loop forever on a parentAgentId cycle', async () => {
+    const A = 'agent-a' as AgentId;
+    const B = 'agent-b' as AgentId;
+    const useAppStore = await importStore();
+
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: {
+        [SESSION_ID]: [
+          buildAgent({ id: A, parentAgentId: B, lastFinishedAt: T2 }),
+          buildAgent({ id: B, parentAgentId: A, lastFinishedAt: T2 }),
+        ],
+      },
+      selectedAgentId: {},
+    });
+
+    await useAppStore.getState().selectAgent(SESSION_ID, A);
+
+    const stamped = markViewedSpy.mock.calls.map((c) => c[0]);
+    expect(stamped).toContain(A);
+    expect(stamped).toContain(B);
+    expect(stamped.length).toBe(2);
+  });
+
+  it('does not stamp sibling subtrees outside the selected parent', async () => {
+    const PARENT = 'agent-parent' as AgentId;
+    const CHILD = 'agent-child' as AgentId;
+    const SIBLING = 'agent-sibling' as AgentId;
+    const SIBLING_CHILD = 'agent-sibling-child' as AgentId;
+    const useAppStore = await importStore();
+
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionPhaseRuns: {
+        [SESSION_ID]: [
+          buildAgent({ id: PARENT, lastFinishedAt: T2 }),
+          buildAgent({ id: CHILD, parentAgentId: PARENT, lastFinishedAt: T2 }),
+          buildAgent({ id: SIBLING, lastFinishedAt: T2 }),
+          buildAgent({ id: SIBLING_CHILD, parentAgentId: SIBLING, lastFinishedAt: T2 }),
+        ],
+      },
+      selectedAgentId: {},
+    });
+
+    await useAppStore.getState().selectAgent(SESSION_ID, PARENT);
+
+    const runs = useAppStore.getState().sessionPhaseRuns[SESSION_ID] ?? [];
+    expect(runs.find((r) => r.id === SIBLING)?.lastViewedAt).toBeUndefined();
+    expect(runs.find((r) => r.id === SIBLING_CHILD)?.lastViewedAt).toBeUndefined();
+    const stamped = markViewedSpy.mock.calls.map((c) => c[0]);
+    expect(stamped).not.toContain(SIBLING);
+    expect(stamped).not.toContain(SIBLING_CHILD);
   });
 });
 


### PR DESCRIPTION
## Summary
- Cascade `lastViewedAt` across the entire `parentAgentId` subtree when a container agent is selected (DB + in-memory), so cluster/scout children no longer stay permanently unread once finished. Writes are awaited before `refreshUnreadWorkspaces` to avoid a SQL race.
- Count descendants in unread badges: the workflow badge and new cluster/scout badges now include `childrenByParentId`, not just direct step agents.
- Surface unread on child rows: `ClusterChildRow` gets a `border-warning/70` indicator; `ScoutSubtree` shows an aggregate unread count when collapsed.
- Refresh unread on child status transitions in cluster (child-failed, next-child) and scout (`settleScout`) flows.
- Treat `status='skipped'` as never-unread in both `agentHasUnread` (TS) and `workspaces_with_unread` (Rust SQL), so skipped workflow steps don't register false unread.

## Test plan
- [x] `tsc --noEmit` clean
- [x] 62 TS tests pass (viewed-stamping cascade + skipped, cluster/scout refresh, ClusterChildRow/ScoutSubtree/AgentsSection UI)
- [x] 89 Rust tests pass
- [ ] manual: select a parent cluster/scout, confirm children clear unread; late-finishing child re-triggers; skipped step shows no yellow border

🤖 Generated with [Claude Code](https://claude.com/claude-code)