### PR TITLE
fix(desktop): open agent chat on click instead of overview

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -310,7 +310,6 @@ export const App = () => {
       const sid = state.currentSessionId;
       if (sid) {
         state.setSessionStudio(sid, null);
-        state.setActiveLens(sid, null);
       }
     };
     const onAddWorkspace = () => setAddWorkspaceOpen(true);

--- a/apps/desktop/src/__tests__/overlay-mutual-exclusion.test.ts
+++ b/apps/desktop/src/__tests__/overlay-mutual-exclusion.test.ts
@@ -180,6 +180,10 @@ function setSessionStudio(s: SessionForeground, kind: SessionStudioKind | null):
     : { ...s, sessionStudio: null };
 }
 
+function revealChat(s: SessionForeground): SessionForeground {
+  return setSessionStudio(s, null);
+}
+
 function foregroundLayer(s: SessionForeground): 'studio' | 'agent' | 'lens' {
   if (s.sessionStudio !== null) return 'studio';
   if (s.selectedAgentId !== null) return 'agent';
@@ -237,6 +241,26 @@ describe('work-surface foreground triad mutual exclusion', () => {
     expect(s.sessionStudio).toBe('workflow');
     expect(s.selectedAgentId).toBeNull();
     expect(foregroundLayer(s)).toBe('studio');
+  });
+
+  it('reveal-chat keeps the just-selected agent overlay instead of dropping to the lens', () => {
+    let s = setActiveLens(emptyForeground(), 'agents');
+    s = selectAgent(s, 'agent-1');
+    s = revealChat(s);
+    expect(s.selectedAgentId).toBe('agent-1');
+    expect(s.activeLens).toBe('agents');
+    expect(foregroundLayer(s)).toBe('agent');
+  });
+
+  it('reveal-chat from a studio over a selected agent restores that agent overlay', () => {
+    let s = setActiveLens(emptyForeground(), 'workflows');
+    s = selectAgent(s, 'agent-7');
+    s = setSessionStudio(s, 'workflow');
+    s = selectAgent(s, 'agent-7');
+    s = revealChat(s);
+    expect(s.selectedAgentId).toBe('agent-7');
+    expect(s.sessionStudio).toBeNull();
+    expect(foregroundLayer(s)).toBe('agent');
   });
 });
 


### PR DESCRIPTION
## Problem

Clicking an agent in any lens (workflows, agents, resolve) bounced back to the session **overview** instead of opening that agent's **chat**.

## Root cause

`onPickAgent` (and every other agent-open path) does `selectAgent(...)` then dispatches `goodboy:reveal-chat`. The `onRevealChat` handler in `App.tsx` called `state.setActiveLens(sid, null)`. `setActiveLens` unconditionally resets `selectedAgentId` to `null` (it's the lens-navigation reset), so the agent that was just selected got dropped and the surface fell back to the bare overview (`lens === null`).

`dispatchEvent` is synchronous, so the clear ran in the same tick as the select, right after it.

## Fix

Drop the `setActiveLens(sid, null)` call from `onRevealChat`. Revealing the chat only needs to:
- dismiss the studio (`setSessionStudio(sid, null)` — kept; `selectAgent` already nulls it too)
- close full-page modals (kept)

It must never reset the active lens or the selected agent. The lens stays as the overlay's back-target, which is exactly the foreground-triad contract already asserted in `overlay-mutual-exclusion.test.ts` ("selecting an agent keeps the lens (back-target) but drops the studio").

Fixes all callers in one place: board `openAgent`, `AgentsSection` (`onPickAgent`/`onResolveFirst`/`onStartStep`), `ChatBreadcrumb`, `ClustersCard`, `SpawnAgentControl`.

## Test

Added two regression assertions to `overlay-mutual-exclusion.test.ts` modelling the fixed `onRevealChat`: select-agent → reveal-chat must keep `foregroundLayer === 'agent'` (not fall to `lens`). Full file green (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)