### PR TITLE
fix(desktop): align open-question ordinal with chat renderer

### DIFF
--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -132,17 +132,72 @@ function userTextEvent(text: string): TurnEvent {
   return { kind: 'user_text', runId: RUN, text, at: AT };
 }
 
-describe('reduceTranscript, open-question answer suppression', () => {
-  it('drops a user_text turn wrapped in the oq-answers marker', () => {
+function assistantTextEvent(delta: string): TurnEvent {
+  return { kind: 'assistant_text', runId: RUN, delta, at: AT };
+}
+
+describe('reduceTranscript, open-question answer boundary', () => {
+  it('emits an oq_answer marker for a user_text wrapped in oq-answers', () => {
     const items = reduceTranscript([
       userTextEvent('<<oq-answers>>\nAnswers to open questions:\n- Q: a\n  A: b\n<</oq-answers>>'),
     ]);
-    expect(items).toHaveLength(0);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('oq_answer');
   });
 
   it('keeps ordinary user_text turns', () => {
     const items = reduceTranscript([userTextEvent('a normal message')]);
     expect(items).toHaveLength(1);
     expect(items[0]!.kind).toBe('user_text');
+  });
+
+  it('detects the oq-answers wrapper despite leading whitespace', () => {
+    const items = reduceTranscript([
+      userTextEvent('\n\n   <<oq-answers>>\nAnswers:\n- Q: a\n  A: b\n<</oq-answers>>'),
+    ]);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('oq_answer');
+  });
+
+  it('does not treat an inline mention of the marker as an answer', () => {
+    const items = reduceTranscript([userTextEvent('here is text then <<oq-answers>> later')]);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('user_text');
+  });
+
+  it('carries no answer text on the oq_answer marker (pure boundary)', () => {
+    const items = reduceTranscript([
+      userTextEvent('<<oq-answers>>\nsecret answer\n<</oq-answers>>'),
+    ]);
+    const item = items[0]!;
+    expect(item.kind).toBe('oq_answer');
+    expect(Object.keys(item)).toEqual(['kind', 'key']);
+  });
+
+  it('assigns distinct keys to consecutive oq_answer markers', () => {
+    const items = reduceTranscript([
+      userTextEvent('<<oq-answers>>\na\n<</oq-answers>>'),
+      userTextEvent('<<oq-answers>>\nb\n<</oq-answers>>'),
+    ]);
+    expect(items).toHaveLength(2);
+    expect(items[0]!.kind).toBe('oq_answer');
+    expect(items[1]!.kind).toBe('oq_answer');
+    expect(items[0]!.key).not.toBe(items[1]!.key);
+  });
+
+  it('flushes buffered assistant_text before emitting the oq_answer marker', () => {
+    const events: TurnEvent[] = [
+      userTextEvent('ask me something'),
+      assistantTextEvent('here is my question'),
+      userTextEvent('<<oq-answers>>\nresolved\n<</oq-answers>>'),
+      assistantTextEvent('thanks, continuing'),
+    ];
+    const items = reduceTranscript(events);
+    expect(items.map((i) => i.kind)).toEqual([
+      'user_text',
+      'assistant_text',
+      'oq_answer',
+      'assistant_text',
+    ]);
   });
 });

--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -206,6 +206,133 @@ describe('ChatView', () => {
     const clusters = screen.getAllByTestId('cluster');
     expect(clusters.map((c) => c.textContent)).toEqual(['q-turn0', 'q-turn1']);
   });
+
+  it('positions OQ cluster before oq_answer boundary (temporal ordering)', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [
+      { kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' },
+      { kind: 'assistant_text', key: 'a0', text: 'response' },
+      { kind: 'oq_answer', key: 'oq-a-1' },
+      { kind: 'assistant_text', key: 'a1', text: 'follow-up' },
+    ];
+    answeredQuestions.current = [
+      {
+        id: 'q-answered',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 1,
+        status: 'answered',
+        userAnswer: 'yes',
+        createdAt: '2026-06-13T00:00:01.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.textContent).toBe('q-answered');
+  });
+
+  it('renders OQs after answer cycle at correct ordinal (no desync)', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [
+      { kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' },
+      { kind: 'assistant_text', key: 'a0', text: 'asking first q' },
+      { kind: 'oq_answer', key: 'oq-a-1' },
+      { kind: 'assistant_text', key: 'a1', text: 'asking second q' },
+    ];
+    answeredQuestions.current = [
+      {
+        id: 'q1',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 1,
+        status: 'answered',
+        createdAt: '2026-06-13T00:00:01.000Z',
+      },
+    ];
+    openQuestions.current = [
+      {
+        id: 'q2',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 2,
+        status: 'open',
+        createdAt: '2026-06-13T00:00:02.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters).toHaveLength(2);
+    expect(clusters.map((c) => c.textContent)).toEqual(['q1', 'q2']);
+  });
+
+  it('stays aligned across multiple answer cycles (no cumulative drift)', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [
+      { kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' },
+      { kind: 'assistant_text', key: 'a0', text: 'q1' },
+      { kind: 'oq_answer', key: 'oq-a-1' },
+      { kind: 'assistant_text', key: 'a1', text: 'q2' },
+      { kind: 'oq_answer', key: 'oq-a-2' },
+      { kind: 'assistant_text', key: 'a2', text: 'q3' },
+    ];
+    answeredQuestions.current = [
+      {
+        id: 'q1',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 1,
+        status: 'answered',
+        createdAt: '2026-06-13T00:00:01.000Z',
+      },
+      {
+        id: 'q2',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 2,
+        status: 'answered',
+        createdAt: '2026-06-13T00:00:02.000Z',
+      },
+    ];
+    openQuestions.current = [
+      {
+        id: 'q3',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 3,
+        status: 'open',
+        createdAt: '2026-06-13T00:00:03.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters.map((c) => c.textContent)).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('advances the ordinal on an oq_answer with no matching question bucket', () => {
+    state.selectedAgentId = { 'sess-1': 'agent-1' };
+    transcriptItems.current = [
+      { kind: 'user_text', key: 'u0', at: '2026-06-13T00:00:00.000Z' },
+      { kind: 'assistant_text', key: 'a0', text: 'something' },
+      { kind: 'oq_answer', key: 'oq-orphan' },
+      { kind: 'assistant_text', key: 'a1', text: 'later question' },
+    ];
+    openQuestions.current = [
+      {
+        id: 'q-after-orphan',
+        createdByAgentId: 'agent-1',
+        turnOrdinal: 2,
+        status: 'open',
+        createdAt: '2026-06-13T00:00:02.000Z',
+      },
+    ];
+
+    render(<ChatView session={session} />);
+
+    const clusters = screen.getAllByTestId('cluster');
+    expect(clusters).toHaveLength(1);
+    expect(clusters[0]?.textContent).toBe('q-after-orphan');
+  });
 });
 
 const clusterRuns = [

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -460,6 +460,11 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
                 };
 
                 rows.forEach((row, idx) => {
+                  if (row.kind === 'item' && row.item.kind === 'oq_answer') {
+                    flushOrdinal(userTurnOrdinal);
+                    userTurnOrdinal += 1;
+                    return;
+                  }
                   if (row.kind === 'item' && row.item.kind === 'user_text') {
                     flushOrdinal(userTurnOrdinal);
                     userTurnOrdinal += 1;

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -90,6 +90,8 @@ function TranscriptCardImpl({
       return <SkillInvocationCard item={item} />;
     case 'step_transition':
       return <PhaseTransitionCard item={item} />;
+    case 'oq_answer':
+      return null;
     case 'done':
       return <Divider />;
     case 'permission_request':

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -44,6 +44,7 @@ export type TranscriptItem =
       carryForwardContext: string;
       at: string;
     }
+  | { kind: 'oq_answer'; key: string }
   | { kind: 'done'; key: string }
   | {
       kind: 'permission_request';
@@ -116,6 +117,7 @@ export const reduceTranscript = (
     switch (event.kind) {
       case 'user_text':
         if (isOpenQuestionAnswerText(event.text)) {
+          items.push({ kind: 'oq_answer', key: `oq-answer-${i}` });
           break;
         }
         items.push({


### PR DESCRIPTION
## Summary
- Open-question cards were misplaced in workflow agent chat: `oq-answer` user_text events inflated the DB `turnOrdinal` past the chat renderer's counter, so OQ clusters landed at the wrong temporal position.
- Fix emits an invisible `oq_answer` marker in `reduceTranscript` instead of dropping the oq-answer event. `ChatView` advances its ordinal on this marker, keeping writer (`sendTurn`) and renderer in lockstep. No `sendTurn` change needed.
- `oq_answer` renders as `null` in `TranscriptCards` (pure ordinal boundary, carries no answer text).

## Test plan
- [x] `reduceTranscript` emits `oq_answer` for wrapped user_text; leading-whitespace tolerant; inline mentions stay `user_text`; distinct keys; flushes buffered assistant_text
- [x] `ChatView` positions OQ cluster correctly across single/multi answer cycles, no cumulative drift, orphan markers still advance ordinal
- [x] 30 tests pass (23 baseline + 7 new edge cases), typecheck exit 0

## Known gap
Writer side (`sendTurn.ts:819`) is not guarded by store tests (would require tauriDatabase + autoPopulateContext mocks). Renderer tests use hand-set ordinals. Risk: silent desync if a future change filters oq-answer user_text from the writer ordinal. Accepted to ship; flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)