### PR TITLE
feat(desktop): surface running agents in session overview

### DIFF
--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -206,6 +206,7 @@ export const useWorkspaceRuns = (
         const hasUnread = runs
           ? runs.some((r) => agentHasUnread(r, isCurrent && r.id === selected))
           : false;
+        const hasRunningAgent = runs ? runs.some((r) => r.status === 'running') : false;
         const openQuestionCount = (s.sessionOpenQuestions[id] ?? []).filter(
           (q) => q.status === 'open',
         ).length;
@@ -214,6 +215,7 @@ export const useWorkspaceRuns = (
           pr: s.sessionGithub[id]?.pr ?? null,
           hasUnread,
           openQuestionCount,
+          hasRunningAgent,
         }).stage;
       }
       return out;

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -80,6 +80,18 @@ const standaloneAgent = (status = 'running') => ({
   status,
 });
 
+const spawnNode = (over: Record<string, unknown> = {}) => ({
+  id: 'node-1',
+  name: 'explore the codebase',
+  kind: 'generic',
+  status: 'running',
+  costUsd: 0,
+  outputSummary: null,
+  children: [],
+  isSelected: false,
+  ...over,
+});
+
 const baseSession = (over: Partial<Session> = {}): Session =>
   ({
     id: 'sess-1',
@@ -250,6 +262,53 @@ describe('SessionOverviewPane nudges', () => {
     hooks.stage = { stage: 'attention', reason: 'PR needs review' } as SessionStageInfo;
     renderPane();
     expect(screen.getByText(/pull request needs you/i)).toBeDefined();
+  });
+});
+
+describe('SessionOverviewPane pipeline agent cards', () => {
+  it('renders one card per free agent with its name', () => {
+    runs.freeAgents = [
+      spawnNode({ id: 'a', name: 'scout the repo' }),
+      spawnNode({ id: 'b', name: 'implement feature' }),
+    ];
+    renderPane();
+    expect(screen.getByText('scout the repo')).toBeDefined();
+    expect(screen.getByText('implement feature')).toBeDefined();
+  });
+
+  it('shows the output summary line when present', () => {
+    runs.freeAgents = [spawnNode({ outputSummary: 'found the bug in auth' })];
+    renderPane();
+    expect(screen.getByText('found the bug in auth')).toBeDefined();
+  });
+
+  it('omits the summary line when outputSummary is null', () => {
+    runs.freeAgents = [spawnNode({ name: 'lonely agent', outputSummary: null })];
+    renderPane();
+    expect(screen.getByText('lonely agent')).toBeDefined();
+    expect(screen.queryByText('found the bug in auth')).toBeNull();
+  });
+
+  it('routes an agent card click to the agents lens', () => {
+    runs.freeAgents = [spawnNode({ name: 'clickable agent' })];
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByText('clickable agent'));
+    expect(onSelectLens).toHaveBeenCalledWith('agents');
+  });
+
+  it('renders the resolve-queue summary separately from agent cards', () => {
+    runs.freeAgents = [spawnNode({ name: 'free agent' })];
+    runs.resolveQueue = [spawnNode({ id: 'r', name: 'resolver' })];
+    const onSelectLens = renderPane();
+    expect(screen.getByText('free agent')).toBeDefined();
+    expect(screen.getByText('1 in resolve queue')).toBeDefined();
+    fireEvent.click(screen.getByText('1 in resolve queue'));
+    expect(onSelectLens).toHaveBeenCalledWith('resolve');
+  });
+
+  it('hides the activity section entirely when no lanes, agents or resolvers', () => {
+    renderPane();
+    expect(screen.queryByText('Activity')).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -42,7 +42,11 @@ import {
 } from '../../../../store';
 import type { FilesTouched, LensKind } from '../../../../store';
 import { STAGE_TONE } from '../../session-stage';
-import { outcomeWord, type SpawnNodeStatus } from '../../../orchestration/components/SpawnTree/lib';
+import {
+  outcomeWord,
+  type SpawnNode,
+  type SpawnNodeStatus,
+} from '../../../orchestration/components/SpawnTree/lib';
 import type { RunLaneModel, StepModel } from '../../../orchestration/hooks/useWorkspaceRuns';
 import { useWorkspaceRuns } from '../../../orchestration/hooks/useWorkspaceRuns';
 import { pickNextWorkflowStep } from '../../../workflows/components/WorkflowNextStepCta';
@@ -106,6 +110,19 @@ const CONTEXT_LINKS: ReadonlyArray<{
 const isGhostStep = (status: SpawnNodeStatus): boolean =>
   status === 'planned' || status === 'queued';
 
+const StatusGlyph = ({ status }: { readonly status: SpawnNodeStatus }) =>
+  status === 'running' ? (
+    <StatusDot tone="info" size="md" pulsing />
+  ) : status === 'done' ? (
+    <span className="flex size-3.5 items-center justify-center rounded-full bg-success/15">
+      <Check size={9} aria-hidden className="text-success" />
+    </span>
+  ) : status === 'stalled' ? (
+    <span className="size-1.5 rounded-full bg-danger" aria-hidden />
+  ) : (
+    <Clock size={11} aria-hidden className="text-muted-foreground/60" />
+  );
+
 const StepBadge = ({
   step,
   onAdvance,
@@ -118,16 +135,8 @@ const StepBadge = ({
     <span className="flex size-3.5 items-center justify-center rounded-full bg-primary/15">
       <Play size={8} aria-hidden className="text-primary" fill="currentColor" />
     </span>
-  ) : step.status === 'running' ? (
-    <StatusDot tone="info" size="md" pulsing />
-  ) : step.status === 'done' ? (
-    <span className="flex size-3.5 items-center justify-center rounded-full bg-success/15">
-      <Check size={9} aria-hidden className="text-success" />
-    </span>
-  ) : step.status === 'stalled' ? (
-    <span className="size-1.5 rounded-full bg-danger" aria-hidden />
   ) : (
-    <Clock size={11} aria-hidden className="text-muted-foreground/60" />
+    <StatusGlyph status={step.status} />
   );
   const inner = (
     <>
@@ -239,6 +248,36 @@ const SummaryRow = ({
   </button>
 );
 
+const AgentRow = ({
+  agent,
+  onClick,
+}: {
+  readonly agent: SpawnNode;
+  readonly onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="group flex items-center gap-2 rounded-lg border border-border-soft bg-elevated px-3.5 py-2.5 text-left shadow-sm transition-colors hover:border-border"
+  >
+    <span className="flex size-3.5 shrink-0 items-center justify-center">
+      <StatusGlyph status={agent.status} />
+    </span>
+    <AgentKindChip kind={agent.kind} />
+    <span className="flex min-w-0 flex-1 flex-col">
+      <span className="truncate text-sm font-medium text-foreground">{agent.name}</span>
+      {agent.outputSummary ? (
+        <span className="truncate text-2xs text-muted-foreground">{agent.outputSummary}</span>
+      ) : null}
+    </span>
+    <ArrowRight
+      size={14}
+      aria-hidden
+      className="shrink-0 text-muted-foreground/30 motion-safe:transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+    />
+  </button>
+);
+
 const StartCard = ({
   icon: Icon,
   tone,
@@ -342,14 +381,9 @@ const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSection
             advance={advanceFor(lane.runId)}
           />
         ))}
-        {freeAgents.length > 0 ? (
-          <SummaryRow
-            icon={Bot}
-            tone="primary"
-            label={`${freeAgents.length} ${freeAgents.length === 1 ? 'agent' : 'agents'}`}
-            onClick={() => onSelectLens('agents')}
-          />
-        ) : null}
+        {freeAgents.map((agent) => (
+          <AgentRow key={agent.id} agent={agent} onClick={() => onSelectLens('agents')} />
+        ))}
         {resolveQueue.length > 0 ? (
           <SummaryRow
             icon={MessageSquareReply}

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -64,6 +64,11 @@ function sessionHasUnreadIn(state: AppState, sessionId: SessionId): boolean {
   return runs.some((r) => agentHasUnread(r, isCurrent && r.id === selected));
 }
 
+function sessionHasRunningAgentIn(state: AppState, sessionId: SessionId): boolean {
+  const runs = state.sessionPhaseRuns[sessionId];
+  return runs ? runs.some((r) => r.status === 'running') : false;
+}
+
 function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
   const sessionId = session.id as SessionId;
   return deriveSessionStage({
@@ -71,6 +76,7 @@ function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
     pr: state.sessionGithub[sessionId]?.pr ?? null,
     hasUnread: sessionHasUnreadIn(state, sessionId),
     openQuestionCount: countOpenQuestions(state, sessionId),
+    hasRunningAgent: sessionHasRunningAgentIn(state, sessionId),
   });
 }
 

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -5,6 +5,7 @@ type Params = {
   pr: PullRequestState | null;
   hasUnread: boolean;
   openQuestionCount: number;
+  hasRunningAgent?: boolean;
 };
 
 const isPrLive = (pr: PullRequestState | null): pr is PullRequestState =>
@@ -18,11 +19,15 @@ export const deriveSessionStage = ({
   pr,
   hasUnread,
   openQuestionCount,
+  hasRunningAgent = false,
 }: Params): SessionStageInfo => {
   if (session.state.kind === 'error') {
     return { stage: 'attention', reason: 'agent errored' };
   }
   if (session.state.kind === 'running' || session.state.kind === 'starting') {
+    return { stage: 'running', reason: 'agent running' };
+  }
+  if (hasRunningAgent) {
     return { stage: 'running', reason: 'agent running' };
   }
   if (isPrLive(pr) && pr.checks === 'failure') {

--- a/apps/desktop/src/store/store.session-view.test.ts
+++ b/apps/desktop/src/store/store.session-view.test.ts
@@ -321,6 +321,63 @@ describe('deriveSessionStage', () => {
     const info = deriveSessionStage({ session: base(1), pr, ...signals });
     expect(info).toEqual({ stage: 'done', reason: 'PR #1 merged' });
   });
+
+  it('idle state + running standalone agent → running', () => {
+    const info = deriveSessionStage({
+      session: base(1),
+      pr: null,
+      ...signals,
+      hasRunningAgent: true,
+    });
+    expect(info.stage).toBe('running');
+  });
+
+  it('error state + running agent → stays attention (error wins)', () => {
+    const session: Session = {
+      ...base(1),
+      state: { kind: 'error', message: 'boom', failedAt: '2024-01-01T00:00:00.000Z' as never },
+    };
+    const info = deriveSessionStage({ session, pr: null, ...signals, hasRunningAgent: true });
+    expect(info.stage).toBe('attention');
+    expect(info.reason).toBe('agent errored');
+  });
+
+  it('running agent + CI failure on live PR → running (agent outranks CI attention)', () => {
+    const pr = { ...makePr(), checks: 'failure' as const };
+    const info = deriveSessionStage({ session: base(1), pr, ...signals, hasRunningAgent: true });
+    expect(info.stage).toBe('running');
+  });
+
+  it('starting state → running', () => {
+    const session: Session = {
+      ...base(1),
+      state: { kind: 'starting', startedAt: '2024-01-01T00:00:00.000Z' as never },
+    };
+    const info = deriveSessionStage({ session, pr: null, ...signals });
+    expect(info).toEqual({ stage: 'running', reason: 'agent running' });
+  });
+
+  it('running agent outranks open questions', () => {
+    const info = deriveSessionStage({
+      session: base(1),
+      pr: null,
+      hasUnread: false,
+      openQuestionCount: 4,
+      hasRunningAgent: true,
+    });
+    expect(info.stage).toBe('running');
+  });
+
+  it('running agent on a merged PR → running, not done', () => {
+    const pr = makePr({ state: 'merged' });
+    const info = deriveSessionStage({ session: base(1), pr, ...signals, hasRunningAgent: true });
+    expect(info.stage).toBe('running');
+  });
+
+  it('hasRunningAgent omitted → defaults to false (no running promotion)', () => {
+    const info = deriveSessionStage({ session: base(1), pr: null, ...signals });
+    expect(info.stage).toBe('building');
+  });
 });
 
 describe('sortAndGroupSessions, pr grouping', () => {


### PR DESCRIPTION
## Summary
- promote a session to the `running` stage when a standalone agent is active (`deriveSessionStage` gains `hasRunningAgent`, wired via `stageInfoOf` + `useWorkspaceRuns`)
- replace the opaque agent count in the overview with per-agent cards (status glyph, kind chip, name, output summary) that route to the agents lens
- extract `StatusGlyph` for reuse between step badges and agent cards

## Why
when an agent is running, the session overview gave no visibility into what was happening. now the overview reflects running state and shows per-agent detail while work is in flight.

## Test plan
- [x] `deriveSessionStage` unit cases: idle+running agent → running, error wins over running, running outranks CI failure / open questions / merged PR, default false
- [x] overview renders one card per free agent, summary line, click routing, resolve-queue separation
- [ ] CI green