### PR TITLE
fix(desktop): guard stage-board column width and card spacing

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -74,7 +74,7 @@ export const StageBoardCard = memo(function StageBoardCard({
       data-archived={archived || undefined}
       onClick={() => nav.selectCard(session)}
       className={cn(
-        'group flex min-h-[7.25rem] flex-col gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
+        'group flex min-h-[7.25rem] shrink-0 flex-col gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
         stage === 'running'
           ? 'border-info/50'
           : stage === 'attention'

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -85,9 +85,9 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
           </div>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 gap-4">
+        <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto">
           {STAGES.map((stage) => (
-            <div key={stage} className="flex min-w-0 flex-1">
+            <div key={stage} className="flex min-w-[16rem] flex-1">
               <StageColumn
                 spec={{ kind: 'stage', stage }}
                 sessions={byStage.get(stage) ?? EMPTY_ARRAY}
@@ -98,7 +98,7 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
               />
             </div>
           ))}
-          <div key="archived" className="flex min-w-0 flex-1">
+          <div key="archived" className="flex min-w-[16rem] flex-1">
             <StageColumn
               spec={{ kind: 'archived' }}
               sessions={archived}


### PR DESCRIPTION
## Problem
Stage-board columns used `flex-1` + `min-w-0` with no minimum width. At Retina logical widths the six columns (BUILDING/RUNNING/NEEDS YOU/IN REVIEW/DONE/ARCHIVED) collapse below ~150px each. Each card's hover action row is 6 icons (~180px) plus chips, so it overflows the column and cards cram/overlap. Columns also had no guaranteed-equal sizing floor.

## Fix
Standard kanban guard (Linear / Trello / GitHub Projects):
- Every column gets an equal `min-w-[16rem]` floor; the board row scrolls horizontally (`overflow-x-auto`) when they don't fit. Columns stay equal width and never collapse below a usable size.
- Cards pinned with `shrink-0` so they never compress in the vertical list.

## Note
Could not visually verify against the live app (computer-use access was denied) and the Vite preview lacks Tauri data. Change is className-only and low-regret. Please glance at the board after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)