### PR TITLE
fix(desktop): gate workflow autorun chaining on step-done marker

### DIFF
--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.test.tsx
@@ -129,4 +129,57 @@ describe('WorkflowNextStepCta', () => {
     ).toBeDefined();
     expect(onAdvance).not.toHaveBeenCalled();
   });
+
+  it('renders force CTA when chain is blocked (failed predecessor)', () => {
+    const blockedRuns: Agent[] = [
+      run('s1' as StepId, 'failed', 0),
+      run('s2' as StepId, 'pending', 1),
+    ];
+    const onAdvance = vi.fn();
+    const onForceAdvance = vi.fn();
+    render(
+      <WorkflowNextStepCta
+        workflow={wf()}
+        runs={blockedRuns}
+        onAdvance={onAdvance}
+        onForceAdvance={onForceAdvance}
+      />,
+    );
+    expect(screen.getByTestId('workflow-force-next-step-cta')).toBeDefined();
+    expect(screen.queryByTestId('workflow-next-step-cta')).toBeNull();
+  });
+
+  it('shows confirmation before executing force advance', async () => {
+    const blockedRuns: Agent[] = [
+      run('s1' as StepId, 'failed', 0),
+      run('s2' as StepId, 'pending', 1),
+    ];
+    const onForceAdvance = vi.fn();
+    render(
+      <WorkflowNextStepCta
+        workflow={wf()}
+        runs={blockedRuns}
+        onAdvance={vi.fn()}
+        onForceAdvance={onForceAdvance}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('workflow-force-next-step-cta'));
+    expect(screen.getByText(/skip the blocked step/i)).toBeDefined();
+    expect(onForceAdvance).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText(/skip and continue/i));
+    await Promise.resolve();
+    expect(onForceAdvance).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing when workflow is complete', () => {
+    const doneRuns: Agent[] = [
+      run('s1' as StepId, 'completed', 0),
+      run('s2' as StepId, 'completed', 1),
+      run('s3' as StepId, 'completed', 2),
+    ];
+    const { container } = render(
+      <WorkflowNextStepCta workflow={wf()} runs={doneRuns} onAdvance={vi.fn()} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
 });

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
-import { ArrowRight, ClipboardList } from 'lucide-react';
+import { AlertTriangle, ArrowRight, ClipboardList } from 'lucide-react';
 import { cn } from '@goodboy/ui';
+import { classifyWorkflowChain } from '@goodboy/core';
 import type { Agent, Step, Workflow } from '@goodboy/types';
 import type { VerbosityLevel } from '../../../../features/settings/verbosity';
 import {
@@ -18,6 +19,7 @@ export type Props = {
     model: string,
     verbosity: VerbosityLevel | undefined,
   ) => void | Promise<void>;
+  readonly onForceAdvance?: () => void | Promise<void>;
   readonly hasOpenQuestions?: boolean;
   readonly consumesActivePlan?: boolean;
   readonly className?: string;
@@ -58,16 +60,78 @@ export const WorkflowNextStepCta = ({
   workflow,
   runs,
   onAdvance,
+  onForceAdvance,
   hasOpenQuestions = false,
   consumesActivePlan = false,
   className,
 }: Props) => {
   const [busy, setBusy] = useState(false);
   const [pendingConfirm, setPendingConfirm] = useState(false);
-  const next = useMemo(() => pickNextWorkflowStep(workflow, runs), [workflow, runs]);
+  const [pendingForce, setPendingForce] = useState(false);
+  const chain = useMemo(() => classifyWorkflowChain(workflow, runs), [workflow, runs]);
+  const next = chain.kind === 'step' ? chain.step : null;
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
   const defaults = AGENT_KIND_DEFAULTS[kind];
   const palette = AGENT_KIND_PALETTE[kind];
+  const doForce = async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    setPendingForce(false);
+    try {
+      await onForceAdvance?.();
+    } finally {
+      setBusy(false);
+    }
+  };
+  if (chain.kind === 'complete') {
+    return null;
+  }
+  if (chain.kind === 'blocked') {
+    return (
+      <div className={cn('flex flex-col gap-1.5', className)}>
+        {pendingForce ? (
+          <div className="flex flex-col gap-2 rounded border border-warning/50 bg-warning/10 px-2.5 py-2 text-2xs">
+            <p className="font-medium text-foreground">
+              Skip the blocked step and start the next agent?
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setPendingForce(false)}
+                className="rounded border border-border px-2 py-0.5 text-2xs font-semibold text-foreground motion-safe:transition-colors hover:bg-muted"
+              >
+                cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void doForce()}
+                disabled={busy}
+                className="rounded bg-warning px-2 py-0.5 text-2xs font-semibold text-warning-foreground motion-safe:transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                skip and continue
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setPendingForce(true)}
+            disabled={busy}
+            data-testid="workflow-force-next-step-cta"
+            title={`step blocked: ${chain.failedStep.name}`}
+            className="group flex w-full items-center justify-between gap-2 rounded-md border border-warning/50 bg-warning/10 px-2.5 py-1.5 text-xs font-medium text-warning shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:border-warning hover:bg-warning/20 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <span className="flex items-center gap-1.5">
+              <AlertTriangle size={13} aria-hidden className="shrink-0" />
+              <span className="font-semibold">force next step</span>
+            </span>
+          </button>
+        )}
+      </div>
+    );
+  }
   if (!next) {
     return null;
   }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
