### PR TITLE
feat(desktop): tooltips on icon-only actions

### DIFF
--- a/apps/desktop/src/app/components/AppTopBar/index.test.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.test.tsx
@@ -44,18 +44,18 @@ import { AppTopBar } from './index';
 describe('AppTopBar', () => {
   it('renders settings button', () => {
     render(<AppTopBar onOpenSettings={vi.fn()} activeStudio={null} />);
-    expect(screen.getByTitle('settings (⌘,)')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'open settings' })).toBeDefined();
   });
 
   it('settings button has active state when settings studio is open', () => {
     render(<AppTopBar onOpenSettings={vi.fn()} activeStudio="settings" />);
-    const btn = screen.getByTitle('settings (⌘,)');
+    const btn = screen.getByRole('button', { name: 'open settings' });
     expect(btn.className).toContain('bg-foreground');
   });
 
   it('settings button is normal when a different studio is open', () => {
     render(<AppTopBar onOpenSettings={vi.fn()} activeStudio="workflow" />);
-    const btn = screen.getByTitle('settings (⌘,)');
+    const btn = screen.getByRole('button', { name: 'open settings' });
     expect(btn.className).not.toContain('bg-foreground');
   });
 });

--- a/apps/desktop/src/app/components/AppTopBar/index.tsx
+++ b/apps/desktop/src/app/components/AppTopBar/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { HelpCircle, Moon, Settings, Smartphone, Sun } from 'lucide-react';
-import { cn, Divider, StatusDot, formatUsd } from '@goodboy/ui';
+import { cn, Divider, StatusDot, Tooltip, formatUsd } from '@goodboy/ui';
 import { DogMascot } from '../../../shared/components/DogMascot';
 import { UpdateIndicator } from '../../../features/updater/components/UpdateIndicator';
 import { bridgeStatus } from '../../../features/companion/bridge';
