### PR TITLE
feat(desktop): restore per-window view on cmd+r reload

### DIFF
--- a/apps/desktop/src/features/workspace/windowView.test.ts
+++ b/apps/desktop/src/features/workspace/windowView.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import type { AgentId, SessionId, WorkspaceId } from '@goodboy/types';
+import { consumeReloadIntent, writeReloadIntent } from './windowView';
+
+const KEY = 'goodboy:window-reload-intent';
+
+const ws = 'ws-1' as WorkspaceId;
+const session = 'sess-1' as SessionId;
+const agent = 'agent-1' as AgentId;
+
+describe('windowView reload intent', () => {
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('round-trips a restore intent', () => {
+    writeReloadIntent({ mode: 'restore', workspaceId: ws, sessionId: session, agentId: agent });
+    expect(consumeReloadIntent()).toEqual({
+      mode: 'restore',
+      workspaceId: ws,
+      sessionId: session,
+      agentId: agent,
+    });
+  });
+
+  it('round-trips a fresh intent', () => {
+    writeReloadIntent({ mode: 'fresh' });
+    expect(consumeReloadIntent()).toEqual({ mode: 'fresh' });
+  });
+
+  it('is one-shot: a second consume returns null', () => {
+    writeReloadIntent({ mode: 'restore', workspaceId: ws, sessionId: null, agentId: null });
+    expect(consumeReloadIntent()).not.toBeNull();
+    expect(consumeReloadIntent()).toBeNull();
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('returns null when no intent is stored', () => {
+    expect(consumeReloadIntent()).toBeNull();
+  });
+
+  it('returns null and clears on malformed json', () => {
+    sessionStorage.setItem(KEY, '{not json');
+    expect(consumeReloadIntent()).toBeNull();
+    expect(sessionStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('rejects a restore intent missing a workspaceId', () => {
+    sessionStorage.setItem(KEY, JSON.stringify({ mode: 'restore', sessionId: session }));
+    expect(consumeReloadIntent()).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/workspace/windowView.ts
+++ b/apps/desktop/src/features/workspace/windowView.ts
@@ -1,0 +1,42 @@
+import type { AgentId, SessionId, WorkspaceId } from '@goodboy/types';
+
+const RELOAD_INTENT_KEY = 'goodboy:window-reload-intent';
+
+type RestoreIntent = {
+  readonly mode: 'restore';
+  readonly workspaceId: WorkspaceId;
+  readonly sessionId: SessionId | null;
+  readonly agentId: AgentId | null;
+};
+
+type FreshIntent = {
+  readonly mode: 'fresh';
+};
+
+export type WindowReloadIntent = RestoreIntent | FreshIntent;
+
+export const writeReloadIntent = (intent: WindowReloadIntent): void => {
+  try {
+    sessionStorage.setItem(RELOAD_INTENT_KEY, JSON.stringify(intent));
+  } catch {}
+};
+
+export const consumeReloadIntent = (): WindowReloadIntent | null => {
+  try {
+    const raw = sessionStorage.getItem(RELOAD_INTENT_KEY);
+    sessionStorage.removeItem(RELOAD_INTENT_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as WindowReloadIntent;
+    if (parsed.mode === 'fresh') {
+      return parsed;
+    }
+    if (parsed.mode === 'restore' && typeof parsed.workspaceId === 'string') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+};

--- a/apps/desktop/src/shared/hooks/useZoomShortcuts/index.ts
+++ b/apps/desktop/src/shared/hooks/useZoomShortcuts/index.ts
@@ -1,5 +1,7 @@
 import { useEffect } from 'react';
 import { applyStoredZoom, zoomIn, zoomOut, zoomReset } from '../../lib/zoom';
+import { writeReloadIntent } from '../../../features/workspace/windowView';
+import { useAppStore } from '../../../store';
 
 const ZOOM_ACTIONS: Record<string, () => Promise<void>> = {
   '=': zoomIn,
@@ -18,6 +20,19 @@ export const useZoomShortcuts = (): void => {
       }
       if (e.key === 'r' || e.key === 'R') {
         e.preventDefault();
+        const s = useAppStore.getState();
+        if (e.shiftKey) {
+          writeReloadIntent({ mode: 'fresh' });
+          window.location.hash = '';
+        } else if (s.currentWorkspaceId) {
+          const sessionId = s.currentSessionId;
+          writeReloadIntent({
+            mode: 'restore',
+            workspaceId: s.currentWorkspaceId,
+            sessionId,
+            agentId: sessionId ? (s.selectedAgentId[sessionId] ?? null) : null,
+          });
+        }
         window.location.reload();
         return;
       }

--- a/apps/desktop/src/store/slices/boot/hydrate.ts
+++ b/apps/desktop/src/store/slices/boot/hydrate.ts
@@ -14,6 +14,7 @@ import {
   type ProviderStatuses,
 } from '../../../features/providers/providers';
 import { setWindowTitle, targetWorkspaceFromHash } from '../../../features/workspace/window';
+import { consumeReloadIntent } from '../../../features/workspace/windowView';
 import {
   SETTING_EDITOR_BINARY,
   SETTING_LAST_SESSION_ID,
@@ -112,30 +113,50 @@ export const hydrate = (set: SetFn, get: GetFn) => {
         );
 
         set({ bootPhase: 'restoring-session' });
-        const hashWorkspaceId = targetWorkspaceFromHash();
-        const hashWorkspace = hashWorkspaceId
-          ? (workspaces.find((w) => w.id === hashWorkspaceId) ?? null)
-          : null;
-        const reopenLast = reopenLastRaw === '1';
-        if (hashWorkspace) {
-          await get().setCurrentWorkspace(hashWorkspace.id);
-          void setWindowTitle(hashWorkspace.name);
-        } else if (reopenLast) {
-          const lastWorkspaceId =
-            lastWorkspaceRaw && lastWorkspaceRaw.length > 0
-              ? (lastWorkspaceRaw as WorkspaceId)
-              : null;
-          const targetWorkspace = lastWorkspaceId
-            ? (workspaces.find((w) => w.id === lastWorkspaceId) ?? null)
+        const reloadIntent = consumeReloadIntent();
+        if (reloadIntent?.mode === 'restore') {
+          const snapWorkspace = workspaces.find((w) => w.id === reloadIntent.workspaceId) ?? null;
+          if (snapWorkspace) {
+            await get().setCurrentWorkspace(snapWorkspace.id);
+            void setWindowTitle(snapWorkspace.name);
+            const snapSessionId = reloadIntent.sessionId;
+            if (snapSessionId && get().sessions.some((s) => s.id === snapSessionId)) {
+              await get().setCurrentSession(snapSessionId);
+              const snapAgentId = reloadIntent.agentId;
+              if (
+                snapAgentId &&
+                (get().sessionPhaseRuns[snapSessionId] ?? []).some((r) => r.id === snapAgentId)
+              ) {
+                await get().selectAgent(snapSessionId, snapAgentId);
+              }
+            }
+          }
+        } else if (!reloadIntent) {
+          const hashWorkspaceId = targetWorkspaceFromHash();
+          const hashWorkspace = hashWorkspaceId
+            ? (workspaces.find((w) => w.id === hashWorkspaceId) ?? null)
             : null;
-          if (targetWorkspace) {
-            await get().setCurrentWorkspace(targetWorkspace.id);
-            const lastSessionId =
-              lastSessionRaw && lastSessionRaw.length > 0 ? (lastSessionRaw as SessionId) : null;
-            if (lastSessionId) {
-              const sessions = get().sessions;
-              if (sessions.some((s) => s.id === lastSessionId)) {
-                await get().setCurrentSession(lastSessionId);
+          const reopenLast = reopenLastRaw === '1';
+          if (hashWorkspace) {
+            await get().setCurrentWorkspace(hashWorkspace.id);
+            void setWindowTitle(hashWorkspace.name);
+          } else if (reopenLast) {
+            const lastWorkspaceId =
+              lastWorkspaceRaw && lastWorkspaceRaw.length > 0
+                ? (lastWorkspaceRaw as WorkspaceId)
+                : null;
+            const targetWorkspace = lastWorkspaceId
+              ? (workspaces.find((w) => w.id === lastWorkspaceId) ?? null)
+              : null;
+            if (targetWorkspace) {
+              await get().setCurrentWorkspace(targetWorkspace.id);
+              const lastSessionId =
+                lastSessionRaw && lastSessionRaw.length > 0 ? (lastSessionRaw as SessionId) : null;
+              if (lastSessionId) {
+                const sessions = get().sessions;
+                if (sessions.some((s) => s.id === lastSessionId)) {
+                  await get().setCurrentSession(lastSessionId);
+                }
               }
             }
           }


### PR DESCRIPTION
## what

cmd+R no longer drops you to workspace/session reselection. it snapshots the focused window's **workspace + session + agent** and restores that exact view after the reload (lens already restores via `SessionWorkspace`). shift+cmd+R keeps the old "from scratch" behavior, forcing the launcher.

## why

refreshing a window wiped all in-memory state. the only restore paths were the URL `#ws=` hash (workspace only, no session) and the global `reopen_last` setting, so a refresh on the main window lost everything and a spawned window lost its session.

## how

- new `windowView.ts`: `writeReloadIntent` / `consumeReloadIntent` over a `sessionStorage` key.
  - **window-local** → refreshing window X never touches window Y (each WebviewWindow has its own sessionStorage).
  - **one-shot** → consumed on boot, so a later non-cmd+R reload (crash recovery, etc.) cleanly falls back to the existing hash/reopen-last path.
- `useZoomShortcuts`: cmd+R writes a `restore` intent from the store; shift+cmd+R writes a `fresh` intent + clears the url hash.
- `hydrate`: `restore` intent re-selects workspace → session → agent; `fresh` → launcher; none → existing hash/reopen-last (unchanged).

## verification

- `windowView` unit test: 6/6 (round-trip, one-shot clear, malformed-json guard, reject restore w/o workspaceId).
- boot suite (regression on the hydrate rewrite): 2/2.
- `tsc --noEmit`: clean.

residual: shift+cmd+R reaching the JS handler in WKWebView is unproven (cmd+R already does, same wry keydown path, no default native binding). sessionStorage survival + per-window isolation are standard WKWebView guarantees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)