### PR TITLE
fix(desktop): un-gate cluster fan-out from hands-free toggle

### DIFF
--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.test.ts
@@ -200,7 +200,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(payload.content).toContain('<<step-done');
   });
 
-  it('an implementer step with multiple clusters fans out under hands-free', async () => {
+  it('an implementer step with multiple clusters fans out', async () => {
     const clusters: ReadonlyArray<ImplementationCluster> = [
       { title: 'a', instructions: 'i1' },
       { title: 'b', instructions: 'i2' },
@@ -218,12 +218,12 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
     expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('an implementer step with multiple clusters does not fan out when hands-free is off', async () => {
+  it('an implementer step with multiple clusters fans out even when hands-free is off', async () => {
     const clusters: ReadonlyArray<ImplementationCluster> = [
       { title: 'a', instructions: 'i1' },
       { title: 'b', instructions: 'i2' },
     ];
-    const { sendTurn, activate } = buildHarness({
+    const { activate } = buildHarness({
       agent: makeAgent('implementer', 'Implement'),
       workflow: makeWorkflow('Implement'),
       plans: [makePlan({ clusters })],
@@ -232,8 +232,7 @@ describe('activateWorkflowAgent, plan consumption by kind', () => {
 
     await activate(SESSION_ID, AGENT_ID);
 
-    expect(fanOutClustersSpy).not.toHaveBeenCalled();
-    expect(sendTurn).toHaveBeenCalledTimes(1);
+    expect(fanOutClustersSpy).toHaveBeenCalledTimes(1);
   });
 
   it('does not re-fan-out a consumed plan: a later step runs its own kickoff instead', async () => {

--- a/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
+++ b/apps/desktop/src/store/slices/workflows/activateWorkflowAgent.ts
@@ -16,7 +16,6 @@ import {
   composeStepBoundary,
 } from '../../kickoff';
 import { fanOutClusters, selectFanOutPlan } from './clusterImplementation';
-import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
 export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
@@ -94,7 +93,7 @@ export const activateWorkflowAgent = (set: SetFn, get: GetFn) => {
 
     const clusters =
       fanOutPlan?.clusters && fanOutPlan.clusters.length >= 2 ? fanOutPlan.clusters : undefined;
-    if (clusters && clusters.length >= 2 && isHandsFree(get, sessionId, agent.workflowRunId)) {
+    if (clusters && clusters.length >= 2) {
       await fanOutClusters(set, get, sessionId, agent, clusters, fanOutPlan!.title);
       return;
     }

--- a/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
@@ -21,7 +21,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentUpdateStatus: hoisted.invokeAgentUpdateStatus,
 }));
 
-import { SCOUT_MAX_CHILDREN, fanOutScouts } from './scoutTree';
+import { SCOUT_MAX_CHILDREN, advanceScoutTree, fanOutScouts } from './scoutTree';
 
 const SID = 'sess-1' as SessionId;
 
@@ -135,5 +135,90 @@ describe('fanOutScouts workflowRunId propagation', () => {
       expect(args.workflowRunId).toBe('wf-9');
     }
     expect(emitNotification).toHaveBeenCalled();
+  });
+});
+
+const WS = 'ws-1';
+
+function makeAdvanceStore(runs: ReadonlyArray<Agent>, fanout: boolean) {
+  const sendTurn = vi.fn(async (_args: { content: string }) => undefined);
+  const emitNotification = vi.fn(async () => undefined);
+  const refreshUnreadWorkspaces = vi.fn(async () => undefined);
+  const state: Record<string, unknown> = {
+    sessionPhaseRuns: { [SID]: runs },
+    agentModelOverride: {},
+    agentKindOverride: {},
+    transcripts: {},
+    agentTurnState: {},
+    sessionNudges: {},
+    workspaceOverrides: { [WS]: { scoutFanout: fanout } },
+    sessions: [{ id: SID, workspaceId: WS }],
+    sendTurn,
+    emitNotification,
+    refreshUnreadWorkspaces,
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((u: unknown) => {
+    const patch =
+      typeof u === 'function'
+        ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (u as Record<string, unknown>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return { state, get, set, sendTurn };
+}
+
+const scoutAgent = (over: Partial<Agent> = {}): Agent => ({
+  id: 'scout' as AgentId,
+  sessionId: SID,
+  ordinal: 0,
+  name: 'scout',
+  status: 'running',
+  kind: 'scout',
+  ...over,
+});
+
+const splitText = (n: number) =>
+  [
+    '<<scout-split>>',
+    JSON.stringify(Array.from({ length: n }, (_, i) => ({ area: `area-${i}`, query: `q-${i}` }))),
+    '<</scout-split>>',
+  ].join('\n');
+
+describe('advanceScoutTree split decision', () => {
+  it('fans out into sub-scouts when the domain is too large and fan-out is enabled', async () => {
+    const root = scoutAgent({ id: 'root-on' as AgentId });
+    const { get, set } = makeAdvanceStore([root], true);
+
+    await advanceScoutTree(set, get)(SID, 'root-on' as AgentId, splitText(3));
+
+    expect(hoisted.insertArgs).toHaveLength(3);
+    for (const args of hoisted.insertArgs) {
+      expect(args.kind).toBe('scout');
+      expect(args.parentAgentId).toBe('root-on');
+    }
+  });
+
+  it('self-explores in one agent without spawning sub-scouts when fan-out is disabled', async () => {
+    const root = scoutAgent({ id: 'root-off' as AgentId });
+    const { get, set, sendTurn } = makeAdvanceStore([root], false);
+
+    await advanceScoutTree(set, get)(SID, 'root-off' as AgentId, splitText(3));
+
+    expect(hoisted.insertArgs).toHaveLength(0);
+    expect(sendTurn).toHaveBeenCalledTimes(1);
+    const [payload] = sendTurn.mock.calls[0]!;
+    expect(payload.content).toContain('do NOT split');
+  });
+
+  it('does not fan out past the depth cap even with a split marker', async () => {
+    const root = scoutAgent({ id: 'r' as AgentId });
+    const mid = scoutAgent({ id: 'm' as AgentId, parentAgentId: 'r' as AgentId });
+    const leaf = scoutAgent({ id: 'leaf' as AgentId, parentAgentId: 'm' as AgentId });
+    const { get, set } = makeAdvanceStore([root, mid, leaf], true);
+
+    await advanceScoutTree(set, get)(SID, 'leaf' as AgentId, splitText(3));
+
+    expect(hoisted.insertArgs).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## problem

#904 gated the initial cluster fan-out behind `isHandsFree` at `activateWorkflowAgent.ts`. With hands-free off, an implementer step with >=2 clusters ran as a **single agent** instead of spawning one sub-agent per cluster. The token regression #904 actually targeted was the continue-retry loop on a missed marker, not the fan-out itself (which advances sequentially on the `cluster-done` marker, and is already paused safely when hands-free is off and a child stalls).

This also left the workflow path inconsistent with the direct spawn path (`spawnAgent.ts`), which was never gated.

## fix

- drop the `isHandsFree` condition on the fan-out in `activateWorkflowAgent.ts` (+ remove now-dead import) so the workflow path matches direct spawn
- invert the #906 test that locked the gated behavior -> now asserts fan-out happens even with hands-free off
- add `advanceScoutTree` split-decision guards (previously untested): toggle on fans out, toggle off self-explores, past depth cap no fan out

## scope note

Scout multi-split was **not** regressed by #904 (`scoutTree.ts` untouched). It is gated by the per-workspace `scoutFanout` toggle, default off. The new tests guard that decision path so it cannot be silently gated the way clusters were.

## tests

full desktop suite green: 2074 passed (230 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)