### PR TITLE
fix(core): route cursor turns to role-selected models with cross-provider mapping

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/useTurnRouting.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import type { ProviderId, Session, TurnProviderOverride } from '@goodboy/types';
-import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from '@goodboy/core';
+import { PROVIDER_CAPABILITIES, getDefaultTurnModel, resolveModelForProvider } from '@goodboy/core';
 import { useAppStore } from '../../../../../store';
 import type { VerbosityLevel } from '../../../../../features/settings/verbosity';
 import { type EffortLevel, clampEffort } from '../../../utils/chat-constants';
@@ -76,10 +76,15 @@ export function useTurnRouting({ session, isRunning }: UseTurnRoutingArgs) {
     getDefaultTurnModel(defaultProvider);
   const effectiveProvider: ProviderId =
     selectedProvider ?? agentProviderOverride ?? defaultProvider;
-  const effectiveModel =
-    selectedModel ??
-    session.modelOverride ??
-    (effectiveProvider === defaultProvider ? defaultModel : getDefaultTurnModel(effectiveProvider));
+  const effectiveModel = resolveModelForProvider({
+    provider: effectiveProvider,
+    modelId:
+      selectedModel ??
+      session.modelOverride ??
+      (effectiveProvider === defaultProvider
+        ? defaultModel
+        : getDefaultTurnModel(effectiveProvider)),
+  });
   const effectiveEffort = clampEffort(effectiveModel, effort);
   const routingOverride: TurnProviderOverride | undefined = allowOverride
     ? { providerId: effectiveProvider, model: effectiveModel }

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -348,6 +348,49 @@ describe('ChatInput, input wiring', () => {
     );
   });
 
+  it('provider override persists across multiple sends (regression for bug D)', async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        session={makeSession({
+          providerPreference: {
+            defaultProvider: 'anthropic' as Session['providerPreference']['defaultProvider'],
+            allowTurnOverride: true,
+          },
+          providerOverride: 'cursor',
+        })}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'first cursor turn');
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledOnce();
+    });
+
+    await user.type(textarea, 'second cursor turn');
+    await user.keyboard('{Enter}');
+    await waitFor(() => {
+      expect(sendTurnMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(sendTurnMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        content: 'first cursor turn',
+        override: { providerId: 'cursor', model: 'composer-2' },
+      }),
+    );
+    expect(sendTurnMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        content: 'second cursor turn',
+        override: { providerId: 'cursor', model: 'composer-2' },
+      }),
+    );
+  });
+
   it('sends cursor when the picker shows cursor even with an anthropic agent model pin', async () => {
     mockStore.setState({
       agentModelOverride: { 'agent-1': 'claude-haiku-4-5' },

--- a/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatInput/index.test.tsx
@@ -175,29 +175,45 @@ vi.mock('../../turn', () => ({
   readDroppedAttachment: readDroppedAttachmentMock,
 }));
 
-vi.mock('@goodboy/core', () => ({
-  buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
-  getDefaultTurnModel: (id: string) => (id === 'cursor' ? 'auto' : 'claude-3-5-sonnet-latest'),
-  getModelDescriptor: () => null,
-  PROVIDER_CAPABILITIES: {
+vi.mock('@goodboy/core', () => {
+  const capabilities = {
     anthropic: {
-      models: [{ id: 'claude-3-5-sonnet-latest', tier: 'turn', contextWindow: 200_000 }],
+      models: [{ id: 'claude-sonnet-4-6', tier: 'turn', contextWindow: 200_000 }],
     },
     cursor: {
       models: [
-        { id: 'auto', tier: 'turn', contextWindow: 200_000 },
-        { id: 'claude-sonnet-4-5', tier: 'turn', contextWindow: 200_000 },
+        { id: 'composer-2', tier: 'turn', contextWindow: 200_000 },
+        { id: 'claude-4.6-sonnet-medium', tier: 'turn', contextWindow: 200_000 },
       ],
     },
     codex: { models: [{ id: 'codex-latest', tier: 'turn', contextWindow: 128_000 }] },
-  },
-  resolveProvider: vi.fn(async () => ({
-    selectedProvider: 'anthropic',
-    selectedModel: 'claude-3-5-sonnet-latest',
-    reason: 'preference',
-  })),
-  assessTurnWeight: () => 'small',
-}));
+  };
+  const defaultTurnModel = (id: string) => (id === 'cursor' ? 'composer-2' : 'claude-sonnet-4-6');
+  return {
+    buildClaudeFlags: () => ({ allowedTools: [], disallowedTools: [] }),
+    getDefaultTurnModel: defaultTurnModel,
+    getModelDescriptor: () => null,
+    PROVIDER_CAPABILITIES: capabilities,
+    resolveModelForProvider: ({
+      provider,
+      modelId,
+    }: {
+      provider: keyof typeof capabilities;
+      modelId: string;
+    }) =>
+      capabilities[provider].models.some((m) => m.id === modelId)
+        ? modelId
+        : provider === 'cursor' && modelId === 'claude-sonnet-4-6'
+          ? 'claude-4.6-sonnet-medium'
+          : defaultTurnModel(provider),
+    resolveProvider: vi.fn(async () => ({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-6',
+      reason: 'preference',
+    })),
+    assessTurnWeight: () => 'small',
+  };
+});
 
 import { ChatInput } from './index';
 
@@ -302,7 +318,7 @@ describe('ChatInput, input wiring', () => {
     expect(sendTurnMock).toHaveBeenCalledWith(expect.objectContaining({ content: 'hi there' }));
   });
 
-  it('provider override persists across sends (regression for bug D)', async () => {
+  it('maps a stale session model into the selected provider namespace', async () => {
     const setSessionConfig = vi.fn(async () => undefined);
     mockStore.setState({ setSessionConfig });
 
@@ -315,6 +331,7 @@ describe('ChatInput, input wiring', () => {
             allowTurnOverride: true,
           },
           providerOverride: 'cursor',
+          modelOverride: 'claude-sonnet-4-6',
         })}
       />,
     );
@@ -326,7 +343,7 @@ describe('ChatInput, input wiring', () => {
     expect(sendTurnMock).toHaveBeenCalledOnce();
     expect(sendTurnMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        override: { providerId: 'cursor', model: 'auto' },
+        override: { providerId: 'cursor', model: 'claude-4.6-sonnet-medium' },
       }),
     );
   });
@@ -355,7 +372,7 @@ describe('ChatInput, input wiring', () => {
 
     expect(sendTurnMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        override: { providerId: 'cursor', model: 'auto' },
+        override: { providerId: 'cursor', model: 'composer-2' },
       }),
     );
   });

--- a/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.commands.test.ts
@@ -37,7 +37,7 @@ const core = vi.hoisted(() => {
         { id: 'claude-haiku', label: 'Haiku', tier: 'utility' },
       ],
     },
-    cursor: { models: [{ id: 'cursor-fast', label: 'Cursor Fast', tier: 'turn' }] },
+    cursor: { models: [{ id: 'composer-2', label: 'Composer 2', tier: 'turn' }] },
     codex: { models: [{ id: 'gpt-5-codex', label: 'Codex', tier: 'turn' }] },
     gemini: { models: [{ id: 'gemini-2-pro', label: 'Gemini Pro', tier: 'turn' }] },
   } as Record<string, { models: Array<{ id: string; label: string; tier: string }> }>;
