### PR TITLE
fix(desktop): don't re-fan consumed planning cluster

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatView/clusterDashboard.test.ts
@@ -79,6 +79,12 @@ describe('selectClusterDashboard', () => {
     expect(selectClusterDashboard(runs, 'container' as AgentId, [])).toBeNull();
   });
 
+  it('still renders for a consumed plan with implementer children (display contract)', () => {
+    const d = selectClusterDashboard(runs, 'container' as AgentId, [plan({ status: 'consumed' })]);
+    expect(d?.containerId).toBe('container');
+    expect(d?.items).toHaveLength(2);
+  });
+
   it('returns null when the selected agent has no cluster siblings', () => {
     const lone: ReadonlyArray<Agent> = [agent({ id: 'solo', ordinal: 0 })];
     expect(selectClusterDashboard(lone, 'solo' as AgentId, [plan({})])).toBeNull();

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -205,7 +205,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('fans out a 2+ cluster plan regardless of status (count-based, status-agnostic)', async () => {
+  it('does not re-fan-out a consumed plan: a later step runs its own kickoff instead', async () => {
     const clusters: ReadonlyArray<ImplementationCluster> = [
       { title: 'a', instructions: 'i1' },
       { title: 'b', instructions: 'i2' },
@@ -219,8 +219,9 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     await activate(SESSION_ID, AGENT_ID);
 
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
-    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
-    expect(sendTurn).not.toHaveBeenCalled();
+    expect(fanOutClustersSpy).not.toHaveBeenCalled();
+    const [payload] = sendTurn.mock.calls[0]!;
+    expect(payload.content).toBe('run the step');
   });
 
   it('does not consume an already-consumed plan', async () => {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -63,6 +63,14 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
       : '';
     const planToConsume = explicitPlan ?? (latestPlan?.status === 'active' ? latestPlan : null);
 
+    const fanOutPlan =
+      effectiveKind === 'implementer'
+        ? selectFanOutPlan(get, sessionId, {
+            workflowRunId: agent.workflowRunId,
+            explicitPlan,
+          })
+        : null;
+
     if (consumesPlan && planToConsume) {
       await invokeAddPlanConsumption(planToConsume.id, agentId);
       const refreshedPlans = await invokeListPlansForSession(sessionId);
@@ -73,13 +81,6 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
       }));
     }
 
-    const fanOutPlan =
-      effectiveKind === 'implementer'
-        ? selectFanOutPlan(get, sessionId, {
-            workflowRunId: agent.workflowRunId,
-            explicitPlan,
-          })
-        : null;
     const clusters =
       fanOutPlan?.clusters && fanOutPlan.clusters.length >= 2 ? fanOutPlan.clusters : undefined;
     if (clusters && clusters.length >= 2) {

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -106,6 +106,15 @@ describe('selectClustersPlan', () => {
     expect(selectClustersPlan([wf1, wf2], 'wf1' as WorkflowRunId)?.id).toBe('p-wf1');
     expect(selectClustersPlan([wf1, wf2], 'wf2' as WorkflowRunId)?.id).toBe('p-wf2');
   });
+
+  it('still returns a consumed plan so the dashboard keeps rendering it (display contract)', () => {
+    const consumed = plan({
+      id: 'planning',
+      status: 'consumed',
+      workflowRunId: 'wf1' as WorkflowRunId,
+    });
+    expect(selectClustersPlan([consumed], 'wf1' as WorkflowRunId)?.id).toBe('planning');
+  });
 });
 
 const fakeGet = (plans: ReadonlyArray<PlanWithCount>): GetFn =>
@@ -140,6 +149,17 @@ describe('selectFanOutPlan', () => {
 
   it('returns null when neither an explicit nor a stored plan qualifies', () => {
     expect(selectFanOutPlan(fakeGet([]), sessionId, {})).toBeNull();
+  });
+
+  it('ignores a consumed plan so a later workflow step does not re-fan-out the same clusters', () => {
+    const consumed = plan({
+      id: 'planning',
+      status: 'consumed',
+      workflowRunId: 'wf1' as WorkflowRunId,
+    });
+    expect(
+      selectFanOutPlan(fakeGet([consumed]), sessionId, { workflowRunId: 'wf1' as WorkflowRunId }),
+    ).toBeNull();
   });
 });
 

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -161,7 +161,8 @@ function findClustersPlan(
   sessionId: SessionId,
   workflowRunId: WorkflowRunId | undefined,
 ) {
-  return selectClustersPlan(get().sessionPlans[sessionId] ?? [], workflowRunId);
+  const p = selectClustersPlan(get().sessionPlans[sessionId] ?? [], workflowRunId);
+  return p?.status === 'active' ? p : null;
 }
 
 export const selectFanOutPlan = (


### PR DESCRIPTION
## Summary
- The implementation agent that merges a PR was re-picking the planning cluster that had already been consumed, re-fanning sub-agents on a stale plan.
- Gate `findClustersPlan` on `status === 'active'` (single chokepoint covering both `activateWorkflowAgent.ts:78` and `spawnAgent.ts:154`) so a consumed plan returns `null`.
- `selectClustersPlan` stays status-agnostic to preserve the dashboard display contract (`clusterDashboard.ts:78`); the `explicitPlan` bypass remains intentional for explicit consume.

## Test plan
- [x] consumed plan not re-fanned (`selectFanOutPlan` null on `status='consumed'`)
- [x] dashboard still renders consumed plans
- [x] explicit-plan bypass works even when consumed
- [x] no double-consume
- [x] 59 targeted tests across 3 files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)