@@ -38,41 +38,44 @@ export const AppTopBar = ({ onOpenSettings, activeStudio }: AppTopBarProps) => {
         <WorkspaceRollupStrip />
 
         <div className="flex shrink-0 items-center gap-0.5">
-          <button
-            type="button"
-            onClick={toggleTheme}
-            title={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-            aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
-            className={TOPBAR_ICON_BTN}
-          >
-            {theme === 'dark' ? <Sun size={14} aria-hidden /> : <Moon size={14} aria-hidden />}
-          </button>
+          <Tooltip content={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}>
+            <button
+              type="button"
+              onClick={toggleTheme}
+              aria-label={theme === 'dark' ? 'switch to light mode' : 'switch to dark mode'}
+              className={TOPBAR_ICON_BTN}
+            >
+              {theme === 'dark' ? <Sun size={14} aria-hidden /> : <Moon size={14} aria-hidden />}
+            </button>
+          </Tooltip>
           <NotificationCenter />
-          <button
-            type="button"
-            onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-guide'))}
-            title="getting started"
-            aria-label="open getting started guide"
-            className={TOPBAR_ICON_BTN}
-          >
-            <HelpCircle size={14} aria-hidden />
-          </button>
+          <Tooltip content="getting started">
+            <button
+              type="button"
+              onClick={() => window.dispatchEvent(new CustomEvent('goodboy:open-guide'))}
+              aria-label="open getting started guide"
+              className={TOPBAR_ICON_BTN}
+            >
+              <HelpCircle size={14} aria-hidden />
+            </button>
+          </Tooltip>
           <OnboardingChip />
           <PairDeviceCta />
-          <button
-            type="button"
-            onClick={onOpenSettings}
-            title="settings (⌘,)"
-            aria-label="open settings"
-            className={cn(
-              'flex items-center justify-center rounded p-1.5 transition-colors',
-              activeStudio === 'settings'
-                ? 'bg-foreground text-background'
-                : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
-            )}
-          >
-            <Settings size={14} aria-hidden />
-          </button>
+          <Tooltip content="settings (⌘,)">
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              aria-label="open settings"
+              className={cn(
+                'flex items-center justify-center rounded p-1.5 transition-colors',
+                activeStudio === 'settings'
+                  ? 'bg-foreground text-background'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted/50',
+              )}
+            >
+              <Settings size={14} aria-hidden />
+            </button>
+          </Tooltip>
           <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary ring-1 ring-primary/15">
             Beta
           </span>

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -11,7 +11,16 @@ import {
   Sparkles,
   Trash2,
 } from 'lucide-react';
-import { Divider, Markdown, ScrollFade, Textarea, cn, tintClasses, type Tone } from '@goodboy/ui';
+import {
+  Divider,
+  Markdown,
+  ScrollFade,
+  Textarea,
+  Tooltip,
+  cn,
+  tintClasses,
+  type Tone,
+} from '@goodboy/ui';
 import type { Agent, PlanId, PlanStatus, PlanWithCount, SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useSessionPlans } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -400,33 +409,36 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
                         </button>
                       ) : null}
                       {selected.status === 'consumed' ? (
-                        <span
-                          className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
-                          title="Consumed plans cannot be deleted"
-                          aria-label="Consumed plans cannot be deleted"
-                        >
-                          <Trash2 size={13} aria-hidden />
-                        </span>
+                        <Tooltip content="Consumed plans cannot be deleted">
+                          <span
+                            className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
+                            aria-label="Consumed plans cannot be deleted"
+                          >
+                            <Trash2 size={13} aria-hidden />
+                          </span>
+                        </Tooltip>
                       ) : selected.status === 'discarded' ? (
-                        <button
-                          type="button"
-                          onClick={() => handleRestore(selected)}
-                          title="Restore plan"
-                          aria-label="Restore plan"
-                          className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
-                        >
-                          <ArchiveRestore size={13} aria-hidden />
-                        </button>
+                        <Tooltip content="Restore plan">
+                          <button
+                            type="button"
+                            onClick={() => handleRestore(selected)}
+                            aria-label="Restore plan"
+                            className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
+                          >
+                            <ArchiveRestore size={13} aria-hidden />
+                          </button>
+                        </Tooltip>
                       ) : (
-                        <button
-                          type="button"
-                          onClick={() => handleDiscard(selected)}
-                          title="Delete plan (soft delete, click restore to recover)"
-                          aria-label="Delete plan"
-                          className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
-                        >
-                          <Trash2 size={13} aria-hidden />
-                        </button>
+                        <Tooltip content="Delete plan (soft delete, click restore to recover)">
+                          <button
+                            type="button"
+                            onClick={() => handleDiscard(selected)}
+                            aria-label="Delete plan"
+                            className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
+                          >
+                            <Trash2 size={13} aria-hidden />
+                          </button>
+                        </Tooltip>
                       )}
                     </div>
                   </div>

--- a/apps/desktop/src/features/session/components/AutoRunToggle/index.tsx
+++ b/apps/desktop/src/features/session/components/AutoRunToggle/index.tsx
@@ -1,5 +1,5 @@
 import { Zap, ZapOff } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { Tooltip, cn } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 
@@ -29,34 +29,37 @@ export const AutoRunToggle = ({ session }: Props) => {
       : 'text-muted-foreground/60 hover:bg-foreground/10 hover:text-foreground';
 
   return (
-    <button
-      type="button"
-      disabled={!hasWorkflow}
-      onClick={() => {
-        if (!hasWorkflow) {
-          return;
-        }
-        void setSessionAutoRun(session.id as SessionId, !on);
-      }}
-      title={tooltip}
-      aria-label={ariaLabel}
-      aria-pressed={on}
-      className={cn(
-        'inline-flex h-6 shrink-0 items-center justify-end rounded-md px-1 transition-colors',
-        cls,
-      )}
-    >
-      <span
-        aria-hidden
-        className={cn(
-          'overflow-hidden whitespace-nowrap text-[10px] font-semibold tracking-wide',
-          'transition-[max-width,opacity,margin] duration-200 ease-out',
-          on ? 'mr-1 max-w-[2.5rem] opacity-100' : 'mr-0 max-w-0 opacity-0',
-        )}
-      >
-        auto
+    <Tooltip content={tooltip}>
+      <span className="inline-flex shrink-0">
+        <button
+          type="button"
+          disabled={!hasWorkflow}
+          onClick={() => {
+            if (!hasWorkflow) {
+              return;
+            }
+            void setSessionAutoRun(session.id as SessionId, !on);
+          }}
+          aria-label={ariaLabel}
+          aria-pressed={on}
+          className={cn(
+            'inline-flex h-6 shrink-0 items-center justify-end rounded-md px-1 transition-colors',
+            cls,
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'overflow-hidden whitespace-nowrap text-[10px] font-semibold tracking-wide',
+              'transition-[max-width,opacity,margin] duration-200 ease-out',
+              on ? 'mr-1 max-w-[2.5rem] opacity-100' : 'mr-0 max-w-0 opacity-0',
+            )}
+          >
+            auto
+          </span>
+          {on ? <Zap size={13} aria-hidden /> : <ZapOff size={13} aria-hidden />}
+        </button>
       </span>
-      {on ? <Zap size={13} aria-hidden /> : <ZapOff size={13} aria-hidden />}
-    </button>
+    </Tooltip>
   );
 };

