### PR TITLE
fix(desktop): show workspace switcher on stage board

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -7,6 +7,7 @@ import { STAGE_ORDER } from '../../../../store/slices/session-view/types';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import { ArchiveSessionDialog } from '../../../session/components/ArchiveSessionDialog';
 import { DeleteSessionDialog } from '../../../session/components/DeleteSessionDialog';
+import { WorkspaceHeader } from '../WorkspaceHeader';
 import { StageColumn } from './StageColumn';
 import { useBoardNavigation } from './useBoardNavigation';
 
@@ -50,6 +51,11 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
 
   return (
     <div className="flex h-full w-full flex-col gap-4 p-6">
+      <div className="-mx-6 -mt-6 shrink-0">
+        <WorkspaceHeader />
+        <Divider />
+      </div>
+
       <div className="flex shrink-0 items-center justify-between gap-4">
         <span className="flex items-baseline gap-2">
           <Eyebrow label="Stage board" />


### PR DESCRIPTION
## Problem
The stage board hides the left sidebar (`leftHidden={!currentSession}`), so the board view showed no workspace indicator and offered no way to switch workspaces.

## Fix
Render `WorkspaceHeader` (the same switcher used in the sidebar) full-bleed at the top of `StageBoard`, just above the STAGE BOARD header + New session CTA, followed by a divider, mirroring the sidebar layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)