### PR TITLE
feat(desktop): start next workflow step on badge click in place

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -12,6 +12,10 @@ type Store = {
   scriptRuns: Record<string, Record<string, { status: string }>>;
   sessionGithub: Record<string, { pr?: unknown }>;
   sessionGitlabMr: Record<string, { mr?: unknown }>;
+  setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
+  activateWorkflowAgent: ReturnType<typeof vi.fn>;
+  phaseTemplates: Record<string, ReadonlyArray<unknown>>;
+  sessionWorkflows: Record<string, ReadonlyArray<unknown>>;
 };
 
 type Runs = {
@@ -28,6 +32,10 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     scriptRuns: {} as Record<string, Record<string, { status: string }>>,
     sessionGithub: {} as Record<string, { pr?: unknown }>,
     sessionGitlabMr: {} as Record<string, { mr?: unknown }>,
+    setFocusedWorkflowRun: vi.fn(),
+    activateWorkflowAgent: vi.fn(async () => undefined),
+    phaseTemplates: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionWorkflows: {} as Record<string, ReadonlyArray<unknown>>,
   } as Store,
   hooks: {
     workspace: { id: 'ws-1', name: 'My workspace' } as Workspace | null,
@@ -110,6 +118,11 @@ beforeEach(() => {
   store.scriptRuns = {};
   store.sessionGithub = {};
   store.sessionGitlabMr = {};
+  store.setFocusedWorkflowRun.mockReset();
+  store.activateWorkflowAgent.mockReset();
+  store.activateWorkflowAgent.mockResolvedValue(undefined);
+  store.phaseTemplates = {};
+  store.sessionWorkflows = {};
   hooks.workspace = { id: 'ws-1', name: 'My workspace' } as Workspace;
   hooks.openQuestions = [];
   hooks.plans = [];
@@ -258,5 +271,95 @@ describe('SessionOverviewPane jump-to links', () => {
     const onSelectLens = renderPane();
     fireEvent.click(screen.getByRole('button', { name: /^goal$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('goal');
+  });
+});
+
+describe('SessionOverviewPane pipeline lane next-step badge', () => {
+  const STEP_ID = 'step-1';
+  const RUN_ID = 'run-1';
+  const WF_ID = 'wf-1';
+  const AGENT_ID = 'agent-1';
+
+  const lane = (steps?: ReadonlyArray<unknown>) => ({
+    runId: RUN_ID,
+    workflowName: 'Ship it',
+    sessionId: 'sess-1',
+    sessionGoal: 'g',
+    stage: 'building',
+    autoRun: false,
+    chainAfterId: null,
+    steps: steps ?? [
+      {
+        stepId: STEP_ID,
+        name: 'Execute',
+        kind: 'generic',
+        status: 'queued',
+        rootAgentId: null,
+        children: [],
+      },
+    ],
+    costUsd: 0,
+  });
+
+  const workflow = {
+    id: WF_ID,
+    workspaceId: 'ws-1',
+    name: 'Ship it',
+    description: '',
+    steps: [{ id: STEP_ID, workflowId: WF_ID, ordinal: 0, name: 'Execute', promptPrefix: '' }],
+    createdAt: '2026-06-22T10:00:00.000Z',
+    updatedAt: '2026-06-22T10:00:00.000Z',
+  };
+
+  const pendingAgent = (status = 'pending') => ({
+    id: AGENT_ID,
+    sessionId: 'sess-1',
+    stepId: STEP_ID,
+    workflowRunId: RUN_ID,
+    parentAgentId: null,
+    ordinal: 0,
+    name: 'Execute',
+    status,
+  });
+
+  const sessionWithRun = () =>
+    baseSession({
+      workflowRuns: [{ id: RUN_ID, workflowId: WF_ID, ordinal: 0, currentStep: 0, autoRun: false }],
+    } as unknown as Partial<Session>);
+
+  beforeEach(() => {
+    runs.lanes = [lane()];
+    store.phaseTemplates = { 'ws-1': [workflow] };
+    store.sessionPhaseRuns = { 'sess-1': [pendingAgent()] };
+  });
+
+  it('clicking the next-step badge starts the step without navigating', () => {
+    const onSelectLens = renderPane(sessionWithRun());
+    fireEvent.click(screen.getByTitle(/^start execute$/i));
+    expect(store.activateWorkflowAgent).toHaveBeenCalledWith('sess-1', AGENT_ID, undefined, false);
+    expect(store.setFocusedWorkflowRun).not.toHaveBeenCalled();
+    expect(onSelectLens).not.toHaveBeenCalledWith('workflows');
+  });
+
+  it('clicking the card body navigates to the workflow without starting the step', () => {
+    const onSelectLens = renderPane(sessionWithRun());
+    fireEvent.click(screen.getByRole('button', { name: /ship it/i }));
+    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith('sess-1', RUN_ID);
+    expect(onSelectLens).toHaveBeenCalledWith('workflows');
+    expect(store.activateWorkflowAgent).not.toHaveBeenCalled();
+  });
+
+  it('open questions suppress the start badge so no step can be launched', () => {
+    hooks.openQuestions = [
+      { status: 'open', text: 'blocked?', workflowRunId: RUN_ID },
+    ] as unknown as ReadonlyArray<OpenQuestion>;
+    renderPane(sessionWithRun());
+    expect(screen.queryByTitle(/^start execute$/i)).toBeNull();
+  });
+
+  it('does not start a step whose agent is no longer pending', () => {
+    store.sessionPhaseRuns = { 'sess-1': [pendingAgent('completed')] };
+    renderPane(sessionWithRun());
+    expect(screen.queryByTitle(/^start execute$/i)).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -324,7 +324,7 @@ const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSection
       onAdvance: async (step) => {
         const agent = runs.find((r) => r.stepId === step.id);
         if (agent?.status === 'pending') {
-          await activateWorkflowAgent(sessionId, agent.id);
+          await activateWorkflowAgent(sessionId, agent.id, undefined, false);
         }
       },
     };

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -144,11 +144,20 @@ function buildHarness(opts: {
   const get = (() => state) as unknown as Parameters<typeof activateWorkflowAgent>[1];
   return {
     sendTurn,
+    set,
+    state,
     activate: activateWorkflowAgent(
       set as unknown as Parameters<typeof activateWorkflowAgent>[0],
       get,
     ),
   };
+}
+
+function mergedSetPartials(set: ReturnType<typeof vi.fn>, state: Record<string, unknown>) {
+  return set.mock.calls.reduce((acc: Record<string, unknown>, call) => {
+    const updater = call[0] as (s: Record<string, unknown>) => Record<string, unknown>;
+    return { ...acc, ...updater({ ...state, ...acc }) };
+  }, {});
 }
 
 describe('activateWorkflowAgent, plan consumption by kind', () => {
@@ -255,6 +264,35 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(payload.content).not.toContain('do the thing');
   });
 
+  it('default call navigates: sets selectedAgentId for the session', async () => {
+    const { set, state, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    const merged = mergedSetPartials(set, state);
+    expect((merged.selectedAgentId as Record<string, unknown>)[SESSION_ID]).toBe(AGENT_ID);
+    expect((merged.agentTurnState as Record<string, unknown>)[AGENT_ID]).toBeDefined();
+  });
+
+  it('navigate=false starts the step without setting selectedAgentId but still inits turn and sends', async () => {
+    const { set, state, sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, undefined, false);
+
+    const merged = mergedSetPartials(set, state);
+    expect(merged.selectedAgentId).toBeUndefined();
+    expect((merged.agentTurnState as Record<string, unknown>)[AGENT_ID]).toBeDefined();
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+  });
+
   it('replays an explicit plan even when it is already consumed', async () => {
     const { activate } = buildHarness({
       agent: makeAgent('generic', 'Execute commits'),
@@ -265,5 +303,99 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     await activate(SESSION_ID, AGENT_ID, PLAN_ID);
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
+  });
+
+  it('navigate=false fans out a multi-cluster implementer without setting selectedAgentId', async () => {
+    const clusters: ReadonlyArray<ImplementationCluster> = [
+      { title: 'a', instructions: 'i1' },
+      { title: 'b', instructions: 'i2' },
+    ];
+    const { set, state, activate } = buildHarness({
+      agent: makeAgent('implementer', 'Implement'),
+      workflow: makeWorkflow('Implement'),
+      plans: [makePlan({ clusters })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, undefined, false);
+
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+    const merged = mergedSetPartials(set, state);
+    expect(merged.selectedAgentId).toBeUndefined();
+    expect((merged.agentTurnState as Record<string, unknown>)[AGENT_ID]).toBeDefined();
+  });
+
+  it('navigate=false on a reviewer step sends the kickoff without navigating', async () => {
+    const { set, state, sendTurn, activate } = buildHarness({
+      agent: makeAgent('reviewer', 'Review'),
+      workflow: makeWorkflow('Review'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, undefined, false);
+
+    const merged = mergedSetPartials(set, state);
+    expect(merged.selectedAgentId).toBeUndefined();
+    expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    expect(sendTurn.mock.calls[0]![0].content).toBe('run the step');
+  });
+
+  it('navigate=false still injects and consumes an explicit plan', async () => {
+    const EXPLICIT_ID = 'plan-explicit' as PlanId;
+    const { set, state, sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan({ id: EXPLICIT_ID, bodyMd: 'explicit body' })],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, EXPLICIT_ID, false);
+
+    expect(addPlanConsumptionSpy).toHaveBeenCalledWith(EXPLICIT_ID, AGENT_ID);
+    const merged = mergedSetPartials(set, state);
+    expect(merged.selectedAgentId).toBeUndefined();
+    expect(sendTurn.mock.calls[0]![0].content).toContain('explicit body');
+  });
+
+  it('navigate=false never emits a selectedAgentId key, leaving prior selection intact', async () => {
+    const { set, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, undefined, false);
+
+    const touchesSelection = set.mock.calls.some((call) => {
+      const updater = call[0] as (s: Record<string, unknown>) => Record<string, unknown>;
+      return 'selectedAgentId' in updater({ selectedAgentId: {} });
+    });
+    expect(touchesSelection).toBe(false);
+  });
+
+  it('explicit navigate=true behaves like the default and navigates', async () => {
+    const { set, state, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await activate(SESSION_ID, AGENT_ID, undefined, true);
+
+    const merged = mergedSetPartials(set, state);
+    expect((merged.selectedAgentId as Record<string, unknown>)[SESSION_ID]).toBe(AGENT_ID);
+  });
+
+  it('throws and never navigates or sends when the agent is missing', async () => {
+    const { set, sendTurn, activate } = buildHarness({
+      agent: makeAgent('generic', 'Execute commits'),
+      workflow: makeWorkflow('Execute commits'),
+      plans: [makePlan()],
+    });
+
+    await expect(activate(SESSION_ID, 'nope' as AgentId, undefined, false)).rejects.toThrow(
+      'agent not found or not a workflow agent',
+    );
+    expect(set).not.toHaveBeenCalled();
+    expect(sendTurn).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -14,7 +14,12 @@ import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId, agentId: AgentId, explicitPlanId?: PlanId) => {
+  return async (
+    sessionId: SessionId,
+    agentId: AgentId,
+    explicitPlanId?: PlanId,
+    navigate = true,
+  ) => {
     const runs = get().sessionPhaseRuns[sessionId] ?? [];
     const agent = runs.find((r) => r.id === agentId);
     if (!agent || !agent.stepId) {
@@ -34,7 +39,6 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
     const goalSection = buildGoalKickoffSection(run?.goal ?? template?.goal);
 
     set((s) => ({
-      selectedAgentId: { ...s.selectedAgentId, [sessionId]: agentId },
       agentTurnState: {
         ...s.agentTurnState,
         [agentId]: {
@@ -42,6 +46,7 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
           lastActivityAt: new Date().toISOString() as IsoDateTime,
         },
       },
+      ...(navigate ? { selectedAgentId: { ...s.selectedAgentId, [sessionId]: agentId } } : {}),
     }));
 
     const effectiveKind: AgentKind =

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -421,6 +421,7 @@ export type AppActions = {
     sessionId: SessionId,
     agentId: AgentId,
     explicitPlanId?: PlanId,
+    navigate?: boolean,
   ): Promise<void>;
   advanceClusterImplementation(
     sessionId: SessionId,


### PR DESCRIPTION
## Summary
- Clicking the next-step badge in the session overview pane now **starts** the pending step in place, instead of navigating into the agent overlay.
- `activateWorkflowAgent` gains a `navigate` option (default `true`); the overview pane passes `false` so only the card body still pushes the agent overlay.
- Distinguishes badge click (advance step) from card-body click (navigate workflow).

## Changes
- `store/slices/workflows/activateWorkflowAgent.ts`: `navigate` param gates the `selectedAgentId` write.
- `store/store.ts`: action signature updated with optional `navigate`.
- `SessionOverviewPane/index.tsx`: badge `onAdvance` calls with `navigate: false`.

## Test plan
- [x] `activateWorkflowAgent.test.ts` (15) — navigate flag, multi-cluster, error paths, no `selectedAgentId` leak
- [x] `SessionOverviewPane/index.test.tsx` (22) — badge avvia no-nav, card navigates, badge suppression states
- [x] desktop `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)