@@ -16,7 +16,7 @@ export function workflowKindName(workflow: Workflow): string {
 export const pluralize = (count: number, singular: string) =>
   `${count} ${singular}${count === 1 ? '' : 's'}`;
 
-export type WorkflowBlockReason = 'questions' | 'summarizer';
+export type WorkflowBlockReason = 'questions' | 'summarizer' | 'failed-step';
 
 export type ResolverState = 'awaiting' | 'committed' | 'wontfix';
 export type ResolverStatus =

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -40,7 +40,11 @@ import {
   useSessionLoading,
   useSessionOpenQuestions,
 } from '../../../../../store';
-import { pickNextWorkflowStep } from '../../../../../features/workflows/components/WorkflowNextStepCta';
+import { classifyWorkflowChain } from '@goodboy/core';
+import {
+  WorkflowNextStepCta,
+  pickNextWorkflowStep,
+} from '../../../../../features/workflows/components/WorkflowNextStepCta';
 import { workflowRunHasOpenQuestions } from '../../../../../features/context/openQuestionsGate';
 import { GoalAttachmentsStrip } from '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip';
 import { PendingResolutionsStrip } from '../../../../../features/context/components/ContextPanel/strips/PendingResolutionsStrip';
@@ -177,6 +181,7 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
   const dequeueResolution = useAppStore((s) => s.dequeueResolution);
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
+  const forceAdvanceWorkflowStep = useAppStore((s) => s.forceAdvanceWorkflowStep);
   const renameAgent = useAppStore((s) => s.renameAgent);
   const deleteAgent = useAppStore((s) => s.deleteAgent);
   const phaseTemplates = useAppStore(
@@ -292,16 +297,19 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
   }, [attachedRuns, agentsByRunId]);
   const blockReasonByRunId = useMemo(() => {
     const map = new Map<string, WorkflowBlockReason | null>();
-    for (const { run } of attachedRuns) {
-      const reason = workflowRunHasOpenQuestions(openQuestions, run.id)
+    for (const { run, workflow } of attachedRuns) {
+      const runAgents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
+      const reason: WorkflowBlockReason | null = workflowRunHasOpenQuestions(openQuestions, run.id)
         ? 'questions'
         : summarizerBusy
           ? 'summarizer'
-          : null;
+          : classifyWorkflowChain(workflow, runAgents).kind === 'blocked'
+            ? 'failed-step'
+            : null;
       map.set(run.id, reason);
     }
     return map;
-  }, [attachedRuns, openQuestions, summarizerBusy]);
+  }, [attachedRuns, agentsByRunId, openQuestions, summarizerBusy]);
 
   const onDiscardWorkflow = useCallback(
     async (runId: WorkflowRunId) => {
@@ -950,6 +958,16 @@ export function AgentsSection({ task, only }: AgentsSectionProps) {
               No agents yet for this workflow.
             </p>
           )
+        ) : null}
+        {expanded && !isDiscarded && wfBlockReason === 'failed-step' ? (
+          <div className={cn('pb-1', forceExpanded ? 'pl-1' : 'pl-3')}>
+            <WorkflowNextStepCta
+              workflow={workflow}
+              runs={wfAgents}
+              onAdvance={() => {}}
+              onForceAdvance={() => void forceAdvanceWorkflowStep(task.id, run.id)}
+            />
+          </div>
         ) : null}
         {expanded ? (
           <div className="pb-1 pl-3">

--- a/apps/desktop/src/store/kickoff.ts
+++ b/apps/desktop/src/store/kickoff.ts
@@ -1,4 +1,4 @@
-import type { PlanWithCount, SessionId, WorkflowRunId } from '@goodboy/types';
+import type { AgentId, PlanWithCount, SessionId, WorkflowRunId } from '@goodboy/types';
 import { listPlansForSession as invokeListPlansForSession } from '../features/plans/plans';
 
 export const buildPlanKickoffSection = async (
@@ -28,3 +28,13 @@ export const buildGoalKickoffSection = (goal?: string): string => {
   const trimmed = (goal ?? '').trim();
   return trimmed.length > 0 ? `Workflow goal:\n\n${trimmed}` : '';
 };
+
+export const stepBoundaryMarker = (agentId: AgentId): string => `<<step-done id="${agentId}">>`;
+
+export const composeStepBoundary = (agentId: AgentId): string =>
+  [
+    'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
+    'When this step is fully complete, emit on its own line exactly:',
+    stepBoundaryMarker(agentId),
+    'Do not emit that marker until the step is truly done.',
+  ].join('\n');

--- a/apps/desktop/src/store/slices/plans/runPlan.ts
+++ b/apps/desktop/src/store/slices/plans/runPlan.ts
@@ -28,6 +28,10 @@ export const runPlan = (get: GetFn) => {
       return;
     }
 
+    if (creatorAgent.status === 'failed') {
+      return;
+    }
+
     const templates = state.phaseTemplates[session.workspaceId] ?? [];
     const creatorRun = session.workflowRuns.find((r) => r.id === creatorAgent.workflowRunId);
     const template =

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -6,6 +6,7 @@ import {
   buildStepPrompt,
   extractCommentResolved,
   extractCommentWontfix,
+  extractPlanFromMarker,
   extractScoutSplit,
   findReusableAgent,
   runsForWorkflowRun,
@@ -18,7 +19,6 @@ import {
   listContextSlotsForSession,
   updateProviderRunStatus,
   updateSessionState,
-  updateSessionWorkflowStep,
   upsertContextSlot,
 } from '@goodboy/db';
 import type {
@@ -730,6 +730,15 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           await get().advanceScoutTree(sessionId, resolvedAgentId, assistantText);
         } else if (ranAgent?.parentAgentId) {
           await get().advanceClusterImplementation(sessionId, resolvedAgentId, assistantText);
+        } else if (!!ranAgent?.stepId && !!ranAgent?.workflowRunId) {
+          const planCapturedThisTurn = extractPlanFromMarker(assistantText) !== null;
+          const { shouldAutoAdvance } = await get().finalizeWorkflowStep(
+            sessionId,
+            resolvedAgentId,
+            assistantText,
+            planCapturedThisTurn,
+          );
+          shouldAutoAdvanceWorkflow = shouldAutoAdvance;
         } else {
           await invokeAgentUpdateStatus(resolvedAgentId, {
             status: 'completed',
@@ -737,41 +746,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             completedAt: now(),
           });
           const refreshedRuns = await invokeAgentList(sessionId);
-          set((state) => {
-            if (!phaseDefinition) {
-              return {
-                sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: refreshedRuns },
-              };
-            }
-            const target = state.sessions.find((s) => s.id === sessionId);
-            const runId2 =
-              phaseWorkflowRunId && target?.workflowRuns.some((r) => r.id === phaseWorkflowRunId)
-                ? phaseWorkflowRunId
-                : null;
-            if (runId2) {
-              void updateSessionWorkflowStep(
-                tauriDatabase,
-                sessionId,
-                runId2,
-                phaseDefinition.ordinal,
-                new Date().toISOString() as IsoDateTime,
-              );
-            }
-            return {
-              sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: refreshedRuns },
-              sessions: state.sessions.map((s) => {
-                if (s.id !== sessionId || !runId2) {
-                  return s;
-                }
-                return {
-                  ...s,
-                  workflowRuns: s.workflowRuns.map((r) =>
-                    r.id === runId2 ? { ...r, currentStep: phaseDefinition!.ordinal } : r,
-                  ),
-                };
-              }),
-            };
-          });
+          set((state) => ({
+            sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: refreshedRuns },
+          }));
           void get().refreshUnreadWorkspaces();
 
           shouldAutoAdvanceWorkflow = true;

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -194,7 +194,8 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
     const [payload] = sendTurn.mock.calls[0]!;
     expect(payload.content).not.toContain('do the thing');
-    expect(payload.content).toBe('run the step');
+    expect(payload.content).toContain('run the step');
+    expect(payload.content).toContain('<<step-done');
   });
 
   it('an implementer step with multiple clusters still fans out (no regression)', async () => {
@@ -230,7 +231,8 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
     const [payload] = sendTurn.mock.calls[0]!;
-    expect(payload.content).toBe('run the step');
+    expect(payload.content).toContain('run the step');
+    expect(payload.content).toContain('<<step-done');
   });
 
   it('does not consume an already-consumed plan', async () => {
@@ -338,7 +340,8 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(merged.selectedAgentId).toBeUndefined();
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
     expect(sendTurn).toHaveBeenCalledTimes(1);
-    expect(sendTurn.mock.calls[0]![0].content).toBe('run the step');
+    expect(sendTurn.mock.calls[0]![0].content).toContain('run the step');
+    expect(sendTurn.mock.calls[0]![0].content).toContain('<<step-done');
   });
 
   it('navigate=false still injects and consumes an explicit plan', async () => {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -9,7 +9,12 @@ import {
   kindConsumesPlan,
   type AgentKind,
 } from '../../../features/session/agent-kind';
-import { buildGoalKickoffSection, buildPlanKickoffSection, composeKickoff } from '../../kickoff';
+import {
+  buildGoalKickoffSection,
+  buildPlanKickoffSection,
+  composeKickoff,
+  composeStepBoundary,
+} from '../../kickoff';
 import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
 import type { GetFn, SetFn } from './types';
 
@@ -93,7 +98,12 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
       return;
     }
 
-    const kickoff = composeKickoff(goalSection, planSection, promptPrefix);
+    const kickoff = composeKickoff(
+      goalSection,
+      planSection,
+      promptPrefix,
+      composeStepBoundary(agentId),
+    );
     if (kickoff.length > 0) {
       void get().sendTurn({ sessionId, agentId, content: kickoff });
     }

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -1,0 +1,109 @@
+import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+import { extractStepDone } from '@goodboy/core';
+import { updateSessionWorkflowStep } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
+import { composeStepBoundary } from '../../kickoff';
+import type { GetFn, SetFn } from './types';
+
+const MAX_CONTINUE = 2;
+
+const continueAttempts = new Map<string, number>();
+
+const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+const composeStepContinue = (agentId: AgentId): string =>
+  [
+    'You stopped before finishing this workflow step.',
+    'Continue with the remaining work now.',
+    composeStepBoundary(agentId),
+  ].join('\n');
+
+const startStep = (
+  set: SetFn,
+  get: GetFn,
+  sessionId: SessionId,
+  agentId: AgentId,
+  content: string,
+): void => {
+  set((s) => ({
+    agentTurnState: {
+      ...s.agentTurnState,
+      [agentId]: { kind: 'idle' as const, lastActivityAt: nowIso() },
+    },
+  }));
+  void get().sendTurn({ sessionId, agentId, content });
+};
+
+export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
+  return async (
+    sessionId: SessionId,
+    agentId: AgentId,
+    assistantText: string,
+    planCapturedThisTurn: boolean,
+    opts?: { readonly force?: boolean },
+  ): Promise<{ readonly shouldAutoAdvance: boolean }> => {
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const agent = runs.find((r) => r.id === agentId);
+    if (!agent || !agent.stepId || !agent.workflowRunId) {
+      return { shouldAutoAdvance: false };
+    }
+
+    const hasMarker = extractStepDone(assistantText) !== null;
+    const satisfied = !!opts?.force || hasMarker || planCapturedThisTurn;
+    if (!satisfied) {
+      const attempts = continueAttempts.get(agentId) ?? 0;
+      if (attempts < MAX_CONTINUE) {
+        continueAttempts.set(agentId, attempts + 1);
+        startStep(set, get, sessionId, agentId, composeStepContinue(agentId));
+      } else {
+        continueAttempts.delete(agentId);
+        await invokeAgentUpdateStatus(agentId, { status: 'failed', completedAt: nowIso() });
+        const stalled = await invokeAgentList(sessionId);
+        set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: stalled } }));
+        void get().refreshUnreadWorkspaces();
+        void get().emitNotification(
+          'error',
+          'warning',
+          `step stalled: ${agent.name}`,
+          'the agent stopped before emitting a step-done marker. open the agent and continue manually.',
+          { sessionId },
+        );
+      }
+      return { shouldAutoAdvance: false };
+    }
+
+    continueAttempts.delete(agentId);
+    await invokeAgentUpdateStatus(agentId, {
+      status: 'completed',
+      outputSummary: assistantText.slice(0, 2000),
+      completedAt: nowIso(),
+    });
+    const refreshed = await invokeAgentList(sessionId);
+    const workflowRunId = agent.workflowRunId;
+    const ordinal = agent.ordinal;
+    set((state) => {
+      const target = state.sessions.find((s) => s.id === sessionId);
+      const runId = target?.workflowRuns.some((r) => r.id === workflowRunId) ? workflowRunId : null;
+      if (runId) {
+        void updateSessionWorkflowStep(tauriDatabase, sessionId, runId, ordinal, nowIso());
+      }
+      return {
+        sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: refreshed },
+        sessions: state.sessions.map((s) => {
+          if (s.id !== sessionId || !runId) {
+            return s;
+          }
+          return {
+            ...s,
+            workflowRuns: s.workflowRuns.map((r) =>
+              r.id === runId ? { ...r, currentStep: ordinal } : r,
+            ),
+          };
+        }),
+      };
+    });
+    void get().refreshUnreadWorkspaces();
+    return { shouldAutoAdvance: true };
+  };
+};

