### PR TITLE
feat(desktop): session overview redesign and unified lens UX

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -22,6 +22,7 @@ import { WorkspaceSettingsPane } from './features/workspace/components/Workspace
 import { SessionSettingsPane } from './features/session/components/SessionSettingsPane';
 import { ToastProvider } from './app/components/Toast';
 import { NotificationToastBridge } from './features/notifications/components/NotificationToastBridge';
+import { WorkspaceHeader } from './features/workspace/components/WorkspaceHeader';
 import { WorkspacesSidebar } from './features/workspace/components/WorkspacesSidebar';
 import { useWindowPresence } from './features/workspace/hooks/useWindowPresence';
 import { WorkspaceLinkDialog } from './features/workspace/components/WorkspaceLinkDialog';
@@ -757,6 +758,7 @@ export const App = () => {
       <NotificationToastBridge />
       <AppShell
         topBar={<AppTopBar onOpenSettings={openSettings} activeStudio={activeStudio} />}
+        workspaceBar={currentWorkspace ? <WorkspaceHeader /> : undefined}
         footer={
           currentWorkspace ? (
             <AppFooter

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
@@ -293,6 +293,43 @@ describe('useWorkspaceRuns', () => {
     expect(result.current.completedFreeAgents!.map((n) => n.id)).toEqual(['done-1']);
   });
 
+  it('places a fully-stalled lane (all steps failed) in completedLanes, not in lanes', () => {
+    store.state = baseState({
+      sessionPhaseRuns: {
+        [SID]: [
+          makeAgent({
+            id: 'scout-fail',
+            name: 'scout',
+            workflowRunId: 'run-1',
+            stepId: 'step-scout',
+            runId: 'r-scout',
+            status: 'failed',
+          }),
+          makeAgent({
+            id: 'impl-fail',
+            name: 'impl',
+            workflowRunId: 'run-1',
+            stepId: 'step-impl',
+            runId: 'r-impl',
+            status: 'failed',
+          }),
+          makeAgent({
+            id: 'review-fail',
+            name: 'review',
+            workflowRunId: 'run-1',
+            stepId: 'step-review',
+            runId: 'r-review',
+            status: 'failed',
+          }),
+        ],
+      },
+    });
+    const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
+    expect(result.current.lanes).toHaveLength(0);
+    expect(result.current.completedLanes).toHaveLength(1);
+    expect(result.current.completedLanes![0]!.runId).toBe('run-1');
+  });
+
   it('places a done resolver in completedResolveQueue and a running one in resolveQueue', () => {
     store.state = baseState({
       sessionPhaseRuns: {

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
@@ -212,4 +212,108 @@ describe('useWorkspaceRuns', () => {
     expect(result.current.aggregate.runningCount).toBe(2);
     expect(result.current.aggregate.agentCount).toBe(2);
   });
+
+  it('places a fully-done lane in completedLanes, not in lanes', () => {
+    store.state = baseState({
+      sessionPhaseRuns: {
+        [SID]: [
+          makeAgent({
+            id: 'scout-1',
+            name: 'scout',
+            workflowRunId: 'run-1',
+            stepId: 'step-scout',
+            runId: 'r-scout',
+            status: 'completed',
+          }),
+          makeAgent({
+            id: 'impl-1',
+            name: 'impl',
+            workflowRunId: 'run-1',
+            stepId: 'step-impl',
+            runId: 'r-impl',
+            status: 'completed',
+          }),
+          makeAgent({
+            id: 'review-1',
+            name: 'review',
+            workflowRunId: 'run-1',
+            stepId: 'step-review',
+            runId: 'r-review',
+            status: 'completed',
+          }),
+        ],
+      },
+    });
+    const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
+    expect(result.current.lanes).toHaveLength(0);
+    expect(result.current.completedLanes).toHaveLength(1);
+    expect(result.current.completedLanes![0]!.runId).toBe('run-1');
+  });
+
+  it('keeps a mixed-status lane (some done, some running) in lanes and NOT in completedLanes', () => {
+    store.state = baseState({
+      sessionPhaseRuns: {
+        [SID]: [
+          makeAgent({
+            id: 'scout-1',
+            name: 'scout',
+            workflowRunId: 'run-1',
+            stepId: 'step-scout',
+            runId: 'r-scout',
+            status: 'completed',
+          }),
+          makeAgent({
+            id: 'impl-1',
+            name: 'impl',
+            workflowRunId: 'run-1',
+            stepId: 'step-impl',
+            runId: 'r-impl',
+            status: 'running',
+          }),
+        ],
+      },
+    });
+    const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
+    expect(result.current.lanes).toHaveLength(1);
+    expect(result.current.lanes[0]!.runId).toBe('run-1');
+    expect(result.current.completedLanes).toHaveLength(0);
+  });
+
+  it('places a done freeAgent in completedFreeAgents and a running one in freeAgents', () => {
+    store.state = baseState({
+      sessionPhaseRuns: {
+        [SID]: [
+          makeAgent({ id: 'running-1', name: 'explore', status: 'running' }),
+          makeAgent({ id: 'done-1', name: 'finished', status: 'completed' }),
+        ],
+      },
+    });
+    const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
+    expect(result.current.freeAgents.map((n) => n.id)).toEqual(['running-1']);
+    expect(result.current.completedFreeAgents!.map((n) => n.id)).toEqual(['done-1']);
+  });
+
+  it('places a done resolver in completedResolveQueue and a running one in resolveQueue', () => {
+    store.state = baseState({
+      sessionPhaseRuns: {
+        [SID]: [
+          makeAgent({
+            id: 'r-running',
+            name: 'resolve-active',
+            status: 'running',
+            sourceThreadId: 'thread-a',
+          }),
+          makeAgent({
+            id: 'r-done',
+            name: 'resolve-done',
+            status: 'completed',
+            sourceThreadId: 'thread-b',
+          }),
+        ],
+      },
+    });
+    const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
+    expect(result.current.resolveQueue.map((n) => n.id)).toEqual(['r-running']);
+    expect(result.current.completedResolveQueue!.map((n) => n.id)).toEqual(['r-done']);
+  });
 });

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -53,7 +53,13 @@ export type WorkspaceRuns = {
   readonly freeAgents: SpawnNode[];
   readonly resolveQueue: SpawnNode[];
   readonly aggregate: RunsAggregate;
+  readonly completedLanes?: RunLaneModel[];
+  readonly completedFreeAgents?: SpawnNode[];
+  readonly completedResolveQueue?: SpawnNode[];
 };
+
+const isRunningOrPending = (status: SpawnNodeStatus): boolean =>
+  status === 'running' || status === 'queued' || status === 'planned';
 
 type CostByAgentId = ReadonlyMap<string, number>;
 
@@ -228,9 +234,12 @@ export const useWorkspaceRuns = (
       workflowById.set(w.id, w);
     }
 
-    const lanes: RunLaneModel[] = [];
-    const freeAgents: SpawnNode[] = [];
-    const resolveQueue: SpawnNode[] = [];
+    const activeLanes: RunLaneModel[] = [];
+    const completedLanes: RunLaneModel[] = [];
+    const activeFreeAgents: SpawnNode[] = [];
+    const completedFreeAgents: SpawnNode[] = [];
+    const activeResolveQueue: SpawnNode[] = [];
+    const completedResolveQueue: SpawnNode[] = [];
 
     let runningCount = 0;
     let stalledCount = 0;
@@ -324,7 +333,7 @@ export const useWorkspaceRuns = (
           }
           return sum + (costByAgentId.get(step.rootAgentId) ?? 0);
         }, 0);
-        lanes.push({
+        const laneModel: RunLaneModel = {
           runId: run.id,
           workflowName: workflow.name,
           sessionId: sid,
@@ -334,7 +343,13 @@ export const useWorkspaceRuns = (
           chainAfterId: run.chainAfterId ?? null,
           steps,
           costUsd: runCost,
-        });
+        };
+        const laneIsActive = steps.some((step) => isRunningOrPending(step.status));
+        if (laneIsActive) {
+          activeLanes.push(laneModel);
+        } else {
+          completedLanes.push(laneModel);
+        }
       }
 
       for (const agent of withKind) {
@@ -342,23 +357,40 @@ export const useWorkspaceRuns = (
           continue;
         }
         const node = agentToNode(agent, childrenByParentId, costByAgentId, selectedAgentId, 0);
+        const nodeActive = isRunningOrPending(node.status);
         if (agent.sourceThreadId != null) {
-          resolveQueue.push(node);
+          if (nodeActive) {
+            activeResolveQueue.push(node);
+          } else {
+            completedResolveQueue.push(node);
+          }
         } else {
-          freeAgents.push(node);
+          if (nodeActive) {
+            activeFreeAgents.push(node);
+          } else {
+            completedFreeAgents.push(node);
+          }
         }
       }
     }
 
     const aggregate: RunsAggregate = {
-      runCount: lanes.length,
+      runCount: activeLanes.length + completedLanes.length,
       agentCount,
       runningCount,
       stalledCount,
       spendUsd,
     };
 
-    return { lanes, freeAgents, resolveQueue, aggregate };
+    return {
+      lanes: activeLanes,
+      freeAgents: activeFreeAgents,
+      resolveQueue: activeResolveQueue,
+      aggregate,
+      completedLanes,
+      completedFreeAgents,
+      completedResolveQueue,
+    };
   }, [
     sessions,
     workspaceId,

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -756,14 +756,16 @@ const DiffViewerContent = ({
         ) : error ? (
           <div className="flex flex-1 items-center justify-center text-xs text-danger">{error}</div>
         ) : files.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center p-8">
-            <EmptyState
-              bordered
-              tone="success"
-              icon={CheckCircle2}
-              title={emptyStateLabel(view, isGitAware)}
-              description={emptyStateBlurb(view, isGitAware) ?? undefined}
-            />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="mx-auto w-full max-w-2xl px-6 py-5">
+              <EmptyState
+                bordered
+                tone="success"
+                icon={CheckCircle2}
+                title={emptyStateLabel(view, isGitAware)}
+                description={emptyStateBlurb(view, isGitAware) ?? undefined}
+              />
+            </div>
           </div>
         ) : (
           <>

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, useCallback, useRef, useLayoutEffect } from 'react';
-import { CheckCircle2, FileEdit } from 'lucide-react';
-import { Dialog, Divider, ScrollFade, Skeleton } from '@goodboy/ui';
+import { CheckCircle2, FileEdit, X } from 'lucide-react';
+import { Dialog, Divider, EmptyState, ScrollFade, Skeleton } from '@goodboy/ui';
 import { parseUnifiedDiff } from '@goodboy/core';
 import type {
   BranchCommit,
@@ -32,7 +32,7 @@ import {
 } from '../../../../features/worktree/worktree';
 import { DiffViewSelector } from '../DiffViewSelector';
 import { StudioShell } from '../../../../shared/components/StudioShell';
-import { type ReviewState } from './lib';
+import { TOOLBAR_ICON_BTN, type ReviewState } from './lib';
 import { FileRail } from './FileTree/FileRail';
 import { FileDiffCard } from './FileDiffCard';
 import { DiffToolbar } from './DiffToolbar';
@@ -650,35 +650,83 @@ const DiffViewerContent = ({
     [],
   );
 
+  const isEmpty = !loading && !error && files.length === 0;
+
   return (
     /* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- container handles keyboard nav */
     <div className="flex h-full min-h-0 w-full flex-col" onKeyDown={handleKeyDown}>
-      <DiffToolbar
-        title={title}
-        prNumber={prNumber}
-        openCommentsCount={comments.filter((c) => c.status === 'open').length}
-        reviewedCount={files.length > 0 ? reviewedCount : null}
-        filesCount={files.length}
-        sidebarCollapsed={sidebarCollapsed}
-        onToggleSidebar={toggleSidebar}
-        status={isGitAware ? status : null}
-        onRefresh={isGitAware ? () => setRefreshTick((t) => t + 1) : undefined}
-        refreshing={loading}
-        showClose={showToolbarClose}
-        onClose={onClose}
-        viewSelector={
-          isGitAware ? (
-            <DiffViewSelector
-              view={view}
-              onChange={setView}
-              commits={commits}
-              status={status}
-              filesCount={loading ? null : files.length}
-              loading={loading}
-            />
-          ) : null
-        }
-      />
+      {isEmpty ? (
+        isGitAware ? (
+          <>
+            <div className="flex shrink-0 items-center gap-2 px-2.5 py-1.5">
+              <div className="flex min-w-0 flex-1 items-center">
+                <DiffViewSelector
+                  view={view}
+                  onChange={setView}
+                  commits={commits}
+                  status={status}
+                  filesCount={loading ? null : files.length}
+                  loading={loading}
+                />
+              </div>
+              {showToolbarClose ? (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  title="close"
+                  aria-label="close"
+                  className={TOOLBAR_ICON_BTN}
+                >
+                  <X size={13} />
+                </button>
+              ) : null}
+            </div>
+            <Divider className="shrink-0" />
+          </>
+        ) : showToolbarClose ? (
+          <>
+            <div className="flex shrink-0 items-center justify-end px-2.5 py-1.5">
+              <button
+                type="button"
+                onClick={onClose}
+                title="close"
+                aria-label="close"
+                className={TOOLBAR_ICON_BTN}
+              >
+                <X size={13} />
+              </button>
+            </div>
+            <Divider className="shrink-0" />
+          </>
+        ) : null
+      ) : (
+        <DiffToolbar
+          title={title}
+          prNumber={prNumber}
+          openCommentsCount={comments.filter((c) => c.status === 'open').length}
+          reviewedCount={files.length > 0 ? reviewedCount : null}
+          filesCount={files.length}
+          sidebarCollapsed={sidebarCollapsed}
+          onToggleSidebar={toggleSidebar}
+          status={isGitAware ? status : null}
+          onRefresh={isGitAware ? () => setRefreshTick((t) => t + 1) : undefined}
+          refreshing={loading}
+          showClose={showToolbarClose}
+          onClose={onClose}
+          viewSelector={
+            isGitAware ? (
+              <DiffViewSelector
+                view={view}
+                onChange={setView}
+                commits={commits}
+                status={status}
+                filesCount={loading ? null : files.length}
+                loading={loading}
+              />
+            ) : null
+          }
+        />
+      )}
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {loading ? (
@@ -708,28 +756,14 @@ const DiffViewerContent = ({
         ) : error ? (
           <div className="flex flex-1 items-center justify-center text-xs text-danger">{error}</div>
         ) : files.length === 0 ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-8 text-center">
-            <span
-              aria-hidden
-              className="flex size-12 items-center justify-center rounded-full bg-muted/50"
-            >
-              <CheckCircle2 size={22} className="text-success" />
-            </span>
-            <div className="flex flex-col items-center gap-1.5">
-              <span className="text-sm font-medium text-foreground">
-                {emptyStateLabel(view, isGitAware)}
-              </span>
-              {emptyStateBlurb(view, isGitAware) ? (
-                <span className="max-w-sm text-xs leading-relaxed text-muted-foreground">
-                  {emptyStateBlurb(view, isGitAware)}
-                </span>
-              ) : null}
-              {isGitAware ? (
-                <span className="mt-1.5 text-[11px] text-muted-foreground/60">
-                  Pick another view from the selector above.
-                </span>
-              ) : null}
-            </div>
+          <div className="flex flex-1 items-center justify-center p-8">
+            <EmptyState
+              bordered
+              tone="success"
+              icon={CheckCircle2}
+              title={emptyStateLabel(view, isGitAware)}
+              description={emptyStateBlurb(view, isGitAware) ?? undefined}
+            />
           </div>
         ) : (
           <>

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -48,8 +48,20 @@ describe('PlanStudio', () => {
     expect(screen.getByText(/no plans yet/i)).toBeDefined();
   });
 
-  it('shows No plan selected placeholder when nothing is selected', () => {
-    render(<PlanStudio sessionId={'sess-1' as never} />);
+  it('shows No plan selected placeholder when a plan exists but none is selected', () => {
+    state.plans = [
+      {
+        id: 'plan-1',
+        agentId: 'agent-deleted',
+        sessionId: 'sess-1',
+        title: 'Lonely plan',
+        bodyMd: 'body',
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        runCount: 0,
+      },
+    ];
+    render(<PlanStudio sessionId={'sess-1' as never} initialPlanId={'missing' as never} />);
     expect(screen.getByText(/no plan selected/i)).toBeDefined();
   });
 

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.test.tsx
@@ -13,6 +13,7 @@ const { state } = vi.hoisted(() => ({
     restorePlan: vi.fn(async () => undefined),
     runPlan: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
+    setFocusedPlanId: vi.fn(),
     plans: [] as ReadonlyArray<unknown>,
   },
 }));

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import {
   Divider,
+  EmptyState,
   Markdown,
   ScrollFade,
   Textarea,
@@ -193,18 +194,21 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
       </div>
       <Divider />
       <div className="flex min-h-0 flex-1">
-        <>
-          <ScrollFade className="w-72 shrink-0">
-            <ul className="flex w-full flex-col gap-1 px-3 py-4">
-              {plans.length === 0 ? (
-                <li className="flex flex-col gap-1 rounded-lg border border-border-soft bg-subtle p-4 text-xs">
-                  <span className="font-medium text-foreground">No plans yet</span>
-                  <span className="leading-relaxed text-muted-foreground">
-                    Plans appear here once an agent drafts one. Run a planning agent to get started.
-                  </span>
-                </li>
-              ) : (
-                plans.map((plan, idx) => {
+        {plans.length === 0 ? (
+          <div className="flex flex-1 items-center justify-center p-6">
+            <EmptyState
+              bordered
+              tone="success"
+              icon={ClipboardList}
+              title="No plans yet"
+              description="Plans appear here once an agent drafts one. Run a planning agent to get started."
+            />
+          </div>
+        ) : (
+          <>
+            <ScrollFade className="w-72 shrink-0">
+              <ul className="flex w-full flex-col gap-1 px-3 py-4">
+                {plans.map((plan, idx) => {
                   const isSel = plan.id === selectedId;
                   const isDiscarded = plan.status === 'discarded';
                   return (
@@ -238,249 +242,252 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
                       </button>
                     </li>
                   );
-                })
-              )}
-            </ul>
-          </ScrollFade>
-          <Divider orientation="vertical" />
-          <div className="min-h-0 flex-1">
-            <div className="mx-auto flex h-full min-h-0 min-w-0 w-full max-w-3xl flex-col gap-2 px-6 py-4">
-              {selected ? (
-                <>
-                  <div className="flex shrink-0 items-start gap-3">
-                    <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-2xs text-muted-foreground">
-                      <div className="flex items-center gap-1.5">
-                        <Sparkles size={11} aria-hidden className="shrink-0 text-warning" />
-                        <span>Created by</span>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            if (creatorDeleted) {
-                              showToast(
-                                'info',
-                                `agent "${selectedAgentName}" was deleted and can no longer be opened`,
-                              );
-                              return;
+                })}
+              </ul>
+            </ScrollFade>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <div className="mx-auto flex h-full min-h-0 min-w-0 w-full max-w-3xl flex-col gap-2 px-6 py-4">
+                {selected ? (
+                  <>
+                    <div className="flex shrink-0 items-start gap-3">
+                      <div className="flex min-w-0 flex-1 flex-col gap-0.5 text-2xs text-muted-foreground">
+                        <div className="flex items-center gap-1.5">
+                          <Sparkles size={11} aria-hidden className="shrink-0 text-warning" />
+                          <span>Created by</span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (creatorDeleted) {
+                                showToast(
+                                  'info',
+                                  `agent "${selectedAgentName}" was deleted and can no longer be opened`,
+                                );
+                                return;
+                              }
+                              openAgent(selected.agentId);
+                            }}
+                            className={cn(
+                              'truncate font-medium underline-offset-2',
+                              creatorDeleted
+                                ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
+                                : 'text-foreground hover:underline',
+                            )}
+                            title={
+                              creatorDeleted
+                                ? 'Agent deleted, click for details'
+                                : 'Open creator agent'
                             }
-                            openAgent(selected.agentId);
-                          }}
-                          className={cn(
-                            'truncate font-medium underline-offset-2',
-                            creatorDeleted
-                              ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
-                              : 'text-foreground hover:underline',
-                          )}
-                          title={
-                            creatorDeleted
-                              ? 'Agent deleted, click for details'
-                              : 'Open creator agent'
-                          }
-                        >
-                          {selectedAgentName}
-                        </button>
-                        {creatorDeleted ? (
-                          <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
-                            Deleted
-                          </span>
-                        ) : null}
-                        <span aria-hidden>·</span>
-                        <span className="shrink-0">{fmtTimestamp(selected.createdAt)}</span>
+                          >
+                            {selectedAgentName}
+                          </button>
+                          {creatorDeleted ? (
+                            <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                              Deleted
+                            </span>
+                          ) : null}
+                          <span aria-hidden>·</span>
+                          <span className="shrink-0">{fmtTimestamp(selected.createdAt)}</span>
+                        </div>
+                        {consumptions.map((c) => {
+                          const ag = agents.find((a) => a.id === c.agentId);
+                          const isDeleted = !ag;
+                          const displayName = ag?.name ?? c.agentName ?? c.agentId.substring(0, 8);
+                          return (
+                            <div key={c.id} className="flex items-center gap-1.5">
+                              <CheckCircle2 size={11} aria-hidden className="shrink-0 text-info" />
+                              <span>Consumed by</span>
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  if (isDeleted) {
+                                    showToast(
+                                      'info',
+                                      `agent "${displayName}" was deleted and can no longer be opened`,
+                                    );
+                                    return;
+                                  }
+                                  openAgent(c.agentId);
+                                }}
+                                className={cn(
+                                  'truncate font-medium underline-offset-2',
+                                  isDeleted
+                                    ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
+                                    : 'text-foreground hover:underline',
+                                )}
+                                title={
+                                  isDeleted ? 'Agent deleted, click for details' : 'Open agent'
+                                }
+                              >
+                                {displayName}
+                              </button>
+                              {isDeleted ? (
+                                <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+                                  Deleted
+                                </span>
+                              ) : null}
+                              <span aria-hidden>·</span>
+                              <span className="shrink-0">{fmtTimestamp(c.consumedAt)}</span>
+                            </div>
+                          );
+                        })}
                       </div>
-                      {consumptions.map((c) => {
-                        const ag = agents.find((a) => a.id === c.agentId);
-                        const isDeleted = !ag;
-                        const displayName = ag?.name ?? c.agentName ?? c.agentId.substring(0, 8);
-                        return (
-                          <div key={c.id} className="flex items-center gap-1.5">
-                            <CheckCircle2 size={11} aria-hidden className="shrink-0 text-info" />
-                            <span>Consumed by</span>
+                      <div className="flex shrink-0 items-center gap-1.5">
+                        <div
+                          role="tablist"
+                          aria-label="Content mode"
+                          className={cn(
+                            'inline-flex items-center rounded-md border border-border-soft p-0.5',
+                            selected.status === 'discarded' && 'opacity-50',
+                          )}
+                        >
+                          <button
+                            type="button"
+                            role="tab"
+                            aria-selected={mode === 'preview'}
+                            onClick={() => {
+                              if (mode === 'edit') commitEdit();
+                              setMode('preview');
+                            }}
+                            className={cn(
+                              'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
+                              mode === 'preview'
+                                ? 'bg-muted text-foreground'
+                                : 'text-muted-foreground hover:text-foreground',
+                            )}
+                            title="Preview rendered markdown"
+                          >
+                            <Eye size={11} aria-hidden />
+                            Preview
+                          </button>
+                          <button
+                            type="button"
+                            role="tab"
+                            aria-selected={mode === 'edit'}
+                            disabled={selected.status === 'discarded'}
+                            onClick={() => setMode('edit')}
+                            className={cn(
+                              'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
+                              mode === 'edit'
+                                ? 'bg-muted text-foreground'
+                                : 'text-muted-foreground hover:text-foreground',
+                              selected.status === 'discarded' &&
+                                'cursor-not-allowed hover:text-muted-foreground',
+                            )}
+                            title={
+                              selected.status === 'discarded'
+                                ? 'Discarded plans cannot be edited, restore first'
+                                : 'Edit markdown source'
+                            }
+                          >
+                            <Pencil size={11} aria-hidden />
+                            Edit
+                          </button>
+                        </div>
+                        {selected.status !== 'discarded' ? (
+                          <button
+                            type="button"
+                            onClick={() => void handleTrigger()}
+                            disabled={spawning}
+                            className={cn(
+                              'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent px-2.5 py-1 text-xs font-medium shadow-sm transition-colors',
+                              retriggerArmed
+                                ? 'w-36 bg-warning/15 text-warning hover:bg-warning/20'
+                                : 'bg-primary text-primary-foreground hover:bg-primary/90',
+                              spawning && 'cursor-not-allowed opacity-60 animate-border-pulse',
+                            )}
+                            title={
+                              retriggerArmed
+                                ? 'Already consumed, click again to confirm and spawn a fresh agent'
+                                : selected.status === 'consumed' || selected.status === 'superseded'
+                                  ? 'Plan already ran, click to replay (asks for confirmation)'
+                                  : 'Spawn new agent to execute this plan'
+                            }
+                          >
+                            {retriggerArmed ? (
+                              <AlertTriangle size={12} aria-hidden />
+                            ) : selected.status === 'active' ? (
+                              <Play size={12} aria-hidden className="fill-current" />
+                            ) : (
+                              <RotateCw size={12} aria-hidden />
+                            )}
+                            {retriggerArmed
+                              ? 'Confirm replay'
+                              : selected.status === 'active'
+                                ? 'Start'
+                                : 'Replay'}
+                          </button>
+                        ) : null}
+                        {selected.status === 'consumed' ? (
+                          <Tooltip content="Consumed plans cannot be deleted">
+                            <span
+                              className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
+                              aria-label="Consumed plans cannot be deleted"
+                            >
+                              <Trash2 size={13} aria-hidden />
+                            </span>
+                          </Tooltip>
+                        ) : selected.status === 'discarded' ? (
+                          <Tooltip content="Restore plan">
                             <button
                               type="button"
-                              onClick={() => {
-                                if (isDeleted) {
-                                  showToast(
-                                    'info',
-                                    `agent "${displayName}" was deleted and can no longer be opened`,
-                                  );
-                                  return;
-                                }
-                                openAgent(c.agentId);
-                              }}
-                              className={cn(
-                                'truncate font-medium underline-offset-2',
-                                isDeleted
-                                  ? 'cursor-help text-muted-foreground line-through hover:text-foreground'
-                                  : 'text-foreground hover:underline',
-                              )}
-                              title={isDeleted ? 'Agent deleted, click for details' : 'Open agent'}
+                              onClick={() => handleRestore(selected)}
+                              aria-label="Restore plan"
+                              className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
                             >
-                              {displayName}
+                              <ArchiveRestore size={13} aria-hidden />
                             </button>
-                            {isDeleted ? (
-                              <span className="shrink-0 rounded-sm bg-muted px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
-                                Deleted
-                              </span>
-                            ) : null}
-                            <span aria-hidden>·</span>
-                            <span className="shrink-0">{fmtTimestamp(c.consumedAt)}</span>
-                          </div>
-                        );
-                      })}
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1.5">
-                      <div
-                        role="tablist"
-                        aria-label="Content mode"
-                        className={cn(
-                          'inline-flex items-center rounded-md border border-border-soft p-0.5',
-                          selected.status === 'discarded' && 'opacity-50',
+                          </Tooltip>
+                        ) : (
+                          <Tooltip content="Delete plan (soft delete, click restore to recover)">
+                            <button
+                              type="button"
+                              onClick={() => handleDiscard(selected)}
+                              aria-label="Delete plan"
+                              className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
+                            >
+                              <Trash2 size={13} aria-hidden />
+                            </button>
+                          </Tooltip>
                         )}
-                      >
-                        <button
-                          type="button"
-                          role="tab"
-                          aria-selected={mode === 'preview'}
-                          onClick={() => {
-                            if (mode === 'edit') commitEdit();
-                            setMode('preview');
-                          }}
-                          className={cn(
-                            'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
-                            mode === 'preview'
-                              ? 'bg-muted text-foreground'
-                              : 'text-muted-foreground hover:text-foreground',
-                          )}
-                          title="Preview rendered markdown"
-                        >
-                          <Eye size={11} aria-hidden />
-                          Preview
-                        </button>
-                        <button
-                          type="button"
-                          role="tab"
-                          aria-selected={mode === 'edit'}
-                          disabled={selected.status === 'discarded'}
-                          onClick={() => setMode('edit')}
-                          className={cn(
-                            'inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-2xs transition',
-                            mode === 'edit'
-                              ? 'bg-muted text-foreground'
-                              : 'text-muted-foreground hover:text-foreground',
-                            selected.status === 'discarded' &&
-                              'cursor-not-allowed hover:text-muted-foreground',
-                          )}
-                          title={
-                            selected.status === 'discarded'
-                              ? 'Discarded plans cannot be edited, restore first'
-                              : 'Edit markdown source'
-                          }
-                        >
-                          <Pencil size={11} aria-hidden />
-                          Edit
-                        </button>
                       </div>
-                      {selected.status !== 'discarded' ? (
-                        <button
-                          type="button"
-                          onClick={() => void handleTrigger()}
-                          disabled={spawning}
-                          className={cn(
-                            'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent px-2.5 py-1 text-xs font-medium shadow-sm transition-colors',
-                            retriggerArmed
-                              ? 'w-36 bg-warning/15 text-warning hover:bg-warning/20'
-                              : 'bg-primary text-primary-foreground hover:bg-primary/90',
-                            spawning && 'cursor-not-allowed opacity-60 animate-border-pulse',
-                          )}
-                          title={
-                            retriggerArmed
-                              ? 'Already consumed, click again to confirm and spawn a fresh agent'
-                              : selected.status === 'consumed' || selected.status === 'superseded'
-                                ? 'Plan already ran, click to replay (asks for confirmation)'
-                                : 'Spawn new agent to execute this plan'
-                          }
-                        >
-                          {retriggerArmed ? (
-                            <AlertTriangle size={12} aria-hidden />
-                          ) : selected.status === 'active' ? (
-                            <Play size={12} aria-hidden className="fill-current" />
-                          ) : (
-                            <RotateCw size={12} aria-hidden />
-                          )}
-                          {retriggerArmed
-                            ? 'Confirm replay'
-                            : selected.status === 'active'
-                              ? 'Start'
-                              : 'Replay'}
-                        </button>
-                      ) : null}
-                      {selected.status === 'consumed' ? (
-                        <Tooltip content="Consumed plans cannot be deleted">
-                          <span
-                            className="inline-flex cursor-not-allowed items-center justify-center rounded-md border border-border-soft p-1.5 text-danger/30"
-                            aria-label="Consumed plans cannot be deleted"
-                          >
-                            <Trash2 size={13} aria-hidden />
-                          </span>
-                        </Tooltip>
-                      ) : selected.status === 'discarded' ? (
-                        <Tooltip content="Restore plan">
-                          <button
-                            type="button"
-                            onClick={() => handleRestore(selected)}
-                            aria-label="Restore plan"
-                            className="inline-flex items-center justify-center rounded-md border border-info/20 p-1.5 text-info transition hover:border-info/40 hover:bg-info/10"
-                          >
-                            <ArchiveRestore size={13} aria-hidden />
-                          </button>
-                        </Tooltip>
-                      ) : (
-                        <Tooltip content="Delete plan (soft delete, click restore to recover)">
-                          <button
-                            type="button"
-                            onClick={() => handleDiscard(selected)}
-                            aria-label="Delete plan"
-                            className="inline-flex items-center justify-center rounded-md border border-danger/20 p-1.5 text-danger transition hover:border-danger/40 hover:bg-danger/10"
-                          >
-                            <Trash2 size={13} aria-hidden />
-                          </button>
-                        </Tooltip>
-                      )}
                     </div>
+                    <div className="shrink-0 py-2">
+                      <Divider />
+                    </div>
+                    <ScrollFade
+                      className={cn(
+                        'min-h-0 flex-1',
+                        mode === 'edit' && 'rounded-md border border-border-soft p-2',
+                      )}
+                    >
+                      {mode === 'edit' ? (
+                        <Textarea
+                          autoFocus
+                          value={draft}
+                          onChange={(e) => setDraft(e.target.value)}
+                          className="h-full w-full resize-none border-0 bg-transparent p-0 font-mono text-xs shadow-none focus-visible:shadow-none focus-visible:ring-0"
+                        />
+                      ) : (
+                        <Markdown text={selected.bodyMd} className="text-xs" />
+                      )}
+                    </ScrollFade>
+                  </>
+                ) : (
+                  <div className="flex flex-1 items-center justify-center p-6">
+                    <EmptyState
+                      bordered
+                      tone="neutral"
+                      icon={ClipboardList}
+                      title="No plan selected"
+                      description="Pick a plan from the list to preview, edit, or run it."
+                    />
                   </div>
-                  <div className="shrink-0 py-2">
-                    <Divider />
-                  </div>
-                  <ScrollFade
-                    className={cn(
-                      'min-h-0 flex-1',
-                      mode === 'edit' && 'rounded-md border border-border-soft p-2',
-                    )}
-                  >
-                    {mode === 'edit' ? (
-                      <Textarea
-                        autoFocus
-                        value={draft}
-                        onChange={(e) => setDraft(e.target.value)}
-                        className="h-full w-full resize-none border-0 bg-transparent p-0 font-mono text-xs shadow-none focus-visible:shadow-none focus-visible:ring-0"
-                      />
-                    ) : (
-                      <Markdown text={selected.bodyMd} className="text-xs" />
-                    )}
-                  </ScrollFade>
-                </>
-              ) : (
-                <div className="flex flex-1 items-center justify-center">
-                  <div className="flex max-w-sm flex-col gap-1 rounded-lg border border-border-soft bg-subtle p-5 text-center">
-                    <span className="text-sm font-medium text-foreground">No plan selected</span>
-                    <span className="text-xs leading-relaxed text-muted-foreground">
-                      Pick a plan from the list to preview, edit, or run it.
-                    </span>
-                  </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
-          </div>
-        </>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -65,6 +65,7 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
   const restorePlan = useAppStore((s) => s.restorePlan);
   const runPlan = useAppStore((s) => s.runPlan);
   const selectAgent = useAppStore((s) => s.selectAgent);
+  const setFocusedPlanId = useAppStore((s) => s.setFocusedPlanId);
   const { showToast } = useToast();
 
   const [selectedId, setSelectedId] = useState<PlanId | null>(initialPlanId ?? null);
@@ -98,6 +99,10 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
   useEffect(() => {
     if (selectedId) void loadConsumptionsForPlan(selectedId);
   }, [selectedId, loadConsumptionsForPlan]);
+
+  useEffect(() => {
+    setFocusedPlanId(sessionId, selectedId);
+  }, [sessionId, selectedId, setFocusedPlanId]);
 
   const selected: PlanWithCount | null = plans.find((p) => p.id === selectedId) ?? null;
 

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -195,7 +195,7 @@ export function PlanStudio({ sessionId, initialPlanId }: Props) {
       <Divider />
       <div className="flex min-h-0 flex-1">
         {plans.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center p-6">
+          <div className="mx-auto w-full max-w-2xl px-6 py-5">
             <EmptyState
               bordered
               tone="success"

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -1,7 +1,25 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react';
-import { Button, Input, StatusDot, Textarea, cn, type StatusDotProps } from '@goodboy/ui';
+import {
+  Button,
+  EmptyState,
+  Input,
+  StatusDot,
+  Textarea,
+  cn,
+  type StatusDotProps,
+} from '@goodboy/ui';
 import type { SessionId, WorkspaceId, WorkspaceScriptId } from '@goodboy/types';
-import { Check, Copy, Pencil, Play, Plus, ScrollText, Square, Trash2 } from 'lucide-react';
+import {
+  Check,
+  Copy,
+  Pencil,
+  Play,
+  Plus,
+  ScrollText,
+  Square,
+  SquareTerminal,
+  Trash2,
+} from 'lucide-react';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore } from '../../../../store';
 import type { ScriptRunStatus } from '../../scripts';
@@ -116,9 +134,13 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
       {error ? <p className="text-xs text-danger">{error}</p> : null}
 
       {list.length === 0 && draft === null && (
-        <p className="rounded-md border border-dashed border-border-soft px-3 py-6 text-center text-xs text-muted-foreground">
-          No scripts yet. Create one, e.g. <code className="font-mono">copy environments</code>.
-        </p>
+        <EmptyState
+          bordered
+          tone="info"
+          icon={SquareTerminal}
+          title="No scripts yet"
+          description="Create one to run setup or checks from inside this session."
+        />
       )}
 
       <ul className="flex flex-col gap-2">

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -216,7 +216,7 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     expect(screen.getByText('Start')).toBeDefined();
     expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
-    expect(screen.getByText('Resolve')).toBeDefined();
+    expect(screen.getByText('No pull request yet')).toBeDefined();
     expect(screen.queryByText('At a glance')).toBeNull();
   });
 
@@ -249,7 +249,7 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     const onSelectLens = renderPane();
     expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
     expect(screen.getByText('No pull request yet')).toBeDefined();
-    const card = screen.getByText('Resolve').closest('[aria-disabled]');
+    const card = screen.getByText('No pull request yet').closest('[aria-disabled]');
     expect(card).toBeDefined();
     fireEvent.click(card!);
     expect(onSelectLens).not.toHaveBeenCalledWith('resolve');
@@ -510,6 +510,16 @@ describe('SessionOverviewPane context links', () => {
     expect(onSelectLens).toHaveBeenCalledWith('scripts');
     fireEvent.click(screen.getByRole('button', { name: /^terminal$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('terminal');
+  });
+
+  it('renders the primary context strip on a non-fresh session and routes correctly', () => {
+    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent()] };
+    const onSelectLens = renderPane();
+    expect(screen.getByRole('button', { name: /^goal$/i })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('decisions');
+    fireEvent.click(screen.getByRole('button', { name: /^last output$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -10,18 +10,29 @@ type Store = {
   spawnAgent: ReturnType<typeof vi.fn>;
   sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   scriptRuns: Record<string, Record<string, { status: string }>>;
-  sessionGithub: Record<string, { pr?: unknown }>;
+  sessionGithub: Record<
+    string,
+    { pr?: unknown; detail?: { comments: ReadonlyArray<unknown> } | null }
+  >;
   sessionGitlabMr: Record<string, { mr?: unknown }>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
+  selectAgent: ReturnType<typeof vi.fn>;
   phaseTemplates: Record<string, ReadonlyArray<unknown>>;
   sessionWorkflows: Record<string, ReadonlyArray<unknown>>;
+  diffComments: Record<string, ReadonlyArray<unknown>>;
+  sessionPendingResolutions: Record<string, ReadonlyArray<unknown>>;
+  agentKindOverride: Record<string, unknown>;
+  messages: Record<string, ReadonlyArray<unknown>>;
 };
 
 type Runs = {
   lanes: ReadonlyArray<unknown>;
   freeAgents: ReadonlyArray<unknown>;
   resolveQueue: ReadonlyArray<unknown>;
+  completedLanes?: ReadonlyArray<unknown>;
+  completedFreeAgents?: ReadonlyArray<unknown>;
+  completedResolveQueue?: ReadonlyArray<unknown>;
 };
 
 const { store, hooks, runs } = vi.hoisted(() => ({
@@ -34,8 +45,13 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     sessionGitlabMr: {} as Record<string, { mr?: unknown }>,
     setFocusedWorkflowRun: vi.fn(),
     activateWorkflowAgent: vi.fn(async () => undefined),
+    selectAgent: vi.fn(async () => undefined),
     phaseTemplates: {} as Record<string, ReadonlyArray<unknown>>,
     sessionWorkflows: {} as Record<string, ReadonlyArray<unknown>>,
+    diffComments: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionPendingResolutions: {} as Record<string, ReadonlyArray<unknown>>,
+    agentKindOverride: {} as Record<string, unknown>,
+    messages: {} as Record<string, ReadonlyArray<unknown>>,
   } as Store,
   hooks: {
     workspace: { id: 'ws-1', name: 'My workspace' } as Workspace | null,
@@ -43,11 +59,19 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     plans: [] as ReadonlyArray<{ status: string }>,
     stage: { stage: 'building', reason: '' } as SessionStageInfo,
   },
-  runs: { lanes: [], freeAgents: [], resolveQueue: [] } as Runs,
+  runs: {
+    lanes: [],
+    freeAgents: [],
+    resolveQueue: [],
+    completedLanes: [],
+    completedFreeAgents: [],
+    completedResolveQueue: [],
+  } as Runs,
 }));
 
 vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
+  agentHasUnread: () => false,
   useAppStore: <T,>(selector: (s: Store) => T) => selector(store),
   useCurrentWorkspace: () => hooks.workspace,
   useSessionOpenQuestions: () => hooks.openQuestions,
@@ -82,6 +106,8 @@ vi.mock('./SessionCostChip', () => ({
 import { SessionOverviewPane } from './index';
 
 const standaloneAgent = (status = 'running') => ({
+  id: 'standalone-agent',
+  name: 'explore the repo',
   parentAgentId: null,
   workflowRunId: null,
   stepId: null,
@@ -133,8 +159,14 @@ beforeEach(() => {
   store.setFocusedWorkflowRun.mockReset();
   store.activateWorkflowAgent.mockReset();
   store.activateWorkflowAgent.mockResolvedValue(undefined);
+  store.selectAgent.mockReset();
+  store.selectAgent.mockResolvedValue(undefined);
   store.phaseTemplates = {};
   store.sessionWorkflows = {};
+  store.diffComments = {};
+  store.sessionPendingResolutions = {};
+  store.agentKindOverride = {};
+  store.messages = {};
   hooks.workspace = { id: 'ws-1', name: 'My workspace' } as Workspace;
   hooks.openQuestions = [];
   hooks.plans = [];
@@ -142,6 +174,9 @@ beforeEach(() => {
   runs.lanes = [];
   runs.freeAgents = [];
   runs.resolveQueue = [];
+  runs.completedLanes = [];
+  runs.completedFreeAgents = [];
+  runs.completedResolveQueue = [];
 });
 afterEach(cleanup);
 
@@ -181,7 +216,7 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     expect(screen.getByText('Start')).toBeDefined();
     expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Resolve' })).toBeDefined();
+    expect(screen.getByText('Resolve')).toBeDefined();
     expect(screen.queryByText('At a glance')).toBeNull();
   });
 
@@ -203,9 +238,28 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', { kindOverride: 'scout' });
   });
 
-  it('routes the resolve card to the resolve lens', () => {
+  it('routes the resolve card to the resolve lens when a PR is present', () => {
+    store.sessionGithub = { 'sess-1': { pr: { number: 1 } } };
     const onSelectLens = renderPane();
     fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+    expect(onSelectLens).toHaveBeenCalledWith('resolve');
+  });
+
+  it('disables the Resolve card with "No pull request yet" when no PR and clicking does not route', () => {
+    const onSelectLens = renderPane();
+    expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
+    expect(screen.getByText('No pull request yet')).toBeDefined();
+    const card = screen.getByText('Resolve').closest('[aria-disabled]');
+    expect(card).toBeDefined();
+    fireEvent.click(card!);
+    expect(onSelectLens).not.toHaveBeenCalledWith('resolve');
+  });
+
+  it('enables the Resolve card and routes when a PR is present', () => {
+    store.sessionGithub = { 'sess-1': { pr: { number: 42 } } };
+    const onSelectLens = renderPane();
+    const btn = screen.getByRole('button', { name: 'Resolve' });
+    fireEvent.click(btn);
     expect(onSelectLens).toHaveBeenCalledWith('resolve');
   });
 
@@ -213,7 +267,7 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
     renderPane();
     expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Resolve' })).toBeDefined();
+    expect(screen.getByText('Resolve')).toBeDefined();
   });
 
   it('treats discarded workflow runs as not active for freshness', () => {
@@ -223,6 +277,27 @@ describe('SessionOverviewPane start row (cluster B)', () => {
       } as unknown as Partial<Session>),
     );
     expect(screen.queryByText('At a glance')).toBeNull();
+  });
+
+  it('renders the teaching block with all three path descriptions when the session is fresh', () => {
+    renderPane();
+    expect(screen.getByText('Choose how to start')).toBeDefined();
+    expect(
+      screen.getByText('Runs a multi-step pipeline: scout, plan, implement, test, review.'),
+    ).toBeDefined();
+    expect(screen.getByText('A single specialist for a one-off task.')).toBeDefined();
+    expect(screen.getByText('Addresses review comments on a pull request or diff.')).toBeDefined();
+    expect(screen.getByText('recommended')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
+  });
+
+  it('hides the teaching block and keeps start buttons when the session has work', () => {
+    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
+    renderPane();
+    expect(screen.queryByText('Choose how to start')).toBeNull();
+    expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
   });
 });
 
@@ -278,6 +353,56 @@ describe('SessionOverviewPane nudges', () => {
     renderPane();
     expect(screen.getByText(/pull request needs you/i)).toBeDefined();
   });
+
+  it('deep-links the agent nudge to the offending agent in one click', () => {
+    store.sessionPhaseRuns = {
+      'sess-1': [
+        {
+          id: 'agent-9',
+          name: 'explore the repo',
+          parentAgentId: null,
+          workflowRunId: null,
+          stepId: null,
+          status: 'running',
+        },
+      ],
+    };
+    hooks.stage = { stage: 'attention', reason: 'idle' } as SessionStageInfo;
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByText(/an agent needs you/i));
+    expect(onSelectLens).toHaveBeenCalledWith('agents');
+    expect(store.selectAgent).toHaveBeenCalledWith('sess-1', 'agent-9');
+  });
+
+  it('deep-links a workflow nudge by focusing the run then switching lens', () => {
+    hooks.stage = { stage: 'attention', reason: 'idle' } as SessionStageInfo;
+    const onSelectLens = renderPane(
+      baseSession({ workflowRuns: [{ id: 'run-7' }] } as unknown as Partial<Session>),
+    );
+    fireEvent.click(screen.getByText(/a workflow needs you/i));
+    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith('sess-1', 'run-7');
+    expect(onSelectLens).toHaveBeenCalledWith('workflows');
+  });
+
+  it('keeps the agents metric calm when attention routes to resolve', () => {
+    store.sessionPhaseRuns = {
+      'sess-1': [
+        {
+          id: 'res-1',
+          name: 'resolve the comment',
+          parentAgentId: null,
+          workflowRunId: null,
+          stepId: null,
+          status: 'running',
+        },
+      ],
+    };
+    hooks.stage = { stage: 'attention', reason: 'idle' } as SessionStageInfo;
+    renderPane();
+    expect(screen.getByText(/a resolver needs you/i)).toBeDefined();
+    const metric = screen.getByText('agents').closest('button');
+    expect(metric?.className).not.toContain('border-warning');
+  });
 });
 
 describe('SessionOverviewPane pipeline agent cards', () => {
@@ -327,11 +452,64 @@ describe('SessionOverviewPane pipeline agent cards', () => {
   });
 });
 
-describe('SessionOverviewPane jump-to links', () => {
-  it('selects the goal lens from the jump-to row', () => {
+describe('SessionOverviewPane completed bucket (cluster D)', () => {
+  it('renders a completed free agent under "Completed" while a running one appears under "Activity"', () => {
+    runs.freeAgents = [spawnNode({ id: 'running-node', name: 'active agent', status: 'running' })];
+    runs.completedFreeAgents = [
+      spawnNode({ id: 'done-node', name: 'finished agent', status: 'done' }),
+    ];
+    renderPane();
+    expect(screen.getByText('Activity')).toBeDefined();
+    expect(screen.getByText('active agent')).toBeDefined();
+    expect(screen.getByText('Completed')).toBeDefined();
+    expect(screen.getByText('finished agent')).toBeDefined();
+  });
+
+  it('omits the "Completed" heading when all completed buckets are empty', () => {
+    runs.freeAgents = [spawnNode({ id: 'running-node', name: 'active agent', status: 'running' })];
+    renderPane();
+    expect(screen.getByText('Activity')).toBeDefined();
+    expect(screen.queryByText('Completed')).toBeNull();
+  });
+
+  it('omits the "Activity" heading when only completed items exist', () => {
+    runs.completedFreeAgents = [
+      spawnNode({ id: 'done-node', name: 'finished agent', status: 'done' }),
+    ];
+    renderPane();
+    expect(screen.queryByText('Activity')).toBeNull();
+    expect(screen.getByText('Completed')).toBeDefined();
+    expect(screen.getByText('finished agent')).toBeDefined();
+  });
+
+  it('returns null (no activity section at all) when all six buckets are empty', () => {
+    renderPane();
+    expect(screen.queryByText('Activity')).toBeNull();
+    expect(screen.queryByText('Completed')).toBeNull();
+  });
+});
+
+describe('SessionOverviewPane context links', () => {
+  it('selects the goal lens from the primary context strip', () => {
     const onSelectLens = renderPane();
     fireEvent.click(screen.getByRole('button', { name: /^goal$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('goal');
+  });
+
+  it('routes Decisions and Last output from the primary strip', () => {
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('decisions');
+    fireEvent.click(screen.getByRole('button', { name: /^last output$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
+  });
+
+  it('routes Scripts and Terminal from the muted jump-to row', () => {
+    const onSelectLens = renderPane();
+    fireEvent.click(screen.getByRole('button', { name: /^scripts$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('scripts');
+    fireEvent.click(screen.getByRole('button', { name: /^terminal$/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('terminal');
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -18,6 +18,7 @@ type Store = {
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
   selectAgent: ReturnType<typeof vi.fn>;
+  loadPendingResolutions: ReturnType<typeof vi.fn>;
   phaseTemplates: Record<string, ReadonlyArray<unknown>>;
   sessionWorkflows: Record<string, ReadonlyArray<unknown>>;
   diffComments: Record<string, ReadonlyArray<unknown>>;
@@ -46,6 +47,7 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     setFocusedWorkflowRun: vi.fn(),
     activateWorkflowAgent: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
+    loadPendingResolutions: vi.fn(async () => undefined),
     phaseTemplates: {} as Record<string, ReadonlyArray<unknown>>,
     sessionWorkflows: {} as Record<string, ReadonlyArray<unknown>>,
     diffComments: {} as Record<string, ReadonlyArray<unknown>>,
@@ -101,6 +103,10 @@ vi.mock('./BranchChip', () => ({
 
 vi.mock('./SessionCostChip', () => ({
   SessionCostChip: () => <span data-testid="cost-chip" />,
+}));
+
+vi.mock('../../../context/components/ContextPanel/strips/PendingResolutionsStrip', () => ({
+  PendingResolutionsStrip: () => <div data-testid="pending-resolutions-strip" />,
 }));
 
 import { SessionOverviewPane } from './index';
@@ -161,6 +167,8 @@ beforeEach(() => {
   store.activateWorkflowAgent.mockResolvedValue(undefined);
   store.selectAgent.mockReset();
   store.selectAgent.mockResolvedValue(undefined);
+  store.loadPendingResolutions.mockReset();
+  store.loadPendingResolutions.mockResolvedValue(undefined);
   store.phaseTemplates = {};
   store.sessionWorkflows = {};
   store.diffComments = {};
@@ -211,63 +219,53 @@ describe('SessionOverviewPane header meta (cluster A)', () => {
 });
 
 describe('SessionOverviewPane start row (cluster B)', () => {
-  it('always shows the start entry cards and hides the metrics strip when fresh', () => {
+  it('renders the unified fresh start card with the workflow and agent options', () => {
     renderPane();
     expect(screen.getByText('Start')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
-    expect(screen.getByText('No pull request yet')).toBeDefined();
+    expect(screen.getByText('Choose how to start')).toBeDefined();
+    expect(screen.getByRole('button', { name: /Workflow/ })).toBeDefined();
+    expect(screen.getByRole('button', { name: /Agent/ })).toBeDefined();
+    expect(screen.getByText('recommended')).toBeDefined();
     expect(screen.queryByText('At a glance')).toBeNull();
   });
 
-  it('opens the workflow builder directly from the new-workflow card', () => {
+  it('does not mention resolve in the fresh start card', () => {
+    renderPane();
+    expect(screen.queryByText('Addresses review comments on a pull request or diff.')).toBeNull();
+  });
+
+  it('opens the workflow builder from the fresh workflow option', () => {
     const handler = vi.fn();
     window.addEventListener('goodboy:open-workflow-builder', handler);
     renderPane();
-    fireEvent.click(screen.getByRole('button', { name: 'New workflow' }));
+    fireEvent.click(screen.getByRole('button', { name: /Workflow/ }));
     expect(handler).toHaveBeenCalledOnce();
     expect((handler.mock.calls[0]![0] as CustomEvent).detail).toEqual({ sessionId: 'sess-1' });
     window.removeEventListener('goodboy:open-workflow-builder', handler);
   });
 
-  it('opens the role-picker menu from the new-agent card and spawns with chosen kind', () => {
+  it('opens the role picker from the fresh agent option and spawns the chosen kind', () => {
     renderPane();
-    fireEvent.click(screen.getByRole('button', { name: 'Create agent' }));
-    const menuitem = screen.getByRole('menuitem', { name: /Scout/i });
-    fireEvent.click(menuitem);
+    fireEvent.click(screen.getByRole('button', { name: /Agent/ }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Scout/i }));
     expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', { kindOverride: 'scout' });
   });
 
-  it('routes the resolve card to the resolve lens when a PR is present', () => {
-    store.sessionGithub = { 'sess-1': { pr: { number: 1 } } };
-    const onSelectLens = renderPane();
-    fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
-    expect(onSelectLens).toHaveBeenCalledWith('resolve');
-  });
-
-  it('disables the Resolve card with "No pull request yet" when no PR and clicking does not route', () => {
-    const onSelectLens = renderPane();
-    expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
-    expect(screen.getByText('No pull request yet')).toBeDefined();
-    const card = screen.getByText('No pull request yet').closest('[aria-disabled]');
-    expect(card).toBeDefined();
-    fireEvent.click(card!);
-    expect(onSelectLens).not.toHaveBeenCalledWith('resolve');
-  });
-
-  it('enables the Resolve card and routes when a PR is present', () => {
-    store.sessionGithub = { 'sess-1': { pr: { number: 42 } } };
-    const onSelectLens = renderPane();
-    const btn = screen.getByRole('button', { name: 'Resolve' });
-    fireEvent.click(btn);
-    expect(onSelectLens).toHaveBeenCalledWith('resolve');
-  });
-
-  it('keeps the start cards once work exists', () => {
+  it('shows the two aligned start cards once work exists and no resolve start card', () => {
     store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
     renderPane();
+    expect(screen.queryByText('Choose how to start')).toBeNull();
     expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
-    expect(screen.getByText('Resolve')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Resolve' })).toBeNull();
+  });
+
+  it('opens the role picker from the non-fresh create-agent card', () => {
+    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
+    renderPane();
+    fireEvent.click(screen.getByRole('button', { name: 'Create agent' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: /Scout/i }));
+    expect(store.spawnAgent).toHaveBeenCalledWith('sess-1', { kindOverride: 'scout' });
   });
 
   it('treats discarded workflow runs as not active for freshness', () => {
@@ -278,26 +276,33 @@ describe('SessionOverviewPane start row (cluster B)', () => {
     );
     expect(screen.queryByText('At a glance')).toBeNull();
   });
+});
 
-  it('renders the teaching block with all three path descriptions when the session is fresh', () => {
-    renderPane();
-    expect(screen.getByText('Choose how to start')).toBeDefined();
-    expect(
-      screen.getByText('Runs a multi-step pipeline: scout, plan, implement, test, review.'),
-    ).toBeDefined();
-    expect(screen.getByText('A single specialist for a one-off task.')).toBeDefined();
-    expect(screen.getByText('Addresses review comments on a pull request or diff.')).toBeDefined();
-    expect(screen.getByText('recommended')).toBeDefined();
-    expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
+describe('SessionOverviewPane resolve section', () => {
+  it('surfaces the resolve section and routes a comment row to the resolve lens', () => {
+    store.sessionGithub = {
+      'sess-1': {
+        pr: { number: 1 },
+        detail: { comments: [{ source: 'review', resolved: false }] },
+      },
+    };
+    const onSelectLens = renderPane();
+    expect(screen.getByText('Resolve')).toBeDefined();
+    const row = screen.getByText('1 comment to resolve');
+    fireEvent.click(row);
+    expect(onSelectLens).toHaveBeenCalledWith('resolve');
   });
 
-  it('hides the teaching block and keeps start buttons when the session has work', () => {
-    store.sessionPhaseRuns = { 'sess-1': [standaloneAgent('running')] };
+  it('renders the push-and-resolve strip when a batch is pending', () => {
+    store.sessionPendingResolutions = { 'sess-1': [{}, {}] };
     renderPane();
-    expect(screen.queryByText('Choose how to start')).toBeNull();
-    expect(screen.getByRole('button', { name: 'New workflow' })).toBeDefined();
-    expect(screen.getByRole('button', { name: 'Create agent' })).toBeDefined();
+    expect(screen.getByText('Resolve')).toBeDefined();
+    expect(screen.getByTestId('pending-resolutions-strip')).toBeDefined();
+  });
+
+  it('omits the resolve section when nothing is resolvable', () => {
+    renderPane();
+    expect(screen.queryByText('Resolve')).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -25,6 +25,8 @@ import { Chip, cn, Divider, Eyebrow, Input, ScrollFade, StatusDot, tintClasses }
 import type { Tone } from '@goodboy/ui';
 import type {
   Agent,
+  AgentId,
+  Message,
   Session,
   SessionId,
   SessionStage,
@@ -33,6 +35,7 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import {
+  agentHasUnread,
   EMPTY_ARRAY,
   useAppStore,
   useCurrentWorkspace,
@@ -56,15 +59,17 @@ import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { SummarizerBadge } from '../../../workspace/components/SessionDetailPanel/SummarizerBadge';
 import { BranchChip } from './BranchChip';
 import { SessionCostChip } from './SessionCostChip';
-import { inferAgentKindFromName } from '../../agent-kind';
+import { resolveAgentKind } from '../../agent-kind';
 import {
   resolveAttentionLens,
   selectAttention,
+  selectNonResolverStandaloneAgents,
   selectOpenQuestions,
   selectStandaloneAgents,
 } from './lib';
 import { SpawnAgentControl } from '../../../workspace/components/WorkspacesSidebar/parts/SpawnAgentControl';
 import { useSessionTitleRename } from '../../hooks/useSessionTitleRename';
+import { useResolvableCount } from '../../hooks/useResolvableCount';
 
 type SessionOverviewPaneProps = {
   readonly session: Session;
@@ -85,6 +90,7 @@ type Nudge = {
   readonly label: string;
   readonly detail: string;
   readonly lens: LensKind;
+  readonly itemId?: string;
 };
 
 type Metric = {
@@ -97,7 +103,7 @@ type Metric = {
   readonly alert?: boolean;
 };
 
-const CONTEXT_LINKS: ReadonlyArray<{
+const PRIMARY_CONTEXT_LINKS: ReadonlyArray<{
   readonly kind: LensKind;
   readonly icon: LucideIcon;
   readonly tone: Tone;
@@ -106,6 +112,14 @@ const CONTEXT_LINKS: ReadonlyArray<{
   { kind: 'goal', icon: Target, tone: 'primary', label: 'Goal' },
   { kind: 'decisions', icon: CheckCheck, tone: 'success', label: 'Decisions' },
   { kind: 'last_output_summary', icon: Activity, tone: 'info', label: 'Last output' },
+];
+
+const SECONDARY_CONTEXT_LINKS: ReadonlyArray<{
+  readonly kind: LensKind;
+  readonly icon: LucideIcon;
+  readonly tone: Tone;
+  readonly label: string;
+}> = [
   { kind: 'scripts', icon: Terminal, tone: 'info', label: 'Scripts' },
   { kind: 'terminal', icon: SquareTerminal, tone: 'neutral', label: 'Terminal' },
 ];
@@ -286,30 +300,62 @@ const StartCard = ({
   tone,
   label,
   onClick,
+  disabled,
+  hint,
+  primary,
 }: {
   readonly icon: LucideIcon;
   readonly tone: Tone;
   readonly label: string;
   readonly onClick: () => void;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="group flex items-center gap-2.5 rounded-lg border border-border-soft bg-elevated px-3 py-2.5 text-left shadow-sm transition-colors hover:border-border"
-  >
-    <span
-      aria-hidden
+  readonly disabled?: boolean;
+  readonly hint?: string;
+  readonly primary?: boolean;
+}) =>
+  disabled ? (
+    <div
+      aria-disabled="true"
+      className="flex cursor-default items-center gap-2.5 rounded-lg border border-border-soft bg-elevated px-3 py-2.5 text-left opacity-45 shadow-sm"
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
+          tintClasses(tone).bg,
+          tintClasses(tone).ring,
+        )}
+      >
+        <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium text-foreground">{label}</span>
+        {hint ? <span className="truncate text-2xs text-muted-foreground">{hint}</span> : null}
+      </span>
+    </div>
+  ) : (
+    <button
+      type="button"
+      onClick={onClick}
       className={cn(
-        'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
-        tintClasses(tone).bg,
-        tintClasses(tone).ring,
+        'group flex items-center gap-2.5 rounded-lg border bg-elevated px-3 py-2.5 text-left shadow-sm transition-colors',
+        primary
+          ? 'border-accent/40 ring-1 ring-accent/30 hover:border-accent/60'
+          : 'border-border-soft hover:border-border',
       )}
     >
-      <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
-    </span>
-    <span className="min-w-0 truncate text-sm font-medium text-foreground">{label}</span>
-  </button>
-);
+      <span
+        aria-hidden
+        className={cn(
+          'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
+          tintClasses(tone).bg,
+          tintClasses(tone).ring,
+        )}
+      >
+        <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
+      </span>
+      <span className="min-w-0 truncate text-sm font-medium text-foreground">{label}</span>
+    </button>
+  );
 
 type PipelineSectionProps = {
   readonly session: Session;
@@ -319,7 +365,17 @@ type PipelineSectionProps = {
 
 const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSectionProps) => {
   const sessionList = useMemo(() => [session], [session]);
-  const { lanes, freeAgents, resolveQueue } = useWorkspaceRuns(workspaceId, sessionList);
+  const {
+    lanes,
+    freeAgents,
+    resolveQueue,
+    completedLanes,
+    completedFreeAgents,
+    completedResolveQueue,
+  } = useWorkspaceRuns(workspaceId, sessionList);
+  const resolvedCompletedLanes = completedLanes ?? EMPTY_ARRAY;
+  const resolvedCompletedFreeAgents = completedFreeAgents ?? EMPTY_ARRAY;
+  const resolvedCompletedResolveQueue = completedResolveQueue ?? EMPTY_ARRAY;
   const sessionId = session.id as SessionId;
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
   const activateWorkflowAgent = useAppStore((s) => s.activateWorkflowAgent);
@@ -341,7 +397,13 @@ const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSection
     return m;
   }, [phaseTemplates, sessionWorkflows]);
 
-  if (lanes.length === 0 && freeAgents.length === 0 && resolveQueue.length === 0) {
+  const hasRunning = lanes.length > 0 || freeAgents.length > 0 || resolveQueue.length > 0;
+  const hasCompleted =
+    resolvedCompletedLanes.length > 0 ||
+    resolvedCompletedFreeAgents.length > 0 ||
+    resolvedCompletedResolveQueue.length > 0;
+
+  if (!hasRunning && !hasCompleted) {
     return null;
   }
 
@@ -356,15 +418,15 @@ const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSection
     if (!run || !workflow) {
       return undefined;
     }
-    const runs = phaseRuns.filter(
+    const workflowAgents = phaseRuns.filter(
       (r) => r.workflowRunId === runId && r.stepId != null && r.parentAgentId == null,
     );
     return {
       workflow,
-      runs,
+      runs: workflowAgents,
       hasOpenQuestions: workflowRunHasOpenQuestions(openQuestions, run.id),
       onAdvance: async (step) => {
-        const agent = runs.find((r) => r.stepId === step.id);
+        const agent = workflowAgents.find((r) => r.stepId === step.id);
         if (agent?.status === 'pending') {
           await activateWorkflowAgent(sessionId, agent.id, undefined, false);
         }
@@ -374,28 +436,54 @@ const PipelineSection = ({ session, workspaceId, onSelectLens }: PipelineSection
 
   return (
     <div className="flex flex-col gap-2">
-      <Eyebrow label="Activity" muted className="px-0.5 font-medium" />
-      <div className="flex flex-col gap-2">
-        {lanes.map((lane) => (
-          <PipelineLane
-            key={lane.runId}
-            lane={lane}
-            onOpen={() => open(lane.runId)}
-            advance={advanceFor(lane.runId)}
-          />
-        ))}
-        {freeAgents.map((agent) => (
-          <AgentRow key={agent.id} agent={agent} onClick={() => onSelectLens('agents')} />
-        ))}
-        {resolveQueue.length > 0 ? (
-          <SummaryRow
-            icon={MessageSquareReply}
-            tone="success"
-            label={`${resolveQueue.length} in resolve queue`}
-            onClick={() => onSelectLens('resolve')}
-          />
-        ) : null}
-      </div>
+      {hasRunning ? (
+        <>
+          <Eyebrow label="Activity" muted className="px-0.5 font-medium" />
+          <div className="flex flex-col gap-2">
+            {lanes.map((lane) => (
+              <PipelineLane
+                key={lane.runId}
+                lane={lane}
+                onOpen={() => open(lane.runId)}
+                advance={advanceFor(lane.runId)}
+              />
+            ))}
+            {freeAgents.map((agent) => (
+              <AgentRow key={agent.id} agent={agent} onClick={() => onSelectLens('agents')} />
+            ))}
+            {resolveQueue.length > 0 ? (
+              <SummaryRow
+                icon={MessageSquareReply}
+                tone="success"
+                label={`${resolveQueue.length} in resolve queue`}
+                onClick={() => onSelectLens('resolve')}
+              />
+            ) : null}
+          </div>
+        </>
+      ) : null}
+      {hasRunning && hasCompleted ? <Divider /> : null}
+      {hasCompleted ? (
+        <>
+          <Eyebrow label="Completed" muted className="px-0.5 font-medium" />
+          <div className="flex flex-col gap-2">
+            {resolvedCompletedLanes.map((lane) => (
+              <PipelineLane key={lane.runId} lane={lane} onOpen={() => open(lane.runId)} />
+            ))}
+            {resolvedCompletedFreeAgents.map((agent) => (
+              <AgentRow key={agent.id} agent={agent} onClick={() => onSelectLens('agents')} />
+            ))}
+            {resolvedCompletedResolveQueue.length > 0 ? (
+              <SummaryRow
+                icon={MessageSquareReply}
+                tone="success"
+                label={`${resolvedCompletedResolveQueue.length} in resolve queue`}
+                onClick={() => onSelectLens('resolve')}
+              />
+            ) : null}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 };
@@ -414,19 +502,53 @@ export const SessionOverviewPane = ({
   const branch = useAppStore((s) => s.sessionBranches[session.id as SessionId] ?? null);
   const attention = selectAttention(stage);
   const openQuestions = selectOpenQuestions(useSessionOpenQuestions(session.id));
-  const agents = selectStandaloneAgents(
+  const rawStandalone = selectStandaloneAgents(
     useAppStore((s) => s.sessionPhaseRuns[session.id] ?? EMPTY_ARRAY),
   );
-  const runningAgents = agents.filter((a) => a.status === 'running').length;
+  const agentKindOverride = useAppStore((s) => s.agentKindOverride);
+  const messages = useAppStore(
+    (s) => s.messages[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<Message>),
+  );
+  const firstUserTextByAgentId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of messages) {
+      if (m.role !== 'user' || map.has(m.agentId)) {
+        continue;
+      }
+      map.set(m.agentId, m.content);
+    }
+    return map;
+  }, [messages]);
+  const kindOf = (agent: Agent): ReturnType<typeof resolveAgentKind> =>
+    resolveAgentKind(
+      agent.name,
+      firstUserTextByAgentId.get(agent.id) ?? null,
+      agentKindOverride[agent.id] ?? null,
+    );
+  const hasResolver = rawStandalone.some((a) => kindOf(a) === 'resolver');
+  const nonResolverAgents = selectNonResolverStandaloneAgents(
+    rawStandalone,
+    agentKindOverride,
+    firstUserTextByAgentId,
+  );
+  const runningAgents = nonResolverAgents.filter((a) => a.status === 'running').length;
   const activePlans = useSessionPlans(session.id).filter((p) => p.status === 'active').length;
   const hasPr = useAppStore(
     (s) => s.sessionGithub[session.id]?.pr != null || s.sessionGitlabMr[session.id]?.mr != null,
   );
+  const resolvable = useResolvableCount(session.id as SessionId);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
 
   const openCount = openQuestions.length;
   const activeWorkflows = session.workflowRuns.filter((r) => r.discardedAt == null).length;
-  const isFresh = activeWorkflows === 0 && agents.length === 0;
+  const isFresh = activeWorkflows === 0 && rawStandalone.length === 0;
   const isRunning = runningAgents > 0 || (activeWorkflows > 0 && stage.stage === 'running');
+  const attentionLens = resolveAttentionLens(stage, {
+    hasNonResolverStandalone: nonResolverAgents.length > 0,
+    hasWorkflow: activeWorkflows > 0,
+    hasResolver,
+  });
 
   const openWorkflowBuilder = () => {
     window.dispatchEvent(
@@ -434,6 +556,46 @@ export const SessionOverviewPane = ({
         detail: { sessionId: session.id as SessionId },
       }),
     );
+  };
+
+  const pickAgentId = (candidates: ReadonlyArray<Agent>): string | undefined => {
+    if (candidates.length === 0) {
+      return undefined;
+    }
+    const needsAttention =
+      candidates.find((a) => agentHasUnread(a, false)) ??
+      candidates.find((a) => a.status === 'failed') ??
+      candidates.find((a) => a.status === 'running');
+    return (needsAttention ?? candidates[0])!.id;
+  };
+
+  const attentionItemId = (lens: LensKind): string | undefined => {
+    if (lens === 'agents') {
+      return pickAgentId(nonResolverAgents);
+    }
+    if (lens === 'resolve') {
+      return pickAgentId(rawStandalone.filter((a) => kindOf(a) === 'resolver'));
+    }
+    if (lens === 'workflows') {
+      const runs = session.workflowRuns.filter((r) => r.discardedAt == null);
+      const withQuestions = runs.find((r) => workflowRunHasOpenQuestions(openQuestions, r.id));
+      return (withQuestions ?? runs[runs.length - 1])?.id;
+    }
+    return undefined;
+  };
+
+  const openNudge = (nudge: Nudge) => {
+    if (nudge.itemId && nudge.lens === 'workflows') {
+      setFocusedWorkflowRun(session.id as SessionId, nudge.itemId);
+      onSelectLens('workflows');
+      return;
+    }
+    if (nudge.itemId && (nudge.lens === 'agents' || nudge.lens === 'resolve')) {
+      onSelectLens(nudge.lens);
+      void selectAgent(session.id as SessionId, nudge.itemId as AgentId);
+      return;
+    }
+    onSelectLens(nudge.lens);
   };
 
   const nudges: Nudge[] = [];
@@ -445,15 +607,6 @@ export const SessionOverviewPane = ({
       lens: 'questions',
     });
   }
-  const agentKindOverride = useAppStore((s) => s.agentKindOverride);
-  const hasResolver = agents.some(
-    (a) => (agentKindOverride?.[a.id] ?? inferAgentKindFromName(a.name ?? '')) === 'resolver',
-  );
-  const attentionLens = resolveAttentionLens(stage, {
-    hasStandalone: agents.length > 0,
-    hasWorkflow: activeWorkflows > 0,
-    hasResolver,
-  });
   if (attention.active && attentionLens && attentionLens !== 'questions') {
     const attentionIcon =
       attentionLens === 'pr'
@@ -476,6 +629,7 @@ export const SessionOverviewPane = ({
       label: attentionLabel,
       detail: attention.reason,
       lens: attentionLens,
+      itemId: attentionItemId(attentionLens),
     });
   }
 
@@ -492,10 +646,13 @@ export const SessionOverviewPane = ({
       kind: 'agents',
       icon: Bot,
       tone: 'primary',
-      value: runningAgents > 0 ? `${runningAgents}/${agents.length}` : String(agents.length),
+      value:
+        runningAgents > 0
+          ? `${runningAgents}/${nonResolverAgents.length}`
+          : String(nonResolverAgents.length),
       label: runningAgents > 0 ? 'running' : 'agents',
-      active: agents.length > 0,
-      alert: attention.active,
+      active: nonResolverAgents.length > 0,
+      alert: attention.active && attentionLens === 'agents',
     },
     {
       kind: 'plans',
@@ -586,14 +743,83 @@ export const SessionOverviewPane = ({
           </div>
         </div>
 
+        <div className="grid grid-cols-3 gap-2">
+          {PRIMARY_CONTEXT_LINKS.map((link) => (
+            <SummaryRow
+              key={link.kind}
+              icon={link.icon}
+              tone={link.tone}
+              label={link.label}
+              onClick={() => onSelectLens(link.kind)}
+            />
+          ))}
+        </div>
+
         <div className="flex flex-col gap-2">
           <Eyebrow label="Start" muted className="px-0.5 font-medium" />
+          {isFresh ? (
+            <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-elevated px-4 py-3.5">
+              <div className="flex flex-col gap-1">
+                <Eyebrow label="New session" className="text-muted-foreground/70" />
+                <p className="text-base font-semibold text-foreground">Choose how to start</p>
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  Three paths are available. Workflows are the recommended starting point for most
+                  tasks.
+                </p>
+              </div>
+              <ul className="flex flex-col gap-2">
+                <li className="flex items-start gap-2.5">
+                  <Workflow
+                    size={14}
+                    aria-hidden
+                    className={cn('mt-0.5 shrink-0', tintClasses('accent').icon)}
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                      Workflow
+                      <Chip tone="accent" size="sm" label="recommended" />
+                    </span>
+                    <span className="text-2xs text-muted-foreground">
+                      Runs a multi-step pipeline: scout, plan, implement, test, review.
+                    </span>
+                  </span>
+                </li>
+                <li className="flex items-start gap-2.5">
+                  <Bot
+                    size={14}
+                    aria-hidden
+                    className={cn('mt-0.5 shrink-0', tintClasses('primary').icon)}
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm font-medium text-foreground">Agent</span>
+                    <span className="text-2xs text-muted-foreground">
+                      A single specialist for a one-off task.
+                    </span>
+                  </span>
+                </li>
+                <li className="flex items-start gap-2.5">
+                  <MessageSquareReply
+                    size={14}
+                    aria-hidden
+                    className={cn('mt-0.5 shrink-0', tintClasses('success').icon)}
+                  />
+                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-sm font-medium text-foreground">Comment resolution</span>
+                    <span className="text-2xs text-muted-foreground">
+                      Addresses review comments on a pull request or diff.
+                    </span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+          ) : null}
           <div className="grid grid-cols-3 gap-2">
             <StartCard
               icon={Workflow}
               tone="accent"
               label="New workflow"
               onClick={openWorkflowBuilder}
+              primary={isFresh}
             />
             <SpawnAgentControl sessionId={session.id as SessionId} className="mt-0" />
             <StartCard
@@ -601,6 +827,8 @@ export const SessionOverviewPane = ({
               tone="success"
               label="Resolve"
               onClick={() => onSelectLens('resolve')}
+              disabled={!resolvable.enabled}
+              hint={resolvable.disabledReason ?? undefined}
             />
           </div>
         </div>
@@ -611,9 +839,9 @@ export const SessionOverviewPane = ({
             <div className="flex flex-col gap-1.5">
               {nudges.map((nudge) => (
                 <button
-                  key={nudge.lens}
+                  key={nudge.itemId ?? nudge.lens}
                   type="button"
-                  onClick={() => onSelectLens(nudge.lens)}
+                  onClick={() => openNudge(nudge)}
                   className="group flex items-center gap-3 rounded-lg border border-warning/30 bg-warning/[0.04] px-3 py-2.5 text-left shadow-sm transition-colors hover:border-warning/50 hover:bg-warning/[0.08]"
                 >
                   <nudge.icon size={15} aria-hidden className="shrink-0 text-warning" />
@@ -689,7 +917,7 @@ export const SessionOverviewPane = ({
         <div className="flex flex-col gap-2">
           <Eyebrow label="Jump to" muted className="px-0.5 font-medium" />
           <div className="flex flex-wrap gap-1.5">
-            {CONTEXT_LINKS.map((link) => (
+            {SECONDARY_CONTEXT_LINKS.map((link) => (
               <button
                 key={link.kind}
                 type="button"

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -804,7 +804,7 @@ export const SessionOverviewPane = ({
                     className={cn('mt-0.5 shrink-0', tintClasses('success').icon)}
                   />
                   <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium text-foreground">Comment resolution</span>
+                    <span className="text-sm font-medium text-foreground">Resolve</span>
                     <span className="text-2xs text-muted-foreground">
                       Addresses review comments on a pull request or diff.
                     </span>

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   Activity,
   ArrowRight,
@@ -67,7 +67,8 @@ import {
   selectOpenQuestions,
   selectStandaloneAgents,
 } from './lib';
-import { SpawnAgentControl } from '../../../workspace/components/WorkspacesSidebar/parts/SpawnAgentControl';
+import { SpawnAgentMenu } from '../../../workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu';
+import { PendingResolutionsStrip } from '../../../context/components/ContextPanel/strips/PendingResolutionsStrip';
 import { useSessionTitleRename } from '../../hooks/useSessionTitleRename';
 import { useResolvableCount } from '../../hooks/useResolvableCount';
 
@@ -295,67 +296,84 @@ const AgentRow = ({
   </button>
 );
 
-const StartCard = ({
+const startRowClass = (primary?: boolean): string =>
+  cn(
+    'group flex w-full items-center gap-3 rounded-lg border bg-elevated px-3.5 py-3 text-left shadow-sm transition-colors',
+    primary
+      ? 'border-accent/40 ring-1 ring-accent/30 hover:border-accent/60'
+      : 'border-border-soft hover:border-border',
+  );
+
+const StartRowContent = ({
   icon: Icon,
   tone,
   label,
-  onClick,
-  disabled,
-  hint,
-  primary,
+  description,
+  chip,
 }: {
   readonly icon: LucideIcon;
   readonly tone: Tone;
   readonly label: string;
-  readonly onClick: () => void;
-  readonly disabled?: boolean;
-  readonly hint?: string;
-  readonly primary?: boolean;
-}) =>
-  disabled ? (
-    <div
-      aria-disabled="true"
-      className="flex cursor-default items-center gap-2.5 rounded-lg border border-border-soft bg-elevated px-3 py-2.5 text-left opacity-45 shadow-sm"
-    >
-      <span
-        aria-hidden
-        className={cn(
-          'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
-          tintClasses(tone).bg,
-          tintClasses(tone).ring,
-        )}
-      >
-        <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
-      </span>
-      <span className="flex min-w-0 flex-col gap-0.5">
-        <span className="truncate text-sm font-medium text-foreground">{label}</span>
-        {hint ? <span className="truncate text-2xs text-muted-foreground">{hint}</span> : null}
-      </span>
-    </div>
-  ) : (
-    <button
-      type="button"
-      onClick={onClick}
+  readonly description: string;
+  readonly chip?: boolean;
+}) => (
+  <>
+    <span
+      aria-hidden
       className={cn(
-        'group flex items-center gap-2.5 rounded-lg border bg-elevated px-3 py-2.5 text-left shadow-sm transition-colors',
-        primary
-          ? 'border-accent/40 ring-1 ring-accent/30 hover:border-accent/60'
-          : 'border-border-soft hover:border-border',
+        'flex size-9 shrink-0 items-center justify-center rounded-lg ring-1',
+        tintClasses(tone).bg,
+        tintClasses(tone).ring,
       )}
     >
-      <span
-        aria-hidden
-        className={cn(
-          'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
-          tintClasses(tone).bg,
-          tintClasses(tone).ring,
-        )}
-      >
-        <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
+      <Icon size={16} aria-hidden className={tintClasses(tone).icon} />
+    </span>
+    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+        {label}
+        {chip ? <Chip tone="accent" size="sm" label="recommended" /> : null}
       </span>
-      <span className="min-w-0 truncate text-sm font-medium text-foreground">{label}</span>
-    </button>
+      <span className="truncate text-2xs text-muted-foreground">{description}</span>
+    </span>
+    <ArrowRight
+      size={15}
+      aria-hidden
+      className="shrink-0 text-muted-foreground/30 motion-safe:transition-transform group-hover:translate-x-0.5 group-hover:text-muted-foreground"
+    />
+  </>
+);
+
+const startTileClass = (primary?: boolean): string =>
+  cn(
+    'group flex items-center gap-2.5 rounded-lg border bg-elevated px-3 py-2.5 text-left shadow-sm transition-colors',
+    primary
+      ? 'border-accent/40 ring-1 ring-accent/30 hover:border-accent/60'
+      : 'border-border-soft hover:border-border',
   );
+
+const StartTileContent = ({
+  icon: Icon,
+  tone,
+  label,
+}: {
+  readonly icon: LucideIcon;
+  readonly tone: Tone;
+  readonly label: string;
+}) => (
+  <>
+    <span
+      aria-hidden
+      className={cn(
+        'flex size-8 shrink-0 items-center justify-center rounded-lg ring-1',
+        tintClasses(tone).bg,
+        tintClasses(tone).ring,
+      )}
+    >
+      <Icon size={15} aria-hidden className={tintClasses(tone).icon} />
+    </span>
+    <span className="min-w-0 truncate text-sm font-medium text-foreground">{label}</span>
+  </>
+);
 
 type PipelineSectionProps = {
   readonly session: Session;
@@ -539,8 +557,15 @@ export const SessionOverviewPane = ({
   const resolvable = useResolvableCount(session.id as SessionId);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
+  const loadPendingResolutions = useAppStore((s) => s.loadPendingResolutions);
+
+  useEffect(() => {
+    void loadPendingResolutions(session.id as SessionId);
+  }, [session.id, loadPendingResolutions]);
 
   const openCount = openQuestions.length;
+  const resolvableItems = resolvable.prComments + resolvable.diffComments + resolvable.pending;
+  const commentsToResolve = resolvable.prComments + resolvable.diffComments;
   const activeWorkflows = session.workflowRuns.filter((r) => r.discardedAt == null).length;
   const isFresh = activeWorkflows === 0 && rawStandalone.length === 0;
   const isRunning = runningAgents > 0 || (activeWorkflows > 0 && stage.stage === 'running');
@@ -755,83 +780,73 @@ export const SessionOverviewPane = ({
           ))}
         </div>
 
-        <div className="flex flex-col gap-2">
-          <Eyebrow label="Start" muted className="px-0.5 font-medium" />
-          {isFresh ? (
+        {isFresh ? (
+          <div className="flex flex-col gap-2">
+            <Eyebrow label="Start" muted className="px-0.5 font-medium" />
             <div className="flex flex-col gap-3 rounded-lg border border-border-soft bg-elevated px-4 py-3.5">
               <div className="flex flex-col gap-1">
                 <Eyebrow label="New session" className="text-muted-foreground/70" />
                 <p className="text-base font-semibold text-foreground">Choose how to start</p>
                 <p className="text-sm leading-relaxed text-muted-foreground">
-                  Three paths are available. Workflows are the recommended starting point for most
-                  tasks.
+                  Two ways to begin. Workflows are the recommended starting point for most tasks.
                 </p>
               </div>
-              <ul className="flex flex-col gap-2">
-                <li className="flex items-start gap-2.5">
-                  <Workflow
-                    size={14}
-                    aria-hidden
-                    className={cn('mt-0.5 shrink-0', tintClasses('accent').icon)}
+              <div className="flex flex-col gap-2">
+                <button type="button" onClick={openWorkflowBuilder} className={startRowClass(true)}>
+                  <StartRowContent
+                    icon={Workflow}
+                    tone="accent"
+                    label="Workflow"
+                    description="Runs a multi-step pipeline: scout, plan, implement, test, review."
+                    chip
                   />
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-                      Workflow
-                      <Chip tone="accent" size="sm" label="recommended" />
-                    </span>
-                    <span className="text-2xs text-muted-foreground">
-                      Runs a multi-step pipeline: scout, plan, implement, test, review.
-                    </span>
-                  </span>
-                </li>
-                <li className="flex items-start gap-2.5">
-                  <Bot
-                    size={14}
-                    aria-hidden
-                    className={cn('mt-0.5 shrink-0', tintClasses('primary').icon)}
-                  />
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium text-foreground">Agent</span>
-                    <span className="text-2xs text-muted-foreground">
-                      A single specialist for a one-off task.
-                    </span>
-                  </span>
-                </li>
-                <li className="flex items-start gap-2.5">
-                  <MessageSquareReply
-                    size={14}
-                    aria-hidden
-                    className={cn('mt-0.5 shrink-0', tintClasses('success').icon)}
-                  />
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="text-sm font-medium text-foreground">Resolve</span>
-                    <span className="text-2xs text-muted-foreground">
-                      Addresses review comments on a pull request or diff.
-                    </span>
-                  </span>
-                </li>
-              </ul>
+                </button>
+                <SpawnAgentMenu
+                  sessionId={session.id as SessionId}
+                  trigger={({ ref, onClick, ...aria }) => (
+                    <button
+                      ref={ref}
+                      type="button"
+                      onClick={onClick}
+                      className={startRowClass()}
+                      {...aria}
+                    >
+                      <StartRowContent
+                        icon={Bot}
+                        tone="primary"
+                        label="Agent"
+                        description="A single specialist for a one-off task."
+                      />
+                    </button>
+                  )}
+                />
+              </div>
             </div>
-          ) : null}
-          <div className="grid grid-cols-3 gap-2">
-            <StartCard
-              icon={Workflow}
-              tone="accent"
-              label="New workflow"
-              onClick={openWorkflowBuilder}
-              primary={isFresh}
-            />
-            <SpawnAgentControl sessionId={session.id as SessionId} className="mt-0" />
-            <StartCard
-              icon={MessageSquareReply}
-              tone="success"
-              label="Resolve"
-              onClick={() => onSelectLens('resolve')}
-              disabled={!resolvable.enabled}
-              hint={resolvable.disabledReason ?? undefined}
-            />
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <Eyebrow label="Start" muted className="px-0.5 font-medium" />
+            <div className="grid grid-cols-2 gap-2">
+              <button type="button" onClick={openWorkflowBuilder} className={startTileClass()}>
+                <StartTileContent icon={Workflow} tone="accent" label="New workflow" />
+              </button>
+              <SpawnAgentMenu
+                sessionId={session.id as SessionId}
+                trigger={({ ref, onClick, ...aria }) => (
+                  <button
+                    ref={ref}
+                    type="button"
+                    onClick={onClick}
+                    className={startTileClass()}
+                    {...aria}
+                  >
+                    <StartTileContent icon={Bot} tone="primary" label="Create agent" />
+                  </button>
+                )}
+              />
+            </div>
+          </div>
+        )}
 
         {nudges.length > 0 ? (
           <div className="flex flex-col gap-2">
@@ -872,6 +887,25 @@ export const SessionOverviewPane = ({
             workspaceId={workspace.id}
             onSelectLens={onSelectLens}
           />
+        ) : null}
+
+        {resolvableItems > 0 ? (
+          <div className="flex flex-col gap-2">
+            <Eyebrow label="Resolve" muted className="px-0.5 font-medium" />
+            <div className="flex flex-col gap-2">
+              {resolvable.pending > 0 ? (
+                <PendingResolutionsStrip sessionId={session.id as SessionId} />
+              ) : null}
+              {commentsToResolve > 0 ? (
+                <SummaryRow
+                  icon={MessageSquareReply}
+                  tone="success"
+                  label={`${commentsToResolve} comment${commentsToResolve === 1 ? '' : 's'} to resolve`}
+                  onClick={() => onSelectLens('resolve')}
+                />
+              ) : null}
+            </div>
+          </div>
         ) : null}
 
         {!isFresh && nudges.length === 0 && !isRunning ? (

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/lib.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from 'vitest';
 import type { Agent, OpenQuestion, SessionStageInfo } from '@goodboy/types';
+import type { AgentKind } from '../../agent-kind';
 import {
   isStandaloneAgent,
   resolveAttentionLens,
   selectAttention,
+  selectNonResolverStandaloneAgents,
   selectOpenQuestions,
   selectStandaloneAgents,
 } from './lib';
 
 const agent = (over: Partial<Agent>): Agent =>
-  ({ parentAgentId: null, workflowRunId: null, stepId: null, ...over }) as unknown as Agent;
+  ({
+    id: 'a',
+    name: '',
+    parentAgentId: null,
+    workflowRunId: null,
+    stepId: null,
+    ...over,
+  }) as unknown as Agent;
 
 const stage = (over: Partial<SessionStageInfo>): SessionStageInfo =>
   ({ stage: 'building', reason: '', ...over }) as SessionStageInfo;
@@ -76,7 +85,7 @@ describe('selectAttention', () => {
 });
 
 describe('resolveAttentionLens', () => {
-  const ctx = { hasStandalone: false, hasWorkflow: false, hasResolver: false };
+  const ctx = { hasNonResolverStandalone: false, hasWorkflow: false, hasResolver: false };
 
   it('returns null when not in the attention stage', () => {
     expect(resolveAttentionLens(stage({ stage: 'running' }), ctx)).toBeNull();
@@ -94,58 +103,78 @@ describe('resolveAttentionLens', () => {
     ).toBe('questions');
   });
 
-  it('prefers standalone agents over workflows', () => {
-    expect(
-      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
-        hasStandalone: true,
-        hasWorkflow: true,
-        hasResolver: false,
-      }),
-    ).toBe('agents');
-  });
+  const lensFor = (
+    hasNonResolverStandalone: boolean,
+    hasWorkflow: boolean,
+    hasResolver: boolean,
+  ) => {
+    if (hasNonResolverStandalone) return 'agents';
+    if (hasResolver) return 'resolve';
+    if (hasWorkflow) return 'workflows';
+    return null;
+  };
 
-  it('falls back to workflows when only a workflow is present', () => {
+  for (const hasNonResolverStandalone of [false, true]) {
+    for (const hasWorkflow of [false, true]) {
+      for (const hasResolver of [false, true]) {
+        const expected = lensFor(hasNonResolverStandalone, hasWorkflow, hasResolver);
+        it(`routes nonResolver=${hasNonResolverStandalone} workflow=${hasWorkflow} resolver=${hasResolver} to ${expected}`, () => {
+          expect(
+            resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
+              hasNonResolverStandalone,
+              hasWorkflow,
+              hasResolver,
+            }),
+          ).toBe(expected);
+        });
+      }
+    }
+  }
+
+  it('routes a workflow-only attention session to workflows, never null', () => {
     expect(
       resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
-        hasStandalone: false,
+        hasNonResolverStandalone: false,
         hasWorkflow: true,
         hasResolver: false,
       }),
     ).toBe('workflows');
   });
 
-  it('defaults to agents when nothing else matches', () => {
-    expect(resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), ctx)).toBe('agents');
+  it('returns null when no agent, resolver or workflow is present', () => {
+    expect(resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), ctx)).toBeNull();
+  });
+});
+
+describe('selectNonResolverStandaloneAgents', () => {
+  const text = new Map<string, string>();
+
+  it('keeps a generic standalone agent', () => {
+    const list = [agent({ id: 'g' as Agent['id'], name: 'explore the repo' })];
+    expect(selectNonResolverStandaloneAgents(list, {}, text)).toHaveLength(1);
   });
 
-  it('routes to resolve when a resolver agent needs attention', () => {
-    expect(
-      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
-        hasStandalone: true,
-        hasWorkflow: false,
-        hasResolver: true,
-      }),
-    ).toBe('resolve');
+  it('excludes a name-classified resolver', () => {
+    const list = [agent({ id: 'r' as Agent['id'], name: 'resolve foo' })];
+    expect(selectNonResolverStandaloneAgents(list, {}, text)).toHaveLength(0);
   });
 
-  it('routes to resolve even when non-resolver standalones are also present', () => {
-    expect(
-      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
-        hasStandalone: true,
-        hasWorkflow: true,
-        hasResolver: true,
-      }),
-    ).toBe('resolve');
+  it('excludes an agent overridden to resolver', () => {
+    const list = [agent({ id: 'o' as Agent['id'], name: 'explore the repo' })];
+    const override: Record<string, AgentKind> = { o: 'resolver' };
+    expect(selectNonResolverStandaloneAgents(list, override, text)).toHaveLength(0);
   });
 
-  it('routes to agents when standalone is non-resolver', () => {
-    expect(
-      resolveAttentionLens(stage({ stage: 'attention', reason: 'idle' }), {
-        hasStandalone: true,
-        hasWorkflow: false,
-        hasResolver: false,
+  it('excludes a workflow-step agent that is not standalone', () => {
+    const list = [
+      agent({
+        id: 'w' as Agent['id'],
+        name: 'step agent',
+        workflowRunId: 'run' as Agent['workflowRunId'],
+        stepId: 'step' as Agent['stepId'],
       }),
-    ).toBe('agents');
+    ];
+    expect(selectNonResolverStandaloneAgents(list, {}, text)).toHaveLength(0);
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/lib.ts
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/lib.ts
@@ -1,4 +1,5 @@
 import type { Agent, OpenQuestion, SessionStageInfo } from '@goodboy/types';
+import { type AgentKind, resolveAgentKind } from '../../agent-kind';
 
 export type AttentionSummary = {
   readonly active: boolean;
@@ -11,6 +12,21 @@ export const isStandaloneAgent = (agent: Agent): boolean =>
 export const selectStandaloneAgents = (agents: ReadonlyArray<Agent>): ReadonlyArray<Agent> =>
   agents.filter(isStandaloneAgent);
 
+export const selectNonResolverStandaloneAgents = (
+  agents: ReadonlyArray<Agent>,
+  agentKindOverride: Record<string, AgentKind>,
+  firstUserTextByAgentId: ReadonlyMap<string, string>,
+): ReadonlyArray<Agent> =>
+  agents.filter(
+    (a) =>
+      isStandaloneAgent(a) &&
+      resolveAgentKind(
+        a.name,
+        firstUserTextByAgentId.get(a.id) ?? null,
+        agentKindOverride[a.id] ?? null,
+      ) !== 'resolver',
+  );
+
 export const selectAttention = (stage: SessionStageInfo): AttentionSummary => ({
   active: stage.stage === 'attention',
   reason: stage.reason,
@@ -21,7 +37,7 @@ export type AttentionLens = 'agents' | 'workflows' | 'questions' | 'pr' | 'resol
 export const resolveAttentionLens = (
   stage: SessionStageInfo,
   ctx: {
-    readonly hasStandalone: boolean;
+    readonly hasNonResolverStandalone: boolean;
     readonly hasWorkflow: boolean;
     readonly hasResolver: boolean;
   },
@@ -29,10 +45,10 @@ export const resolveAttentionLens = (
   if (stage.stage !== 'attention') return null;
   if (stage.reason.startsWith('PR')) return 'pr';
   if (stage.reason.includes('question')) return 'questions';
-  if (ctx.hasStandalone && !ctx.hasResolver) return 'agents';
+  if (ctx.hasNonResolverStandalone) return 'agents';
   if (ctx.hasResolver) return 'resolve';
   if (ctx.hasWorkflow) return 'workflows';
-  return 'agents';
+  return null;
 };
 
 export const selectOpenQuestions = (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -1,15 +1,23 @@
-import { useEffect } from 'react';
-import { ArrowLeft, ChevronRight } from 'lucide-react';
-import type { AgentId, Session, SessionId } from '@goodboy/types';
+import { useEffect, useMemo } from 'react';
+import { ArrowLeft } from 'lucide-react';
+import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
 import { Divider, ScrollFade, cn } from '@goodboy/ui';
 import { ChatView } from '../../../chat/components/ChatView';
 import { TerminalDock } from '../../../terminal/components/TerminalDock';
 import { PlanStudio } from '../../../plans/components/PlanStudio';
 import { ScriptsPanel } from '../../../scripts';
-import { readPersistedLens, useAppStore, useFilesTouched } from '../../../../store';
+import {
+  EMPTY_ARRAY,
+  readPersistedLens,
+  useAppStore,
+  useFilesTouched,
+  useSessionPlans,
+} from '../../../../store';
 import type { LensKind } from '../../../../store';
 import { worktreeStatus } from '../../../worktree/worktree';
 import { AgentsSection } from '../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
+import { workflowKindName } from '../../../workspace/components/WorkspacesSidebar/lib';
+import { AppBreadcrumb } from '../../../../app/components/AppBreadcrumb';
 import { SessionOverviewPane } from '../SessionOverviewPane';
 import { SessionStudioLayer } from './parts/SessionStudioLayer';
 import { SessionTopBar } from './parts/SessionTopBar';
@@ -20,6 +28,7 @@ import { PrPane } from './parts/PrPane';
 import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
 import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
+import { buildSessionBreadcrumb } from './sessionBreadcrumb';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -53,8 +62,21 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const workingDir = useAppStore((s) => (s.sessionWorktrees[sessionId] ?? [])[0] ?? null);
   const studio = useAppStore((s) => s.sessionStudio[sessionId] ?? null);
   const setSessionStudio = useAppStore((s) => s.setSessionStudio);
+  const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
+  const setFocusedPlanId = useAppStore((s) => s.setFocusedPlanId);
   const reconcileSessionBranch = useAppStore((s) => s.reconcileSessionBranch);
   const filesTouched = useFilesTouched(sessionId, isActive);
+  const phaseRuns = useAppStore(
+    (s) => s.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
+  );
+  const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId[sessionId] ?? null);
+  const phaseTemplates = useAppStore(
+    (s) => s.phaseTemplates[session.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const sessionWorkflows = useAppStore(
+    (s) => s.sessionWorkflows[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const plans = useSessionPlans(sessionId);
 
   useEffect(() => {
     if (activeLens === undefined) {
@@ -90,6 +112,65 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const onBareOverview = showLens && lens === null;
   const overlayHome = agentHome ?? 'agents';
 
+  const selectedAgentName = useMemo(
+    () =>
+      selectedAgentId != null
+        ? (phaseRuns.find((r) => r.id === selectedAgentId)?.name ?? 'Agent')
+        : null,
+    [phaseRuns, selectedAgentId],
+  );
+  const focusedWorkflowName = useMemo(() => {
+    if (focusedWorkflowRunId == null) return null;
+    const run = session.workflowRuns.find((r) => r.id === focusedWorkflowRunId);
+    if (!run) return null;
+    const workflow =
+      phaseTemplates.find((w) => w.id === run.workflowId) ??
+      sessionWorkflows.find((w) => w.id === run.workflowId) ??
+      null;
+    return workflow ? workflowKindName(workflow) : null;
+  }, [focusedWorkflowRunId, session.workflowRuns, phaseTemplates, sessionWorkflows]);
+  const focusedPlanTitle = useMemo(
+    () => plans.find((p) => p.id === focusedPlanId)?.title ?? null,
+    [plans, focusedPlanId],
+  );
+
+  const crumbs = useMemo(
+    () =>
+      buildSessionBreadcrumb({
+        lens,
+        studio,
+        selectedAgentName,
+        overlayHomeLens: overlayHome,
+        focusedWorkflowName,
+        focusedPlanTitle,
+        lensLabel: (l) => LENS_LABEL[l],
+        handlers: {
+          toOverview: () => setActiveLens(sessionId, null),
+          toLens: (l) => setActiveLens(sessionId, l),
+          toWorkflowsList: () => {
+            setFocusedWorkflowRun(sessionId, null);
+            setActiveLens(sessionId, 'workflows');
+          },
+          toPlansList: () => {
+            setFocusedPlanId(sessionId, null);
+            setActiveLens(sessionId, 'plans');
+          },
+        },
+      }),
+    [
+      lens,
+      studio,
+      selectedAgentName,
+      overlayHome,
+      focusedWorkflowName,
+      focusedPlanTitle,
+      sessionId,
+      setActiveLens,
+      setFocusedWorkflowRun,
+      setFocusedPlanId,
+    ],
+  );
+
   useEffect(() => {
     if (!showAgentOverlay) return;
     const onKeyDown = (event: KeyboardEvent) => {
@@ -104,6 +185,10 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   return (
     <div className="flex h-full w-full flex-col">
       <SessionTopBar session={session} />
+      <div className="flex shrink-0 items-center px-6 py-2.5">
+        <AppBreadcrumb crumbs={crumbs} />
+      </div>
+      <Divider />
       <div className="flex min-h-0 flex-1">
         {onBareOverview ? null : (
           <>
@@ -119,20 +204,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
           </>
         )}
         <div className="relative flex min-w-0 flex-1 flex-col">
-          {showLens && lens !== null ? (
-            <div className="flex shrink-0 items-center gap-1.5 px-6 pb-3 pt-4 text-xs text-muted-foreground">
-              <button
-                type="button"
-                onClick={onSelectOverview}
-                className="inline-flex items-center gap-1 rounded font-medium text-foreground transition-colors hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-              >
-                <ArrowLeft size={12} aria-hidden className="shrink-0" />
-                Back to overview
-              </button>
-              <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/40" />
-              <span className="font-medium text-foreground">{LENS_LABEL[lens]}</span>
-            </div>
-          ) : null}
           <div className="relative min-h-0 flex-1">
             {showLens ? (
               <div className="absolute inset-0 z-0">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/FilesPane.tsx
@@ -1,5 +1,6 @@
 import { FileDiff } from 'lucide-react';
 import type { SessionId } from '@goodboy/types';
+import { EmptyState } from '@goodboy/ui';
 import { useCurrentWorkspace } from '../../../../../store';
 import { DiffViewerPane } from '../../../../permissions/components/DiffViewerDialog';
 import { PaneShell } from './PaneShell';
@@ -16,18 +17,13 @@ export const FilesPane = ({ sessionId, workingDir, onClose }: FilesPaneProps) =>
   if (!workingDir) {
     return (
       <PaneShell title="Diff" description="Changes across this session's working tree.">
-        <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-6 py-8 text-center">
-          <span
-            aria-hidden
-            className="flex size-12 items-center justify-center rounded-md bg-muted/50"
-          >
-            <FileDiff size={24} className="text-muted-foreground" />
-          </span>
-          <p className="text-sm font-medium text-foreground">No worktree for this session</p>
-          <p className="max-w-xs text-xs leading-relaxed text-muted-foreground">
-            This session has no checked-out worktree, so there is no diff to show.
-          </p>
-        </div>
+        <EmptyState
+          bordered
+          tone="info"
+          icon={FileDiff}
+          title="No worktree for this session"
+          description="This session has no checked-out worktree, so there is no diff to show."
+        />
       </PaneShell>
     );
   }

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -59,8 +59,10 @@ type LensGroup = {
 export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensColumnProps) => {
   const sessionId = session.id as SessionId;
   const openCount = selectOpenQuestions(useSessionOpenQuestions(sessionId)).length;
-  const hasStandaloneAgent = useAppStore((s) =>
-    (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some(isStandaloneAgent),
+  const hasNonResolverStandalone = useAppStore((s) =>
+    (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some(
+      (a) => isStandaloneAgent(a) && !isResolverAgent(a, s.agentKindOverride[a.id] ?? null),
+    ),
   );
   const hasRunningAgent = useAppStore((s) =>
     (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some(
@@ -74,7 +76,7 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
     ),
   );
   const attentionLens = resolveAttentionLens(useSessionStageInfo(session), {
-    hasStandalone: hasStandaloneAgent,
+    hasNonResolverStandalone,
     hasWorkflow: activeWorkflows > 0,
     hasResolver: hasResolverAgent,
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
@@ -16,7 +17,7 @@ import {
 import { ScrollFade, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type { Agent, Session, SessionId } from '@goodboy/types';
-import { type AgentKind, inferAgentKindFromName } from '../../../../session/agent-kind';
+import { resolveAgentKind } from '../../../../session/agent-kind';
 import {
   EMPTY_ARRAY,
   useAppStore,
@@ -30,9 +31,6 @@ import {
   resolveAttentionLens,
   selectOpenQuestions,
 } from '../../SessionOverviewPane/lib';
-
-const isResolverAgent = (agent: Agent, override: AgentKind | null): boolean =>
-  isStandaloneAgent(agent) && (override ?? inferAgentKindFromName(agent.name)) === 'resolver';
 
 type LensColumnProps = {
   readonly session: Session;
@@ -59,22 +57,48 @@ type LensGroup = {
 export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensColumnProps) => {
   const sessionId = session.id as SessionId;
   const openCount = selectOpenQuestions(useSessionOpenQuestions(sessionId)).length;
-  const hasNonResolverStandalone = useAppStore((s) =>
-    (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some(
-      (a) => isStandaloneAgent(a) && !isResolverAgent(a, s.agentKindOverride[a.id] ?? null),
-    ),
+  const messages = useAppStore((s) => s.messages[sessionId] ?? EMPTY_ARRAY);
+  const agentKindOverride = useAppStore((s) => s.agentKindOverride);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+
+  const firstUserTextByAgentId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of messages) {
+      if (m.role !== 'user') {
+        continue;
+      }
+      if (map.has(m.agentId)) {
+        continue;
+      }
+      map.set(m.agentId, m.content);
+    }
+    return map;
+  }, [messages]);
+
+  const isResolver = useMemo(
+    () => (agent: Agent) =>
+      resolveAgentKind(
+        agent.name,
+        firstUserTextByAgentId.get(agent.id) ?? null,
+        agentKindOverride[agent.id] ?? null,
+      ) === 'resolver',
+    [firstUserTextByAgentId, agentKindOverride],
   );
-  const hasRunningAgent = useAppStore((s) =>
-    (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some(
-      (a) => a.status === 'running' && isStandaloneAgent(a),
-    ),
+
+  const hasNonResolverStandalone = useMemo(
+    () => phaseRuns.some((a) => isStandaloneAgent(a) && !isResolver(a)),
+    [phaseRuns, isResolver],
   );
+  const hasResolverAgent = useMemo(
+    () => phaseRuns.some((a) => isStandaloneAgent(a) && isResolver(a)),
+    [phaseRuns, isResolver],
+  );
+  const hasRunningAgent = useMemo(
+    () => phaseRuns.some((a) => a.status === 'running' && isStandaloneAgent(a) && !isResolver(a)),
+    [phaseRuns, isResolver],
+  );
+
   const activeWorkflows = session.workflowRuns.filter((r) => r.discardedAt == null).length;
-  const hasResolverAgent = useAppStore((s) =>
-    (s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY).some((a) =>
-      isResolverAgent(a, s.agentKindOverride[a.id] ?? null),
-    ),
-  );
   const attentionLens = resolveAttentionLens(useSessionStageInfo(session), {
     hasNonResolverStandalone,
     hasWorkflow: activeWorkflows > 0,
@@ -92,18 +116,20 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
   const hasPr = useAppStore(
     (s) => s.sessionGithub[sessionId]?.pr != null || s.sessionGitlabMr[sessionId]?.mr != null,
   );
-  const openResolvers = useAppStore((s) => {
-    const runs = s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY;
-    return runs.reduce(
-      (n, r) =>
-        n +
-        (isResolverAgent(r, s.agentKindOverride[r.id] ?? null) &&
-        (r.status === 'pending' || r.status === 'running')
-          ? 1
-          : 0),
-      0,
-    );
-  });
+  const openResolvers = useMemo(
+    () =>
+      phaseRuns.reduce(
+        (n, r) =>
+          n +
+          (isStandaloneAgent(r) &&
+          isResolver(r) &&
+          (r.status === 'pending' || r.status === 'running')
+            ? 1
+            : 0),
+        0,
+      ),
+    [phaseRuns, isResolver],
+  );
   const hasPendingBatch = useAppStore(
     (s) => (s.sessionPendingResolutions[sessionId]?.length ?? 0) > 0,
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -102,15 +102,15 @@ const GithubPrCard = ({ session }: { session: Session }) => {
 
   if (!pr) {
     return (
-      <div className="animate-fade-in relative flex flex-col items-center gap-5 rounded-lg border border-border-soft bg-elevated px-8 py-8 text-center">
+      <div className="animate-fade-in relative flex flex-col items-center gap-5 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-8 py-8 text-center">
         <div className="absolute right-3 top-3">
           <RefreshButton onClick={refresh} loading={loading} error={error} />
         </div>
         <span
           aria-hidden
-          className="flex size-14 items-center justify-center rounded-md bg-primary/10 ring-1 ring-primary/15"
+          className="flex size-12 items-center justify-center rounded-full bg-primary/10"
         >
-          <GitPullRequest size={26} className="text-primary" />
+          <GitPullRequest size={24} className="text-primary" />
         </span>
         <div className="flex flex-col items-center gap-1.5">
           <h2 className="text-base font-semibold text-foreground">Open a pull request</h2>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/QuestionsPane.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo } from 'react';
 import { ArrowRight, Bot, CircleCheck } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { EmptyState, cn } from '@goodboy/ui';
 import type {
   Agent,
   AgentId,
@@ -295,18 +295,13 @@ export const QuestionsPane = ({ session }: QuestionsPaneProps) => {
     return (
       <PaneShell title="Questions" description="Decisions agents need from you to keep going.">
         <div className="flex flex-col gap-6">
-          <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-6 py-8 text-center">
-            <span
-              aria-hidden
-              className="flex size-12 items-center justify-center rounded-md bg-success/10"
-            >
-              <CircleCheck size={24} aria-hidden className="text-success" />
-            </span>
-            <p className="text-sm font-medium text-foreground">No open questions</p>
-            <p className="max-w-xs text-xs leading-relaxed text-muted-foreground">
-              When an agent needs a decision, it shows up here.
-            </p>
-          </div>
+          <EmptyState
+            bordered
+            tone="success"
+            icon={CircleCheck}
+            title="No open questions"
+            description="When an agent needs a decision, it shows up here."
+          />
           <AnsweredHistory clusters={answeredClusters} sessionId={sessionId} />
         </div>
       </PaneShell>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
-import { History, RotateCcw } from 'lucide-react';
-import { Dialog, Markdown, Textarea, cn } from '@goodboy/ui';
+import { CheckSquare, FileText, History, RotateCcw, Target } from 'lucide-react';
+import { Button, Dialog, EmptyState, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
+import type { LucideIcon } from 'lucide-react';
 import type { ContextSlotHistoryEntry, Session, SessionId } from '@goodboy/types';
 import {
   useAppStore,
@@ -30,6 +31,24 @@ const SLOT_EMPTY_CTA: Record<SlotKey, string> = {
   goal: 'Add the session goal',
   decisions: 'Log a decision',
   last_output_summary: 'Write a manual summary',
+};
+
+const SLOT_ICON: Record<SlotKey, LucideIcon> = {
+  goal: Target,
+  decisions: CheckSquare,
+  last_output_summary: FileText,
+};
+
+const SLOT_TONE: Record<SlotKey, Tone> = {
+  goal: 'primary',
+  decisions: 'success',
+  last_output_summary: 'info',
+};
+
+const SLOT_EMPTY_DESCRIPTION: Record<SlotKey, string> = {
+  goal: 'What this session is meant to achieve.',
+  decisions: 'Choices already locked in for this session.',
+  last_output_summary: "Summary of the agent's most recent reply.",
 };
 
 const MARKDOWN_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>(['decisions', 'last_output_summary']);
@@ -125,18 +144,18 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
             maxRows={24}
           />
         ) : !hasValue ? (
-          <button
-            type="button"
-            onClick={startEditing}
-            disabled={isSummarizing}
-            className={cn(
-              'flex flex-col items-start gap-1 rounded-lg border border-dashed border-border-soft px-4 py-6 text-left transition-colors',
-              isSummarizing ? 'cursor-default' : 'hover:border-border hover:bg-foreground/[0.02]',
-            )}
-          >
-            <span className="text-sm text-muted-foreground">{SLOT_EMPTY_CTA[slotKey]}</span>
-            <span className="text-xs text-muted-foreground/50">Click to edit</span>
-          </button>
+          <EmptyState
+            bordered
+            tone={SLOT_TONE[slotKey]}
+            icon={SLOT_ICON[slotKey]}
+            title={SLOT_EMPTY_CTA[slotKey]}
+            description={SLOT_EMPTY_DESCRIPTION[slotKey]}
+            action={
+              <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
+                Add
+              </Button>
+            }
+          />
         ) : renderAsMarkdown ? (
           <div
             role={isSummarizing ? undefined : 'button'}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildSessionBreadcrumb } from './sessionBreadcrumb';
+import type { SessionBreadcrumbHandlers, SessionBreadcrumbInput } from './sessionBreadcrumb';
+import type { LensKind } from '../../../../store';
+
+const makeHandlers = (): SessionBreadcrumbHandlers => ({
+  toOverview: vi.fn(),
+  toLens: vi.fn(),
+  toWorkflowsList: vi.fn(),
+  toPlansList: vi.fn(),
+});
+
+const lensLabel = (lens: LensKind) => lens;
+
+const base = (
+  overrides: Partial<SessionBreadcrumbInput>,
+  handlers: SessionBreadcrumbHandlers,
+): SessionBreadcrumbInput => ({
+  lens: null,
+  studio: null,
+  selectedAgentName: null,
+  overlayHomeLens: null,
+  focusedWorkflowName: null,
+  focusedPlanTitle: null,
+  lensLabel,
+  handlers,
+  ...overrides,
+});
+
+const labels = (crumbs: ReturnType<typeof buildSessionBreadcrumb>) => crumbs.map((c) => c.label);
+const last = (crumbs: ReturnType<typeof buildSessionBreadcrumb>) => crumbs[crumbs.length - 1];
+
+describe('buildSessionBreadcrumb', () => {
+  it('renders a single non-clickable Overview crumb on bare overview', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({}, h));
+    expect(labels(crumbs)).toEqual(['Overview']);
+    expect(crumbs).toHaveLength(1);
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders Overview > lens for a leaf lens, Overview clickable', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({ lens: 'questions' }, h));
+    expect(labels(crumbs)).toEqual(['Overview', 'questions']);
+    crumbs[0]!.onClick!();
+    expect(h.toOverview).toHaveBeenCalledOnce();
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders Overview > Workflows > {name} for a focused workflow run', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ lens: 'workflows', focusedWorkflowName: 'refactor' }, h),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'refactor']);
+    crumbs[1]!.onClick!();
+    expect(h.toWorkflowsList).toHaveBeenCalledOnce();
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders Overview > Workflows > Create for the workflow builder studio', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({ studio: { kind: 'workflow' } }, h));
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'Create']);
+    crumbs[1]!.onClick!();
+    expect(h.toWorkflowsList).toHaveBeenCalledOnce();
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders Overview > {home} > {agent} for an agent overlay', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ selectedAgentName: 'scout-1', overlayHomeLens: 'agents' }, h),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'agents', 'scout-1']);
+    crumbs[1]!.onClick!();
+    expect(h.toLens).toHaveBeenCalledWith('agents');
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('routes the overlay-home crumb through toWorkflowsList when home is workflows', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ selectedAgentName: 'scout-1', overlayHomeLens: 'workflows' }, h),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'workflows', 'scout-1']);
+    crumbs[1]!.onClick!();
+    expect(h.toWorkflowsList).toHaveBeenCalledOnce();
+    expect(h.toLens).not.toHaveBeenCalled();
+  });
+
+  it('degrades a workflows lens with no focused run to a two-crumb leaf trail', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ lens: 'workflows', focusedWorkflowName: null }, h),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'workflows']);
+    expect(crumbs).toHaveLength(2);
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders PR #n for a github studio with a prNumber', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({ studio: { kind: 'github', prNumber: 42 } }, h));
+    expect(labels(crumbs)).toEqual(['Overview', 'pr', 'PR #42']);
+    crumbs[1]!.onClick!();
+    expect(h.toLens).toHaveBeenCalledWith('pr');
+    expect(last(crumbs)?.onClick).toBeUndefined();
+  });
+
+  it('renders GitHub for a github studio without a prNumber', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({ studio: { kind: 'github' } }, h));
+    expect(labels(crumbs)).toEqual(['Overview', 'pr', 'GitHub']);
+  });
+
+  it('renders Merge request for an mr studio', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(base({ studio: { kind: 'mr' } }, h));
+    expect(labels(crumbs)).toEqual(['Overview', 'pr', 'Merge request']);
+    crumbs[1]!.onClick!();
+    expect(h.toLens).toHaveBeenCalledWith('pr');
+  });
+
+  it('renders Overview > Plans > {title} for a focused plan', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base({ lens: 'plans', focusedPlanTitle: 'migration plan' }, h),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'Plans', 'migration plan']);
+    crumbs[1]!.onClick!();
+    expect(h.toPlansList).toHaveBeenCalledOnce();
+  });
+
+  it('lets the studio trail win over agent and workflow inputs', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base(
+        {
+          studio: { kind: 'workflow' },
+          selectedAgentName: 'scout-1',
+          overlayHomeLens: 'agents',
+          lens: 'workflows',
+          focusedWorkflowName: 'refactor',
+        },
+        h,
+      ),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'Create']);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -1,0 +1,104 @@
+import type { BreadcrumbCrumb } from '../../../../app/components/AppBreadcrumb/buildBreadcrumb';
+import type { LensKind, SessionStudio } from '../../../../store';
+
+export type SessionBreadcrumbHandlers = {
+  toOverview: () => void;
+  toLens: (lens: LensKind) => void;
+  toWorkflowsList: () => void;
+  toPlansList: () => void;
+};
+
+export type SessionBreadcrumbInput = {
+  lens: LensKind | null;
+  studio: SessionStudio | null;
+  selectedAgentName: string | null;
+  overlayHomeLens: LensKind | null;
+  focusedWorkflowName: string | null;
+  focusedPlanTitle: string | null;
+  lensLabel: (lens: LensKind) => string;
+  handlers: SessionBreadcrumbHandlers;
+};
+
+const sealLast = (crumbs: BreadcrumbCrumb[]): BreadcrumbCrumb[] => {
+  const copy = crumbs.map((crumb) => ({ ...crumb }));
+  const last = copy[copy.length - 1];
+  if (last) delete last.onClick;
+  return copy;
+};
+
+export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): BreadcrumbCrumb[] => {
+  const {
+    lens,
+    studio,
+    selectedAgentName,
+    overlayHomeLens,
+    focusedWorkflowName,
+    focusedPlanTitle,
+    lensLabel,
+    handlers,
+  } = input;
+
+  const overview: BreadcrumbCrumb = {
+    id: 'overview',
+    label: 'Overview',
+    onClick: handlers.toOverview,
+  };
+  const workflowsList: BreadcrumbCrumb = {
+    id: 'workflows',
+    label: 'Workflows',
+    onClick: handlers.toWorkflowsList,
+  };
+  const plansList: BreadcrumbCrumb = {
+    id: 'plans',
+    label: 'Plans',
+    onClick: handlers.toPlansList,
+  };
+
+  if (studio != null) {
+    if (studio.kind === 'workflow') {
+      return sealLast([overview, workflowsList, { id: 'create', label: 'Create' }]);
+    }
+    if (studio.kind === 'github') {
+      return sealLast([
+        overview,
+        { id: 'pr', label: lensLabel('pr'), onClick: () => handlers.toLens('pr') },
+        {
+          id: 'github',
+          label: studio.prNumber != null ? `PR #${studio.prNumber}` : 'GitHub',
+        },
+      ]);
+    }
+    return sealLast([
+      overview,
+      { id: 'pr', label: lensLabel('pr'), onClick: () => handlers.toLens('pr') },
+      { id: 'mr', label: 'Merge request' },
+    ]);
+  }
+
+  if (selectedAgentName != null && overlayHomeLens != null) {
+    const home = overlayHomeLens;
+    return sealLast([
+      overview,
+      {
+        id: 'overlay-home',
+        label: lensLabel(home),
+        onClick: () => (home === 'workflows' ? handlers.toWorkflowsList() : handlers.toLens(home)),
+      },
+      { id: 'agent', label: selectedAgentName },
+    ]);
+  }
+
+  if (lens === 'workflows' && focusedWorkflowName != null) {
+    return sealLast([overview, workflowsList, { id: 'workflow-run', label: focusedWorkflowName }]);
+  }
+
+  if (lens === 'plans' && focusedPlanTitle != null) {
+    return sealLast([overview, plansList, { id: 'plan', label: focusedPlanTitle }]);
+  }
+
+  if (lens != null) {
+    return sealLast([overview, { id: `lens-${lens}`, label: lensLabel(lens) }]);
+  }
+
+  return sealLast([overview]);
+};

--- a/apps/desktop/src/features/session/hooks/useResolvableCount/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useResolvableCount/index.test.ts
@@ -10,7 +10,6 @@ const { store } = vi.hoisted(() => {
 });
 
 vi.mock('../../../../store', () => ({
-  EMPTY_ARRAY: [],
   useAppStore: Object.assign((selector: (s: StoreState) => unknown) => selector(store.state), {
     getState: () => store.state,
   }),
@@ -20,22 +19,11 @@ import { useResolvableCount } from './index';
 
 const SID = 'sess-1' as SessionId;
 
-const makeAgent = (over: Record<string, unknown> = {}) => ({
-  id: 'a',
-  parentAgentId: null,
-  workflowRunId: null,
-  sourceThreadId: null,
-  status: 'running',
-  ...over,
-});
-
 beforeEach(() => {
   store.state = {
     sessionGithub: {},
-    sessionGitlabMr: {},
     diffComments: {},
     sessionPendingResolutions: {},
-    sessionPhaseRuns: {},
   };
 });
 
@@ -44,31 +32,20 @@ afterEach(() => {
 });
 
 describe('useResolvableCount', () => {
-  it('no PR, no resolvers, nothing loaded -> disabled with "No pull request yet" and total 0', () => {
+  it('nothing loaded -> all counts are zero', () => {
     const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(false);
-    expect(result.current.disabledReason).toBe('No pull request yet');
-    expect(result.current.total).toBe(0);
+    expect(result.current).toEqual({ prComments: 0, diffComments: 0, pending: 0 });
   });
 
-  it('PR present but detail not loaded -> enabled (proxy), no disabledReason', () => {
-    store.state = {
-      ...store.state,
-      sessionGithub: { [SID]: { pr: { number: 1 }, detail: null } },
-    };
-    const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(true);
-    expect(result.current.disabledReason).toBeNull();
-  });
-
-  it('PR present, detail loaded with zero unresolved review comments -> disabled with "No comments in the PR"', () => {
+  it('counts unresolved review comments from loaded PR detail', () => {
     store.state = {
       ...store.state,
       sessionGithub: {
         [SID]: {
-          pr: { number: 1 },
           detail: {
             comments: [
+              { source: 'review', resolved: false },
+              { source: 'review', resolved: false },
               { source: 'review', resolved: true },
               { source: 'issue', resolved: false },
             ],
@@ -77,47 +54,31 @@ describe('useResolvableCount', () => {
       },
     };
     const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(false);
-    expect(result.current.disabledReason).toBe('No comments in the PR');
-    expect(result.current.total).toBe(0);
+    expect(result.current.prComments).toBe(2);
+    expect(result.current.diffComments).toBe(0);
+    expect(result.current.pending).toBe(0);
   });
 
-  it('PR present, detail loaded with one unresolved review comment -> enabled, total >= 1', () => {
+  it('counts open diff comments', () => {
     store.state = {
       ...store.state,
-      sessionGithub: {
-        [SID]: {
-          pr: { number: 1 },
-          detail: {
-            comments: [{ source: 'review', resolved: false }],
-          },
-        },
+      diffComments: {
+        [SID]: [{ status: 'open' }, { status: 'open' }, { status: 'resolved' }],
       },
     };
     const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(true);
-    expect(result.current.total).toBeGreaterThanOrEqual(1);
+    expect(result.current.diffComments).toBe(2);
+    expect(result.current.prComments).toBe(0);
   });
 
-  it('standalone resolver agent present -> enabled, total >= 1', () => {
+  it('reports the pending batch length', () => {
     store.state = {
       ...store.state,
-      sessionPhaseRuns: {
-        [SID]: [makeAgent({ sourceThreadId: 'thread-123' })],
-      },
+      sessionPendingResolutions: { [SID]: [{}, {}, {}] },
     };
     const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(true);
-    expect(result.current.total).toBeGreaterThanOrEqual(1);
-  });
-
-  it('diff loaded with zero open comments and no PR -> "No pull request yet"', () => {
-    store.state = {
-      ...store.state,
-      diffComments: { [SID]: [{ status: 'resolved' }, { status: 'consumed' }] },
-    };
-    const { result } = renderHook(() => useResolvableCount(SID));
-    expect(result.current.enabled).toBe(false);
-    expect(result.current.disabledReason).toBe('No pull request yet');
+    expect(result.current.pending).toBe(3);
+    expect(result.current.prComments).toBe(0);
+    expect(result.current.diffComments).toBe(0);
   });
 });

--- a/apps/desktop/src/features/session/hooks/useResolvableCount/index.test.ts
+++ b/apps/desktop/src/features/session/hooks/useResolvableCount/index.test.ts
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionId } from '@goodboy/types';
+
+type StoreState = Record<string, unknown>;
+
+const { store } = vi.hoisted(() => {
+  const store: { state: StoreState } = { state: {} };
+  return { store };
+});
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: Object.assign((selector: (s: StoreState) => unknown) => selector(store.state), {
+    getState: () => store.state,
+  }),
+}));
+
+import { useResolvableCount } from './index';
+
+const SID = 'sess-1' as SessionId;
+
+const makeAgent = (over: Record<string, unknown> = {}) => ({
+  id: 'a',
+  parentAgentId: null,
+  workflowRunId: null,
+  sourceThreadId: null,
+  status: 'running',
+  ...over,
+});
+
+beforeEach(() => {
+  store.state = {
+    sessionGithub: {},
+    sessionGitlabMr: {},
+    diffComments: {},
+    sessionPendingResolutions: {},
+    sessionPhaseRuns: {},
+  };
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useResolvableCount', () => {
+  it('no PR, no resolvers, nothing loaded -> disabled with "No pull request yet" and total 0', () => {
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.disabledReason).toBe('No pull request yet');
+    expect(result.current.total).toBe(0);
+  });
+
+  it('PR present but detail not loaded -> enabled (proxy), no disabledReason', () => {
+    store.state = {
+      ...store.state,
+      sessionGithub: { [SID]: { pr: { number: 1 }, detail: null } },
+    };
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.disabledReason).toBeNull();
+  });
+
+  it('PR present, detail loaded with zero unresolved review comments -> disabled with "No comments in the PR"', () => {
+    store.state = {
+      ...store.state,
+      sessionGithub: {
+        [SID]: {
+          pr: { number: 1 },
+          detail: {
+            comments: [
+              { source: 'review', resolved: true },
+              { source: 'issue', resolved: false },
+            ],
+          },
+        },
+      },
+    };
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.disabledReason).toBe('No comments in the PR');
+    expect(result.current.total).toBe(0);
+  });
+
+  it('PR present, detail loaded with one unresolved review comment -> enabled, total >= 1', () => {
+    store.state = {
+      ...store.state,
+      sessionGithub: {
+        [SID]: {
+          pr: { number: 1 },
+          detail: {
+            comments: [{ source: 'review', resolved: false }],
+          },
+        },
+      },
+    };
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it('standalone resolver agent present -> enabled, total >= 1', () => {
+    store.state = {
+      ...store.state,
+      sessionPhaseRuns: {
+        [SID]: [makeAgent({ sourceThreadId: 'thread-123' })],
+      },
+    };
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(true);
+    expect(result.current.total).toBeGreaterThanOrEqual(1);
+  });
+
+  it('diff loaded with zero open comments and no PR -> "No pull request yet"', () => {
+    store.state = {
+      ...store.state,
+      diffComments: { [SID]: [{ status: 'resolved' }, { status: 'consumed' }] },
+    };
+    const { result } = renderHook(() => useResolvableCount(SID));
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.disabledReason).toBe('No pull request yet');
+  });
+});

--- a/apps/desktop/src/features/session/hooks/useResolvableCount/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolvableCount/index.ts
@@ -1,49 +1,25 @@
 import { useMemo } from 'react';
 import type { SessionId } from '@goodboy/types';
-import { useAppStore, EMPTY_ARRAY } from '../../../../store';
+import { useAppStore } from '../../../../store';
 
 export type ResolvableState = {
-  readonly total: number;
-  readonly enabled: boolean;
-  readonly disabledReason: string | null;
+  readonly prComments: number;
+  readonly diffComments: number;
+  readonly pending: number;
 };
 
 export const useResolvableCount = (sessionId: SessionId): ResolvableState => {
-  const hasPr = useAppStore(
-    (s) => s.sessionGithub[sessionId]?.pr != null || s.sessionGitlabMr[sessionId]?.mr != null,
-  );
   const prDetail = useAppStore((s) => s.sessionGithub[sessionId]?.detail ?? null);
   const diff = useAppStore((s) => s.diffComments[sessionId] ?? null);
   const pending = useAppStore((s) => s.sessionPendingResolutions[sessionId]?.length ?? 0);
-  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
 
   return useMemo(() => {
-    const prDetailLoaded = prDetail != null;
-    const prOpenComments = prDetailLoaded
+    const prComments = prDetail
       ? prDetail.comments.filter((c) => c.source === 'review' && c.resolved === false).length
       : 0;
 
-    const diffLoaded = diff != null;
-    const diffOpenComments = diffLoaded ? diff.filter((c) => c.status === 'open').length : 0;
+    const diffComments = diff ? diff.filter((c) => c.status === 'open').length : 0;
 
-    const queue = phaseRuns.filter(
-      (a) => a.parentAgentId == null && a.workflowRunId == null && a.sourceThreadId != null,
-    ).length;
-
-    const total = prOpenComments + diffOpenComments + pending + queue;
-
-    const enabled = total > 0 || (hasPr && !prDetailLoaded);
-
-    const disabledReason: string | null = enabled
-      ? null
-      : !hasPr
-        ? 'No pull request yet'
-        : prDetailLoaded && prOpenComments === 0
-          ? 'No comments in the PR'
-          : diffLoaded && diffOpenComments === 0
-            ? 'No comments in the diff'
-            : 'No pull request yet';
-
-    return { total, enabled, disabledReason };
-  }, [hasPr, prDetail, diff, pending, phaseRuns]);
+    return { prComments, diffComments, pending };
+  }, [prDetail, diff, pending]);
 };

--- a/apps/desktop/src/features/session/hooks/useResolvableCount/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolvableCount/index.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore, EMPTY_ARRAY } from '../../../../store';
+
+export type ResolvableState = {
+  readonly total: number;
+  readonly enabled: boolean;
+  readonly disabledReason: string | null;
+};
+
+export const useResolvableCount = (sessionId: SessionId): ResolvableState => {
+  const hasPr = useAppStore(
+    (s) => s.sessionGithub[sessionId]?.pr != null || s.sessionGitlabMr[sessionId]?.mr != null,
+  );
+  const prDetail = useAppStore((s) => s.sessionGithub[sessionId]?.detail ?? null);
+  const diff = useAppStore((s) => s.diffComments[sessionId] ?? null);
+  const pending = useAppStore((s) => s.sessionPendingResolutions[sessionId]?.length ?? 0);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+
+  return useMemo(() => {
+    const prDetailLoaded = prDetail != null;
+    const prOpenComments = prDetailLoaded
+      ? prDetail.comments.filter((c) => c.source === 'review' && c.resolved === false).length
+      : 0;
+
+    const diffLoaded = diff != null;
+    const diffOpenComments = diffLoaded ? diff.filter((c) => c.status === 'open').length : 0;
+
+    const queue = phaseRuns.filter(
+      (a) => a.parentAgentId == null && a.workflowRunId == null && a.sourceThreadId != null,
+    ).length;
+
+    const total = prOpenComments + diffOpenComments + pending + queue;
+
+    const enabled = total > 0 || (hasPr && !prDetailLoaded);
+
+    const disabledReason: string | null = enabled
+      ? null
+      : !hasPr
+        ? 'No pull request yet'
+        : prDetailLoaded && prOpenComments === 0
+          ? 'No comments in the PR'
+          : diffLoaded && diffOpenComments === 0
+            ? 'No comments in the diff'
+            : 'No pull request yet';
+
+    return { total, enabled, disabledReason };
+  }, [hasPr, prDetail, diff, pending, phaseRuns]);
+};

--- a/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
+++ b/apps/desktop/src/features/terminal/components/TerminalDock/index.tsx
@@ -3,6 +3,7 @@ import { SquareTerminal } from 'lucide-react';
 import { Button, Divider, EmptyState } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { PaneShell } from '../../../session/components/SessionWorkspace/parts/PaneShell';
 import {
   GenericTerminalPanel,
   type TerminalDriver,
@@ -110,8 +111,10 @@ export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
 
   if (tabs.length === 0) {
     return (
-      <div className="flex min-h-0 flex-1 items-center justify-center">
+      <PaneShell title="Terminal" description="Run commands in this session's worktree.">
         <EmptyState
+          bordered
+          tone="info"
           icon={SquareTerminal}
           title="No terminal"
           description="Open a terminal to run commands in this worktree."
@@ -121,7 +124,7 @@ export const TerminalDock = ({ sessionId, isActive, cwd }: Props) => {
             </Button>
           }
         />
-      </div>
+      </PaneShell>
     );
   }
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -75,7 +75,7 @@ export const StageColumn = ({
   );
 
   return (
-    <div className={cn('flex min-h-0 shrink-0 flex-col gap-3', collapsed ? 'w-auto' : 'w-72')}>
+    <div className={cn('flex min-h-0 shrink-0 flex-col gap-3 w-72')}>
       {view.collapsible ? (
         <button
           type="button"

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.test.tsx
@@ -28,7 +28,6 @@ vi.mock('./StageColumn', () => ({
   ),
 }));
 
-vi.mock('../WorkspaceHeader', () => ({ WorkspaceHeader: () => <div /> }));
 vi.mock('../../../session/components/ArchiveSessionDialog', () => ({
   ArchiveSessionDialog: () => null,
 }));

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -7,7 +7,6 @@ import { STAGE_ORDER } from '../../../../store/slices/session-view/types';
 import { DogMascot } from '../../../../shared/components/DogMascot';
 import { ArchiveSessionDialog } from '../../../session/components/ArchiveSessionDialog';
 import { DeleteSessionDialog } from '../../../session/components/DeleteSessionDialog';
-import { WorkspaceHeader } from '../WorkspaceHeader';
 import { StageColumn } from './StageColumn';
 import { useBoardNavigation } from './useBoardNavigation';
 
@@ -73,11 +72,6 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: StageBoar
 
   return (
     <div className="flex h-full w-full flex-col gap-4 p-6">
-      <div className="-mx-6 -mt-6 shrink-0">
-        <WorkspaceHeader />
-        <Divider />
-      </div>
-
       <div className="flex shrink-0 items-center justify-between gap-4">
         <span className="flex items-baseline gap-2">
           <Eyebrow label="Stage board" />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
@@ -26,7 +26,6 @@ vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: [] as never[],
 }));
 
-vi.mock('../WorkspaceHeader', () => ({ WorkspaceHeader: () => null }));
 vi.mock('../SessionActivityBar', () => ({ SessionActivityBar: () => null }));
 vi.mock('../WorkspaceLinkDialog', () => ({ WorkspaceLinkDialog: () => null }));
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useState } from 'react';
-import { Divider } from '@goodboy/ui';
 import { ArrowLeft } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
 import {
@@ -9,7 +8,6 @@ import {
   useCurrentWorkspace,
   useSessions,
 } from '../../../../store';
-import { WorkspaceHeader } from '../WorkspaceHeader';
 import { WorkspaceLinkDialog } from '../WorkspaceLinkDialog';
 import { SessionActivityBar } from '../SessionActivityBar';
 import { NoWorkspaceEmpty } from './parts/NoWorkspaceEmpty';
@@ -40,13 +38,6 @@ export const WorkspacesSidebar = () => {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {currentWorkspace ? (
-        <>
-          <WorkspaceHeader />
-          <Divider />
-        </>
-      ) : null}
-
       {currentWorkspace && currentSession ? (
         <button
           type="button"

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { ArrowLeft } from 'lucide-react';
+import { Kanban } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -39,15 +39,17 @@ export const WorkspacesSidebar = () => {
   return (
     <div className="flex h-full min-h-0 flex-col">
       {currentWorkspace && currentSession ? (
-        <button
-          type="button"
-          onClick={() => void setCurrentSession(null)}
-          aria-label="back to board"
-          className="mx-2 mb-1 mt-2 inline-flex shrink-0 items-center gap-1.5 self-start rounded-md px-2 py-1.5 text-xs font-semibold text-foreground motion-safe:transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-        >
-          <ArrowLeft size={14} aria-hidden />
-          Back to board
-        </button>
+        <div className="shrink-0 px-2 pt-2 pb-1">
+          <button
+            type="button"
+            onClick={() => void setCurrentSession(null)}
+            aria-label="back to board"
+            className="w-full flex items-center justify-center gap-1.5 rounded-md bg-accent/10 px-2 py-1.5 text-xs font-semibold text-accent ring-1 ring-accent/20 motion-safe:transition-colors hover:bg-accent/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+          >
+            <Kanban size={14} aria-hidden />
+            Board
+          </button>
+        </div>
       ) : null}
 
       <div className="flex min-h-0 flex-1">

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentControl.tsx
@@ -1,168 +1,31 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { createPortal } from 'react-dom';
-import { Popover, cn } from '@goodboy/ui';
+import { cn } from '@goodboy/ui';
 import { Plus } from 'lucide-react';
 import type { SessionId } from '@goodboy/types';
-import { useAppStore } from '../../../../../store';
-import {
-  AGENT_KIND_DEFAULTS,
-  AGENT_KIND_META,
-  AGENT_KIND_ORDER,
-  AGENT_KIND_PALETTE,
-} from '../../../../../features/session/agent-kind';
+import { SpawnAgentMenu } from './SpawnAgentMenu';
 
 type SpawnAgentControlProps = {
   sessionId: SessionId;
   className?: string;
 };
 
-const MENU_WIDTH = 320;
-const MENU_MAX_HEIGHT = 288;
-const MENU_MARGIN = 8;
-
-type PopoverAnchor = {
-  readonly left: number;
-  readonly top: number | null;
-  readonly bottom: number | null;
-  readonly direction: 'up' | 'down';
-};
-
 export function SpawnAgentControl({ sessionId, className }: SpawnAgentControlProps) {
-  const [open, setOpen] = useState(false);
-  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const spawnAgent = useAppStore((s) => s.spawnAgent);
-
-  const computeAnchor = useCallback((): PopoverAnchor | null => {
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (!rect) {
-      return null;
-    }
-    const spaceAbove = rect.top;
-    const spaceBelow = window.innerHeight - rect.bottom;
-    const direction: 'up' | 'down' =
-      spaceBelow > MENU_MAX_HEIGHT || spaceBelow > spaceAbove ? 'down' : 'up';
-    const left = Math.max(
-      MENU_MARGIN,
-      Math.min(rect.left, window.innerWidth - MENU_WIDTH - MENU_MARGIN),
-    );
-    if (direction === 'down') {
-      return { left, top: rect.bottom + 4, bottom: null, direction };
-    }
-    return { left, top: null, bottom: window.innerHeight - rect.top + 4, direction };
-  }, []);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-    const onDocClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (triggerRef.current?.contains(target)) {
-        return;
-      }
-      if (menuRef.current?.contains(target)) {
-        return;
-      }
-      setOpen(false);
-    };
-    const onReanchor = () => {
-      const next = computeAnchor();
-      if (next) {
-        setAnchor(next);
-      } else {
-        setOpen(false);
-      }
-    };
-    window.addEventListener('mousedown', onDocClick);
-    window.addEventListener('resize', onReanchor);
-    window.addEventListener('scroll', onReanchor, true);
-    return () => {
-      window.removeEventListener('mousedown', onDocClick);
-      window.removeEventListener('resize', onReanchor);
-      window.removeEventListener('scroll', onReanchor, true);
-    };
-  }, [open, computeAnchor]);
-
-  const onToggle = () => {
-    if (!open) {
-      const next = computeAnchor();
-      if (next) {
-        setAnchor(next);
-      }
-    }
-    setOpen((v) => !v);
-  };
-
-  const menu =
-    open && anchor
-      ? createPortal(
-          <Popover
-            innerRef={menuRef}
-            role="menu"
-            style={{
-              position: 'fixed',
-              left: anchor.left,
-              width: MENU_WIDTH,
-              ...(anchor.top !== null ? { top: anchor.top } : {}),
-              ...(anchor.bottom !== null ? { bottom: anchor.bottom } : {}),
-            }}
-            className="z-50 max-h-72 overflow-y-auto py-1"
-          >
-            <div className="px-3 pb-1 pt-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
-              by role
-            </div>
-            {[...AGENT_KIND_ORDER]
-              .filter((kind) => AGENT_KIND_DEFAULTS[kind].visible !== false)
-              .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))
-              .map((kind) => {
-                const meta = AGENT_KIND_META[kind];
-                const palette = AGENT_KIND_PALETTE[kind];
-                return (
-                  <button
-                    key={kind}
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setOpen(false);
-                      void spawnAgent(sessionId, { kindOverride: kind });
-                      window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
-                    }}
-                    className="flex w-full items-start gap-2.5 px-3 py-2 text-left transition-colors hover:bg-muted"
-                  >
-                    <span
-                      className={cn('mt-1 size-2 shrink-0 rounded-full', palette.bg)}
-                      aria-hidden
-                    />
-                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                      <span className="text-xs font-medium text-foreground">{meta.label}</span>
-                      <span className="text-2xs leading-snug text-muted-foreground">
-                        {meta.hint}
-                      </span>
-                    </span>
-                  </button>
-                );
-              })}
-          </Popover>,
-          document.body,
-        )
-      : null;
-
   return (
     <div className={cn('relative mt-1', className)}>
-      <button
-        ref={triggerRef}
-        type="button"
-        onClick={onToggle}
-        className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        <Plus size={13} aria-hidden />
-        Create agent
-      </button>
-      {menu}
+      <SpawnAgentMenu
+        sessionId={sessionId}
+        trigger={({ ref, onClick, ...aria }) => (
+          <button
+            ref={ref}
+            type="button"
+            onClick={onClick}
+            className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
+            {...aria}
+          >
+            <Plus size={13} aria-hidden />
+            Create agent
+          </button>
+        )}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu.tsx
@@ -1,0 +1,179 @@
+import { type ReactNode, type Ref, useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Popover, cn } from '@goodboy/ui';
+import type { SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import {
+  AGENT_KIND_DEFAULTS,
+  AGENT_KIND_META,
+  AGENT_KIND_ORDER,
+  AGENT_KIND_PALETTE,
+} from '../../../../../features/session/agent-kind';
+
+type SpawnAgentMenuProps = {
+  readonly sessionId: SessionId;
+  readonly trigger: (props: {
+    readonly ref: Ref<HTMLButtonElement>;
+    readonly onClick: () => void;
+    readonly 'aria-haspopup': 'menu';
+    readonly 'aria-expanded': boolean;
+  }) => ReactNode;
+  readonly onSpawned?: () => void;
+};
+
+const MENU_WIDTH = 320;
+const MENU_MAX_HEIGHT = 288;
+const MENU_MARGIN = 8;
+
+type PopoverAnchor = {
+  readonly left: number;
+  readonly top: number | null;
+  readonly bottom: number | null;
+  readonly direction: 'up' | 'down';
+};
+
+export function SpawnAgentMenu({ sessionId, trigger, onSpawned }: SpawnAgentMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const spawnAgent = useAppStore((s) => s.spawnAgent);
+
+  const computeAnchor = useCallback((): PopoverAnchor | null => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) {
+      return null;
+    }
+    const spaceAbove = rect.top;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const direction: 'up' | 'down' =
+      spaceBelow > MENU_MAX_HEIGHT || spaceBelow > spaceAbove ? 'down' : 'up';
+    const left = Math.max(
+      MENU_MARGIN,
+      Math.min(rect.left, window.innerWidth - MENU_WIDTH - MENU_MARGIN),
+    );
+    if (direction === 'down') {
+      return { left, top: rect.bottom + 4, bottom: null, direction };
+    }
+    return { left, top: null, bottom: window.innerHeight - rect.top + 4, direction };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onDocClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) {
+        return;
+      }
+      if (menuRef.current?.contains(target)) {
+        return;
+      }
+      setOpen(false);
+    };
+    const onReanchor = () => {
+      const next = computeAnchor();
+      if (next) {
+        setAnchor(next);
+      } else {
+        setOpen(false);
+      }
+    };
+    const onEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    window.addEventListener('mousedown', onDocClick);
+    window.addEventListener('resize', onReanchor);
+    window.addEventListener('scroll', onReanchor, true);
+    window.addEventListener('keydown', onEscape);
+    return () => {
+      window.removeEventListener('mousedown', onDocClick);
+      window.removeEventListener('resize', onReanchor);
+      window.removeEventListener('scroll', onReanchor, true);
+      window.removeEventListener('keydown', onEscape);
+    };
+  }, [open, computeAnchor]);
+
+  const onToggle = () => {
+    if (!open) {
+      const next = computeAnchor();
+      if (next) {
+        setAnchor(next);
+      }
+    }
+    setOpen((v) => !v);
+  };
+
+  const menu =
+    open && anchor
+      ? createPortal(
+          <Popover
+            innerRef={menuRef}
+            role="menu"
+            style={{
+              position: 'fixed',
+              left: anchor.left,
+              width: MENU_WIDTH,
+              ...(anchor.top !== null ? { top: anchor.top } : {}),
+              ...(anchor.bottom !== null ? { bottom: anchor.bottom } : {}),
+            }}
+            className="z-50 max-h-72 overflow-y-auto py-1"
+          >
+            <div className="px-3 pb-1 pt-1.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+              by role
+            </div>
+            {[...AGENT_KIND_ORDER]
+              .filter((kind) => AGENT_KIND_DEFAULTS[kind].visible !== false)
+              .sort((a, b) => AGENT_KIND_META[a].label.localeCompare(AGENT_KIND_META[b].label))
+              .map((kind) => {
+                const meta = AGENT_KIND_META[kind];
+                const palette = AGENT_KIND_PALETTE[kind];
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setOpen(false);
+                      void spawnAgent(sessionId, { kindOverride: kind });
+                      if (onSpawned) {
+                        onSpawned();
+                      } else {
+                        window.dispatchEvent(new CustomEvent('goodboy:reveal-chat'));
+                      }
+                    }}
+                    className="flex w-full items-start gap-2.5 px-3 py-2 text-left transition-colors hover:bg-muted"
+                  >
+                    <span
+                      className={cn('mt-1 size-2 shrink-0 rounded-full', palette.bg)}
+                      aria-hidden
+                    />
+                    <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="text-xs font-medium text-foreground">{meta.label}</span>
+                      <span className="text-2xs leading-snug text-muted-foreground">
+                        {meta.hint}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+          </Popover>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <>
+      {trigger({
+        ref: triggerRef,
+        onClick: onToggle,
+        'aria-haspopup': 'menu',
+        'aria-expanded': open,
+      })}
+      {menu}
+    </>
+  );
+}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStartButton.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStartButton.tsx
@@ -1,4 +1,5 @@
-import { Plus } from 'lucide-react';
+import { Plus, Workflow as WorkflowIcon } from 'lucide-react';
+import { EmptyState } from '@goodboy/ui';
 import type { SessionId } from '@goodboy/types';
 
 export function WorkflowStartButton({
@@ -13,17 +14,38 @@ export function WorkflowStartButton({
       new CustomEvent('goodboy:open-workflow-builder', { detail: { sessionId } }),
     );
   };
+
+  if (variant === 'empty') {
+    return (
+      <EmptyState
+        bordered
+        tone="accent"
+        icon={WorkflowIcon}
+        title="No workflows yet"
+        description="Attach a workflow to run structured multi-step tasks for this session."
+        action={
+          <button
+            type="button"
+            onClick={onClick}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-foreground/[0.04] px-3 py-1.5 text-xs font-medium text-foreground ring-1 ring-border-soft transition-colors hover:bg-foreground/[0.08]"
+          >
+            <Plus size={13} aria-hidden className="shrink-0" />
+            Start a workflow
+          </button>
+        }
+      />
+    );
+  }
+
   return (
-    <div className={variant === 'empty' ? '' : 'mt-1.5'}>
+    <div className="mt-1.5">
       <button
         type="button"
         onClick={onClick}
         className="flex w-full items-center gap-2 rounded border border-dashed border-border-soft px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:border-border hover:bg-muted/50 hover:text-foreground"
       >
         <Plus size={13} aria-hidden className="shrink-0" />
-        <span className="min-w-0 truncate">
-          {variant === 'empty' ? 'Start a workflow' : 'Attach another workflow'}
-        </span>
+        <span className="min-w-0 truncate">Attach another workflow</span>
       </button>
     </div>
   );

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { cn } from '../cn';
 
 export type AppShellProps = {
   topBar?: ReactNode;
+  workspaceBar?: ReactNode;
   footer?: ReactNode;
   leftSidebar?: ReactNode;
   leftHidden?: boolean;
@@ -107,6 +108,7 @@ function buildLayout(opts: {
 
 export const AppShell = ({
   topBar,
+  workspaceBar,
   footer,
   leftSidebar,
   leftHidden = false,
@@ -238,6 +240,7 @@ export const AppShell = ({
   return (
     <div className="flex h-screen w-screen flex-col bg-background">
       {topBar != null ? <div className="shrink-0">{topBar}</div> : null}
+      {workspaceBar != null ? <div className="shrink-0">{workspaceBar}</div> : null}
       <div
         className={cn(
           'grid min-h-0 w-full flex-1 overflow-hidden text-foreground motion-safe:transition-[grid-template-columns] duration-200 ease-out',

--- a/packages/ui/src/components/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState.tsx
@@ -1,6 +1,8 @@
 import type { LucideIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { cn } from '../cn';
+import { tintClasses } from '../tint';
+import type { Tone } from '../tint';
 
 export type EmptyStateProps = {
   readonly icon: LucideIcon;
@@ -8,6 +10,7 @@ export type EmptyStateProps = {
   readonly description?: string;
   readonly action?: ReactNode;
   readonly bordered?: boolean;
+  readonly tone?: Tone;
   readonly className?: string;
 };
 
@@ -17,23 +20,32 @@ export const EmptyState = ({
   description,
   action,
   bordered = false,
+  tone,
   className,
 }: EmptyStateProps) => {
+  const tint = tone ? tintClasses(tone) : null;
+  const iconBg = tint ? tint.bg : 'bg-muted';
+  const iconColor = tint ? tint.icon : 'text-muted-foreground';
+
   return (
     <div
       className={cn(
         'flex flex-col items-center gap-3 px-6 py-10 text-center',
-        bordered && 'rounded-lg border border-dashed border-border-soft bg-muted/10',
+        bordered && 'rounded-lg border border-dashed border-border-soft bg-elevated/40',
         className,
       )}
     >
-      <span className="flex size-10 items-center justify-center rounded-full bg-muted text-muted-foreground">
-        <Icon size={18} aria-hidden />
+      <span
+        className={cn('flex size-12 items-center justify-center rounded-full', iconBg, iconColor)}
+      >
+        <Icon size={24} aria-hidden />
       </span>
       <div className="flex flex-col gap-1">
         <span className="text-sm font-medium text-foreground">{title}</span>
         {description ? (
-          <span className="max-w-xs text-2xs text-muted-foreground">{description}</span>
+          <span className="max-w-xs text-xs leading-relaxed text-muted-foreground">
+            {description}
+          </span>
         ) : null}
       </div>
       {action ?? null}


### PR DESCRIPTION
Redesigns the session overview and unifies the in-session navigation and empty states. Eight focused commits on top of #910.

## Overview
- Lift goal / decisions / last output into a prominent context strip under the title.
- Split activity into running and completed buckets (mixed lanes stay active).
- Replace the always-on resolve start card with a dedicated Resolve section shown only when there is resolvable work (PR/MR or diff comments, or a pending push-and-resolve batch).
- One-click deep-link nudges that open the exact offending agent or workflow.
- Route attention away from an empty agents lens; align the resolver classifier across the rail, the metric and the agents lens.
- Fresh session: one card with two clickable paths (workflow, recommended, opens the builder; agent, opens the role picker); the two start cards stay aligned once the session is running. Extracts a reusable SpawnAgentMenu.

## Navigation and layout
- Full-width workspace bar in the app shell (board and session views share it; sidebar and detail sit below).
- Persistent session breadcrumb (Overview to the deepest sub-page) that stays visible over the studio and agent overlays; reuses the AppBreadcrumb component.
- More prominent back-to-board control (board icon, centered, accent tint).
- Collapsed stage-board columns keep the full column width.

## Empty states
- Refine the shared EmptyState primitive (opt-in tone, larger tinted icon, elevated dashed card) and route every lens empty state through it: questions, scripts, diff, plans, slots, pull request, workflows, terminal.
- Hide the plans two-pane sidebar when there are no plans; hide the diff chrome when a view is empty while keeping the view selector reachable.

## Verification
- 2117 desktop tests pass, tsc clean on apps/desktop and packages/ui.
- Every step adversarially reviewed by a critic agent; findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)