### PR TITLE
fix(db): run migrations in crash-safe transactional segments

### DIFF
--- a/packages/db/src/migrations/runner.test.ts
+++ b/packages/db/src/migrations/runner.test.ts
@@ -15,9 +15,10 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
+import type { Database } from '../client';
 import { makeTestDatabase } from '../test-helpers/test-db';
 import { migrate } from './runner';
-import { migrations } from './index';
+import { migrations, type Migration } from './index';
 import { getWorkspaceById, insertWorkspace } from '../queries/workspace';
 import { getSessionById, insertSession } from '../queries/session';
 import { listWorkflows, getWorkflow, upsertWorkflow, deleteWorkflow } from '../queries/workflow';
@@ -37,6 +38,42 @@ import {
 
 const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
+type Params = {
+  readonly database: Database;
+  readonly failureStatement?: string;
+  readonly statements?: string[];
+};
+
+const makeForwardingDatabase = ({
+  database,
+  failureStatement,
+  statements = [],
+}: Params): Database => {
+  let hasFailed = false;
+
+  return {
+    exec: async (sql) => {
+      statements.push(sql);
+      await database.exec(sql);
+      if (!hasFailed && failureStatement != null && sql.includes(failureStatement)) {
+        hasFailed = true;
+        throw new Error(`Injected failure after ${failureStatement}`);
+      }
+    },
+    execute: async (sql, params) => {
+      statements.push(sql);
+      const result = await database.execute(sql, params);
+      if (!hasFailed && failureStatement != null && sql.includes(failureStatement)) {
+        hasFailed = true;
+        throw new Error(`Injected failure after ${failureStatement}`);
+      }
+      return result;
+    },
+    select: async <T>(sql: string, params?: ReadonlyArray<unknown>) =>
+      database.select<T>(sql, params),
+  };
+};
+
 describe('migrate', () => {
   it('applies all migrations on a fresh db', async () => {
     const db = makeTestDatabase();
@@ -52,6 +89,301 @@ describe('migrate', () => {
     const second = await migrate(db);
     expect(second.applied).toEqual([]);
     expect(second.skipped).toEqual(migrations.map((m) => m.version));
+  });
+
+  describe('transaction safety', () => {
+    it('rolls back a rebuild failure and applies it cleanly on retry', async () => {
+      const database = makeTestDatabase();
+      await migrate(
+        database,
+        migrations.filter((migration) => migration.version < 67),
+      );
+      await database.exec('PRAGMA foreign_keys = OFF');
+      await database.execute(
+        `INSERT INTO provider_runs
+          (id, session_id, provider, model, status_kind, status_payload, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        ['run-crash', 'missing-session', 'anthropic', 'model', 'pending', '{}', 1],
+      );
+      await database.exec('PRAGMA foreign_keys = ON');
+
+      const rebuildMigration = migrations.find((migration) => migration.version === 67);
+      if (rebuildMigration == null) {
+        throw new Error('Migration 67 should exist');
+      }
+      const failingDatabase = makeForwardingDatabase({
+        database,
+        failureStatement: 'DROP TABLE provider_runs',
+      });
+
+      await expect(migrate(failingDatabase, [rebuildMigration])).rejects.toThrow(
+        'Injected failure',
+      );
+
+      const runsAfterFailure = await database.select<{ id: string }>(
+        'SELECT id FROM provider_runs',
+      );
+      const versionsAfterFailure = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 67',
+      );
+      const foreignKeysAfterFailure = await database.select<{ foreign_keys: number }>(
+        'PRAGMA foreign_keys',
+      );
+      expect({
+        foreignKeys: foreignKeysAfterFailure[0]?.foreign_keys,
+        runs: runsAfterFailure,
+        versions: versionsAfterFailure,
+      }).toEqual({ foreignKeys: 1, runs: [{ id: 'run-crash' }], versions: [] });
+
+      const result = await migrate(database, [rebuildMigration]);
+      const runsAfterRetry = await database.select<{ id: string }>('SELECT id FROM provider_runs');
+      const versionsAfterRetry = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 67',
+      );
+      expect({
+        applied: result.applied,
+        runs: runsAfterRetry,
+        versions: versionsAfterRetry,
+      }).toEqual({
+        applied: [67],
+        runs: [{ id: 'run-crash' }],
+        versions: [{ version: 67 }],
+      });
+    });
+
+    it('rolls back the final segment when version recording fails', async () => {
+      const database = makeTestDatabase();
+      const migration = {
+        version: 1001,
+        sql: `
+          CREATE TABLE final_segment_test (id INTEGER PRIMARY KEY);
+          INSERT INTO final_segment_test (id) VALUES (1);
+        `,
+      } satisfies Migration;
+      const failingDatabase = makeForwardingDatabase({
+        database,
+        failureStatement: 'INSERT OR IGNORE INTO schema_version',
+      });
+
+      await expect(migrate(failingDatabase, [migration])).rejects.toThrow('Injected failure');
+
+      const tables = await database.select<{ name: string }>(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'final_segment_test'",
+      );
+      const versions = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 1001',
+      );
+      expect({ tables, versions }).toEqual({ tables: [], versions: [] });
+    });
+
+    it('does not roll back a transaction it did not begin', async () => {
+      const database = makeTestDatabase();
+      const statements: string[] = [];
+      const forwardingDatabase = makeForwardingDatabase({ database, statements });
+      const migration = {
+        version: 1002,
+        sql: 'CREATE TABLE begin_ownership_test (id INTEGER PRIMARY KEY);',
+      } satisfies Migration;
+      await database.exec('BEGIN IMMEDIATE');
+
+      await expect(migrate(forwardingDatabase, [migration])).rejects.toThrow(
+        'cannot start a transaction within a transaction',
+      );
+
+      expect(statements).toContain('BEGIN IMMEDIATE');
+      expect(statements).not.toContain('ROLLBACK');
+      await database.exec('ROLLBACK');
+    });
+
+    it('records a pragma-only migration once', async () => {
+      const database = makeTestDatabase();
+      const statements: string[] = [];
+      const forwardingDatabase = makeForwardingDatabase({ database, statements });
+      const migration = {
+        version: 1003,
+        sql: 'PRAGMA foreign_keys = ON;',
+      } satisfies Migration;
+
+      const first = await migrate(forwardingDatabase, [migration]);
+      const second = await migrate(forwardingDatabase, [migration]);
+      const versions = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 1003',
+      );
+      const pragmaExecutions = statements.filter(
+        (statement) => statement === 'PRAGMA foreign_keys = ON',
+      ).length;
+      expect({ first, pragmaExecutions, second, versions }).toEqual({
+        first: { applied: [1003], currentVersion: 1003, skipped: [] },
+        pragmaExecutions: 1,
+        second: { applied: [], currentVersion: 1003, skipped: [1003] },
+        versions: [{ version: 1003 }],
+      });
+    });
+  });
+
+  describe('segment resume', () => {
+    it('skips checkpointed work while replaying foreign key pragmas', async () => {
+      const database = makeTestDatabase();
+      const migration = {
+        version: 1002,
+        sql: `
+          PRAGMA foreign_keys = ON;
+          CREATE TABLE resume_first (id INTEGER PRIMARY KEY);
+          INSERT INTO resume_first (id) VALUES (1);
+          PRAGMA foreign_keys = OFF;
+          CREATE TABLE resume_final (id INTEGER PRIMARY KEY);
+          INSERT INTO resume_final (id) VALUES (2);
+          PRAGMA foreign_keys = ON;
+        `,
+      } satisfies Migration;
+      const failingDatabase = makeForwardingDatabase({
+        database,
+        failureStatement: 'PRAGMA foreign_keys = OFF',
+      });
+
+      await expect(migrate(failingDatabase, [migration])).rejects.toThrow('Injected failure');
+
+      const checkpointsAfterFailure = await database.select<{ segment: number }>(
+        'SELECT segment FROM schema_migration_segment WHERE version = 1002',
+      );
+      expect(checkpointsAfterFailure).toEqual([{ segment: 0 }]);
+
+      const resumedStatements: string[] = [];
+      const resumedDatabase = makeForwardingDatabase({ database, statements: resumedStatements });
+      const result = await migrate(resumedDatabase, [migration]);
+      const firstRows = await database.select<{ id: number }>('SELECT id FROM resume_first');
+      const finalRows = await database.select<{ id: number }>('SELECT id FROM resume_final');
+      const checkpointsAfterRetry = await database.select<{ segment: number }>(
+        'SELECT segment FROM schema_migration_segment WHERE version = 1002',
+      );
+      const versions = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 1002',
+      );
+      expect({
+        applied: result.applied,
+        checkpoints: checkpointsAfterRetry,
+        finalRows,
+        firstRows,
+        versions,
+      }).toEqual({
+        applied: [1002],
+        checkpoints: [],
+        finalRows: [{ id: 2 }],
+        firstRows: [{ id: 1 }],
+        versions: [{ version: 1002 }],
+      });
+      const resumedPragmas = resumedStatements.filter((statement) =>
+        statement.startsWith('PRAGMA foreign_keys'),
+      );
+      expect({
+        didRepeatFirstSegment: resumedStatements.some((statement) =>
+          statement.includes('CREATE TABLE resume_first'),
+        ),
+        pragmas: resumedPragmas,
+      }).toEqual({
+        didRepeatFirstSegment: false,
+        pragmas: [
+          'PRAGMA foreign_keys = ON',
+          'PRAGMA foreign_keys = OFF',
+          'PRAGMA foreign_keys = ON',
+        ],
+      });
+    });
+
+    it('resumes the real m031 migration without repeating its renames', async () => {
+      const database = makeTestDatabase();
+      await migrate(
+        database,
+        migrations.filter((migration) => migration.version < 31),
+      );
+      await database.execute(
+        `INSERT INTO workspaces (id, name, root_path, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)`,
+        ['workspace-31', 'Workspace 31', '/tmp/workspace-31', 1, 1],
+      );
+      await database.execute(
+        `INSERT INTO tasks (id, workspace_id, goal, state_kind, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['task-31', 'workspace-31', 'Keep m031 data', 'idle', 1, 1],
+      );
+      await database.execute(
+        `INSERT INTO sessions (id, task_id, ordinal, name, status)
+         VALUES (?, ?, ?, ?, ?)`,
+        ['agent-31', 'task-31', 0, 'Agent 31', 'pending'],
+      );
+      await database.execute(
+        `INSERT INTO permission_rules (id, scope, task_id, pattern_tool, decision)
+         VALUES (?, ?, ?, ?, ?)`,
+        ['rule-31', 'task', 'task-31', 'Read', 'allow'],
+      );
+      await database.execute(
+        `INSERT INTO diff_comments
+          (id, task_id, file_path, body, created_at, consumed_by_agent_id)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['comment-31', 'task-31', 'runner.ts', 'Keep this row', 1, 'agent-31'],
+      );
+
+      const migration = migrations.find((candidate) => candidate.version === 31);
+      if (migration == null) {
+        throw new Error('Migration 31 should exist');
+      }
+      const failingDatabase = makeForwardingDatabase({
+        database,
+        failureStatement: 'PRAGMA foreign_keys = OFF',
+      });
+
+      await expect(migrate(failingDatabase, [migration])).rejects.toThrow('Injected failure');
+
+      const checkpointsAfterFailure = await database.select<{ segment: number }>(
+        'SELECT segment FROM schema_migration_segment WHERE version = 31',
+      );
+      expect(checkpointsAfterFailure).toEqual([{ segment: 0 }]);
+
+      const resumedStatements: string[] = [];
+      const resumedDatabase = makeForwardingDatabase({ database, statements: resumedStatements });
+      const result = await migrate(resumedDatabase, [migration]);
+      const sessions = await database.select<{ id: string; workspace_id: string; goal: string }>(
+        'SELECT id, workspace_id, goal FROM sessions WHERE id = ?',
+        ['task-31'],
+      );
+      const agents = await database.select<{ id: string; session_id: string; name: string }>(
+        'SELECT id, session_id, name FROM agents WHERE id = ?',
+        ['agent-31'],
+      );
+      const rules = await database.select<{ id: string; scope: string; session_id: string }>(
+        'SELECT id, scope, session_id FROM permission_rules WHERE id = ?',
+        ['rule-31'],
+      );
+      const comments = await database.select<{
+        id: string;
+        session_id: string;
+        consumed_by_agent_id: string;
+      }>('SELECT id, session_id, consumed_by_agent_id FROM diff_comments WHERE id = ?', [
+        'comment-31',
+      ]);
+      const checkpointsAfterResume = await database.select<{ segment: number }>(
+        'SELECT segment FROM schema_migration_segment WHERE version = 31',
+      );
+      const versions = await database.select<{ version: number }>(
+        'SELECT version FROM schema_version WHERE version = 31',
+      );
+      expect({ agents, comments, result, rules, sessions }).toEqual({
+        agents: [{ id: 'agent-31', name: 'Agent 31', session_id: 'task-31' }],
+        comments: [{ consumed_by_agent_id: 'agent-31', id: 'comment-31', session_id: 'task-31' }],
+        result: { applied: [31], currentVersion: 31, skipped: [] },
+        rules: [{ id: 'rule-31', scope: 'session', session_id: 'task-31' }],
+        sessions: [{ goal: 'Keep m031 data', id: 'task-31', workspace_id: 'workspace-31' }],
+      });
+      expect({ checkpoints: checkpointsAfterResume, versions }).toEqual({
+        checkpoints: [],
+        versions: [{ version: 31 }],
+      });
+      expect(
+        resumedStatements.some((statement) =>
+          statement.includes('ALTER TABLE sessions RENAME TO agents'),
+        ),
+      ).toBe(false);
+    });
   });
 
   it('round-trips a workspace through the schema', async () => {

--- a/packages/db/src/migrations/runner.ts
+++ b/packages/db/src/migrations/runner.ts
@@ -1,12 +1,56 @@
 import type { Database } from '../client';
 import { migrations as defaultMigrations, type Migration } from './index';
 
-const ENSURE_VERSION_TABLE = `
+const ENSURE_MIGRATION_TABLES = `
 CREATE TABLE IF NOT EXISTS schema_version (
   version INTEGER PRIMARY KEY,
   applied_at INTEGER NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS schema_migration_segment (
+  version INTEGER NOT NULL,
+  segment INTEGER NOT NULL,
+  applied_at INTEGER NOT NULL,
+  PRIMARY KEY (version, segment)
+);
 `;
+
+const FOREIGN_KEYS_PRAGMA = /^[\t ]*PRAGMA[\t ]+foreign_keys[\t ]*=[\t ]*(ON|OFF)[\t ]*$/im;
+
+type MigrationPart =
+  | {
+      readonly kind: 'pragma';
+      readonly statement: string;
+    }
+  | {
+      readonly kind: 'segment';
+      readonly index: number;
+      readonly statements: ReadonlyArray<string>;
+    };
+
+type SegmentRow = {
+  readonly segment: number;
+};
+
+type ApplyMigrationInput = {
+  readonly db: Database;
+  readonly migration: Migration;
+};
+
+type ExecuteStatementInput = {
+  readonly db: Database;
+  readonly statement: string;
+  readonly version: number;
+};
+
+type RestoreAfterFailureInput = {
+  readonly db: Database;
+  readonly isTransactionOwned: boolean;
+};
+
+type SplitMigrationInput = {
+  readonly sql: string;
+};
 
 export type MigrateResult = {
   readonly applied: ReadonlyArray<number>;
@@ -18,7 +62,7 @@ export const migrate = async (
   db: Database,
   migrations: ReadonlyArray<Migration> = defaultMigrations,
 ): Promise<MigrateResult> => {
-  await db.exec(ENSURE_VERSION_TABLE);
+  await db.exec(ENSURE_MIGRATION_TABLES);
 
   const rows = await db.select<{ version: number }>('SELECT version FROM schema_version');
   const applied = new Set(rows.map((row) => row.version));
@@ -32,11 +76,7 @@ export const migrate = async (
       skipped.push(migration.version);
       continue;
     }
-    await applyMigrationSql(db, migration);
-    await db.execute('INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)', [
-      migration.version,
-      Date.now(),
-    ]);
+    await applyMigrationSql({ db, migration });
     newlyApplied.push(migration.version);
   }
 
@@ -44,43 +84,149 @@ export const migrate = async (
   return { applied: newlyApplied, skipped, currentVersion };
 };
 
-async function applyMigrationSql(db: Database, migration: Migration): Promise<void> {
-  const statements = migration.sql
+const splitMigration = ({ sql }: SplitMigrationInput): ReadonlyArray<MigrationPart> => {
+  const statements = sql
     .split(';')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+  const parts: MigrationPart[] = [];
+  let segmentStatements: string[] = [];
+  let segmentIndex = 0;
 
-  for (const stmt of statements) {
-    try {
-      await db.exec(stmt);
-    } catch (err) {
-      if (isAlreadyExistsError(err)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[migrations] v${migration.version}: skipping idempotent statement (already applied): ${truncate(stmt)}`,
-        );
+  for (const statement of statements) {
+    const pragmaMatch = statement.match(FOREIGN_KEYS_PRAGMA);
+    if (pragmaMatch == null) {
+      segmentStatements.push(statement);
+      continue;
+    }
+    if (segmentStatements.length > 0) {
+      parts.push({ kind: 'segment', index: segmentIndex, statements: segmentStatements });
+      segmentStatements = [];
+      segmentIndex += 1;
+    }
+    parts.push({ kind: 'pragma', statement: pragmaMatch[0].trim() });
+  }
+
+  if (segmentStatements.length > 0) {
+    parts.push({ kind: 'segment', index: segmentIndex, statements: segmentStatements });
+  }
+
+  return parts;
+};
+
+const applyMigrationSql = async ({ db, migration }: ApplyMigrationInput): Promise<void> => {
+  const parts = splitMigration({ sql: migration.sql });
+  const segmentCount = parts.filter((part) => part.kind === 'segment').length;
+  let isTransactionOwned = false;
+
+  try {
+    const rows = await db.select<SegmentRow>(
+      'SELECT segment FROM schema_migration_segment WHERE version = ?',
+      [migration.version],
+    );
+    const appliedSegments = new Set(rows.map((row) => row.segment));
+
+    for (const part of parts) {
+      if (part.kind === 'pragma') {
+        await db.exec(part.statement);
         continue;
       }
-      throw err;
+      if (appliedSegments.has(part.index)) {
+        continue;
+      }
+
+      await db.exec('BEGIN IMMEDIATE');
+      isTransactionOwned = true;
+      for (const statement of part.statements) {
+        await executeStatement({ db, statement, version: migration.version });
+      }
+
+      const isFinalSegment = part.index === segmentCount - 1;
+      if (isFinalSegment) {
+        await db.execute(
+          'INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)',
+          [migration.version, Date.now()],
+        );
+        await db.execute('DELETE FROM schema_migration_segment WHERE version = ?', [
+          migration.version,
+        ]);
+      }
+      if (!isFinalSegment) {
+        await db.execute(
+          'INSERT OR IGNORE INTO schema_migration_segment (version, segment, applied_at) VALUES (?, ?, ?)',
+          [migration.version, part.index, Date.now()],
+        );
+      }
+      await db.exec('COMMIT');
+      isTransactionOwned = false;
     }
-  }
-}
 
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) {
-    return err.message;
+    if (segmentCount === 0) {
+      await db.execute('INSERT OR IGNORE INTO schema_version (version, applied_at) VALUES (?, ?)', [
+        migration.version,
+        Date.now(),
+      ]);
+    }
+  } catch (error) {
+    await restoreAfterFailure({ db, isTransactionOwned });
+    throw error;
   }
-  if (typeof err === 'object' && err !== null && 'message' in err) {
-    return String((err as { message: unknown }).message);
+};
+
+const executeStatement = async ({
+  db,
+  statement,
+  version,
+}: ExecuteStatementInput): Promise<void> => {
+  try {
+    await db.exec(statement);
+  } catch (error) {
+    if (isAlreadyExistsError({ error })) {
+      console.warn(
+        `[migrations] v${version}: skipping idempotent statement (already applied): ${truncate({ value: statement })}`,
+      );
+      return;
+    }
+    throw error;
   }
-  return String(err);
-}
+};
 
-function isAlreadyExistsError(err: unknown): boolean {
-  const msg = errorMessage(err).toLowerCase();
-  return msg.includes('duplicate column name') || msg.includes('already exists');
-}
+const restoreAfterFailure = async ({
+  db,
+  isTransactionOwned,
+}: RestoreAfterFailureInput): Promise<void> => {
+  if (isTransactionOwned) {
+    try {
+      await db.exec('ROLLBACK');
+    } catch {}
+  }
+  try {
+    await db.exec('PRAGMA foreign_keys = ON');
+  } catch {}
+};
 
-function truncate(s: string): string {
-  return s.length > 80 ? `${s.slice(0, 77)}...` : s;
-}
+type ErrorMessageInput = {
+  readonly error: unknown;
+};
+
+const errorMessage = ({ error }: ErrorMessageInput): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String(error.message);
+  }
+  return String(error);
+};
+
+const isAlreadyExistsError = ({ error }: ErrorMessageInput): boolean => {
+  const message = errorMessage({ error }).toLowerCase();
+  return message.includes('duplicate column name') || message.includes('already exists');
+};
+
+type TruncateInput = {
+  readonly value: string;
+};
+
+const truncate = ({ value }: TruncateInput): string =>
+  value.length > 80 ? `${value.slice(0, 77)}...` : value;


### PR DESCRIPTION
## Summary
Fixes #923. A crash between DROP TABLE and ALTER TABLE RENAME inside a rebuild migration (m015, m031, m045, m067, m068 and similar) permanently destroyed user data: the re-run's DROP TABLE IF EXISTS x_new deleted the only surviving copy and every subsequent boot failed.

## Changes
- Migration statements now run inside BEGIN IMMEDIATE transactions, segmented at PRAGMA foreign_keys boundaries (pragmas execute outside transactions where they actually take effect).
- The schema_version row is inserted inside the final segment's transaction, so a migration is recorded if and only if it fully applied.
- New runner-owned schema_migration_segment checkpoint table makes the one multi-segment migration (m031) resumable: committed segments are skipped on retry, checkpoints are cleaned atomically with the version insert.
- On failure the runner issues ROLLBACK only for transactions it opened (avoids aborting a concurrent window's in-flight migration on the shared connection) and restores PRAGMA foreign_keys = ON.
- Empty or pragma-only migrations still record their version.

## Tests
Fault-injection wrapper over the test database: crash after the real m067 DROP TABLE provider_runs (data survives, rerun succeeds), version-insert atomicity, checkpoint resume against real m031 SQL with seeded rows, BEGIN ownership guard, foreign_keys restoration, pragma-only idempotence. 84/84 db tests green, db and desktop typecheck clean.

## Follow-ups (out of scope)
- Repair path for databases already bricked under the old runner (rename surviving _new table back).
- Process-level once-guard so only one window runs migrations on shared connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)