--- a/apps/desktop/src/store/slices/workflows/forceAdvanceWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/forceAdvanceWorkflowStep.ts
@@ -1,0 +1,52 @@
+import type { IsoDateTime, SessionId, WorkflowRunId } from '@goodboy/types';
+import { classifyWorkflowChain, findReusableAgent, runsForWorkflowRun } from '@goodboy/core';
+import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
+import type { GetFn, SetFn } from './types';
+
+const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+export const forceAdvanceWorkflowStep = (set: SetFn, get: GetFn) => {
+  return async (sessionId: SessionId, workflowRunId: WorkflowRunId) => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (!session) {
+      return;
+    }
+    const run = session.workflowRuns.find((r) => r.id === workflowRunId);
+    if (!run || run.discardedAt) {
+      return;
+    }
+    const templates = get().phaseTemplates[session.workspaceId] ?? [];
+    const template = templates.find((t) => t.id === run.workflowId);
+    if (!template) {
+      return;
+    }
+    const runs = get().sessionPhaseRuns[sessionId] ?? [];
+    const chain = classifyWorkflowChain(template, runsForWorkflowRun(runs, workflowRunId));
+    if (chain.kind !== 'blocked') {
+      return;
+    }
+    const blockedAgent = findReusableAgent(
+      runsForWorkflowRun(runs, workflowRunId),
+      chain.failedStep.id,
+    );
+    if (!blockedAgent) {
+      return;
+    }
+    await invokeAgentUpdateStatus(blockedAgent.id, { status: 'skipped', completedAt: nowIso() });
+    const refreshed = await invokeAgentList(sessionId);
+    set((s) => ({ sessionPhaseRuns: { ...s.sessionPhaseRuns, [sessionId]: refreshed } }));
+    void get().refreshUnreadWorkspaces();
+
+    const nextChain = classifyWorkflowChain(template, runsForWorkflowRun(refreshed, workflowRunId));
+    if (nextChain.kind !== 'step') {
+      return;
+    }
+    const nextAgent = runsForWorkflowRun(refreshed, workflowRunId).find(
+      (r) => r.stepId === nextChain.step.id && r.status === 'pending',
+    );
+    if (!nextAgent) {
+      return;
+    }
+    await get().activateWorkflowAgent(sessionId, nextAgent.id);
+  };
+};

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -5,6 +5,8 @@ import { deleteStepDef } from './deleteStepDef';
 import { deleteWorkflow } from './deleteWorkflow';
 import { detachWorkflowFromSession } from './detachWorkflowFromSession';
 import { discardWorkflow } from './discardWorkflow';
