### PR TITLE
feat(desktop): clamp session titles to 60 chars

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -21,7 +21,7 @@ import {
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import { FolderGit2 } from 'lucide-react';
-import { Chip, cn, Divider, Eyebrow, ScrollFade, StatusDot, tintClasses } from '@goodboy/ui';
+import { Chip, cn, Divider, Eyebrow, Input, ScrollFade, StatusDot, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type {
   Agent,
@@ -64,6 +64,7 @@ import {
   selectStandaloneAgents,
 } from './lib';
 import { SpawnAgentControl } from '../../../workspace/components/WorkspacesSidebar/parts/SpawnAgentControl';
+import { useSessionTitleRename } from '../../hooks/useSessionTitleRename';
 
 type SessionOverviewPaneProps = {
   readonly session: Session;
@@ -405,6 +406,10 @@ export const SessionOverviewPane = ({
   onSelectLens,
 }: SessionOverviewPaneProps) => {
   const stage = useSessionStageInfo(session);
+  const rename = useSessionTitleRename({
+    sessionId: session.id as SessionId,
+    currentTitle: session.goal,
+  });
   const workspace = useCurrentWorkspace();
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
   const attention = selectAttention(stage);
@@ -527,25 +532,41 @@ export const SessionOverviewPane = ({
             <StatusDot tone={STAGE_TONE[stage.stage]} pulsing={stage.stage === 'running'} />
             <Eyebrow label={STAGE_LABEL[stage.stage]} />
           </div>
-          <div className="group/goal flex items-start gap-2">
-            <h1 className="text-balance text-xl font-semibold leading-snug text-foreground">
-              {session.goal || 'Untitled session'}
-            </h1>
-            <button
-              type="button"
-              onClick={() => onSelectLens('goal')}
-              aria-label="edit goal"
-              title="Edit goal"
-              className={cn(
-                'mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/50',
-                'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
-                'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-                'group-hover/goal:opacity-100 motion-reduce:opacity-60',
-              )}
-            >
-              <Pencil size={13} aria-hidden />
-            </button>
-          </div>
+          {rename.renaming ? (
+            <div className="flex flex-col gap-1">
+              <Input
+                autoFocus
+                value={rename.draft}
+                maxLength={rename.maxLength}
+                onChange={(e) => rename.setDraft(e.target.value)}
+                onBlur={() => void rename.commit()}
+                onKeyDown={rename.onKeyDown}
+                aria-label="session goal"
+                className="text-xl font-semibold"
+              />
+              {rename.error && <span className="text-2xs text-danger">{rename.error}</span>}
+            </div>
+          ) : (
+            <div className="group/goal flex items-start gap-2">
+              <h1 className="text-balance text-xl font-semibold leading-snug text-foreground">
+                {session.goal || 'Untitled session'}
+              </h1>
+              <button
+                type="button"
+                onClick={rename.start}
+                aria-label="edit goal"
+                title="Edit goal"
+                className={cn(
+                  'mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground/50',
+                  'opacity-0 transition-[opacity,color,background-color] hover:bg-muted hover:text-foreground',
+                  'focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+                  'group-hover/goal:opacity-100 motion-reduce:opacity-60',
+                )}
+              >
+                <Pencil size={13} aria-hidden />
+              </button>
+            </div>
+          )}
           {stage.reason ? (
             <p className="text-sm leading-relaxed text-muted-foreground">{stage.reason}</p>
           ) : null}

--- a/apps/desktop/src/features/session/hooks/useSessionTitleRename/index.ts
+++ b/apps/desktop/src/features/session/hooks/useSessionTitleRename/index.ts
@@ -1,0 +1,63 @@
+import { useState, type KeyboardEvent } from 'react';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { formatError } from '../../../../shared/lib/errors';
+import { MAX_SESSION_TITLE_LENGTH } from '../../../../store/slices/sessions/titleLimit';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly currentTitle: string;
+};
+
+export const useSessionTitleRename = ({ sessionId, currentTitle }: Params) => {
+  const renameTask = useAppStore((s) => s.renameTask);
+  const [renaming, setRenaming] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const start = () => {
+    setDraft(currentTitle);
+    setError(null);
+    setRenaming(true);
+  };
+
+  const cancel = () => {
+    setRenaming(false);
+    setError(null);
+  };
+
+  const commit = async () => {
+    if (!draft.trim()) {
+      setError('name cannot be empty');
+      return;
+    }
+    try {
+      await renameTask(sessionId, draft.trim());
+      setRenaming(false);
+      setError(null);
+    } catch (err) {
+      setError(formatError(err));
+    }
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      void commit();
+    }
+    if (e.key === 'Escape') {
+      cancel();
+    }
+  };
+
+  return {
+    renaming,
+    draft,
+    error,
+    maxLength: MAX_SESSION_TITLE_LENGTH,
+    setDraft,
+    start,
+    cancel,
+    commit,
+    onKeyDown,
+  };
+};

--- a/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionDetailPanel/index.tsx
@@ -20,6 +20,7 @@ import { OverflowMenu, type OverflowMenuItem } from '../../../../shared/componen
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
+import { useSessionTitleRename } from '../../../session/hooks/useSessionTitleRename';
 
 // The folder CTA only ever opens the reference editors Goodboy auto-detects.
 // Other detected editors (Zed, Vim, …) are intentionally not surfaced here.
@@ -80,7 +81,6 @@ type SessionDetailPanelProps = {
 
 export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDetailPanelProps) => {
   const worktreePath = useAppStore((s) => s.sessionWorktrees[session.id as SessionId]?.[0] ?? null);
-  const renameTask = useAppStore((s) => s.renameTask);
   const externalTask = useAppStore(
     (s) => s.sessionExternalTasks?.[session.id as SessionId] ?? null,
   );
@@ -93,9 +93,10 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
   const { showToast } = useToast();
   const archived = Boolean(session.archivedAt);
 
-  const [renaming, setRenaming] = useState(false);
-  const [renameDraft, setRenameDraft] = useState('');
-  const [renameError, setRenameError] = useState<string | null>(null);
+  const rename = useSessionTitleRename({
+    sessionId: session.id as SessionId,
+    currentTitle: session.goal,
+  });
   const [armed, setArmed] = useState<'archive' | 'delete' | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -205,53 +206,24 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [detectedEditors, worktreePath]);
 
-  const startRename = () => {
-    setRenameDraft(session.goal);
-    setRenameError(null);
-    setRenaming(true);
-  };
-
-  const commitRename = async () => {
-    if (!renameDraft.trim()) {
-      setRenameError('name cannot be empty');
-      return;
-    }
-    try {
-      await renameTask(session.id as SessionId, renameDraft.trim());
-      setRenaming(false);
-      setRenameError(null);
-    } catch (err) {
-      setRenameError(formatError(err));
-    }
-  };
-
-  const onRenameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      void commitRename();
-    }
-    if (e.key === 'Escape') {
-      setRenaming(false);
-      setRenameError(null);
-    }
-  };
-
   return (
     <div className="flex shrink-0 flex-col gap-2 px-2 pb-2 pt-2.5">
       <div className="flex items-center gap-2">
         <SessionStageBadge session={session} />
         <div className="group/goal flex min-w-0 flex-1 items-center gap-1.5">
-          {renaming ? (
+          {rename.renaming ? (
             <div className="flex flex-1 flex-col gap-0.5">
               <Input
                 autoFocus
-                value={renameDraft}
-                onChange={(e) => setRenameDraft(e.target.value)}
-                onBlur={() => void commitRename()}
-                onKeyDown={onRenameKeyDown}
+                value={rename.draft}
+                maxLength={rename.maxLength}
+                onChange={(e) => rename.setDraft(e.target.value)}
+                onBlur={() => void rename.commit()}
+                onKeyDown={rename.onKeyDown}
                 aria-label="session goal"
                 className="h-7 text-xs font-semibold"
               />
-              {renameError && <span className="text-2xs text-danger">{renameError}</span>}
+              {rename.error && <span className="text-2xs text-danger">{rename.error}</span>}
             </div>
           ) : (
             <>
@@ -260,7 +232,7 @@ export const SessionDetailPanel = ({ session, onOpenSessionSettings }: SessionDe
               </span>
               <button
                 type="button"
-                onClick={startRename}
+                onClick={rename.start}
                 title="Edit goal"
                 aria-label="edit goal"
                 className="inline-flex size-5 shrink-0 items-center justify-center rounded text-muted-foreground/50 opacity-0 transition-[opacity,color,background-color] hover:bg-muted/60 hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] group-hover/goal:opacity-100 motion-reduce:opacity-60"

--- a/apps/desktop/src/store/slices/sessions/autoTitleSession.ts
+++ b/apps/desktop/src/store/slices/sessions/autoTitleSession.ts
@@ -1,11 +1,13 @@
 import type { IsoDateTime, SessionId } from '@goodboy/types';
 import { renameSession as renameSessionInDb } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { clampTitle } from './titleLimit';
 import type { GetFn, SetFn } from './types';
 
 export const autoTitleSession = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, title: string) => {
-    if (!title.trim()) {
+    const clamped = clampTitle(title);
+    if (!clamped) {
       return;
     }
     const session = get().sessions.find((s) => s.id === sessionId);
@@ -14,8 +16,8 @@ export const autoTitleSession = (set: SetFn, get: GetFn) => {
     }
     const now = new Date().toISOString() as IsoDateTime;
     set((state) => ({
-      sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, goal: title.trim() } : s)),
+      sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, goal: clamped } : s)),
     }));
-    await renameSessionInDb(tauriDatabase, sessionId, title.trim(), now, false);
+    await renameSessionInDb(tauriDatabase, sessionId, clamped, now, false);
   };
 };

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_BRANCH_PREFIX,
 } from '../../../features/settings/settings';
 import { markSessionMobileShared } from '../../../features/companion/mobileConfinement';
+import { clampTitle } from './titleLimit';
 import type { GetFn, SetFn } from './types';
 
 const slugifyDir = (raw: string): string =>
@@ -155,7 +156,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     const session: Session = {
       id: sessionId,
       workspaceId,
-      goal: goal.trim() || worktree.slug,
+      goal: clampTitle(goal.trim() || worktree.slug),
       state: initialState,
       contextSlots: [],
       providerPreference: providerPreference ?? inheritedPreference,
@@ -218,7 +219,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       });
     }
 
