### PR TITLE
chore(repo): bump version to 0.1.26

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.25"
+version = "0.1.26"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump version 0.1.25 → 0.1.26 across `package.json`, `apps/desktop/package.json`, `tauri.conf.json`, `Cargo.toml` (+ `Cargo.lock`).
- Release prep per `docs/release.md` step 1.

## Regression check vs 0.1.25 (DB migrations focus)
- v0.1.25 shipped migrations up to **66**; main adds **67-70** (forward-only, no gaps/dupes).
- Runner is version-gated (`schema_version`), upgraders run 67→68→69→70 cleanly.
- m067/m068 rebuild `provider_runs` to add `gemini` to the provider CHECK; preserve all 7 columns (same table-rebuild pattern as shipped m031).
- m069 uses `INSERT OR IGNORE`, no `deleted_at` filter on workspaces; m070 idempotent soft-delete.
- Full `@goodboy/db` suite green (78/78), migration runner tests green (8/8).

## Test plan
- [ ] CI green (rust `cargo test --locked`, JS)
- [ ] Merge, then dry-run rc tag per release.md step 2 before cutting v0.1.26