+import { finalizeWorkflowStep } from './finalizeWorkflowStep';
+import { forceAdvanceWorkflowStep } from './forceAdvanceWorkflowStep';
 import { loadPhaseRunsForSession } from './loadPhaseRunsForSession';
 import { loadPhaseTemplates } from './loadPhaseTemplates';
 import { loadStepLibrary } from './loadStepLibrary';
@@ -38,6 +40,8 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     reprocessGoalForWorkflow: reprocessGoalForWorkflow(set, get),
     activateWorkflowAgent: activateWorkflowAgent(set, get),
     advanceClusterImplementation: advanceClusterImplementation(set, get),
+    finalizeWorkflowStep: finalizeWorkflowStep(set, get),
+    forceAdvanceWorkflowStep: forceAdvanceWorkflowStep(set, get),
     advanceScoutTree: advanceScoutTree(set, get),
     maybeAutoAdvanceWorkflow: maybeAutoAdvanceWorkflow(set, get),
   };

--- a/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
+++ b/apps/desktop/src/store/slices/workflows/maybeAutoAdvanceWorkflow.ts
@@ -47,9 +47,6 @@ export const maybeAutoAdvanceWorkflow = (_set: SetFn, get: GetFn) => {
     if (activeRuns.length === 0) {
       return;
     }
-    if (runs.some((r) => r.status === 'failed')) {
-      return;
-    }
     const summarizerBusy = state.summarizerStatus[sessionId]?.status === 'running';
     if (summarizerBusy) {
       return;

--- a/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
+++ b/apps/desktop/src/store/store.plan-consumption-ordering.test.ts
@@ -409,7 +409,9 @@ describe('autorun plan consumption ordering', () => {
   it('persists the plan before the implementer reads it, recording a consumption (plan flips to consumed)', async () => {
     const { useAppStore } = await import('./store');
     seedStore(useAppStore);
-    runTurnSpy.mockImplementationOnce(streamText(PLAN_MARKER));
+    runTurnSpy
+      .mockImplementationOnce(streamText(PLAN_MARKER))
+      .mockImplementationOnce(streamText(`<<step-done id="${IMPL_ID}">>`));
 
     await useAppStore.getState().sendTurn({
       sessionId: SESSION_ID,
@@ -431,7 +433,7 @@ describe('autorun plan consumption ordering', () => {
     expect(kickoffPrompt).toBeDefined();
   });
 
-  it('still auto-advances on empty planner output, recording no consumption', async () => {
+  it('does not auto-advance on empty planner output: retries then fails the step', async () => {
     const { useAppStore } = await import('./store');
     seedStore(useAppStore);
     runTurnSpy.mockImplementation(() => emptyStream());
@@ -442,9 +444,15 @@ describe('autorun plan consumption ordering', () => {
       content: 'plan it',
     });
 
+    await vi.waitFor(() =>
+      expect(phaseRunUpdateStatusSpy).toHaveBeenCalledWith(
+        PLANNER_ID,
+        expect.objectContaining({ status: 'failed' }),
+      ),
+    );
     expect(upsertPlanSpy).not.toHaveBeenCalled();
     expect(addPlanConsumptionSpy).not.toHaveBeenCalled();
-    expect(useAppStore.getState().selectedAgentId[SESSION_ID]).toBe(IMPL_ID);
+    expect(useAppStore.getState().selectedAgentId[SESSION_ID]).toBe(PLANNER_ID);
   });
 
   it('fans out when the persisted plan carries 2+ clusters, after recording the consumption', async () => {
@@ -468,7 +476,9 @@ describe('autorun plan consumption ordering', () => {
   it('persists the plan strictly before recording its consumption (race-fix invariant)', async () => {
     const { useAppStore } = await import('./store');
     seedStore(useAppStore);
-    runTurnSpy.mockImplementationOnce(streamText(PLAN_MARKER));
+    runTurnSpy
+      .mockImplementationOnce(streamText(PLAN_MARKER))
+      .mockImplementationOnce(streamText(`<<step-done id="${IMPL_ID}">>`));
 
     await useAppStore.getState().sendTurn({
       sessionId: SESSION_ID,
@@ -476,8 +486,8 @@ describe('autorun plan consumption ordering', () => {
       content: 'plan it',
     });
 
+    await vi.waitFor(() => expect(addPlanConsumptionSpy).toHaveBeenCalledTimes(1));
     expect(upsertPlanSpy).toHaveBeenCalledTimes(1);
-    expect(addPlanConsumptionSpy).toHaveBeenCalledTimes(1);
     expect(upsertPlanSpy.mock.invocationCallOrder[0]!).toBeLessThan(
       addPlanConsumptionSpy.mock.invocationCallOrder[0]!,
     );
@@ -508,7 +518,9 @@ describe('autorun plan consumption ordering', () => {
     const { useAppStore } = await import('./store');
     seedStore(useAppStore);
     upsertPlanSpy.mockRejectedValueOnce(new Error('db unavailable'));
-    runTurnSpy.mockImplementationOnce(streamText(PLAN_MARKER));
+    runTurnSpy
+      .mockImplementationOnce(streamText(PLAN_MARKER))
+      .mockImplementationOnce(streamText(`<<step-done id="${IMPL_ID}">>`));
 
     await useAppStore.getState().sendTurn({
       sessionId: SESSION_ID,

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -429,7 +429,15 @@ export type AppActions = {
     assistantText: string,
     opts?: { readonly force?: boolean },
   ): Promise<void>;
+  finalizeWorkflowStep(
+    sessionId: SessionId,
+    agentId: AgentId,
+    assistantText: string,
+    planCapturedThisTurn: boolean,
+    opts?: { readonly force?: boolean },
+  ): Promise<{ readonly shouldAutoAdvance: boolean }>;
   advanceScoutTree(sessionId: SessionId, agentId: AgentId, assistantText: string): Promise<void>;
+  forceAdvanceWorkflowStep(sessionId: SessionId, workflowRunId: WorkflowRunId): Promise<void>;
   maybeAutoAdvanceWorkflow(sessionId: SessionId): Promise<void>;
   reprocessGoalForWorkflow(sessionId: SessionId): Promise<void>;
   loadTranscript(agentId: AgentId, sessionId: SessionId): Promise<void>;

--- a/packages/core/src/context/extractors.test.ts
+++ b/packages/core/src/context/extractors.test.ts
@@ -11,6 +11,7 @@ import {
   extractMarkers,
   extractPlanFromMarker,
   extractScoutSplit,
+  extractStepDone,
   isOpenQuestionAnswerText,
   isReviewThreadId,
   mergeIntoSlot,
@@ -571,5 +572,38 @@ describe('open-question answer markers', () => {
   it('returns false for ordinary text', () => {
     expect(isOpenQuestionAnswerText('just a normal answer')).toBe(false);
     expect(isOpenQuestionAnswerText('mentions <<oq-answers>> mid sentence')).toBe(false);
+  });
+});
+
+describe('extractStepDone', () => {
+  it('returns null for text without marker', () => {
+    expect(extractStepDone('no markers here')).toBeNull();
+  });
+
+  it('extracts id from a valid step-done marker', () => {
+    expect(extractStepDone('work done\n<<step-done id="agent-42">>')).toEqual({ id: 'agent-42' });
+  });
+
+  it('returns last match when multiple markers present', () => {
+    const text = '<<step-done id="first">> middle <<step-done id="second">>';
+    expect(extractStepDone(text)).toEqual({ id: 'second' });
+  });
+
+  it('ignores marker without id attribute', () => {
+    expect(extractStepDone('<<step-done foo="bar">>')).toBeNull();
+  });
+
+  it('ignores marker with empty id', () => {
+    expect(extractStepDone('<<step-done id="">> text')).toBeNull();
+  });
+
+  it('resets regex state across calls', () => {
+    extractStepDone('<<step-done id="a">>');
+    expect(extractStepDone('<<step-done id="b">>')).toEqual({ id: 'b' });
+  });
+
+  it('is stripped by stripControlMarkers (SELF_MARKER_ALT coverage)', () => {
+    const text = 'result\n<<step-done id="x">>\ndone';
+    expect(stripControlMarkers(text)).toBe('result\n\ndone');
   });
 });

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -230,6 +230,7 @@ export const extractCommentWontfix = (assistantText: string): ExtractedCommentWo
 
 const CLUSTERS_RE = /<<clusters>>([\s\S]*?)<<\/clusters>>/g;
 const CLUSTER_DONE_RE = /<<cluster-done\s+([^>]+?)>>/g;
+const STEP_DONE_RE = /<<step-done\s+([^>]+?)>>/g;
 
 export type ExtractedCluster = {
   readonly title: string;
@@ -292,6 +293,22 @@ export const extractClusterDone = (assistantText: string): { readonly id: string
   let last: { id: string } | null = null;
   let m: RegExpExecArray | null;
   while ((m = CLUSTER_DONE_RE.exec(assistantText)) !== null) {
+    const inner = m[1] ?? '';
+    const attrs = parseHandoffAttrs(inner);
+    const id = (attrs.id ?? '').trim();
+    if (id.length === 0) {
+      continue;
+    }
+    last = { id };
+  }
+  return last;
+};
+
+export const extractStepDone = (assistantText: string): { readonly id: string } | null => {
+  STEP_DONE_RE.lastIndex = 0;
+  let last: { id: string } | null = null;
+  let m: RegExpExecArray | null;
+  while ((m = STEP_DONE_RE.exec(assistantText)) !== null) {
     const inner = m[1] ?? '';
     const attrs = parseHandoffAttrs(inner);
     const id = (attrs.id ?? '').trim();
@@ -407,7 +424,7 @@ export const assessPlanReadiness = (input: PlanReadinessInput): PlanReadinessRes
 
 const BLOCK_MARKER_ALT =
   'plan|clusters|scout-split|workflow|goal|ctx-decision|ctx-resolved|ctx-question';
-const SELF_MARKER_ALT = 'handoff|comment-resolved|comment-wontfix|cluster-done';
+const SELF_MARKER_ALT = 'handoff|comment-resolved|comment-wontfix|cluster-done|step-done';
 
 const CONTROL_BLOCK_STRIP_RE = new RegExp(
   `<<(?:${BLOCK_MARKER_ALT})(?:\\s[^>]*)?>>[\\s\\S]*?<<\\/(?:${BLOCK_MARKER_ALT})>>`,

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -161,6 +161,9 @@ export const extractHandoff = (assistantText: string): ExtractedHandoff | null =
 
 function parseHandoffAttrs(inner: string): Record<string, string> {
   const out: Record<string, string> = {};
+  if (inner.length > 1000) {
+    return out;
+  }
   HANDOFF_ATTR_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = HANDOFF_ATTR_RE.exec(inner)) !== null) {
@@ -230,7 +233,7 @@ export const extractCommentWontfix = (assistantText: string): ExtractedCommentWo
 
 const CLUSTERS_RE = /<<clusters>>([\s\S]*?)<<\/clusters>>/g;
 const CLUSTER_DONE_RE = /<<cluster-done\s+([^>]+?)>>/g;
-const STEP_DONE_RE = /<<step-done\s+([^>]+?)>>/g;
+const STEP_DONE_RE = /<<step-done\s+([^>\s][^>]*?)>>/g;
 
 export type ExtractedCluster = {
   readonly title: string;

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -233,7 +233,7 @@ export const extractCommentWontfix = (assistantText: string): ExtractedCommentWo
 
 const CLUSTERS_RE = /<<clusters>>([\s\S]*?)<<\/clusters>>/g;
 const CLUSTER_DONE_RE = /<<cluster-done\s+([^>]+?)>>/g;
-const STEP_DONE_RE = /<<step-done\s+([^>\s][^>]*?)>>/g;
+const STEP_DONE_RE = /<<step-done\s([^>]*)>>/g;
 
 export type ExtractedCluster = {
   readonly title: string;

--- a/packages/core/src/context/extractors.ts
+++ b/packages/core/src/context/extractors.ts
@@ -233,7 +233,7 @@ export const extractCommentWontfix = (assistantText: string): ExtractedCommentWo
 
 const CLUSTERS_RE = /<<clusters>>([\s\S]*?)<<\/clusters>>/g;
 const CLUSTER_DONE_RE = /<<cluster-done\s+([^>]+?)>>/g;
-const STEP_DONE_RE = /<<step-done\s([^>]*)>>/g;
+const STEP_DONE_RE = /<<step-done\s([^<>]*)>>/g;
 
 export type ExtractedCluster = {
   readonly title: string;

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -19,6 +19,7 @@ export {
   extractMarkers,
   extractPlanFromMarker,
   extractScoutSplit,
+  extractStepDone,
   isOpenQuestionAnswerText,
   isReviewThreadId,
   mergeIntoSlot,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export {
   extractMarkers,
   extractPlanFromMarker,
   extractScoutSplit,
+  extractStepDone,
   isOpenQuestionAnswerText,
   isReviewThreadId,
   isSlotKey,
@@ -148,11 +149,13 @@ export {
 
 export {
   buildStepPrompt,
+  classifyWorkflowChain,
   currentStep,
   findReusableAgent,
   isWorkflowComplete,
   nextStep,
   runsForWorkflowRun,
+  type WorkflowChainState,
   WorkflowPropagator,
   type WorkflowPropagatorDeps,
   WORKFLOW_LIBRARY,

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -1,10 +1,12 @@
 export {
   buildStepPrompt,
+  classifyWorkflowChain,
   currentStep,
   findReusableAgent,
   isWorkflowComplete,
   nextStep,
   runsForWorkflowRun,
+  type WorkflowChainState,
 } from './sequencer';
 export { WorkflowPropagator, type WorkflowPropagatorDeps } from './propagator';
 export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';

--- a/packages/core/src/workflows/sequencer.test.ts
+++ b/packages/core/src/workflows/sequencer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Step, Agent, Workflow } from '@goodboy/types';
 import {
   buildStepPrompt,
+  classifyWorkflowChain,
   currentStep,
   findReusableAgent,
   isWorkflowComplete,
@@ -282,5 +283,80 @@ describe('buildStepPrompt', () => {
       userMessage: '\n',
     });
     expect(result).toBe('You are an expert.');
+  });
+});
+
+describe('classifyWorkflowChain', () => {
+  it('returns step for first pending step when no runs exist', () => {
+    const chain = classifyWorkflowChain(TEMPLATE, []);
+    expect(chain).toEqual({ kind: 'step', step: D1 });
+  });
+
+  it('returns step for next pending step after completed predecessor', () => {
+    const runs = [makeRun('d1', 'completed', 1)];
+    const chain = classifyWorkflowChain(TEMPLATE, runs);
+    expect(chain).toEqual({ kind: 'step', step: D2 });
+  });
+
+  it('returns blocked when predecessor has failed', () => {
+    const runs = [makeRun('d1', 'failed', 1, '2026-01-01T00:00:00Z')];
+    const chain = classifyWorkflowChain(TEMPLATE, runs);
+    expect(chain.kind).toBe('blocked');
+    if (chain.kind === 'blocked') {
+      expect(chain.failedStep).toBe(D1);
+    }
+  });
+
+  it('returns complete when all steps done', () => {
+    const runs = [
+      makeRun('d1', 'completed', 1),
+      makeRun('d2', 'completed', 2),
+      makeRun('d3', 'completed', 3),
+    ];
+    expect(classifyWorkflowChain(TEMPLATE, runs)).toEqual({ kind: 'complete' });
+  });
+
+  it('returns complete when mix of completed and skipped', () => {
+    const runs = [
+      makeRun('d1', 'completed', 1),
+      makeRun('d2', 'skipped', 2),
+      makeRun('d3', 'completed', 3),
+    ];
+    expect(classifyWorkflowChain(TEMPLATE, runs)).toEqual({ kind: 'complete' });
+  });
+
+  it('returns step (not blocked) when pending step has no agent yet', () => {
+    const runs = [makeRun('d1', 'completed', 1)];
+    const chain = classifyWorkflowChain(TEMPLATE, runs);
+    expect(chain.kind).toBe('step');
+  });
+
+  it('returns step when pending step agent is still running', () => {
+    const runs = [
+      makeRun('d1', 'completed', 1),
+      makeRun('d2', 'running', 2, '2026-01-02T00:00:00Z'),
+    ];
+    const chain = classifyWorkflowChain(TEMPLATE, runs);
+    expect(chain.kind).toBe('step');
+    if (chain.kind === 'step') {
+      expect(chain.step).toBe(D2);
+    }
+  });
+
+  it('returns complete for empty template', () => {
+    const empty: Workflow = { ...TEMPLATE, steps: [] };
+    expect(classifyWorkflowChain(empty, [])).toEqual({ kind: 'complete' });
+  });
+
+  it('blocked on second step when it has a failed agent', () => {
+    const runs = [
+      makeRun('d1', 'completed', 1),
+      makeRun('d2', 'failed', 2, '2026-01-02T00:00:00Z'),
+    ];
+    const chain = classifyWorkflowChain(TEMPLATE, runs);
+    expect(chain.kind).toBe('blocked');
+    if (chain.kind === 'blocked') {
+      expect(chain.failedStep).toBe(D2);
+    }
   });
 });

--- a/packages/core/src/workflows/sequencer.ts
+++ b/packages/core/src/workflows/sequencer.ts
@@ -80,6 +80,33 @@ export const buildStepPrompt = (input: {
   return parts.join('\n\n');
 };
 
+export type WorkflowChainState =
+  | { readonly kind: 'step'; readonly step: Step }
+  | { readonly kind: 'blocked'; readonly failedStep: Step }
+  | { readonly kind: 'complete' };
+
+export const classifyWorkflowChain = (
+  template: Workflow,
+  runs: ReadonlyArray<Agent>,
+): WorkflowChainState => {
+  const doneIds = new Set(
+    runs
+      .filter((r) => r.status === 'completed' || r.status === 'skipped')
+      .map((r) => r.stepId)
+      .filter((id): id is Step['id'] => id !== undefined),
+  );
+  const sorted = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
+  const pending = sorted.find((s) => !doneIds.has(s.id));
+  if (pending === undefined) {
+    return { kind: 'complete' };
+  }
+  const latest = findReusableAgent(runs, pending.id);
+  if (latest?.status === 'failed') {
+    return { kind: 'blocked', failedStep: pending };
+  }
+  return { kind: 'step', step: pending };
+};
+
 export const isWorkflowComplete = (template: Workflow, runs: ReadonlyArray<Agent>): boolean => {
   const doneIds = new Set(
     runs


### PR DESCRIPTION
## Summary
- Workflow steps now auto-advance only after emitting an explicit success marker `<<step-done id="...">>` (mirrors `<<cluster-done>>`). Planners are exempt: capturing a plan in the turn counts as the success signal, so planner→implementer chaining still works.
- The gate applies **only** to agents that are workflow steps (`stepId && workflowRunId`); standalone/resolver/scout/cluster-child agents are untouched (no regression).
- A step without a marker is retried with a continue-prompt up to `MAX_CONTINUE`, then marked `failed`.
- Fixes failure-gating: the session-wide `failed` guard in `maybeAutoAdvanceWorkflow` is moved per-run, and `runPlan` early-returns when the creator agent is `failed`, so a failed step 1 no longer kicks off step 2.
- Adds a confirm-gated **force next step** escape hatch, shown only in the `blocked` state (predecessor failed/stalled): skips the blocking step and activates the next one.

## Implementation
- `packages/core`: `extractStepDone` marker extractor + `classifyWorkflowChain` (`step` / `blocked` / `complete`).
- `apps/desktop`: new `finalizeWorkflowStep` and `forceAdvanceWorkflowStep` store slices; `sendTurn` routes workflow-step completion through the gate; `composeStepBoundary` appends the marker instruction to step kickoffs; sidebar surfaces the `failed-step` block reason + force CTA.

## Test plan
- [x] `pnpm typecheck` (5/5)
- [x] core suite (789 passed)
- [x] desktop suite (1926 passed) — updated pre-existing plan-consumption-ordering and activateWorkflowAgent tests to the new marker-gated contract
- [ ] manual: run a 2-step autorun workflow; verify step 2 only starts after step 1's `<<step-done>>`, and that a failed step 1 blocks step 2 + shows the force CTA