### PR TITLE
feat(desktop): distinct workflow kickoff card in chat transcript

### DIFF
--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -201,3 +201,107 @@ describe('reduceTranscript, open-question answer boundary', () => {
     ]);
   });
 });
+
+const workflowMarker = [
+  'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
+  'When this step is fully complete, emit on its own line exactly:',
+  '<<step-done id="agent-1">>',
+  'Do not emit that marker until the step is truly done.',
+].join('\n');
+
+describe('reduceTranscript, workflow kickoff boundary', () => {
+  it('maps a composed kickoff to a workflow_kickoff item with parsed sections', () => {
+    const kickoff = [
+      'Workflow goal:\n\nShip the onboarding wizard',
+      'Active plan to execute:\n\n1. wire steps',
+      'Focus on the providers step only.',
+      workflowMarker,
+    ].join('\n\n');
+    const items = reduceTranscript([userTextEvent(kickoff)]);
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.kind).toBe('workflow_kickoff');
+    if (item.kind === 'workflow_kickoff') {
+      expect(item.goal).toBe('Ship the onboarding wizard');
+      expect(item.instructions).toContain('Focus on the providers step only.');
+      expect(item.parsed).toBe(true);
+      expect(item.raw).toBe(kickoff);
+    }
+  });
+
+  it('keeps ordinary user_text turns that are not kickoffs', () => {
+    const items = reduceTranscript([userTextEvent('fix the login bug')]);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('user_text');
+  });
+
+  it('emits a workflow_kickoff even when parsed:false (malformed goal)', () => {
+    const malformed = `Workflow goal:\n\n\n\n${workflowMarker}`;
+    const items = reduceTranscript([userTextEvent(malformed)]);
+    expect(items).toHaveLength(1);
+    const item = items[0]!;
+    expect(item.kind).toBe('workflow_kickoff');
+    if (item.kind === 'workflow_kickoff') {
+      expect(item.parsed).toBe(false);
+      expect(item.raw).toBe(malformed);
+    }
+  });
+
+  it('carries the at timestamp from the event', () => {
+    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const items = reduceTranscript([userTextEvent(kickoff)]);
+    const item = items[0]!;
+    expect(item.kind).toBe('workflow_kickoff');
+    if (item.kind === 'workflow_kickoff') {
+      expect(item.at).toBe(AT);
+    }
+  });
+
+  it('key starts with kickoff-', () => {
+    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const items = reduceTranscript([userTextEvent(kickoff)]);
+    const item = items[0]!;
+    expect(item.key).toMatch(/^kickoff-/);
+  });
+
+  it('multiple kickoff events get distinct keys', () => {
+    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const items = reduceTranscript([userTextEvent(kickoff), userTextEvent(kickoff)]);
+    expect(items).toHaveLength(2);
+    expect(items[0]!.key).not.toBe(items[1]!.key);
+  });
+
+  it('oq_answer takes priority over workflow_kickoff check (oq-answers wrapping)', () => {
+    const items = reduceTranscript([
+      userTextEvent('<<oq-answers>>\nAnswers:\n- Q: a\n  A: b\n<</oq-answers>>'),
+    ]);
+    expect(items[0]!.kind).toBe('oq_answer');
+  });
+
+  it('flushes buffered assistant_text before a kickoff event', () => {
+    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const events: TurnEvent[] = [
+      assistantTextEvent('some assistant output'),
+      userTextEvent(kickoff),
+    ];
+    const items = reduceTranscript(events);
+    expect(items.map((i) => i.kind)).toEqual(['assistant_text', 'workflow_kickoff']);
+  });
+
+  it('kickoff followed by assistant_text produces both items in order', () => {
+    const kickoff = `Workflow goal:\n\nGoal text\n\n${workflowMarker}`;
+    const events: TurnEvent[] = [userTextEvent(kickoff), assistantTextEvent('ok, starting')];
+    const items = reduceTranscript(events);
+    expect(items.map((i) => i.kind)).toEqual(['workflow_kickoff', 'assistant_text']);
+  });
+
+  it('kickoff without plan section produces empty instructions', () => {
+    const noInstructions = `Workflow goal:\n\nOnly a goal\n\n${workflowMarker}`;
+    const items = reduceTranscript([userTextEvent(noInstructions)]);
+    const item = items[0]!;
+    expect(item.kind).toBe('workflow_kickoff');
+    if (item.kind === 'workflow_kickoff') {
+      expect(item.instructions).toBe('');
+    }
+  });
+});

