### PR TITLE
fix(desktop): keep stage-board columns at constant width

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -75,7 +75,7 @@ export const StageColumn = ({
   );
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
+    <div className={cn('flex min-h-0 shrink-0 flex-col gap-3', collapsed ? 'w-auto' : 'w-72')}>
       {view.collapsible ? (
         <button
           type="button"

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -93,27 +93,25 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
       ) : (
         <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto">
           {STAGES.map((stage) => (
-            <div key={stage} className="flex min-w-[16rem] flex-1">
-              <StageColumn
-                spec={{ kind: 'stage', stage }}
-                sessions={byStage.get(stage) ?? EMPTY_ARRAY}
-                nav={nav}
-                onArchive={onArchive}
-                onDelete={onDelete}
-                onRestore={nav.restore}
-              />
-            </div>
-          ))}
-          <div key="archived" className="flex min-w-[16rem] flex-1">
             <StageColumn
-              spec={{ kind: 'archived' }}
-              sessions={archived}
+              key={stage}
+              spec={{ kind: 'stage', stage }}
+              sessions={byStage.get(stage) ?? EMPTY_ARRAY}
               nav={nav}
               onArchive={onArchive}
               onDelete={onDelete}
               onRestore={nav.restore}
             />
-          </div>
+          ))}
+          <StageColumn
+            key="archived"
+            spec={{ kind: 'archived' }}
+            sessions={archived}
+            nav={nav}
+            onArchive={onArchive}
+            onDelete={onDelete}
+            onRestore={nav.restore}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## what

Stage-board columns now hold a constant width regardless of card content or how many columns are collapsed.

## why

Columns used `flex-1` without `min-w-0`, so a flex item's default `min-width: auto` let non-wrapping card content (cost badge, branch chip, agent-count chip) inflate one column's min-content past its siblings. Net effect: the BUILDING column rendered wider than the others.

## change

- `StageBoard/index.tsx`: drop the per-column `flex min-w-[16rem] flex-1` wrapper; render `StageColumn` directly inside the `overflow-x-auto` row.
- `StageColumn/index.tsx`: fixed width on the column root, `w-72` when expanded (constant), `w-auto` when collapsed; `shrink-0` so columns never grow or shrink. Horizontal scroll kicks in on narrow windows.

Standard kanban behavior (Linear / Trello / Notion all use fixed-width columns with horizontal scroll). Collapsing DONE/ARCHIVED no longer resizes the other columns.

## verification

- `tsc --noEmit` clean
- 1984/1984 desktop tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)