### PR TITLE
feat(desktop): realign gemini provider to antigravity cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ spend.
 Bring the subscription you already pay for. Goodboy drives the official CLIs
 locally, on your existing plan, never on a metered API key.
 
-| Provider               | CLI                                  | Subscription     |
-| ---------------------- | ------------------------------------ | ---------------- |
-| **Anthropic (Claude)** | `npm i -g @anthropic-ai/claude-code` | Claude Max / Pro |
-| **Cursor**             | Cursor desktop app                   | Cursor Pro       |
-| **OpenAI (Codex)**     | `npm i -g @openai/codex`             | ChatGPT Pro      |
-| **Google (Gemini)**    | `npm i -g @google/gemini-cli`        | Google AI Pro    |
+| Provider                 | CLI                                                            | Subscription     |
+| ------------------------ | -------------------------------------------------------------- | ---------------- |
+| **Anthropic (Claude)**   | `npm i -g @anthropic-ai/claude-code`                           | Claude Max / Pro |
+| **Cursor**               | Cursor desktop app                                             | Cursor Pro       |
+| **OpenAI (Codex)**       | `npm i -g @openai/codex`                                       | ChatGPT Pro      |
+| **Google (Antigravity)** | `curl -fsSL https://antigravity.google/cli/install.sh \| bash` | Google AI Pro    |
 
 One connected CLI is enough to start. Full guide:
 [docs/providers.md](./docs/providers.md).

--- a/apps/desktop/src-tauri/src/planner.rs
+++ b/apps/desktop/src-tauri/src/planner.rs
@@ -105,10 +105,11 @@ fn build_cli_args(args: &PlannerArgs) -> Result<Vec<String>, PlannerError> {
             format!("{}\n\n{}", args.system_prompt, args.user_message),
         ]),
         "gemini" => Ok(vec![
-            "-m".to_string(),
-            args.model.clone(),
             "-p".to_string(),
             format!("{}\n\n{}", args.system_prompt, args.user_message),
+            "--model".to_string(),
+            args.model.clone(),
+            "--sandbox".to_string(),
         ]),
         other => Err(PlannerError::UnknownProvider(other.to_string())),
     }

--- a/apps/desktop/src-tauri/src/providers.rs
+++ b/apps/desktop/src-tauri/src/providers.rs
@@ -59,7 +59,7 @@ pub fn detect_codex() -> ProviderStatus {
 }
 
 pub fn detect_gemini() -> ProviderStatus {
-    detect_binary("gemini", "gemini")
+    detect_binary("gemini", "agy")
 }
 
 fn detect_binary(id: &str, binary: &str) -> ProviderStatus {
@@ -417,14 +417,14 @@ fn check_codex_auth() -> AuthState {
     }
 }
 