@@ -203,9 +203,11 @@ describe('queryProviders (read-only menu RPC)', () => {
       }
     ).providers;
     const anthropic = providers.find((p) => p.id === 'anthropic')!;
+    const cursor = providers.find((p) => p.id === 'cursor')!;
     const codex = providers.find((p) => p.id === 'codex')!;
     expect(anthropic.connection).toBe('connected');
     expect(anthropic.defaultModel).toBe('claude-opus-4-8');
+    expect(cursor.defaultModel).toBe('composer-2');
     expect(codex.connection).toBe('missing'); // not in store → falls back
     expect(anthropic.models.length).toBeGreaterThan(0);
   });

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -72,15 +72,30 @@ vi.mock('@goodboy/core', async (importOriginal) => {
 
 vi.mock('../ProviderSelect', () => ({
   ProviderSelect: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
-    <button type="button" onClick={() => onChange(value === '' ? 'anthropic' : '')}>
+    <button type="button" onClick={() => onChange(value === '' ? 'cursor' : '')}>
       provider:{value === '' ? 'default' : value}
     </button>
   ),
 }));
 
 vi.mock('../ModelSelect', () => ({
-  ModelSelect: ({ value, onChange }: { value: string; onChange: (model: string) => void }) => (
-    <button type="button" onClick={() => onChange('claude-opus-4-6')}>
+  ModelSelect: ({
+    value,
+    onChange,
+    provider,
+    recommendedModel,
+  }: {
+    value: string;
+    onChange: (model: string) => void;
+    provider: string;
+    recommendedModel: string;
+  }) => (
+    <button
+      type="button"
+      data-provider={provider}
+      data-recommended-model={recommendedModel}
+      onClick={() => onChange('claude-opus-4-6')}
+    >
       model:{value === '' ? 'auto' : value}
     </button>
   ),
@@ -581,17 +596,21 @@ describe('WorkflowBuilderView (step management in custom mode)', () => {
     expect(steps[1]!.role).toBe('scout');
   });
 
-  it('providerOverride on a step is included in the saved workflow template', async () => {
+  it('uses a step provider override for its recommendation and saved template', async () => {
     render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
     await draftPlan();
     expandStep(0);
 
     fireEvent.click(screen.getAllByRole('button', { name: /^provider:default$/i })[0]!);
 
+    const model = screen.getAllByRole('button', { name: /^model:auto$/i })[0]!;
+    expect(model.dataset['provider']).toBe('cursor');
+    expect(model.dataset['recommendedModel']).toBe('composer-2-fast');
+
     fireEvent.click(startBtn());
     await waitFor(() => expect(mockSavePhaseTemplate).toHaveBeenCalledOnce());
     const saved = mockSavePhaseTemplate.mock.calls[0]![0];
-    expect(saved.steps[0]!.providerOverride).toBe('anthropic');
+    expect(saved.steps[0]!.providerOverride).toBe('cursor');
     expect(saved.steps[1]!.providerOverride).toBeUndefined();
   });
 });

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -26,12 +26,11 @@ import { Button, Divider, Skeleton, Textarea, cn } from '@goodboy/ui';
 import {
   PlannerClient,
   type PlannerOutput,
-  autoModelForRole,
   defaultsForRole,
-  getDefaultTurnModel,
   isWorkflowComplete,
   polishStepInstruction,
   polishWorkflowGoal,
+  recommendedModelForRole,
   runsForWorkflowRun,
 } from '@goodboy/core';
 import type {
@@ -382,10 +381,10 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const draggingKey = drag?.kind === 'step' ? (steps[drag.fromIndex]?.key ?? null) : null;
 
   const recommendedProvider = (_step: EditableStep): ProviderId => providerId;
-  const recommendedModel = (step: EditableStep): string =>
-    autoModelForRole(step.role ?? 'custom', [providerId])?.model ?? getDefaultTurnModel(providerId);
   const resolvedProvider = (step: EditableStep): ProviderId =>
     step.providerOverride ?? recommendedProvider(step);
+  const recommendedModel = (step: EditableStep): string =>
+    recommendedModelForRole({ role: step.role ?? 'custom', provider: resolvedProvider(step) });
   const resolvedModel = (step: EditableStep): string =>
     step.modelOverride !== undefined && step.modelOverride !== ''
       ? step.modelOverride

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Input, Textarea, Tooltip } from '@goodboy/ui';
 import { X } from 'lucide-react';
-import { autoModelForRole, getDefaultTurnModel } from '@goodboy/core';
+import { recommendedModelForRole } from '@goodboy/core';
 import type {
   AgentEffort,
   AgentRole,
@@ -55,9 +55,8 @@ export const LibraryStepForm = ({
   );
 
   const recommendedProv: ProviderId = connectedProviders[0] ?? 'anthropic';
-  const recommendedMod: string =
-    autoModelForRole(role, [recommendedProv])?.model ?? getDefaultTurnModel(recommendedProv);
   const effProvider: ProviderId = providerOverride !== '' ? providerOverride : recommendedProv;
+  const recommendedMod: string = recommendedModelForRole({ role, provider: effProvider });
   const modelValue = modelOverride !== '' ? modelOverride : recommendedMod;
 
   type FormState = {

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Button, Divider, FieldRow, Input, SectionHeader, ScrollFade, cn } from '@goodboy/ui';
 import { Check, Plus, Sparkles, X } from 'lucide-react';
-import { autoModelForRole, getDefaultTurnModel } from '@goodboy/core';
+import { recommendedModelForRole } from '@goodboy/core';
 import type { ProviderId, StepDef, StepDefId, WorkspaceId } from '@goodboy/types';
 import type { StepDefUpsertArgs } from '../../../workflows';
 import type { DefinitionForm, TemplateForm } from '../../../form';
@@ -98,13 +98,13 @@ export const WorkflowComposer = ({
 
   const recommendedProvider = (_def: DefinitionForm): ProviderId => defaultProvider;
 
-  const recommendedModel = (def: DefinitionForm): string =>
-    autoModelForRole(def.role, [defaultProvider])?.model ?? getDefaultTurnModel(defaultProvider);
-
   const resolvedProvider = (def: DefinitionForm): ProviderId =>
     def.providerOverride !== undefined && def.providerOverride !== ''
       ? (def.providerOverride as ProviderId)
       : recommendedProvider(def);
+
+  const recommendedModel = (def: DefinitionForm): string =>
+    recommendedModelForRole({ role: def.role, provider: resolvedProvider(def) });
 
   const resolvedModel = (def: DefinitionForm): string =>
     def.modelOverride !== undefined && def.modelOverride !== ''

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -9,6 +9,7 @@ import {
   extractPlanFromMarker,
   extractScoutSplit,
   findReusableAgent,
+  resolveModelForProvider,
   runsForWorkflowRun,
   turnReducer,
   type ClaudeFlagSet,
@@ -320,18 +321,21 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       phaseDefinition != null && !phaseDefinition.modelOverride
         ? (autoModelForRole(phaseDefinition.role ?? 'custom', [provider])?.model ?? null)
         : null;
-    const model =
-      phaseDefinition?.modelOverride && phaseDefinition.providerOverride === undefined
-        ? phaseDefinition.modelOverride
-        : autoStepModel != null
-          ? autoStepModel
-          : turnOverrideActive
-            ? routingDecision.selectedModel
-            : routingDecision.fallbackUsed
+    const model = resolveModelForProvider({
+      provider,
+      modelId:
+        phaseDefinition?.modelOverride && phaseDefinition.providerOverride === undefined
+          ? phaseDefinition.modelOverride
+          : autoStepModel != null
+            ? autoStepModel
+            : turnOverrideActive
               ? routingDecision.selectedModel
-              : agentModelApplies
-                ? agentKindModel
-                : routingDecision.selectedModel;
+              : routingDecision.fallbackUsed
+                ? routingDecision.selectedModel
+                : agentModelApplies
+                  ? agentKindModel
+                  : routingDecision.selectedModel,
+    });
 
     const wsBindings = get().workspaceOverrides[session.workspaceId]?.providerBindings ?? {};
     const sessBindings = get().sessionOverrides[sessionId]?.providerBindings ?? {};

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -11,9 +11,9 @@ import type {
 } from '@goodboy/types';
 import { attachWorkflowToSession as attachWorkflowToSessionInDb } from '@goodboy/db';
 import {
-  autoModelForRole,
-  getDefaultTurnModel,
   isWorkflowComplete,
+  recommendedModelForRole,
+  resolveModelForProvider,
   runsForWorkflowRun,
 } from '@goodboy/core';
 import { tauriDatabase } from '../../../shared/lib/db';
@@ -104,10 +104,12 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
       });
       const resolvedProvider = step.providerOverride ?? sessionDefaultProvider;
       agentProviderOverrides[agent.id] = resolvedProvider;
-      agentModelOverrides[agent.id] =
-        step.modelOverride ??
-        autoModelForRole(step.role ?? 'custom', [sessionDefaultProvider])?.model ??
-        getDefaultTurnModel(sessionDefaultProvider);
+      agentModelOverrides[agent.id] = resolveModelForProvider({
+        provider: resolvedProvider,
+        modelId:
+          step.modelOverride ??
+          recommendedModelForRole({ role: step.role ?? 'custom', provider: resolvedProvider }),
+      });
       agentKindOverrides[agent.id] = kind;
       if (step.effort) {
         agentEffortOverrides[agent.id] = step.effort;

--- a/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
+++ b/apps/desktop/src/store/slices/workflows/chainTriggers.test.ts
@@ -4,6 +4,7 @@ import type {
   AgentId,
   AgentStatus,
   IsoDateTime,
+  ProviderId,
   Session,
   SessionId,
   StepId,
@@ -491,8 +492,10 @@ describe('attachWorkflowToSession trigger modes', () => {
       providers: [],
       transcripts: {},
       agentTurnState: {},
-      agentModelOverride: {},
-      agentKindOverride: {},
+      agentModelOverride: {} as Record<string, string>,
+      agentKindOverride: {} as Record<string, string>,
+      agentProviderOverride: {} as Record<string, ProviderId>,
+      agentEffortOverride: {} as Record<string, string>,
       sessionWorkflows: {},
       reprocessGoalForWorkflow: vi.fn(async () => undefined),
       maybeAutoAdvanceWorkflow: vi.fn(async () => undefined),
@@ -609,5 +612,28 @@ describe('attachWorkflowToSession trigger modes', () => {
     expect(attachInDbSpy.mock.calls[0]?.[7]).toBe('immediate');
     expect(state['maybeAutoAdvanceWorkflow']).toHaveBeenCalledWith(SESSION_ID);
     expect(state['activateWorkflowAgent']).not.toHaveBeenCalled();
+  });
+
+  it('uses the step provider when recommending the attached agent model', async () => {
+    const state = baseState([], []);
+    const workflow = makeWorkflow(WF_ID, [{ stepId: 's0', name: 'Scout' }]);
+    state.phaseTemplates = {
+      [WS_ID]: [
+        {
+          ...workflow,
+          steps: workflow.steps.map((step) => ({
+            ...step,
+            role: 'scout' as const,
+            providerOverride: 'cursor' as const,
+          })),
+        },
+      ],
+    };
+    const { set, get } = harness(state);
+
+    await attachWorkflowToSession(set, get)(SESSION_ID, WF_ID, { autoRun: false });
+
+    expect(state.agentProviderOverride['agent-1']).toBe('cursor');
+    expect(state.agentModelOverride['agent-1']).toBe('composer-2-fast');
   });
 });

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -96,7 +96,7 @@ vi.mock('../features/providers/providers', () => ({
 vi.mock('../features/providers/routing', () => ({
   resolveProviderForTurn: vi.fn(async () => ({
     selectedProvider: 'anthropic',
-    selectedModel: 'claude-3-5-sonnet-latest',
+    selectedModel: 'claude-sonnet-4-5',
     reason: 'preference',
   })),
 }));
@@ -197,7 +197,7 @@ describe('sendTurn, agent routing', () => {
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',
-      selectedModel: 'claude-3-5-sonnet-latest',
+      selectedModel: 'claude-sonnet-4-5',
       reason: 'preference',
     });
   });
@@ -305,7 +305,7 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',
-      selectedModel: 'claude-3-5-sonnet-latest',
+      selectedModel: 'claude-sonnet-4-5',
       reason: 'preference',
     });
     const workflowsMod = await import('../features/workflows/workflows');
@@ -350,6 +350,12 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     const useAppStore = await importStore();
     setup(useAppStore);
     useAppStore.setState({ agentEffortOverride: { [AGENT_A]: 'extra-high' } });
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-opus-4-8',
+      reason: 'preference',
+    });
 
     await useAppStore
       .getState()
@@ -543,12 +549,12 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
           providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
         },
       ],
-      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+      agentModelOverride: { [AGENT_A]: 'claude-haiku-4-5' },
     });
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',
-      selectedModel: 'claude-3-5-sonnet-latest',
+      selectedModel: 'claude-sonnet-4-5',
       reason: 'override',
     });
 
@@ -556,24 +562,24 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       sessionId: SESSION_ID,
       agentId: AGENT_A,
       content: 'go',
-      override: { providerId: 'anthropic', model: 'claude-3-5-sonnet-latest' },
+      override: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
     });
 
