### PR TITLE
feat(desktop): board-only home with archived column and card actions

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -1,5 +1,14 @@
 import { memo, useMemo } from 'react';
-import { Bot, Code, FileDiff, SquareTerminal, type LucideIcon } from 'lucide-react';
+import {
+  Archive,
+  Bot,
+  Code,
+  FileDiff,
+  RotateCcw,
+  SquareTerminal,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
 import { Chip, cn, StatusDot, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId, TelemetryRecord } from '@goodboy/types';
 import {
@@ -17,9 +26,20 @@ import type { BoardNavigation } from '../useBoardNavigation';
 type StageBoardCardProps = {
   readonly session: Session;
   readonly nav: BoardNavigation;
+  readonly archived?: boolean;
+  readonly onArchive?: (session: Session) => void;
+  readonly onDelete?: (session: Session) => void;
+  readonly onRestore?: (session: Session) => void;
 };
 
-export const StageBoardCard = memo(function StageBoardCard({ session, nav }: StageBoardCardProps) {
+export const StageBoardCard = memo(function StageBoardCard({
+  session,
+  nav,
+  archived,
+  onArchive,
+  onDelete,
+  onRestore,
+}: StageBoardCardProps) {
   const id = session.id as SessionId;
   const { stage, reason } = useSessionStageInfo(session);
   const isAutoMode =
@@ -51,9 +71,10 @@ export const StageBoardCard = memo(function StageBoardCard({ session, nav }: Sta
   return (
     <button
       type="button"
+      data-archived={archived || undefined}
       onClick={() => nav.selectCard(session)}
       className={cn(
-        'group flex flex-col gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
+        'group flex min-h-[7.25rem] flex-col gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
         stage === 'running'
           ? isAutoMode
             ? 'border-danger/50'
@@ -100,31 +121,54 @@ export const StageBoardCard = memo(function StageBoardCard({ session, nav }: Sta
         </span>
       )}
 
-      <span className="-mb-1 -ml-1 flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100">
+      <span className="-mb-1 -ml-1 mt-auto flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100">
+        {archived ? (
+          <CardAction
+            icon={RotateCcw}
+            color="text-primary"
+            label="restore"
+            onClick={() => onRestore?.(session)}
+          />
+        ) : (
+          <>
+            <CardAction
+              icon={Bot}
+              color="text-primary"
+              label="open agent"
+              onClick={() => nav.openAgent(session)}
+            />
+            <CardAction
+              icon={FileDiff}
+              color="text-info"
+              label="open diff"
+              onClick={() => nav.openDiff(session)}
+            />
+            <CardAction
+              icon={SquareTerminal}
+              color="text-muted-foreground"
+              label="open terminal"
+              onClick={() => nav.openTerminal(session)}
+            />
+            <CardAction
+              icon={Code}
+              color="text-muted-foreground"
+              label="open in editor"
+              onClick={() => nav.openIDE(session)}
+              disabled={!worktreePath}
+            />
+            <CardAction
+              icon={Archive}
+              color="text-muted-foreground"
+              label="archive"
+              onClick={() => onArchive?.(session)}
+            />
+          </>
+        )}
         <CardAction
-          icon={Bot}
-          color="text-primary"
-          label="open agent"
-          onClick={() => nav.openAgent(session)}
-        />
-        <CardAction
-          icon={FileDiff}
-          color="text-info"
-          label="open diff"
-          onClick={() => nav.openDiff(session)}
-        />
-        <CardAction
-          icon={SquareTerminal}
-          color="text-muted-foreground"
-          label="open terminal"
-          onClick={() => nav.openTerminal(session)}
-        />
-        <CardAction
-          icon={Code}
-          color="text-muted-foreground"
-          label="open in editor"
-          onClick={() => nav.openIDE(session)}
-          disabled={!worktreePath}
+          icon={Trash2}
+          color="text-danger"
+          label="delete"
+          onClick={() => onDelete?.(session)}
         />
       </span>
     </button>

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -1,46 +1,87 @@
 import { useState } from 'react';
 import { ChevronDown } from 'lucide-react';
-import { cn, Eyebrow, ScrollFade } from '@goodboy/ui';
+import { cn, Eyebrow, ScrollFade, type Tone } from '@goodboy/ui';
 import type { Session, SessionStage } from '@goodboy/types';
 import { SESSION_STAGE_META, STAGE_TONE } from '../../../../session/session-stage';
 import { StageBoardCard } from '../StageBoardCard';
 import type { BoardNavigation } from '../useBoardNavigation';
 
-const ZERO_STATE: Record<SessionStage, string> = {
+const ZERO_STATE: Record<SessionStage | 'archived', string> = {
   attention: 'nothing needs you',
   running: 'nothing running',
   review: 'nothing in review',
   building: 'nothing building',
   done: 'nothing done yet',
+  archived: 'nothing archived',
+};
+
+export type ColumnSpec =
+  | { readonly kind: 'stage'; readonly stage: SessionStage }
+  | { readonly kind: 'archived' };
+
+type ColumnView = {
+  readonly key: SessionStage | 'archived';
+  readonly label: string;
+  readonly tone: Tone;
+  readonly collapsible: boolean;
+  readonly archived: boolean;
+};
+
+const viewFor = (spec: ColumnSpec): ColumnView => {
+  if (spec.kind === 'archived') {
+    return {
+      key: 'archived',
+      label: 'archived',
+      tone: 'neutral',
+      collapsible: true,
+      archived: true,
+    };
+  }
+  return {
+    key: spec.stage,
+    label: SESSION_STAGE_META[spec.stage].label,
+    tone: STAGE_TONE[spec.stage],
+    collapsible: spec.stage === 'done',
+    archived: false,
+  };
 };
 
 type StageColumnProps = {
-  readonly stage: SessionStage;
+  readonly spec: ColumnSpec;
   readonly sessions: ReadonlyArray<Session>;
   readonly nav: BoardNavigation;
+  readonly onArchive: (session: Session) => void;
+  readonly onDelete: (session: Session) => void;
+  readonly onRestore: (session: Session) => void;
 };
 
-export const StageColumn = ({ stage, sessions, nav }: StageColumnProps) => {
-  const collapsible = stage === 'done';
-  const [collapsed, setCollapsed] = useState(collapsible);
-  const meta = SESSION_STAGE_META[stage];
+export const StageColumn = ({
+  spec,
+  sessions,
+  nav,
+  onArchive,
+  onDelete,
+  onRestore,
+}: StageColumnProps) => {
+  const view = viewFor(spec);
+  const [collapsed, setCollapsed] = useState(view.collapsible);
   const empty = sessions.length === 0;
 
   const header = (
     <span className="flex items-center gap-1.5">
-      <Eyebrow label={meta.label} tone={STAGE_TONE[stage]} badge muted={empty} />
+      <Eyebrow label={view.label} tone={view.tone} badge muted={empty} />
       <span className="text-2xs tabular-nums text-muted-foreground/60">{sessions.length}</span>
     </span>
   );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
-      {collapsible ? (
+      {view.collapsible ? (
         <button
           type="button"
           onClick={() => setCollapsed((v) => !v)}
           aria-expanded={!collapsed}
-          title={collapsed ? 'expand done' : 'collapse done'}
+          title={collapsed ? `expand ${view.label}` : `collapse ${view.label}`}
           className="flex shrink-0 items-center gap-1 text-left"
         >
           <ChevronDown
@@ -62,11 +103,19 @@ export const StageColumn = ({ stage, sessions, nav }: StageColumnProps) => {
           <div className="flex flex-col gap-2">
             {empty ? (
               <p className="px-1 py-6 text-center text-2xs text-muted-foreground/50">
-                {ZERO_STATE[stage]}
+                {ZERO_STATE[view.key]}
               </p>
             ) : (
               sessions.map((session) => (
-                <StageBoardCard key={session.id} session={session} nav={nav} />
+                <StageBoardCard
+                  key={session.id}
+                  session={session}
+                  nav={nav}
+                  archived={view.archived}
+                  onArchive={onArchive}
+                  onDelete={onDelete}
+                  onRestore={onRestore}
+                />
               ))
             )}
           </div>

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -1,12 +1,16 @@
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus } from 'lucide-react';
 import { Button, Divider, Eyebrow } from '@goodboy/ui';
 import type { Session, SessionStage, WorkspaceId } from '@goodboy/types';
-import { EMPTY_ARRAY, useStageGroupedSessions } from '../../../../store';
+import { EMPTY_ARRAY, useAppStore, useStageGroupedSessions } from '../../../../store';
 import { STAGE_ORDER } from '../../../../store/slices/session-view/types';
 import { DogMascot } from '../../../../shared/components/DogMascot';
+import { ArchiveSessionDialog } from '../../../session/components/ArchiveSessionDialog';
+import { DeleteSessionDialog } from '../../../session/components/DeleteSessionDialog';
 import { StageColumn } from './StageColumn';
 import { useBoardNavigation } from './useBoardNavigation';
+
+type Confirm = { readonly kind: 'archive' | 'delete'; readonly session: Session };
 
 const STAGES: ReadonlyArray<SessionStage> = (
   Object.entries(STAGE_ORDER) as Array<[SessionStage, number]>
@@ -23,6 +27,16 @@ type StageBoardProps = {
 export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoardProps) => {
   const groups = useStageGroupedSessions(workspaceId, sessions);
   const nav = useBoardNavigation();
+  const archived = useAppStore((s) => s.archivedSessions[workspaceId] ?? EMPTY_ARRAY);
+  const loadArchivedSessions = useAppStore((s) => s.loadArchivedSessions);
+  const [confirm, setConfirm] = useState<Confirm | null>(null);
+
+  const onArchive = useCallback((session: Session) => setConfirm({ kind: 'archive', session }), []);
+  const onDelete = useCallback((session: Session) => setConfirm({ kind: 'delete', session }), []);
+
+  useEffect(() => {
+    void loadArchivedSessions(workspaceId);
+  }, [loadArchivedSessions, workspaceId]);
 
   const byStage = useMemo(() => {
     const map = new Map<string, ReadonlyArray<Session>>();
@@ -74,10 +88,34 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
         <div className="flex min-h-0 flex-1 gap-4">
           {STAGES.map((stage) => (
             <div key={stage} className="flex min-w-0 flex-1">
-              <StageColumn stage={stage} sessions={byStage.get(stage) ?? EMPTY_ARRAY} nav={nav} />
+              <StageColumn
+                spec={{ kind: 'stage', stage }}
+                sessions={byStage.get(stage) ?? EMPTY_ARRAY}
+                nav={nav}
+                onArchive={onArchive}
+                onDelete={onDelete}
+                onRestore={nav.restore}
+              />
             </div>
           ))}
+          <div key="archived" className="flex min-w-0 flex-1">
+            <StageColumn
+              spec={{ kind: 'archived' }}
+              sessions={archived}
+              nav={nav}
+              onArchive={onArchive}
+              onDelete={onDelete}
+              onRestore={nav.restore}
+            />
+          </div>
         </div>
+      )}
+
+      {confirm?.kind === 'archive' && (
+        <ArchiveSessionDialog session={confirm.session} open onClose={() => setConfirm(null)} />
+      )}
+      {confirm?.kind === 'delete' && (
+        <DeleteSessionDialog session={confirm.session} open onClose={() => setConfirm(null)} />
       )}
     </div>
   );

--- a/apps/desktop/src/features/workspace/components/StageBoard/useBoardNavigation/index.test.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/useBoardNavigation/index.test.ts
@@ -6,6 +6,7 @@ type StoreState = {
   setCurrentSession: ReturnType<typeof vi.fn>;
   setActiveLens: ReturnType<typeof vi.fn>;
   selectAgent: ReturnType<typeof vi.fn>;
+  unarchiveTask: ReturnType<typeof vi.fn>;
   sessionPhaseRuns: Record<string, ReadonlyArray<{ id: string }>>;
   sessionWorktrees: Record<string, ReadonlyArray<string>>;
 };
@@ -14,6 +15,7 @@ const {
   setCurrentSessionMock,
   setActiveLensMock,
   selectAgentMock,
+  unarchiveTaskMock,
   openInEditorMock,
   markStepMock,
   store,
@@ -21,11 +23,13 @@ const {
   const setCurrentSessionMock = vi.fn(async () => undefined);
   const setActiveLensMock = vi.fn();
   const selectAgentMock = vi.fn(async () => undefined);
+  const unarchiveTaskMock = vi.fn(async () => undefined);
   const store: { state: StoreState } = {
     state: {
       setCurrentSession: setCurrentSessionMock,
       setActiveLens: setActiveLensMock,
       selectAgent: selectAgentMock,
+      unarchiveTask: unarchiveTaskMock,
       sessionPhaseRuns: {},
       sessionWorktrees: {},
     },
@@ -34,6 +38,7 @@ const {
     setCurrentSessionMock,
     setActiveLensMock,
     selectAgentMock,
+    unarchiveTaskMock,
     openInEditorMock: vi.fn(),
     markStepMock: vi.fn(),
     store,
@@ -64,16 +69,19 @@ function reset() {
     setCurrentSession: setCurrentSessionMock,
     setActiveLens: setActiveLensMock,
     selectAgent: selectAgentMock,
+    unarchiveTask: unarchiveTaskMock,
     sessionPhaseRuns: {},
     sessionWorktrees: {},
   };
   setCurrentSessionMock.mockClear();
   setActiveLensMock.mockClear();
   selectAgentMock.mockClear();
+  unarchiveTaskMock.mockClear();
   openInEditorMock.mockClear();
   markStepMock.mockClear();
   setCurrentSessionMock.mockResolvedValue(undefined);
   selectAgentMock.mockResolvedValue(undefined);
+  unarchiveTaskMock.mockResolvedValue(undefined);
 }
 
 describe('useBoardNavigation', () => {
@@ -112,5 +120,45 @@ describe('useBoardNavigation', () => {
     const revealed = dispatch.mock.calls.some((c) => c[0].type === 'goodboy:reveal-chat');
     expect(revealed).toBe(true);
     dispatch.mockRestore();
+  });
+
+  it('openAgent with no agents still reveals chat', async () => {
+    store.state.sessionPhaseRuns = {};
+    const dispatch = vi.spyOn(window, 'dispatchEvent');
+    const { result } = renderHook(() => useBoardNavigation());
+    result.current.openAgent(session);
+    await Promise.resolve();
+    expect(selectAgentMock).not.toHaveBeenCalled();
+    const revealed = dispatch.mock.calls.some((c) => c[0].type === 'goodboy:reveal-chat');
+    expect(revealed).toBe(true);
+    dispatch.mockRestore();
+  });
+
+  it('openTerminal sets lens to terminal', async () => {
+    const { result } = renderHook(() => useBoardNavigation());
+    result.current.openTerminal(session);
+    await Promise.resolve();
+    expect(setCurrentSessionMock).toHaveBeenCalledWith(SESSION_ID);
+    expect(setActiveLensMock).toHaveBeenCalledWith(SESSION_ID, 'terminal');
+  });
+
+  it('openIDE calls openInEditor with the first worktree path', () => {
+    store.state.sessionWorktrees = { [SESSION_ID]: ['/tmp/wt'] };
+    const { result } = renderHook(() => useBoardNavigation());
+    result.current.openIDE(session);
+    expect(openInEditorMock).toHaveBeenCalledWith('/tmp/wt');
+  });
+
+  it('openIDE does nothing when no worktree exists', () => {
+    store.state.sessionWorktrees = {};
+    const { result } = renderHook(() => useBoardNavigation());
+    result.current.openIDE(session);
+    expect(openInEditorMock).not.toHaveBeenCalled();
+  });
+
+  it('restore unarchives the session', () => {
+    const { result } = renderHook(() => useBoardNavigation());
+    result.current.restore(session);
+    expect(unarchiveTaskMock).toHaveBeenCalledWith(SESSION_ID);
   });
 });

--- a/apps/desktop/src/features/workspace/components/StageBoard/useBoardNavigation/index.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/useBoardNavigation/index.ts
@@ -10,12 +10,14 @@ export type BoardNavigation = {
   readonly openDiff: (session: Session) => void;
   readonly openTerminal: (session: Session) => void;
   readonly openIDE: (session: Session) => void;
+  readonly restore: (session: Session) => void;
 };
 
 export const useBoardNavigation = (): BoardNavigation => {
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const selectAgent = useAppStore((s) => s.selectAgent);
+  const unarchiveTask = useAppStore((s) => s.unarchiveTask);
 
   return useMemo<BoardNavigation>(() => {
     const selectCard = (session: Session): void => {
@@ -60,6 +62,10 @@ export const useBoardNavigation = (): BoardNavigation => {
       }
     };
 
-    return { selectCard, openAgent, openDiff, openTerminal, openIDE };
-  }, [setCurrentSession, setActiveLens, selectAgent]);
+    const restore = (session: Session): void => {
+      void unarchiveTask(session.id as SessionId);
+    };
+
+    return { selectCard, openAgent, openDiff, openTerminal, openIDE, restore };
+  }, [setCurrentSession, setActiveLens, selectAgent, unarchiveTask]);
 };

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -104,18 +104,24 @@ export const WorkspacesSidebar = ({
       ) : null}
 
       <div className="flex min-h-0 flex-1">
-        {currentWorkspace ? (
+        {!currentWorkspace ? (
+          <NoWorkspaceEmpty onAddWorkspace={() => setAddWorkspaceOpen(true)} />
+        ) : currentSession ? (
           <SessionActivityBar
             workspaceId={currentWorkspace.id}
             sessions={activeSessions}
             archivedSessions={archivedSessions}
-            currentSessionId={currentSession?.id ?? null}
+            currentSessionId={currentSession.id}
             onSelectSession={onSelectSession}
             onNewSession={() => window.dispatchEvent(new CustomEvent('goodboy:new-session'))}
             onArchivedTabOpen={onArchivedTabOpen}
           />
         ) : (
-          <NoWorkspaceEmpty onAddWorkspace={() => setAddWorkspaceOpen(true)} />
+          <div className="flex flex-1 items-center justify-center px-6 text-center">
+            <p className="text-xs text-muted-foreground">
+              select a session from the board to see its activity
+            </p>
+          </div>
         )}
       </div>
 

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -52,10 +52,10 @@ export const VALID_SORTS = new Set<SessionSortKey>(['updatedAt', 'goal', 'create
 export const VALID_GROUPS = new Set<SessionGroupKey>(['none', 'stage', 'pr']);
 
 export const STAGE_ORDER: Record<SessionStage, number> = {
-  attention: 0,
+  building: 0,
   running: 1,
-  review: 2,
-  building: 3,
+  attention: 2,
+  review: 3,
   done: 4,
 };
 

--- a/apps/desktop/src/store/store.session-view.test.ts
+++ b/apps/desktop/src/store/store.session-view.test.ts
@@ -9,6 +9,7 @@ import {
 } from './slices/session-view';
 import type { SessionViewPrefs } from '@goodboy/types';
 import { STORAGE_PREFIXES } from '../shared/lib/storage-keys';
+import { STAGE_ORDER } from './slices/session-view/types';
 
 function sid(n: number): SessionId {
   return `session-${n}` as SessionId;
@@ -178,7 +179,7 @@ describe('sortAndGroupSessions, createdAt sort', () => {
 describe('sortAndGroupSessions, stage grouping', () => {
   const prefs: SessionViewPrefs = { sort: 'updatedAt', group: 'stage' };
 
-  it('produces groups in attention→running→review→building→done order', () => {
+  it('produces groups in building→running→attention→review→done order', () => {
     const sessions = [sid(1), sid(2), sid(3), sid(4), sid(5)].map((id) => makeSession(id));
     const result = sortAndGroupSessions(
       sessions,
@@ -192,7 +193,7 @@ describe('sortAndGroupSessions, stage grouping', () => {
         [sid(5)]: 'attention',
       },
     );
-    expect(keys(result)).toEqual(['attention', 'running', 'review', 'building', 'done']);
+    expect(keys(result)).toEqual(['building', 'running', 'attention', 'review', 'done']);
   });
 
   it('omits empty buckets', () => {
@@ -724,5 +725,24 @@ describe('sortAndGroupSessions, performance', () => {
     const elapsed = performance.now() - start;
 
     expect(elapsed).toBeLessThan(3000);
+  });
+});
+
+describe('STAGE_ORDER', () => {
+  it('defines building(0) → running(1) → attention(2) → review(3) → done(4)', () => {
+    expect(STAGE_ORDER).toEqual({
+      building: 0,
+      running: 1,
+      attention: 2,
+      review: 3,
+      done: 4,
+    });
+  });
+
+  it('sorted keys produce the expected column sequence', () => {
+    const sorted = (Object.entries(STAGE_ORDER) as Array<[string, number]>)
+      .sort((a, b) => a[1] - b[1])
+      .map(([k]) => k);
+    expect(sorted).toEqual(['building', 'running', 'attention', 'review', 'done']);
   });
 });


### PR DESCRIPTION
## Summary
- board and session list are now mutually exclusive: the activity list shows only when a session is selected, board view shows a placeholder hint
- reordered stage columns to building → running → attention → review → done (STAGE_ORDER)
- appended a parallel **Archived** column after Done, fed from the archived-sessions store slice (no change to SessionStage)
- uniform board cards (min-height) with hover actions: open agent/diff/terminal/editor + archive + delete; archived cards expose restore + delete

## Test plan
- [x] `pnpm typecheck` clean
- [x] store.session-view + StageBoard tests green (66)
- [x] workspace + session suites green (318)
- [x] app-level snapshots/a11y/keyboard green (179)

🤖 Generated with [Claude Code](https://claude.com/claude-code)