### PR TITLE
fix(desktop): per-provider context window bars

### DIFF
--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -11,7 +11,7 @@ import {
   type AgentAggregate,
 } from '../../../../../features/session/components/AgentMetricsBlock';
 import { ProviderGlyph } from './ProviderGlyph';
-import { ContextWindowBar } from './ContextWindowBar';
+import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
 import { AgentLifetime } from './AgentLifetime';
 
 type AgentRowProps = {
@@ -20,6 +20,7 @@ type AgentRowProps = {
   readonly index: number;
   readonly telemetry: TelemetryRecord | null;
   readonly aggregate: AgentAggregate | null;
+  readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
   readonly turns: number;
   readonly turnsLoading: boolean;
   readonly isSelected: boolean;
@@ -38,6 +39,7 @@ export function AgentRow({
   index,
   telemetry,
   aggregate,
+  contextUsage,
   turns,
   turnsLoading,
   isSelected,
@@ -205,7 +207,7 @@ export function AgentRow({
               turnsLoading={turnsLoading}
               variant="adhoc"
             />
-            <ContextWindowBar telemetry={telemetry} aggregate={aggregate} />
+            <ContextWindowBar usage={contextUsage} />
           </div>
         </div>
       </div>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -20,6 +20,7 @@ import { DogMascot } from '../../../../../shared/components/DogMascot';
 import type {
   Agent,
   AgentId,
+  ProviderName,
   ProviderRunId,
   Session,
   TelemetryRecord,
@@ -27,6 +28,7 @@ import type {
   WorkflowRun,
   WorkflowRunId,
 } from '@goodboy/types';
+import type { ProviderContextUsage } from './ContextWindowBar';
 import {
   EMPTY_ARRAY,
   agentHasUnread,
@@ -446,6 +448,102 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
     return map;
   }, [telemetry, phaseRuns, agentRunHistory]);
 
+  const providerUsageByAgentId = useMemo(() => {
+    type Entry = {
+      provider: ProviderName;
+      model: string;
+      recordedAt: string;
+      inputTokens: number;
+      outputTokens: number;
+    };
+    const merge = (target: Map<ProviderName, Entry>, rec: Entry) => {
+      const e = target.get(rec.provider);
+      if (!e) {
+        target.set(rec.provider, { ...rec });
+        return;
+      }
+      e.inputTokens += rec.inputTokens;
+      e.outputTokens += rec.outputTokens;
+      if (e.recordedAt < rec.recordedAt) {
+        e.recordedAt = rec.recordedAt;
+        e.model = rec.model;
+      }
+    };
+    const telemetryByRun = new Map<string, TelemetryRecord>();
+    for (const rec of telemetry) {
+      if (rec.kind !== 'turn') {
+        continue;
+      }
+      const existing = telemetryByRun.get(rec.runId);
+      if (!existing || existing.recordedAt < rec.recordedAt) {
+        telemetryByRun.set(rec.runId, rec);
+      }
+    }
+    const map = new Map<string, Map<ProviderName, Entry>>();
+    for (const run of phaseRuns) {
+      const runIds = agentRunHistory[run.id] ?? (run.runId ? [run.runId] : []);
+      const byProvider = new Map<ProviderName, Entry>();
+      for (const rid of runIds) {
+        const rec = telemetryByRun.get(rid);
+        if (!rec) {
+          continue;
+        }
+        merge(byProvider, {
+          provider: rec.provider,
+          model: rec.model,
+          recordedAt: rec.recordedAt,
+          inputTokens: rec.inputTokens,
+          outputTokens: rec.outputTokens,
+        });
+      }
+      map.set(run.id, byProvider);
+    }
+    const childIds = new Map<string, string[]>();
+    for (const run of phaseRuns) {
+      if (run.parentAgentId == null) {
+        continue;
+      }
+      const bucket = childIds.get(run.parentAgentId) ?? [];
+      bucket.push(run.id);
+      childIds.set(run.parentAgentId, bucket);
+    }
+    const rolled = new Set<string>();
+    const rollup = (id: string) => {
+      if (rolled.has(id)) {
+        return;
+      }
+      rolled.add(id);
+      const self = map.get(id);
+      if (!self) {
+        return;
+      }
+      for (const cid of childIds.get(id) ?? []) {
+        rollup(cid);
+        const child = map.get(cid);
+        if (!child) {
+          continue;
+        }
+        for (const ce of child.values()) {
+          merge(self, ce);
+        }
+      }
+    };
+    for (const run of phaseRuns) rollup(run.id);
+    const result = new Map<string, ReadonlyArray<ProviderContextUsage>>();
+    for (const [id, byProvider] of map) {
+      const list = [...byProvider.values()]
+        .map((e) => ({
+          provider: e.provider,
+          model: e.model,
+          inputTokens: e.inputTokens,
+          outputTokens: e.outputTokens,
+        }))
+        .sort((a, b) => b.inputTokens + b.outputTokens - (a.inputTokens + a.outputTokens));
+      result.set(id, list);
+    }
+    return result;
+  }, [telemetry, phaseRuns, agentRunHistory]);
+
   const latestTelemetryByAgentId = useMemo(
     () => computeLatestTelemetryByAgentId(phaseRuns, agentRunHistory, telemetryByRunId),
     [telemetryByRunId, phaseRuns, agentRunHistory],
@@ -522,6 +620,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
           index={index}
           telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
           aggregate={aggregatesByAgentId.get(run.id) ?? null}
+          contextUsage={providerUsageByAgentId.get(run.id) ?? EMPTY_ARRAY}
           turns={turnsByAgentId.get(run.id) ?? 0}
           turnsLoading={run.id === selectedAgentId && loading.transcript}
           isSelected={run.id === selectedAgentId}
@@ -723,6 +822,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
                       isEditing={editingId === run.id}
                       telemetry={latestTelemetryByAgentId.get(run.id) ?? null}
                       aggregate={aggregatesByAgentId.get(run.id) ?? null}
+                      contextUsage={providerUsageByAgentId.get(run.id) ?? EMPTY_ARRAY}
                       turns={turnsByAgentId.get(run.id) ?? 0}
                       turnsLoading={run.id === selectedAgentId && loading.transcript}
                       onStart={() => void onStartStepAgent(run)}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ContextWindowBar.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ContextWindowBar.tsx
@@ -1,71 +1,70 @@
 import { cn } from '@goodboy/ui';
 import { Gauge } from 'lucide-react';
-import type { TelemetryRecord } from '@goodboy/types';
+import type { ProviderId, ProviderName } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES } from '@goodboy/core';
 import { formatTokens } from '../../../../../features/session/agent-row-format';
-import type { AgentAggregate } from '../../../../../features/session/components/AgentMetricsBlock';
+import { ProviderGlyph } from './ProviderGlyph';
 
-function findContextWindow(model: string): number | null {
-  for (const cap of Object.values(PROVIDER_CAPABILITIES)) {
-    const m = cap.models.find((mm) => mm.id === model);
-    if (m) {
-      return m.contextWindow;
-    }
-  }
-  return null;
-}
+export type ProviderContextUsage = {
+  readonly provider: ProviderName;
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+};
 
-export function ContextWindowBar({
-  telemetry,
-  aggregate,
-}: {
-  telemetry: TelemetryRecord | null;
-  aggregate: AgentAggregate | null;
-}) {
-  if (!telemetry) {
+function findContextWindow(provider: ProviderName, model: string): number | null {
+  const cap = PROVIDER_CAPABILITIES[provider as ProviderId];
+  if (!cap) {
     return null;
   }
-  const window = findContextWindow(telemetry.model);
+  const exact = cap.models.find((m) => m.id === model);
+  if (exact) {
+    return exact.contextWindow;
+  }
+  const fallback = cap.models.find((m) => m.tier === 'turn') ?? cap.models[0];
+  return fallback?.contextWindow ?? null;
+}
+
+function tone(pct: number, prefix: 'bg' | 'text'): string {
+  if (pct >= 0.9) {
+    return `${prefix}-danger`;
+  }
+  if (pct >= 0.75) {
+    return `${prefix}-warning`;
+  }
+  if (pct >= 0.5) {
+    return `${prefix}-info`;
+  }
+  return `${prefix}-success`;
+}
+
+function ProviderBar({
+  usage,
+  showProvider,
+}: {
+  usage: ProviderContextUsage;
+  showProvider: boolean;
+}) {
+  const window = findContextWindow(usage.provider, usage.model);
   if (!window) {
     return null;
   }
-  const cumulativeInput = aggregate?.inputTokens ?? telemetry.inputTokens;
-  const cumulativeOutput = aggregate?.outputTokens ?? telemetry.outputTokens;
-  const used = cumulativeInput + cumulativeOutput;
+  const used = usage.inputTokens + usage.outputTokens;
   const pct = Math.min(1, used / window);
-  const barTone = (() => {
-    if (pct >= 0.9) {
-      return 'bg-danger';
-    }
-    if (pct >= 0.75) {
-      return 'bg-warning';
-    }
-    if (pct >= 0.5) {
-      return 'bg-info';
-    }
-    return 'bg-success';
-  })();
-  const iconTone = (() => {
-    if (pct >= 0.9) {
-      return 'text-danger';
-    }
-    if (pct >= 0.75) {
-      return 'text-warning';
-    }
-    if (pct >= 0.5) {
-      return 'text-info';
-    }
-    return 'text-success';
-  })();
   const windowLabel = window >= 1_000_000 ? `${window / 1_000_000}M` : `${window / 1_000}k`;
   const tooltip =
+    `${usage.provider} · ${usage.model}\n` +
     `context: ${used.toLocaleString()} / ${window.toLocaleString()} tokens (${Math.round(pct * 100)}%)\n` +
-    `cumulative input: ${cumulativeInput.toLocaleString()} · output: ${cumulativeOutput.toLocaleString()}`;
+    `cumulative input: ${usage.inputTokens.toLocaleString()} · output: ${usage.outputTokens.toLocaleString()}`;
   return (
     <div className="flex flex-col gap-0.5" title={tooltip}>
       <div className="flex items-center justify-between text-[9px] uppercase tracking-wide text-muted-foreground/60">
-        <span className={cn('flex items-center gap-0.5', iconTone)}>
-          <Gauge size={9} aria-hidden />
+        <span className={cn('flex items-center gap-0.5', tone(pct, 'text'))}>
+          {showProvider ? (
+            <ProviderGlyph provider={usage.provider} />
+          ) : (
+            <Gauge size={9} aria-hidden />
+          )}
           ctx
         </span>
         <span className="font-mono">
@@ -74,10 +73,24 @@ export function ContextWindowBar({
       </div>
       <div className="h-0.5 w-full overflow-hidden rounded-full bg-muted/60">
         <div
-          className={cn('h-full rounded-full transition-all', barTone)}
+          className={cn('h-full rounded-full transition-all', tone(pct, 'bg'))}
           style={{ width: `${pct * 100}%` }}
         />
       </div>
+    </div>
+  );
+}
+
+export function ContextWindowBar({ usage }: { usage: ReadonlyArray<ProviderContextUsage> }) {
+  if (usage.length === 0) {
+    return null;
+  }
+  const showProvider = usage.length > 1;
+  return (
+    <div className="flex flex-col gap-1">
+      {usage.map((u) => (
+        <ProviderBar key={u.provider} usage={u} showProvider={showProvider} />
+      ))}
     </div>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRow.tsx
@@ -11,7 +11,7 @@ import {
   type AgentAggregate,
 } from '../../../../../features/session/components/AgentMetricsBlock';
 import { ProviderGlyph } from './ProviderGlyph';
-import { ContextWindowBar } from './ContextWindowBar';
+import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
 import type { WorkflowBlockReason } from '../lib';
 
 type WorkflowStepRowProps = {
@@ -26,6 +26,7 @@ type WorkflowStepRowProps = {
   readonly isEditing: boolean;
   readonly telemetry: TelemetryRecord | null;
   readonly aggregate: AgentAggregate | null;
+  readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
   readonly turns: number;
   readonly turnsLoading: boolean;
   readonly onStart: () => void;
@@ -48,6 +49,7 @@ export function WorkflowStepRow({
   isEditing,
   telemetry,
   aggregate,
+  contextUsage,
   turns,
   turnsLoading,
   onStart,
@@ -256,7 +258,7 @@ export function WorkflowStepRow({
                 turnsLoading={turnsLoading}
                 variant="workflow"
               />
-              <ContextWindowBar telemetry={telemetry} aggregate={aggregate} />
+              <ContextWindowBar usage={contextUsage} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- context window now resolved against the telemetry provider's own capabilities (`PROVIDER_CAPABILITIES[provider]`) instead of a global model-id scan, so non-claude providers compute correctly
- the ctx gauge is split per provider: multi-provider agents get one ad-hoc bar each (with provider glyph) instead of conflating all usage into a single bar
- per-provider token usage aggregated (and rolled up across child agents) in `AgentsSection`, threaded through `AgentRow` and `WorkflowStepRow`

## Test plan
- [x] `pnpm typecheck` (desktop) green
- [x] `vitest` for WorkspacesSidebar + AgentMetricsBlock suites green (47 tests)
- [ ] visual: agent using a single provider shows one bar (Gauge icon); agent using 2+ providers shows one bar per provider with brand glyph

🤖 Generated with [Claude Code](https://claude.com/claude-code)