### PR TITLE
feat(desktop): lighter, distinct workflow system cards

### DIFF
--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
@@ -23,6 +23,11 @@ describe('PhaseTransitionCard', () => {
     expect(screen.getByText(/plan/i)).toBeDefined();
   });
 
+  it('keeps the carry-forward context collapsed by default', () => {
+    render(<PhaseTransitionCard item={item} />);
+    expect(screen.queryByText('carry me forward')).toBeNull();
+  });
+
   it('reveals the carry-forward context when expanded', () => {
     render(<PhaseTransitionCard item={item} />);
     fireEvent.click(screen.getByRole('button'));

--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { Target } from 'lucide-react';
-import { Collapsible, Markdown } from '@goodboy/ui';
+import { ArrowRight, ChevronRight } from 'lucide-react';
+import { Markdown, cn } from '@goodboy/ui';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatCardTime } from '../../utils/format-card-time';
 
@@ -10,29 +10,50 @@ type Props = {
 
 export const PhaseTransitionCard = ({ item }: Props) => {
   const [open, setOpen] = useState(false);
-  const header = `Step ${item.fromStep.ordinal + 1} ${item.fromStep.name} → Step ${item.toStep.ordinal + 1} ${item.toStep.name}`;
   const timestamp = formatCardTime(item.at);
+  const hasContext = item.carryForwardContext.trim().length > 0;
 
   return (
-    <div className="rounded-md border border-success/30 bg-success/5 px-2 py-1.5">
-      <Collapsible
-        open={open}
-        onOpenChange={setOpen}
-        trigger={
-          <span className="flex items-center gap-2 text-xs font-medium">
-            <Target size={11} aria-hidden className="text-success" />
-            <span className="text-2xs font-medium uppercase tracking-wide text-success/80">
-              step
-            </span>
-            <span className="text-foreground/85">{header}</span>
-          </span>
-        }
+    <div className="border-l-2 border-merged/40">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 rounded-r-md py-1 pl-2 pr-2 text-left motion-safe:transition-colors hover:bg-merged/5"
       >
-        <div className="mt-1 overflow-x-auto rounded-md bg-background p-2 text-xs">
-          <Markdown text={item.carryForwardContext} />
+        <ChevronRight
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-merged/50 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <span className="shrink-0 text-2xs font-medium uppercase tracking-wide text-merged/80">
+          step
+        </span>
+        <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-foreground/70">
+          <span className="truncate">
+            {item.fromStep.ordinal + 1}. {item.fromStep.name}
+          </span>
+          <ArrowRight size={11} aria-hidden className="shrink-0 text-merged/60" />
+          <span className="truncate">
+            {item.toStep.ordinal + 1}. {item.toStep.name}
+          </span>
+        </span>
+        <span className="shrink-0 font-mono text-2xs text-muted-foreground">{timestamp}</span>
+      </button>
+
+      {open && hasContext ? (
+        <div className="ml-2 flex flex-col gap-1 border-l border-merged/20 py-2 pl-3 pr-2">
+          <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+            carried forward
+          </span>
+          <div className="overflow-x-auto text-xs text-foreground/80">
+            <Markdown text={item.carryForwardContext} />
+          </div>
         </div>
-        <p className="mt-1 text-right text-2xs text-muted-foreground">{timestamp}</p>
-      </Collapsible>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.test.tsx
@@ -18,24 +18,35 @@ const parsedItem = {
   parsed: true,
 } as Extract<TranscriptItem, { kind: 'workflow_kickoff' }>;
 
-describe('WorkflowKickoffCard', () => {
-  it('shows the instructions expanded by default', () => {
-    render(<WorkflowKickoffCard item={parsedItem} />);
-    expect(screen.getByText('Focus on the providers step only.')).toBeDefined();
-  });
+const expand = () => fireEvent.click(screen.getByRole('button', { expanded: false }));
 
-  it('keeps the goal collapsed until expanded', () => {
+describe('WorkflowKickoffCard', () => {
+  it('shows the goal as a preview in the collapsed header', () => {
     render(<WorkflowKickoffCard item={parsedItem} />);
-    expect(screen.queryByText('Ship the onboarding wizard')).toBeNull();
-    fireEvent.click(screen.getByText(/^goal$/i));
     expect(screen.getByText('Ship the onboarding wizard')).toBeDefined();
   });
 
-  it('keeps the marker collapsed until expanded', () => {
+  it('keeps instructions and marker collapsed until expanded', () => {
     render(<WorkflowKickoffCard item={parsedItem} />);
+    expect(screen.queryByText('Focus on the providers step only.')).toBeNull();
     expect(screen.queryByText('Complete ONLY this workflow step.')).toBeNull();
-    fireEvent.click(screen.getByText(/marker to emit/i));
+  });
+
+  it('reveals goal, instructions and marker once expanded', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expand();
+    expect(screen.getByText('Focus on the providers step only.')).toBeDefined();
     expect(screen.getByText('Complete ONLY this workflow step.')).toBeDefined();
+    expect(screen.getByText(/what to do/i)).toBeDefined();
+    expect(screen.getByText(/marker to emit/i)).toBeDefined();
+  });
+
+  it('can collapse again after expanding', () => {
+    render(<WorkflowKickoffCard item={parsedItem} />);
+    expand();
+    expect(screen.getByText('Focus on the providers step only.')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+    expect(screen.queryByText('Focus on the providers step only.')).toBeNull();
   });
 
   it('falls back to raw text when not parsed', () => {
@@ -44,15 +55,15 @@ describe('WorkflowKickoffCard', () => {
       { kind: 'workflow_kickoff' }
     >;
     render(<WorkflowKickoffCard item={raw} />);
+    expect(screen.queryByText('raw kickoff text')).toBeNull();
+    expand();
     expect(screen.getByText('raw kickoff text')).toBeDefined();
   });
 
-  it('shows workflow start header in both parsed and unparsed states', () => {
+  it('shows the workflow start header in both parsed and unparsed states', () => {
     render(<WorkflowKickoffCard item={parsedItem} />);
     expect(screen.getByText(/workflow start/i)).toBeDefined();
-  });
-
-  it('shows workflow start header when not parsed', () => {
+    cleanup();
     const raw = { ...parsedItem, parsed: false } as Extract<
       TranscriptItem,
       { kind: 'workflow_kickoff' }
@@ -67,34 +78,18 @@ describe('WorkflowKickoffCard', () => {
       { kind: 'workflow_kickoff' }
     >;
     render(<WorkflowKickoffCard item={noInstructions} />);
+    expand();
     expect(screen.queryByText(/what to do/i)).toBeNull();
   });
 
-  it('omits "marker to emit" collapsible when marker is empty', () => {
+  it('omits "marker to emit" section when marker is empty', () => {
     const noMarker = { ...parsedItem, marker: '' } as Extract<
       TranscriptItem,
       { kind: 'workflow_kickoff' }
     >;
     render(<WorkflowKickoffCard item={noMarker} />);
+    expand();
     expect(screen.queryByText(/marker to emit/i)).toBeNull();
-  });
-
-  it('can collapse the goal again after expanding it', () => {
-    render(<WorkflowKickoffCard item={parsedItem} />);
-    const trigger = screen.getByText(/^goal$/i);
-    fireEvent.click(trigger);
-    expect(screen.getByText('Ship the onboarding wizard')).toBeDefined();
-    fireEvent.click(trigger);
-    expect(screen.queryByText('Ship the onboarding wizard')).toBeNull();
-  });
-
-  it('can collapse the marker again after expanding it', () => {
-    render(<WorkflowKickoffCard item={parsedItem} />);
-    const trigger = screen.getByText(/marker to emit/i);
-    fireEvent.click(trigger);
-    expect(screen.getByText('Complete ONLY this workflow step.')).toBeDefined();
-    fireEvent.click(trigger);
-    expect(screen.queryByText('Complete ONLY this workflow step.')).toBeNull();
   });
 
   it('renders the timestamp', () => {

--- a/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/WorkflowKickoffCard/index.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import { Rocket } from 'lucide-react';
-import { Collapsible, Markdown } from '@goodboy/ui';
+import { useState, type ReactNode } from 'react';
+import { ChevronRight, Rocket } from 'lucide-react';
+import { Markdown, cn } from '@goodboy/ui';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatCardTime } from '../../utils/format-card-time';
 
@@ -8,79 +8,81 @@ type Props = {
   readonly item: Extract<TranscriptItem, { kind: 'workflow_kickoff' }>;
 };
 
-export const WorkflowKickoffCard = ({ item }: Props) => {
-  const [goalOpen, setGoalOpen] = useState(false);
-  const [markerOpen, setMarkerOpen] = useState(false);
-  const timestamp = formatCardTime(item.at);
+const Section = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="flex flex-col gap-1">
+    <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+      {label}
+    </span>
+    {children}
+  </div>
+);
 
-  if (!item.parsed) {
-    return (
-      <div className="rounded-md border border-success/30 bg-success/5 px-3 py-2">
-        <span className="flex items-center gap-2">
-          <Rocket size={11} aria-hidden className="text-success" />
-          <span className="text-2xs font-medium uppercase tracking-wide text-success/80">
-            workflow start
-          </span>
-        </span>
-        <div className="mt-1 overflow-x-auto rounded-md bg-background p-2 text-xs">
-          <Markdown text={item.raw} />
-        </div>
-        <p className="mt-1 text-right text-2xs text-muted-foreground">{timestamp}</p>
-      </div>
-    );
-  }
+export const WorkflowKickoffCard = ({ item }: Props) => {
+  const [open, setOpen] = useState(false);
+  const timestamp = formatCardTime(item.at);
+  const preview = item.parsed ? item.goal : '';
 
   return (
-    <div className="flex flex-col gap-1.5 rounded-md border border-success/30 bg-success/5 px-3 py-2">
-      <span className="flex items-center gap-2">
-        <Rocket size={11} aria-hidden className="text-success" />
-        <span className="text-2xs font-medium uppercase tracking-wide text-success/80">
+    <div className="border-l-2 border-primary/40">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 rounded-r-md py-1 pl-2 pr-2 text-left motion-safe:transition-colors hover:bg-primary/5"
+      >
+        <ChevronRight
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-primary/50 motion-safe:transition-transform',
+            open && 'rotate-90',
+          )}
+        />
+        <Rocket size={11} aria-hidden className="shrink-0 text-primary" />
+        <span className="shrink-0 text-2xs font-medium uppercase tracking-wide text-primary/80">
           workflow start
         </span>
-      </span>
+        {preview.length > 0 ? (
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground/55">{preview}</span>
+        ) : (
+          <span className="flex-1" />
+        )}
+        <span className="shrink-0 font-mono text-2xs text-muted-foreground">{timestamp}</span>
+      </button>
 
-      <Collapsible
-        open={goalOpen}
-        onOpenChange={setGoalOpen}
-        trigger={
-          <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-            goal
-          </span>
-        }
-      >
-        <div className="overflow-x-auto text-xs text-foreground/85">
-          <Markdown text={item.goal} />
-        </div>
-      </Collapsible>
-
-      {item.instructions.length > 0 ? (
-        <div className="flex flex-col gap-1">
-          <span className="px-2 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-            what to do
-          </span>
-          <div className="overflow-x-auto rounded-md bg-background p-2 text-xs text-foreground">
-            <Markdown text={item.instructions} />
-          </div>
+      {open ? (
+        <div className="ml-2 flex flex-col gap-2.5 border-l border-primary/20 py-2 pl-3 pr-2">
+          {item.parsed ? (
+            <>
+              {item.goal.length > 0 ? (
+                <Section label="goal">
+                  <div className="overflow-x-auto text-xs text-foreground/85">
+                    <Markdown text={item.goal} />
+                  </div>
+                </Section>
+              ) : null}
+              {item.instructions.length > 0 ? (
+                <Section label="what to do">
+                  <div className="overflow-x-auto text-xs text-foreground">
+                    <Markdown text={item.instructions} />
+                  </div>
+                </Section>
+              ) : null}
+              {item.marker.length > 0 ? (
+                <Section label="marker to emit">
+                  <div className="overflow-x-auto text-xs text-foreground/60">
+                    <Markdown text={item.marker} />
+                  </div>
+                </Section>
+              ) : null}
+            </>
+          ) : (
+            <div className="overflow-x-auto text-xs text-foreground/85">
+              <Markdown text={item.raw} />
+            </div>
+          )}
         </div>
       ) : null}
-
-      {item.marker.length > 0 ? (
-        <Collapsible
-          open={markerOpen}
-          onOpenChange={setMarkerOpen}
-          trigger={
-            <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-              marker to emit
-            </span>
-          }
-        >
-          <div className="overflow-x-auto rounded-md bg-background p-2 text-xs text-foreground/70">
-            <Markdown text={item.marker} />
-          </div>
-        </Collapsible>
-      ) : null}
-
-      <p className="text-right text-2xs text-muted-foreground">{timestamp}</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Workflow kickoff and step-transition transcript cards were heavy boxed cards, both green and with nested card-in-card backgrounds, and the kickoff always rendered its full instructions (lots of vertical space).
- Reworked both to the lightweight left-border style already used by tool/skill cards: single collapsed header row, no nested background boxes, expand on click.
- Distinct accents so they read apart from each other and from user/assistant bubbles: teal (primary) for `workflow start`, violet (merged) for `step` transitions.
- Both collapse by default. Kickoff header shows a one-line goal preview; expanded view stacks goal / what to do / marker as plain labelled sections. Step header shows `1. from -> 2. to` with carried-forward context on expand.

## Test plan
- [ ] `pnpm --filter @goodboy/desktop test` for WorkflowKickoffCard + PhaseTransitionCard (12 tests green locally)
- [ ] `pnpm --filter @goodboy/desktop typecheck` (clean locally)
- [ ] Visual: open a workflow session chat, confirm both cards collapse by default, expand cleanly, and use teal vs violet accents with no nested boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)