-    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-sonnet-latest');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-sonnet-4-5');
   });
 
   it('keeps the agent kind model pin when no per-turn override is supplied', async () => {
     const useAppStore = await importStore();
     setup(useAppStore);
     useAppStore.setState({
-      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+      agentModelOverride: { [AGENT_A]: 'claude-haiku-4-5' },
     });
 
     await useAppStore
       .getState()
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
 
-    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-haiku-latest');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-haiku-4-5');
   });
 
   it('does not apply an anthropic model pin when the routed provider is cursor', async () => {
@@ -582,7 +588,7 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'cursor',
-      selectedModel: 'auto',
+      selectedModel: 'composer-2',
       reason: 'override',
     });
     useAppStore.setState({
@@ -592,7 +598,7 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
           providerPreference: { defaultProvider: 'cursor', allowTurnOverride: true },
         },
       ],
-      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+      agentModelOverride: { [AGENT_A]: 'claude-haiku-4-5' },
     });
 
     await useAppStore
@@ -600,7 +606,79 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
 
     expect(runTurnSpy.mock.calls[0]?.[0]?.provider).toBe('cursor');
-    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('auto');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('composer-2');
+  });
+
+  it('maps a workflow phase model override into the routed provider namespace', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    const workflowRunId = 'workflow-run-1' as never;
+    const workflowId = 'workflow-1' as never;
+    const stepId = 'step-1' as never;
+    const agent = {
+      ...buildAgent(AGENT_A, 0),
+      stepId,
+      workflowRunId,
+    };
+    const session: Session = {
+      ...buildSession(),
+      providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+      workflowRuns: [
+        {
+          id: workflowRunId,
+          workflowId,
+          ordinal: 0,
+          currentStep: 0,
+          autoRun: false,
+          triggerMode: 'immediate',
+        },
+      ],
+    };
+    useAppStore.setState({
+      sessions: [session],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      phaseTemplates: {
+        [WORKSPACE_ID]: [
+          {
+            id: workflowId,
+            workspaceId: WORKSPACE_ID,
+            name: 'workflow',
+            description: '',
+            steps: [
+              {
+                id: stepId,
+                workflowId,
+                ordinal: 0,
+                name: 'step',
+                promptPrefix: '',
+                modelOverride: 'claude-sonnet-4-6',
+              },
+            ],
+            createdAt: NOW,
+            updatedAt: NOW,
+          },
+        ],
+      },
+    });
+    const workflowsMod = await import('../features/workflows/workflows');
+    (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockResolvedValue([agent]);
+    (workflowsMod.invokeAgentUpdateStatus as ReturnType<typeof vi.fn>).mockResolvedValue(agent);
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'cursor',
+      selectedModel: 'composer-2',
+      reason: 'override',
+    });
+
+    await useAppStore.getState().sendTurn({
+      sessionId: SESSION_ID,
+      agentId: AGENT_A,
+      content: 'go',
+      override: { providerId: 'cursor', model: 'composer-2' },
+    });
+
+    expect(runTurnSpy.mock.calls[0]?.[0]?.provider).toBe('cursor');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-4.6-sonnet-medium');
   });
 
   it('an explicit per-turn model override beats both the agent provider and model pin', async () => {
@@ -614,12 +692,12 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
         },
       ],
       agentProviderOverride: { [AGENT_A]: 'anthropic' },
