### PR TITLE
fix(desktop): sync agent provider/model pins read by turn routing

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -118,7 +118,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const sessionPhaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns?.[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<never>),
   );
-  const providers = useAppStore((s) => s.providers);
+  const providers = useAppStore((s) => s.providers ?? (EMPTY_ARRAY as ReadonlyArray<never>));
   const setWorkflowDraft = useAppStore((s) => s.setWorkflowDraft);
   const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const sessionSlots = useSessionSlots(session.id);

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -118,6 +118,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const sessionPhaseRuns = useAppStore(
     (s) => s.sessionPhaseRuns?.[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<never>),
   );
+  const providers = useAppStore((s) => s.providers);
   const setWorkflowDraft = useAppStore((s) => s.setWorkflowDraft);
   const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const sessionSlots = useSessionSlots(session.id);
@@ -239,7 +240,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     onClose();
   };
 
-  const providerId: ProviderId = session.providerPreference.defaultProvider;
+  const providerId =
+    providers.find((p) => p.id === session.providerOverride)?.id ??
+    session.providerPreference.defaultProvider;
   const blocked = busy || planning;
 
   const patchStep = (i: number, patch: Partial<StepEdit>) =>

--- a/apps/desktop/src/shared/lib/ls-to-db-migration.ts
+++ b/apps/desktop/src/shared/lib/ls-to-db-migration.ts
@@ -195,7 +195,7 @@ async function migrateAgentConfig(): Promise<void> {
     if (!agent) {
       continue;
     }
-    const update: { effort?: Effort; modelOverride?: string; providerOverride?: string } = {};
+    const update: { effort?: Effort; modelOverride?: string; providerOverride?: ProviderLite } = {};
     if (fields.effort && !agent.effort) {
       update.effort = fields.effort;
     }

--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -494,6 +494,7 @@ describe('store contract', () => {
         sessionGithub: {},
         volatilePermissionAllows: new Set<string>(),
         agentModelOverride: {},
+        agentProviderOverride: {},
         agentKindOverride: {},
         agentDraft: {},
         diffComments: {},
@@ -845,6 +846,24 @@ describe('store contract', () => {
       await store.getState().setAgentConfig(SESSION_ID, AGENT_ID, { verbosity: 'normal' });
       const updated = store.getState().sessionPhaseRuns[SESSION_ID]?.find((r) => r.id === AGENT_ID);
       expect(updated?.verbosity).toBe('normal');
+    });
+
+    it('setAgentConfig syncs provider and model pins used by turn routing', async () => {
+      const store = await getStore();
+      const agent = buildAgent({ id: AGENT_ID });
+      store.setState({ sessionPhaseRuns: { [SESSION_ID]: [agent] } });
+      await store.getState().setAgentConfig(SESSION_ID, AGENT_ID, {
+        providerOverride: 'cursor',
+        modelOverride: 'cursor-auto',
+      });
+      expect(store.getState().agentProviderOverride[AGENT_ID]).toBe('cursor');
+      expect(store.getState().agentModelOverride[AGENT_ID]).toBe('cursor-auto');
+      await store.getState().setAgentConfig(SESSION_ID, AGENT_ID, {
+        providerOverride: null,
+        modelOverride: null,
+      });
+      expect(store.getState().agentProviderOverride[AGENT_ID]).toBeUndefined();
+      expect(store.getState().agentModelOverride[AGENT_ID]).toBeUndefined();
     });
   });
 });

--- a/apps/desktop/src/store/slices/sessions/setAgentConfig.ts
+++ b/apps/desktop/src/store/slices/sessions/setAgentConfig.ts
@@ -11,6 +11,8 @@ export const setAgentConfig = (set: SetFn, get: GetFn) => {
     if (!prevAgent) {
       return;
     }
+    const prevModelOverride = get().agentModelOverride;
+    const prevProviderOverride = get().agentProviderOverride;
     const applyFields = (a: Agent): Agent => {
       const { verbosity, effort, modelOverride, providerOverride, ...rest } = a;
       const nextVerbosity = fields.verbosity !== undefined ? fields.verbosity : (verbosity ?? null);
@@ -31,11 +33,29 @@ export const setAgentConfig = (set: SetFn, get: GetFn) => {
     };
     set((state) => {
       const runs = state.sessionPhaseRuns[sessionId] ?? [];
+      const nextModelOverride = { ...state.agentModelOverride };
+      const nextProviderOverride = { ...state.agentProviderOverride };
+      if (fields.modelOverride !== undefined) {
+        if (fields.modelOverride != null) {
+          nextModelOverride[agentId] = fields.modelOverride;
+        } else {
+          delete nextModelOverride[agentId];
+        }
+      }
+      if (fields.providerOverride !== undefined) {
+        if (fields.providerOverride != null) {
+          nextProviderOverride[agentId] = fields.providerOverride;
+        } else {
+          delete nextProviderOverride[agentId];
+        }
+      }
       return {
         sessionPhaseRuns: {
           ...state.sessionPhaseRuns,
           [sessionId]: runs.map((r) => (r.id === agentId ? applyFields(r) : r)),
         },
+        agentModelOverride: nextModelOverride,
+        agentProviderOverride: nextProviderOverride,
       };
     });
     try {
@@ -46,6 +66,8 @@ export const setAgentConfig = (set: SetFn, get: GetFn) => {
           ...state.sessionPhaseRuns,
           [sessionId]: prevRuns,
         },
+        agentModelOverride: prevModelOverride,
+        agentProviderOverride: prevProviderOverride,
       }));
       throw err;
     }

--- a/packages/db/src/queries/agent.ts
+++ b/packages/db/src/queries/agent.ts
@@ -4,6 +4,7 @@ import type {
   AgentStatus,
   IsoDateTime,
   ModelEffort,
+  ProviderId,
   ProviderRunId,
   SessionId,
   StepId,
@@ -181,7 +182,7 @@ export type AgentConfigUpdate = {
   verbosity?: 'brief' | 'normal' | 'verbose' | null;
   effort?: ModelEffort | null;
   modelOverride?: string | null;
-  providerOverride?: string | null;
+  providerOverride?: ProviderId | null;
   kind?: string | null;
 };
 


### PR DESCRIPTION
## Summary
- `setAgentConfig` now writes `agentProviderOverride` / `agentModelOverride` (the maps `sendTurn` reads), so picking a provider/model in chat actually routes there. Codex/Cursor no longer cross over.
- Pins roll back alongside `sessionPhaseRuns` if the DB write fails.
- `WorkflowBuilderView` honors the session provider override when valid instead of always forcing the session default.
- `AgentConfigUpdate.providerOverride` narrowed to `ProviderId`.

## Test plan
- [ ] `setAgentConfig` syncs provider/model pins, clears them on null (unit test added)
- [ ] Change agent provider/model in chat → next turn routes to picked provider/model
- [ ] Workflow builder uses session provider override