### PR TITLE
feat(desktop): skeleton-gate stage board on workspace entry

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Session, WorkspaceId } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    boardReady: true,
+    archivedSessions: {} as Record<string, ReadonlyArray<Session>>,
+    loadArchivedSessions: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: (selector: (s: typeof state) => unknown) => selector(state),
+  useStageGroupedSessions: () => [],
+}));
+
+vi.mock('./useBoardNavigation', () => ({
+  useBoardNavigation: () => ({ restore: vi.fn() }),
+}));
+
+vi.mock('./StageColumn', () => ({
+  StageColumn: ({ spec }: { spec: { kind: string; stage?: string } }) => (
+    <div data-testid="stage-column">{spec.kind === 'stage' ? spec.stage : 'archived'}</div>
+  ),
+}));
+
+vi.mock('../WorkspaceHeader', () => ({ WorkspaceHeader: () => <div /> }));
+vi.mock('../../../session/components/ArchiveSessionDialog', () => ({
+  ArchiveSessionDialog: () => null,
+}));
+vi.mock('../../../session/components/DeleteSessionDialog', () => ({
+  DeleteSessionDialog: () => null,
+}));
+vi.mock('../../../../shared/components/DogMascot', () => ({ DogMascot: () => <div /> }));
+
+import { StageBoard } from './index';
+
+const session = { id: 's-1' } as Session;
+const wsId = 'ws-a' as WorkspaceId;
+const onCreate = vi.fn();
+
+beforeEach(() => {
+  state.boardReady = true;
+  state.archivedSessions = {};
+  state.loadArchivedSessions = vi.fn();
+});
+afterEach(cleanup);
+
+describe('StageBoard loading gate', () => {
+  it('shows the skeleton board while boardReady is false, hiding columns and empty state', () => {
+    state.boardReady = false;
+    render(<StageBoard workspaceId={wsId} sessions={[session]} onCreateSession={onCreate} />);
+    expect(screen.getByLabelText('Loading board')).toBeDefined();
+    expect(screen.queryByTestId('stage-column')).toBeNull();
+    expect(screen.queryByText('Start your first session')).toBeNull();
+  });
+
+  it('renders the empty state once ready with no sessions', () => {
+    render(<StageBoard workspaceId={wsId} sessions={[]} onCreateSession={onCreate} />);
+    expect(screen.queryByLabelText('Loading board')).toBeNull();
+    expect(screen.getByText('Start your first session')).toBeDefined();
+  });
+
+  it('renders stage columns once ready with sessions', () => {
+    render(<StageBoard workspaceId={wsId} sessions={[session]} onCreateSession={onCreate} />);
+    expect(screen.queryByLabelText('Loading board')).toBeNull();
+    expect(screen.getAllByTestId('stage-column').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus } from 'lucide-react';
-import { Button, Divider, Eyebrow } from '@goodboy/ui';
+import { Button, Divider, Eyebrow, Skeleton } from '@goodboy/ui';
 import type { Session, SessionStage, WorkspaceId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useStageGroupedSessions } from '../../../../store';
 import { STAGE_ORDER } from '../../../../store/slices/session-view/types';
@@ -19,6 +19,27 @@ const STAGES: ReadonlyArray<SessionStage> = (
   .sort((a, b) => a[1] - b[1])
   .map(([stage]) => stage);
 
+const SKELETON_COLUMNS = [3, 2, 2, 1, 2];
+
+const BoardSkeleton = () => (
+  <div
+    className="flex min-h-0 flex-1 gap-4 overflow-x-hidden"
+    role="status"
+    aria-label="Loading board"
+  >
+    {SKELETON_COLUMNS.map((cards, col) => (
+      <div key={col} className="flex min-h-0 w-72 shrink-0 flex-col gap-3">
+        <Skeleton className="h-4 w-24 rounded-full" />
+        <div className="flex flex-col gap-2">
+          {Array.from({ length: cards }).map((_, i) => (
+            <Skeleton key={i} className="h-20 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
 type StageBoardProps = {
   readonly workspaceId: WorkspaceId;
   readonly sessions: ReadonlyArray<Session>;
@@ -29,6 +50,7 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
   const groups = useStageGroupedSessions(workspaceId, sessions);
   const nav = useBoardNavigation();
   const archived = useAppStore((s) => s.archivedSessions[workspaceId] ?? EMPTY_ARRAY);
+  const boardReady = useAppStore((s) => s.boardReady);
   const loadArchivedSessions = useAppStore((s) => s.loadArchivedSessions);
   const [confirm, setConfirm] = useState<Confirm | null>(null);
 
@@ -69,7 +91,9 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
 
       <Divider />
 
-      {empty ? (
+      {!boardReady ? (
+        <BoardSkeleton />
+      ) : empty ? (
         <div className="flex flex-1 items-center justify-center">
           <div className="flex max-w-md flex-col items-center gap-6 text-center">
             <div className="flex h-20 w-20 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40">

--- a/apps/desktop/src/store/slices/github/sweepGithub.test.ts
+++ b/apps/desktop/src/store/slices/github/sweepGithub.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
+
+import { sweepGithub } from './sweepGithub';
+
+const WS_ID = 'ws-1' as WorkspaceId;
+const WS_ID_2 = 'ws-2' as WorkspaceId;
+const S1 = 's-1' as SessionId;
+const S2 = 's-2' as SessionId;
+
+function makeState(overrides: Record<string, unknown> = {}) {
+  return {
+    githubStatus: { available: true },
+    currentWorkspaceId: WS_ID,
+    sessions: [],
+    sessionBranches: {} as Record<string, string>,
+    sessionGithub: {} as Record<string, { pr: unknown; fetchedAt: string } | undefined>,
+    currentSessionId: null as SessionId | null,
+    refreshSessionPr: vi.fn(async () => undefined),
+    refreshSessionPrDetail: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+describe('sweepGithub', () => {
+  let set: ReturnType<typeof vi.fn>;
+  let state: ReturnType<typeof makeState>;
+  let get: () => ReturnType<typeof makeState>;
+
+  beforeEach(() => {
+    set = vi.fn();
+    state = makeState();
+    get = () => state;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('github-off path', () => {
+    it('releases boardReady immediately when github unavailable', () => {
+      state = makeState({ githubStatus: { available: false } });
+      sweepGithub(set as never, get as never)();
+      expect(set).toHaveBeenCalledWith({ boardReady: true });
+    });
+
+    it('releases boardReady immediately when githubStatus is null', () => {
+      state = makeState({ githubStatus: null });
+      sweepGithub(set as never, get as never)();
+      expect(set).toHaveBeenCalledWith({ boardReady: true });
+    });
+
+    it('does not call refreshSessionPr when github is off', () => {
+      state = makeState({
+        githubStatus: { available: false },
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+      });
+      sweepGithub(set as never, get as never)();
+      expect(state.refreshSessionPr).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('no-branch path', () => {
+    it('does not call set({boardReady}) when no sessions have branches', () => {
+      state = makeState({ sessions: [{ id: S1 }], sessionBranches: {} });
+      sweepGithub(set as never, get as never)();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('does not call set({boardReady}) when all sessions are branchless', () => {
+      state = makeState({
+        sessions: [{ id: S1 }, { id: S2 }],
+        sessionBranches: {},
+      });
+      sweepGithub(set as never, get as never)();
+      expect(set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with-branch happy path', () => {
+    it('releases boardReady after all PR refreshes settle', async () => {
+      let resolve!: () => void;
+      const p = new Promise<void>((r) => {
+        resolve = r;
+      });
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        sessionGithub: {},
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)();
+
+      expect(set).not.toHaveBeenCalled();
+
+      resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(set).toHaveBeenCalledWith({ boardReady: true });
+    });
+
+    it('releases boardReady after all sessions settle (multiple sessions)', async () => {
+      let r1!: () => void;
+      let r2!: () => void;
+      const p1 = new Promise<void>((r) => {
+        r1 = r;
+      });
+      const p2 = new Promise<void>((r) => {
+        r2 = r;
+      });
+      state = makeState({
+        sessions: [{ id: S1 }, { id: S2 }],
+        sessionBranches: { [S1]: 'feat/foo', [S2]: 'feat/bar' },
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>)
+        .mockReturnValueOnce(p1)
+        .mockReturnValueOnce(p2);
+
+      sweepGithub(set as never, get as never)();
+      expect(set).not.toHaveBeenCalled();
+
+      r1();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(set).not.toHaveBeenCalled();
+
+      r2();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(set).toHaveBeenCalledWith({ boardReady: true });
+    });
+  });
+
+  describe('stale-sweep guard', () => {
+    it('does not release boardReady when workspace changed before Promise.all settles', async () => {
+      let resolve!: () => void;
+      const p = new Promise<void>((r) => {
+        resolve = r;
+      });
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)();
+
+      state.currentWorkspaceId = WS_ID_2;
+
+      resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('releases boardReady when workspace is unchanged at settlement', async () => {
+      let resolve!: () => void;
+      const p = new Promise<void>((r) => {
+        resolve = r;
+      });
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        currentWorkspaceId: WS_ID,
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)();
+
+      resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(set).toHaveBeenCalledWith({ boardReady: true });
+    });
+  });
+
+  describe('skip rules', () => {
+    it('skips merged PRs (does not add to promises)', async () => {
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        sessionGithub: { [S1]: { pr: { state: 'merged' }, fetchedAt: '2025-01-01T00:00:00Z' } },
+      });
+
+      sweepGithub(set as never, get as never)();
+
+      expect(state.refreshSessionPr).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('skips closed PRs (does not add to promises)', async () => {
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        sessionGithub: { [S1]: { pr: { state: 'closed' }, fetchedAt: '2025-01-01T00:00:00Z' } },
+      });
+
+      sweepGithub(set as never, get as never)();
+
+      expect(state.refreshSessionPr).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalled();
+    });
+
+    it('skips unknown-PR sessions when skipUnknownPr=true and fetchedAt is set', () => {
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        sessionGithub: { [S1]: { pr: null, fetchedAt: '2025-01-01T00:00:00Z' } },
+      });
+
+      sweepGithub(set as never, get as never)({ skipUnknownPr: true });
+
+      expect(state.refreshSessionPr).not.toHaveBeenCalled();
+    });
+
+    it('does not skip null-PR sessions when skipUnknownPr=false', async () => {
+      const p = Promise.resolve();
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        sessionGithub: { [S1]: { pr: null, fetchedAt: '2025-01-01T00:00:00Z' } },
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)({ skipUnknownPr: false });
+
+      expect(state.refreshSessionPr).toHaveBeenCalledWith(S1, expect.anything());
+    });
+  });
+
+  describe('current session detail refresh', () => {
+    it('calls refreshSessionPrDetail for the current session after PR resolves', async () => {
+      const p = Promise.resolve();
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        currentSessionId: S1,
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)();
+
+      await p;
+      await Promise.resolve();
+
+      expect(state.refreshSessionPrDetail).toHaveBeenCalledWith(S1, expect.anything());
+    });
+
+    it('does not call refreshSessionPrDetail for non-current sessions', async () => {
+      const p = Promise.resolve();
+      state = makeState({
+        sessions: [{ id: S1 }],
+        sessionBranches: { [S1]: 'feat/foo' },
+        currentSessionId: S2,
+      });
+      (state.refreshSessionPr as ReturnType<typeof vi.fn>).mockReturnValueOnce(p);
+
+      sweepGithub(set as never, get as never)();
+
+      await p;
+      await Promise.resolve();
+
+      expect(state.refreshSessionPrDetail).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/desktop/src/store/slices/github/sweepGithub.ts
+++ b/apps/desktop/src/store/slices/github/sweepGithub.ts
@@ -2,13 +2,16 @@ import type { GetFn, SetFn } from './types';
 
 type Params = { skipUnknownPr?: boolean };
 
-export const sweepGithub = (_set: SetFn, get: GetFn) => {
+export const sweepGithub = (set: SetFn, get: GetFn) => {
   return (opts?: Params) => {
     if (!get().githubStatus?.available) {
+      set({ boardReady: true });
       return;
     }
+    const wsAtStart = get().currentWorkspaceId;
     const { sessions, sessionBranches, sessionGithub, currentSessionId } = get();
     const subOpts = { silent: true, retries: 1 } as const;
+    const promises: Promise<void>[] = [];
     for (const session of sessions) {
       if (!sessionBranches[session.id]) {
         continue;
@@ -22,9 +25,17 @@ export const sweepGithub = (_set: SetFn, get: GetFn) => {
         continue;
       }
       const head = get().refreshSessionPr(session.id, subOpts);
+      promises.push(head);
       if (session.id === currentSessionId) {
         void head.then(() => get().refreshSessionPrDetail(session.id, subOpts));
       }
+    }
+    if (promises.length > 0) {
+      void Promise.all(promises).then(() => {
+        if (get().currentWorkspaceId === wsAtStart) {
+          set({ boardReady: true });
+        }
+      });
     }
   };
 };

--- a/apps/desktop/src/store/slices/workspaces/index.test.ts
+++ b/apps/desktop/src/store/slices/workspaces/index.test.ts
@@ -392,6 +392,17 @@ function buildSession(overrides: Partial<Session> = {}): Session {
   };
 }
 
+function buildWorktree(sessionId: SessionId, worktreePath: string, branch: string) {
+  return {
+    id: `wt_${sessionId}`,
+    sessionId,
+    worktreePath,
+    branch,
+    parallelIndex: 0,
+    createdAt: Date.now(),
+  };
+}
+
 function buildAgent(overrides: Partial<Agent> & Pick<Agent, 'id'>): Agent {
   return {
     sessionId: SESSION_ID,
@@ -620,6 +631,61 @@ describe('store contract', () => {
       const s = store.getState();
       expect(s.currentWorkspaceId).toBeNull();
       expect(s.providerSpendBreakdown).toEqual([]);
+    });
+
+    describe('boardReady flag', () => {
+      it('sets boardReady=false before sessions load on workspace switch', async () => {
+        const store = await getStore();
+        store.setState({ workspaces: [buildWorkspace()], boardReady: true } as never);
+
+        const promise = store.getState().setCurrentWorkspace(WS_ID);
+        await Promise.resolve();
+
+        expect(store.getState().boardReady).toBe(false);
+        await promise;
+      });
+
+      it('releases boardReady=true for a workspace with no session branches', async () => {
+        const store = await getStore();
+        const db = await import('@goodboy/db');
+        vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+          buildSession(),
+          buildSession({ id: SESSION_ID_2 }),
+        ]);
+        vi.mocked(db.listWorktreesForSessions).mockResolvedValueOnce(new Map());
+
+        store.setState({ workspaces: [buildWorkspace()] });
+        await store.getState().setCurrentWorkspace(WS_ID);
+
+        expect(store.getState().boardReady).toBe(true);
+      });
+
+      it('does NOT release boardReady=true when sessions have branches (delegated to sweepGithub)', async () => {
+        const store = await getStore();
+        const db = await import('@goodboy/db');
+        vi.mocked(db.listSessionsForWorkspace).mockResolvedValueOnce([
+          buildSession(),
+          buildSession({ id: SESSION_ID_2 }),
+        ]);
+        vi.mocked(db.listWorktreesForSessions).mockResolvedValueOnce(
+          new Map([
+            [SESSION_ID, [buildWorktree(SESSION_ID, '/tmp/wt', 'feat/foo')]],
+            [SESSION_ID_2, [buildWorktree(SESSION_ID_2, '/tmp/wt2', 'feat/bar')]],
+          ]),
+        );
+
+        store.setState({ workspaces: [buildWorkspace()] });
+        await store.getState().setCurrentWorkspace(WS_ID);
+
+        expect(store.getState().boardReady).toBe(false);
+      });
+
+      it('boardReady stays false when workspace null (no id branch)', async () => {
+        const store = await getStore();
+        store.setState({ boardReady: true } as never);
+        await store.getState().setCurrentWorkspace(null);
+        expect(store.getState().boardReady).toBe(false);
+      });
     });
   });
 });

--- a/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
+++ b/apps/desktop/src/store/slices/workspaces/setCurrentWorkspace.ts
@@ -73,6 +73,7 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
       sidebarStateFilter: [],
       sidebarProviderFilter: [],
       sessionLoading: {},
+      boardReady: false,
     });
     if (id) {
       const touchNow = new Date().toISOString() as IsoDateTime;
@@ -151,6 +152,9 @@ export const setCurrentWorkspace = (set: SetFn, get: GetFn) => {
         agentKindOverride: { ...state.agentKindOverride, ...kindOverridesFromDb },
         sessionExternalTasks: { ...state.sessionExternalTasks, ...externalTasksMap },
       }));
+      if (get().currentWorkspaceId === id && Object.keys(sessionBranches).length === 0) {
+        set({ boardReady: true });
+      }
       // eslint-disable-next-line no-console
       console.log(`[perf] workspace:firstPaint ${(performance.now() - tWsLoad).toFixed(0)}ms`);
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -274,6 +274,7 @@ export type AppState = UpdaterState & {
   } | null;
   readonly sessionNudges: Readonly<Record<SessionId, SessionNudge | null>>;
   readonly sessionLoading: Readonly<Record<SessionId, SessionLoadingFlags>>;
+  readonly boardReady: boolean;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -791,6 +792,7 @@ export const initialState: AppState = {
   sessionAnsweredQuestions: {},
   openQuestionScrollTarget: null,
   sessionLoading: {},
+  boardReady: true,
   sessionViewPrefs: {},
   activeLens: {},
   lensHistory: {},


### PR DESCRIPTION
## Summary
- Add a `boardReady` flag to app state, reset to `false` on workspace switch and released once session PR/branch info has settled.
- Gate the StageBoard render: show skeleton columns until `boardReady`, so sessions appear only after their info loads instead of flashing into the `building` column.
- Release path: github-off / no-branch workspaces release immediately in `setCurrentWorkspace`; branch-backed workspaces release in `sweepGithub` after `Promise.all` of PR refreshes settles, guarded against stale sweeps after a workspace switch.

## Test plan
- [x] `sweepGithub.test.ts` (15 tests): github-off, null status, no-branch hold, happy path single/multi, stale-sweep guard, skip rules, current-session detail.
- [x] `workspaces/index.test.ts` (boardReady block): reset timing, zero-branch release, multi-branch hold, null workspace.
- [x] `StageBoard/index.test.tsx`: skeleton shown while loading, empty state once ready, columns once ready with sessions.
- [x] Full desktop suite green (2006 tests), lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)