### PR TITLE
fix(repo): restore provider icon colors on the website hero

### DIFF
--- a/website/src/styles.css
+++ b/website/src/styles.css
@@ -28,11 +28,6 @@
   --color-info: oklch(0.69 0.11 238);
   --color-merged: oklch(0.70 0.15 305);
 
-  --color-provider-anthropic: oklch(0.74 0.15 55);
-  --color-provider-cursor: oklch(0.70 0.16 290);
-  --color-provider-codex: oklch(0.72 0.16 150);
-  --color-provider-gemini: oklch(0.70 0.15 255);
-
   --text-2xs: 11px;
   --text-xs: 12px;
   --text-sm: 14px;
@@ -62,6 +57,13 @@
     0 18px 40px -10px oklch(0 0 0 / 0.52),
     0 6px 12px -4px oklch(0 0 0 / 0.38),
     inset 0 1px 0 0 oklch(1 0 0 / 0.05);
+}
+
+:root {
+  --color-provider-anthropic: oklch(0.74 0.15 55);
+  --color-provider-cursor: oklch(0.7 0.16 290);
+  --color-provider-codex: oklch(0.72 0.16 150);
+  --color-provider-gemini: oklch(0.7 0.15 255);
 }
 
 html {


### PR DESCRIPTION
## What

The hero ThreadGraph SVG renders the four provider brand icons (Cursor, Anthropic, Codex, Gemini) with `fill="var(--color-provider-*)"`. After #895 those icons render flat black.

## Why

Tailwind v4 only emits an `@theme` variable into the build when a generated utility class references it. The provider colors were consumed only as raw `var()` in inline SVG fills, never via a `*-provider-*` utility. The cleanup in #895 removed the last components that used those utilities, so Tailwind tree-shook the four tokens out of the production CSS and the fills fell back to the SVG default (black).

## Fix

Move the four `--color-provider-*` tokens from `@theme` to `:root`, where they are emitted unconditionally regardless of utility usage.

## Verify

- dev: the four vars resolve, icon fills = cursor purple / anthropic orange / codex green / gemini blue
- `pnpm build` green, all four `--color-provider-*` present in the production CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)