+fn gemini_creds_dir() -> Option<std::path::PathBuf> {
+    Some(dirs::home_dir()?.join(".gemini/antigravity-cli"))
+}
+
 fn extract_gemini_identity_from_creds() -> Option<String> {
-    // gemini-cli stores OAuth credentials at `~/.gemini/oauth_creds.json` after
-    // an interactive login; the `email` field carries the user's Google identity.
-    // Fallback paths covered: legacy `~/.config/gemini/auth.json`.
-    let home = dirs::home_dir()?;
-    for rel in ["./.gemini/oauth_creds.json", "./.config/gemini/auth.json"] {
-        let path = home.join(rel);
-        let Ok(content) = std::fs::read_to_string(&path) else {
+    let dir = gemini_creds_dir()?;
+    for entry in std::fs::read_dir(&dir).ok()?.flatten() {
+        let Ok(content) = std::fs::read_to_string(entry.path()) else {
             continue;
         };
         let Ok(root) = serde_json::from_str::<serde_json::Value>(&content) else {
@@ -442,17 +442,29 @@ fn extract_gemini_identity_from_creds() -> Option<String> {
     None
 }
 
+fn gemini_creds_present() -> bool {
+    gemini_creds_dir()
+        .and_then(|d| std::fs::read_dir(d).ok())
+        .map(|mut entries| entries.any(|e| e.is_ok()))
+        .unwrap_or(false)
+}
+
 fn check_gemini_auth() -> AuthState {
-    // gemini-cli (v0.x) has no `auth status`-like subcommand. Past attempts to
-    // probe `gemini auth status`/`whoami` either hung interactively (no TTY)
-    // or printed help, costing 3 × AUTH_TIMEOUT per refresh. The credentials
-    // file is the actual ground truth — gemini writes it on every successful
-    // login and removes it on logout — so we read it directly. Fast, accurate,
-    // no subprocess.
+    // antigravity (`agy`) persists session state under `~/.gemini/antigravity-cli/`
+    // after a successful login and clears it on logout, so the directory is the
+    // ground truth. Read it directly: fast, accurate, no interactive subprocess.
+    // API-key auth (GEMINI_API_KEY) leaves no creds dir and is surfaced as
+    // connected by the credential layer instead.
     if let Some(identity) = extract_gemini_identity_from_creds() {
         return AuthState {
             state: AuthStateKind::Connected,
             identity: Some(identity),
+        };
+    }
+    if gemini_creds_present() {
+        return AuthState {
+            state: AuthStateKind::Connected,
+            identity: None,
         };
     }
     AuthState {
@@ -569,7 +581,7 @@ pub fn refresh_codex_status(state: State<'_, CodexState>) -> ProviderStatus {
 pub fn get_gemini_status(state: State<'_, GeminiState>) -> ProviderStatus {
     state.0.lock().map(|s| s.clone()).unwrap_or_else(|_| ProviderStatus {
         id: "gemini".to_string(),
-        binary: "gemini".to_string(),
+        binary: "agy".to_string(),
         available: false,
         version: None,
         error: Some("status mutex poisoned".to_string()),

--- a/apps/desktop/src-tauri/src/turn.rs
+++ b/apps/desktop/src-tauri/src/turn.rs
@@ -139,24 +139,24 @@ fn build_provider_cli_args(binary: &str, args: &SpawnOneArgs<'_>) -> Vec<String>
             v.shrink_to_fit();
             v
         }
-        "gemini" => {
-            // gemini-cli v0.x headless mode: `-m <model> -p <prompt>`. Working
-            // directory is set on the spawned child via current_dir(), the CLI
-            // has no --cwd/--workspace flag yet. No resume/system_prompt/tool
-            // gates are honoured by the binary today.
+        "agy" => {
             let _ = (
-                args.permission_mode,
                 args.allowed_tools,
                 args.disallowed_tools,
                 args.resume_session_id,
                 args.system_prompt,
             );
             let mut v = vec![
-                "-m".to_string(),
-                args.model.to_string(),
                 "-p".to_string(),
                 args.prompt.to_string(),
+                "--model".to_string(),
+                args.model.to_string(),
             ];
+            if args.permission_mode == "bypassPermissions" {
+                v.push("--dangerously-skip-permissions".to_string());
+            } else {
+                v.push("--sandbox".to_string());
+            }
             v.shrink_to_fit();
             v
         }

--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -17,7 +17,7 @@ const ANTHROPIC = [
 
 const CODEX = ['gpt-5.4-mini', 'gpt-5.2', 'gpt-5.3-codex', 'gpt-5.4', 'gpt-5.5'];
 
-const GEMINI = ['gemini-2.5-flash-lite', 'gemini-2.5-flash', 'gemini-2.5-pro'];
+const GEMINI = ['gemini-3.5-flash', 'gemini-3.1-pro'];
 
 describe('suggestLighterModel', () => {
   it('Opus 4.8 → Sonnet 4.6, strong, about 1.7x cheaper', () => {
@@ -59,7 +59,7 @@ describe('suggestLighterModel', () => {
   });
 
   it('gemini: Pro has no mid tier, so no suggestion instead of falling to Flash', () => {
-    expect(suggestLighterModel('gemini-2.5-pro', GEMINI)).toBeNull();
+    expect(suggestLighterModel('gemini-3.1-pro', GEMINI)).toBeNull();
   });
 });
 
@@ -121,11 +121,11 @@ describe('suggestHeavierModel', () => {
   });
 
   it('gemini: Flash → Pro', () => {
-    expect(suggestHeavierModel('gemini-2.5-flash', GEMINI)?.id).toBe('gemini-2.5-pro');
+    expect(suggestHeavierModel('gemini-3.5-flash', GEMINI)?.id).toBe('gemini-3.1-pro');
   });
 
   it('never downgrades the cost tier to gain weight', () => {
-    expect(suggestHeavierModel('gemini-2.5-pro', GEMINI)).toBeNull();
+    expect(suggestHeavierModel('gemini-3.1-pro', GEMINI)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -38,7 +38,8 @@ const {
     providerSpendBreakdown: ReadonlyArray<never>;
     selectedAgentId: Record<string, string>;
     agentTurnState: Record<string, never>;
-    agentModelOverride: Record<string, never>;
+    agentModelOverride: Record<string, string>;
+    agentProviderOverride: Record<string, never>;
     agentKindOverride: Record<string, never>;
     agentRunHistory: Record<string, never>;
     agentDraft: Record<string, string>;
@@ -79,6 +80,7 @@ const {
     selectedAgentId: { 'session-1': 'agent-1' },
     agentTurnState: {},
     agentModelOverride: {},
+    agentProviderOverride: {},
     agentKindOverride: {},
     agentRunHistory: {},
     agentDraft: {},
@@ -155,13 +157,18 @@ vi.mock('../../turn', () => ({
 
 vi.mock('@goodboy/core', () => ({
   buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
-  getDefaultTurnModel: () => 'claude-3-5-sonnet-latest',
+  getDefaultTurnModel: (id: string) => (id === 'cursor' ? 'auto' : 'claude-3-5-sonnet-latest'),
   getModelDescriptor: () => null,
   PROVIDER_CAPABILITIES: {
     anthropic: {
       models: [{ id: 'claude-3-5-sonnet-latest', tier: 'turn', contextWindow: 200_000 }],
     },
-    cursor: { models: [{ id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 }] },
+    cursor: {
+      models: [
+        { id: 'auto', tier: 'turn', contextWindow: 200_000 },
+        { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
+      ],
+    },
     codex: { models: [{ id: 'codex-latest', tier: 'turn', contextWindow: 128_000 }] },
   },
   resolveProvider: vi.fn(async () => ({
@@ -299,7 +306,36 @@ describe('ChatInput, input wiring', () => {
     expect(sendTurnMock).toHaveBeenCalledOnce();
     expect(sendTurnMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        override: expect.objectContaining({ providerId: 'cursor' }),
+        override: { providerId: 'cursor', model: 'auto' },
+      }),
+    );
+  });
+
+  it('sends cursor when the picker shows cursor even with an anthropic agent model pin', async () => {
+    mockStore.setState({
+      agentModelOverride: { 'agent-1': 'claude-haiku-4-5' },
+    });
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        session={makeSession({
+          providerPreference: {
+            defaultProvider: 'anthropic' as Session['providerPreference']['defaultProvider'],
+            allowTurnOverride: true,
+          },
+          providerOverride: 'cursor',
+        })}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'use cursor');
+    await user.keyboard('{Enter}');
+
+    expect(sendTurnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        override: { providerId: 'cursor', model: 'auto' },
       }),
     );
   });

--- a/apps/desktop/src/features/chat/components/ChatInput/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.tsx
@@ -123,12 +123,22 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
   };
   const [lastFailedTurn, setLastFailedTurn] = useState<FailedTurn | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const [selectedProvider, setSelectedProviderState] = useState<ProviderId | null>(() =>
-    asProvider(session.providerOverride),
-  );
-  const [selectedModel, setSelectedModelState] = useState<string | null>(
-    () => session.modelOverride ?? null,
-  );
+  const [selectedProvider, setSelectedProviderState] = useState<ProviderId | null>(() => {
+    const initialAgentId = useAppStore.getState().selectedAgentId[session.id] ?? null;
+    const initialRuns = useAppStore.getState().sessionPhaseRuns[session.id] ?? [];
+    const initialAgent = initialAgentId
+      ? (initialRuns.find((r) => r.id === initialAgentId) ?? null)
+      : null;
+    return asProvider(initialAgent?.providerOverride) ?? asProvider(session.providerOverride);
+  });
+  const [selectedModel, setSelectedModelState] = useState<string | null>(() => {
+    const initialAgentId = useAppStore.getState().selectedAgentId[session.id] ?? null;
+    const initialRuns = useAppStore.getState().sessionPhaseRuns[session.id] ?? [];
+    const initialAgent = initialAgentId
+      ? (initialRuns.find((r) => r.id === initialAgentId) ?? null)
+      : null;
+    return initialAgent?.modelOverride ?? session.modelOverride ?? null;
+  });
   const [effort, setEffortState] = useState<EffortLevel>(
     () => asEffortLevel(session.effort) ?? 'medium',
   );
@@ -176,6 +186,9 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
   const agentModelOverride = useAppStore((s) =>
     selectedAgentId ? (s.agentModelOverride[selectedAgentId] ?? null) : null,
   );
+  const agentProviderOverride = useAppStore((s) =>
+    selectedAgentId ? (s.agentProviderOverride[selectedAgentId] ?? null) : null,
+  );
   const isFirstTurnForAgent = useAppStore((s) =>
     selectedAgentId ? (s.agentRunHistory[selectedAgentId]?.length ?? 0) === 0 : false,
   );
@@ -205,27 +218,23 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
   const allowOverride = session.providerPreference.allowTurnOverride;
   const defaultProvider = session.providerPreference.defaultProvider;
 
-  const effectiveProvider: ProviderId = selectedProvider ?? defaultProvider;
+  const effectiveProvider: ProviderId =
+    selectedProvider ?? agentProviderOverride ?? defaultProvider;
   const defaultModel =
     agentModelOverride ??
     session.providerPreference.defaultModel ??
     getDefaultTurnModel(defaultProvider);
   const effectiveModel =
     selectedModel ??
+    session.modelOverride ??
     (effectiveProvider === defaultProvider ? defaultModel : getDefaultTurnModel(effectiveProvider));
   const effectiveEffort = clampEffort(effectiveModel, effort);
 
   const providerModels = PROVIDER_CAPABILITIES[effectiveProvider].models;
 
-  const providerChanged = selectedProvider !== null && selectedProvider !== defaultProvider;
-  const modelChanged = selectedModel !== null && selectedModel !== defaultModel;
-  const routingOverride: TurnProviderOverride | undefined =
-    allowOverride && (providerChanged || modelChanged)
-      ? {
-          providerId: effectiveProvider,
-          ...(modelChanged ? { model: effectiveModel } : {}),
-        }
-      : undefined;
+  const routingOverride: TurnProviderOverride | undefined = allowOverride
+    ? { providerId: effectiveProvider, model: effectiveModel }
+    : undefined;
 
   const connectedProviderIds = connectedProviders.map((p) => p.id);
 
@@ -341,14 +350,9 @@ export const ChatInput = ({ session, providerDisconnected = false }: Props) => {
     atts: ReadonlyArray<PendingAttachment>,
     modelOverrideId: string | null,
   ) => {
-    const useModel = modelOverrideId ?? (modelChanged ? effectiveModel : null);
-    const override: TurnProviderOverride | undefined =
-      allowOverride && (providerChanged || useModel !== null)
-        ? {
-            providerId: effectiveProvider,
-            ...(useModel !== null ? { model: useModel } : {}),
-          }
-        : undefined;
+    const override: TurnProviderOverride | undefined = allowOverride
+      ? { providerId: effectiveProvider, model: modelOverrideId ?? effectiveModel }
+      : undefined;
 
     if (isRunning) {
       enqueue({ id: crypto.randomUUID(), content, attachments: atts, override });

--- a/apps/desktop/src/features/chat/components/ModelPicker/index.tsx
+++ b/apps/desktop/src/features/chat/components/ModelPicker/index.tsx
@@ -231,14 +231,15 @@ export const ModelPicker = ({
                   if (isConnected) {
                     return CHIP_INACTIVE;
                   }
-                  return 'text-muted-foreground/35 hover:bg-muted/50';
+                  return 'cursor-not-allowed text-muted-foreground/35 opacity-60 hover:bg-muted/40';
                 })();
                 return (
                   <button
                     key={id}
                     type="button"
                     onClick={() => onSelectProvider(id)}
-                    title={isConnected ? undefined : 'not connected'}
+                    aria-disabled={!isConnected}
+                    title={isConnected ? undefined : 'not connected, click to connect'}
                     className={cn('rounded-full px-2.5 py-0.5 transition-colors', chipTone)}
                   >
                     {PROVIDER_LABEL[id]}

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/guides.ts
@@ -16,7 +16,7 @@ export type ProviderGuide = {
 const ANTHROPIC_DOCS = 'https://docs.claude.com/en/docs/claude-code/overview';
 const CURSOR_DOCS = 'https://docs.cursor.com/en/cli/installation';
 const CODEX_DOCS = 'https://github.com/openai/codex#installation';
-const GEMINI_DOCS = 'https://github.com/google-gemini/gemini-cli#installation';
+const GEMINI_DOCS = 'https://antigravity.google/cli';
 
 const INSTALL_GUIDES: Record<ProviderId, ProviderGuide> = {
   anthropic: {
@@ -80,24 +80,24 @@ const INSTALL_GUIDES: Record<ProviderId, ProviderGuide> = {
     docsLabel: 'Codex install guide',
   },
   gemini: {
-    headline: 'Install Gemini CLI',
-    subscription: 'Google AI Pro plan, or any Google account on the free tier.',
+    headline: 'Install Antigravity CLI',
+    subscription: 'Google AI Pro plan, or a Gemini API key on the free tier.',
     steps: [
       {
-        title: 'npm global install',
-        body: 'Fetches `@google/gemini-cli` and exposes the `gemini` command on your PATH. Node 20+ required.',
+        title: 'Curl installer',
+        body: 'The official script downloads the `agy` binary for your OS and drops it into `~/.local/bin`. Antigravity is the successor to the Gemini CLI.',
       },
       {
-        title: 'Sign-in is interactive',
-        body: 'Running `gemini` opens an interactive menu in the terminal where you pick the OAuth flow. Click in the terminal and use the arrow keys, the prompt accepts input directly.',
+        title: 'PATH check',
+        body: 'After install, restart Goodboy if `agy` does not show up. Some shells need a new session before the new PATH takes effect.',
       },
       {
-        title: 'Auth lives in a file',
-        body: 'After login Gemini writes `~/.gemini/oauth_creds.json`. Goodboy reads that file to know you are connected, no subprocess polling needed.',
+        title: 'Then connect',
+        body: 'Goodboy moves to the connect step. You sign in with `agy login` or paste a Gemini API key, whichever you prefer.',
       },
     ],
     docsUrl: GEMINI_DOCS,
-    docsLabel: 'Gemini CLI docs',
+    docsLabel: 'Antigravity CLI docs',
   },
 };
 
@@ -151,20 +151,20 @@ const LOGIN_GUIDES: Record<ProviderId, ProviderGuide> = {
     docsLabel: 'Codex sign-in',
   },
   gemini: {
-    headline: 'Sign in to Gemini',
-    subscription: 'Your Google account (free or AI Pro).',
+    headline: 'Connect Antigravity',
+    subscription: 'Your Google account, or a Gemini API key.',
     steps: [
       {
-        title: 'Pick the OAuth flow',
-        body: 'Gemini drops you into an interactive menu. Click in the terminal and use the arrow keys to choose "Login with Google".',
+        title: 'Browser handoff',
+        body: '`agy login` opens Google in the browser. Sign in, grant the scopes, and Antigravity writes the session to `~/.gemini/antigravity-cli/`.',
       },
       {
-        title: 'Browser handoff',
-        body: 'Google opens in the browser. Sign in, grant the requested scopes, and Gemini writes the token to `~/.gemini/oauth_creds.json`.',
+        title: 'API-key alternative',
+        body: 'Prefer a key? Paste a Gemini API key instead and Goodboy stores it as GEMINI_API_KEY for `agy`. No browser round-trip.',
       },
     ],
     docsUrl: GEMINI_DOCS,
-    docsLabel: 'Gemini CLI auth',
+    docsLabel: 'Antigravity CLI auth',
   },
 };
 
@@ -206,16 +206,16 @@ const LOGOUT_GUIDES: Record<ProviderId, ProviderGuide> = {
     docsLabel: 'Codex docs',
   },
   gemini: {
-    headline: 'Sign out of Gemini',
+    headline: 'Sign out of Antigravity',
     subscription: '',
     steps: [
       {
-        title: 'File removal',
-        body: 'Gemini has no `logout` subcommand. Goodboy removes `~/.gemini/oauth_creds.json` directly, which is what gemini reads on startup.',
+        title: 'Local-only',
+        body: 'Goodboy removes `~/.gemini/antigravity-cli/`, the session state `agy` reads on startup. Your Google account stays intact.',
       },
     ],
     docsUrl: GEMINI_DOCS,
-    docsLabel: 'Gemini CLI docs',
+    docsLabel: 'Antigravity CLI docs',
   },
 };
 

--- a/apps/desktop/src/features/providers/pricing.json
+++ b/apps/desktop/src/features/providers/pricing.json
@@ -11,12 +11,7 @@
     "codex-mini-latest": { "inputPerMtok": 1.5, "outputPerMtok": 6, "cachedInputPerMtok": 0.75 }
   },
   "gemini": {
-    "gemini-2.5-pro": { "inputPerMtok": 1.25, "outputPerMtok": 10, "cachedInputPerMtok": 0.31 },
-    "gemini-2.5-flash": { "inputPerMtok": 0.3, "outputPerMtok": 2.5, "cachedInputPerMtok": 0.075 },
-    "gemini-2.5-flash-lite": {
-      "inputPerMtok": 0.1,
-      "outputPerMtok": 0.4,
-      "cachedInputPerMtok": 0.025
-    }
+    "gemini-3.1-pro": { "inputPerMtok": 2, "outputPerMtok": 12 },
+    "gemini-3.5-flash": { "inputPerMtok": 1.5, "outputPerMtok": 9 }
   }
 }

--- a/apps/desktop/src/features/providers/providers.ts
+++ b/apps/desktop/src/features/providers/providers.ts
@@ -39,14 +39,14 @@ const PROVIDER_DOCS: Record<ProviderId, string> = {
   anthropic: 'https://docs.claude.com/en/docs/claude-code/overview',
   cursor: 'https://docs.cursor.com/en/cli/installation',
   codex: 'https://github.com/openai/codex#installation',
-  gemini: 'https://github.com/google-gemini/gemini-cli#installation',
+  gemini: 'https://antigravity.google/cli',
 };
 
 const PROVIDER_DEFAULT_BINARY: Record<ProviderId, string> = {
   anthropic: 'claude',
   cursor: 'cursor-agent',
   codex: 'codex',
-  gemini: 'gemini',
+  gemini: 'agy',
 };
 
 const TAURI_GET_CMD: Record<ProviderId, string> = {

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -84,7 +84,7 @@ function getCheapModel(providerId: ProviderId): string {
     case 'codex':
       return 'gpt-5.4-mini';
     case 'gemini':
-      return 'gemini-2.5-flash';
+      return 'gemini-3.5-flash';
     default: {
       const _exhaustive: never = providerId;
       void _exhaustive;

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -310,6 +310,11 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
 
     const provider: ProviderId = routingDecision.selectedProvider;
     const agentKindModel = get().agentModelOverride[activeAgentId] ?? null;
+    const agentModelApplies =
+      agentKindModel != null &&
+      (agentProvider != null
+        ? agentProvider === routingDecision.selectedProvider
+        : routingDecision.selectedProvider === 'anthropic');
     const turnOverrideActive = turnOverride !== undefined && effectiveOverride === turnOverride;
     const autoStepModel =
       phaseDefinition != null && !phaseDefinition.modelOverride
@@ -324,7 +329,9 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
             ? routingDecision.selectedModel
             : routingDecision.fallbackUsed
               ? routingDecision.selectedModel
-              : (agentKindModel ?? routingDecision.selectedModel);
+              : agentModelApplies
+                ? agentKindModel
+                : routingDecision.selectedModel;
 
     const wsBindings = get().workspaceOverrides[session.workspaceId]?.providerBindings ?? {};
     const sessBindings = get().sessionOverrides[sessionId]?.providerBindings ?? {};

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -394,7 +394,7 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'gemini',
-      selectedModel: 'gemini-2.5-pro',
+      selectedModel: 'gemini-3.1-pro',
       reason: 'override',
     });
     useAppStore.setState({ agentEffortOverride: { [AGENT_A]: 'high' } });
@@ -574,6 +574,33 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
 
     expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-haiku-latest');
+  });
+
+  it('does not apply an anthropic model pin when the routed provider is cursor', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'cursor',
+      selectedModel: 'auto',
+      reason: 'override',
+    });
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          providerPreference: { defaultProvider: 'cursor', allowTurnOverride: true },
+        },
+      ],
+      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.provider).toBe('cursor');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('auto');
   });
 
   it('an explicit per-turn model override beats both the agent provider and model pin', async () => {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -152,60 +152,62 @@ Skipped by default; opt in when you want to verify a fresh install.
 
 ---
 
-## Google (Gemini)
+## Google (Antigravity)
+
+Google deprecated the Gemini CLI consumer "login with Google" flow on 2026-06-18. Antigravity (`agy`) is its official successor: a single Go binary installed via curl.
 
 ### Install
 
 ```bash
-npm install -g @google/gemini-cli
+curl -fsSL https://antigravity.google/cli/install.sh | bash
 ```
 
-Docs: <https://github.com/google-gemini/gemini-cli>
+Docs: <https://antigravity.google/cli>
 
-Verify: `gemini --version`
+Verify: `agy --version`
 
 ### Connect
 
 ```bash
-gemini
+agy login
 ```
 
-Launching the bare binary triggers the OAuth flow on first run — Goodboy spawns it in an external terminal. Complete the Google sign-in in the browser that opens; credentials land in `~/.gemini/oauth_creds.json`.
+`agy login` opens the Google OAuth flow in the browser; session state lands in `~/.gemini/antigravity-cli/`. Alternatively, set a Gemini API key via `GEMINI_API_KEY`, which `agy` honors with no browser round-trip.
 
 ### Disconnect
 
 ```bash
-rm -f ~/.gemini/oauth_creds.json
+rm -rf ~/.gemini/antigravity-cli
 ```
 
-gemini-cli v0.x has no `logout` subcommand. Goodboy wires the disconnect button to remove the credentials file directly.
+Goodboy wires the disconnect button to remove the session directory directly.
 
 ### Subscription tier
 
-Requires **Google AI Pro** (or the free tier with rate caps). Goodboy uses the local CLI's authenticated Google account; no API key is needed when signed in via OAuth.
+Requires **Google AI Pro** (or the free tier with rate caps). Goodboy uses the local CLI's authenticated Google account, or a `GEMINI_API_KEY` credential when set.
 
 ### Default models
 
-Per Google's Gemini 2.5 lineup:
+Per Google's Gemini 3.x lineup:
 
-- **Turn**: `gemini-2.5-pro` (default).
-- **Cheap**: `gemini-2.5-flash` (default), `gemini-2.5-flash-lite`.
+- **Turn**: `gemini-3.1-pro`.
+- **Cheap**: `gemini-3.5-flash` (default).
 
-All three support a 1M-token context window.
+Both support a 1M-token context window.
 
 ### Turn spawn args
 
-Goodboy spawns gemini non-interactively:
+Goodboy spawns `agy` non-interactively:
 
 ```
-gemini -m <MODEL> -p <PROMPT>
+agy -p <PROMPT> --model <MODEL> --sandbox
 ```
 
-The working directory is set on the spawned process; gemini-cli has no `--cwd` flag yet. There is no stable structured JSON output today, so the parser treats each stdout line as an `assistant_text` delta and is forward-compatible with a future `--output-format json` mode.
+`--sandbox` is replaced by `--dangerously-skip-permissions` under bypass permission mode. The working directory is set on the spawned process. `agy` has no stable structured JSON output, so the parser treats each stdout line as an `assistant_text` delta; per-turn token usage is unavailable in headless mode, so cost is estimated from per-token pricing.
 
 ### Auth detection
 
-gemini-cli does not ship a stable `auth status` subcommand. Goodboy probes a few candidates (`gemini auth status`, `gemini whoami`) and falls back to reading the email claim from `~/.gemini/oauth_creds.json` as ground truth. If the providers panel shows "not logged in" after a successful browser flow, click **refresh** so the file check runs again.
+`agy` has no stable `auth status` subcommand. Goodboy reads `~/.gemini/antigravity-cli/` directly as ground truth: an email claim in a session file populates the identity, and any session file marks the provider connected. API-key auth leaves no session directory and is surfaced as connected by the credential layer. If the providers panel shows "not logged in" after a successful login, click **refresh** so the file check runs again.
 
 ---
 

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -33,21 +33,21 @@ describe('autoModelForRole', () => {
     it('picks the matching expensive-tier model for a high-tier role', () => {
       expect(autoModelForRole('planner', ['gemini'])).toEqual({
         provider: 'gemini',
-        model: 'gemini-2.5-pro',
+        model: 'gemini-3.1-pro',
       });
     });
 
     it('picks the highest-weight cheap model for a low-tier role', () => {
       expect(autoModelForRole('scout', ['gemini'])).toEqual({
         provider: 'gemini',
-        model: 'gemini-2.5-flash',
+        model: 'gemini-3.5-flash',
       });
     });
 
     it('treats an unknown role as the custom default tier', () => {
       expect(autoModelForRole('totally-made-up', ['gemini'])).toEqual({
         provider: 'gemini',
-        model: 'gemini-2.5-pro',
+        model: 'gemini-3.1-pro',
       });
     });
 

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,7 +1,7 @@
 import type { ModelEffort, ProviderId, ProviderRegistryCapabilities } from '@goodboy/types';
 import { CURSOR_AUTO_MODEL, CURSOR_MODELS } from './cursor/models';
 import { CODEX_MODELS } from './codex/constants';
-import { GEMINI_MODELS } from './gemini/constants';
+import { GEMINI_DEFAULT_MODEL, GEMINI_MODELS } from './gemini/constants';
 
 const OPUS_EFFORT: ReadonlyArray<ModelEffort> = ['low', 'medium', 'high', 'extra-high', 'max'];
 const SONNET_EFFORT: ReadonlyArray<ModelEffort> = ['low', 'medium', 'high'];
@@ -125,6 +125,9 @@ export const getCapabilities = (id: ProviderId): ProviderRegistryCapabilities =>
 export const getDefaultTurnModel = (id: ProviderId): string => {
   if (id === 'cursor') {
     return CURSOR_AUTO_MODEL;
+  }
+  if (id === 'gemini') {
+    return GEMINI_DEFAULT_MODEL;
   }
   const caps = PROVIDER_CAPABILITIES[id];
   return caps.models.find((m) => m.tier === 'turn')?.id ?? caps.models[0]!.id;

--- a/packages/core/src/providers/gemini/adapter.test.ts
+++ b/packages/core/src/providers/gemini/adapter.test.ts
@@ -126,19 +126,23 @@ describe('GeminiAdapter.spawn', () => {
     await expect(collect(adapter)).rejects.toThrow('ENOENT gemini');
   });
 
-  it('passes -m <model> -p <prompt> with system prompt prepended', async () => {
+  it('passes -p <prompt> --model <model> --sandbox with system prompt prepended', async () => {
     let captured: ReadonlyArray<string> = [];
+    let capturedBin = '';
     const child = new FakeChild(['ok']);
-    const spawnFn = ((_bin: string, args: ReadonlyArray<string>) => {
+    const spawnFn = ((bin: string, args: ReadonlyArray<string>) => {
+      capturedBin = bin;
       captured = args;
       return child;
     }) as never;
     const adapter = new GeminiAdapter({ now: fakeNow, spawnFn });
     await collect(adapter);
-    expect(captured[0]).toBe('-m');
-    expect(captured[1]).toBe(GEMINI_DEFAULT_MODEL);
-    expect(captured[2]).toBe('-p');
-    expect(captured[3]).toBe('sys\n\nhi');
+    expect(capturedBin).toBe('agy');
+    expect(captured[0]).toBe('-p');
+    expect(captured[1]).toBe('sys\n\nhi');
+    expect(captured[2]).toBe('--model');
+    expect(captured[3]).toBe(GEMINI_DEFAULT_MODEL);
+    expect(captured[4]).toBe('--sandbox');
   });
 
   it('kills the child on early break', async () => {

--- a/packages/core/src/providers/gemini/adapter.ts
+++ b/packages/core/src/providers/gemini/adapter.ts
@@ -41,7 +41,7 @@ export class GeminiAdapter implements ProviderAdapter {
   private readonly priceOverride: GeminiModelPriceOverride | null;
 
   constructor(deps: GeminiAdapterDeps = {}) {
-    this.binary = deps.binary ?? 'gemini';
+    this.binary = deps.binary ?? 'agy';
     this.now = deps.now ?? (() => new Date().toISOString() as IsoDateTime);
     this.spawnFn = deps.spawnFn ?? spawn;
     this.onUnknown = deps.onUnknown ?? (() => undefined);
@@ -93,7 +93,7 @@ async function* spawnGemini(
   const prompt = request.systemPrompt
     ? `${request.systemPrompt}\n\n${request.userMessage}`
     : request.userMessage;
-  const args = ['-m', request.model, '-p', prompt];
+  const args = ['-p', prompt, '--model', request.model, '--sandbox'];
 
   const child: ChildProcess = spawnFn(binary, args, {
     stdio: ['ignore', 'pipe', 'pipe'],

--- a/packages/core/src/providers/gemini/constants.ts
+++ b/packages/core/src/providers/gemini/constants.ts
@@ -1,43 +1,31 @@
 import type { ModelTier } from '@goodboy/types';
 
-export const GEMINI_DEFAULT_MODEL = 'gemini-2.5-pro';
-export const GEMINI_CHEAP_MODEL = 'gemini-2.5-flash';
+export const GEMINI_DEFAULT_MODEL = 'gemini-3.5-flash';
+export const GEMINI_CHEAP_MODEL = 'gemini-3.5-flash';
 
 export const GEMINI_MODELS: ReadonlyArray<ModelTier> = [
   {
-    id: 'gemini-2.5-pro',
+    id: 'gemini-3.1-pro',
     tier: 'turn',
     contextWindow: 1_000_000,
     family: 'gemini',
     subfamily: 'pro',
-    label: '2.5 Pro',
-    variantLabel: '2.5',
+    label: '3.1 Pro',
+    variantLabel: '3.1',
     costTier: 'expensive',
     weight: 30,
     effort: null,
   },
   {
-    id: 'gemini-2.5-flash',
+    id: 'gemini-3.5-flash',
     tier: 'cheap',
     contextWindow: 1_000_000,
     family: 'gemini',
     subfamily: 'flash',
-    label: '2.5 Flash',
-    variantLabel: '2.5',
+    label: '3.5 Flash',
+    variantLabel: '3.5',
     costTier: 'cheap',
     weight: 8,
-    effort: null,
-  },
-  {
-    id: 'gemini-2.5-flash-lite',
-    tier: 'cheap',
-    contextWindow: 1_000_000,
-    family: 'gemini',
-    subfamily: 'flash',
-    label: '2.5 Flash-Lite',
-    variantLabel: '2.5 Lite',
-    costTier: 'cheap',
-    weight: 6,
     effort: null,
   },
 ];

--- a/packages/core/src/providers/model-price.test.ts
+++ b/packages/core/src/providers/model-price.test.ts
@@ -33,7 +33,7 @@ describe('getModelPrice', () => {
   });
 
   it('returns null for gemini picker ids with no static price table', () => {
-    expect(getModelPrice('gemini-2.5-pro')).toBeNull();
+    expect(getModelPrice('gemini-3.1-pro')).toBeNull();
   });
 
   it('returns null for an unknown model with no fallback', () => {

--- a/packages/core/src/providers/registry.test.ts
+++ b/packages/core/src/providers/registry.test.ts
@@ -9,6 +9,8 @@ import {
   getCapabilities,
   listSupportedProviders,
 } from './registry';
+import { getDefaultTurnModel } from './capabilities';
+import { GEMINI_DEFAULT_MODEL } from './gemini/constants';
 
 describe('listSupportedProviders', () => {
   it('returns all four provider ids', () => {
@@ -88,6 +90,11 @@ describe('getCapabilities', () => {
     const caps = getCapabilities('gemini');
     expect(caps.models.length).toBeGreaterThan(0);
     expect(caps.models.some((m) => m.tier === 'cheap')).toBe(true);
+  });
+
+  it('getDefaultTurnModel for gemini returns the cheap default, not the pro turn model', () => {
+    expect(getDefaultTurnModel('gemini')).toBe(GEMINI_DEFAULT_MODEL);
+    expect(getDefaultTurnModel('gemini')).toBe('gemini-3.5-flash');
   });
 
   it('all models have required fields', () => {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -64,6 +64,8 @@ import { m063OpenQuestionsRecommendedAnswer } from './m063-open-questions-recomm
 import { m064SentryProvider } from './m064-sentry-provider';
 import { m065IntegrationGitlabProvider } from './m065-integration-gitlab-provider';
 import { m066GoalAttachments } from './m066-goal-attachments';
+import { m067GeminiProviderRun } from './m067-gemini-provider-run';
+import { m068ProviderRunsGeminiRepair } from './m068-provider-runs-gemini-repair';
 
 export type Migration = {
   readonly version: number;
@@ -137,4 +139,6 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 64, sql: m064SentryProvider },
   { version: 65, sql: m065IntegrationGitlabProvider },
   { version: 66, sql: m066GoalAttachments },
+  { version: 67, sql: m067GeminiProviderRun },
+  { version: 68, sql: m068ProviderRunsGeminiRepair },
 ];

--- a/packages/db/src/migrations/m067-gemini-provider-run.ts
+++ b/packages/db/src/migrations/m067-gemini-provider-run.ts
@@ -1,0 +1,29 @@
+export const m067GeminiProviderRun = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS provider_runs_new;
+
+CREATE TABLE provider_runs_new (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('anthropic','openai','cursor','codex','gemini')),
+  model TEXT NOT NULL,
+  status_kind TEXT NOT NULL CHECK (status_kind IN ('pending','streaming','succeeded','failed','cancelled')),
+  status_payload TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO provider_runs_new (id, session_id, provider, model, status_kind, status_payload, created_at)
+  SELECT id, session_id, provider, model, status_kind, status_payload, created_at
+  FROM provider_runs;
+
+DROP TABLE provider_runs;
+ALTER TABLE provider_runs_new RENAME TO provider_runs;
+
+DROP INDEX IF EXISTS idx_provider_runs_session_id;
+CREATE INDEX idx_provider_runs_session_id ON provider_runs(session_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/db/src/migrations/m068-provider-runs-gemini-repair.ts
+++ b/packages/db/src/migrations/m068-provider-runs-gemini-repair.ts
@@ -1,0 +1,29 @@
+export const m068ProviderRunsGeminiRepair = /* sql */ `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS provider_runs_repair;
+
+CREATE TABLE provider_runs_repair (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('anthropic','openai','cursor','codex','gemini')),
+  model TEXT NOT NULL,
+  status_kind TEXT NOT NULL CHECK (status_kind IN ('pending','streaming','succeeded','failed','cancelled')),
+  status_payload TEXT NOT NULL DEFAULT '{}',
+  created_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO provider_runs_repair (id, session_id, provider, model, status_kind, status_payload, created_at)
+  SELECT id, session_id, provider, model, status_kind, status_payload, created_at
+  FROM provider_runs;
+
+DROP TABLE provider_runs;
+ALTER TABLE provider_runs_repair RENAME TO provider_runs;
+
+DROP INDEX IF EXISTS idx_provider_runs_session_id;
+CREATE INDEX idx_provider_runs_session_id ON provider_runs(session_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/types/src/provider-commands.ts
+++ b/packages/types/src/provider-commands.ts
@@ -46,11 +46,11 @@ export const PROVIDER_LIFECYCLE_COMMANDS: Record<ProviderId, ProviderLifecycleCo
   },
   gemini: {
     install: {
-      darwin: 'npm install -g @google/gemini-cli',
-      linux: 'npm install -g @google/gemini-cli',
-      win32: 'npm install -g @google/gemini-cli',
+      darwin: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+      linux: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+      win32: 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
     },
-    login: 'gemini',
-    logout: 'rm -f ~/.gemini/oauth_creds.json && echo "gemini credentials removed"',
+    login: 'agy login',
+    logout: 'rm -rf ~/.gemini/antigravity-cli && echo "antigravity credentials removed"',
   },
 };


### PR DESCRIPTION
## Summary
- Migrate gemini off the deprecated gemini-cli "login with google" oauth path (Code Assist for individuals retired 2026-06-18) to the antigravity cli (`agy`).
- Switch binary `gemini`→`agy`, install→curl `antigravity.google/cli/install.sh`, creds `~/.gemini/antigravity-cli/`, env auth `GEMINI_API_KEY`; spawn `-p <prompt> --model <id>`.
- Update models to gemini 3.x: `gemini-3.5-flash` (cheap) + `gemini-3.1-pro`, with pricing; remove oauth login + arrow-key onboarding copy.
- Model picker disables disconnected providers (`aria-disabled`, opacity, `cursor-not-allowed`); click-to-connect still opens Provider Studio.
- DB: `m067` rebuilds `provider_runs` to add `gemini` to the provider CHECK; `m068` repairs partial-apply desync.
- Guard cross-provider model-pin leak (kind agents pinning a claude model while provider=cursor) via `agentModelApplies` in sendTurn.

## Test plan
- [x] `pnpm turbo run test` — 2044 passed
- [x] `pnpm turbo run typecheck` — green
- [x] `cargo test --locked` (src-tauri) — 89 passed
- [x] `pnpm knip` — only config hints, no errors
- [x] `pnpm turbo run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)