### PR TITLE
fix(desktop): cap hands-free workflow retry at one continue

### DIFF
--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -371,12 +371,11 @@ describe('advanceClusterImplementation', () => {
     const advance = advanceClusterImplementation(store.set, store.get);
 
     await advance(SID, 'cont-b' as AgentId, 'no marker 1');
-    await advance(SID, 'cont-b' as AgentId, 'no marker 2');
-    expect(store.sendTurn).toHaveBeenCalledTimes(2);
+    expect(store.sendTurn).toHaveBeenCalledTimes(1);
     expect(store.emitNotification).not.toHaveBeenCalled();
 
-    await advance(SID, 'cont-b' as AgentId, 'no marker 3');
-    expect(store.sendTurn).toHaveBeenCalledTimes(2);
+    await advance(SID, 'cont-b' as AgentId, 'no marker 2');
+    expect(store.sendTurn).toHaveBeenCalledTimes(1);
     expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith('cont-b', {
       status: 'failed',
       completedAt: expect.any(String),

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -16,7 +16,7 @@ import {
 import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
-const MAX_CONTINUE = 2;
+const MAX_CONTINUE = 1;
 
 const continueAttempts = new Map<string, number>();
 

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -7,7 +7,7 @@ import { composeStepBoundary } from '../../kickoff';
 import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
-const MAX_CONTINUE = 2;
+const MAX_CONTINUE = 1;
 
 const continueAttempts = new Map<string, number>();
 


### PR DESCRIPTION
## what
cap the hands-free auto-continue retry `MAX_CONTINUE` from 2 → 1 in both `finalizeWorkflowStep` (workflow steps) and `clusterImplementation` (cluster implementers).

## why (token audit v0.1.20 → main)
workflow step / cluster agents that finish a turn **without** emitting their `<<step-done>>` / `<<cluster-done>>` marker are auto-continued in hands-free mode. at `MAX_CONTINUE = 2` that is up to **two** extra full-context turns per agent every time the (brittle, exact-UUID) marker is missed. on multi-step / multi-cluster autoRun workflows this multiplies turn volume and is the residual driver of elevated Claude token consumption.

the core gate (retries only fire in hands-free) already landed in #904; this trims the leftover cost for autoRun users.

## tradeoff (no functional regression)
- marker emitters: unaffected.
- a stalled agent that would only have recovered on the **second** nudge now pauses for manual continue (graceful "step/cluster paused" notification) instead of spending a second turn.
- exhaustion outcome unchanged (`failed` + notify); the per-step `allDone` gate still halts downstream so nothing advances on incomplete work.

## tests
`vitest run src/store` → 454 passed (47 files). cluster exhaustion test updated to the one-retry cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)