### PR TITLE
refactor(core): shared context budgets, session tldr, writer coordination

### DIFF
--- a/apps/desktop/src/features/providers/slot-routing.test.ts
+++ b/apps/desktop/src/features/providers/slot-routing.test.ts
@@ -23,6 +23,10 @@ describe('AGENT_KIND_SLOTS', () => {
     expect(AGENT_KIND_SLOTS.debugger).not.toContain('open_questions');
   });
 
+  it('resolver receives the goal and touched files', () => {
+    expect(slotsForKind('resolver')).toEqual(['goal', 'files_touched']);
+  });
+
   it('generic has no entry → fallback (all slots)', () => {
     expect(slotsForKind('generic')).toBeUndefined();
   });

--- a/apps/desktop/src/features/providers/slot-routing.ts
+++ b/apps/desktop/src/features/providers/slot-routing.ts
@@ -8,7 +8,7 @@ export const AGENT_KIND_SLOTS: Partial<Record<AgentKind, ReadonlyArray<SlotKey>>
   reviewer: ['goal', 'files_touched', 'last_output_summary'],
   scout: ['goal', 'last_output_summary'],
   docs: ['goal', 'last_output_summary'],
-  resolver: ['files_touched'],
+  resolver: ['goal', 'files_touched'],
 };
 
 export const slotsForKind = (kind: AgentKind): ReadonlyArray<SlotKey> | undefined => {

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -520,11 +520,11 @@ describe('SessionOverviewPane context links', () => {
     expect(onSelectLens).toHaveBeenCalledWith('goal');
   });
 
-  it('routes Decisions and Last output from the primary strip', () => {
+  it('routes Decisions and Session TLDR from the primary strip', () => {
     const onSelectLens = renderPane();
     fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('decisions');
-    fireEvent.click(screen.getByRole('button', { name: /^last output$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^session tldr$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
   });
 
@@ -542,7 +542,7 @@ describe('SessionOverviewPane context links', () => {
     expect(screen.getByRole('button', { name: /^goal$/i })).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('decisions');
-    fireEvent.click(screen.getByRole('button', { name: /^last output$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^session tldr$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -520,11 +520,11 @@ describe('SessionOverviewPane context links', () => {
     expect(onSelectLens).toHaveBeenCalledWith('goal');
   });
 
-  it('routes Decisions and Session TLDR from the primary strip', () => {
+  it('routes Decisions and Session summary from the primary strip', () => {
     const onSelectLens = renderPane();
     fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('decisions');
-    fireEvent.click(screen.getByRole('button', { name: /^session tldr$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^session summary$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
   });
 
@@ -542,7 +542,7 @@ describe('SessionOverviewPane context links', () => {
     expect(screen.getByRole('button', { name: /^goal$/i })).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: /^decisions$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('decisions');
-    fireEvent.click(screen.getByRole('button', { name: /^session tldr$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^session summary$/i }));
     expect(onSelectLens).toHaveBeenCalledWith('last_output_summary');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -91,7 +91,7 @@ const PRIMARY_CONTEXT_LINKS: ReadonlyArray<{
 }> = [
   { kind: 'goal', icon: Target, tone: 'primary', label: 'Goal' },
   { kind: 'decisions', icon: CheckCheck, tone: 'success', label: 'Decisions' },
-  { kind: 'last_output_summary', icon: Activity, tone: 'info', label: 'Last output' },
+  { kind: 'last_output_summary', icon: Activity, tone: 'info', label: 'Session TLDR' },
 ];
 
 const SECONDARY_CONTEXT_LINKS: ReadonlyArray<{

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -91,7 +91,7 @@ const PRIMARY_CONTEXT_LINKS: ReadonlyArray<{
 }> = [
   { kind: 'goal', icon: Target, tone: 'primary', label: 'Goal' },
   { kind: 'decisions', icon: CheckCheck, tone: 'success', label: 'Decisions' },
-  { kind: 'last_output_summary', icon: Activity, tone: 'info', label: 'Session TLDR' },
+  { kind: 'last_output_summary', icon: Activity, tone: 'info', label: 'Session summary' },
 ];
 
 const SECONDARY_CONTEXT_LINKS: ReadonlyArray<{

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -40,7 +40,7 @@ const LENS_LABEL: Record<LensKind, string> = {
   terminal: 'Terminal',
   goal: 'Goal',
   decisions: 'Decisions',
-  last_output_summary: 'Session TLDR',
+  last_output_summary: 'Session summary',
   pr: 'Pull request',
   files: 'Diff',
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -40,7 +40,7 @@ const LENS_LABEL: Record<LensKind, string> = {
   terminal: 'Terminal',
   goal: 'Goal',
   decisions: 'Decisions',
-  last_output_summary: 'Last output',
+  last_output_summary: 'Session TLDR',
   pr: 'Pull request',
   files: 'Diff',
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -116,7 +116,7 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
   const contextRows: ReadonlyArray<LensRow> = [
     { kind: 'goal', label: 'Goal', icon: Target, tone: 'primary' },
     { kind: 'decisions', label: 'Decisions', icon: CheckCheck, tone: 'success' },
-    { kind: 'last_output_summary', label: 'Last output', icon: Activity, tone: 'info' },
+    { kind: 'last_output_summary', label: 'Session TLDR', icon: Activity, tone: 'info' },
     {
       kind: 'pr',
       label: 'Pull request',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -116,7 +116,7 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
   const contextRows: ReadonlyArray<LensRow> = [
     { kind: 'goal', label: 'Goal', icon: Target, tone: 'primary' },
     { kind: 'decisions', label: 'Decisions', icon: CheckCheck, tone: 'success' },
-    { kind: 'last_output_summary', label: 'Session TLDR', icon: Activity, tone: 'info' },
+    { kind: 'last_output_summary', label: 'Session summary', icon: Activity, tone: 'info' },
     {
       kind: 'pr',
       label: 'Pull request',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -18,19 +18,20 @@ type SlotKey = 'goal' | 'decisions' | 'last_output_summary';
 const SLOT_TITLE: Record<SlotKey, string> = {
   goal: 'Goal',
   decisions: 'Decisions',
-  last_output_summary: 'Last output',
+  last_output_summary: 'Session TLDR',
 };
 
 const SLOT_DESCRIPTION: Record<SlotKey, string> = {
   goal: 'What this session is meant to achieve.',
   decisions: 'Choices already locked in for this session.',
-  last_output_summary: "Summary of the agent's most recent reply.",
+  last_output_summary:
+    'What this session has accomplished, its current state, and what is in flight.',
 };
 
 const SLOT_EMPTY_CTA: Record<SlotKey, string> = {
   goal: 'Add the session goal',
   decisions: 'Log a decision',
-  last_output_summary: 'Write a manual summary',
+  last_output_summary: 'Write a manual session TLDR',
 };
 
 const SLOT_ICON: Record<SlotKey, LucideIcon> = {
@@ -48,7 +49,8 @@ const SLOT_TONE: Record<SlotKey, Tone> = {
 const SLOT_EMPTY_DESCRIPTION: Record<SlotKey, string> = {
   goal: 'What this session is meant to achieve.',
   decisions: 'Choices already locked in for this session.',
-  last_output_summary: "Summary of the agent's most recent reply.",
+  last_output_summary:
+    'What this session has accomplished, its current state, and what is in flight.',
 };
 
 const MARKDOWN_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>(['decisions', 'last_output_summary']);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -18,7 +18,7 @@ type SlotKey = 'goal' | 'decisions' | 'last_output_summary';
 const SLOT_TITLE: Record<SlotKey, string> = {
   goal: 'Goal',
   decisions: 'Decisions',
-  last_output_summary: 'Session TLDR',
+  last_output_summary: 'Session summary',
 };
 
 const SLOT_DESCRIPTION: Record<SlotKey, string> = {
@@ -31,7 +31,7 @@ const SLOT_DESCRIPTION: Record<SlotKey, string> = {
 const SLOT_EMPTY_CTA: Record<SlotKey, string> = {
   goal: 'Add the session goal',
   decisions: 'Log a decision',
-  last_output_summary: 'Write a manual session TLDR',
+  last_output_summary: 'Write a manual session summary',
 };
 
 const SLOT_ICON: Record<SlotKey, LucideIcon> = {

--- a/apps/desktop/src/store/preamble.test.ts
+++ b/apps/desktop/src/store/preamble.test.ts
@@ -30,6 +30,18 @@ describe('buildContextPreamble', () => {
     expect(out).not.toContain('a.ts');
   });
 
+  it('drops disabled slots from shared context', () => {
+    const disabledDecision: ContextSlot = {
+      key: 'decisions',
+      value: 'hidden decision',
+      enabled: false,
+    };
+    const out = buildContextPreamble([slot('goal', 'visible goal'), disabledDecision]);
+
+    expect(out).toContain('visible goal');
+    expect(out).not.toContain('hidden decision');
+  });
+
   it('empty filter result → no shared context block', () => {
     const out = buildContextPreamble([slot('open_questions', 'q?')], ['goal']);
     expect(out).not.toContain('## shared context');
@@ -50,7 +62,7 @@ describe('buildContextPreamble', () => {
     const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
     const slots = [
       slot('goal', 'g'.repeat(280)),
-      slot('files_touched', 'f'.repeat(600)),
+      slot('files_touched', 'f'.repeat(1_600)),
       slot('decisions', 'd'.repeat(1_200)),
       slot('open_questions', 'q'.repeat(800)),
       slot('last_output_summary', 's'.repeat(900)),

--- a/apps/desktop/src/store/preamble.test.ts
+++ b/apps/desktop/src/store/preamble.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
 import type { ContextSlot, IsoDateTime, ProviderRunId, TurnEvent } from '@goodboy/types';
+import { describe, expect, it, vi } from 'vitest';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from './preamble';
 
 const NOW = '2026-05-11T00:00:00.000Z' as IsoDateTime;
@@ -34,6 +34,42 @@ describe('buildContextPreamble', () => {
     const out = buildContextPreamble([slot('open_questions', 'q?')], ['goal']);
     expect(out).not.toContain('## shared context');
     expect(out).toContain('context handoff protocol');
+  });
+
+  it('budget-compacts oversized slots before rendering the preamble', () => {
+    const decisions = Array.from(
+      { length: 20 },
+      (_, index) => `- decision-${index}-${'x'.repeat(80)}`,
+    ).join('\n');
+    const out = buildContextPreamble([slot('decisions', decisions)]);
+    expect(out).toContain('- ...');
+    expect(out).not.toContain('decision-19');
+  });
+
+  it('logs serialized slot sizes in development above 80 percent of the total budget', () => {
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    const slots = [
+      slot('goal', 'g'.repeat(280)),
+      slot('files_touched', 'f'.repeat(600)),
+      slot('decisions', 'd'.repeat(1_200)),
+      slot('open_questions', 'q'.repeat(800)),
+      slot('last_output_summary', 's'.repeat(900)),
+    ];
+    buildContextPreamble(slots);
+    expect(debug).toHaveBeenCalledWith(
+      '[context-preamble] serialized slot budget usage',
+      expect.objectContaining({
+        totalChars: expect.any(Number),
+        slotChars: expect.objectContaining({
+          goal: expect.any(Number),
+          files_touched: expect.any(Number),
+          decisions: expect.any(Number),
+          open_questions: expect.any(Number),
+          last_output_summary: expect.any(Number),
+        }),
+      }),
+    );
+    debug.mockRestore();
   });
 });
 

--- a/apps/desktop/src/store/preamble.ts
+++ b/apps/desktop/src/store/preamble.ts
@@ -22,9 +22,10 @@ export const buildContextPreamble = (
   slotFilter?: ReadonlyArray<SlotKey>,
 ): string => {
   const parts: string[] = [];
+  const enabledSlots = sharedSlots.filter((slot) => slot.enabled !== false);
   const filtered = slotFilter
-    ? sharedSlots.filter((s) => (slotFilter as ReadonlyArray<string>).includes(s.key))
-    : sharedSlots;
+    ? enabledSlots.filter((slot) => (slotFilter as ReadonlyArray<string>).includes(slot.key))
+    : enabledSlots;
   const rendered = filtered.length > 0 ? serializeSlotsBudgeted({ slots: filtered }) : '';
   if (import.meta.env.DEV && rendered.length > PREAMBLE_SLOT_TOTAL_BUDGET * 0.8) {
     const byKey = new Map<SlotKey, ContextSlot>();

--- a/apps/desktop/src/store/preamble.ts
+++ b/apps/desktop/src/store/preamble.ts
@@ -1,4 +1,12 @@
-import { serializeSlots, type SlotKey, PROVIDER_CAPABILITIES } from '@goodboy/core';
+import {
+  isSlotKey,
+  PREAMBLE_SLOT_TOTAL_BUDGET,
+  PROVIDER_CAPABILITIES,
+  serializeSlotsBudgeted,
+  SLOT_KEYS,
+  SLOT_LABELS,
+  type SlotKey,
+} from '@goodboy/core';
 import type { ContextSlot, TurnEvent } from '@goodboy/types';
 import { estimateTokens } from '../shared/utils/estimate-tokens';
 
@@ -17,7 +25,38 @@ export const buildContextPreamble = (
   const filtered = slotFilter
     ? sharedSlots.filter((s) => (slotFilter as ReadonlyArray<string>).includes(s.key))
     : sharedSlots;
-  const rendered = filtered.length > 0 ? serializeSlots(filtered) : '';
+  const rendered = filtered.length > 0 ? serializeSlotsBudgeted({ slots: filtered }) : '';
+  if (import.meta.env.DEV && rendered.length > PREAMBLE_SLOT_TOTAL_BUDGET * 0.8) {
+    const byKey = new Map<SlotKey, ContextSlot>();
+    for (const slot of filtered) {
+      if (isSlotKey(slot.key)) {
+        byKey.set(slot.key, slot);
+      }
+    }
+    const emptySerialized = serializeSlotsBudgeted({ slots: [] });
+    const slotChars: Record<SlotKey, number> = {
+      goal: 0,
+      files_touched: 0,
+      decisions: 0,
+      open_questions: 0,
+      last_output_summary: 0,
+    };
+    for (const key of SLOT_KEYS) {
+      const emptySection = `## ${SLOT_LABELS[key]}\n·`;
+      const omittedSection = `## ${SLOT_LABELS[key]}\n(omitted, over budget)`;
+      if (rendered.includes(omittedSection)) {
+        slotChars[key] = omittedSection.length;
+        continue;
+      }
+      const slot = byKey.get(key);
+      const isolated = serializeSlotsBudgeted({ slots: slot == null ? [] : [slot] });
+      slotChars[key] = emptySection.length + isolated.length - emptySerialized.length;
+    }
+    console.debug('[context-preamble] serialized slot budget usage', {
+      totalChars: rendered.length,
+      slotChars,
+    });
+  }
   if (rendered.length > 0) {
     parts.push('## shared context (already loaded by orchestrator, do not re-derive)\n' + rendered);
   }

--- a/apps/desktop/src/store/slices/slots/index.test.ts
+++ b/apps/desktop/src/store/slices/slots/index.test.ts
@@ -530,12 +530,19 @@ describe('store contract', () => {
 
     it('toggleSessionSlot upserts the slot with new enabled flag', async () => {
       const store = await getStore();
+      const db = await import('@goodboy/db');
       store.setState({
         sessionSlots: { [SESSION_ID]: [{ key: 'goal', value: 'g', enabled: true } as ContextSlot] },
       });
       await store.getState().toggleSessionSlot(SESSION_ID, 'goal', false);
       const slot = store.getState().sessionSlots[SESSION_ID]?.find((s) => s.key === 'goal');
       expect(slot?.enabled).toBe(false);
+      expect(db.upsertContextSlot).toHaveBeenCalledWith(
+        expect.anything(),
+        SESSION_ID,
+        { key: 'goal', value: 'g', enabled: false },
+        'user',
+      );
     });
   });
 

--- a/apps/desktop/src/store/slices/slots/toggleSessionSlot.ts
+++ b/apps/desktop/src/store/slices/slots/toggleSessionSlot.ts
@@ -9,7 +9,7 @@ export const toggleSessionSlot = (set: SetFn, get: GetFn) => {
     const existing = get().sessionSlots[sessionId] ?? [];
     const prev = existing.find((s) => s.key === key);
     const next: ContextSlot = { key, value: prev?.value ?? '', enabled };
-    await upsertContextSlot(tauriDatabase, sessionId, next);
+    await upsertContextSlot(tauriDatabase, sessionId, next, 'user');
     set((state) => ({
       sessionSlots: {
         ...state.sessionSlots,

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -88,7 +88,9 @@ vi.mock('../features/providers/provider-pricing', () => ({
 }));
 
 let resolveSummarize: (() => void) | null = null;
-let summarizerUpserts: ReadonlyArray<{ readonly key: SlotKey; readonly value: string }> = [];
+type SummarizerUpsert = { readonly key: SlotKey; readonly value: string };
+let summarizerUpserts: ReadonlyArray<SummarizerUpsert> = [];
+let summarizerUpsertSequence: Array<ReadonlyArray<SummarizerUpsert>> = [];
 const summarizeSpy = vi.fn(
   () =>
     new Promise<void>((resolve) => {
@@ -102,7 +104,7 @@ vi.mock('@goodboy/core', async (importOriginal) => {
     ...original,
     Summarizer: class {
       summarize() {
-        const upserts = summarizerUpserts;
+        const upserts = summarizerUpsertSequence.shift() ?? summarizerUpserts;
         return summarizeSpy().then(() => ({
           delta: { upserts },
           usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 },
@@ -204,6 +206,7 @@ describe('summarizer queue, coalescing and no-stack', () => {
     summarizeSpy.mockReset();
     resolveSummarize = null;
     summarizerUpserts = [];
+    summarizerUpsertSequence = [];
     dbSlots = [];
     upsertContextSlotSpy.mockClear();
     summarizeSpy.mockResolvedValue(undefined);
@@ -239,13 +242,21 @@ describe('summarizer queue, coalescing and no-stack', () => {
     const state = useAppStore.getState();
     const queue = {
       inFlight: true,
-      queued: null as null | { turnInput: string; turnOutput: string },
+      queued: null as null | {
+        turnInput: string;
+        turnOutput: string;
+        oversizeRetried: boolean;
+      },
     };
     summarizerQueues.set(SESSION_ID, queue);
 
     for (let i = 1; i <= 4; i++) {
       if (queue.inFlight) {
-        queue.queued = { turnInput: `input-${i}`, turnOutput: `output-${i}` };
+        queue.queued = {
+          turnInput: `input-${i}`,
+          turnOutput: `output-${i}`,
+          oversizeRetried: false,
+        };
       }
     }
 
@@ -272,7 +283,11 @@ describe('summarizer queue, coalescing and no-stack', () => {
 
     const queue = {
       inFlight: false,
-      queued: null as null | { turnInput: string; turnOutput: string },
+      queued: null as null | {
+        turnInput: string;
+        turnOutput: string;
+        oversizeRetried: boolean;
+      },
     };
     sq.set(SESSION_ID, queue);
 
@@ -293,17 +308,29 @@ describe('summarizer queue, coalescing and no-stack', () => {
 
     const queue = {
       inFlight: true,
-      queued: null as null | { turnInput: string; turnOutput: string },
+      queued: null as null | {
+        turnInput: string;
+        turnOutput: string;
+        oversizeRetried: boolean;
+      },
     };
     sq.set(SESSION_ID, queue);
 
     for (let i = 0; i < 10; i++) {
       if (queue.inFlight) {
-        queue.queued = { turnInput: `t${i}`, turnOutput: `o${i}` };
+        queue.queued = {
+          turnInput: `t${i}`,
+          turnOutput: `o${i}`,
+          oversizeRetried: false,
+        };
       }
     }
 
-    expect(queue.queued).toEqual({ turnInput: 't9', turnOutput: 'o9' });
+    expect(queue.queued).toEqual({
+      turnInput: 't9',
+      turnOutput: 'o9',
+      oversizeRetried: false,
+    });
 
     sq.delete(SESSION_ID);
   });
@@ -319,12 +346,16 @@ describe('summarizer queue, coalescing and no-stack', () => {
 
     const queue = {
       inFlight: true,
-      queued: null as null | { turnInput: string; turnOutput: string },
+      queued: null as null | {
+        turnInput: string;
+        turnOutput: string;
+        oversizeRetried: boolean;
+      },
     };
     sq.set(SESSION_ID, queue);
 
     const before = Date.now();
-    queue.queued = { turnInput: 'next-input', turnOutput: '' };
+    queue.queued = { turnInput: 'next-input', turnOutput: '', oversizeRetried: false };
     const elapsed = Date.now() - before;
 
     expect(elapsed).toBeLessThan(50);
@@ -446,9 +477,10 @@ describe('summarizer queue, coalescing and no-stack', () => {
     expect(upsertContextSlotSpy).not.toHaveBeenCalled();
   });
 
-  it('re-enqueues once for a changed slot above twice its budget', async () => {
-    const oversizeGoal = 'x'.repeat(561);
-    summarizerUpserts = [{ key: 'goal', value: oversizeGoal }];
+  it('re-enqueues only once when every pass changes an oversize slot', async () => {
+    summarizerUpsertSequence = Array.from({ length: 10 }, (_, index) => [
+      { key: 'goal', value: `${index}${'x'.repeat(561)}` },
+    ]);
     dbSlots = [{ key: 'goal', value: 'original goal', enabled: true }];
 
     const { useAppStore } = await import('./store');

--- a/apps/desktop/src/store/store.summarizer-queue.test.ts
+++ b/apps/desktop/src/store/store.summarizer-queue.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type { SlotKey } from '@goodboy/core';
+import type { ContextSlot, IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: vi.fn(),
@@ -87,6 +88,7 @@ vi.mock('../features/providers/provider-pricing', () => ({
 }));
 
 let resolveSummarize: (() => void) | null = null;
+let summarizerUpserts: ReadonlyArray<{ readonly key: SlotKey; readonly value: string }> = [];
 const summarizeSpy = vi.fn(
   () =>
     new Promise<void>((resolve) => {
@@ -100,8 +102,9 @@ vi.mock('@goodboy/core', async (importOriginal) => {
     ...original,
     Summarizer: class {
       summarize() {
+        const upserts = summarizerUpserts;
         return summarizeSpy().then(() => ({
-          delta: { upserts: [] },
+          delta: { upserts },
           usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, estimatedCostUsd: 0 },
           model: 'claude-haiku-4-5',
           nextActions: [],
@@ -111,16 +114,24 @@ vi.mock('@goodboy/core', async (importOriginal) => {
   };
 });
 
+let dbSlots: ReadonlyArray<ContextSlot> = [];
+const upsertContextSlotSpy = vi.fn(
+  async (_database: unknown, _sessionId: SessionId, slot: ContextSlot, _author: string) => {
+    dbSlots = [...dbSlots.filter((existing) => existing.key !== slot.key), slot];
+  },
+);
+
 vi.mock('@goodboy/db', () => ({
   getSetting: vi.fn(),
   insertMessage: vi.fn(),
-  insertProviderRun: vi.fn(),
+  insertProviderRun: vi.fn(async () => undefined),
   insertSession: vi.fn(),
   insertSessionWorktree: vi.fn(),
-  insertTelemetry: vi.fn(),
+  insertTelemetry: vi.fn(async () => undefined),
   insertWorkspace: vi.fn(),
   insertContextSlotHistory: vi.fn(async () => undefined),
-  listContextSlotsForSession: vi.fn(async () => []),
+  listContextSlotHistory: vi.fn(async () => []),
+  listContextSlotsForSession: vi.fn(async () => dbSlots),
   listMessagesForSession: vi.fn(async () => []),
   listSessionsForWorkspace: vi.fn(async () => []),
   listTelemetryForSession: vi.fn(async () => []),
@@ -131,9 +142,9 @@ vi.mock('@goodboy/db', () => ({
   summarizeSessionTelemetry: vi.fn(async () => null),
   summarizeWorkspaceTelemetry: vi.fn(async () => null),
   summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
-  updateProviderRunStatus: vi.fn(),
+  updateProviderRunStatus: vi.fn(async () => undefined),
   updateSessionState: vi.fn(),
-  upsertContextSlot: vi.fn(),
+  upsertContextSlot: upsertContextSlotSpy,
   insertOpenQuestion: vi.fn(async () => undefined),
   markOpenQuestionsResolvedByText: vi.fn(async () => 0),
   listResolvedQuestionTextsForSession: vi.fn(async () => []),
@@ -192,6 +203,9 @@ describe('summarizer queue, coalescing and no-stack', () => {
   beforeEach(() => {
     summarizeSpy.mockReset();
     resolveSummarize = null;
+    summarizerUpserts = [];
+    dbSlots = [];
+    upsertContextSlotSpy.mockClear();
     summarizeSpy.mockResolvedValue(undefined);
   });
 
@@ -318,5 +332,177 @@ describe('summarizer queue, coalescing and no-stack', () => {
     expect(queue.inFlight).toBe(true);
 
     sq.delete(SESSION_ID);
+  });
+
+  it('skips a conflicting slot write without blocking non-conflicting upserts', async () => {
+    let resolveFirst: () => void = () => undefined;
+    summarizeSpy
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    summarizerUpserts = [
+      { key: 'goal', value: 'summarized goal' },
+      { key: 'decisions', value: '- summarized decision' },
+    ];
+    dbSlots = [
+      { key: 'goal', value: 'original goal', enabled: true },
+      { key: 'decisions', value: '- original decision', enabled: true },
+    ];
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: dbSlots },
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+    await vi.waitFor(() => expect(summarizeSpy).toHaveBeenCalledTimes(1));
+
+    const concurrentGoal: ContextSlot = {
+      key: 'goal',
+      value: 'concurrent user goal',
+      enabled: true,
+    };
+    dbSlots = [concurrentGoal, { key: 'decisions', value: '- original decision', enabled: true }];
+    useAppStore.setState({ sessionSlots: { [SESSION_ID]: dbSlots } });
+    summarizerUpserts = [];
+    resolveFirst();
+
+    await vi.waitFor(() => expect(summarizeSpy).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(upsertContextSlotSpy).toHaveBeenCalledTimes(1);
+    expect(upsertContextSlotSpy.mock.calls[0]?.[2]).toMatchObject({
+      key: 'decisions',
+      value: '- summarized decision',
+    });
+    expect(useAppStore.getState().sessionSlots[SESSION_ID]).toContainEqual(concurrentGoal);
+  });
+
+  it('coalesces multiple conflicts into one follow-up pass', async () => {
+    let resolveFirst: () => void = () => undefined;
+    summarizeSpy
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+    summarizerUpserts = [
+      { key: 'goal', value: 'summarized goal' },
+      { key: 'decisions', value: '- summarized decision' },
+    ];
+    dbSlots = [
+      { key: 'goal', value: 'original goal', enabled: true },
+      { key: 'decisions', value: '- original decision', enabled: true },
+    ];
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: dbSlots },
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+    await vi.waitFor(() => expect(summarizeSpy).toHaveBeenCalledTimes(1));
+    dbSlots = [
+      { key: 'goal', value: 'concurrent goal', enabled: true },
+      { key: 'decisions', value: '- concurrent decision', enabled: true },
+    ];
+    useAppStore.setState({ sessionSlots: { [SESSION_ID]: dbSlots } });
+    summarizerUpserts = [];
+    resolveFirst();
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(summarizeSpy).toHaveBeenCalledTimes(2);
+    expect(upsertContextSlotSpy).not.toHaveBeenCalled();
+  });
+
+  it('re-enqueues once for a changed slot above twice its budget', async () => {
+    const oversizeGoal = 'x'.repeat(561);
+    summarizerUpserts = [{ key: 'goal', value: oversizeGoal }];
+    dbSlots = [{ key: 'goal', value: 'original goal', enabled: true }];
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: dbSlots },
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(summarizeSpy).toHaveBeenCalledTimes(2);
+    expect(upsertContextSlotSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not re-enqueue for an unchanged slot above twice its budget', async () => {
+    const oversizeGoal = 'x'.repeat(561);
+    summarizerUpserts = [{ key: 'goal', value: oversizeGoal }];
+    dbSlots = [{ key: 'goal', value: oversizeGoal, enabled: true }];
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues: queues } = await import('./turn-helpers');
+    queues.clear();
+    useAppStore.setState({
+      sessions: [buildSession()],
+      sessionSlots: { [SESSION_ID]: dbSlots },
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'turn input',
+      'turn output',
+    );
+
+    await vi.waitFor(() => expect(queues.get(SESSION_ID)?.inFlight).toBe(false));
+    expect(summarizeSpy).toHaveBeenCalledTimes(1);
+    expect(upsertContextSlotSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -4,6 +4,7 @@ import {
   extractClustersFromMarker,
   extractHandoff,
   extractPlanFromMarker,
+  SLOT_BUDGETS,
   Summarizer,
   type ExtractedHandoff,
   type SlotKey,
@@ -104,6 +105,13 @@ type SummarizerTaskQueue = {
 
 export const summarizerQueues = new Map<SessionId, SummarizerTaskQueue>();
 
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly entry: SummarizerQueueEntry;
+};
+
 function scheduleIdle(fn: () => void): void {
   if (typeof requestIdleCallback === 'function') {
     requestIdleCallback(() => fn());
@@ -111,6 +119,32 @@ function scheduleIdle(fn: () => void): void {
     queueMicrotask(fn);
   }
 }
+
+const runQueuedSummarizer = ({ set, get, sessionId, entry }: Params): void => {
+  void runSummarizer(set, get, sessionId, entry.turnInput, entry.turnOutput).finally(() => {
+    const queue = summarizerQueues.get(sessionId);
+    if (queue == null) {
+      return;
+    }
+    const next = queue.queued;
+    if (next == null) {
+      queue.inFlight = false;
+      return;
+    }
+    queue.queued = null;
+    scheduleIdle(() => {
+      runQueuedSummarizer({ set, get, sessionId, entry: next });
+    });
+  });
+};
+
+const reenqueueSummarizer = ({ set, get, sessionId, entry }: Params): void => {
+  const queue = summarizerQueues.get(sessionId);
+  if (queue?.queued != null) {
+    return;
+  }
+  enqueueSummarizer(set, get, sessionId, entry.turnInput, entry.turnOutput);
+};
 
 export const enqueueSummarizer = (
   set: SetFn,
@@ -132,31 +166,9 @@ export const enqueueSummarizer = (
 
   queue.inFlight = true;
   queue.queued = null;
-
-  const run = (): void => {
-    void runSummarizer(set, get, sessionId, turnInput, turnOutput).finally(() => {
-      const q = summarizerQueues.get(sessionId);
-      if (!q) {
-        return;
-      }
-      const next = q.queued;
-      if (next) {
-        q.queued = null;
-        scheduleIdle(() => {
-          void runSummarizer(set, get, sessionId, next.turnInput, next.turnOutput).finally(() => {
-            const q2 = summarizerQueues.get(sessionId);
-            if (q2) {
-              q2.inFlight = false;
-            }
-          });
-        });
-      } else {
-        q.inFlight = false;
-      }
-    });
-  };
-
-  scheduleIdle(run);
+  scheduleIdle(() => {
+    runQueuedSummarizer({ set, get, sessionId, entry: { turnInput, turnOutput } });
+  });
 };
 
 async function runSummarizer(
@@ -193,6 +205,7 @@ async function runSummarizer(
     const providerId = session.providerPreference.defaultProvider;
     const summarizer = new Summarizer({ providerId, invokeFn: invoke });
     const prevSlots = get().sessionSlots[sessionId] ?? [];
+    const slotValueSnapshot = new Map(prevSlots.map((slot) => [slot.key, slot.value]));
     const ghPr = get().sessionGithub[sessionId]?.pr ?? null;
     const prState = ghPr
       ? {
@@ -202,21 +215,51 @@ async function runSummarizer(
       : null;
     const result = await summarizer.summarize({ prevSlots, turnInput, turnOutput, prState });
 
-    const changedKeys = (
-      await Promise.all(
-        result.delta.upserts.map(async (upsert) => {
-          const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
-          const prevValue = existing && existing.value !== upsert.value ? existing.value : null;
-          const next: ContextSlot = {
+    const upsertResults = await Promise.all(
+      result.delta.upserts.map(async (upsert) => {
+        const existing = (get().sessionSlots[sessionId] ?? []).find((s) => s.key === upsert.key);
+        if (existing?.value !== slotValueSnapshot.get(upsert.key)) {
+          return {
             key: upsert.key,
             value: upsert.value,
-            enabled: existing?.enabled ?? true,
+            previousValue: null,
+            didChange: false,
+            hasConflict: true,
           };
-          await upsertContextSlot(tauriDatabase, sessionId, next, 'summarizer');
-          return prevValue !== null ? upsert.key : null;
-        }),
+        }
+        const didChange = existing?.value !== upsert.value;
+        const previousValue = existing != null && didChange ? existing.value : null;
+        const next: ContextSlot = {
+          key: upsert.key,
+          value: upsert.value,
+          enabled: existing?.enabled ?? true,
+        };
+        await upsertContextSlot(tauriDatabase, sessionId, next, 'summarizer');
+        return {
+          key: upsert.key,
+          value: upsert.value,
+          previousValue,
+          didChange,
+          hasConflict: false,
+        };
+      }),
+    );
+    const changedKeys = upsertResults
+      .filter(
+        (upsert): upsert is typeof upsert & { previousValue: string } =>
+          upsert.previousValue !== null,
       )
-    ).filter((k): k is SlotKey => k !== null);
+      .map((upsert) => upsert.key);
+    const hasConflict = upsertResults.some((upsert) => upsert.hasConflict);
+    const hasChangedOversizeSlot = upsertResults.some(
+      (upsert) =>
+        !upsert.hasConflict &&
+        upsert.didChange &&
+        upsert.value.length > SLOT_BUDGETS[upsert.key] * 2,
+    );
+    if (hasConflict || hasChangedOversizeSlot) {
+      reenqueueSummarizer({ set, get, sessionId, entry: { turnInput, turnOutput } });
+    }
 
     if (
       !get().sessionGithub[sessionId]?.pr &&

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -96,6 +96,7 @@ export const toRelPath = (absPath: string, workingDir: string): string => {
 type SummarizerQueueEntry = {
   readonly turnInput: string;
   readonly turnOutput: string;
+  readonly oversizeRetried: boolean;
 };
 
 type SummarizerTaskQueue = {
@@ -121,7 +122,7 @@ function scheduleIdle(fn: () => void): void {
 }
 
 const runQueuedSummarizer = ({ set, get, sessionId, entry }: Params): void => {
-  void runSummarizer(set, get, sessionId, entry.turnInput, entry.turnOutput).finally(() => {
+  void runSummarizer({ set, get, sessionId, entry }).finally(() => {
     const queue = summarizerQueues.get(sessionId);
     if (queue == null) {
       return;
@@ -143,7 +144,26 @@ const reenqueueSummarizer = ({ set, get, sessionId, entry }: Params): void => {
   if (queue?.queued != null) {
     return;
   }
-  enqueueSummarizer(set, get, sessionId, entry.turnInput, entry.turnOutput);
+  enqueueSummarizerEntry({ set, get, sessionId, entry });
+};
+
+const enqueueSummarizerEntry = ({ set, get, sessionId, entry }: Params): void => {
+  let queue = summarizerQueues.get(sessionId);
+  if (!queue) {
+    queue = { inFlight: false, queued: null };
+    summarizerQueues.set(sessionId, queue);
+  }
+
+  if (queue.inFlight) {
+    queue.queued = entry;
+    return;
+  }
+
+  queue.inFlight = true;
+  queue.queued = null;
+  scheduleIdle(() => {
+    runQueuedSummarizer({ set, get, sessionId, entry });
+  });
 };
 
 export const enqueueSummarizer = (
@@ -153,31 +173,16 @@ export const enqueueSummarizer = (
   turnInput: string,
   turnOutput: string,
 ): void => {
-  let queue = summarizerQueues.get(sessionId);
-  if (!queue) {
-    queue = { inFlight: false, queued: null };
-    summarizerQueues.set(sessionId, queue);
-  }
-
-  if (queue.inFlight) {
-    queue.queued = { turnInput, turnOutput };
-    return;
-  }
-
-  queue.inFlight = true;
-  queue.queued = null;
-  scheduleIdle(() => {
-    runQueuedSummarizer({ set, get, sessionId, entry: { turnInput, turnOutput } });
+  enqueueSummarizerEntry({
+    set,
+    get,
+    sessionId,
+    entry: { turnInput, turnOutput, oversizeRetried: false },
   });
 };
 
-async function runSummarizer(
-  set: SetFn,
-  get: GetFn,
-  sessionId: SessionId,
-  turnInput: string,
-  turnOutput: string,
-): Promise<void> {
+const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<void> => {
+  const { turnInput, turnOutput } = entry;
   const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
   set((state) => {
@@ -257,8 +262,16 @@ async function runSummarizer(
         upsert.didChange &&
         upsert.value.length > SLOT_BUDGETS[upsert.key] * 2,
     );
-    if (hasConflict || hasChangedOversizeSlot) {
-      reenqueueSummarizer({ set, get, sessionId, entry: { turnInput, turnOutput } });
+    if (hasConflict) {
+      reenqueueSummarizer({ set, get, sessionId, entry });
+    }
+    if (!hasConflict && hasChangedOversizeSlot && !entry.oversizeRetried) {
+      reenqueueSummarizer({
+        set,
+        get,
+        sessionId,
+        entry: { ...entry, oversizeRetried: true },
+      });
     }
 
     if (
@@ -381,7 +394,7 @@ async function runSummarizer(
       sessionId,
     });
   }
-}
+};
 
 export const capturePlanFromTurn = async (
   set: SetFn,

--- a/packages/core/src/context/budgets.ts
+++ b/packages/core/src/context/budgets.ts
@@ -8,4 +8,4 @@ export const SLOT_BUDGETS = {
   last_output_summary: 900,
 } satisfies Record<SlotKey, number>;
 
-export const PREAMBLE_SLOT_TOTAL_BUDGET = 4_800;
+export const PREAMBLE_SLOT_TOTAL_BUDGET = 5_600;

--- a/packages/core/src/context/budgets.ts
+++ b/packages/core/src/context/budgets.ts
@@ -1,0 +1,11 @@
+import type { SlotKey } from './slots';
+
+export const SLOT_BUDGETS = {
+  goal: 280,
+  decisions: 1_200,
+  open_questions: 800,
+  files_touched: 1_600,
+  last_output_summary: 900,
+} satisfies Record<SlotKey, number>;
+
+export const PREAMBLE_SLOT_TOTAL_BUDGET = 4_800;

--- a/packages/core/src/context/engine.test.ts
+++ b/packages/core/src/context/engine.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { migrate, type Database as DbInterface } from '@goodboy/db';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { ContextEngine } from './engine';
-import { InvalidSlotKeyError, serializeSlots, SLOT_KEYS } from './slots';
+import { InvalidSlotKeyError, serializeSlots, SLOT_KEYS, SLOT_LABELS } from './slots';
 
 function makeDb(): DbInterface {
   const db = new Database(':memory:');
@@ -42,7 +42,7 @@ describe('serializeSlots', () => {
   it('emits every slot key with placeholder when missing', () => {
     const out = serializeSlots([]);
     for (const key of SLOT_KEYS) {
-      expect(out).toContain(`## ${key.replace(/_/g, ' ')}`);
+      expect(out).toContain(`## ${SLOT_LABELS[key]}`);
     }
     expect(out.split('·').length - 1).toBe(SLOT_KEYS.length);
   });

--- a/packages/core/src/context/index.ts
+++ b/packages/core/src/context/index.ts
@@ -4,10 +4,12 @@ export {
   InvalidSlotKeyError,
   isSlotKey,
   serializeSlots,
+  serializeSlotsBudgeted,
   SLOT_KEYS,
   SLOT_LABELS,
   type SlotKey,
 } from './slots';
+export { PREAMBLE_SLOT_TOTAL_BUDGET, SLOT_BUDGETS } from './budgets';
 export {
   assessPlanReadiness,
   extractClusterDone,

--- a/packages/core/src/context/slots.test.ts
+++ b/packages/core/src/context/slots.test.ts
@@ -24,6 +24,16 @@ describe('serializeSlotsBudgeted', () => {
     expect(output).not.toContain(latest);
   });
 
+  it('hard-slices a first line that exceeds the decisions budget', () => {
+    const decision = 'd'.repeat(SLOT_BUDGETS.decisions + 1);
+    const output = serializeSlotsBudgeted({
+      slots: [slot({ key: 'decisions', value: decision })],
+    });
+
+    expect(output).toContain(`## decisions\n${'d'.repeat(1_194)}\n- ...`);
+    expect(output).not.toContain(`## decisions\n- ...`);
+  });
+
   it('keeps the most recent file paths when truncating', () => {
     const oldest = 'src/oldest.ts';
     const newest = 'src/newest.ts';
@@ -37,7 +47,7 @@ describe('serializeSlotsBudgeted', () => {
     expect(output).toContain('- ...');
   });
 
-  it('omits files before higher-priority slots when the total is over budget', () => {
+  it('renders every slot at its per-slot budget without omitting a section', () => {
     const output = serializeSlotsBudgeted({
       slots: [
         slot({ key: 'goal', value: 'g'.repeat(SLOT_BUDGETS.goal) }),
@@ -52,8 +62,11 @@ describe('serializeSlotsBudgeted', () => {
     });
 
     expect(output.length).toBeLessThanOrEqual(PREAMBLE_SLOT_TOTAL_BUDGET);
-    expect(output).toContain('## files touched\n(omitted, over budget)');
-    expect(output).toContain('## session tldr');
+    expect(output).not.toContain('(omitted, over budget)');
+    expect(output).toContain('g'.repeat(SLOT_BUDGETS.goal));
+    expect(output).toContain('d'.repeat(SLOT_BUDGETS.decisions));
+    expect(output).toContain('f'.repeat(SLOT_BUDGETS.files_touched));
     expect(output).toContain('q'.repeat(SLOT_BUDGETS.open_questions));
+    expect(output).toContain('s'.repeat(SLOT_BUDGETS.last_output_summary));
   });
 });

--- a/packages/core/src/context/slots.test.ts
+++ b/packages/core/src/context/slots.test.ts
@@ -53,6 +53,7 @@ describe('serializeSlotsBudgeted', () => {
 
     expect(output.length).toBeLessThanOrEqual(PREAMBLE_SLOT_TOTAL_BUDGET);
     expect(output).toContain('## files touched\n(omitted, over budget)');
+    expect(output).toContain('## session tldr');
     expect(output).toContain('q'.repeat(SLOT_BUDGETS.open_questions));
   });
 });

--- a/packages/core/src/context/slots.test.ts
+++ b/packages/core/src/context/slots.test.ts
@@ -1,0 +1,58 @@
+import type { ContextSlot } from '@goodboy/types';
+import { describe, expect, it } from 'vitest';
+import { PREAMBLE_SLOT_TOTAL_BUDGET, SLOT_BUDGETS } from './budgets';
+import { serializeSlotsBudgeted } from './slots';
+
+type Params = {
+  readonly key: string;
+  readonly value: string;
+};
+
+const slot = ({ key, value }: Params): ContextSlot => ({ key, value, enabled: true });
+
+describe('serializeSlotsBudgeted', () => {
+  it('keeps established decision lines and marks pending compaction', () => {
+    const established = '- established decision';
+    const latest = '- latest decision';
+    const filler = '- x'.repeat(SLOT_BUDGETS.decisions);
+    const output = serializeSlotsBudgeted({
+      slots: [slot({ key: 'decisions', value: `${established}\n${filler}\n${latest}` })],
+    });
+
+    expect(output).toContain(established);
+    expect(output).toContain('- ...');
+    expect(output).not.toContain(latest);
+  });
+
+  it('keeps the most recent file paths when truncating', () => {
+    const oldest = 'src/oldest.ts';
+    const newest = 'src/newest.ts';
+    const filler = `src/${'x'.repeat(SLOT_BUDGETS.files_touched)}.ts`;
+    const output = serializeSlotsBudgeted({
+      slots: [slot({ key: 'files_touched', value: `${oldest}\n${filler}\n${newest}` })],
+    });
+
+    expect(output).not.toContain(oldest);
+    expect(output).toContain(newest);
+    expect(output).toContain('- ...');
+  });
+
+  it('omits files before higher-priority slots when the total is over budget', () => {
+    const output = serializeSlotsBudgeted({
+      slots: [
+        slot({ key: 'goal', value: 'g'.repeat(SLOT_BUDGETS.goal) }),
+        slot({ key: 'decisions', value: 'd'.repeat(SLOT_BUDGETS.decisions) }),
+        slot({ key: 'open_questions', value: 'q'.repeat(SLOT_BUDGETS.open_questions) }),
+        slot({ key: 'files_touched', value: 'f'.repeat(SLOT_BUDGETS.files_touched) }),
+        slot({
+          key: 'last_output_summary',
+          value: 's'.repeat(SLOT_BUDGETS.last_output_summary),
+        }),
+      ],
+    });
+
+    expect(output.length).toBeLessThanOrEqual(PREAMBLE_SLOT_TOTAL_BUDGET);
+    expect(output).toContain('## files touched\n(omitted, over budget)');
+    expect(output).toContain('q'.repeat(SLOT_BUDGETS.open_questions));
+  });
+});

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -119,10 +119,10 @@ export const serializeSlotsBudgeted = ({ slots }: Params): string => {
         keptLines.push(line);
       }
     }
-    const body =
-      keptLines.length > 0
-        ? `${keptLines.join('\n')}\n${COMPACTING_PLACEHOLDER}`
-        : COMPACTING_PLACEHOLDER;
+    const compactedContentBudget = budget - COMPACTING_PLACEHOLDER.length - 1;
+    const compactedLines =
+      keptLines.length > 0 ? keptLines.join('\n') : lines[0]!.slice(0, compactedContentBudget);
+    const body = `${compactedLines}\n${COMPACTING_PLACEHOLDER}`;
     sections.push({ key, body });
   }
 

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -18,7 +18,7 @@ export const SLOT_LABELS: Record<SlotKey, string> = {
   files_touched: 'files touched',
   decisions: 'decisions',
   open_questions: 'open questions',
-  last_output_summary: 'session tldr',
+  last_output_summary: 'session summary',
 };
 
 const EMPTY_PLACEHOLDER = '·';

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -18,7 +18,7 @@ export const SLOT_LABELS: Record<SlotKey, string> = {
   files_touched: 'files touched',
   decisions: 'decisions',
   open_questions: 'open questions',
-  last_output_summary: 'last output summary',
+  last_output_summary: 'session tldr',
 };
 
 const EMPTY_PLACEHOLDER = '·';

--- a/packages/core/src/context/slots.ts
+++ b/packages/core/src/context/slots.ts
@@ -1,4 +1,5 @@
 import type { ContextSlot } from '@goodboy/types';
+import { PREAMBLE_SLOT_TOTAL_BUDGET, SLOT_BUDGETS } from './budgets';
 
 export const SLOT_KEYS = [
   'goal',
@@ -21,6 +22,15 @@ export const SLOT_LABELS: Record<SlotKey, string> = {
 };
 
 const EMPTY_PLACEHOLDER = '·';
+const COMPACTING_PLACEHOLDER = '- ...';
+const OMITTED_PLACEHOLDER = '(omitted, over budget)';
+const SLOT_PRIORITY = [
+  'goal',
+  'decisions',
+  'last_output_summary',
+  'open_questions',
+  'files_touched',
+] satisfies ReadonlyArray<SlotKey>;
 
 export class InvalidSlotKeyError extends Error {
   constructor(public readonly key: string) {
@@ -54,4 +64,84 @@ export const serializeSlots = (slots: ReadonlyArray<ContextSlot>): string => {
   });
 
   return sections.join('\n\n');
+};
+
+type Params = {
+  readonly slots: ReadonlyArray<ContextSlot>;
+};
+
+type BudgetedSection = {
+  readonly key: SlotKey;
+  body: string;
+};
+
+export const serializeSlotsBudgeted = ({ slots }: Params): string => {
+  const byKey = new Map<SlotKey, ContextSlot>();
+  for (const slot of slots) {
+    if (isSlotKey(slot.key)) {
+      byKey.set(slot.key, slot);
+    }
+  }
+
+  const sections: BudgetedSection[] = [];
+  for (const key of SLOT_KEYS) {
+    const value = byKey.get(key)?.value.trim() ?? '';
+    const budget = SLOT_BUDGETS[key];
+    if (value.length === 0) {
+      sections.push({ key, body: EMPTY_PLACEHOLDER });
+      continue;
+    }
+    if (value.length <= budget) {
+      sections.push({ key, body: value });
+      continue;
+    }
+
+    const lines = value.split('\n');
+    const keptLines: string[] = [];
+    if (key === 'files_touched') {
+      for (let index = lines.length - 1; index >= 0; index -= 1) {
+        const line = lines[index]!;
+        const bodyLength = keptLines.join('\n').length;
+        const candidateLength = line.length + (bodyLength > 0 ? bodyLength + 1 : 0);
+        if (candidateLength + 1 + COMPACTING_PLACEHOLDER.length > budget) {
+          break;
+        }
+        keptLines.unshift(line);
+      }
+    }
+    if (key !== 'files_touched') {
+      for (const line of lines) {
+        const bodyLength = keptLines.join('\n').length;
+        const candidateLength = bodyLength + (bodyLength > 0 ? 1 : 0) + line.length;
+        if (candidateLength + 1 + COMPACTING_PLACEHOLDER.length > budget) {
+          break;
+        }
+        keptLines.push(line);
+      }
+    }
+    const body =
+      keptLines.length > 0
+        ? `${keptLines.join('\n')}\n${COMPACTING_PLACEHOLDER}`
+        : COMPACTING_PLACEHOLDER;
+    sections.push({ key, body });
+  }
+
+  let rendered = sections.map(({ key, body }) => `## ${SLOT_LABELS[key]}\n${body}`).join('\n\n');
+  if (rendered.length <= PREAMBLE_SLOT_TOTAL_BUDGET) {
+    return rendered;
+  }
+
+  for (const key of [...SLOT_PRIORITY].reverse()) {
+    const section = sections.find((candidate) => candidate.key === key);
+    if (section == null || section.body === EMPTY_PLACEHOLDER) {
+      continue;
+    }
+    section.body = OMITTED_PLACEHOLDER;
+    rendered = sections.map((item) => `## ${SLOT_LABELS[item.key]}\n${item.body}`).join('\n\n');
+    if (rendered.length <= PREAMBLE_SLOT_TOTAL_BUDGET) {
+      return rendered;
+    }
+  }
+
+  return rendered;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,8 @@ export {
 export {
   ContextEngine,
   InvalidSlotKeyError,
+  PREAMBLE_SLOT_TOTAL_BUDGET,
+  SLOT_BUDGETS,
   SLOT_KEYS,
   SLOT_LABELS,
   assertSlotKey,
@@ -42,6 +44,7 @@ export {
   removeFromSlot,
   removeQuestionsFromSlot,
   serializeSlots,
+  serializeSlotsBudgeted,
   stripControlMarkers,
   wrapOpenQuestionAnswers,
   type AutoPopulateInput,

--- a/packages/core/src/summarizer/cli.ts
+++ b/packages/core/src/summarizer/cli.ts
@@ -1,10 +1,11 @@
 import { spawn } from 'node:child_process';
 import type { ContextSlot, ProviderId } from '@goodboy/types';
-import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
+import { isSlotKey, SLOT_KEYS, type SlotKey } from '../context/slots';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { CURSOR_AUTO_MODEL } from '../providers/cursor/models';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
+import { SUMMARIZER_SYSTEM_PROMPT } from './prompt';
 
 type ContextSlotDeltaUpsert = Readonly<{ key: SlotKey; value: string }>;
 
@@ -58,44 +59,6 @@ export class SummarizerParseError extends Error {
     this.name = 'SummarizerParseError';
   }
 }
-
-const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session. The summary is the handoff payload, a fresh agent must be able to read these slots alone and continue the work without seeing any prior turns.
-
-There are exactly five slots, each with a stable key:
-${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
-
-INPUT
-You receive the previous slot values plus the most recent user turn and assistant turn.
-
-CONTEXT PRESERVATION (critical)
-Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
-Never silently drop facts that are still valid. Per slot:
-- goal: refine over time as intent clarifies; do not erase prior framing if still valid.
-- decisions: append new decisions to the existing list. Never remove accepted ones.
-- open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
-- files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
-- last_output_summary: REPLACE, not merge, it summarizes only the latest assistant turn.
-
-FORMATTING (critical, values render as markdown in the UI)
-Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
-Rules:
-- Prefer short bullet lists ("- " prefix). One fact per bullet, under ~100 chars; split long bullets in two.
-- Insert a blank line between logically distinct groups of bullets.
-- Use two-space indent + "- " for sub-bullets when nesting context.
-- Use \`backticks\` for identifiers, paths, commands. Use **bold** sparingly for keys/file names that aid scanning.
-- Do NOT use markdown headings (#), the slot label is already the heading.
-- Do NOT wrap the value in code fences unless quoting actual code.
-- Exclude raw tool output and chat-style narration.
-- The "goal" slot stays as one tight sentence or two, no bullets needed unless multiple sub-goals exist.
-
-OUTPUT
-You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.
-The value field is a JSON string; encode newlines inside it as the escape sequence \\n so the rendered markdown breaks across lines.
-Schema:
-{ "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
-
-Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
-If nothing should change, return { "upserts": [] }.`;
 
 function getCheapModel(providerId: ProviderId): string {
   if (providerId === 'cursor') {
@@ -172,7 +135,7 @@ export class Summarizer {
     userMessage: string,
   ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
     return new Promise((resolve, reject) => {
-      const args = buildCliArgs(this.providerId, this.model, SYSTEM_PROMPT, userMessage);
+      const args = buildCliArgs(this.providerId, this.model, SUMMARIZER_SYSTEM_PROMPT, userMessage);
       const child = this.spawnFn(this.binary, args, {
         stdio: ['ignore', 'pipe', 'pipe'],
       });

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -4,6 +4,7 @@ import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
 import { Summarizer as ClientSummarizer, type SummarizerDeps } from './client';
 import { Summarizer, SummarizerParseError, SummarizerSpawnError } from './cli';
+import { SUMMARIZER_SYSTEM_PROMPT } from './prompt';
 
 type MockChild = EventEmitter & {
   stdout: Readable;
@@ -83,6 +84,7 @@ describe('Summarizer client prompt', () => {
       throw new Error('invalid summarizer system prompt');
     }
 
+    expect(systemPrompt).toBe(SUMMARIZER_SYSTEM_PROMPT);
     expect(systemPrompt).toContain('- last_output_summary (session tldr)');
     expect(systemPrompt).toContain(
       '- goal: 280\n- files_touched: 1600\n- decisions: 1200\n- open_questions: 800\n- last_output_summary: 900\n\nIf a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.',
@@ -119,6 +121,7 @@ describe('Summarizer (CLI-based)', () => {
     expect(args).toContain('--output-format');
     expect(args).toContain('json');
     expect(args).toContain('--no-session-persistence');
+    expect(args[args.indexOf('--system-prompt') + 1]).toBe(SUMMARIZER_SYSTEM_PROMPT);
   });
 
   it('spawns cursor-agent CLI with correct args for cursor provider', async () => {

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -2,6 +2,7 @@ import { type ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { describe, expect, it, vi } from 'vitest';
+import { Summarizer as ClientSummarizer, type SummarizerDeps } from './client';
 import { Summarizer, SummarizerParseError, SummarizerSpawnError } from './cli';
 
 type MockChild = EventEmitter & {
@@ -53,6 +54,50 @@ function makeClaudeJsonOutput(text: string, inputTokens = 100, outputTokens = 20
     is_error: false,
   });
 }
+
+describe('Summarizer client prompt', () => {
+  it('defines cumulative session tldr, compaction, decisions, and goal rules', async () => {
+    let request: Record<string, unknown> | undefined;
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(
+      _cmd: string,
+      args?: Record<string, unknown>,
+    ): Promise<T> => {
+      request = args;
+      throw new Error('prompt captured');
+    };
+    const summarizer = new ClientSummarizer({ providerId: 'cursor', invokeFn });
+
+    await summarizer
+      .summarize({ prevSlots: [], turnInput: 'q', turnOutput: 'a' })
+      .catch(() => undefined);
+
+    if (request == null) {
+      throw new Error('missing summarizer request');
+    }
+    const args = request['args'];
+    if (typeof args !== 'object' || args === null || !('systemPrompt' in args)) {
+      throw new Error('missing summarizer system prompt');
+    }
+    const systemPrompt = args.systemPrompt;
+    if (typeof systemPrompt !== 'string') {
+      throw new Error('invalid summarizer system prompt');
+    }
+
+    expect(systemPrompt).toContain('- last_output_summary (session tldr)');
+    expect(systemPrompt).toContain(
+      '- goal: 280\n- files_touched: 1600\n- decisions: 1200\n- open_questions: 800\n- last_output_summary: 900\n\nIf a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.',
+    );
+    expect(systemPrompt).toContain(
+      'When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.',
+    );
+    expect(systemPrompt).toContain(
+      'On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight.',
+    );
+    expect(systemPrompt).toContain(
+      'Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.',
+    );
+  });
+});
 
 describe('Summarizer (CLI-based)', () => {
   it('spawns claude CLI with correct args for anthropic provider', async () => {

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -57,7 +57,7 @@ function makeClaudeJsonOutput(text: string, inputTokens = 100, outputTokens = 20
 }
 
 describe('Summarizer client prompt', () => {
-  it('defines cumulative session tldr, compaction, decisions, and goal rules', async () => {
+  it('defines cumulative session summary, compaction, decisions, and goal rules', async () => {
     let request: Record<string, unknown> | undefined;
     const invokeFn: SummarizerDeps['invokeFn'] = async <T>(
       _cmd: string,
@@ -85,7 +85,7 @@ describe('Summarizer client prompt', () => {
     }
 
     expect(systemPrompt).toBe(SUMMARIZER_SYSTEM_PROMPT);
-    expect(systemPrompt).toContain('- last_output_summary (session tldr)');
+    expect(systemPrompt).toContain('- last_output_summary (session summary)');
     expect(systemPrompt).toContain(
       '- goal: 280\n- files_touched: 1600\n- decisions: 1200\n- open_questions: 800\n- last_output_summary: 900\n\nIf a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.',
     );
@@ -93,7 +93,7 @@ describe('Summarizer client prompt', () => {
       'When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.',
     );
     expect(systemPrompt).toContain(
-      'On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight.',
+      'On every turn, REWORK the previous summary together with the latest assistant turn into a new summary covering what the session has accomplished so far, the current state, and what is in flight.',
     );
     expect(systemPrompt).toContain(
       'Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.',

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,4 +1,5 @@
 import type { ContextSlot, ProviderId } from '@goodboy/types';
+import { SLOT_BUDGETS } from '../context/budgets';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { CURSOR_AUTO_MODEL } from '../providers/cursor/models';
@@ -102,11 +103,16 @@ You receive the previous slot values plus the most recent user turn and assistan
 CONTEXT PRESERVATION (critical)
 Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
 Never silently drop facts that are still valid. Per slot:
-- goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent.
-- decisions: append new decisions to the existing list. Never remove accepted ones.
+- goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent. Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.
+- decisions: append new decisions to the existing list. When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.
 - open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
 - files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
-- last_output_summary: this slot is REPLACE, not merge, it summarizes only the latest assistant turn.
+- last_output_summary: the rolling cumulative TLDR of the whole session. On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative TLDR. Do not summarize only the latest turn and do not append a turn-by-turn log.
+
+SLOT BUDGETS (hard maximum characters per emitted value)
+${SLOT_KEYS.map((key) => `- ${key}: ${SLOT_BUDGETS[key]}`).join('\n')}
+
+If a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.
 
 FORMATTING (critical, values render as markdown in the UI)
 Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -1,10 +1,10 @@
 import type { ContextSlot, ProviderId } from '@goodboy/types';
-import { SLOT_BUDGETS } from '../context/budgets';
 import { computeCostUsd } from '../providers/claude/cost';
 import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { CURSOR_AUTO_MODEL } from '../providers/cursor/models';
-import { isSlotKey, SLOT_KEYS, SLOT_LABELS, type SlotKey } from '../context/slots';
+import { isSlotKey, SLOT_KEYS, type SlotKey } from '../context/slots';
 import { inferNextActions, type NextAction, type NextActionsPrState } from './next-actions';
+import { SUMMARIZER_SYSTEM_PROMPT } from './prompt';
 
 export const getCheapModel = (providerId: ProviderId): string => {
   if (providerId === 'cursor') {
@@ -92,49 +92,6 @@ type SummarizeCommandResult = {
   readonly exitCode: number | null;
 };
 
-const SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session. The summary is the handoff payload, a fresh agent must be able to read these slots alone and continue the work without seeing any prior turns.
-
-There are exactly five slots, each with a stable key:
-${SLOT_KEYS.map((k) => `- ${k} (${SLOT_LABELS[k]})`).join('\n')}
-
-INPUT
-You receive the previous slot values plus the most recent user turn and assistant turn.
-
-CONTEXT PRESERVATION (critical)
-Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
-Never silently drop facts that are still valid. Per slot:
-- goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent. Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.
-- decisions: append new decisions to the existing list. When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.
-- open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
-- files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
-- last_output_summary: the rolling cumulative TLDR of the whole session. On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative TLDR. Do not summarize only the latest turn and do not append a turn-by-turn log.
-
-SLOT BUDGETS (hard maximum characters per emitted value)
-${SLOT_KEYS.map((key) => `- ${key}: ${SLOT_BUDGETS[key]}`).join('\n')}
-
-If a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.
-
-FORMATTING (critical, values render as markdown in the UI)
-Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
-Rules:
-- Prefer short bullet lists ("- " prefix). One fact per bullet, under ~100 chars; split long bullets in two.
-- Insert a blank line between logically distinct groups of bullets so the UI does not render them squashed.
-- Use two-space indent + "- " for sub-bullets when nesting context.
-- Use \`backticks\` for identifiers, paths, commands. Use **bold** sparingly for keys/file names that aid scanning.
-- Do NOT use markdown headings (#), the slot label is already the heading.
-- Do NOT wrap the value in code fences unless quoting actual code.
-- Exclude raw tool output and chat-style narration.
-- The "goal" slot is one tight high-level sentence (two at most). No bullets, no status, no progress, no per-turn detail.
-
-OUTPUT
-You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.
-The value field is a JSON string; encode newlines inside it as the escape sequence \\n so the rendered markdown breaks across lines.
-Schema:
-{ "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
-
-Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
-If nothing should change, return { "upserts": [] }.`;
-
 export class Summarizer {
   private readonly providerId: ProviderId;
   private readonly binary: string;
@@ -157,7 +114,7 @@ export class Summarizer {
         model: this.model,
         binary: this.binary,
         userMessage,
-        systemPrompt: SYSTEM_PROMPT,
+        systemPrompt: SUMMARIZER_SYSTEM_PROMPT,
       },
     });
 

--- a/packages/core/src/summarizer/prompt.ts
+++ b/packages/core/src/summarizer/prompt.ts
@@ -16,7 +16,7 @@ Never silently drop facts that are still valid. Per slot:
 - decisions: append new decisions to the existing list. When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.
 - open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
 - files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
-- last_output_summary: the rolling cumulative TLDR of the whole session. On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative TLDR. Do not summarize only the latest turn and do not append a turn-by-turn log.
+- last_output_summary: the rolling cumulative summary of the whole session. On every turn, REWORK the previous summary together with the latest assistant turn into a new summary covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative summary. Do not summarize only the latest turn and do not append a turn-by-turn log.
 
 SLOT BUDGETS (hard maximum characters per emitted value)
 ${SLOT_KEYS.map((key) => `- ${key}: ${SLOT_BUDGETS[key]}`).join('\n')}

--- a/packages/core/src/summarizer/prompt.ts
+++ b/packages/core/src/summarizer/prompt.ts
@@ -1,0 +1,45 @@
+import { SLOT_BUDGETS } from '../context/budgets';
+import { SLOT_KEYS, SLOT_LABELS } from '../context/slots';
+
+export const SUMMARIZER_SYSTEM_PROMPT = `You maintain a small structured summary for an AI coding session. The summary is the handoff payload, a fresh agent must be able to read these slots alone and continue the work without seeing any prior turns.
+
+There are exactly five slots, each with a stable key:
+${SLOT_KEYS.map((key) => `- ${key} (${SLOT_LABELS[key]})`).join('\n')}
+
+INPUT
+You receive the previous slot values plus the most recent user turn and assistant turn.
+
+CONTEXT PRESERVATION (critical)
+Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
+Never silently drop facts that are still valid. Per slot:
+- goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent. Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.
+- decisions: append new decisions to the existing list. When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.
+- open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
+- files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
+- last_output_summary: the rolling cumulative TLDR of the whole session. On every turn, REWORK the previous TLDR together with the latest assistant turn into a new TLDR covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative TLDR. Do not summarize only the latest turn and do not append a turn-by-turn log.
+
+SLOT BUDGETS (hard maximum characters per emitted value)
+${SLOT_KEYS.map((key) => `- ${key}: ${SLOT_BUDGETS[key]}`).join('\n')}
+
+If a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.
+
+FORMATTING (critical, values render as markdown in the UI)
+Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
+Rules:
+- Prefer short bullet lists ("- " prefix). One fact per bullet, under ~100 chars; split long bullets in two.
+- Insert a blank line between logically distinct groups of bullets so the UI does not render them squashed.
+- Use two-space indent + "- " for sub-bullets when nesting context.
+- Use \`backticks\` for identifiers, paths, commands. Use **bold** sparingly for keys/file names that aid scanning.
+- Do NOT use markdown headings (#), the slot label is already the heading.
+- Do NOT wrap the value in code fences unless quoting actual code.
+- Exclude raw tool output and chat-style narration.
+- The "goal" slot is one tight high-level sentence (two at most). No bullets, no status, no progress, no per-turn detail.
+
+OUTPUT
+You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.
+The value field is a JSON string; encode newlines inside it as the escape sequence \\n so the rendered markdown breaks across lines.
+Schema:
+{ "upserts": [ { "key": "<one of the five keys>", "value": "<full merged slot value, as compact markdown>" } ] }
+
+Only include slots that actually change. Omit slots that stay the same. Never invent new keys.
+If nothing should change, return { "upserts": [] }.`;

--- a/packages/core/src/summarizer/round-trip.test.ts
+++ b/packages/core/src/summarizer/round-trip.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { migrate, type Database as DbInterface } from '@goodboy/db';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { ContextEngine } from '../context/engine';
-import { SLOT_KEYS } from '../context/slots';
+import { SLOT_KEYS, SLOT_LABELS } from '../context/slots';
 import { Summarizer } from './cli';
 
 function makeDb(): DbInterface {
@@ -103,6 +103,8 @@ describe('synthetic context engine round-trip', () => {
     for (const slot of after) {
       expect(slot.value).toBe(`seeded ${slot.key}`);
     }
+    const serialized = await engine.serialize(sessionId);
+    expect(serialized).toContain(`## ${SLOT_LABELS.last_output_summary}`);
   });
 
   it('partial state → summarizer updates some, leaves others alone', async () => {


### PR DESCRIPTION
## Summary

Area 1 of the core refactor (context, workflow handoff, chat). Foundations: the shared-context slots get size discipline, a real session TLDR, and coordinated writers. Two follow-up stacked PRs will consume this (workflow handoff, chat coherence).

## Slot budgets and compaction

- New `SLOT_BUDGETS` (per-slot char budgets) and `PREAMBLE_SLOT_TOTAL_BUDGET` in `packages/core/src/context/budgets.ts`.
- `serializeSlotsBudgeted`: preamble-time enforcement with priority degradation (goal > decisions > tldr > open_questions > files_touched). files_touched truncates from the head (keeps most recent paths); other slots truncate on line boundaries; a single over-budget line is hard-sliced, never silently dropped.
- The DB always stores the full value: compaction is done by the summarizer (prompt now carries the budgets and instructions to merge semantic duplicates and replace superseded decisions), not by destructive truncation.

## last_output_summary becomes a session TLDR

- Key string unchanged (renaming would require a data migration, a localStorage lens migration and 20+ file touches for zero user value). Semantics change: rolling cumulative TLDR of the whole session, reworked every turn (old TLDR + latest output), REPLACE stays the storage mechanism.
- Display label is now "session tldr" everywhere (SlotPane, SessionWorkspace, SessionOverviewPane, LensColumn).

## Writer coordination

- Markers stay the immediate raw ingest (autoPopulateContext untouched). The summarizer is the only reworker/compactor.
- Compare-and-set on summarizer writes: snapshot at read, per-upsert re-read, skip + coalesced re-enqueue on conflict. Concurrent marker/user writes are never clobbered by a stale LLM result.
- Oversize-triggered re-enqueue is hard-capped at one retry per turn (prevents the unbounded retry-loop failure class we hit in the v0.1.2x token regression).
- `toggleSessionSlot` now records author "user".

## Preamble

- `buildContextPreamble` uses the budgeted serialization, honors `enabled: false` (toggling a slot off now actually removes it from agent prompts), and logs dev-only size telemetry above 80% of budget.
- Slot routing: resolver gains `goal`.

## Design decisions

- Budget total (5600) is deliberately larger than the per-slot sum so a full-context render never force-drops a whole section; degradation only kicks in on pathological values.
- Summarizer prompt deduplicated into `summarizer/prompt.ts` (cli.ts carried a stale divergent copy with the old latest-turn-only semantics).
- Goal writers unchanged (creation seed, first-turn heuristic rename, summarizer sharpening, workflow reprocess); prompt hardened with a two-sentence hard rule.

## Test plan

- `pnpm typecheck` green (5 packages).
- `@goodboy/core`: 803 passed, 7 skipped.
- `desktop`: 2142 passed (233 files).
- New coverage: budget degradation and slicing, CAS conflict skip, oversize retry cap with nondeterministic LLM output, disabled-slot filtering, resolver routing, tldr label.