--- a/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/index.tsx
@@ -12,6 +12,7 @@ import { AuthRequiredCallout } from '../AuthRequiredCallout';
 import { ImageLightbox } from '../ImageLightbox';
 import { SkillInvocationCard } from '../SkillInvocationCard';
 import { PhaseTransitionCard } from '../PhaseTransitionCard';
+import { WorkflowKickoffCard } from '../WorkflowKickoffCard';
 import { PermissionRequestCard } from '../../../../features/permissions/components/PermissionRequestCard';
 import { PermissionDecisionCard } from '../../../../features/permissions/components/PermissionDecisionCard';
 import { displayPath } from '../../../../shared/utils/display-path';
@@ -90,6 +91,8 @@ function TranscriptCardImpl({
       return <SkillInvocationCard item={item} />;
     case 'step_transition':
       return <PhaseTransitionCard item={item} />;
+    case 'workflow_kickoff':
+      return <WorkflowKickoffCard item={item} />;
     case 'oq_answer':
       return null;
     case 'done':

--- a/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { WorkflowKickoffCard } from './index';
+
+afterEach(cleanup);
+
+const parsedItem = {
+  kind: 'workflow_kickoff',
+  key: 'kickoff-1',
+  at: '2026-05-28T03:00:00Z',
+  goal: 'Ship the onboarding wizard',
+  instructions: 'Focus on the providers step only.',
+  marker: 'Complete ONLY this workflow step.',
+  raw: 'raw kickoff text',
+  parsed: true,
+} as Extract<TranscriptItem, { kind: 'workflow_kickoff' }>;
+
+describe('WorkflowKickoffCard', () => {
+  it('shows the instructions expanded by default', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.getByText('Focus on the providers step only.')).toBeDefined();
+  });
+
+  it('keeps the goal collapsed until expanded', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.queryByText('Ship the onboarding wizard')).toBeNull();
+    fireEvent.click(screen.getByText(/^goal$/i));
+    expect(screen.getByText('Ship the onboarding wizard')).toBeDefined();
+  });
+
+  it('keeps the marker collapsed until expanded', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.queryByText('Complete ONLY this workflow step.')).toBeNull();
+    fireEvent.click(screen.getByText(/marker to emit/i));
+    expect(screen.getByText('Complete ONLY this workflow step.')).toBeDefined();
+  });
+
+  it('falls back to raw text when not parsed', () => {
+    const raw = { ...parsedItem, parsed: false } as Extract<
+      TranscriptItem,
+      { kind: 'workflow_kickoff' }
+    >;
+    render(<WorkflowKickoffCard item={raw} />);
+    expect(screen.getByText('raw kickoff text')).toBeDefined();
+  });
+
+  it('shows workflow start header in both parsed and unparsed states', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.getByText(/workflow start/i)).toBeDefined();
+  });
+
+  it('shows workflow start header when not parsed', () => {
+    const raw = { ...parsedItem, parsed: false } as Extract<
+      TranscriptItem,
+      { kind: 'workflow_kickoff' }
+    >;
+    render(<WorkflowKickoffCard item={raw} />);
+    expect(screen.getByText(/workflow start/i)).toBeDefined();
+  });
+
+  it('omits "what to do" section when instructions are empty', () => {
+    const noInstructions = { ...parsedItem, instructions: '' } as Extract<
+      TranscriptItem,
+      { kind: 'workflow_kickoff' }
+    >;
+    render(<WorkflowKickoffCard item={noInstructions} />);
+    expect(screen.queryByText(/what to do/i)).toBeNull();
+  });
+
+  it('omits "marker to emit" collapsible when marker is empty', () => {
+    const noMarker = { ...parsedItem, marker: '' } as Extract<
+      TranscriptItem,
+      { kind: 'workflow_kickoff' }
+    >;
+    render(<WorkflowKickoffCard item={noMarker} />);
+    expect(screen.queryByText(/marker to emit/i)).toBeNull();
+  });
+
+  it('can collapse the goal again after expanding it', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    const trigger = screen.getByText(/^goal$/i);
+    fireEvent.click(trigger);
+    expect(screen.getByText('Ship the onboarding wizard')).toBeDefined();
+    fireEvent.click(trigger);
+    expect(screen.queryByText('Ship the onboarding wizard')).toBeNull();
+  });
+
+  it('can collapse the marker again after expanding it', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    const trigger = screen.getByText(/marker to emit/i);
+    fireEvent.click(trigger);
+    expect(screen.getByText('Complete ONLY this workflow step.')).toBeDefined();
+    fireEvent.click(trigger);
+    expect(screen.queryByText('Complete ONLY this workflow step.')).toBeNull();
+  });
+
+  it('renders the timestamp', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.getByText(/\d{2}:\d{2}:\d{2}/)).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { Rocket } from 'lucide-react';
+import { Collapsible, Markdown } from '@goodboy/ui';
+import type { TranscriptItem } from '../../utils/transcript-items';
+import { formatCardTime } from '../../utils/format-card-time';
+
+type Props = {
+  readonly item: Extract<TranscriptItem, { kind: 'workflow_kickoff' }>;
+};
+
+export const WorkflowKickoffCard = ({ item }: Props) => {
+  const [goalOpen, setGoalOpen] = useState(false);
+  const [markerOpen, setMarkerOpen] = useState(false);
+  const timestamp = formatCardTime(item.at);
+
+  if (!item.parsed) {
+    return (
+      <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2">
+        <span className="flex items-center gap-2">
+          <Rocket size={11} aria-hidden className="text-success" />
+          <span className="text-2xs font-medium uppercase tracking-wide text-success/80">
+            workflow start
+          </span>
+        </span>
+        <div className="mt-1 overflow-x-auto rounded-md bg-background p-2 text-xs">
+          <Markdown text={item.raw} />
+        </div>
+        <p className="mt-1 text-right text-2xs text-muted-foreground">{timestamp}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-success/30 bg-success/5 px-3 py-2">
+      <span className="flex items-center gap-2">
+        <Rocket size={11} aria-hidden className="text-success" />
+        <span className="text-2xs font-medium uppercase tracking-wide text-success/80">
+          workflow start
+        </span>
+      </span>
+
+      <Collapsible
+        open={goalOpen}
+        onOpenChange={setGoalOpen}
+        trigger={
+          <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+            goal
+          </span>
+        }
+      >
+        <div className="overflow-x-auto text-xs text-foreground/85">
+          <Markdown text={item.goal} />
+        </div>
+      </Collapsible>
+
+      {item.instructions.length > 0 ? (
+        <div className="flex flex-col gap-1">
+          <span className="px-2 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+            what to do
+          </span>
+          <div className="overflow-x-auto rounded-md bg-background p-2 text-xs text-foreground">
+            <Markdown text={item.instructions} />
+          </div>
+        </div>
+      ) : null}
+
+      {item.marker.length > 0 ? (
+        <Collapsible
+          open={markerOpen}
+          onOpenChange={setMarkerOpen}
+          trigger={
+            <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+              marker to emit
+            </span>
+          }
+        >
+          <div className="overflow-x-auto rounded-md bg-background p-2 text-xs text-foreground/70">
+            <Markdown text={item.marker} />
+          </div>
+        </Collapsible>
+      ) : null}
+
+      <p className="text-right text-2xs text-muted-foreground">{timestamp}</p>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.test.ts
+++ b/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { isWorkflowKickoff, parseWorkflowKickoff } from './parse-workflow-kickoff';
+
+const marker = [
+  'Complete ONLY this workflow step. Do not start later steps or work on their scope.',
+  'When this step is fully complete, emit on its own line exactly:',
+  '<<step-done id="agent-1">>',
+  'Do not emit that marker until the step is truly done.',
+].join('\n');
+
+const withPlan = [
+  'Workflow goal:\n\nShip the onboarding wizard',
+  'Active plan to execute:\n\n1. wire steps\n2. add tests',
+  'Focus on the providers step only.',
+  marker,
+].join('\n\n');
+
+const withoutPlan = [
+  'Workflow goal:\n\nShip the onboarding wizard',
+  'Focus on the providers step only.',
+  marker,
+].join('\n\n');
+
+describe('isWorkflowKickoff', () => {
+  it('is true for a composed kickoff', () => {
+    expect(isWorkflowKickoff(withPlan)).toBe(true);
+    expect(isWorkflowKickoff(withoutPlan)).toBe(true);
+  });
+
+  it('is false for a plain user message', () => {
+    expect(isWorkflowKickoff('can you fix the login bug?')).toBe(false);
+  });
+
+  it('is false when only one anchor is present', () => {
+    expect(isWorkflowKickoff('Workflow goal:\n\ndo a thing')).toBe(false);
+    expect(isWorkflowKickoff('Complete ONLY this workflow step now')).toBe(false);
+  });
+});
+
+describe('parseWorkflowKickoff', () => {
+  it('splits goal, instructions (incl. plan) and marker when a plan is present', () => {
+    const parsed = parseWorkflowKickoff(withPlan);
+    expect(parsed.parsed).toBe(true);
+    expect(parsed.goal).toBe('Ship the onboarding wizard');
+    expect(parsed.instructions).toContain('Active plan to execute:');
+    expect(parsed.instructions).toContain('Focus on the providers step only.');
+    expect(parsed.marker.startsWith('Complete ONLY this workflow step')).toBe(true);
+  });
+
+  it('splits on the first paragraph when no plan is present', () => {
+    const parsed = parseWorkflowKickoff(withoutPlan);
+    expect(parsed.parsed).toBe(true);
+    expect(parsed.goal).toBe('Ship the onboarding wizard');
+    expect(parsed.instructions).toBe('Focus on the providers step only.');
+  });
+
+  it('keeps only the first paragraph as goal for a multi-paragraph goal', () => {
+    const text = ['Workflow goal:\n\nMain objective', 'Secondary detail paragraph', marker].join(
+      '\n\n',
+    );
+    const parsed = parseWorkflowKickoff(text);
+    expect(parsed.parsed).toBe(true);
+    expect(parsed.goal).toBe('Main objective');
+    expect(parsed.instructions).toBe('Secondary detail paragraph');
+  });
+
+  it('returns parsed:false for non-kickoff text', () => {
+    const parsed = parseWorkflowKickoff('just a normal message');
+    expect(parsed.parsed).toBe(false);
+    expect(parsed.goal).toBe('');
+    expect(parsed.marker).toBe('');
+  });
+
+  it('returns parsed:false when the goal body is empty', () => {
+    const malformed = `Workflow goal:\n\n\n\n${marker}`;
+    const parsed = parseWorkflowKickoff(malformed);
+    expect(parsed.parsed).toBe(false);
+  });
+
+  it('returns parsed:false when the goal is only whitespace', () => {
+    const malformed = `Workflow goal:\n\n   \n\n${marker}`;
+    const parsed = parseWorkflowKickoff(malformed);
+    expect(parsed.parsed).toBe(false);
+    expect(parsed.goal).toBe('');
+  });
+
+  it('still captures the marker on a parsed:false empty-goal result', () => {
+    const malformed = `Workflow goal:\n\n\n\n${marker}`;
+    const parsed = parseWorkflowKickoff(malformed);
+    expect(parsed.parsed).toBe(false);
+    expect(parsed.marker).toContain('Complete ONLY this workflow step');
+  });
+
+  it('handles no paragraph break — goal is the whole body, instructions empty', () => {
+    const text = `Workflow goal:\n\nSingle line goal with no break\n\n${marker}`;
+    const parsed = parseWorkflowKickoff(text);
+    expect(parsed.parsed).toBe(true);
+    expect(parsed.goal).toBe('Single line goal with no break');
+    expect(parsed.instructions).toBe('');
+  });
+
+  it('returns all four fields on a successful parse', () => {
+    const parsed = parseWorkflowKickoff(withPlan);
+    expect(typeof parsed.goal).toBe('string');
+    expect(typeof parsed.instructions).toBe('string');
+    expect(typeof parsed.marker).toBe('string');
+    expect(parsed.parsed).toBe(true);
+  });
+
+  it('marker contains the full step-done instruction block', () => {
+    const parsed = parseWorkflowKickoff(withPlan);
+    expect(parsed.marker).toContain('Complete ONLY this workflow step');
+    expect(parsed.marker).toContain('<<step-done id="agent-1">>');
+    expect(parsed.marker).toContain('Do not emit that marker until the step is truly done.');
+  });
+
+  it('instructions include plan body when plan is present', () => {
+    const parsed = parseWorkflowKickoff(withPlan);
+    expect(parsed.instructions).toContain('1. wire steps');
+    expect(parsed.instructions).toContain('2. add tests');
+  });
+
+  it('is deterministic — same input produces same output on repeated calls', () => {
+    const a = parseWorkflowKickoff(withPlan);
+    const b = parseWorkflowKickoff(withPlan);
+    expect(a).toEqual(b);
+  });
+});

--- a/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.ts
+++ b/apps/desktop/src/features/chat/utils/parse-workflow-kickoff.ts
@@ -1,0 +1,49 @@
+const GOAL_LABEL = 'Workflow goal:';
+const PLAN_LABEL = 'Active plan to execute:';
+const MARKER_ANCHOR = 'Complete ONLY this workflow step';
+
+export type ParsedWorkflowKickoff = {
+  goal: string;
+  instructions: string;
+  marker: string;
+  parsed: boolean;
+};
+
+export const isWorkflowKickoff = (text: string): boolean =>
+  text.startsWith(GOAL_LABEL) && text.includes(MARKER_ANCHOR);
+
+export const parseWorkflowKickoff = (text: string): ParsedWorkflowKickoff => {
+  const fail: ParsedWorkflowKickoff = { goal: '', instructions: '', marker: '', parsed: false };
+  if (!isWorkflowKickoff(text)) {
+    return fail;
+  }
+
+  const markerIndex = text.indexOf(MARKER_ANCHOR);
+  if (markerIndex < 0) {
+    return fail;
+  }
+  const marker = text.slice(markerIndex).trim();
+  const body = text.slice(GOAL_LABEL.length, markerIndex).replace(/^\s+/, '');
+
+  const planIndex = body.indexOf(PLAN_LABEL);
+  let goal: string;
+  let instructions: string;
+  if (planIndex >= 0) {
+    goal = body.slice(0, planIndex).trim();
+    instructions = body.slice(planIndex).trim();
+  } else {
+    const paragraphBreak = body.indexOf('\n\n');
+    if (paragraphBreak >= 0) {
+      goal = body.slice(0, paragraphBreak).trim();
+      instructions = body.slice(paragraphBreak).trim();
+    } else {
+      goal = body.trim();
+      instructions = '';
+    }
+  }
+
+  if (goal.length === 0) {
+    return { goal: '', instructions: '', marker, parsed: false };
+  }
+  return { goal, instructions, marker, parsed: true };
+};

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -9,6 +9,7 @@ import type {
 } from '@goodboy/types';
 import { isOpenQuestionAnswerText } from '@goodboy/core';
 import { decodeAuthRequiredMessage } from '../turn';
+import { isWorkflowKickoff, parseWorkflowKickoff } from './parse-workflow-kickoff';
 
 export type TranscriptItem =
   | {
@@ -43,6 +44,16 @@ export type TranscriptItem =
       toStep: { ordinal: number; name: string };
       carryForwardContext: string;
       at: string;
+    }
+  | {
+      kind: 'workflow_kickoff';
+      key: string;
+      goal: string;
+      instructions: string;
+      marker: string;
+      raw: string;
+      parsed: boolean;
+      at: IsoDateTime;
     }
   | { kind: 'oq_answer'; key: string }
   | { kind: 'done'; key: string }
@@ -118,6 +129,20 @@ export const reduceTranscript = (
       case 'user_text':
         if (isOpenQuestionAnswerText(event.text)) {
           items.push({ kind: 'oq_answer', key: `oq-answer-${i}` });
+          break;
+        }
+        if (isWorkflowKickoff(event.text)) {
+          const parsed = parseWorkflowKickoff(event.text);
+          items.push({
+            kind: 'workflow_kickoff',
+            key: `kickoff-${i}`,
+            goal: parsed.goal,
+            instructions: parsed.instructions,
+            marker: parsed.marker,
+            raw: event.text,
+            parsed: parsed.parsed,
+            at: event.at,
+          });
           break;
         }
         items.push({


### PR DESCRIPTION
## Summary
- Workflow kickoff messages now render as a dedicated `WorkflowKickoffCard`, visually separate from plain user messages.
- Card layout: explicit **what to do** (instructions, expanded), with **goal** and **marker to emit** collapsed by default.
- New `parse-workflow-kickoff` util splits the kickoff text (emitted by `store/kickoff.ts`) into goal / instructions / marker; falls back to raw markdown when unparseable.
- New `workflow_kickoff` transcript item kind, branched in the `user_text` reducer path after the OQ check.

## Test plan
- [ ] `parse-workflow-kickoff.test.ts` — parser: plan-present/absent, whitespace goal, no breaks, determinism, `parsed:false`
- [ ] `transcript-items.test.ts` — reducer: item shape, `at`/`key`, priority order, buffering
- [ ] `WorkflowKickoffCard/index.test.tsx` — header states, collapse toggles, empty-section omission, raw fallback, timestamp
- [ ] Full desktop suite green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)