### PR TITLE
test(desktop): align workflow fan-out tests with hands-free gate

### DIFF
--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -99,8 +99,10 @@ function buildHarness(opts: {
   agent: Agent;
   workflow: Workflow;
   plans: ReadonlyArray<PlanWithCount>;
+  autoRun?: boolean;
 }) {
   listPlansForSessionSpy.mockResolvedValue(opts.plans);
+  const handsFree = opts.autoRun ?? false;
   const session: Session = {
     id: SESSION_ID,
     workspaceId: WS_ID,
@@ -118,11 +120,11 @@ function buildHarness(opts: {
         workflowId: WF_ID,
         ordinal: 0,
         currentStep: 0,
-        autoRun: false,
+        autoRun: handsFree,
         triggerMode: 'immediate' as const,
       },
     ],
-    autoRun: false,
+    autoRun: handsFree,
     titleUserEdited: false,
     createdAt: NOW,
     updatedAt: NOW,
@@ -198,7 +200,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(payload.content).toContain('<<step-done');
   });
 
-  it('an implementer step with multiple clusters still fans out (no regression)', async () => {
+  it('an implementer step with multiple clusters fans out under hands-free', async () => {
     const clusters: ReadonlyArray<ImplementationCluster> = [
       { title: 'a', instructions: 'i1' },
       { title: 'b', instructions: 'i2' },
@@ -207,12 +209,31 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       agent: makeAgent('implementer', 'Implement'),
       workflow: makeWorkflow('Implement'),
       plans: [makePlan({ clusters })],
+      autoRun: true,
     });
 
     await activate(SESSION_ID, AGENT_ID);
 
     expect(addPlanConsumptionSpy).toHaveBeenCalledWith(PLAN_ID, AGENT_ID);
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('an implementer step with multiple clusters does not fan out when hands-free is off', async () => {
+    const clusters: ReadonlyArray<ImplementationCluster> = [
+      { title: 'a', instructions: 'i1' },
+      { title: 'b', instructions: 'i2' },
+    ];
+    const { sendTurn, activate } = buildHarness({
+      agent: makeAgent('implementer', 'Implement'),
+      workflow: makeWorkflow('Implement'),
+      plans: [makePlan({ clusters })],
+      autoRun: false,
+    });
+
+    await activate(SESSION_ID, AGENT_ID);
+
+    expect(fanOutClustersSpy).not.toHaveBeenCalled();
+    expect(sendTurn).toHaveBeenCalledTimes(1);
   });
 
   it('does not re-fan-out a consumed plan: a later step runs its own kickoff instead', async () => {
@@ -317,6 +338,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
       agent: makeAgent('implementer', 'Implement'),
       workflow: makeWorkflow('Implement'),
       plans: [makePlan({ clusters })],
+      autoRun: true,
     });
 
     await activate(SESSION_ID, AGENT_ID, undefined, false);

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -202,6 +202,9 @@ const childAgent = (over: Omit<Partial<Agent>, 'id'> & { id: string; ordinal: nu
     id: over.id as AgentId,
   }) as Agent;
 
+const sessionRow = (autoRun: boolean) =>
+  ({ id: SID, autoRun, workflowRuns: [] }) as unknown as Record<string, unknown>;
+
 function makeStore(initial: Record<string, unknown>) {
   const sendTurn = vi.fn(async () => undefined);
   const emitNotification = vi.fn(async () => undefined);
@@ -210,6 +213,7 @@ function makeStore(initial: Record<string, unknown>) {
   const state: Record<string, unknown> = {
     sessionPhaseRuns: {},
     sessionPlans: {},
+    sessions: [sessionRow(true)],
     transcripts: {},
     agentTurnState: {},
     agentKindOverride: {},
@@ -379,6 +383,31 @@ describe('advanceClusterImplementation', () => {
     });
     expect(store.emitNotification).toHaveBeenCalled();
     expect(store.refreshUnreadWorkspaces).toHaveBeenCalled();
+  });
+
+  it('does not continue and pauses the child when hands-free is off', async () => {
+    const child = childAgent({ id: 'cont-c', ordinal: 0 });
+    const p = plan({});
+    const store = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+      sessionPlans: { [SID]: [p] },
+      sessions: [sessionRow(false)],
+    });
+
+    await advanceClusterImplementation(store.set, store.get)(SID, 'cont-c' as AgentId, 'no marker');
+
+    expect(store.sendTurn).not.toHaveBeenCalled();
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith('cont-c', {
+      status: 'failed',
+      completedAt: expect.any(String),
+    });
+    expect(store.emitNotification).toHaveBeenCalledWith(
+      'error',
+      'warning',
+      expect.stringContaining('cluster paused'),
+      expect.stringContaining('hands-free is off'),
+      { sessionId: SID },
+    );
   });
 
   it('marks the child completed and starts the next child on a done marker', async () => {


### PR DESCRIPTION
## what

Fixes the 4 failing tests on `main` introduced by [#904](https://github.com/akhayam99/goodboy/pull/904) (`fix(desktop): gate workflow auto-advance behind hands-free toggle`). `main` HEAD has been red since #904 landed.

## why

#904 gated cluster fan-out and continue-retries behind `isHandsFree` (reads `session.autoRun` / `run.autoRun`), but didn't update the tests:

- `activateWorkflowAgent.test.ts` — two tests asserted fan-out with the harness `autoRun: false`, so fan-out is now correctly skipped → `fanOutClusters` called 0 times.
- `clusterImplementation.test.ts` — `makeStore` built **no `sessions` array**, so the new `isHandsFree` (`get().sessions.find(...)`) threw; and the two continue-retry tests assumed ungated retries.

## how

- `activateWorkflowAgent` harness gains an `autoRun` option; the fan-out tests opt into hands-free.
- `clusterImplementation` `makeStore` seeds a `sessions` row (hands-free on by default).
- Added the gated-off counterparts that lock in #904's intent: **no fan-out** and an **immediate pause** (no continue) when `autoRun` is off.

No source changes — #904's gating behavior is preserved as intended.

## verification

full desktop suite **2047/2047 pass** (was `4 failed | 2041 passed` on main), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)