--- a/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryCard/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { cn } from '@goodboy/ui';
+import { Tooltip, cn } from '@goodboy/ui';
 import { Check, GripVertical, Pencil, Trash2, X } from 'lucide-react';
 import type { StepDef } from '@goodboy/types';
 import { AGENT_KIND_PALETTE, ROLE_LABEL, ROLE_TO_KIND } from '../../../session/agent-kind';
@@ -62,51 +62,55 @@ export const LibraryCard = ({ def, dragDisabled, onStartDrag, onEdit, onDelete }
             onPointerDown={(e) => e.stopPropagation()}
           >
             <span className="px-1 text-2xs text-muted-foreground">Delete?</span>
-            <button
-              type="button"
-              onClick={() => {
-                setConfirming(false);
-                onDelete();
-              }}
-              title="confirm delete"
-              aria-label={`confirm delete ${def.name}`}
-              className="rounded p-0.5 text-danger motion-safe:transition-colors hover:bg-danger/10"
-            >
-              <Check size={12} aria-hidden />
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirming(false)}
-              title="cancel"
-              aria-label="cancel delete"
-              className="rounded p-0.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
-            >
-              <X size={12} aria-hidden />
-            </button>
+            <Tooltip content="confirm delete">
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirming(false);
+                  onDelete();
+                }}
+                aria-label={`confirm delete ${def.name}`}
+                className="rounded p-0.5 text-danger motion-safe:transition-colors hover:bg-danger/10"
+              >
+                <Check size={12} aria-hidden />
+              </button>
+            </Tooltip>
+            <Tooltip content="cancel">
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                aria-label="cancel delete"
+                className="rounded p-0.5 text-muted-foreground motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
+              >
+                <X size={12} aria-hidden />
+              </button>
+            </Tooltip>
           </div>
         ) : (
           <div className="hidden items-center gap-0.5 group-focus-within:flex group-hover:flex">
-            <button
-              type="button"
-              onPointerDown={(e) => e.stopPropagation()}
-              onClick={onEdit}
-              title={isGlobal ? 'edit (creates a workspace copy)' : 'edit step'}
-              aria-label={`edit ${def.name}`}
-              className="rounded p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
-            >
-              <Pencil size={12} aria-hidden />
-            </button>
-            {!isGlobal && (
+            <Tooltip content={isGlobal ? 'edit (creates a workspace copy)' : 'edit step'}>
               <button
                 type="button"
                 onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => setConfirming(true)}
-                title="delete step"
-                aria-label={`delete ${def.name}`}
-                className="rounded p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-danger/10 hover:text-danger"
+                onClick={onEdit}
+                aria-label={`edit ${def.name}`}
+                className="rounded p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
               >
-                <Trash2 size={12} aria-hidden />
+                <Pencil size={12} aria-hidden />
               </button>
+            </Tooltip>
+            {!isGlobal && (
+              <Tooltip content="delete step">
+                <button
+                  type="button"
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onClick={() => setConfirming(true)}
+                  aria-label={`delete ${def.name}`}
+                  className="rounded p-1 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] motion-safe:transition-colors hover:bg-danger/10 hover:text-danger"
+                >
+                  <Trash2 size={12} aria-hidden />
+                </button>
+              </Tooltip>
             )}
           </div>
         )}

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Input, Textarea } from '@goodboy/ui';
+import { Input, Textarea, Tooltip } from '@goodboy/ui';
 import { X } from 'lucide-react';
 import { getDefaultTurnModel } from '@goodboy/core';
 import type {
@@ -122,15 +122,16 @@ export const LibraryStepForm = ({
             disabled={false}
           />
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="close"
-          aria-label="close step editor"
-          className="shrink-0 rounded p-1 text-muted-foreground motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
-        >
-          <X size={13} aria-hidden />
-        </button>
+        <Tooltip content="close">
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="close step editor"
+            className="shrink-0 rounded p-1 text-muted-foreground motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <X size={13} aria-hidden />
+          </button>
+        </Tooltip>
       </div>
 
       {isGlobal ? (

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/StepFlowCard.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/StepFlowCard.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { cn } from '@goodboy/ui';
+import { Tooltip, cn } from '@goodboy/ui';
 import { ChevronDown, ChevronUp, GripVertical, X } from 'lucide-react';
 import type { DefinitionForm } from '../../form';
 import { AGENT_KIND_PALETTE, ROLE_LABEL, ROLE_TO_KIND } from '../../../session/agent-kind';
@@ -46,24 +46,25 @@ export const StepFlowCard = ({
       )}
     >
       <div className="flex items-stretch">
-        <button
-          type="button"
-          onPointerDown={onStartDrag}
-          onKeyDown={(e) => {
-            if (e.key === 'ArrowUp') {
-              e.preventDefault();
-              onMoveLeft();
-            } else if (e.key === 'ArrowDown') {
-              e.preventDefault();
-              onMoveRight();
-            }
-          }}
-          title="drag to reorder (or arrow keys)"
-          aria-label="reorder step, use up and down arrow keys"
-          className="flex shrink-0 cursor-grab touch-none items-center rounded-l-lg px-1 text-muted-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-focus-ring)] active:cursor-grabbing motion-safe:transition-colors hover:bg-muted/40 hover:text-muted-foreground"
-        >
-          <GripVertical size={14} aria-hidden />
-        </button>
+        <Tooltip content="drag to reorder (or arrow keys)">
+          <button
+            type="button"
+            onPointerDown={onStartDrag}
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                onMoveLeft();
+              } else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                onMoveRight();
+              }
+            }}
+            aria-label="reorder step, use up and down arrow keys"
+            className="flex shrink-0 cursor-grab touch-none items-center rounded-l-lg px-1 text-muted-foreground/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-focus-ring)] active:cursor-grabbing motion-safe:transition-colors hover:bg-muted/40 hover:text-muted-foreground"
+          >
+            <GripVertical size={14} aria-hidden />
+          </button>
+        </Tooltip>
 
         <button
           type="button"
@@ -96,35 +97,42 @@ export const StepFlowCard = ({
         </button>
 
         <div className="flex shrink-0 items-center gap-px self-start px-1 py-1 opacity-0 focus-within:opacity-100 motion-safe:transition-opacity group-hover:opacity-100">
-          <button
-            type="button"
-            className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-muted/50 hover:text-foreground disabled:opacity-25"
-            onClick={onMoveLeft}
-            disabled={ordinal === 0}
-            title="move up"
-            aria-label="move step up"
-          >
-            <ChevronUp size={13} aria-hidden />
-          </button>
-          <button
-            type="button"
-            className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-muted/50 hover:text-foreground disabled:opacity-25"
-            onClick={onMoveRight}
-            disabled={ordinal === total - 1}
-            title="move down"
-            aria-label="move step down"
-          >
-            <ChevronDown size={13} aria-hidden />
-          </button>
-          <button
-            type="button"
-            className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-danger/10 hover:text-danger"
-            onClick={onRemove}
-            title="remove step"
-            aria-label="remove step"
-          >
-            <X size={13} aria-hidden />
-          </button>
+          <Tooltip content="move up">
+            <span className="inline-flex">
+              <button
+                type="button"
+                className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-muted/50 hover:text-foreground disabled:opacity-25"
+                onClick={onMoveLeft}
+                disabled={ordinal === 0}
+                aria-label="move step up"
+              >
+                <ChevronUp size={13} aria-hidden />
+              </button>
+            </span>
+          </Tooltip>
+          <Tooltip content="move down">
+            <span className="inline-flex">
+              <button
+                type="button"
+                className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-muted/50 hover:text-foreground disabled:opacity-25"
+                onClick={onMoveRight}
+                disabled={ordinal === total - 1}
+                aria-label="move step down"
+              >
+                <ChevronDown size={13} aria-hidden />
+              </button>
+            </span>
+          </Tooltip>
+          <Tooltip content="remove step">
+            <button
+              type="button"
+              className="rounded p-0.5 text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)] hover:bg-danger/10 hover:text-danger"
+              onClick={onRemove}
+              aria-label="remove step"
+            >
+              <X size={13} aria-hidden />
+            </button>
+          </Tooltip>
         </div>
       </div>
 

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowsRail/index.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, ScrollFade, SectionHeader, cn } from '@goodboy/ui';
+import { EmptyState, ScrollFade, SectionHeader, Tooltip, cn } from '@goodboy/ui';
 import { Check, Layers, Plus, RotateCcw, X } from 'lucide-react';
 import type { Workflow, WorkflowId } from '@goodboy/types';
 import { PresetCard } from '../../PresetCard';
@@ -81,26 +81,32 @@ export const WorkflowsRail = ({
               Restore the built-in presets? Your edits to them are overwritten. Custom presets you
               made are kept.
             </span>
-            <button
-              type="button"
-              onClick={onReset}
-              disabled={resetting}
-              title="confirm restore"
-              aria-label="confirm restore defaults"
-              className="rounded p-0.5 text-warning transition-colors hover:bg-warning/10 disabled:opacity-50"
-            >
-              <Check size={13} aria-hidden />
-            </button>
-            <button
-              type="button"
-              onClick={() => setConfirmReset(false)}
-              disabled={resetting}
-              title="cancel"
-              aria-label="cancel restore defaults"
-              className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
-            >
-              <X size={13} aria-hidden />
-            </button>
+            <Tooltip content="confirm restore">
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={onReset}
+                  disabled={resetting}
+                  aria-label="confirm restore defaults"
+                  className="rounded p-0.5 text-warning transition-colors hover:bg-warning/10 disabled:opacity-50"
+                >
+                  <Check size={13} aria-hidden />
+                </button>
+              </span>
+            </Tooltip>
+            <Tooltip content="cancel">
+              <span className="inline-flex">
+                <button
+                  type="button"
+                  onClick={() => setConfirmReset(false)}
+                  disabled={resetting}
+                  aria-label="cancel restore defaults"
+                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+                >
+                  <X size={13} aria-hidden />
+                </button>
+              </span>
+            </Tooltip>
           </div>
         ) : (
           <button


### PR DESCRIPTION
## Summary
- Migrate icon-only buttons (theme/help/settings, plan restore/delete, workflow step controls, auto-run toggle, library card actions) to the `@goodboy/ui` `Tooltip` primitive so non-self-evident icons explain themselves on hover.
- Drop redundant native `title` attrs when wrapping in `Tooltip`; keep every `aria-label` (accessibility name + test query source).
- Wrap disabled buttons in a `<span>` so the tooltip still fires (disabled controls swallow mouse events; the custom Tooltip listens on `onMouseEnter`).

## Scope notes
- AppFooter left untouched: those buttons are text-labeled (icon + visible label) with already-descriptive native `title`, out of the icon-only migration scope.
- TerminalTabStrip (self-evident icons) and StageBoard dynamic actions intentionally skipped.

## Test plan
- [ ] `pnpm test` (desktop) green
- [ ] Hover icon-only actions show the tooltip after the delay
- [ ] Disabled auto-run toggle / step move-boundary buttons still show their tooltip on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)