### PR TITLE
refactor(core): workflow handoff chain, real step summaries, parallel merge

### DIFF
--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -329,6 +329,37 @@ describe('parallel e2e, fan-out/fan-in', () => {
     );
   });
 
+  it('caps raw output stored for non-representative completed branches', async () => {
+    const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
+    wirePhaseRunSpies(insertedPhaseRuns);
+    const { effects } = makeEffects();
+    const inputs = makeInputs([makeDef('d-a', 1), makeDef('d-b', 2)]);
+    const branchPromise = runParallelBranch(inputs, makeDeps(effects));
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const spawnedRunIds = (
+      invokeParallelPhaseRunSpawnSpy.mock.calls as unknown as ReadonlyArray<
+        [{ runs: ReadonlyArray<{ runId: string }> }]
+      >
+    ).map(([args]) => args.runs[0]!.runId) as [string, string];
+    const [representativeRunId, rawRunId] = spawnedRunIds;
+    const rawOutput = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+    emitLine(representativeRunId, 'representative output');
+    emitLine(rawRunId, rawOutput);
+    emitEnd(representativeRunId, 0);
+    emitEnd(rawRunId, 0);
+
+    await branchPromise;
+
+    expect(phaseRunUpdateStatusSpy).toHaveBeenCalledWith(
+      'pr-d-b',
+      expect.objectContaining({
+        outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
+      }),
+    );
+  });
+
   it('error path: 1 of 3 runs fails → partial merge proceeds, anyFailed=true, group still completes', async () => {
     const insertedPhaseRuns: Parameters<typeof wirePhaseRunSpies>[0] = [];
     wirePhaseRunSpies(insertedPhaseRuns);

--- a/apps/desktop/src/__tests__/parallel-e2e.test.ts
+++ b/apps/desktop/src/__tests__/parallel-e2e.test.ts
@@ -142,6 +142,7 @@ function makeInputs(
 ): ParallelBranchInputs {
   return {
     session: makeSession(),
+    workflowRunId: 'run-1' as WorkflowRunId,
     orchestratingAgentId: 'orchestrator-agent' as AgentId,
     workspace: makeWorkspace(),
     currentDef: groupDefs[0]!,
@@ -185,10 +186,17 @@ function wirePhaseRunSpies(
     name: string;
     status: AgentStatus;
     runId: ProviderRunId;
+    workflowRunId?: WorkflowRunId;
   }>,
 ): void {
   phaseRunInsertSpy.mockImplementation(
-    async (args: { stepId: string; ordinal: number; name: string; providerRunId: string }) => {
+    async (args: {
+      stepId: string;
+      workflowRunId?: WorkflowRunId;
+      ordinal: number;
+      name: string;
+      providerRunId: string;
+    }) => {
       const row = {
         id: `pr-${args.stepId}` as AgentId,
         sessionId: SESSION_ID,
@@ -197,6 +205,7 @@ function wirePhaseRunSpies(
         name: args.name,
         status: 'running' as AgentStatus,
         runId: args.providerRunId as ProviderRunId,
+        ...(args.workflowRunId != null && { workflowRunId: args.workflowRunId }),
       };
       insertedPhaseRuns.push(row);
       return row;
@@ -295,7 +304,29 @@ describe('parallel e2e, fan-out/fan-in', () => {
     expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(3);
 
     const phaseTransitions = events.filter((e) => e.kind === 'step_transition');
-    expect(phaseTransitions).toHaveLength(1);
+    expect(phaseTransitions).toEqual([
+      expect.objectContaining({
+        carryForwardContext: [
+          '## workflow handoff',
+          '### parallel group output: d-a',
+          '#### branch 1: d-a',
+          'run-a output',
+          '#### branch 2: d-b',
+          'run-b output',
+          '#### branch 3: d-c',
+          'run-c output',
+        ].join('\n'),
+      }),
+    ]);
+    expect(phaseRunInsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowRunId: 'run-1' }),
+    );
+    expect(phaseRunUpdateStatusSpy).toHaveBeenCalledWith(
+      'pr-d-a',
+      expect.objectContaining({
+        outputSummary: expect.stringContaining('### parallel group output: d-a'),
+      }),
+    );
   });
 
   it('error path: 1 of 3 runs fails → partial merge proceeds, anyFailed=true, group still completes', async () => {
@@ -345,6 +376,13 @@ describe('parallel e2e, fan-out/fan-in', () => {
     expect(seenRunIds.has(idA as ProviderRunId)).toBe(true);
     expect(seenRunIds.has(idB as ProviderRunId)).toBe(true);
     expect(seenRunIds.has(idC as ProviderRunId)).toBe(false);
+
+    const phaseTransition = events.find((event) => event.kind === 'step_transition');
+    expect(phaseTransition).toEqual(
+      expect.objectContaining({
+        carryForwardContext: expect.stringContaining('#### branch 3: d-c (failed)\nrun failed'),
+      }),
+    );
   });
 
   it('all-fail path: all 3 runs fail → allFailed=true, group completedAt not set', async () => {

--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -128,6 +128,34 @@ describe('reduceTranscript, request + decision pair', () => {
   });
 });
 
+describe('reduceTranscript, step_transition', () => {
+  it('passes degraded handoff metadata through to the transcript item', () => {
+    const event = {
+      kind: 'step_transition',
+      runId: RUN,
+      fromStep: { ordinal: 0, name: 'discover' },
+      toStep: { ordinal: 1, name: 'plan' },
+      carryForwardContext: 'carry me forward',
+      degraded: true,
+      durationMs: 252_000,
+      at: AT,
+    } satisfies TurnEvent;
+
+    expect(reduceTranscript([event])).toEqual([
+      {
+        kind: 'step_transition',
+        key: 'phase-0',
+        fromStep: event.fromStep,
+        toStep: event.toStep,
+        carryForwardContext: event.carryForwardContext,
+        degraded: true,
+        durationMs: 252_000,
+        at: AT,
+      },
+    ]);
+  });
+});
+
 function userTextEvent(text: string): TurnEvent {
   return { kind: 'user_text', runId: RUN, text, at: AT };
 }

--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/formatStepDuration.ts
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/formatStepDuration.ts
@@ -1,0 +1,16 @@
+type Params = {
+  durationMs: number;
+};
+
+export const formatStepDuration = ({ durationMs }: Params): string => {
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+  const seconds = Math.round(durationMs / 1_000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+};

--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.test.tsx
@@ -14,7 +14,7 @@ const item = {
   fromStep: { ordinal: 0, name: 'discover' },
   toStep: { ordinal: 1, name: 'plan' },
   carryForwardContext: 'carry me forward',
-} as Extract<TranscriptItem, { kind: 'step_transition' }>;
+} satisfies Extract<TranscriptItem, { kind: 'step_transition' }>;
 
 describe('PhaseTransitionCard', () => {
   it('renders the step transition header with both step names', () => {
@@ -32,5 +32,26 @@ describe('PhaseTransitionCard', () => {
     render(<PhaseTransitionCard item={item} />);
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('carry me forward')).toBeDefined();
+  });
+
+  it('renders the degraded handoff badge only when degraded', () => {
+    const { rerender } = render(<PhaseTransitionCard item={item} />);
+    expect(screen.queryByText('degraded handoff')).toBeNull();
+
+    const degradedItem = {
+      ...item,
+      degraded: true,
+    } satisfies Extract<TranscriptItem, { kind: 'step_transition' }>;
+    rerender(<PhaseTransitionCard item={degradedItem} />);
+    expect(screen.getByText('degraded handoff')).toBeDefined();
+  });
+
+  it('renders the step duration when present', () => {
+    const timedItem = {
+      ...item,
+      durationMs: 252_000,
+    } satisfies Extract<TranscriptItem, { kind: 'step_transition' }>;
+    render(<PhaseTransitionCard item={timedItem} />);
+    expect(screen.getByText('4m 12s')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
+++ b/apps/desktop/src/features/chat/components/PhaseTransitionCard/index.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, ChevronRight } from 'lucide-react';
 import { Markdown, cn } from '@goodboy/ui';
 import type { TranscriptItem } from '../../utils/transcript-items';
 import { formatCardTime } from '../../utils/format-card-time';
+import { formatStepDuration } from './formatStepDuration';
 
 type Props = {
   readonly item: Extract<TranscriptItem, { kind: 'step_transition' }>;
@@ -32,6 +33,11 @@ export const PhaseTransitionCard = ({ item }: Props) => {
         <span className="shrink-0 text-2xs font-medium uppercase tracking-wide text-merged/80">
           step
         </span>
+        {item.degraded === true && (
+          <span className="shrink-0 rounded-md bg-warning/15 px-1 py-px text-2xs font-medium text-warning">
+            degraded handoff
+          </span>
+        )}
         <span className="flex min-w-0 flex-1 items-center gap-1.5 text-xs text-foreground/70">
           <span className="truncate">
             {item.fromStep.ordinal + 1}. {item.fromStep.name}
@@ -41,7 +47,12 @@ export const PhaseTransitionCard = ({ item }: Props) => {
             {item.toStep.ordinal + 1}. {item.toStep.name}
           </span>
         </span>
-        <span className="shrink-0 font-mono text-2xs text-muted-foreground">{timestamp}</span>
+        <span className="flex shrink-0 items-center gap-1.5 font-mono text-2xs text-muted-foreground">
+          {item.durationMs != null && (
+            <span>{formatStepDuration({ durationMs: item.durationMs })}</span>
+          )}
+          <span>{timestamp}</span>
+        </span>
       </button>
 
       {open && hasContext ? (

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -43,6 +43,8 @@ export type TranscriptItem =
       fromStep: { ordinal: number; name: string };
       toStep: { ordinal: number; name: string };
       carryForwardContext: string;
+      degraded?: true;
+      durationMs?: number;
       at: string;
     }
   | {
@@ -227,6 +229,8 @@ export const reduceTranscript = (
           fromStep: event.fromStep,
           toStep: event.toStep,
           carryForwardContext: event.carryForwardContext,
+          degraded: event.degraded,
+          durationMs: event.durationMs,
           at: event.at,
         });
         break;

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -4,6 +4,7 @@ import {
   buildStepPrompt,
   detectConflicts,
   fanOut,
+  fallbackStepOutputSummary,
   awaitMerge,
   cancelGroup,
   resolveConflicts,
@@ -404,7 +405,7 @@ export const runParallelBranch = async (
           ...(status?.runId === representativeRunId && carryForwardContext.length > 0
             ? { outputSummary: carryForwardContext }
             : status?.outputSummary != null
-              ? { outputSummary: status.outputSummary }
+              ? { outputSummary: fallbackStepOutputSummary({ output: status.outputSummary }) }
               : {}),
         });
       }

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -1,5 +1,6 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import {
+  buildParallelCarryForward,
   buildStepPrompt,
   detectConflicts,
   fanOut,
@@ -35,6 +36,7 @@ import type {
   SessionId,
   TurnEvent,
   Workspace,
+  WorkflowRunId,
 } from '@goodboy/types';
 import {
   invokeParallelGroupCreate,
@@ -48,6 +50,7 @@ import { inferAgentKindFromName } from '../features/session/agent-kind';
 
 export type ParallelBranchInputs = {
   readonly session: Session;
+  readonly workflowRunId?: WorkflowRunId;
   readonly orchestratingAgentId: AgentId;
   readonly workspace: Workspace;
   readonly currentDef: Step;
@@ -192,11 +195,17 @@ function buildSchedulerDeps(args: BuildSchedulerDepsArgs): SchedulerDeps {
       if (!handler) {
         return { status: 'failed', outputSummary: null, error: 'no settle handler registered' };
       }
-      handler.onEvent(onEvent);
+      let outputSummary = '';
+      handler.onEvent((event) => {
+        onEvent(event);
+        if (event.kind === 'assistant_text') {
+          outputSummary += event.delta;
+        }
+      });
       const result = await handler.promise;
       return {
         status: result.status,
-        outputSummary: null,
+        outputSummary: outputSummary.trim().length > 0 ? outputSummary.trim() : null,
         ...(result.error !== undefined && { error: result.error }),
       };
     },
@@ -306,6 +315,7 @@ export const runParallelBranch = async (
       sessionId: session.id,
       stepId: def.id,
       parentAgentId: orchestratingAgentId,
+      ...(inputs.workflowRunId != null && { workflowRunId: inputs.workflowRunId }),
       ordinal: def.ordinal,
       name: def.name,
       status: 'running',
@@ -320,6 +330,7 @@ export const runParallelBranch = async (
     id: crypto.randomUUID() as ParallelAgentId,
     groupId,
     stepId: def.id,
+    ...(inputs.workflowRunId != null && { workflowRunId: inputs.workflowRunId }),
     parallelIndex: i,
     runId: runIds[i]!,
     status: 'running',
@@ -364,6 +375,21 @@ export const runParallelBranch = async (
     );
 
     const merge = await awaitMerge(handle);
+    const carryForwardContext = buildParallelCarryForward({
+      groupName: currentDef.name,
+      branches: cappedDefs.map((def, index) => {
+        const status = merge.runStatuses.find((runStatus) => runStatus.runId === runIds[index]);
+        return {
+          name: def.name,
+          status: status?.status,
+          outputSummary: status?.outputSummary,
+          error: status?.error,
+        };
+      }),
+    });
+    const representativeRunId = merge.runStatuses.find(
+      (runStatus) => runStatus.status === 'completed',
+    )?.runId;
 
     for (let i = 0; i < cappedDefs.length; i++) {
       const def = cappedDefs[i]!;
@@ -375,6 +401,11 @@ export const runParallelBranch = async (
         await invokeAgentUpdateStatus(row.id, {
           status: (status?.status ?? 'failed') as AgentStatus,
           completedAt: now(),
+          ...(status?.runId === representativeRunId && carryForwardContext.length > 0
+            ? { outputSummary: carryForwardContext }
+            : status?.outputSummary != null
+              ? { outputSummary: status.outputSummary }
+              : {}),
         });
       }
     }
@@ -423,7 +454,7 @@ export const runParallelBranch = async (
         runId: runIds[0]!,
         fromStep: { ordinal: currentDef.ordinal, name: currentDef.name },
         toStep: { ordinal: currentDef.ordinal + 1, name: 'next' },
-        carryForwardContext: '',
+        carryForwardContext,
         at: now(),
       });
     }

--- a/apps/desktop/src/store/preamble.test.ts
+++ b/apps/desktop/src/store/preamble.test.ts
@@ -117,6 +117,43 @@ describe('buildPriorTurnsBlock', () => {
     expect(out.indexOf('hi there')).toBeLessThan(out.indexOf('bye'));
   });
 
+  it('renders workflow handoffs in chronological position', () => {
+    const events: TurnEvent[] = [
+      { kind: 'user_text', runId: RUN, text: 'implement', at: NOW },
+      { kind: 'assistant_text', runId: RUN, delta: 'implementation complete', at: NOW },
+      {
+        kind: 'step_transition',
+        runId: RUN,
+        fromStep: { ordinal: 0, name: 'Implement' },
+        toStep: { ordinal: 1, name: 'Review' },
+        carryForwardContext: 'changed `src/auth.ts`',
+        at: NOW,
+      },
+      { kind: 'user_text', runId: RUN, text: 'review', at: NOW },
+    ];
+
+    const out = buildPriorTurnsBlock(events, 1000);
+
+    expect(out).toContain('workflow handoff (carried forward): changed `src/auth.ts`');
+    expect(out.indexOf('implementation complete')).toBeLessThan(out.indexOf('workflow handoff'));
+    expect(out.indexOf('workflow handoff')).toBeLessThan(out.indexOf('review'));
+  });
+
+  it('applies the prior-turn token budget to workflow handoffs', () => {
+    const events: TurnEvent[] = [
+      {
+        kind: 'step_transition',
+        runId: RUN,
+        fromStep: { ordinal: 0, name: 'Implement' },
+        toStep: { ordinal: 1, name: 'Review' },
+        carryForwardContext: 'x'.repeat(4000),
+        at: NOW,
+      },
+    ];
+
+    expect(buildPriorTurnsBlock(events, 10)).toBe('');
+  });
+
   it('drops oldest first when over budget', () => {
     const longText = 'x'.repeat(4000);
     const events: TurnEvent[] = [

--- a/apps/desktop/src/store/preamble.ts
+++ b/apps/desktop/src/store/preamble.ts
@@ -71,22 +71,35 @@ export const buildPriorTurnsBlock = (
   transcripts: ReadonlyArray<TurnEvent>,
   maxTokens: number,
 ): string => {
-  type Line = { role: 'user' | 'assistant'; text: string };
+  type Line = { label: 'user' | 'assistant' | 'workflow handoff (carried forward)'; text: string };
   const grouped: Line[] = [];
   let pendingAssistant = '';
   for (const ev of transcripts) {
     if (ev.kind === 'user_text') {
       if (pendingAssistant.length > 0) {
-        grouped.push({ role: 'assistant', text: pendingAssistant });
+        grouped.push({ label: 'assistant', text: pendingAssistant });
         pendingAssistant = '';
       }
-      grouped.push({ role: 'user', text: ev.text });
-    } else if (ev.kind === 'assistant_text') {
+      grouped.push({ label: 'user', text: ev.text });
+      continue;
+    }
+    if (ev.kind === 'assistant_text') {
       pendingAssistant += ev.delta;
+      continue;
+    }
+    if (ev.kind === 'step_transition') {
+      if (pendingAssistant.length > 0) {
+        grouped.push({ label: 'assistant', text: pendingAssistant });
+        pendingAssistant = '';
+      }
+      grouped.push({
+        label: 'workflow handoff (carried forward)',
+        text: ev.carryForwardContext,
+      });
     }
   }
   if (pendingAssistant.length > 0) {
-    grouped.push({ role: 'assistant', text: pendingAssistant });
+    grouped.push({ label: 'assistant', text: pendingAssistant });
   }
 
   if (grouped.length === 0) {
@@ -101,7 +114,7 @@ export const buildPriorTurnsBlock = (
     if (text.length === 0) {
       continue;
     }
-    const formatted = `${line.role}: ${text}`;
+    const formatted = `${line.label}: ${text}`;
     const cost = estimateTokens(formatted);
     if (cost > budget) {
       break;

--- a/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
+++ b/apps/desktop/src/store/slices/turn/dispatchParallelTurn.ts
@@ -12,6 +12,7 @@ import type {
   Step,
   TurnState,
   Workflow,
+  WorkflowRunId,
 } from '@goodboy/types';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { formatError } from '../../../shared/lib/errors';
@@ -39,6 +40,7 @@ type Params = {
   userTurnText: string;
   userPromptForPhase: string;
   phasePromptCarryForward: string;
+  phaseWorkflowRunId: WorkflowRunId | null;
   now: () => IsoDateTime;
 };
 
@@ -59,6 +61,7 @@ export const dispatchParallelTurn = async (
     userTurnText,
     userPromptForPhase,
     phasePromptCarryForward,
+    phaseWorkflowRunId,
     now,
   }: Params,
 ): Promise<void> => {
@@ -141,6 +144,7 @@ export const dispatchParallelTurn = async (
     const result = await runParallelBranch(
       {
         session,
+        ...(phaseWorkflowRunId != null && { workflowRunId: phaseWorkflowRunId }),
         orchestratingAgentId: activeAgentId,
         workspace,
         currentDef: parallelDispatch.currentDef,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -208,14 +208,47 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const nextDef = template.steps.find((s) => s.id === activeAgentRow!.stepId) ?? null;
         if (nextDef) {
           const sortedDefs = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-          const completedPredecessors = sortedDefs
-            .filter((definition) => definition.ordinal < nextDef.ordinal)
-            .flatMap((definition) => {
+          const predecessorDefinitions = sortedDefs.filter(
+            (definition) => definition.ordinal < nextDef.ordinal,
+          );
+          const completedPredecessors = predecessorDefinitions.flatMap(
+            (definition, _index, definitions) => {
+              if (definition.parallelGroup !== undefined) {
+                const groupDefinitions = definitions.filter(
+                  (candidate) => candidate.parallelGroup === definition.parallelGroup,
+                );
+                if (groupDefinitions.at(-1)?.id !== definition.id) {
+                  return [];
+                }
+                const representative = groupDefinitions
+                  .map((groupDefinition) =>
+                    runAgents.find(
+                      (agent) =>
+                        agent.stepId === groupDefinition.id && agent.status === 'completed',
+                    ),
+                  )
+                  .find((agent) => agent != null);
+                if (representative == null) {
+                  return [];
+                }
+                const groupSummary = representative.outputSummary ?? '';
+                return [
+                  {
+                    ...representative,
+                    ordinal: groupDefinitions.at(-1)?.ordinal ?? definition.ordinal,
+                    name: groupDefinitions[0]?.name ?? definition.name,
+                    outputSummary: groupSummary.startsWith('## workflow handoff\n')
+                      ? groupSummary.slice('## workflow handoff\n'.length)
+                      : groupSummary,
+                  },
+                ];
+              }
               const completedAgent = runAgents.find(
                 (agent) => agent.stepId === definition.id && agent.status === 'completed',
               );
               return completedAgent == null ? [] : [completedAgent];
-            });
+            },
+          );
           const immediatePredecessor = completedPredecessors.at(-1) ?? null;
           const hasAssistantTurn = (before.transcripts[activeAgentId] ?? []).some(
             (event) => event.kind === 'assistant_text',
@@ -528,6 +561,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         userTurnText,
         userPromptForPhase,
         phasePromptCarryForward,
+        phaseWorkflowRunId,
         now,
       });
       return;

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -73,6 +73,7 @@ import { estimateTokens } from '../../../shared/utils/estimate-tokens';
 import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
+import { summarizeAgentOutput } from '../../summarizeAgentOutput';
 import {
   applyHeuristicTitle,
   buildGoalAttachmentsBlock,
@@ -751,9 +752,13 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           );
           shouldAutoAdvanceWorkflow = shouldAutoAdvance;
         } else {
+          const outputSummary = await summarizeAgentOutput({
+            output: assistantText,
+            providerId: session.providerPreference.defaultProvider,
+          });
           await invokeAgentUpdateStatus(resolvedAgentId, {
             status: 'completed',
-            outputSummary: assistantText.slice(0, 2000),
+            outputSummary,
             completedAt: now(),
           });
           const refreshedRuns = await invokeAgentList(sessionId);

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -9,6 +9,8 @@ import {
   extractPlanFromMarker,
   extractScoutSplit,
   findReusableAgent,
+  fallbackStepOutputSummary,
+  isFallbackStepOutputSummary,
   resolveModelForProvider,
   runsForWorkflowRun,
   turnReducer,
@@ -73,7 +75,6 @@ import { estimateTokens } from '../../../shared/utils/estimate-tokens';
 import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
-import { summarizeAgentOutput } from '../../summarizeAgentOutput';
 import {
   applyHeuristicTitle,
   buildGoalAttachmentsBlock,
@@ -261,7 +262,10 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
                 outputSummary: agent.outputSummary,
               })),
             });
-            const isDegraded = (immediatePredecessor.outputSummary ?? '').trim().length === 0;
+            const predecessorSummary = immediatePredecessor.outputSummary ?? '';
+            const isDegraded =
+              predecessorSummary.trim().length === 0 ||
+              isFallbackStepOutputSummary({ summary: predecessorSummary });
             const durationMs =
               immediatePredecessor.startedAt != null && immediatePredecessor.completedAt != null
                 ? new Date(immediatePredecessor.completedAt).getTime() -
@@ -794,10 +798,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
           );
           shouldAutoAdvanceWorkflow = shouldAutoAdvance;
         } else {
-          const outputSummary = await summarizeAgentOutput({
-            output: assistantText,
-            providerId: session.providerPreference.defaultProvider,
-          });
+          const outputSummary = fallbackStepOutputSummary({ output: assistantText });
           await invokeAgentUpdateStatus(resolvedAgentId, {
             status: 'completed',
             outputSummary,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -1,7 +1,7 @@
 import {
-  WorkflowPropagator,
   autoModelForRole,
   buildClaudeFlags,
+  buildChainCarryForward,
   autoPopulateContext,
   buildStepPrompt,
   extractCommentResolved,
@@ -208,37 +208,45 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
         const nextDef = template.steps.find((s) => s.id === activeAgentRow!.stepId) ?? null;
         if (nextDef) {
           const sortedDefs = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
-          const prevDef =
-            sortedDefs
-              .filter((d) => d.ordinal < nextDef.ordinal)
-              .reverse()
-              .find((d) => runAgents.some((r) => r.stepId === d.id && r.status === 'completed')) ??
-            null;
-          const prevRun = prevDef
-            ? (runAgents.find((r) => r.stepId === prevDef.id && r.status === 'completed') ?? null)
-            : null;
-          const isFirstTurnOfStep = !runAgents.some(
-            (r) => r.stepId === nextDef.id && r.status !== 'pending',
+          const completedPredecessors = sortedDefs
+            .filter((definition) => definition.ordinal < nextDef.ordinal)
+            .flatMap((definition) => {
+              const completedAgent = runAgents.find(
+                (agent) => agent.stepId === definition.id && agent.status === 'completed',
+              );
+              return completedAgent == null ? [] : [completedAgent];
+            });
+          const immediatePredecessor = completedPredecessors.at(-1) ?? null;
+          const hasAssistantTurn = (before.transcripts[activeAgentId] ?? []).some(
+            (event) => event.kind === 'assistant_text',
           );
-          if (prevDef && prevRun && isFirstTurnOfStep) {
-            const propagator = new WorkflowPropagator({
-              summarizer: { summarizePhaseOutput: async (text) => text },
+          if (immediatePredecessor != null && !hasAssistantTurn) {
+            const carryForwardContext = buildChainCarryForward({
+              steps: completedPredecessors.map((agent) => ({
+                ordinal: agent.ordinal,
+                name: agent.name,
+                outputSummary: agent.outputSummary,
+              })),
             });
-            const transition = await propagator.buildTransition({
-              fromOrdinal: prevDef.ordinal,
-              toOrdinal: nextDef.ordinal,
-              completedPhaseOutput: prevRun.outputSummary ?? '',
-              existingSlots: get().sessionSlots[sessionId] ?? [],
-              at: now(),
-            });
-            phasePromptCarryForward = transition.carryForwardContext;
+            const isDegraded = (immediatePredecessor.outputSummary ?? '').trim().length === 0;
+            const durationMs =
+              immediatePredecessor.startedAt != null && immediatePredecessor.completedAt != null
+                ? new Date(immediatePredecessor.completedAt).getTime() -
+                  new Date(immediatePredecessor.startedAt).getTime()
+                : null;
+            phasePromptCarryForward = carryForwardContext;
             phaseTransitionEvent = {
               kind: 'step_transition',
               runId: 'pending' as ProviderRunId,
-              fromStep: { ordinal: prevDef.ordinal, name: prevDef.name },
+              fromStep: {
+                ordinal: immediatePredecessor.ordinal,
+                name: immediatePredecessor.name,
+              },
               toStep: { ordinal: nextDef.ordinal, name: nextDef.name },
-              carryForwardContext: transition.carryForwardContext,
-              at: transition.at,
+              carryForwardContext,
+              ...(isDegraded && { degraded: true }),
+              ...(durationMs != null && { durationMs }),
+              at: now(),
             };
           }
           phaseDefinition = nextDef;

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.test.ts
@@ -466,6 +466,28 @@ describe('advanceClusterImplementation', () => {
     expect(state.selectedAgentId).toBe(PARENT);
   });
 
+  it('stores deterministic head and tail output for a completed cluster', async () => {
+    const child = childAgent({ id: 'summary-child', ordinal: 0, status: 'running' });
+    const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+    const { get, set } = makeStore({
+      sessionPhaseRuns: { [SID]: [container({ status: 'running' }), child] },
+      sessionPlans: { [SID]: [plan({})] },
+    });
+    hoisted.invokeAgentList.mockResolvedValue([
+      container({ status: 'running' }),
+      childAgent({ id: 'summary-child', ordinal: 0, status: 'completed' }),
+    ]);
+
+    await advanceClusterImplementation(set, get)(SID, child.id, assistantText, { force: true });
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      child.id,
+      expect.objectContaining({
+        outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
+      }),
+    );
+  });
+
   it('completes the container and auto-advances when the last child finishes', async () => {
     const c0 = childAgent({ id: 'm0', ordinal: 0, status: 'completed' });
     const c1 = childAgent({ id: 'm1', ordinal: 1 });

--- a/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
+++ b/apps/desktop/src/store/slices/workflows/clusterImplementation.ts
@@ -7,7 +7,7 @@ import type {
   SessionId,
   WorkflowRunId,
 } from '@goodboy/types';
-import { extractClusterDone } from '@goodboy/core';
+import { extractClusterDone, fallbackStepOutputSummary } from '@goodboy/core';
 import {
   invokeAgentInsert,
   invokeAgentList,
@@ -234,7 +234,9 @@ export const advanceClusterImplementation = (set: SetFn, get: GetFn) => {
 
     continueAttempts.delete(childAgentId);
     const outputSummary =
-      assistantText.length > 0 ? assistantText.slice(0, 2000) : 'advanced to next cluster manually';
+      assistantText.length > 0
+        ? fallbackStepOutputSummary({ output: assistantText })
+        : 'advanced to next cluster manually';
     await invokeAgentUpdateStatus(childAgentId, {
       status: 'completed',
       outputSummary,

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -81,10 +81,14 @@ const session: Session = {
   updatedAt: NOW,
 };
 
-const buildHarness = () => {
+type Params = {
+  readonly sessions?: ReadonlyArray<Session>;
+};
+
+const buildHarness = ({ sessions = [session] }: Params = {}) => {
   const state = {
     sessionPhaseRuns: { [SESSION_ID]: [agent] },
-    sessions: [session],
+    sessions,
     refreshUnreadWorkspaces: vi.fn(),
     emitNotification: vi.fn(),
     sendTurn: vi.fn(),
@@ -165,5 +169,22 @@ describe('finalizeWorkflowStep output summary', () => {
       AGENT_ID,
       expect.objectContaining({ outputSummary: 'timeout output' }),
     );
+  });
+
+  it('completes with deterministic fallback when the session row is missing', async () => {
+    const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+    const finalize = buildHarness({ sessions: [] });
+
+    const result = await finalize(SESSION_ID, AGENT_ID, assistantText, false, { force: true });
+
+    expect(summarizeStepOutputSpy).not.toHaveBeenCalled();
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({
+        status: 'completed',
+        outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
+      }),
+    );
+    expect(result).toEqual({ shouldAutoAdvance: true });
   });
 });

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  Session,
+  SessionId,
+  StepId,
+  WorkflowId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+const { invokeAgentListSpy, invokeAgentUpdateStatusSpy, summarizeStepOutputSpy } = vi.hoisted(
+  () => ({
+    invokeAgentListSpy: vi.fn(),
+    invokeAgentUpdateStatusSpy: vi.fn(),
+    summarizeStepOutputSpy: vi.fn(),
+  }),
+);
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+vi.mock('@goodboy/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/core')>();
+  return { ...actual, summarizeStepOutput: summarizeStepOutputSpy };
+});
+
+vi.mock('@goodboy/db', () => ({ updateSessionWorkflowStep: vi.fn() }));
+
+vi.mock('../../../shared/lib/db', () => ({
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentList: invokeAgentListSpy,
+  invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
+}));
+
+import { finalizeWorkflowStep } from './finalizeWorkflowStep';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+const WORKFLOW_RUN_ID = 'workflow-run-1' as WorkflowRunId;
+const STEP_ID = 'step-1' as StepId;
+const NOW = '2026-07-21T00:00:00.000Z' as IsoDateTime;
+
+const agent: Agent = {
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  stepId: STEP_ID,
+  workflowRunId: WORKFLOW_RUN_ID,
+  ordinal: 0,
+  name: 'Implement',
+  status: 'running',
+};
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'implement the change',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [
+    {
+      id: WORKFLOW_RUN_ID,
+      workflowId: WORKFLOW_ID,
+      ordinal: 0,
+      currentStep: 0,
+      autoRun: true,
+      triggerMode: 'immediate',
+    },
+  ],
+  autoRun: true,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const buildHarness = () => {
+  const state = {
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    sessions: [session],
+    refreshUnreadWorkspaces: vi.fn(),
+    emitNotification: vi.fn(),
+    sendTurn: vi.fn(),
+  };
+  const set = vi.fn();
+  const get = (() => state) as unknown as Parameters<typeof finalizeWorkflowStep>[1];
+  return finalizeWorkflowStep(set as unknown as Parameters<typeof finalizeWorkflowStep>[0], get);
+};
+
+describe('finalizeWorkflowStep output summary', () => {
+  beforeEach(() => {
+    invokeAgentListSpy.mockResolvedValue([{ ...agent, status: 'completed' }]);
+    invokeAgentUpdateStatusSpy.mockResolvedValue({ ...agent, status: 'completed' });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('stores the LLM summary before allowing auto-advance', async () => {
+    summarizeStepOutputSpy.mockResolvedValue(
+      'Implemented the workflow handoff.\n- `sendTurn.ts` updated',
+    );
+    const finalize = buildHarness();
+
+    const result = await finalize(SESSION_ID, AGENT_ID, 'raw assistant output', false, {
+      force: true,
+    });
+
+    expect(summarizeStepOutputSpy).toHaveBeenCalledWith({
+      providerId: 'anthropic',
+      invokeFn: expect.any(Function),
+      output: 'raw assistant output',
+    });
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({
+        status: 'completed',
+        outputSummary: 'Implemented the workflow handoff.\n- `sendTurn.ts` updated',
+      }),
+    );
+    expect(result).toEqual({ shouldAutoAdvance: true });
+  });
+
+  it('stores deterministic head and tail fallback when summarization fails', async () => {
+    const assistantText = `${'h'.repeat(1500)}${'m'.repeat(100)}${'t'.repeat(400)}`;
+    const expectedSummary = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    summarizeStepOutputSpy.mockRejectedValue(new Error('provider unavailable'));
+    const finalize = buildHarness();
+
+    await finalize(SESSION_ID, AGENT_ID, assistantText, false, { force: true });
+
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({ outputSummary: expectedSummary }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[step-output] summarization failed, using deterministic fallback: provider unavailable',
+    );
+  });
+
+  it('uses the fallback when summarization exceeds 15 seconds', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    summarizeStepOutputSpy.mockImplementation(() => new Promise(() => undefined));
+    const finalize = buildHarness();
+    const completion = finalize(SESSION_ID, AGENT_ID, 'timeout output', false, { force: true });
+
+    await vi.advanceTimersByTimeAsync(14_999);
+    expect(invokeAgentUpdateStatusSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await completion;
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({ outputSummary: 'timeout output' }),
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -1,5 +1,5 @@
 import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
-import { extractStepDone } from '@goodboy/core';
+import { extractStepDone, fallbackStepOutputSummary } from '@goodboy/core';
 import { updateSessionWorkflowStep } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
@@ -80,13 +80,13 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
 
     continueAttempts.delete(agentId);
     const session = get().sessions.find((candidate) => candidate.id === sessionId);
-    if (session == null) {
-      return { shouldAutoAdvance: false };
-    }
-    const outputSummary = await summarizeAgentOutput({
-      output: assistantText,
-      providerId: session.providerPreference.defaultProvider,
-    });
+    const outputSummary =
+      session == null
+        ? fallbackStepOutputSummary({ output: assistantText })
+        : await summarizeAgentOutput({
+            output: assistantText,
+            providerId: session.providerPreference.defaultProvider,
+          });
     await invokeAgentUpdateStatus(agentId, {
       status: 'completed',
       outputSummary,

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -4,6 +4,7 @@ import { updateSessionWorkflowStep } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
 import { composeStepBoundary } from '../../kickoff';
+import { summarizeAgentOutput } from '../../summarizeAgentOutput';
 import { isHandsFree } from './handsFree';
 import type { GetFn, SetFn } from './types';
 
@@ -78,9 +79,17 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
     }
 
     continueAttempts.delete(agentId);
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    if (session == null) {
+      return { shouldAutoAdvance: false };
+    }
+    const outputSummary = await summarizeAgentOutput({
+      output: assistantText,
+      providerId: session.providerPreference.defaultProvider,
+    });
     await invokeAgentUpdateStatus(agentId, {
       status: 'completed',
-      outputSummary: assistantText.slice(0, 2000),
+      outputSummary,
       completedAt: nowIso(),
     });
     const refreshed = await invokeAgentList(sessionId);

--- a/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.fanout.test.ts
@@ -221,4 +221,19 @@ describe('advanceScoutTree split decision', () => {
 
     expect(hoisted.insertArgs).toHaveLength(0);
   });
+
+  it('stores deterministic head and tail output for a completed scout', async () => {
+    const scout = scoutAgent({ id: 'summary-scout' as AgentId });
+    const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+    const { get, set } = makeAdvanceStore([scout], true);
+
+    await advanceScoutTree(set, get)(SID, scout.id, assistantText);
+
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      scout.id,
+      expect.objectContaining({
+        outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
+      }),
+    );
+  });
 });

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -1,5 +1,9 @@
 import type { Agent, AgentId, IsoDateTime, SessionId } from '@goodboy/types';
-import { extractScoutSplit, type ExtractedScoutArea } from '@goodboy/core';
+import {
+  extractScoutSplit,
+  fallbackStepOutputSummary,
+  type ExtractedScoutArea,
+} from '@goodboy/core';
 import {
   invokeAgentInsert,
   invokeAgentList,
@@ -290,6 +294,12 @@ export const advanceScoutTree = (set: SetFn, get: GetFn) => {
       }
     }
 
-    await settleScout(set, get, sessionId, agentId, assistantText.slice(0, 2000));
+    await settleScout(
+      set,
+      get,
+      sessionId,
+      agentId,
+      fallbackStepOutputSummary({ output: assistantText }),
+    );
   };
 };

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -12,6 +12,8 @@ import type {
 
 const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
+const invokeSpy = vi.fn();
+const invokeAgentUpdateStatusSpy = vi.fn();
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: (args: unknown) => runTurnSpy(args),
@@ -31,7 +33,7 @@ vi.mock('../features/permissions/permissions', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
+  invoke: invokeSpy,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -46,7 +48,7 @@ vi.mock('../shared/lib/db', () => ({
 vi.mock('@goodboy/db', () => ({
   getSetting: vi.fn(),
   insertMessage: vi.fn(),
-  insertProviderRun: vi.fn(),
+  insertProviderRun: vi.fn(async () => undefined),
   insertSession: vi.fn(),
   insertSessionWorktree: vi.fn(),
   insertTelemetry: vi.fn(),
@@ -126,13 +128,14 @@ vi.mock('../features/workflows/workflows', () => ({
   invokeWorkflowDelete: vi.fn(),
   invokeAgentList: vi.fn(async () => []),
   invokeAgentInsert: vi.fn(),
-  invokeAgentUpdateStatus: vi.fn(),
+  invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
   invokeAgentMarkViewed: vi.fn(async () => undefined),
 }));
 
 vi.mock('../features/worktree/worktree', () => ({
   createWorktree: vi.fn(),
   removeWorktree: vi.fn(),
+  worktreeChangedFiles: vi.fn(async () => ({ files: [], numstat: '' })),
 }));
 
 vi.mock('../shared/lib/repo', () => ({
@@ -193,7 +196,14 @@ describe('sendTurn, agent routing', () => {
   beforeEach(async () => {
     runTurnSpy.mockReset();
     cancelTurnSpy.mockReset();
+    invokeSpy.mockReset();
+    invokeAgentUpdateStatusSpy.mockReset();
     runTurnSpy.mockImplementation(() => emptyStream());
+    invokeSpy.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    });
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',
@@ -296,12 +306,50 @@ describe('sendTurn, agent routing', () => {
 
     expect(runTurnSpy).toHaveBeenCalledOnce();
   });
+
+  it('stores summarized output when a non-workflow agent completes', async () => {
+    const useAppStore = await importStore();
+    setupTwoAgents(useAppStore, AGENT_A);
+    invokeSpy.mockResolvedValueOnce({
+      stdout: JSON.stringify({ result: 'Summarized agent output.' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    runTurnSpy.mockImplementation(async function* (args: { runId: ProviderRunId }) {
+      yield {
+        kind: 'assistant_text' as const,
+        runId: args.runId,
+        delta: 'raw free-agent output',
+        at: NOW,
+      };
+      yield { kind: 'done' as const, runId: args.runId, at: NOW };
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'finish the task' });
+
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_A,
+      expect.objectContaining({
+        status: 'completed',
+        outputSummary: 'Summarized agent output.',
+      }),
+    );
+  });
 });
 
 describe('sendTurn, resolver config (provider pin + effort)', () => {
   beforeEach(async () => {
     runTurnSpy.mockReset();
+    invokeSpy.mockReset();
+    invokeAgentUpdateStatusSpy.mockReset();
     runTurnSpy.mockImplementation(() => emptyStream());
+    invokeSpy.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    });
     const routingMod = await import('../features/providers/routing');
     (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
       selectedProvider: 'anthropic',

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -366,6 +366,146 @@ describe('sendTurn, workflow carry-forward', () => {
     vi.clearAllMocks();
   });
 
+  it('collapses a completed parallel group into one predecessor entry', async () => {
+    const useAppStore = await importStore();
+    const workflowId = 'workflow-parallel-carry' as WorkflowId;
+    const workflowRunId = 'workflow-run-parallel-carry' as WorkflowRunId;
+    const apiStepId = 'step-api' as StepId;
+    const uiStepId = 'step-ui' as StepId;
+    const reviewStepId = 'step-review-parallel' as StepId;
+    const apiAgentId = 'agent-api' as AgentId;
+    const uiAgentId = 'agent-ui' as AgentId;
+    const reviewAgentId = 'agent-review-parallel' as AgentId;
+    const mergedSummary = [
+      '## workflow handoff',
+      '### parallel group output: API',
+      '#### branch 1: API',
+      'Added endpoint.',
+      '#### branch 2: UI',
+      'Built form.',
+    ].join('\n');
+    const workflow: Workflow = {
+      id: workflowId,
+      workspaceId: WORKSPACE_ID,
+      name: 'parallel carry-forward workflow',
+      description: '',
+      steps: [
+        {
+          id: apiStepId,
+          workflowId,
+          ordinal: 0,
+          name: 'API',
+          promptPrefix: '',
+          parallelGroup: 9,
+        },
+        {
+          id: uiStepId,
+          workflowId,
+          ordinal: 1,
+          name: 'UI',
+          promptPrefix: '',
+          parallelGroup: 9,
+        },
+        { id: reviewStepId, workflowId, ordinal: 2, name: 'Review', promptPrefix: 'review' },
+      ],
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    const agents: Agent[] = [
+      {
+        ...buildAgent(apiAgentId, 0),
+        stepId: apiStepId,
+        workflowRunId,
+        name: 'API',
+        status: 'completed',
+        outputSummary: mergedSummary,
+      },
+      {
+        ...buildAgent(uiAgentId, 1),
+        stepId: uiStepId,
+        workflowRunId,
+        name: 'UI',
+        status: 'completed',
+        outputSummary: 'Built form.',
+      },
+      {
+        ...buildAgent(reviewAgentId, 2),
+        stepId: reviewStepId,
+        workflowRunId,
+        name: 'Review',
+      },
+    ];
+    const workflowsMod = await import('../features/workflows/workflows');
+    (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockResolvedValue(agents);
+    invokeAgentUpdateStatusSpy.mockImplementation(async (id: AgentId, fields: object) => ({
+      ...agents.find((agent) => agent.id === id)!,
+      ...fields,
+    }));
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          workflowRuns: [
+            {
+              id: workflowRunId,
+              workflowId,
+              ordinal: 0,
+              currentStep: 2,
+              autoRun: false,
+              triggerMode: 'immediate',
+            },
+          ],
+        },
+      ],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionPhaseRuns: { [SESSION_ID]: agents },
+      selectedAgentId: { [SESSION_ID]: reviewAgentId },
+      transcripts: { [reviewAgentId]: [] },
+      phaseTemplates: { [WORKSPACE_ID]: [workflow] },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: { anthropic: { state: 'connected', identity: 'test' } } as never,
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'review group' });
+
+    const expectedCarryForward = [
+      '## workflow handoff',
+      '### step 1 output: API',
+      '### parallel group output: API',
+      '#### branch 1: API',
+      'Added endpoint.',
+      '#### branch 2: UI',
+      'Built form.',
+    ].join('\n');
+    expect(runTurnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining(expectedCarryForward) }),
+    );
+    expect(runTurnSpy.mock.calls[0]?.[0]?.prompt).not.toContain('### earlier steps');
+    expect(
+      (useAppStore.getState().transcripts[reviewAgentId] ?? []).filter(
+        (event) => event.kind === 'step_transition',
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        fromStep: { ordinal: 1, name: 'API' },
+        carryForwardContext: expectedCarryForward,
+      }),
+    ]);
+  });
+
   it('injects the same full chain on retry without duplicating slots', async () => {
     const useAppStore = await importStore();
     const workflowId = 'workflow-carry' as WorkflowId;

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -216,7 +216,9 @@ describe('sendTurn, agent routing', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.clearAllMocks();
   });
 
@@ -361,7 +363,9 @@ describe('sendTurn, workflow carry-forward', () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.clearAllMocks();
   });
 
@@ -719,7 +723,9 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
     (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     vi.clearAllMocks();
   });
 

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -6,7 +6,11 @@ import type {
   ProviderRunId,
   Session,
   SessionId,
+  StepId,
   TurnEvent,
+  Workflow,
+  WorkflowId,
+  WorkflowRunId,
   WorkspaceId,
 } from '@goodboy/types';
 
@@ -336,6 +340,203 @@ describe('sendTurn, agent routing', () => {
         outputSummary: 'Summarized agent output.',
       }),
     );
+  });
+});
+
+describe('sendTurn, workflow carry-forward', () => {
+  beforeEach(async () => {
+    runTurnSpy.mockReset();
+    invokeSpy.mockReset();
+    invokeAgentUpdateStatusSpy.mockReset();
+    runTurnSpy.mockImplementation(() => emptyStream());
+    invokeSpy.mockResolvedValue({
+      stdout: JSON.stringify({ result: JSON.stringify({ upserts: [] }) }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const routingMod = await import('../features/providers/routing');
+    (routingMod.resolveProviderForTurn as ReturnType<typeof vi.fn>).mockResolvedValue({
+      selectedProvider: 'anthropic',
+      selectedModel: 'claude-sonnet-4-5',
+      reason: 'preference',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('injects the same full chain on retry without duplicating slots', async () => {
+    const useAppStore = await importStore();
+    const workflowId = 'workflow-carry' as WorkflowId;
+    const workflowRunId = 'workflow-run-carry' as WorkflowRunId;
+    const planStepId = 'step-plan' as StepId;
+    const researchStepId = 'step-research' as StepId;
+    const implementStepId = 'step-implement' as StepId;
+    const reviewStepId = 'step-review' as StepId;
+    const planAgentId = 'agent-plan' as AgentId;
+    const researchAgentId = 'agent-research' as AgentId;
+    const implementAgentId = 'agent-implement' as AgentId;
+    const reviewAgentId = 'agent-review' as AgentId;
+    const researchSummary = `${'r'.repeat(275)}\nresearch tail omitted`;
+    const workflow: Workflow = {
+      id: workflowId,
+      workspaceId: WORKSPACE_ID,
+      name: 'carry-forward workflow',
+      description: '',
+      steps: [
+        { id: planStepId, workflowId, ordinal: 0, name: 'Plan', promptPrefix: '' },
+        { id: researchStepId, workflowId, ordinal: 1, name: 'Research', promptPrefix: '' },
+        {
+          id: implementStepId,
+          workflowId,
+          ordinal: 2,
+          name: 'Implement',
+          promptPrefix: '',
+        },
+        { id: reviewStepId, workflowId, ordinal: 3, name: 'Review', promptPrefix: 'review' },
+      ],
+      createdAt: NOW,
+      updatedAt: NOW,
+    };
+    let agents: Agent[] = [
+      {
+        ...buildAgent(planAgentId, 0),
+        stepId: planStepId,
+        workflowRunId,
+        name: 'Plan',
+        status: 'completed',
+        outputSummary: 'Plan outcome.\nPlan details omitted.',
+      },
+      {
+        ...buildAgent(researchAgentId, 1),
+        stepId: researchStepId,
+        workflowRunId,
+        name: 'Research',
+        status: 'completed',
+        outputSummary: researchSummary,
+      },
+      {
+        ...buildAgent(implementAgentId, 2),
+        stepId: implementStepId,
+        workflowRunId,
+        name: 'Implement',
+        status: 'completed',
+        outputSummary: '',
+        startedAt: '2026-05-18T00:00:01.000Z' as IsoDateTime,
+        completedAt: '2026-05-18T00:00:04.000Z' as IsoDateTime,
+      },
+      {
+        ...buildAgent(reviewAgentId, 3),
+        stepId: reviewStepId,
+        workflowRunId,
+        name: 'Review',
+      },
+    ];
+    const workflowsMod = await import('../features/workflows/workflows');
+    (workflowsMod.invokeAgentList as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => agents,
+    );
+    invokeAgentUpdateStatusSpy.mockImplementation(
+      async (
+        id: AgentId,
+        fields: {
+          readonly status: Agent['status'];
+          readonly startedAt?: IsoDateTime;
+          readonly completedAt?: IsoDateTime;
+        },
+      ) => {
+        let updated: Agent | null = null;
+        agents = agents.map((agent) => {
+          if (agent.id !== id) {
+            return agent;
+          }
+          updated = {
+            ...agent,
+            status: fields.status,
+            ...(fields.startedAt != null && { startedAt: fields.startedAt }),
+            ...(fields.completedAt != null && { completedAt: fields.completedAt }),
+          };
+          return updated;
+        });
+        return updated ?? agents.find((agent) => agent.id === id) ?? agents[0]!;
+      },
+    );
+    useAppStore.setState({
+      sessions: [
+        {
+          ...buildSession(),
+          workflowRuns: [
+            {
+              id: workflowRunId,
+              workflowId,
+              ordinal: 0,
+              currentStep: 3,
+              autoRun: false,
+              triggerMode: 'immediate',
+            },
+          ],
+        },
+      ],
+      sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+      sessionPhaseRuns: { [SESSION_ID]: agents },
+      selectedAgentId: { [SESSION_ID]: reviewAgentId },
+      transcripts: { [reviewAgentId]: [] },
+      sessionSlots: {
+        [SESSION_ID]: [{ key: 'decisions', value: 'decision-slot-only-value', enabled: true }],
+      },
+      phaseTemplates: { [WORKSPACE_ID]: [workflow] },
+      providers: [
+        {
+          id: 'anthropic',
+          binary: 'claude',
+          connection: 'connected',
+          name: 'Claude',
+          installation: 'installed',
+        } as never,
+      ],
+      authResults: { anthropic: { state: 'connected', identity: 'test' } } as never,
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'first attempt' });
+    expect(agents.find((agent) => agent.id === reviewAgentId)?.status).toBe('failed');
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'retry' });
+
+    const transitions = (useAppStore.getState().transcripts[reviewAgentId] ?? []).filter(
+      (event) => event.kind === 'step_transition',
+    );
+    const expectedCarryForward = [
+      '## workflow handoff',
+      '### step 2 output: Implement',
+      '(no output captured)',
+      '### earlier steps',
+      `- step 1 Research: ${researchSummary.slice(0, 280)}`,
+      '- step 0 Plan: Plan outcome.',
+    ].join('\n');
+    expect(transitions).toEqual([
+      expect.objectContaining({
+        carryForwardContext: expectedCarryForward,
+        degraded: true,
+        durationMs: 3000,
+      }),
+      expect.objectContaining({
+        carryForwardContext: expectedCarryForward,
+        degraded: true,
+        durationMs: 3000,
+      }),
+    ]);
+    expect(runTurnSpy.mock.calls.map((call) => call[0]?.prompt)).toEqual([
+      expect.stringContaining(expectedCarryForward),
+      expect.stringContaining(expectedCarryForward),
+    ]);
   });
 });
 

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -311,19 +311,15 @@ describe('sendTurn, agent routing', () => {
     expect(runTurnSpy).toHaveBeenCalledOnce();
   });
 
-  it('stores summarized output when a non-workflow agent completes', async () => {
+  it('stores deterministic fallback output without an LLM call for a non-workflow agent', async () => {
     const useAppStore = await importStore();
     setupTwoAgents(useAppStore, AGENT_A);
-    invokeSpy.mockResolvedValueOnce({
-      stdout: JSON.stringify({ result: 'Summarized agent output.' }),
-      stderr: '',
-      exitCode: 0,
-    });
+    const assistantText = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
     runTurnSpy.mockImplementation(async function* (args: { runId: ProviderRunId }) {
       yield {
         kind: 'assistant_text' as const,
         runId: args.runId,
-        delta: 'raw free-agent output',
+        delta: assistantText,
         at: NOW,
       };
       yield { kind: 'done' as const, runId: args.runId, at: NOW };
@@ -337,8 +333,11 @@ describe('sendTurn, agent routing', () => {
       AGENT_A,
       expect.objectContaining({
         status: 'completed',
-        outputSummary: 'Summarized agent output.',
+        outputSummary: `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
       }),
+    );
+    expect(JSON.stringify(invokeSpy.mock.calls)).not.toContain(
+      'Condense an AI coding agent step output',
     );
   });
 });
@@ -677,6 +676,25 @@ describe('sendTurn, workflow carry-forward', () => {
       expect.stringContaining(expectedCarryForward),
       expect.stringContaining(expectedCarryForward),
     ]);
+
+    const fallbackSummary = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
+    agents = agents.map((agent) =>
+      agent.id === implementAgentId ? { ...agent, outputSummary: fallbackSummary } : agent,
+    );
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: reviewAgentId, content: 'fallback retry' });
+
+    const fallbackTransition = (useAppStore.getState().transcripts[reviewAgentId] ?? [])
+      .filter((event) => event.kind === 'step_transition')
+      .at(-1);
+    expect(fallbackTransition).toEqual(
+      expect.objectContaining({
+        degraded: true,
+        carryForwardContext: expect.stringContaining(fallbackSummary),
+      }),
+    );
   });
 });
 

--- a/apps/desktop/src/store/summarizeAgentOutput.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.ts
@@ -1,0 +1,37 @@
+import { invoke } from '@tauri-apps/api/core';
+import { fallbackStepOutputSummary, summarizeStepOutput } from '@goodboy/core';
+import type { ProviderId } from '@goodboy/types';
+import { formatError } from '../shared/lib/errors';
+
+const SUMMARY_TIMEOUT_MS = 15_000;
+
+type Params = {
+  readonly output: string;
+  readonly providerId: ProviderId;
+};
+
+export const summarizeAgentOutput = async ({ output, providerId }: Params): Promise<string> => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error('step output summarization timed out')),
+      SUMMARY_TIMEOUT_MS,
+    );
+  });
+
+  try {
+    return await Promise.race([
+      summarizeStepOutput({ providerId, invokeFn: invoke, output }),
+      timeout,
+    ]);
+  } catch (error) {
+    console.warn(
+      `[step-output] summarization failed, using deterministic fallback: ${formatError(error)}`,
+    );
+    return fallbackStepOutputSummary({ output });
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -160,6 +160,7 @@ export {
 
 export {
   buildChainCarryForward,
+  buildParallelCarryForward,
   buildStepPrompt,
   classifyWorkflowChain,
   currentStep,
@@ -168,6 +169,7 @@ export {
   nextStep,
   runsForWorkflowRun,
   type ChainCarryForwardStep,
+  type ParallelCarryForwardBranch,
   type WorkflowChainState,
   WORKFLOW_LIBRARY,
   type WorkflowLibraryEntry,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -139,8 +139,10 @@ export {
   Summarizer,
   SummarizerParseError,
   SummarizerSpawnError,
+  fallbackStepOutputSummary,
   inferNextActions,
   rewriteWorkflowGoal,
+  summarizeStepOutput,
   buildGoalRewriteUserPrompt,
   type ContextSlotDelta,
   type ContextSlotDeltaUpsert,
@@ -157,6 +159,7 @@ export {
 } from './summarizer';
 
 export {
+  buildChainCarryForward,
   buildStepPrompt,
   classifyWorkflowChain,
   currentStep,
@@ -164,6 +167,7 @@ export {
   isWorkflowComplete,
   nextStep,
   runsForWorkflowRun,
+  type ChainCarryForwardStep,
   type WorkflowChainState,
   WorkflowPropagator,
   type WorkflowPropagatorDeps,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -140,6 +140,7 @@ export {
   SummarizerParseError,
   SummarizerSpawnError,
   fallbackStepOutputSummary,
+  isFallbackStepOutputSummary,
   inferNextActions,
   rewriteWorkflowGoal,
   summarizeStepOutput,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -169,8 +169,6 @@ export {
   runsForWorkflowRun,
   type ChainCarryForwardStep,
   type WorkflowChainState,
-  WorkflowPropagator,
-  type WorkflowPropagatorDeps,
   WORKFLOW_LIBRARY,
   type WorkflowLibraryEntry,
   type WorkflowLibraryStep,

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -22,4 +22,8 @@ export {
   type GoalRewriteDeps,
   type GoalRewriteInput,
 } from './goal-rewrite';
-export { fallbackStepOutputSummary, summarizeStepOutput } from './step-output';
+export {
+  fallbackStepOutputSummary,
+  isFallbackStepOutputSummary,
+  summarizeStepOutput,
+} from './step-output';

--- a/packages/core/src/summarizer/index.ts
+++ b/packages/core/src/summarizer/index.ts
@@ -22,3 +22,4 @@ export {
   type GoalRewriteDeps,
   type GoalRewriteInput,
 } from './goal-rewrite';
+export { fallbackStepOutputSummary, summarizeStepOutput } from './step-output';

--- a/packages/core/src/summarizer/step-output.test.ts
+++ b/packages/core/src/summarizer/step-output.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { SummarizerDeps } from './client';
 import { SummarizerParseError } from './client';
-import { fallbackStepOutputSummary, summarizeStepOutput } from './step-output';
+import {
+  fallbackStepOutputSummary,
+  isFallbackStepOutputSummary,
+  summarizeStepOutput,
+} from './step-output';
 
 describe('summarizeStepOutput', () => {
   it('uses the summarizer invoke channel and dedicated handoff prompt', async () => {
@@ -57,10 +61,11 @@ describe('summarizeStepOutput', () => {
 describe('fallbackStepOutputSummary', () => {
   it('keeps short output and joins the exact long-output head and tail', () => {
     const longOutput = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+    const fallback = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
 
     expect(fallbackStepOutputSummary({ output: 'short' })).toBe('short');
-    expect(fallbackStepOutputSummary({ output: longOutput })).toBe(
-      `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
-    );
+    expect(fallbackStepOutputSummary({ output: longOutput })).toBe(fallback);
+    expect(isFallbackStepOutputSummary({ summary: fallback })).toBe(true);
+    expect(isFallbackStepOutputSummary({ summary: 'short\n...\nsummary' })).toBe(false);
   });
 });

--- a/packages/core/src/summarizer/step-output.test.ts
+++ b/packages/core/src/summarizer/step-output.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { SummarizerDeps } from './client';
+import { SummarizerParseError } from './client';
+import { fallbackStepOutputSummary, summarizeStepOutput } from './step-output';
+
+describe('summarizeStepOutput', () => {
+  it('uses the summarizer invoke channel and dedicated handoff prompt', async () => {
+    let command = '';
+    let request: Record<string, unknown> | undefined;
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(
+      cmd: string,
+      args?: Record<string, unknown>,
+    ): Promise<T> => {
+      command = cmd;
+      request = args;
+      return { stdout: 'Implemented auth flow.\n- `src/auth.ts`', stderr: '', exitCode: 0 } as T;
+    };
+
+    const result = await summarizeStepOutput({ providerId: 'cursor', invokeFn, output: 'raw' });
+    const args = request?.['args'];
+    const systemPrompt =
+      typeof args === 'object' && args !== null && 'systemPrompt' in args
+        ? args.systemPrompt
+        : null;
+
+    expect(command).toBe('summarize_session');
+    expect(systemPrompt).toContain('File paths touched');
+    expect(systemPrompt).toContain('1200 characters or fewer');
+    expect(result).toBe('Implemented auth flow.\n- `src/auth.ts`');
+  });
+
+  it('parses the anthropic result envelope', async () => {
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
+      return {
+        stdout: JSON.stringify({ result: 'Review passed.\n- No blockers' }),
+        stderr: '',
+        exitCode: 0,
+      } as T;
+    };
+
+    await expect(
+      summarizeStepOutput({ providerId: 'anthropic', invokeFn, output: 'raw review' }),
+    ).resolves.toBe('Review passed.\n- No blockers');
+  });
+
+  it('rejects summaries that violate the output contract', async () => {
+    const invokeFn: SummarizerDeps['invokeFn'] = async <T>(): Promise<T> => {
+      return { stdout: 'x'.repeat(121), stderr: '', exitCode: 0 } as T;
+    };
+
+    await expect(
+      summarizeStepOutput({ providerId: 'cursor', invokeFn, output: 'raw' }),
+    ).rejects.toBeInstanceOf(SummarizerParseError);
+  });
+});
+
+describe('fallbackStepOutputSummary', () => {
+  it('keeps short output and joins the exact long-output head and tail', () => {
+    const longOutput = `${'h'.repeat(1500)}middle${'t'.repeat(400)}`;
+
+    expect(fallbackStepOutputSummary({ output: 'short' })).toBe('short');
+    expect(fallbackStepOutputSummary({ output: longOutput })).toBe(
+      `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`,
+    );
+  });
+});

--- a/packages/core/src/summarizer/step-output.ts
+++ b/packages/core/src/summarizer/step-output.ts
@@ -1,0 +1,95 @@
+import {
+  getCheapModel,
+  getDefaultBinary,
+  SummarizerParseError,
+  SummarizerSpawnError,
+  type SummarizerDeps,
+} from './client';
+
+const MAX_SUMMARY_LENGTH = 1200;
+const MAX_FIRST_LINE_LENGTH = 120;
+const FALLBACK_HEAD_LENGTH = 1500;
+const FALLBACK_TAIL_LENGTH = 400;
+
+const STEP_OUTPUT_SYSTEM_PROMPT = `Condense an AI coding agent step output into compact markdown for the next workflow step.
+
+Preserve useful facts in this priority order:
+1. File paths touched
+2. Decisions made
+3. Actions completed
+4. Problems found
+5. Explicit blockers
+
+The first line MUST be a one-line outcome summary of 120 characters or fewer. The complete response MUST be 1200 characters or fewer. Keep concrete paths, identifiers, commands, results, and unresolved issues. Remove narration, repetition, greetings, and raw tool output.
+
+Output ONLY the compact markdown summary. No preamble, no surrounding quotes, no JSON, and no markdown fence.`;
+
+type Params = {
+  readonly output: string;
+};
+
+type OneShotResult = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+};
+
+export const summarizeStepOutput = async ({
+  providerId,
+  binary,
+  invokeFn,
+  output,
+}: Params & SummarizerDeps): Promise<string> => {
+  const result = await invokeFn<OneShotResult>('summarize_session', {
+    args: {
+      providerId,
+      model: getCheapModel(providerId),
+      binary: binary ?? getDefaultBinary(providerId),
+      userMessage: output,
+      systemPrompt: STEP_OUTPUT_SYSTEM_PROMPT,
+    },
+  });
+  if ((result.exitCode ?? 0) !== 0) {
+    throw new SummarizerSpawnError(result.exitCode, result.stderr);
+  }
+
+  const stdout = result.stdout.trim();
+  let summary = stdout;
+  if (providerId === 'anthropic') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new SummarizerParseError(
+        'step output summary response was not valid JSON',
+        result.stdout,
+      );
+    }
+    if (typeof parsed !== 'object' || parsed === null || !('result' in parsed)) {
+      throw new SummarizerParseError(
+        'step output summary response was missing result',
+        result.stdout,
+      );
+    }
+    if (typeof parsed.result !== 'string') {
+      throw new SummarizerParseError('step output summary result was not text', result.stdout);
+    }
+    summary = parsed.result.trim();
+  }
+  const firstLine = summary.split(/\r?\n/, 1)[0] ?? '';
+  if (
+    summary.length === 0 ||
+    summary.length > MAX_SUMMARY_LENGTH ||
+    firstLine.length > MAX_FIRST_LINE_LENGTH
+  ) {
+    throw new SummarizerParseError('step output summary violated the response contract', summary);
+  }
+  return summary;
+};
+
+export const fallbackStepOutputSummary = ({ output }: Params): string => {
+  if (output.length <= FALLBACK_HEAD_LENGTH + FALLBACK_TAIL_LENGTH) {
+    return output;
+  }
+  return `${output.slice(0, FALLBACK_HEAD_LENGTH)}\n...\n${output.slice(-FALLBACK_TAIL_LENGTH)}`;
+};

--- a/packages/core/src/summarizer/step-output.ts
+++ b/packages/core/src/summarizer/step-output.ts
@@ -10,6 +10,7 @@ const MAX_SUMMARY_LENGTH = 1200;
 const MAX_FIRST_LINE_LENGTH = 120;
 const FALLBACK_HEAD_LENGTH = 1500;
 const FALLBACK_TAIL_LENGTH = 400;
+const FALLBACK_JOINER = '\n...\n';
 
 const STEP_OUTPUT_SYSTEM_PROMPT = `Condense an AI coding agent step output into compact markdown for the next workflow step.
 
@@ -26,6 +27,10 @@ Output ONLY the compact markdown summary. No preamble, no surrounding quotes, no
 
 type Params = {
   readonly output: string;
+};
+
+type FallbackDetection = {
+  readonly summary: string;
 };
 
 type OneShotResult = {
@@ -91,5 +96,10 @@ export const fallbackStepOutputSummary = ({ output }: Params): string => {
   if (output.length <= FALLBACK_HEAD_LENGTH + FALLBACK_TAIL_LENGTH) {
     return output;
   }
-  return `${output.slice(0, FALLBACK_HEAD_LENGTH)}\n...\n${output.slice(-FALLBACK_TAIL_LENGTH)}`;
+  return `${output.slice(0, FALLBACK_HEAD_LENGTH)}${FALLBACK_JOINER}${output.slice(-FALLBACK_TAIL_LENGTH)}`;
 };
+
+export const isFallbackStepOutputSummary = ({ summary }: FallbackDetection): boolean =>
+  summary.length === FALLBACK_HEAD_LENGTH + FALLBACK_JOINER.length + FALLBACK_TAIL_LENGTH &&
+  summary.slice(FALLBACK_HEAD_LENGTH, FALLBACK_HEAD_LENGTH + FALLBACK_JOINER.length) ===
+    FALLBACK_JOINER;

--- a/packages/core/src/workflows/__tests__/orchestration.test.ts
+++ b/packages/core/src/workflows/__tests__/orchestration.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { IsoDateTime, Step, Agent, Workflow } from '@goodboy/types';
-import { nextStep, isWorkflowComplete } from '../sequencer';
-import { WorkflowPropagator } from '../propagator';
+import { buildStepPrompt, nextStep, isWorkflowComplete } from '../sequencer';
+import { buildChainCarryForward } from '../propagator';
 
 const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
 
@@ -37,65 +37,72 @@ const TEMPLATE: Workflow = {
   updatedAt: AT,
 };
 
-function completedRun(def: Step, summary: string): Agent {
+type Params = {
+  readonly definition: Step;
+  readonly summary: string;
+};
+
+const completedRun = ({ definition, summary }: Params): Agent => {
   return {
-    id: `run-${def.id}` as Agent['id'],
+    id: `run-${definition.id}` as Agent['id'],
     sessionId: 's1' as Agent['sessionId'],
-    stepId: def.id,
-    ordinal: def.ordinal,
-    name: def.name,
+    stepId: definition.id,
+    ordinal: definition.ordinal,
+    name: definition.name,
     status: 'completed',
     outputSummary: summary,
   };
-}
+};
 
 describe('phase orchestration end-to-end', () => {
-  it('drives planner → coder → reviewer with carry-forward context', async () => {
-    const summarizer = {
-      async summarizePhaseOutput(text: string): Promise<string> {
-        return `summary(${text})`;
-      },
-    };
-    const propagator = new WorkflowPropagator({ summarizer });
-
+  it('drives planner to coder to reviewer with carry-forward context', () => {
     const runs: Agent[] = [];
 
     const first = nextStep(TEMPLATE, runs);
     expect(first).toBe(PLANNER);
     expect(first?.ordinal).toBe(1);
-    runs.push(completedRun(PLANNER, 'plan output v1'));
+    runs.push(completedRun({ definition: PLANNER, summary: 'plan output v1' }));
 
     const second = nextStep(TEMPLATE, runs);
     expect(second).toBe(CODER);
     expect(second?.ordinal).toBe(2);
 
-    const transitionToCoder = await propagator.buildTransition({
-      fromOrdinal: PLANNER.ordinal,
-      toOrdinal: CODER.ordinal,
-      completedPhaseOutput: 'plan output v1',
-      existingSlots: [],
-      at: AT,
+    const carryForwardToCoder = buildChainCarryForward({
+      steps: runs.map((run) => ({
+        ordinal: run.ordinal,
+        name: run.name,
+        outputSummary: run.outputSummary,
+      })),
     });
-    expect(transitionToCoder.fromOrdinal).toBe(1);
-    expect(transitionToCoder.toOrdinal).toBe(2);
-    expect(transitionToCoder.carryForwardContext).toContain('plan output v1');
+    expect(carryForwardToCoder).toBe(
+      '## workflow handoff\n### step 1 output: planner\nplan output v1',
+    );
+    expect(
+      buildStepPrompt({
+        definition: CODER,
+        carryForwardContext: carryForwardToCoder,
+        userMessage: 'ship it',
+      }),
+    ).toBe(`implement plan\n\n${carryForwardToCoder}\n\nship it`);
 
-    runs.push(completedRun(CODER, 'code diff v1'));
+    runs.push(completedRun({ definition: CODER, summary: 'code diff v1' }));
 
     const third = nextStep(TEMPLATE, runs);
     expect(third).toBe(REVIEWER);
     expect(third?.ordinal).toBe(3);
 
-    const transitionToReviewer = await propagator.buildTransition({
-      fromOrdinal: CODER.ordinal,
-      toOrdinal: REVIEWER.ordinal,
-      completedPhaseOutput: 'code diff v1',
-      existingSlots: [],
-      at: AT,
+    const carryForwardToReviewer = buildChainCarryForward({
+      steps: runs.map((run) => ({
+        ordinal: run.ordinal,
+        name: run.name,
+        outputSummary: run.outputSummary,
+      })),
     });
-    expect(transitionToReviewer.carryForwardContext).toContain('code diff v1');
+    expect(carryForwardToReviewer).toBe(
+      '## workflow handoff\n### step 2 output: coder\ncode diff v1\n### earlier steps\n- step 1 planner: plan output v1',
+    );
 
-    runs.push(completedRun(REVIEWER, 'review notes'));
+    runs.push(completedRun({ definition: REVIEWER, summary: 'review notes' }));
 
     expect(nextStep(TEMPLATE, runs)).toBeNull();
     expect(isWorkflowComplete(TEMPLATE, runs)).toBe(true);

--- a/packages/core/src/workflows/exports.test.ts
+++ b/packages/core/src/workflows/exports.test.ts
@@ -5,6 +5,7 @@ import * as phases from './index';
 describe('phases barrel exports', () => {
   it('exposes browser-safe sequencer and propagator from @goodboy/core root', () => {
     expect(core.nextStep).toBeTypeOf('function');
+    expect(core.buildChainCarryForward).toBeTypeOf('function');
     expect(core.buildStepPrompt).toBeTypeOf('function');
     expect(core.isWorkflowComplete).toBeTypeOf('function');
     expect(core.WorkflowPropagator).toBeTypeOf('function');
@@ -12,6 +13,7 @@ describe('phases barrel exports', () => {
 
   it('exposes the same symbols from the phases sub-barrel', () => {
     expect(phases.nextStep).toBeTypeOf('function');
+    expect(phases.buildChainCarryForward).toBeTypeOf('function');
     expect(phases.buildStepPrompt).toBeTypeOf('function');
     expect(phases.isWorkflowComplete).toBeTypeOf('function');
     expect(phases.WorkflowPropagator).toBeTypeOf('function');

--- a/packages/core/src/workflows/exports.test.ts
+++ b/packages/core/src/workflows/exports.test.ts
@@ -8,7 +8,6 @@ describe('phases barrel exports', () => {
     expect(core.buildChainCarryForward).toBeTypeOf('function');
     expect(core.buildStepPrompt).toBeTypeOf('function');
     expect(core.isWorkflowComplete).toBeTypeOf('function');
-    expect(core.WorkflowPropagator).toBeTypeOf('function');
   });
 
   it('exposes the same symbols from the phases sub-barrel', () => {
@@ -16,7 +15,6 @@ describe('phases barrel exports', () => {
     expect(phases.buildChainCarryForward).toBeTypeOf('function');
     expect(phases.buildStepPrompt).toBeTypeOf('function');
     expect(phases.isWorkflowComplete).toBeTypeOf('function');
-    expect(phases.WorkflowPropagator).toBeTypeOf('function');
   });
 
   it('does NOT expose WorkflowRegistry from the root @goodboy/core barrel (node-only)', () => {

--- a/packages/core/src/workflows/exports.test.ts
+++ b/packages/core/src/workflows/exports.test.ts
@@ -6,6 +6,7 @@ describe('phases barrel exports', () => {
   it('exposes browser-safe sequencer and propagator from @goodboy/core root', () => {
     expect(core.nextStep).toBeTypeOf('function');
     expect(core.buildChainCarryForward).toBeTypeOf('function');
+    expect(core.buildParallelCarryForward).toBeTypeOf('function');
     expect(core.buildStepPrompt).toBeTypeOf('function');
     expect(core.isWorkflowComplete).toBeTypeOf('function');
   });
@@ -13,6 +14,7 @@ describe('phases barrel exports', () => {
   it('exposes the same symbols from the phases sub-barrel', () => {
     expect(phases.nextStep).toBeTypeOf('function');
     expect(phases.buildChainCarryForward).toBeTypeOf('function');
+    expect(phases.buildParallelCarryForward).toBeTypeOf('function');
     expect(phases.buildStepPrompt).toBeTypeOf('function');
     expect(phases.isWorkflowComplete).toBeTypeOf('function');
   });

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -8,12 +8,7 @@ export {
   runsForWorkflowRun,
   type WorkflowChainState,
 } from './sequencer';
-export {
-  buildChainCarryForward,
-  type ChainCarryForwardStep,
-  WorkflowPropagator,
-  type WorkflowPropagatorDeps,
-} from './propagator';
+export { buildChainCarryForward, type ChainCarryForwardStep } from './propagator';
 export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';
 export { seedWorkflowLibrary, type SeedResult, type SeedWorkflowLibraryDeps } from './seeder';
 export {

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -8,7 +8,12 @@ export {
   runsForWorkflowRun,
   type WorkflowChainState,
 } from './sequencer';
-export { WorkflowPropagator, type WorkflowPropagatorDeps } from './propagator';
+export {
+  buildChainCarryForward,
+  type ChainCarryForwardStep,
+  WorkflowPropagator,
+  type WorkflowPropagatorDeps,
+} from './propagator';
 export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';
 export { seedWorkflowLibrary, type SeedResult, type SeedWorkflowLibraryDeps } from './seeder';
 export {

--- a/packages/core/src/workflows/index.ts
+++ b/packages/core/src/workflows/index.ts
@@ -8,7 +8,12 @@ export {
   runsForWorkflowRun,
   type WorkflowChainState,
 } from './sequencer';
-export { buildChainCarryForward, type ChainCarryForwardStep } from './propagator';
+export {
+  buildChainCarryForward,
+  buildParallelCarryForward,
+  type ChainCarryForwardStep,
+  type ParallelCarryForwardBranch,
+} from './propagator';
 export { WORKFLOW_LIBRARY, type WorkflowLibraryEntry, type WorkflowLibraryStep } from './library';
 export { seedWorkflowLibrary, type SeedResult, type SeedWorkflowLibraryDeps } from './seeder';
 export {

--- a/packages/core/src/workflows/propagator.test.ts
+++ b/packages/core/src/workflows/propagator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildChainCarryForward } from './propagator';
+import { buildChainCarryForward, buildParallelCarryForward } from './propagator';
 
 describe('buildChainCarryForward', () => {
   it('returns an empty string without predecessors', () => {
@@ -46,5 +46,53 @@ describe('buildChainCarryForward', () => {
 
     expect(result).toContain('### step 2 output: Implement\n(no output captured)');
     expect(result).toContain('- step 1 Plan: (no output captured)');
+  });
+});
+
+describe('buildParallelCarryForward', () => {
+  it('returns an empty string without branch statuses', () => {
+    expect(buildParallelCarryForward({ groupName: 'Implementation', branches: [] })).toBe('');
+  });
+
+  it('renders completed summaries and failed branch errors', () => {
+    const result = buildParallelCarryForward({
+      groupName: 'Implementation',
+      branches: [
+        { name: 'API', status: 'completed', outputSummary: 'Added the API route.' },
+        {
+          name: 'UI',
+          status: 'failed',
+          outputSummary: 'This summary is not rendered.',
+          error: 'Typecheck failed\nadditional diagnostics',
+        },
+      ],
+    });
+
+    expect(result).toBe(
+      [
+        '## workflow handoff',
+        '### parallel group output: Implementation',
+        '#### branch 1: API',
+        'Added the API route.',
+        '#### branch 2: UI (failed)',
+        'Typecheck failed',
+      ].join('\n'),
+    );
+  });
+
+  it('degrades every branch body when the merged block exceeds 3000 characters', () => {
+    const result = buildParallelCarryForward({
+      groupName: 'Wide implementation',
+      branches: Array.from({ length: 5 }, (_, index) => ({
+        name: `Worker ${index + 1}`,
+        status: 'completed',
+        outputSummary: String(index + 1).repeat(700),
+      })),
+    });
+
+    expect(result).toContain(`#### branch 1: Worker 1\n${'1'.repeat(280)}`);
+    expect(result).not.toContain('1'.repeat(281));
+    expect(result).toContain(`#### branch 5: Worker 5\n${'5'.repeat(280)}`);
+    expect(result).not.toContain('5'.repeat(281));
   });
 });

--- a/packages/core/src/workflows/propagator.test.ts
+++ b/packages/core/src/workflows/propagator.test.ts
@@ -1,75 +1,50 @@
 import { describe, expect, it } from 'vitest';
-import type { ContextSlot, IsoDateTime } from '@goodboy/types';
-import { WorkflowPropagator } from './propagator';
+import { buildChainCarryForward } from './propagator';
 
-const AT = '2024-01-01T00:00:00.000Z' as IsoDateTime;
-
-function makeSummarizer(summary: string) {
-  return {
-    async summarizePhaseOutput(_text: string): Promise<string> {
-      return summary;
-    },
-  };
-}
-
-const SLOTS: ReadonlyArray<ContextSlot> = [{ key: 'goal', value: 'refactor auth', enabled: true }];
-
-describe('WorkflowPropagator.buildTransition', () => {
-  it('combines summary and serialized slots in carryForwardContext', async () => {
-    const propagator = new WorkflowPropagator({ summarizer: makeSummarizer('phase summary') });
-    const result = await propagator.buildTransition({
-      fromOrdinal: 0,
-      toOrdinal: 1,
-      completedPhaseOutput: 'raw output',
-      existingSlots: SLOTS,
-      at: AT,
-    });
-
-    expect(result.fromOrdinal).toBe(0);
-    expect(result.toOrdinal).toBe(1);
-    expect(result.at).toBe(AT);
-    expect(result.carryForwardContext).toContain('phase summary');
-    expect(result.carryForwardContext).toContain('refactor auth');
+describe('buildChainCarryForward', () => {
+  it('returns an empty string without predecessors', () => {
+    expect(buildChainCarryForward({ steps: [] })).toBe('');
   });
 
-  it('empty summary → slots text present without a leading double-newline', async () => {
-    const propagator = new WorkflowPropagator({ summarizer: makeSummarizer('') });
-    const result = await propagator.buildTransition({
-      fromOrdinal: 1,
-      toOrdinal: 2,
-      completedPhaseOutput: 'output',
-      existingSlots: SLOTS,
-      at: AT,
+  it('renders the full immediate predecessor summary without earlier steps', () => {
+    const result = buildChainCarryForward({
+      steps: [
+        { ordinal: 2, name: 'Implement', outputSummary: 'Changed `src/auth.ts`.\n- Tests pass' },
+      ],
     });
 
-    expect(result.carryForwardContext).not.toMatch(/^\n\n/);
-    expect(result.carryForwardContext).toContain('refactor auth');
+    expect(result).toBe(
+      '## workflow handoff\n### step 2 output: Implement\nChanged `src/auth.ts`.\n- Tests pass',
+    );
+    expect(result).not.toContain('### earlier steps');
   });
 
-  it('no slots → summary joined with serialized slot headers', async () => {
-    const propagator = new WorkflowPropagator({ summarizer: makeSummarizer('only summary') });
-    const result = await propagator.buildTransition({
-      fromOrdinal: 0,
-      toOrdinal: 1,
-      completedPhaseOutput: 'output',
-      existingSlots: [],
-      at: AT,
+  it('sorts predecessors and degrades older summaries by distance', () => {
+    const nearestSummary = `${'n'.repeat(275)}\nnearest tail`;
+    const result = buildChainCarryForward({
+      steps: [
+        { ordinal: 3, name: 'Review', outputSummary: 'Review passed.\nNo blockers.' },
+        { ordinal: 1, name: 'Plan', outputSummary: 'Plan selected option A.\nPlan details.' },
+        { ordinal: 2, name: 'Implement', outputSummary: nearestSummary },
+      ],
     });
 
-    expect(result.carryForwardContext).toContain('only summary');
+    expect(result).toContain('### step 3 output: Review\nReview passed.\nNo blockers.');
+    expect(result).toContain(`- step 2 Implement: ${nearestSummary.slice(0, 280)}`);
+    expect(result).toContain('- step 1 Plan: Plan selected option A.');
+    expect(result.indexOf('- step 2')).toBeLessThan(result.indexOf('- step 1'));
   });
 
-  it('empty summary and no slots → carryForwardContext contains only slot headers', async () => {
-    const propagator = new WorkflowPropagator({ summarizer: makeSummarizer('') });
-    const result = await propagator.buildTransition({
-      fromOrdinal: 0,
-      toOrdinal: 1,
-      completedPhaseOutput: '',
-      existingSlots: [],
-      at: AT,
+  it('degrades missing and empty output without throwing', () => {
+    const result = buildChainCarryForward({
+      steps: [
+        undefined,
+        { ordinal: 1, name: 'Plan' },
+        { ordinal: 2, name: 'Implement', outputSummary: '' },
+      ],
     });
 
-    expect(result.carryForwardContext).not.toMatch(/^\n\n/);
-    expect(result.carryForwardContext.trim().length).toBeGreaterThan(0);
+    expect(result).toContain('### step 2 output: Implement\n(no output captured)');
+    expect(result).toContain('- step 1 Plan: (no output captured)');
   });
 });

--- a/packages/core/src/workflows/propagator.ts
+++ b/packages/core/src/workflows/propagator.ts
@@ -1,5 +1,3 @@
-import type { ContextSlot, IsoDateTime, StepTransition } from '@goodboy/types';
-
 const EARLIER_STEP_PREVIEW_LENGTH = 280;
 const NO_OUTPUT = '(no output captured)';
 
@@ -51,39 +49,3 @@ export const buildChainCarryForward = ({ steps }: Params): string => {
   });
   return lines.join('\n');
 };
-
-export type WorkflowPropagatorDeps = {
-  readonly summarizer: { summarizePhaseOutput(text: string): Promise<string> };
-};
-
-type LegacyTransitionInput = {
-  readonly fromOrdinal: number;
-  readonly toOrdinal: number;
-  readonly completedPhaseOutput: string;
-  readonly existingSlots: ReadonlyArray<ContextSlot>;
-  readonly at: IsoDateTime;
-};
-
-export class WorkflowPropagator {
-  constructor(_deps?: WorkflowPropagatorDeps) {}
-
-  buildChainCarryForward({ steps }: Params): string {
-    return buildChainCarryForward({ steps });
-  }
-
-  buildTransition({
-    fromOrdinal,
-    toOrdinal,
-    completedPhaseOutput,
-    at,
-  }: LegacyTransitionInput): Promise<StepTransition> {
-    return Promise.resolve({
-      fromOrdinal,
-      toOrdinal,
-      carryForwardContext: buildChainCarryForward({
-        steps: [{ ordinal: fromOrdinal, name: '', outputSummary: completedPhaseOutput }],
-      }),
-      at,
-    });
-  }
-}

--- a/packages/core/src/workflows/propagator.ts
+++ b/packages/core/src/workflows/propagator.ts
@@ -1,5 +1,9 @@
 const EARLIER_STEP_PREVIEW_LENGTH = 280;
+const PARALLEL_BRANCH_PREVIEW_LENGTH = 600;
+const PARALLEL_BRANCH_DEGRADED_LENGTH = 280;
+const PARALLEL_HANDOFF_MAX_LENGTH = 3000;
 const NO_OUTPUT = '(no output captured)';
+const NO_ERROR = '(no error captured)';
 
 export type ChainCarryForwardStep = {
   readonly ordinal?: number | null;
@@ -7,11 +11,50 @@ export type ChainCarryForwardStep = {
   readonly outputSummary?: string | null;
 };
 
-type Params = {
+export type ParallelCarryForwardBranch = {
+  readonly name?: string | null;
+  readonly status?: string | null;
+  readonly outputSummary?: string | null;
+  readonly error?: string | null;
+};
+
+type ChainParams = {
   readonly steps?: ReadonlyArray<ChainCarryForwardStep | null | undefined> | null;
 };
 
-export const buildChainCarryForward = ({ steps }: Params): string => {
+type ParallelParams = {
+  readonly groupName?: string | null;
+  readonly branches?: ReadonlyArray<ParallelCarryForwardBranch | null | undefined> | null;
+};
+
+type NormalizedParallelBranch = {
+  readonly name: string;
+  readonly isFailed: boolean;
+  readonly body: string;
+};
+
+type RenderParallelParams = {
+  readonly groupName: string;
+  readonly branches: ReadonlyArray<NormalizedParallelBranch>;
+  readonly bodyLength: number;
+};
+
+const renderParallelCarryForward = ({
+  groupName,
+  branches,
+  bodyLength,
+}: RenderParallelParams): string => {
+  const lines = ['## workflow handoff', `### parallel group output: ${groupName}`];
+  branches.forEach((branch, index) => {
+    lines.push(
+      `#### branch ${index + 1}: ${branch.name}${branch.isFailed ? ' (failed)' : ''}`,
+      branch.body.slice(0, bodyLength),
+    );
+  });
+  return lines.join('\n');
+};
+
+export const buildChainCarryForward = ({ steps }: ChainParams): string => {
   const orderedSteps = (steps ?? [])
     .filter((step): step is ChainCarryForwardStep => step != null)
     .map((step) => ({
@@ -48,4 +91,45 @@ export const buildChainCarryForward = ({ steps }: Params): string => {
     lines.push(`- step ${step.ordinal} ${step.name}: ${preview ?? ''}`);
   });
   return lines.join('\n');
+};
+
+export const buildParallelCarryForward = ({ groupName, branches }: ParallelParams): string => {
+  const normalizedBranches = (branches ?? [])
+    .filter((branch): branch is ParallelCarryForwardBranch => branch != null)
+    .map((branch) => {
+      const isFailed = branch.status !== 'completed';
+      const outputSummary =
+        typeof branch.outputSummary === 'string' ? branch.outputSummary.trim() : '';
+      const error = typeof branch.error === 'string' ? branch.error.trim() : '';
+      const firstErrorLine = error.split(/\r?\n/, 1)[0] ?? '';
+      return {
+        name: typeof branch.name === 'string' ? branch.name.trim() : '',
+        isFailed,
+        body: isFailed
+          ? firstErrorLine.length > 0
+            ? firstErrorLine
+            : NO_ERROR
+          : outputSummary.length > 0
+            ? outputSummary
+            : NO_OUTPUT,
+      };
+    });
+  if (normalizedBranches.length === 0) {
+    return '';
+  }
+
+  const normalizedGroupName = typeof groupName === 'string' ? groupName.trim() : '';
+  const carryForward = renderParallelCarryForward({
+    groupName: normalizedGroupName,
+    branches: normalizedBranches,
+    bodyLength: PARALLEL_BRANCH_PREVIEW_LENGTH,
+  });
+  if (carryForward.length <= PARALLEL_HANDOFF_MAX_LENGTH) {
+    return carryForward;
+  }
+  return renderParallelCarryForward({
+    groupName: normalizedGroupName,
+    branches: normalizedBranches,
+    bodyLength: PARALLEL_BRANCH_DEGRADED_LENGTH,
+  });
 };

--- a/packages/core/src/workflows/propagator.ts
+++ b/packages/core/src/workflows/propagator.ts
@@ -1,29 +1,89 @@
 import type { ContextSlot, IsoDateTime, StepTransition } from '@goodboy/types';
-import { serializeSlots } from '../context';
+
+const EARLIER_STEP_PREVIEW_LENGTH = 280;
+const NO_OUTPUT = '(no output captured)';
+
+export type ChainCarryForwardStep = {
+  readonly ordinal?: number | null;
+  readonly name?: string | null;
+  readonly outputSummary?: string | null;
+};
+
+type Params = {
+  readonly steps?: ReadonlyArray<ChainCarryForwardStep | null | undefined> | null;
+};
+
+export const buildChainCarryForward = ({ steps }: Params): string => {
+  const orderedSteps = (steps ?? [])
+    .filter((step): step is ChainCarryForwardStep => step != null)
+    .map((step) => ({
+      ordinal: typeof step.ordinal === 'number' && Number.isFinite(step.ordinal) ? step.ordinal : 0,
+      name: typeof step.name === 'string' ? step.name.trim() : '',
+      outputSummary: typeof step.outputSummary === 'string' ? step.outputSummary : '',
+    }))
+    .sort((left, right) => left.ordinal - right.ordinal);
+  const immediateStep = orderedSteps.at(-1);
+  if (immediateStep == null) {
+    return '';
+  }
+
+  const immediateSummary = immediateStep.outputSummary.trim();
+  const lines = [
+    '## workflow handoff',
+    `### step ${immediateStep.ordinal} output: ${immediateStep.name}`,
+    immediateSummary.length > 0 ? immediateSummary : NO_OUTPUT,
+  ];
+  if (orderedSteps.length === 1) {
+    return lines.join('\n');
+  }
+
+  lines.push('### earlier steps');
+  const earlierSteps = orderedSteps.slice(0, -1).reverse();
+  earlierSteps.forEach((step, index) => {
+    const summary = step.outputSummary.trim();
+    if (summary.length === 0) {
+      lines.push(`- step ${step.ordinal} ${step.name}: ${NO_OUTPUT}`);
+      return;
+    }
+    const preview =
+      index === 0 ? summary.slice(0, EARLIER_STEP_PREVIEW_LENGTH) : summary.split(/\r?\n/, 1)[0];
+    lines.push(`- step ${step.ordinal} ${step.name}: ${preview ?? ''}`);
+  });
+  return lines.join('\n');
+};
 
 export type WorkflowPropagatorDeps = {
   readonly summarizer: { summarizePhaseOutput(text: string): Promise<string> };
 };
 
+type LegacyTransitionInput = {
+  readonly fromOrdinal: number;
+  readonly toOrdinal: number;
+  readonly completedPhaseOutput: string;
+  readonly existingSlots: ReadonlyArray<ContextSlot>;
+  readonly at: IsoDateTime;
+};
+
 export class WorkflowPropagator {
-  constructor(private readonly deps: WorkflowPropagatorDeps) {}
-  async buildTransition(input: {
-    fromOrdinal: number;
-    toOrdinal: number;
-    completedPhaseOutput: string;
-    existingSlots: ReadonlyArray<ContextSlot>;
-    at: IsoDateTime;
-  }): Promise<StepTransition> {
-    const summary = await this.deps.summarizer.summarizePhaseOutput(input.completedPhaseOutput);
-    const slotsText = serializeSlots(input.existingSlots);
-    const carryForwardContext = [summary, slotsText]
-      .filter((s) => s.trim().length > 0)
-      .join('\n\n');
-    return {
-      fromOrdinal: input.fromOrdinal,
-      toOrdinal: input.toOrdinal,
-      carryForwardContext,
-      at: input.at,
-    };
+  constructor(_deps?: WorkflowPropagatorDeps) {}
+
+  buildChainCarryForward({ steps }: Params): string {
+    return buildChainCarryForward({ steps });
+  }
+
+  buildTransition({
+    fromOrdinal,
+    toOrdinal,
+    completedPhaseOutput,
+    at,
+  }: LegacyTransitionInput): Promise<StepTransition> {
+    return Promise.resolve({
+      fromOrdinal,
+      toOrdinal,
+      carryForwardContext: buildChainCarryForward({
+        steps: [{ ordinal: fromOrdinal, name: '', outputSummary: completedPhaseOutput }],
+      }),
+      at,
+    });
   }
 }

--- a/packages/core/src/workflows/sequencer.test.ts
+++ b/packages/core/src/workflows/sequencer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { Step, Agent, Workflow } from '@goodboy/types';
+import type { Step, Agent, Workflow, WorkflowRunId } from '@goodboy/types';
 import {
   buildStepPrompt,
   classifyWorkflowChain,
@@ -7,6 +7,7 @@ import {
   findReusableAgent,
   isWorkflowComplete,
   nextStep,
+  runsForWorkflowRun,
 } from './sequencer';
 
 const D1: Step = {
@@ -167,6 +168,35 @@ describe('isWorkflowComplete', () => {
       makeRun('d3', 'pending', 3),
     ];
     expect(isWorkflowComplete(TEMPLATE, runs)).toBe(false);
+  });
+
+  it('advances past completed parallel branch rows scoped to the workflow run', () => {
+    const workflowRunId = 'workflow-run-parallel' as WorkflowRunId;
+    const parallelTemplate: Workflow = {
+      ...TEMPLATE,
+      steps: [{ ...D1, parallelGroup: 7 }, { ...D2, parallelGroup: 7 }, D3],
+    };
+    const rows = [
+      { ...makeRun('d1', 'pending', 1), workflowRunId },
+      { ...makeRun('d2', 'pending', 2), workflowRunId },
+      { ...makeRun('d3', 'pending', 3), workflowRunId },
+      { ...makeRun('d1', 'completed', 1, 'branch-a'), workflowRunId },
+      { ...makeRun('d2', 'completed', 2, 'branch-b'), workflowRunId },
+      {
+        ...makeRun('d1', 'completed', 1, 'foreign'),
+        workflowRunId: 'workflow-run-foreign' as WorkflowRunId,
+      },
+    ];
+    const scopedRows = runsForWorkflowRun(rows, workflowRunId);
+
+    expect(nextStep(parallelTemplate, scopedRows)).toBe(D3);
+    expect(isWorkflowComplete(parallelTemplate, scopedRows)).toBe(false);
+    expect(
+      isWorkflowComplete(parallelTemplate, [
+        ...scopedRows,
+        { ...makeRun('d3', 'completed', 3), workflowRunId },
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -97,6 +97,8 @@ export type TurnEvent =
       fromStep: { ordinal: number; name: string };
       toStep: { ordinal: number; name: string };
       carryForwardContext: string;
+      degraded?: true;
+      durationMs?: number;
       at: IsoDateTime;
     }
   | {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -109,7 +109,6 @@ export type {
   ParallelGroup,
   Step,
   StepDef,
-  StepTransition,
   Workflow,
 } from './workflow';
 export type {

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -103,14 +103,6 @@ export type Agent = Readonly<{
   sourceCommentUrl?: string;
 }>;
 
-export type StepTransition = Readonly<{
-  workflowRunId?: WorkflowRunId;
-  fromOrdinal: number;
-  toOrdinal: number;
-  carryForwardContext: string;
-  at: IsoDateTime;
-}>;
-
 export type ParallelGroup = {
   readonly id: ParallelGroupId;
   readonly sessionId: SessionId;


### PR DESCRIPTION
## Summary

Area 2 of the core refactor, stacked on #937 (retarget to main once #937 merges). The workflow step-to-step handoff goes from a blind 2000-char slice to a summarized, chained, retry-safe carry-forward.

## Output capture

- `slice(0, 2000)` is gone. Workflow step finalize summarizes the step output via a dedicated cheap-model prompt (`summarizeStepOutput`): <=1200 chars of compact markdown preserving file paths, decisions, actions, problems, blockers; the first line is a <=120 char outcome one-liner reused by the chain.
- 15s timeout with a deterministic fallback (head 1500 + tail 400); the fallback can never hang auto-advance and a summarizer error can never fail the step.
- Plain (non-workflow) agents and cluster/scout captures use the deterministic capture only: no per-turn LLM calls (deliberate, avoids the v0.1.2x-style token regression).

## Carry-forward chain

- `buildChainCarryForward`: every step receives ALL completed predecessors with degrading weight (N-1 full summary, N-2 first 280 chars, N-3+ first line) in a structured `## workflow handoff` markdown block. Empty predecessors render "(no output captured)". Never throws.
- Slots are no longer duplicated into the carry-forward: they enter the prompt once, via the preamble (closes the double-injection from the old `buildTransition`, which is deleted along with `WorkflowPropagator`, `StepTransition` and the identity `summarizePhaseOutput`).

## Retry safety

- Injection gate is transcript-based (no assistant output yet) instead of status-based: a retry after a failed attempt reconstructs the exact same carry-forward from persisted summaries.
- For providers without native session resume (codex, cursor, gemini), `buildPriorTurnsBlock` now replays step-transition handoffs chronologically inside the prior-turns block, under the same token budget, so the handoff survives retries and auto-continues on every provider, not just claude's `--resume`.

## Parallel groups

- After a fan-out the next step receives `buildParallelCarryForward`: per-branch sections (first 600 chars, degrading to 280 each above 3000 total), failed branches labeled with a one-line error. The group collapses to ONE predecessor entry in later chains.
- Branch agent rows now carry `workflowRunId` so run scoping sees them (covered by a dedicated sequencer test); non-representative branch summaries are capped deterministically.

## Observability

- `step_transition` events gain optional `degraded` (empty or fallback-truncated predecessor summary) and `durationMs`; PhaseTransitionCard shows a small warning badge and a compact duration. Backward compatible with old persisted transcripts.

## Known limits

- A summarizer timeout does not kill the spawned CLI process (cost still incurred; invoke API has no kill handle here).
- The step summarizer uses the session default provider, same policy as the slot summarizer.
- A manual next-step send during the <=15s finalize window can miss the still-finalizing predecessor in its chain (self-heals on the next injection).

## Test plan

- `pnpm typecheck` green (5 packages).
- `@goodboy/core`: 811 passed, 7 skipped.
- `desktop`: 2157 passed.
- New coverage: chain degrading weights, retry-identical carry-forward, prior-turns handoff replay, parallel merge (failed branch, oversize degradation), stuck-finalize repair, fallback detection, parallel-group scoping.