### PR TITLE
fix(desktop): drop mobile permission clamp that blocked worktree edits

### DIFF
--- a/apps/desktop/src/features/companion/mobileConfinement.test.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.test.ts
@@ -1,13 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import type {
-  ClaudePermissionMode,
-  PullRequestState,
-  SessionId,
-  WorkflowId,
-  WorkspaceId,
-} from '@goodboy/types';
+import type { PullRequestState, SessionId, WorkflowId, WorkspaceId } from '@goodboy/types';
 import {
-  clampMobilePermissionMode,
   clearMobileCreateRateState,
   clearMobileSharedSessions,
   evaluateMobileCreateSession,
@@ -39,37 +32,6 @@ const eligiblePr = (over: Partial<PullRequestState> = {}): PullRequestState => (
 });
 
 afterEach(() => clearMobileSharedSessions());
-
-describe('clampMobilePermissionMode', () => {
-  it('preserves read-only plan mode', () => {
-    expect(clampMobilePermissionMode('plan')).toBe('plan');
-  });
-
-  it('caps every writable mode at default so the phone cannot auto-approve writes', () => {
-    const writable: ClaudePermissionMode[] = [
-      'default',
-      'acceptEdits',
-      'bypassPermissions',
-      'dontAsk',
-    ];
-    for (const mode of writable) {
-      expect(clampMobilePermissionMode(mode)).toBe('default');
-    }
-  });
-
-  it('never yields a mode more permissive than default', () => {
-    const all: ClaudePermissionMode[] = [
-      'plan',
-      'default',
-      'acceptEdits',
-      'bypassPermissions',
-      'dontAsk',
-    ];
-    for (const mode of all) {
-      expect(['plan', 'default']).toContain(clampMobilePermissionMode(mode));
-    }
-  });
-});
 
 describe('mobile shared-session registry', () => {
   it('starts empty and marks a session shared', () => {

--- a/apps/desktop/src/features/companion/mobileConfinement.ts
+++ b/apps/desktop/src/features/companion/mobileConfinement.ts
@@ -1,5 +1,4 @@
 import type {
-  ClaudePermissionMode,
   PrMergeMethod,
   PullRequestState,
   SessionId,
@@ -11,16 +10,11 @@ import type {
   WorkspaceIntegrationProvider,
 } from '@goodboy/types';
 
-// Sessions a paired phone is currently driving. Every turn a mobile command
-// triggers — kickoffs, fan-out children, scout/resolver chains — funnels
-// through `sendTurn`, which consults this set and clamps the permission mode.
-// Tracking it here (module scope, not React state) makes the choke point
-// impossible to bypass: any present or future internal `sendTurn` caller is
-// covered without having to thread a flag through every path.
-//
-// Sticky by design: a session stays confined until the desktop revokes mobile
-// access (bridge stop / device revoke). The human, not the phone, decides when
-// full power returns — so a mobile client can never quietly lift the ceiling.
+// TODO (@ak): mobile-origin session registry. The permission-mode clamp that
+// read this set was removed (desktop + mobile both run bypassPermissions).
+// Retained as the origin signal for the pending sandbox-exec confinement of
+// mobile-origin spawns; sticky until the desktop revokes via
+// clearMobileSharedSessions.
 const mobileSharedSessions = new Set<SessionId>();
 
 export const markSessionMobileShared = (sessionId: SessionId): void => {
@@ -33,20 +27,6 @@ export const isSessionMobileShared = (sessionId: SessionId): boolean =>
 export const clearMobileSharedSessions = (): void => {
   mobileSharedSessions.clear();
 };
-
-// A mobile-driven turn may never run more permissively than `default`: every
-// edit/Bash that isn't covered by a desktop-set allow-rule then requires
-// explicit desktop approval, so the phone cannot auto-approve writes that
-// escape the worktree. `plan` (read-only) is preserved when already in effect.
-//
-// TODO (@ak): the clamp gates tool *approval*, not the process. A desktop
-// allow-rule that broadly permits Bash would still let a mobile-initiated agent
-// run absolute-path commands outside the worktree (cwd doesn't constrain Bash).
-// Hard confinement needs an OS sandbox (sandbox-exec/seccomp) on mobile-origin
-// spawns — tracked as a follow-up; the clamp + worktree-scope prompt are the
-// interim guard.
-export const clampMobilePermissionMode = (mode: ClaudePermissionMode): ClaudePermissionMode =>
-  mode === 'plan' ? 'plan' : 'default';
 
 // ---------------------------------------------------------------------------
 // Mobile merge-PR gate (write path).
@@ -124,9 +104,6 @@ export const evaluateMobileMerge = (
 //      can't point at a workspace where the integration isn't wired up);
 //   3. a basic rate/abuse guard — session creation spins up a worktree + agents,
 //      so an unbounded mobile loop could exhaust disk/compute. We cap the rate.
-// The new session's permission mode is clamped exactly like sendTurn (the same
-// `clampMobilePermissionMode` choke point), so a mobile-launched session can
-// never auto-approve escaping writes.
 // ---------------------------------------------------------------------------
 
 /** Providers a phone may launch a session from. The closed set the bridge accepts. */

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -36,10 +36,7 @@ import {
   SETTING_LAST_SESSION_ID,
   DEFAULT_BRANCH_PREFIX,
 } from '../../../features/settings/settings';
-import {
-  clampMobilePermissionMode,
-  markSessionMobileShared,
-} from '../../../features/companion/mobileConfinement';
+import { markSessionMobileShared } from '../../../features/companion/mobileConfinement';
 import type { GetFn, SetFn } from './types';
 
 const slugifyDir = (raw: string): string =>
@@ -69,12 +66,9 @@ type Input = {
     title: string;
   };
   attachmentInputs?: ReadonlyArray<AttachmentInput>;
-  // Origin marker. When true, this session was launched by a paired phone: it is
-  // registered mobile-shared SYNCHRONOUSLY (before any kickoff turn is
-  // dispatched) and its stored permission mode is clamped at creation, so the
-  // confinement is intrinsic and order-independent — a kickoff turn fired during
-  // creation can never run before the mark lands. Default false → desktop
-  // behavior is unchanged (full `bypassPermissions`, no mark).
+  // TODO (@ak): origin marker for the pending sandbox-exec confinement. Marked
+  // synchronously before any async kickoff so a turn fired during creation is
+  // already tagged mobile-origin. No longer affects permission mode.
   mobileShared?: boolean;
 };
 
@@ -104,13 +98,6 @@ export const createSession = (set: SetFn, get: GetFn) => {
       branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
     const trimmedExisting = existingBranch?.trim();
     const sessionId = crypto.randomUUID() as SessionId;
-    // SECURITY (ordering): register the confinement BEFORE anything async that
-    // could dispatch a turn for this session (worktree setup, workflow prespawn,
-    // the kickoff sendTurn at the end of this fn). markSessionMobileShared is
-    // synchronous and module-scoped, so once this line runs every sendTurn for
-    // sessionId — including a kickoff fired during creation — clamps at the
-    // sendTurn choke point. Doing it here (not after createSession resolves in
-    // the executor) closes the race where a kickoff could outrun the mark.
     if (mobileShared) {
       markSessionMobileShared(sessionId);
     }
@@ -172,12 +159,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       state: initialState,
       contextSlots: [],
       providerPreference: providerPreference ?? inheritedPreference,
-      // Desktop sessions run at full power; a mobile-launched session stores a
-      // clamped mode so the ceiling is intrinsic to the session (not only
-      // applied at sendTurn). Belt-and-suspenders with the sendTurn clamp.
-      permissionMode: mobileShared
-        ? clampMobilePermissionMode('bypassPermissions')
-        : 'bypassPermissions',
+      permissionMode: 'bypassPermissions',
       workflowRuns:
         workflowId !== undefined && workflowRunId !== undefined
           ? [

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -60,10 +60,6 @@ import { clampEffort, type EffortLevel } from '../../../features/chat/utils/chat
 import { verbosityDirective } from '../../../features/settings/verbosity';
 import { detectDrift } from '../../../features/session/drift-detection';
 import {
-  clampMobilePermissionMode,
-  isSessionMobileShared,
-} from '../../../features/companion/mobileConfinement';
-import {
   AGENT_KIND_DEFAULTS,
   inferAgentKindFromName,
   type AgentKind,
@@ -464,12 +460,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
 
     const providerInfo = get().providers.find((p) => p.id === provider);
 
-    // Mobile-driven sessions run gated: never more permissive than `default`,
-    // so phone-initiated edits/Bash outside desktop allow-rules need approval.
-    const effectivePermissionMode = isSessionMobileShared(sessionId)
-      ? clampMobilePermissionMode(session.permissionMode)
-      : session.permissionMode;
-
     let claudeFlags: Partial<ClaudeFlagSet> = {};
     let effectiveRules: ReadonlyArray<PermissionRule> = [];
     if (provider === 'anthropic') {
@@ -483,7 +473,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const flags = buildClaudeFlags({
           rules: effectiveRules,
           scope: { workspaceId: session.workspaceId, sessionId },
-          permissionMode: effectivePermissionMode,
+          permissionMode: session.permissionMode,
         });
         claudeFlags = {
           allowedTools: flags.allowedTools,
@@ -498,7 +488,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         claudeFlags = {
           allowedTools: [],
           disallowedTools: [],
-          permissionMode: effectivePermissionMode,
+          permissionMode: session.permissionMode,
         };
       }
     }

--- a/apps/desktop/src/store/store.workflow-stepper.test.ts
+++ b/apps/desktop/src/store/store.workflow-stepper.test.ts
@@ -641,14 +641,13 @@ describe('createSession, step.role drives agent kind over name inference (#793)'
   });
 });
 
-// FINDING 2 (ordering): a mobile-launched session must be confined from its FIRST
-// turn. createSession fires a kickoff turn DURING creation (the workflow's first
-// step promptPrefix → sendTurn), so the confinement must be registered
-// synchronously before that kickoff dispatches — never after createSession
-// resolves. We verify by inspecting the permissionMode that reaches runTurn on
-// that kickoff: a mobile-shared session is clamped (bypassPermissions → default)
-// the instant it runs; a desktop session keeps full bypassPermissions.
-describe('createSession mobile confinement is ordered (#A2 finding 2)', () => {
+// FINDING 2 (ordering): a mobile-launched session must be tagged mobile-origin
+// from its FIRST turn. createSession fires a kickoff turn DURING creation (the
+// workflow's first step promptPrefix sendTurn), so the mark must be registered
+// synchronously before that kickoff dispatches, never after createSession
+// resolves. The permission-mode clamp was removed, so both mobile and desktop
+// reach runTurn at bypassPermissions; only the mobile-origin mark differs.
+describe('createSession mobile-origin marking is ordered (#A2 finding 2)', () => {
   beforeEach(async () => {
     wirePhaseSpies();
     runTurnSpy.mockReset();
@@ -669,7 +668,7 @@ describe('createSession mobile confinement is ordered (#A2 finding 2)', () => {
     clearMobileSharedSessions();
   });
 
-  it('clamps the FIRST kickoff turn of a mobile-launched session (mark precedes kickoff)', async () => {
+  it('marks a mobile-launched session before its FIRST kickoff turn, at full bypass', async () => {
     const { useAppStore } = await import('./store');
     const { isSessionMobileShared } = await import('../features/companion/mobileConfinement');
     useAppStore.setState({
@@ -687,16 +686,15 @@ describe('createSession mobile confinement is ordered (#A2 finding 2)', () => {
       mobileShared: true,
     });
 
-    // The kickoff turn must have already run, and at the moment it reached runTurn
-    // the permission mode was clamped — proving the mark landed before kickoff.
+    // The kickoff turn must have already run; the mark landed before it (origin
+    // tag) and, with the clamp removed, runTurn sees full bypassPermissions.
     await new Promise<void>((r) => setTimeout(r, 50));
     expect(runTurnSpy).toHaveBeenCalledTimes(1);
     const callArgs = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(callArgs['permissionMode']).toBe('default'); // clamped, not bypassPermissions
+    expect(callArgs['permissionMode']).toBe('bypassPermissions');
     expect(isSessionMobileShared(session.id)).toBe(true);
-    // And the stored mode is clamped intrinsically, not left at bypass.
     expect(useAppStore.getState().sessions.find((s) => s.id === session.id)?.permissionMode).toBe(
-      'default',
+      'bypassPermissions',
     );
   });
 


### PR DESCRIPTION
## What
The companion bridge (#845 / #865) clamped `bypassPermissions` to `default` for any session ever touched by a phone, sticky in-memory. It silently blocked in-worktree edits on **desktop** too, while the permission picker still showed "Bypass". That is the "can't edit files in the worktree in bypass mode" bug.

## Change
- Remove `clampMobilePermissionMode` and both call sites (`sendTurn`, `createSession`). Desktop and mobile both run `bypassPermissions`; in-worktree work is unrestricted.
- Retain mobile-origin tracking (`markSessionMobileShared` / `isSessionMobileShared`) as scaffold for the planned sandbox confinement.
- Update tests (`mobileConfinement.test.ts`, `store.workflow-stepper.test.ts`).

## Follow-up
Real out-of-worktree write confinement (including bash) needs an OS sandbox (sandbox-exec on mobile-origin spawns); CLI permission modes/rules cannot confine bash. Tracked separately. Interim: mobile-origin writes are unconfined.

## Checks (local)
typecheck, 1806 tests, knip, build, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)