### PR TITLE
fix(desktop): gate workflow auto-advance behind hands-free toggle

### DIFF
--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -758,7 +758,6 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           }));
           void get().refreshUnreadWorkspaces();
 
-          shouldAutoAdvanceWorkflow = true;
           if (ranKind === 'resolver') {
             const resolvedMarker = extractCommentResolved(assistantText);
             const wontfixMarker = extractCommentWontfix(assistantText);

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -16,6 +16,7 @@ import {
   composeStepBoundary,
 } from '../../kickoff';
 import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
+import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
@@ -93,7 +94,7 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
 
     const clusters =
       fanOutPlan?.clusters && fanOutPlan.clusters.length >= 2 ? fanOutPlan.clusters : undefined;
-    if (clusters && clusters.length >= 2) {
+    if (clusters && clusters.length >= 2 && isHandsFree(get, sessionId, agent.workflowRunId)) {
       await fanOutClusters(set, get, sessionId, agent, clusters, fanOutPlan!.title);
       return;
     }

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -13,6 +13,7 @@ import {
   invokeAgentList,
   invokeAgentUpdateStatus,
 } from '../../../features/workflows/workflows';
+import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
 const MAX_CONTINUE = 2;
@@ -201,8 +202,9 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
     );
 
     if (!opts?.force && !extractClusterDone(assistantText)) {
+      const handsFree = isHandsFree(get, sessionId, child.workflowRunId);
       const attempts = continueAttempts.get(childAgentId) ?? 0;
-      if (attempts < MAX_CONTINUE) {
+      if (handsFree && attempts < MAX_CONTINUE) {
         continueAttempts.set(childAgentId, attempts + 1);
         startChild(
           set,
@@ -220,8 +222,10 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
         void get().emitNotification(
           'error',
           'warning',
-          `cluster stalled: ${child.name}`,
-          'the implementer stopped before completing this cluster. open the agent and continue manually.',
+          `cluster paused: ${child.name}`,
+          handsFree
+            ? 'the implementer stopped before completing this cluster. open the agent and continue manually.'
+            : 'hands-free is off, so this cluster will not continue on its own. open the agent and continue manually, or enable hands-free.',
           { sessionId },
         );
       }

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -4,6 +4,7 @@ import { updateSessionWorkflowStep } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
 import { composeStepBoundary } from '../../kickoff';
+import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
 const MAX_CONTINUE = 2;
@@ -52,8 +53,9 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
     const hasMarker = extractStepDone(assistantText) !== null;
     const satisfied = !!opts?.force || hasMarker || planCapturedThisTurn;
     if (!satisfied) {
+      const handsFree = isHandsFree(get, sessionId, agent.workflowRunId);
       const attempts = continueAttempts.get(agentId) ?? 0;
-      if (attempts < MAX_CONTINUE) {
+      if (handsFree && attempts < MAX_CONTINUE) {
         continueAttempts.set(agentId, attempts + 1);
         startStep(set, get, sessionId, agentId, composeStepContinue(agentId));
       } else {
@@ -65,8 +67,10 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
         void get().emitNotification(
           'error',
           'warning',
-          `step stalled: ${agent.name}`,
-          'the agent stopped before emitting a step-done marker. open the agent and continue manually.',
+          `step paused: ${agent.name}`,
+          handsFree
+            ? 'the agent stopped before emitting a step-done marker. open the agent and continue manually.'
+            : 'hands-free is off, so this step will not continue on its own. open the agent and continue manually, or enable hands-free.',
           { sessionId },
         );
       }

--- a/apps/desktop/src/store/slices/workflows/handsFree.ts
+++ b/apps/desktop/src/store/slices/workflows/handsFree.ts
@@ -1,0 +1,20 @@
+import type { SessionId, WorkflowRunId } from '@goodboy/types';
+import type { GetFn } from './types';
+
+export const isHandsFree = (
+  get: GetFn,
+  sessionId: SessionId,
+  workflowRunId?: WorkflowRunId | null | undefined,
+): boolean => {
+  const session = get().sessions.find((s) => s.id === sessionId);
+  if (!session) {
+    return false;
+  }
+  if (workflowRunId != null) {
+    const run = session.workflowRuns.find((r) => r.id === workflowRunId);
+    if (run) {
+      return run.autoRun;
+    }
+  }
+  return session.autoRun;
+};


### PR DESCRIPTION
## Summary

- **cluster fan-out** (`activateWorkflowAgent`), **continue-retries** (`finalizeWorkflowStep`, `clusterImplementation`), and **per-turn auto-advance** (`sendTurn`) were all ungated, causing token consumption even with `autoRun` off
- centralized `isHandsFree` helper in `workflows/handsFree.ts` checks `autoRun` at workflow-run level, falling back to session level
- wired `isHandsFree` into all 3 auto-advance sinks; when off, agents are marked failed with an actionable notification instead of silently burning tokens
- removed stray `shouldAutoAdvanceWorkflow = true` in sendTurn that bypassed the auto-advance gate for non-step agent completions

## Test plan

- [ ] start workflow with hands-free OFF: steps should pause after agent reply, not auto-continue
- [ ] start workflow with hands-free ON: auto-advance, retries, and cluster fan-out should work as before
- [ ] toggle hands-free mid-workflow: next step respects the new state
- [ ] notification shows "hands-free is off" hint when paused due to gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)