-    const goalText = session.goal.trim();
+    const goalText = goal.trim() || worktree.slug;
     if (goalText.length > 0) {
       await upsertContextSlot(tauriDatabase, session.id, {
         key: 'goal',

--- a/apps/desktop/src/store/slices/sessions/renameTask.ts
+++ b/apps/desktop/src/store/slices/sessions/renameTask.ts
@@ -1,11 +1,13 @@
 import type { IsoDateTime, SessionId } from '@goodboy/types';
 import { renameSession as renameSessionInDb } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
+import { clampTitle } from './titleLimit';
 import type { GetFn, SetFn } from './types';
 
 export const renameTask = (set: SetFn, get: GetFn) => {
   return async (sessionId: SessionId, goal: string) => {
-    if (!goal.trim()) {
+    const title = clampTitle(goal);
+    if (!title) {
       throw new Error('session name cannot be empty');
     }
     const now = new Date().toISOString() as IsoDateTime;
@@ -15,11 +17,11 @@ export const renameTask = (set: SetFn, get: GetFn) => {
     }
     set((state) => ({
       sessions: state.sessions.map((s) =>
-        s.id === sessionId ? { ...s, goal: goal.trim(), titleUserEdited: true, updatedAt: now } : s,
+        s.id === sessionId ? { ...s, goal: title, titleUserEdited: true, updatedAt: now } : s,
       ),
     }));
     try {
-      await renameSessionInDb(tauriDatabase, sessionId, goal.trim(), now, true);
+      await renameSessionInDb(tauriDatabase, sessionId, title, now, true);
     } catch (err) {
       set((state) => ({
         sessions: state.sessions.map((s) => (s.id === sessionId ? prev : s)),

--- a/apps/desktop/src/store/slices/sessions/titleLimit.ts
+++ b/apps/desktop/src/store/slices/sessions/titleLimit.ts
@@ -1,0 +1,3 @@
+export const MAX_SESSION_TITLE_LENGTH = 60;
+
+export const clampTitle = (s: string) => s.trim().slice(0, MAX_SESSION_TITLE_LENGTH);


### PR DESCRIPTION
## Summary
- Enforce a shared 60-char clamp on session titles across all three set paths (`createSession`, `renameTask`, `autoTitleSession`) via `clampTitle` helper in `titleLimit.ts`.
- Extract inline-rename logic into a shared `useSessionTitleRename` hook; `SessionDetailPanel` and `SessionOverviewPane` both consume it.
- Overview pencil now edits the title in place instead of jumping to the Goal lens; `maxLength={60}` added on both inputs as a UX hint (store is the authoritative gate).
- DB layer left validation-free (shared persistence, no migration of legacy long titles); goal-context slot stores the unclamped goal text by design.

## Test plan
- [ ] Create session with >60 char goal → title clamped to 60
- [ ] Rename via SessionDetailPanel input → clamped, empty rejected
- [ ] Rename via SessionOverviewPane pencil → edits inline, no lens jump
- [ ] Auto-title with long text → clamped

🤖 Generated with [Claude Code](https://claude.com/claude-code)