### PR TITLE
feat(desktop): linked work section in session overview

### DIFF
--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { SessionExternalTask, SessionId } from '@goodboy/types';
+
+type Store = {
+  sessionGithub: Record<
+    string,
+    {
+      pr?: {
+        number: number;
+        title: string;
+        state: 'draft' | 'open' | 'approved' | 'queued' | 'merged' | 'closed';
+      } | null;
+      linkedIssues?: ReadonlyArray<{ number: number; title?: string; url: string }>;
+      detail?: {
+        comments: ReadonlyArray<{ source: 'issue' | 'review'; resolved?: boolean }>;
+      } | null;
+    }
+  >;
+  sessionGitlabMr: Record<
+    string,
+    {
+      mr?: {
+        iid: number;
+        title: string;
+        state: string;
+        draft: boolean;
+      } | null;
+    }
+  >;
+  sessionExternalTasks: Record<string, SessionExternalTask>;
+};
+
+const { store, mocks } = vi.hoisted(() => ({
+  store: {
+    sessionGithub: {},
+    sessionGitlabMr: {},
+    sessionExternalTasks: {},
+  } as Store,
+  mocks: {
+    openUrl: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
+}));
+
+vi.mock('../../../../shared/lib/editor', () => ({
+  openUrl: mocks.openUrl,
+}));
+
+import { LinkedWorkSection } from './LinkedWorkSection';
+
+beforeEach(() => {
+  store.sessionGithub = {};
+  store.sessionGitlabMr = {};
+  store.sessionExternalTasks = {};
+  mocks.openUrl.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('LinkedWorkSection', () => {
+  it('renders a pull request with its state and unresolved review count', () => {
+    store.sessionGithub = {
+      'sess-1': {
+        pr: { number: 42, title: 'Ship linked work', state: 'open' },
+        detail: {
+          comments: [
+            { source: 'review', resolved: false },
+            { source: 'review', resolved: false },
+            { source: 'review', resolved: true },
+            { source: 'issue', resolved: false },
+          ],
+        },
+      },
+    };
+    const onSelectLens = vi.fn();
+
+    render(<LinkedWorkSection sessionId={'sess-1' as SessionId} onSelectLens={onSelectLens} />);
+
+    expect(screen.getByText('#42 Ship linked work')).toBeDefined();
+    expect(screen.getByText('In review · 2 unresolved')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /#42 Ship linked work/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('pr');
+  });
+
+  it('renders a merge request and routes it to the pull request lens', () => {
+    store.sessionGitlabMr = {
+      'sess-1': {
+        mr: { iid: 17, title: 'GitLab work', state: 'opened', draft: true },
+      },
+    };
+    const onSelectLens = vi.fn();
+
+    render(<LinkedWorkSection sessionId={'sess-1' as SessionId} onSelectLens={onSelectLens} />);
+
+    expect(screen.getByText('#17 GitLab work')).toBeDefined();
+    expect(screen.getByText('Draft')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /#17 GitLab work/i }));
+    expect(onSelectLens).toHaveBeenCalledWith('pr');
+  });
+
+  it('renders every linked issue and opens its external URL', () => {
+    store.sessionGithub = {
+      'sess-1': {
+        linkedIssues: [
+          { number: 7, title: 'First issue', url: 'https://github.com/acme/repo/issues/7' },
+          { number: 9, title: 'Second issue', url: 'https://github.com/acme/repo/issues/9' },
+        ],
+      },
+    };
+
+    render(<LinkedWorkSection sessionId={'sess-1' as SessionId} onSelectLens={vi.fn()} />);
+
+    expect(screen.getByText('#7 First issue')).toBeDefined();
+    expect(screen.getByText('#9 Second issue')).toBeDefined();
+    expect(screen.getAllByText('linked issue')).toHaveLength(2);
+    fireEvent.click(screen.getByRole('button', { name: /#9 Second issue/i }));
+    expect(mocks.openUrl).toHaveBeenCalledWith('https://github.com/acme/repo/issues/9');
+  });
+
+  it('renders the full external task chip with its default studio action', () => {
+    store.sessionExternalTasks = {
+      'sess-1': {
+        sessionId: 'sess-1',
+        provider: 'linear',
+        externalId: 'linear-42',
+        identifier: 'ENG-42',
+        url: 'https://linear.app/acme/issue/ENG-42',
+        title: 'Track linked work',
+        createdAt: '2026-07-21T10:00:00.000Z',
+      } as SessionExternalTask,
+    };
+    const handler = vi.fn();
+    window.addEventListener('goodboy:open-linear-studio', handler);
+
+    render(<LinkedWorkSection sessionId={'sess-1' as SessionId} onSelectLens={vi.fn()} />);
+
+    expect(screen.getByText('ENG-42')).toBeDefined();
+    expect(screen.getByText('Track linked work')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'open ENG-42 in Linear studio' }));
+    expect(handler).toHaveBeenCalledOnce();
+    expect((handler.mock.calls[0]![0] as CustomEvent).detail).toEqual({
+      issueExternalId: 'linear-42',
+    });
+    window.removeEventListener('goodboy:open-linear-studio', handler);
+  });
+
+  it('returns null when no linked work exists', () => {
+    const { container } = render(
+      <LinkedWorkSection sessionId={'sess-1' as SessionId} onSelectLens={vi.fn()} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
@@ -1,0 +1,89 @@
+import { CircleDot, GitPullRequest } from 'lucide-react';
+import { Eyebrow } from '@goodboy/ui';
+import type { PullRequestStateKind, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import type { LensKind } from '../../../../store';
+import { openUrl } from '../../../../shared/lib/editor';
+import { ExternalTaskChip } from '../../../integrations/components/ExternalTaskChip';
+import { pullRequestMeta } from '../../../github/components/PullRequestChip';
+import { SummaryRow } from './SummaryRow';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly onSelectLens: (lens: LensKind) => void;
+};
+
+export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {
+  const github = useAppStore((s) => s.sessionGithub[sessionId]);
+  const mergeRequest = useAppStore((s) => s.sessionGitlabMr[sessionId]?.mr ?? null);
+  const externalTask = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? null);
+  const pullRequest = github?.pr ?? null;
+  const linkedIssues = github?.linkedIssues ?? [];
+  const unresolvedReviewComments =
+    github?.detail?.comments.filter(
+      (comment) => comment.source === 'review' && comment.resolved === false,
+    ).length ?? 0;
+
+  if (
+    pullRequest == null &&
+    mergeRequest == null &&
+    linkedIssues.length === 0 &&
+    externalTask == null
+  ) {
+    return null;
+  }
+
+  const pullRequestLabel =
+    pullRequest == null
+      ? null
+      : `${pullRequestMeta(pullRequest.state).label}${
+          unresolvedReviewComments > 0 ? ` · ${unresolvedReviewComments} unresolved` : ''
+        }`;
+  const mergeRequestState: PullRequestStateKind | null =
+    mergeRequest == null
+      ? null
+      : mergeRequest.draft
+        ? 'draft'
+        : mergeRequest.state === 'merged'
+          ? 'merged'
+          : mergeRequest.state === 'closed'
+            ? 'closed'
+            : 'open';
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Eyebrow label="Linked work" muted className="px-0.5 font-medium" />
+      <div className="flex flex-col gap-2">
+        {pullRequest != null && pullRequestLabel != null ? (
+          <SummaryRow
+            icon={GitPullRequest}
+            tone="accent"
+            value={`#${pullRequest.number} ${pullRequest.title}`}
+            label={pullRequestLabel}
+            onClick={() => onSelectLens('pr')}
+          />
+        ) : null}
+        {mergeRequest != null && mergeRequestState != null ? (
+          <SummaryRow
+            icon={GitPullRequest}
+            tone="accent"
+            value={`#${mergeRequest.iid} ${mergeRequest.title}`}
+            label={pullRequestMeta(mergeRequestState).label}
+            onClick={() => onSelectLens('pr')}
+          />
+        ) : null}
+        {linkedIssues.map((issue) => (
+          <SummaryRow
+            key={issue.url}
+            icon={CircleDot}
+            tone="info"
+            value={`#${issue.number}${issue.title != null ? ` ${issue.title}` : ''}`}
+            label="linked issue"
+            onClick={() => void openUrl(issue.url)}
+          />
+        ))}
+        {externalTask != null ? <ExternalTaskChip task={externalTask} variant="full" /> : null}
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/SummaryRow.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/SummaryRow.tsx
@@ -6,18 +6,22 @@ import type { Tone } from '@goodboy/ui';
 type Props = {
   readonly icon: LucideIcon;
   readonly tone: Tone;
+  readonly value?: string;
   readonly label: string;
   readonly onClick: () => void;
 };
 
-export const SummaryRow = ({ icon: Icon, tone, label, onClick }: Props) => (
+export const SummaryRow = ({ icon: Icon, tone, value, label, onClick }: Props) => (
   <button
     type="button"
     onClick={onClick}
     className="group flex items-center gap-2 rounded-lg border border-border-soft bg-elevated px-3.5 py-2.5 text-left shadow-sm transition-colors hover:border-border"
   >
     <Icon size={14} aria-hidden className={cn('shrink-0', tintClasses(tone).icon)} />
-    <span className="min-w-0 flex-1 truncate text-sm text-foreground">{label}</span>
+    <span className="min-w-0 flex-1 truncate text-sm text-foreground">{value ?? label}</span>
+    {value != null ? (
+      <span className="shrink-0 text-2xs text-muted-foreground">{label}</span>
+    ) : null}
     <ArrowRight
       size={14}
       aria-hidden

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.test.tsx
@@ -2,7 +2,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
-import type { OpenQuestion, Session, SessionStageInfo, Workspace } from '@goodboy/types';
+import type {
+  OpenQuestion,
+  Session,
+  SessionExternalTask,
+  SessionStageInfo,
+  Workspace,
+} from '@goodboy/types';
 import type { FilesTouched } from '../../../../store';
 
 type Store = {
@@ -15,6 +21,7 @@ type Store = {
     { pr?: unknown; detail?: { comments: ReadonlyArray<unknown> } | null }
   >;
   sessionGitlabMr: Record<string, { mr?: unknown }>;
+  sessionExternalTasks: Record<string, SessionExternalTask>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
   activateWorkflowAgent: ReturnType<typeof vi.fn>;
   selectAgent: ReturnType<typeof vi.fn>;
@@ -44,6 +51,7 @@ const { store, hooks, runs } = vi.hoisted(() => ({
     scriptRuns: {} as Record<string, Record<string, { status: string }>>,
     sessionGithub: {} as Record<string, { pr?: unknown }>,
     sessionGitlabMr: {} as Record<string, { mr?: unknown }>,
+    sessionExternalTasks: {} as Record<string, SessionExternalTask>,
     setFocusedWorkflowRun: vi.fn(),
     activateWorkflowAgent: vi.fn(async () => undefined),
     selectAgent: vi.fn(async () => undefined),
@@ -181,6 +189,7 @@ beforeEach(() => {
   store.scriptRuns = {};
   store.sessionGithub = {};
   store.sessionGitlabMr = {};
+  store.sessionExternalTasks = {};
   store.setFocusedWorkflowRun.mockReset();
   store.activateWorkflowAgent.mockReset();
   store.activateWorkflowAgent.mockResolvedValue(undefined);
@@ -301,7 +310,7 @@ describe('SessionOverviewPane resolve section', () => {
   it('surfaces the resolve section and routes a comment row to the resolve lens', () => {
     store.sessionGithub = {
       'sess-1': {
-        pr: { number: 1 },
+        pr: { number: 1, title: 'Resolve review', state: 'open' },
         detail: { comments: [{ source: 'review', resolved: false }] },
       },
     };

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/index.tsx
@@ -45,8 +45,8 @@ import { SpawnAgentMenu } from '../../../workspace/components/WorkspacesSidebar/
 import { PendingResolutionsStrip } from '../../../context/components/ContextPanel/strips/PendingResolutionsStrip';
 import { useSessionTitleRename } from '../../hooks/useSessionTitleRename';
 import { useResolvableCount } from '../../hooks/useResolvableCount';
-import { pullRequestMeta } from '../../../github/components/PullRequestChip';
 import { PipelineSection } from './PipelineSection';
+import { LinkedWorkSection } from './LinkedWorkSection';
 import { StartRowContent } from './StartRowContent';
 import { StartTileContent } from './StartTileContent';
 import { SummaryRow } from './SummaryRow';
@@ -145,25 +145,6 @@ export const SessionOverviewPane = ({
   const unreadLens = useSessionUnreadLens(session.id as SessionId);
   const runningAgents = nonResolverAgents.filter((a) => a.status === 'running').length;
   const activePlans = useSessionPlans(session.id).filter((p) => p.status === 'active').length;
-  const pullRequestState = useAppStore((s) => s.sessionGithub[session.id]?.pr?.state ?? null);
-  const mergeRequest = useAppStore((s) => s.sessionGitlabMr[session.id]?.mr ?? null);
-  const mergeRequestState =
-    mergeRequest == null
-      ? null
-      : mergeRequest.draft
-        ? 'draft'
-        : mergeRequest.state === 'merged'
-          ? 'merged'
-          : mergeRequest.state === 'closed'
-            ? 'closed'
-            : 'open';
-  const pullRequestLabel =
-    pullRequestState != null
-      ? pullRequestMeta(pullRequestState).label
-      : mergeRequestState != null
-        ? pullRequestMeta(mergeRequestState).label
-        : 'None';
-  const hasPr = pullRequestState != null || mergeRequest != null;
   const resolvable = useResolvableCount(session.id as SessionId);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setFocusedWorkflowRun = useAppStore((s) => s.setFocusedWorkflowRun);
@@ -310,14 +291,6 @@ export const SessionOverviewPane = ({
       label: openCount === 1 ? 'question' : 'questions',
       active: openCount > 0,
       alert: openCount > 0,
-    },
-    {
-      kind: 'pr',
-      icon: GitPullRequest,
-      tone: 'accent',
-      value: pullRequestLabel,
-      label: 'pull request',
-      active: hasPr,
     },
   ];
 
@@ -503,6 +476,8 @@ export const SessionOverviewPane = ({
             onSelectLens={onSelectLens}
           />
         ) : null}
+
+        <LinkedWorkSection sessionId={session.id as SessionId} onSelectLens={onSelectLens} />
 
         {resolvableItems > 0 ? (
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## What
The pull request no longer lives as a metric inside "At a glance". The session overview gets a dedicated **Linked work** section (between Activity and Resolve) that gathers everything externally linked to the session's task:

- **GitHub PR** row: number + title, state label, unresolved review comment count. Click opens the PR lens.
- **GitLab MR** row: same shape, mapped through the same state labels. Click opens the PR lens (PrPane already renders the MR strip).
- **Linked issues**: one row per `linkedIssues` entry, click opens the issue URL.
- **External task**: the existing ExternalTaskChip (Linear / Sentry / GitLab issue the session was created from), click opens the studio.

Section hides entirely when nothing is linked. "At a glance" keeps files, agents, plans, questions.

This is the first step toward a task-scoped tracking view (comments, status, future Linear/Jira/Sentry detail) living in one place instead of scattered under context.

## Implementation
- New `SessionOverviewPane/LinkedWorkSection.tsx` following the existing section pattern (Eyebrow + SummaryRow).
- `SummaryRow` gains an optional `value` prop (value + trailing label) with unchanged rendering when omitted.
- All data comes from existing store slices: `sessionGithub` (pr, detail.comments, linkedIssues), `sessionGitlabMr`, `sessionExternalTasks`. No backend or store changes.

## Verification
- typecheck 5/5
- desktop suite: 2139 passed
- new tests: PR row with state + unresolved count, MR row, linked issue rows via openUrl, ExternalTaskChip render, section hidden when empty; overview test updated for the metric removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)