### PR TITLE
fix(db): make the migration runner crash-safe

### DIFF
--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -15,6 +15,7 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
+import type { Database } from '../client';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrate } from './runner';
 import { migrations } from './index';
@@ -389,5 +390,135 @@ describe('migrate', () => {
     const afterDelete = await listGroupsForSession(db, session.id);
     expect(afterDelete).toHaveLength(1);
     expect(afterDelete[0]!.id).toBe(group2.id);
+  });
+});
+
+const upToV66 = migrations.filter((m) => m.version <= 66);
+
+const withCrashOn = (db: Database, shouldCrash: (sql: string) => boolean): Database => {
+  let armed = true;
+  const crash = (sql: string): void => {
+    if (armed && shouldCrash(sql)) {
+      armed = false;
+      throw new Error('simulated crash');
+    }
+  };
+  return {
+    async exec(sql) {
+      crash(sql);
+      await db.exec(sql);
+    },
+    async execute(sql, params = []) {
+      crash(sql);
+      return db.execute(sql, params);
+    },
+    select: (sql, params) => db.select(sql, params),
+  };
+};
+
+const seedProviderRun = async (db: Database): Promise<void> => {
+  await db.execute(
+    'INSERT INTO workspaces (id, name, root_path, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    ['ws_crash', 'crash-test', '/tmp/crash-test', Date.now(), Date.now()],
+  );
+  await db.execute(
+    'INSERT INTO sessions (id, workspace_id, goal, state_kind, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ['session_crash', 'ws_crash', 'crash test', 'idle', Date.now(), Date.now()],
+  );
+  await db.execute(
+    'INSERT INTO provider_runs (id, session_id, provider, model, status_kind, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ['run_crash', 'session_crash', 'anthropic', 'claude-opus-4', 'succeeded', Date.now()],
+  );
+};
+
+describe('migrate crash safety', () => {
+  it('rolls back an interrupted table rebuild instead of losing the table', async () => {
+    const db = makeTestDatabase();
+    await migrate(db, upToV66);
+    await seedProviderRun(db);
+
+    const crashing = withCrashOn(db, (sql) =>
+      sql.startsWith('ALTER TABLE provider_runs_new RENAME'),
+    );
+    await expect(migrate(crashing)).rejects.toThrow('simulated crash');
+
+    const runs = await db.select<{ id: string }>('SELECT id FROM provider_runs');
+    expect(runs).toEqual([{ id: 'run_crash' }]);
+    const recorded = await db.select<{ version: number }>(
+      'SELECT version FROM schema_version WHERE version = 67',
+    );
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('completes the chain and preserves data on the run after a crash', async () => {
+    const db = makeTestDatabase();
+    await migrate(db, upToV66);
+    await seedProviderRun(db);
+
+    const crashing = withCrashOn(db, (sql) =>
+      sql.startsWith('ALTER TABLE provider_runs_new RENAME'),
+    );
+    await expect(migrate(crashing)).rejects.toThrow('simulated crash');
+
+    const result = await migrate(db);
+    expect(result.applied).toContain(67);
+    expect(result.currentVersion).toBe(migrations.at(-1)?.version);
+
+    const runs = await db.select<{ id: string; provider: string }>(
+      'SELECT id, provider FROM provider_runs',
+    );
+    expect(runs).toEqual([{ id: 'run_crash', provider: 'anthropic' }]);
+  });
+
+  it('records a version only together with its migration', async () => {
+    const db = makeTestDatabase();
+    await migrate(db, upToV66);
+    await seedProviderRun(db);
+
+    const crashing = withCrashOn(db, (sql) =>
+      sql.startsWith('INSERT OR IGNORE INTO schema_version'),
+    );
+    await expect(migrate(crashing)).rejects.toThrow('simulated crash');
+
+    const versions = await db.select<{ v: number }>('SELECT MAX(version) AS v FROM schema_version');
+    expect(versions).toEqual([{ v: 66 }]);
+    const runs = await db.select<{ id: string }>('SELECT id FROM provider_runs');
+    expect(runs).toEqual([{ id: 'run_crash' }]);
+  });
+
+  it('does not destroy surviving data left behind by an old interrupted rebuild', async () => {
+    const db = makeTestDatabase();
+    await migrate(db, upToV66);
+    await seedProviderRun(db);
+
+    const m067 = migrations.find((m) => m.version === 67);
+    const statements = (m067?.sql ?? '')
+      .split(';')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    for (const stmt of statements) {
+      if (stmt.startsWith('ALTER TABLE provider_runs_new RENAME')) {
+        break;
+      }
+      await db.exec(stmt);
+    }
+
+    await expect(migrate(db)).rejects.toThrow('no such table');
+    const survivors = await db.select<{ id: string }>('SELECT id FROM provider_runs_new');
+    expect(survivors).toEqual([{ id: 'run_crash' }]);
+  });
+
+  it('starts clean when a previous run left a transaction open', async () => {
+    const db = makeTestDatabase();
+    await db.exec('BEGIN');
+    const result = await migrate(db);
+    expect(result.applied).toEqual(migrations.map((m) => m.version));
+  });
+
+  it('keeps foreign key enforcement on after the chain runs', async () => {
+    const db = makeTestDatabase();
+    await migrate(db);
+    const fk = await db.select<{ foreign_keys: number }>('PRAGMA foreign_keys');
+    expect(fk).toEqual([{ foreign_keys: 1 }]);
   });
 });

--- a/packages/db/src/migrations/runner.ts
+++ b/packages/db/src/migrations/runner.ts
@@ -18,6 +18,7 @@ export const migrate = async (
   db: Database,
   migrations: ReadonlyArray<Migration> = defaultMigrations,
 ): Promise<MigrateResult> => {
+  await abandonOpenTransaction(db);
   await db.exec(ENSURE_VERSION_TABLE);
 
   const rows = await db.select<{ version: number }>('SELECT version FROM schema_version');
@@ -32,11 +33,7 @@ export const migrate = async (
       skipped.push(migration.version);
       continue;
     }
-    await applyMigrationSql(db, migration);
-    await db.execute('INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)', [
-      migration.version,
-      Date.now(),
-    ]);
+    await applyMigration(db, migration);
     newlyApplied.push(migration.version);
   }
 
@@ -44,25 +41,108 @@ export const migrate = async (
   return { applied: newlyApplied, skipped, currentVersion };
 };
 
-async function applyMigrationSql(db: Database, migration: Migration): Promise<void> {
-  const statements = migration.sql
+type MigrationStep =
+  | { kind: 'pragma'; sql: string }
+  | { kind: 'transaction'; statements: ReadonlyArray<string> };
+
+async function applyMigration(db: Database, migration: Migration): Promise<void> {
+  const steps = planSteps(migration.sql);
+  const lastTransaction = steps.reduce(
+    (last, step, index) => (step.kind === 'transaction' ? index : last),
+    -1,
+  );
+  let versionRecorded = false;
+
+  for (const [index, step] of steps.entries()) {
+    if (step.kind === 'pragma') {
+      await db.exec(step.sql);
+      continue;
+    }
+    await db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const stmt of step.statements) {
+        await execSkippingApplied(db, migration, stmt);
+      }
+      if (index === lastTransaction) {
+        await recordVersion(db, migration);
+        versionRecorded = true;
+      }
+      await db.exec('COMMIT');
+    } catch (err) {
+      await abandonOpenTransaction(db);
+      throw err;
+    }
+  }
+
+  if (!versionRecorded) {
+    await recordVersion(db, migration);
+  }
+}
+
+function planSteps(sql: string): ReadonlyArray<MigrationStep> {
+  const statements = sql
     .split(';')
     .map((s) => s.trim())
     .filter((s) => s.length > 0);
 
+  const steps: MigrationStep[] = [];
+  let pending: string[] = [];
+
+  const flushPending = () => {
+    if (pending.length === 0) {
+      return;
+    }
+    steps.push({ kind: 'transaction', statements: pending });
+    pending = [];
+  };
+
   for (const stmt of statements) {
-    try {
-      await db.exec(stmt);
-    } catch (err) {
-      if (isAlreadyExistsError(err)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[migrations] v${migration.version}: skipping idempotent statement (already applied): ${truncate(stmt)}`,
-        );
-        continue;
-      }
+    if (isPragma(stmt)) {
+      flushPending();
+      steps.push({ kind: 'pragma', sql: stmt });
+      continue;
+    }
+    pending.push(stmt);
+  }
+  flushPending();
+
+  return steps;
+}
+
+function isPragma(stmt: string): boolean {
+  return /^pragma\b/i.test(stmt);
+}
+
+async function execSkippingApplied(
+  db: Database,
+  migration: Migration,
+  stmt: string,
+): Promise<void> {
+  try {
+    await db.exec(stmt);
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) {
       throw err;
     }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[migrations] v${migration.version}: skipping idempotent statement (already applied): ${truncate(stmt)}`,
+    );
+  }
+}
+
+async function recordVersion(db: Database, migration: Migration): Promise<void> {
+  await db.execute('INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)', [
+    migration.version,
+    Date.now(),
+  ]);
+}
+
+async function abandonOpenTransaction(db: Database): Promise<void> {
+  try {
+    await db.exec('ROLLBACK');
+  } catch {
+    return;
   }
 }
 


### PR DESCRIPTION
## What

Makes the migration runner atomic. Each migration's statements now run inside `BEGIN IMMEDIATE ... COMMIT` transactions, segmented at `PRAGMA foreign_keys` boundaries (the pragmas are connection state and would be no-ops inside a transaction, and m031 needs FK on for its rename section and off for its rebuild section). The `schema_version` row is written inside the migration's final segment, so a migration and its version record commit together. A stale open transaction left by an interrupted run is rolled back before the chain starts.

No behavior change on the happy path: same statements, same order, same idempotent skip logging, same `migrate()` signature.

## Why

A crash between `DROP TABLE provider_runs` and the `RENAME` in m067 leaves the data only in `provider_runs_new`. On the next boot the re-run starts with `DROP TABLE IF EXISTS provider_runs_new`, destroying the surviving copy, and then fails on `no such table: provider_runs`. Boot is bricked and the data is gone. The m015/m031/m045 rebuilds fail the same way with the data stranded in the `_new` table. Details and reproduction in #923.

With transactions the partial state can never be observed: an interrupted rebuild rolls back to the pre-migration state and the next boot applies it cleanly.

## Test plan

- Six new tests in `runner.test.ts` drive the real migration chain on better-sqlite3 with fault injection: crash at the rename statement (rolls back, data intact, version unrecorded), recovery run after a crash (chain completes, data preserved), crash at the version insert (migration and version roll back together), re-run over a legacy interrupted rebuild (surviving `_new` data is no longer destroyed), stale open transaction at start, FK enforcement still on after the chain.
- The three data-loss tests fail against the current runner and pass with this one; the other three pin the new contract.
- `pnpm turbo run typecheck test --filter=...@goodboy/db` green (84 db tests, plus core and desktop suites).
- `pnpm format:check` clean on the touched files.

Closes #923