-      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+      agentModelOverride: { [AGENT_A]: 'claude-haiku-4-5' },
     });
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',
-      selectedModel: 'claude-3-5-sonnet-latest',
+      selectedModel: 'claude-sonnet-4-5',
       reason: 'override',
     });
 
@@ -627,10 +705,10 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       sessionId: SESSION_ID,
       agentId: AGENT_A,
       content: 'go',
-      override: { providerId: 'anthropic', model: 'claude-3-5-sonnet-latest' },
+      override: { providerId: 'anthropic', model: 'claude-sonnet-4-5' },
     });
 
-    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-sonnet-latest');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-sonnet-4-5');
   });
 
   it('keeps both the agent provider and model pin when no per-turn override is supplied', async () => {
@@ -638,14 +716,14 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     setup(useAppStore);
     useAppStore.setState({
       agentProviderOverride: { [AGENT_A]: 'anthropic' },
-      agentModelOverride: { [AGENT_A]: 'claude-3-5-haiku-latest' },
+      agentModelOverride: { [AGENT_A]: 'claude-haiku-4-5' },
     });
 
     await useAppStore
       .getState()
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'go' });
 
-    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-3-5-haiku-latest');
+    expect(runTurnSpy.mock.calls[0]?.[0]?.model).toBe('claude-haiku-4-5');
   });
 
   it('activateNextResolver runs only the head of the queue and dequeues it', async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -81,7 +81,13 @@ export {
   getDefaultTurnModel,
 } from './providers/capabilities';
 
-export { autoModelForRole, type AutoModelChoice } from './providers/auto-model';
+export {
+  autoModelForRole,
+  recommendedModelForRole,
+  type AutoModelChoice,
+} from './providers/auto-model';
+
+export { resolveModelForProvider } from './providers/model-map';
 
 export { getModelDescriptor, getModelProvider } from './providers/model-display';
 

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { autoModelForRole } from './auto-model';
+import { CURSOR_MODELS } from './cursor/models';
 
 describe('autoModelForRole', () => {
   it('returns null when no providers are available', () => {
@@ -71,10 +72,16 @@ describe('autoModelForRole', () => {
       expect(['gemini', 'codex']).toContain(result?.provider);
     });
 
-    it('cursor provider: picks a model for a mid-tier role', () => {
+    it('cursor provider: picks a real cursor slug for a mid-tier role, not auto', () => {
       const result = autoModelForRole('product', ['cursor']);
       expect(result?.provider).toBe('cursor');
-      expect(typeof result?.model).toBe('string');
+      expect(result?.model).not.toBe('auto');
+      expect(CURSOR_MODELS.some((m) => m.id === result?.model)).toBe(true);
+    });
+
+    it('cursor provider: picks a real expensive slug for a high-tier role', () => {
+      const result = autoModelForRole('planner', ['cursor']);
+      expect(result).toEqual({ provider: 'cursor', model: 'claude-opus-4-7-thinking-high' });
     });
   });
 });

--- a/packages/core/src/providers/auto-model.ts
+++ b/packages/core/src/providers/auto-model.ts
@@ -1,11 +1,15 @@
 import type { ModelCostTier, ProviderId } from '@goodboy/types';
-import { PROVIDER_CAPABILITIES } from './capabilities';
-import { CURSOR_AUTO_MODEL } from './cursor/models';
+import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from './capabilities';
 import { defaultsForRole } from '../roles';
 
 export type AutoModelChoice = {
   readonly provider: ProviderId;
   readonly model: string;
+};
+
+type Params = {
+  readonly role: string;
+  readonly provider: ProviderId;
 };
 
 const COST_RANK: Readonly<Record<ModelCostTier, number>> = {
@@ -46,8 +50,9 @@ export const autoModelForRole = (
   if (best === null) {
     return null;
   }
-  return {
-    provider: best.provider,
-    model: best.provider === 'cursor' ? CURSOR_AUTO_MODEL : best.model,
-  };
+  return { provider: best.provider, model: best.model };
+};
+
+export const recommendedModelForRole = ({ role, provider }: Params): string => {
+  return autoModelForRole(role, [provider])?.model ?? getDefaultTurnModel(provider);
 };

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -1,5 +1,5 @@
 import type { ModelEffort, ProviderId, ProviderRegistryCapabilities } from '@goodboy/types';
-import { CURSOR_AUTO_MODEL, CURSOR_MODELS } from './cursor/models';
+import { CURSOR_MODELS } from './cursor/models';
 import { CODEX_MODELS } from './codex/constants';
 import { GEMINI_DEFAULT_MODEL, GEMINI_MODELS } from './gemini/constants';
 
@@ -123,9 +123,6 @@ export const getCapabilities = (id: ProviderId): ProviderRegistryCapabilities =>
 };
 
 export const getDefaultTurnModel = (id: ProviderId): string => {
-  if (id === 'cursor') {
-    return CURSOR_AUTO_MODEL;
-  }
   if (id === 'gemini') {
     return GEMINI_DEFAULT_MODEL;
   }

--- a/packages/core/src/providers/cursor/adapter.integration.test.ts
+++ b/packages/core/src/providers/cursor/adapter.integration.test.ts
@@ -17,7 +17,7 @@ describe.skipIf(!enabled)('CursorAdapter, integration (requires cursor-agent + a
     const request: TurnRequest = {
       runId: 'run_integration' as ProviderRunId,
       sessionId: 'sess_integration' as SessionId,
-      model: 'cursor-small',
+      model: 'composer-2',
       workingDir: '/tmp',
       systemPrompt: 'You are a test assistant. Be brief.',
       userMessage: 'Reply with only: "integration ok"',

--- a/packages/core/src/providers/cursor/adapter.test.ts
+++ b/packages/core/src/providers/cursor/adapter.test.ts
@@ -57,7 +57,7 @@ function makeRequest(): TurnRequest {
   return {
     runId: 'run_1' as ProviderRunId,
     sessionId: 'sess_1' as SessionId,
-    model: 'cursor-small',
+    model: 'composer-2',
     workingDir: '/tmp/demo',
     systemPrompt: 'sys',
     userMessage: 'hi',

--- a/packages/core/src/providers/model-map.test.ts
+++ b/packages/core/src/providers/model-map.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveModelForProvider } from './model-map';
+
+describe('resolveModelForProvider', () => {
+  it('returns the model unchanged when it belongs to the provider', () => {
+    expect(resolveModelForProvider({ provider: 'anthropic', modelId: 'claude-sonnet-4-6' })).toBe(
+      'claude-sonnet-4-6',
+    );
+    expect(resolveModelForProvider({ provider: 'cursor', modelId: 'composer-2' })).toBe(
+      'composer-2',
+    );
+  });
+
+  it('maps a native claude id to the closest cursor slug', () => {
+    expect(resolveModelForProvider({ provider: 'cursor', modelId: 'claude-sonnet-4-6' })).toBe(
+      'claude-4.6-sonnet-medium',
+    );
+    expect(resolveModelForProvider({ provider: 'cursor', modelId: 'claude-opus-4-8' })).toBe(
+      'claude-opus-4-7-thinking-high',
+    );
+  });
+
+  it('maps a cursor slug back to the closest native id', () => {
+    expect(
+      resolveModelForProvider({
+        provider: 'anthropic',
+        modelId: 'claude-4.6-sonnet-medium',
+      }),
+    ).toBe('claude-sonnet-4-6');
+    expect(
+      resolveModelForProvider({
+        provider: 'anthropic',
+        modelId: 'claude-opus-4-7-thinking-high',
+      }),
+    ).toBe('claude-opus-4-8');
+  });
+
+  it('falls back to the family match when no subfamily counterpart exists', () => {
+    expect(resolveModelForProvider({ provider: 'cursor', modelId: 'gpt-5.4-mini' })).toBe(
+      'gpt-5.3-codex',
+    );
+  });
+
+  it('falls back to the default turn model for an unknown id', () => {
+    expect(resolveModelForProvider({ provider: 'cursor', modelId: 'totally-unknown-model' })).toBe(
+      'composer-2',
+    );
+    expect(
+      resolveModelForProvider({ provider: 'anthropic', modelId: 'totally-unknown-model' }),
+    ).toBe('claude-opus-4-8');
+  });
+
+  it('falls back to the default turn model when the family has no counterpart', () => {
+    expect(resolveModelForProvider({ provider: 'anthropic', modelId: 'auto' })).toBe(
+      'claude-opus-4-8',
+    );
+  });
+});

--- a/packages/core/src/providers/model-map.ts
+++ b/packages/core/src/providers/model-map.ts
@@ -1,0 +1,32 @@
+import type { ModelTier, ProviderId } from '@goodboy/types';
+import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from './capabilities';
+import { getModelDescriptor } from './model-display';
+
+type Params = {
+  readonly provider: ProviderId;
+  readonly modelId: string;
+};
+
+export const resolveModelForProvider = ({ provider, modelId }: Params): string => {
+  const models = PROVIDER_CAPABILITIES[provider].models;
+  if (models.some((m) => m.id === modelId)) {
+    return modelId;
+  }
+  const descriptor = getModelDescriptor(modelId);
+  if (descriptor === null) {
+    return getDefaultTurnModel(provider);
+  }
+  const sameSubfamily = models.filter(
+    (m) => m.family === descriptor.family && m.subfamily === descriptor.subfamily,
+  );
+  const sameFamily = models.filter((m) => m.family === descriptor.family);
+  const candidates = sameSubfamily.length > 0 ? sameSubfamily : sameFamily;
+  if (candidates.length > 0) {
+    return candidates.reduce((best, model) =>
+      Math.abs(model.weight - descriptor.weight) < Math.abs(best.weight - descriptor.weight)
+        ? model
+        : best,
+    ).id;
+  }
+  return getDefaultTurnModel(provider);
+};

--- a/packages/core/src/providers/registry.test.ts
+++ b/packages/core/src/providers/registry.test.ts
@@ -97,6 +97,10 @@ describe('getCapabilities', () => {
     expect(getDefaultTurnModel('gemini')).toBe('gemini-3.5-flash');
   });
 
+  it('getDefaultTurnModel for cursor returns the composer turn model', () => {
+    expect(getDefaultTurnModel('cursor')).toBe('composer-2');
+  });
+
   it('all models have required fields', () => {
     for (const id of listSupportedProviders()) {
       const caps = getCapabilities(id);


### PR DESCRIPTION
## Problem

With cursor as the preferred provider, workflow generation failed or ran the wrong model:

- `autoModelForRole` discarded the role/weight-selected model and forced `CURSOR_AUTO_MODEL`, and `getDefaultTurnModel('cursor')` always returned the `auto` sentinel, so every step ran `--model auto` and role-based routing was a no-op.
- Native model ids (e.g. `claude-sonnet-4-6`) leaked verbatim into `cursor-agent --model`, which only accepts cursor slugs (`claude-4.6-sonnet-high`, `composer-2`), so turns errored out. Leak points: `sendTurn` final model resolution, `attachWorkflowToSession` fallback computed against the session provider instead of the step provider, and stale cross-provider `session.modelOverride` in `useTurnRouting`.
- `recommendedModel` logic was duplicated in three UI sites with drifting base providers.

## Fix

- Cursor now receives the role/weight-selected model; its default turn model is `composer-2`.
- New `resolveModelForProvider` helper (`packages/core/src/providers/model-map.ts`): passthrough when the id belongs to the provider, otherwise deterministic mapping via family/subfamily and closest weight, with default turn model as fallback. Applied at the three leak points, wrapping only the final resolved value so the routing precedence ladder is untouched. Legacy stored ids are healed at runtime, so no migration.
- `recommendedModelForRole` shared core helper replaces the three duplicated UI copies and uses each step's resolved provider.

## Verification

- `pnpm --filter @goodboy/core typecheck` and `test`: 798 passed, 7 skipped.
- `pnpm --filter @goodboy/desktop typecheck` and `test`: 2119 passed (232 files).
- New tests: model-map mapping/passthrough/fallback, cursor roles get real slugs, cursor default model, provider-consistent workflow attachment, stale anthropic-to-cursor mapping in chat input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)