### PR TITLE
refactor(desktop): workflow nav overhaul, breadcrumb stepper + lens redesign

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -77,6 +77,8 @@ export const App = () => {
   const hasWorkspaces = workspaces.length > 0;
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
+  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
+  const toggleSessionsSidebar = useAppStore((s) => s.toggleSessionsSidebar);
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
       (i) => i.provider === 'linear',
@@ -686,6 +688,7 @@ export const App = () => {
   useKeyboardShortcut('cmd+k', () => openPalette());
   useKeyboardShortcut('cmd+o', () => setSwitcherOpen(true));
   useKeyboardShortcut('cmd+n', openNewSession, { ignoreInInputs: false });
+  useKeyboardShortcut('cmd+b', toggleSessionsSidebar, { ignoreInInputs: false });
   useKeyboardShortcut('cmd+[', () => navigateLens(-1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+]', () => navigateLens(1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+shift+[', () => navigateSession(-1), { ignoreInInputs: false });
@@ -804,7 +807,7 @@ export const App = () => {
             />
           ) : undefined
         }
-        leftHidden={!currentSession}
+        leftHidden={!currentSession || sessionsSidebarCollapsed}
         leftSidebar={hasWorkspaces ? <WorkspacesSidebar /> : undefined}
         main={
           <div className="relative h-full w-full">

--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -70,6 +70,29 @@ describe('resolveRootAgent', () => {
     expect(agentHomeLens(resolved, classifyAgent(resolved, null))).toBe('workflows');
   });
 
+  it('routes a parallel branch with only a step binding to its orchestrator home', () => {
+    const orchestrator = agentOf({
+      id: 'orchestrator' as AgentId,
+      workflowRunId: WF,
+      stepId: STEP,
+      kind: 'implementer',
+    });
+    const branch = agentOf({
+      id: 'branch' as AgentId,
+      parentAgentId: orchestrator.id,
+      stepId: 'branch-step' as StepId,
+      kind: 'implementer',
+    });
+
+    const resolved = resolveRootAgent({ agents: [branch, orchestrator], agentId: branch.id });
+
+    expect(resolved).toBe(orchestrator);
+    if (resolved == null) {
+      throw new Error('Expected an orchestrating agent');
+    }
+    expect(agentHomeLens(resolved, classifyAgent(resolved, null))).toBe('workflows');
+  });
+
   it('stops at the highest available agent when a parent is missing', () => {
     const child = agentOf({ id: 'child' as AgentId, parentAgentId: 'missing' as AgentId });
 

--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -13,6 +13,7 @@ import {
   isStandaloneAgent,
   kindConsumesPlan,
   resolveAgentKind,
+  resolveRootAgent,
   selectNonResolverStandaloneAgents,
   selectStandaloneAgents,
 } from './agent-kind';
@@ -44,6 +45,45 @@ const ALL_KINDS: ReadonlyArray<AgentKind> = [
 function makeStep(role: string, name = role): WorkflowLibraryStep {
   return { name, role, promptPrefix: '', expectedOutput: '' };
 }
+
+describe('resolveRootAgent', () => {
+  it('routes a cluster child through its topmost workflow-step ancestor', () => {
+    const root = agentOf({
+      id: 'root' as AgentId,
+      workflowRunId: WF,
+      stepId: STEP,
+      kind: 'implementer',
+    });
+    const child = agentOf({
+      id: 'child' as AgentId,
+      parentAgentId: root.id,
+      workflowRunId: WF,
+      kind: 'scout',
+    });
+
+    const resolved = resolveRootAgent({ agents: [child, root], agentId: child.id });
+
+    expect(resolved).toBe(root);
+    if (resolved == null) {
+      throw new Error('Expected a root agent');
+    }
+    expect(agentHomeLens(resolved, classifyAgent(resolved, null))).toBe('workflows');
+  });
+
+  it('stops at the highest available agent when a parent is missing', () => {
+    const child = agentOf({ id: 'child' as AgentId, parentAgentId: 'missing' as AgentId });
+
+    expect(resolveRootAgent({ agents: [child], agentId: child.id })).toBe(child);
+    expect(resolveRootAgent({ agents: [child], agentId: 'unknown' as AgentId })).toBeNull();
+  });
+
+  it('stops safely when the parent chain contains a cycle', () => {
+    const first = agentOf({ id: 'first' as AgentId, parentAgentId: 'second' as AgentId });
+    const second = agentOf({ id: 'second' as AgentId, parentAgentId: first.id });
+
+    expect(resolveRootAgent({ agents: [first, second], agentId: first.id })).toBe(second);
+  });
+});
 
 describe('agentHomeLens', () => {
   it('routes a full workflow step agent (workflowRunId + stepId) to workflows', () => {

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -1,9 +1,34 @@
 import { classifyFirstTurn, type AgentKindLabel, type WorkflowLibraryStep } from '@goodboy/core';
-import type { Agent, AgentRole } from '@goodboy/types';
+import type { Agent, AgentId, AgentRole } from '@goodboy/types';
 
 export type AgentKind = AgentKindLabel;
 
 export type AgentHomeLens = 'agents' | 'resolve' | 'workflows';
+
+type Params = {
+  readonly agents: ReadonlyArray<Agent>;
+  readonly agentId: AgentId;
+};
+
+export const resolveRootAgent = ({ agents, agentId }: Params): Agent | null => {
+  const agentsById = new Map(agents.map((agent) => [agent.id, agent]));
+  let agent = agentsById.get(agentId) ?? null;
+  const visited = new Set<AgentId>();
+
+  while (agent != null) {
+    visited.add(agent.id);
+    if (agent.parentAgentId == null || visited.has(agent.parentAgentId)) {
+      return agent;
+    }
+    const parent = agentsById.get(agent.parentAgentId) ?? null;
+    if (parent == null) {
+      return agent;
+    }
+    agent = parent;
+  }
+
+  return null;
+};
 
 export const agentHomeLens = (agent: Agent, kind: AgentKind): AgentHomeLens => {
   if (agent.workflowRunId != null && agent.stepId != null) {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, SessionId, StepId, WorkflowRunId } from '@goodboy/types';
+
+type StoreState = {
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  selectedAgentId: Record<string, AgentId>;
+  agentKindOverride: Record<string, string>;
+};
+
+const { store } = vi.hoisted(() => {
+  const store: { state: StoreState } = {
+    state: {
+      sessionPhaseRuns: {},
+      selectedAgentId: {},
+      agentKindOverride: {},
+    },
+  };
+  return { store };
+});
+
+vi.mock('../../../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: (selector: (state: StoreState) => unknown) => selector(store.state),
+}));
+
+import { useSelectedAgentHome } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const ROOT_ID = 'root' as AgentId;
+const CHILD_ID = 'child' as AgentId;
+
+type Params = {
+  readonly id: AgentId;
+  readonly kind: string;
+  readonly parentAgentId?: AgentId;
+  readonly workflowRunId?: WorkflowRunId;
+  readonly stepId?: StepId;
+};
+
+const createAgent = ({ id, kind, parentAgentId, workflowRunId, stepId }: Params): Agent => ({
+  id,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: kind,
+  status: 'pending',
+  kind,
+  parentAgentId,
+  workflowRunId,
+  stepId,
+});
+
+beforeEach(() => {
+  store.state = {
+    sessionPhaseRuns: {},
+    selectedAgentId: { [SESSION_ID]: CHILD_ID },
+    agentKindOverride: {},
+  };
+});
+
+describe('useSelectedAgentHome', () => {
+  it('routes a cluster sub-agent to the workflow-step parent home', () => {
+    store.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        createAgent({
+          id: ROOT_ID,
+          kind: 'implementer',
+          workflowRunId: 'workflow-1' as WorkflowRunId,
+          stepId: 'step-1' as StepId,
+        }),
+        createAgent({
+          id: CHILD_ID,
+          kind: 'scout',
+          parentAgentId: ROOT_ID,
+          workflowRunId: 'workflow-1' as WorkflowRunId,
+        }),
+      ],
+    };
+
+    const { result } = renderHook(() => useSelectedAgentHome(SESSION_ID));
+
+    expect(result.current).toBe('workflows');
+  });
+
+  it('keeps an ad-hoc scout child in the agents home', () => {
+    store.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        createAgent({ id: ROOT_ID, kind: 'scout' }),
+        createAgent({ id: CHILD_ID, kind: 'scout', parentAgentId: ROOT_ID }),
+      ],
+    };
+
+    const { result } = renderHook(() => useSelectedAgentHome(SESSION_ID));
+
+    expect(result.current).toBe('agents');
+  });
+
+  it('uses the resolver root override instead of the child override', () => {
+    store.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        createAgent({ id: ROOT_ID, kind: 'generic' }),
+        createAgent({ id: CHILD_ID, kind: 'scout', parentAgentId: ROOT_ID }),
+      ],
+    };
+    store.state.agentKindOverride = {
+      [ROOT_ID]: 'resolver',
+      [CHILD_ID]: 'implementer',
+    };
+
+    const { result } = renderHook(() => useSelectedAgentHome(SESSION_ID));
+
+    expect(result.current).toBe('resolve');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/hooks/useSelectedAgentHome/index.ts
@@ -1,23 +1,32 @@
 import { useMemo } from 'react';
 import type { SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
-import { agentHomeLens, classifyAgent, type AgentHomeLens } from '../../../../agent-kind';
+import {
+  agentHomeLens,
+  classifyAgent,
+  resolveRootAgent,
+  type AgentHomeLens,
+} from '../../../../agent-kind';
 
 export const useSelectedAgentHome = (sessionId: SessionId): AgentHomeLens | null => {
   const selectedAgentId = useAppStore((s) => s.selectedAgentId[sessionId] ?? null);
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
-  const override = useAppStore((s) =>
-    selectedAgentId ? (s.agentKindOverride[selectedAgentId] ?? null) : null,
-  );
+  const rootAgent = useMemo(() => {
+    if (selectedAgentId == null) {
+      return null;
+    }
+    return resolveRootAgent({ agents: phaseRuns, agentId: selectedAgentId });
+  }, [selectedAgentId, phaseRuns]);
+  const override = useAppStore((s) => {
+    if (rootAgent == null) {
+      return null;
+    }
+    return s.agentKindOverride[rootAgent.id] ?? null;
+  });
   return useMemo(() => {
-    if (!selectedAgentId) {
+    if (rootAgent == null) {
       return null;
     }
-    const agent = phaseRuns.find((r) => r.id === selectedAgentId);
-    if (!agent) {
-      return null;
-    }
-    const kind = classifyAgent(agent, override);
-    return agentHomeLens(agent, kind);
-  }, [selectedAgentId, phaseRuns, override]);
+    return agentHomeLens(rootAgent, classifyAgent(rootAgent, override));
+  }, [rootAgent, override]);
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -72,7 +72,9 @@ vi.mock('../../../workspace/components/WorkspacesSidebar/parts/AgentsSection', (
   ),
 }));
 vi.mock('../../../../app/components/AppBreadcrumb', () => ({
-  AppBreadcrumb: () => <div data-testid="breadcrumb" />,
+  AppBreadcrumb: ({ crumbs }: { crumbs: ReadonlyArray<{ label: string }> }) => (
+    <div data-testid="breadcrumb">{crumbs.map((crumb) => crumb.label).join(' / ')}</div>
+  ),
 }));
 vi.mock('../SessionOverviewPane', () => ({ SessionOverviewPane: () => null }));
 vi.mock('./parts/SessionStudioLayer', () => ({ SessionStudioLayer: () => null }));
@@ -150,5 +152,38 @@ describe('SessionWorkspace agent overlay', () => {
         .getAllByTestId('divider')
         .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
     ).toHaveLength(2);
+  });
+});
+
+describe('SessionWorkspace workflow breadcrumb', () => {
+  it('uses the visible workflow name when the only run is not explicitly focused', () => {
+    store.activeLens = { [SESSION_ID]: 'workflows' };
+    store.selectedAgentId = {};
+    store.phaseTemplates = {
+      'workspace-1': [
+        {
+          id: 'workflow-1',
+          name: 'refactor',
+          steps: [],
+        },
+      ],
+    };
+    const workflowSession = {
+      ...session,
+      workflowRuns: [
+        {
+          id: 'run-1',
+          workflowId: 'workflow-1',
+          ordinal: 0,
+          currentStep: 0,
+          autoRun: true,
+          triggerMode: 'immediate',
+        },
+      ],
+    } as unknown as Session;
+
+    render(<SessionWorkspace session={workflowSession} isActive />);
+
+    expect(screen.getByTestId('breadcrumb').textContent).toBe('Overview / Workflows / refactor');
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, Session } from '@goodboy/types';
+import type { LensKind } from '../../../../store';
+
+type Store = {
+  activeLens: Record<string, LensKind | null>;
+  selectedAgentId: Record<string, string>;
+  sessionWorktrees: Record<string, ReadonlyArray<string>>;
+  sessionStudio: Record<string, null>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  focusedWorkflowRunId: Record<string, string | null>;
+  phaseTemplates: Record<string, ReadonlyArray<unknown>>;
+  sessionWorkflows: Record<string, ReadonlyArray<unknown>>;
+  focusedPlanId: Record<string, string | null>;
+  setActiveLens: ReturnType<typeof vi.fn>;
+  setSessionStudio: ReturnType<typeof vi.fn>;
+  setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
+  setFocusedPlanId: ReturnType<typeof vi.fn>;
+  reconcileSessionBranch: ReturnType<typeof vi.fn>;
+};
+
+const { store, hooks } = vi.hoisted(() => ({
+  store: {
+    activeLens: {},
+    selectedAgentId: {},
+    sessionWorktrees: {},
+    sessionStudio: {},
+    sessionPhaseRuns: {},
+    focusedWorkflowRunId: {},
+    phaseTemplates: {},
+    sessionWorkflows: {},
+    focusedPlanId: {},
+    setActiveLens: vi.fn(),
+    setSessionStudio: vi.fn(),
+    setFocusedWorkflowRun: vi.fn(),
+    setFocusedPlanId: vi.fn(),
+    reconcileSessionBranch: vi.fn(async () => undefined),
+  } as Store,
+  hooks: { agentHome: 'workflows' as LensKind },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  readPersistedLens: () => null,
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
+  useFilesTouched: () => ({ count: 0 }),
+  useSessionPlans: () => [],
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    Divider: ({ orientation }: { orientation?: string }) => (
+      <div data-testid="divider" data-orientation={orientation ?? 'horizontal'} />
+    ),
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+vi.mock('../../../chat/components/ChatView', () => ({
+  ChatView: () => <div data-testid="chat-view" />,
+}));
+vi.mock('../../../terminal/components/TerminalDock', () => ({ TerminalDock: () => null }));
+vi.mock('../../../plans/components/PlanStudio', () => ({ PlanStudio: () => null }));
+vi.mock('../../../scripts', () => ({ ScriptsPanel: () => null }));
+vi.mock('../../../worktree/worktree', () => ({ worktreeStatus: vi.fn() }));
+vi.mock('../../../workspace/components/WorkspacesSidebar/parts/AgentsSection', () => ({
+  AgentsSection: ({ only }: { only: string }) => (
+    <div data-testid="agents-section" data-home={only} />
+  ),
+}));
+vi.mock('../../../../app/components/AppBreadcrumb', () => ({
+  AppBreadcrumb: () => <div data-testid="breadcrumb" />,
+}));
+vi.mock('../SessionOverviewPane', () => ({ SessionOverviewPane: () => null }));
+vi.mock('./parts/SessionStudioLayer', () => ({ SessionStudioLayer: () => null }));
+vi.mock('./parts/SessionTopBar', () => ({ SessionTopBar: () => null }));
+vi.mock('./parts/LensColumn', () => ({ LensColumn: () => null }));
+vi.mock('./parts/QuestionsPane', () => ({ QuestionsPane: () => null }));
+vi.mock('./parts/SlotPane', () => ({ SlotPane: () => null }));
+vi.mock('./parts/PrPane', () => ({ PrPane: () => null }));
+vi.mock('./parts/FilesPane', () => ({ FilesPane: () => null }));
+vi.mock('./parts/PaneShell', () => ({
+  PaneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('./hooks/useSelectedAgentHome', () => ({
+  useSelectedAgentHome: () => hooks.agentHome,
+}));
+vi.mock('./parts/WorkflowStrip', () => ({
+  WorkflowStrip: () => <div data-testid="workflow-strip" />,
+}));
+
+import { SessionWorkspace } from './index';
+
+const SESSION_ID = 'session-1';
+const selectedAgent = {
+  id: 'agent-1',
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'Selected agent',
+  status: 'running',
+} as Agent;
+const session = {
+  id: SESSION_ID,
+  workspaceId: 'workspace-1',
+  workflowRuns: [],
+} as unknown as Session;
+
+beforeEach(() => {
+  store.activeLens = { [SESSION_ID]: 'agents' };
+  store.selectedAgentId = { [SESSION_ID]: selectedAgent.id };
+  store.sessionWorktrees = {};
+  store.sessionStudio = { [SESSION_ID]: null };
+  store.sessionPhaseRuns = { [SESSION_ID]: [selectedAgent] };
+  store.focusedWorkflowRunId = {};
+  store.phaseTemplates = {};
+  store.sessionWorkflows = {};
+  store.focusedPlanId = {};
+  store.setActiveLens.mockReset();
+  hooks.agentHome = 'workflows';
+});
+
+afterEach(cleanup);
+
+describe('SessionWorkspace agent overlay', () => {
+  it('uses the full overlay width and workflow strip for workflow agents', () => {
+    const { container } = render(<SessionWorkspace session={session} isActive />);
+    expect(screen.getByTestId('workflow-strip')).toBeDefined();
+    expect(screen.getByTestId('chat-view')).toBeDefined();
+    expect(container.querySelector('.w-72')).toBeNull();
+    expect(screen.queryByTestId('agents-section')).toBeNull();
+    expect(
+      screen
+        .getAllByTestId('divider')
+        .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
+    ).toHaveLength(1);
+  });
+
+  it('keeps the agents-home overlay panel unchanged', () => {
+    hooks.agentHome = 'agents';
+    const { container } = render(<SessionWorkspace session={session} isActive />);
+    expect(screen.queryByTestId('workflow-strip')).toBeNull();
+    expect(container.querySelector('.w-72')).not.toBeNull();
+    expect(screen.getByTestId('agents-section').getAttribute('data-home')).toBe('agents');
+    expect(screen.getByRole('button', { name: 'Agents' })).toBeDefined();
+    expect(
+      screen
+        .getAllByTestId('divider')
+        .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
+    ).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { ArrowLeft } from 'lucide-react';
-import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
+import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { Divider, ScrollFade, cn } from '@goodboy/ui';
 import { ChatView } from '../../../chat/components/ChatView';
 import { TerminalDock } from '../../../terminal/components/TerminalDock';
@@ -30,6 +30,8 @@ import { PaneShell } from './parts/PaneShell';
 import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
 import { buildSessionBreadcrumb } from './sessionBreadcrumb';
 import { WorkflowStrip } from './parts/WorkflowStrip';
+import { WorkflowsPane } from './parts/WorkflowsPane';
+import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -71,12 +73,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     (s) => s.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId[sessionId] ?? null);
-  const phaseTemplates = useAppStore(
-    (s) => s.phaseTemplates[session.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
-  );
-  const sessionWorkflows = useAppStore(
-    (s) => s.sessionWorkflows[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
-  );
+  const attachedWorkflowRuns = useAttachedWorkflowRuns({ session });
   const plans = useSessionPlans(sessionId);
 
   useEffect(() => {
@@ -122,15 +119,10 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     [phaseRuns, selectedAgentId],
   );
   const focusedWorkflowName = useMemo(() => {
-    if (focusedWorkflowRunId == null) return null;
-    const run = session.workflowRuns.find((r) => r.id === focusedWorkflowRunId);
-    if (!run) return null;
-    const workflow =
-      phaseTemplates.find((w) => w.id === run.workflowId) ??
-      sessionWorkflows.find((w) => w.id === run.workflowId) ??
-      null;
-    return workflow ? workflowKindName(workflow) : null;
-  }, [focusedWorkflowRunId, session.workflowRuns, phaseTemplates, sessionWorkflows]);
+    const focusedRun = attachedWorkflowRuns.find(({ run }) => run.id === focusedWorkflowRunId);
+    const visibleRun = focusedRun ?? (lens === 'workflows' ? attachedWorkflowRuns[0] : null);
+    return visibleRun == null ? null : workflowKindName(visibleRun.workflow);
+  }, [focusedWorkflowRunId, attachedWorkflowRuns, lens]);
   const focusedPlanTitle = useMemo(
     () => plans.find((p) => p.id === focusedPlanId)?.title ?? null,
     [plans, focusedPlanId],
@@ -229,15 +221,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 {lens === 'plans' ? (
                   <PlanStudio sessionId={sessionId} initialPlanId={focusedPlanId ?? undefined} />
                 ) : null}
-                {lens === 'workflows' ? (
-                  <PaneShell
-                    title="Workflows"
-                    description="Sequences of agents that drive this session toward its goal."
-                    width="3xl"
-                  >
-                    <AgentsSection task={session} only="workflows" />
-                  </PaneShell>
-                ) : null}
+                {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
                 {lens === 'resolve' ? (
                   <PaneShell
                     title="Resolve"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -29,6 +29,7 @@ import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
 import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
 import { buildSessionBreadcrumb } from './sessionBreadcrumb';
+import { WorkflowStrip } from './parts/WorkflowStrip';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -111,6 +112,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const showLens = selectedAgentId == null && !showStudio;
   const onBareOverview = showLens && lens === null;
   const overlayHome = agentHome ?? 'agents';
+  const showWorkflowStrip = showAgentOverlay && overlayHome === 'workflows';
 
   const selectedAgentName = useMemo(
     () =>
@@ -141,6 +143,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
         studio,
         selectedAgentName,
         overlayHomeLens: overlayHome,
+        suppressAgentTail: showWorkflowStrip,
         focusedWorkflowName,
         focusedPlanTitle,
         lensLabel: (l) => LENS_LABEL[l],
@@ -162,6 +165,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
       studio,
       selectedAgentName,
       overlayHome,
+      showWorkflowStrip,
       focusedWorkflowName,
       focusedPlanTitle,
       sessionId,
@@ -185,8 +189,15 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   return (
     <div className="flex h-full w-full flex-col">
       <SessionTopBar session={session} />
-      <div className="flex shrink-0 items-center px-6 py-2.5">
+      <div className="flex min-w-0 shrink-0 items-center gap-2 px-6 py-2.5">
         <AppBreadcrumb crumbs={crumbs} />
+        {showWorkflowStrip && selectedAgentId != null ? (
+          <WorkflowStrip
+            sessionId={sessionId}
+            session={session}
+            selectedAgentId={selectedAgentId}
+          />
+        ) : null}
       </div>
       <Divider />
       <div className="flex min-h-0 flex-1">
@@ -270,23 +281,27 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
 
             {showAgentOverlay ? (
               <div className="absolute inset-0 z-20 flex bg-background motion-safe:animate-studio-in">
-                <div className="flex w-72 shrink-0 flex-col bg-background">
-                  <button
-                    type="button"
-                    onClick={() => setActiveLens(sessionId, overlayHome)}
-                    className="flex shrink-0 items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.03] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-                  >
-                    <ArrowLeft size={14} aria-hidden className="shrink-0" />
-                    <span className="truncate">{LENS_LABEL[overlayHome]}</span>
-                  </button>
-                  <Divider />
-                  <ScrollFade className="min-h-0 flex-1">
-                    <div className="px-2 py-2">
-                      <AgentsSection task={session} only={overlayHome} />
+                {overlayHome === 'workflows' ? null : (
+                  <>
+                    <div className="flex w-72 shrink-0 flex-col bg-background">
+                      <button
+                        type="button"
+                        onClick={() => setActiveLens(sessionId, overlayHome)}
+                        className="flex shrink-0 items-center gap-1.5 px-3 py-2 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.03] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+                      >
+                        <ArrowLeft size={14} aria-hidden className="shrink-0" />
+                        <span className="truncate">{LENS_LABEL[overlayHome]}</span>
+                      </button>
+                      <Divider />
+                      <ScrollFade className="min-h-0 flex-1">
+                        <div className="px-2 py-2">
+                          <AgentsSection task={session} only={overlayHome} />
+                        </div>
+                      </ScrollFade>
                     </div>
-                  </ScrollFade>
-                </div>
-                <Divider orientation="vertical" />
+                    <Divider orientation="vertical" />
+                  </>
+                )}
                 <div className="min-h-0 min-w-0 flex-1">
                   <ChatView session={session} isActive={isActive && selectedAgentId != null} />
                 </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Session } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    sessionsSidebarCollapsed: false,
+    setSessionsSidebarCollapsed: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../workspace/components/SessionDetailPanel', () => ({
+  SessionDetailPanel: () => <div>session details</div>,
+}));
+
+import { SessionTopBar } from './SessionTopBar';
+
+const SESSION = { goal: 'test session' } as Session;
+
+beforeEach(() => {
+  state.sessionsSidebarCollapsed = false;
+  state.setSessionsSidebarCollapsed.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionTopBar', () => {
+  it('does not render the reopen button while the sessions sidebar is visible', () => {
+    render(<SessionTopBar session={SESSION} />);
+    expect(screen.queryByRole('button', { name: 'show sessions' })).toBeNull();
+  });
+
+  it('reopens the sessions sidebar from an open session', () => {
+    state.sessionsSidebarCollapsed = true;
+    render(<SessionTopBar session={SESSION} />);
+    fireEvent.click(screen.getByRole('button', { name: 'show sessions' }));
+    expect(state.setSessionsSidebarCollapsed).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
@@ -1,5 +1,7 @@
-import { Divider } from '@goodboy/ui';
+import { PanelLeftOpen } from 'lucide-react';
+import { Divider, Tooltip, cn } from '@goodboy/ui';
 import type { Session } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
 import { SessionDetailPanel } from '../../../../workspace/components/SessionDetailPanel';
 
 type SessionTopBarProps = {
@@ -7,9 +9,29 @@ type SessionTopBarProps = {
 };
 
 export const SessionTopBar = ({ session }: SessionTopBarProps) => {
+  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
+  const setSessionsSidebarCollapsed = useAppStore((s) => s.setSessionsSidebarCollapsed);
+
   return (
     <>
-      <div className="flex w-full items-center gap-3 bg-background pr-3">
+      <div
+        className={cn(
+          'flex w-full items-center gap-3 bg-background pr-3',
+          sessionsSidebarCollapsed && 'pl-2',
+        )}
+      >
+        {sessionsSidebarCollapsed ? (
+          <Tooltip content="show sessions (⌘B)" side="bottom">
+            <button
+              type="button"
+              onClick={() => setSessionsSidebarCollapsed(false)}
+              aria-label="show sessions"
+              className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            >
+              <PanelLeftOpen size={13} aria-hidden />
+            </button>
+          </Tooltip>
+        ) : null}
         <div className="min-w-0 flex-1">
           <SessionDetailPanel
             session={session}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowAttachButton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowAttachButton.tsx
@@ -1,0 +1,24 @@
+import { Plus } from 'lucide-react';
+import type { SessionId } from '@goodboy/types';
+import { Button, cn } from '@goodboy/ui';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly placement: 'header' | 'rail';
+};
+
+export const WorkflowAttachButton = ({ sessionId, placement }: Props) => (
+  <Button
+    variant={placement === 'header' ? 'secondary' : 'ghost'}
+    size="sm"
+    onClick={() => {
+      window.dispatchEvent(
+        new CustomEvent('goodboy:open-workflow-builder', { detail: { sessionId } }),
+      );
+    }}
+    className={cn(placement === 'rail' && 'w-full justify-start text-muted-foreground')}
+  >
+    <Plus size={13} aria-hidden className="shrink-0" />
+    Attach another workflow
+  </Button>
+);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowRailCard.tsx
@@ -1,0 +1,53 @@
+import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
+import { WorkflowRunStatus } from '../../../../workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus';
+
+type Props = {
+  readonly run: WorkflowRun;
+  readonly workflow: Workflow;
+  readonly agents: ReadonlyArray<Agent>;
+  readonly predecessorName: string;
+  readonly isSelected: boolean;
+  readonly onSelect: () => void;
+};
+
+export const WorkflowRailCard = ({
+  run,
+  workflow,
+  agents,
+  predecessorName,
+  isSelected,
+  onSelect,
+}: Props) => {
+  const completedSteps = agents.filter(
+    (agent) => agent.status === 'completed' || agent.status === 'skipped',
+  ).length;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={isSelected ? 'true' : undefined}
+      className={cn(
+        'flex w-full flex-col items-start gap-1.5 rounded-md px-2.5 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+        isSelected ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/40',
+      )}
+    >
+      <span className="line-clamp-2 text-xs font-medium text-foreground">
+        {workflowKindName(workflow)}
+      </span>
+      <div className="flex w-full items-center justify-between gap-2">
+        <WorkflowRunStatus
+          run={run}
+          workflow={workflow}
+          agents={agents}
+          predecessorName={predecessorName}
+        />
+        <span className="shrink-0 text-2xs tabular-nums text-muted-foreground">
+          {completedSteps}/{workflow.steps.length} steps
+        </span>
+      </div>
+    </button>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStrip.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStrip.test.tsx
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  Session,
+  SessionId,
+  Step,
+  StepId,
+  Workflow,
+  WorkflowId,
+  WorkflowRunId,
+  WorkspaceId,
+} from '@goodboy/types';
+
+type Store = {
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  phaseTemplates: Record<string, ReadonlyArray<Workflow>>;
+  sessionWorkflows: Record<string, ReadonlyArray<Workflow>>;
+  selectAgent: ReturnType<typeof vi.fn>;
+  setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
+  setActiveLens: ReturnType<typeof vi.fn>;
+};
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    sessionPhaseRuns: {},
+    phaseTemplates: {},
+    sessionWorkflows: {},
+    selectAgent: vi.fn(async () => undefined),
+    setFocusedWorkflowRun: vi.fn(),
+    setActiveLens: vi.fn(),
+  } as Store,
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
+}));
+
+import { WorkflowStrip } from './WorkflowStrip';
+
+const NOW = '2026-07-21T00:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const WORKFLOW_ID = 'workflow-1' as WorkflowId;
+const RUN_ID = 'run-1' as WorkflowRunId;
+
+const steps = ['Plan', 'Build', 'Verify', 'Ship', 'Later'].map(
+  (name, index): Step => ({
+    id: `step-${index + 1}` as StepId,
+    workflowId: WORKFLOW_ID,
+    ordinal: index,
+    name,
+    promptPrefix: '',
+  }),
+);
+
+const workflow: Workflow = {
+  id: WORKFLOW_ID,
+  workspaceId: WORKSPACE_ID,
+  name: 'Release flow',
+  description: '',
+  steps,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+const session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  workflowRuns: [
+    {
+      id: RUN_ID,
+      workflowId: WORKFLOW_ID,
+      ordinal: 0,
+      currentStep: 1,
+      autoRun: true,
+      triggerMode: 'immediate',
+    },
+  ],
+} as unknown as Session;
+
+type AgentParams = {
+  readonly id: string;
+  readonly stepIndex?: number;
+  readonly name: string;
+  readonly status: Agent['status'];
+  readonly parentAgentId?: AgentId;
+  readonly hasWorkflow?: boolean;
+};
+
+const createAgent = ({
+  id,
+  stepIndex,
+  name,
+  status,
+  parentAgentId,
+  hasWorkflow = true,
+}: AgentParams): Agent => ({
+  id: id as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: stepIndex ?? 0,
+  name,
+  status,
+  ...(stepIndex != null && { stepId: steps[stepIndex]?.id }),
+  ...(hasWorkflow && { workflowRunId: RUN_ID }),
+  ...(parentAgentId != null && { parentAgentId }),
+});
+
+const roots = [
+  createAgent({ id: 'root-plan', stepIndex: 0, name: 'Plan agent', status: 'completed' }),
+  createAgent({ id: 'root-build', stepIndex: 1, name: 'Build agent', status: 'running' }),
+  createAgent({ id: 'root-verify', stepIndex: 2, name: 'Verify agent', status: 'failed' }),
+  createAgent({ id: 'root-ship', stepIndex: 3, name: 'Ship agent', status: 'pending' }),
+];
+const selectedChild = createAgent({
+  id: 'child-selected',
+  name: 'Child selected',
+  status: 'completed',
+  parentAgentId: roots[1]?.id,
+});
+const runningChild = createAgent({
+  id: 'child-running',
+  name: 'Child running',
+  status: 'running',
+  parentAgentId: roots[1]?.id,
+});
+
+beforeEach(() => {
+  store.sessionPhaseRuns = { [SESSION_ID]: [...roots, selectedChild, runningChild] };
+  store.phaseTemplates = { [WORKSPACE_ID]: [workflow] };
+  store.sessionWorkflows = {};
+  store.selectAgent.mockReset();
+  store.selectAgent.mockResolvedValue(undefined);
+  store.setFocusedWorkflowRun.mockReset();
+  store.setActiveLens.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('WorkflowStrip', () => {
+  it('maps statuses and accents the selected child parent step', () => {
+    render(
+      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+    );
+
+    expect(screen.getByLabelText('Plan status: completed')).toBeDefined();
+    expect(screen.getByLabelText('Build status: running')).toBeDefined();
+    expect(screen.getByLabelText('Verify status: failed')).toBeDefined();
+    expect(screen.getByLabelText('Ship status: pending')).toBeDefined();
+    expect(screen.getByLabelText('Later status: pending')).toBeDefined();
+    expect(screen.getByRole('button', { name: '2 Build' }).getAttribute('aria-current')).toBe(
+      'step',
+    );
+    expect(screen.getByRole('button', { name: '2 Build' }).parentElement?.className).toContain(
+      'bg-primary/10',
+    );
+  });
+
+  it('selects an available step root and keeps pending steps inert', () => {
+    render(
+      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '1 Plan' }));
+    expect(store.selectAgent).toHaveBeenCalledWith(SESSION_ID, roots[0]?.id);
+
+    store.selectAgent.mockClear();
+    const pendingRoot = screen.getByRole('button', { name: '4 Ship' });
+    const missingRoot = screen.getByRole('button', { name: '5 Later' });
+    expect(pendingRoot).toHaveProperty('disabled', true);
+    expect(missingRoot).toHaveProperty('disabled', true);
+    fireEvent.click(pendingRoot);
+    fireEvent.click(missingRoot);
+    expect(store.selectAgent).not.toHaveBeenCalled();
+  });
+
+  it('opens clusters, marks the selected child, and selects another child', () => {
+    render(
+      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'clusters 1/2 for Build' }));
+    expect(screen.getByRole('menu', { name: 'clusters for Build agent' })).toBeDefined();
+    expect(
+      screen.getByRole('menuitem', { name: /Child selected/ }).getAttribute('aria-current'),
+    ).toBe('true');
+    fireEvent.click(screen.getByRole('menuitem', { name: /Child running/ }));
+    expect(store.selectAgent).toHaveBeenCalledWith(SESSION_ID, runningChild.id);
+  });
+
+  it('opens the workflow lens at the focused run from the workflow chip', () => {
+    render(
+      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Release flow' }));
+    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
+    expect(store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'workflows');
+  });
+
+  it('renders nothing for a non-workflow agent', () => {
+    const standalone = createAgent({
+      id: 'standalone',
+      name: 'Standalone',
+      status: 'running',
+      hasWorkflow: false,
+    });
+    store.sessionPhaseRuns = { [SESSION_ID]: [standalone] };
+    const { container } = render(
+      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={standalone.id} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStrip.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStrip.tsx
@@ -1,0 +1,224 @@
+import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDown, Workflow as WorkflowIcon } from 'lucide-react';
+import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
+import { Popover, cn } from '@goodboy/ui';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { resolveRootAgent } from '../../../agent-kind';
+import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
+import { WorkflowStripStatus } from './WorkflowStripStatus';
+
+const POPOVER_WIDTH = 224;
+const POPOVER_EDGE_INSET = 8;
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly session: Session;
+  readonly selectedAgentId: AgentId;
+};
+
+export const WorkflowStrip = ({ sessionId, session, selectedAgentId }: Props) => {
+  const phaseRuns = useAppStore(
+    (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
+  );
+  const phaseTemplates = useAppStore(
+    (state) =>
+      state.phaseTemplates[session.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const sessionWorkflows = useAppStore(
+    (state) => state.sessionWorkflows[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const selectAgent = useAppStore((state) => state.selectAgent);
+  const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
+  const setActiveLens = useAppStore((state) => state.setActiveLens);
+  const [openClusterRootId, setOpenClusterRootId] = useState<AgentId | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState<Readonly<{
+    top: number;
+    left: number;
+  }> | null>(null);
+
+  const rootAgent = useMemo(
+    () => resolveRootAgent({ agents: phaseRuns, agentId: selectedAgentId }),
+    [phaseRuns, selectedAgentId],
+  );
+  const workflowById = useMemo(() => {
+    const workflows = new Map<string, Workflow>();
+    for (const workflow of phaseTemplates) {
+      workflows.set(workflow.id, workflow);
+    }
+    for (const workflow of sessionWorkflows) {
+      workflows.set(workflow.id, workflow);
+    }
+    return workflows;
+  }, [phaseTemplates, sessionWorkflows]);
+
+  if (rootAgent?.workflowRunId == null) {
+    return null;
+  }
+  const run = session.workflowRuns.find((candidate) => candidate.id === rootAgent.workflowRunId);
+  if (run == null) {
+    return null;
+  }
+  const workflow = workflowById.get(run.workflowId) ?? null;
+  if (workflow == null) {
+    return null;
+  }
+
+  const stepRoots = new Map(
+    phaseRuns
+      .filter(
+        (agent) =>
+          agent.workflowRunId === run.id && agent.stepId != null && agent.parentAgentId == null,
+      )
+      .map((agent) => [agent.stepId, agent]),
+  );
+  const openClusterRoot =
+    openClusterRootId == null
+      ? null
+      : (phaseRuns.find((agent) => agent.id === openClusterRootId) ?? null);
+  const openClusterChildren =
+    openClusterRoot == null
+      ? EMPTY_ARRAY
+      : phaseRuns.filter((agent) => agent.parentAgentId === openClusterRoot.id);
+
+  return (
+    <div
+      className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto whitespace-nowrap"
+      aria-label="workflow steps"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          setFocusedWorkflowRun(sessionId, run.id);
+          setActiveLens(sessionId, 'workflows');
+        }}
+        className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border-soft bg-subtle px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+      >
+        <WorkflowIcon size={12} aria-hidden className="shrink-0 text-accent" />
+        <span className="max-w-40 truncate">{workflowKindName(workflow)}</span>
+      </button>
+      {workflow.steps.map((step, index) => {
+        const stepRoot = stepRoots.get(step.id) ?? null;
+        const isPending = stepRoot == null || stepRoot.status === 'pending';
+        const isCurrent = stepRoot?.id === rootAgent.id;
+        const clusterChildren =
+          stepRoot == null
+            ? EMPTY_ARRAY
+            : phaseRuns.filter((agent) => agent.parentAgentId === stepRoot.id);
+        const completedChildren = clusterChildren.filter(
+          (agent) => agent.status === 'completed' || agent.status === 'skipped',
+        ).length;
+
+        return (
+          <div
+            key={step.id}
+            className={cn(
+              'flex shrink-0 items-center rounded-lg border text-xs transition-colors',
+              isCurrent
+                ? 'border-primary/40 bg-primary/10 text-foreground ring-1 ring-primary/20'
+                : isPending
+                  ? 'border-border-soft/60 bg-subtle/50 text-muted-foreground/60'
+                  : 'border-border-soft bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
+            )}
+          >
+            <button
+              type="button"
+              disabled={isPending}
+              aria-current={isCurrent ? 'step' : undefined}
+              aria-label={`${index + 1} ${step.name}`}
+              onClick={() => {
+                if (stepRoot == null || isPending) {
+                  return;
+                }
+                void selectAgent(sessionId, stepRoot.id);
+              }}
+              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-default"
+            >
+              <span className="text-2xs font-semibold tabular-nums text-muted-foreground">
+                {index + 1}
+              </span>
+              <WorkflowStripStatus
+                status={stepRoot?.status ?? null}
+                label={step.name}
+                variant="pill"
+              />
+              <span>{step.name}</span>
+            </button>
+            {stepRoot != null && clusterChildren.length > 0 ? (
+              <button
+                type="button"
+                aria-haspopup="menu"
+                aria-expanded={openClusterRootId === stepRoot.id}
+                aria-label={`clusters ${completedChildren}/${clusterChildren.length} for ${step.name}`}
+                onClick={(event) => {
+                  if (openClusterRootId === stepRoot.id) {
+                    setOpenClusterRootId(null);
+                    setPopoverPosition(null);
+                    return;
+                  }
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  setOpenClusterRootId(stepRoot.id);
+                  setPopoverPosition({
+                    top: rect.bottom + 6,
+                    left: Math.max(
+                      POPOVER_EDGE_INSET,
+                      Math.min(rect.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH),
+                    ),
+                  });
+                }}
+                className="flex items-center gap-1 rounded-lg px-1.5 py-1 text-2xs font-medium tabular-nums text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+              >
+                {completedChildren}/{clusterChildren.length}
+                <ChevronDown size={10} aria-hidden />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+      {openClusterRoot != null && popoverPosition != null
+        ? createPortal(
+            <>
+              <div
+                className="fixed inset-0 z-30"
+                onClick={() => {
+                  setOpenClusterRootId(null);
+                  setPopoverPosition(null);
+                }}
+                aria-hidden
+              />
+              <Popover
+                role="menu"
+                ariaLabel={`clusters for ${openClusterRoot.name}`}
+                className="fixed z-40 flex w-56 flex-col gap-0.5 p-1"
+                style={popoverPosition}
+              >
+                {openClusterChildren.map((child) => (
+                  <button
+                    key={child.id}
+                    type="button"
+                    role="menuitem"
+                    aria-current={child.id === selectedAgentId ? 'true' : undefined}
+                    onClick={() => {
+                      setOpenClusterRootId(null);
+                      setPopoverPosition(null);
+                      void selectAgent(sessionId, child.id);
+                    }}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+                      child.id === selectedAgentId
+                        ? 'bg-primary/10 text-foreground'
+                        : 'text-muted-foreground',
+                    )}
+                  >
+                    <WorkflowStripStatus status={child.status} label={child.name} variant="child" />
+                    <span className="min-w-0 flex-1 truncate">{child.name}</span>
+                  </button>
+                ))}
+              </Popover>
+            </>,
+            document.body,
+          )
+        : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStripStatus.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStripStatus.tsx
@@ -1,0 +1,61 @@
+import { Check, CircleX, Clock } from 'lucide-react';
+import type { AgentStatus } from '@goodboy/types';
+import { StatusDot } from '@goodboy/ui';
+
+type Props = {
+  readonly status: AgentStatus | null;
+  readonly label: string;
+  readonly variant: 'pill' | 'child';
+};
+
+export const WorkflowStripStatus = ({ status, label, variant }: Props) => {
+  const resolvedStatus = status ?? 'pending';
+  const ariaLabel = `${label} status: ${resolvedStatus}`;
+
+  if (variant === 'child') {
+    const tone =
+      resolvedStatus === 'completed'
+        ? 'success'
+        : resolvedStatus === 'running'
+          ? 'primary'
+          : resolvedStatus === 'failed'
+            ? 'danger'
+            : 'neutral';
+    return (
+      <StatusDot
+        tone={tone}
+        size="sm"
+        pulsing={resolvedStatus === 'running'}
+        ariaLabel={ariaLabel}
+      />
+    );
+  }
+
+  if (resolvedStatus === 'running') {
+    return <StatusDot tone="primary" size="sm" pulsing ariaLabel={ariaLabel} />;
+  }
+  if (resolvedStatus === 'completed') {
+    return <Check size={11} className="shrink-0 text-success" role="img" aria-label={ariaLabel} />;
+  }
+  if (resolvedStatus === 'failed') {
+    return <CircleX size={11} className="shrink-0 text-danger" role="img" aria-label={ariaLabel} />;
+  }
+  if (resolvedStatus === 'skipped') {
+    return (
+      <Check
+        size={11}
+        className="shrink-0 text-muted-foreground"
+        role="img"
+        aria-label={ariaLabel}
+      />
+    );
+  }
+  return (
+    <Clock
+      size={11}
+      className="shrink-0 text-muted-foreground/60"
+      role="img"
+      aria-label={ariaLabel}
+    />
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, Session, Workflow } from '@goodboy/types';
+
+type Store = {
+  phaseTemplates: Record<string, ReadonlyArray<Workflow>>;
+  sessionWorkflows: Record<string, ReadonlyArray<Workflow>>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  focusedWorkflowRunId: Record<string, string | null>;
+  setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
+};
+
+type ButtonMockProps = React.ComponentProps<'button'>;
+type DividerMockProps = { readonly orientation?: string };
+type ChildrenMockProps = { readonly children: React.ReactNode };
+type AgentsSectionMockProps = { readonly workflowRunId?: string };
+type WorkflowStartButtonMockProps = { readonly variant: string };
+type PaneShellMockProps = {
+  readonly title: string;
+  readonly actions?: React.ReactNode;
+  readonly children: React.ReactNode;
+};
+type BuildWorkflowParams = { readonly id: string; readonly name: string };
+type BuildSessionParams = { readonly runIds: ReadonlyArray<string> };
+
+const store: Store = {
+  phaseTemplates: {},
+  sessionWorkflows: {},
+  sessionPhaseRuns: {},
+  focusedWorkflowRunId: {},
+  setFocusedWorkflowRun: vi.fn(),
+};
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
+}));
+
+vi.mock('@goodboy/ui', () => ({
+  Button: ({ children, onClick, className }: ButtonMockProps) => (
+    <button type="button" onClick={onClick} className={className}>
+      {children}
+    </button>
+  ),
+  Divider: ({ orientation }: DividerMockProps) => (
+    <div data-testid="divider" data-orientation={orientation ?? 'horizontal'} />
+  ),
+  ScrollFade: ({ children }: ChildrenMockProps) => <div>{children}</div>,
+  StatusDot: () => <span data-testid="status-dot" />,
+  cn: (...values: ReadonlyArray<unknown>) => values.filter(Boolean).join(' '),
+}));
+
+vi.mock('../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection', () => ({
+  AgentsSection: ({ workflowRunId }: AgentsSectionMockProps) => (
+    <div data-testid="workflow-detail" data-run-id={workflowRunId} />
+  ),
+}));
+
+vi.mock('../../../../workspace/components/WorkspacesSidebar/parts/WorkflowStartButton', () => ({
+  WorkflowStartButton: ({ variant }: WorkflowStartButtonMockProps) => (
+    <div data-testid="workflow-start" data-variant={variant} />
+  ),
+}));
+
+vi.mock('./PaneShell', () => ({
+  PaneShell: ({ title, actions, children }: PaneShellMockProps) => (
+    <div data-testid="pane-shell">
+      <h1>{title}</h1>
+      {actions}
+      {children}
+    </div>
+  ),
+}));
+
+import { WorkflowsPane } from './WorkflowsPane';
+
+const SESSION_ID = 'session-1';
+const WORKSPACE_ID = 'workspace-1';
+
+const buildWorkflow = ({ id, name }: BuildWorkflowParams) =>
+  ({
+    id,
+    workspaceId: WORKSPACE_ID,
+    name,
+    description: '',
+    steps: [
+      { id: `${id}-step-1`, workflowId: id, ordinal: 0, name: 'First', promptPrefix: '' },
+      { id: `${id}-step-2`, workflowId: id, ordinal: 1, name: 'Second', promptPrefix: '' },
+    ],
+    createdAt: '2026-07-21T00:00:00.000Z',
+    updatedAt: '2026-07-21T00:00:00.000Z',
+  }) as unknown as Workflow;
+
+const firstWorkflow = buildWorkflow({ id: 'workflow-1', name: 'First workflow' });
+const secondWorkflow = buildWorkflow({ id: 'workflow-2', name: 'Second workflow' });
+
+const buildSession = ({ runIds }: BuildSessionParams) =>
+  ({
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    workflowRuns: runIds.map((id, ordinal) => ({
+      id,
+      workflowId: id === 'run-1' ? firstWorkflow.id : secondWorkflow.id,
+      ordinal,
+      currentStep: 0,
+      autoRun: true,
+      triggerMode: 'immediate',
+    })),
+  }) as unknown as Session;
+
+beforeEach(() => {
+  store.phaseTemplates = { [WORKSPACE_ID]: [firstWorkflow, secondWorkflow] };
+  store.sessionWorkflows = {};
+  store.sessionPhaseRuns = {};
+  store.focusedWorkflowRunId = {};
+  store.setFocusedWorkflowRun.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('WorkflowsPane', () => {
+  it('keeps the existing empty state for zero runs', () => {
+    render(<WorkflowsPane session={buildSession({ runIds: [] })} />);
+
+    expect(screen.getByTestId('pane-shell')).toBeDefined();
+    expect(screen.getByTestId('workflow-start').getAttribute('data-variant')).toBe('empty');
+    expect(screen.queryByRole('complementary', { name: 'Attached workflows' })).toBeNull();
+  });
+
+  it('shows one full detail without a rail and puts attach in the header', () => {
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1'] })} />);
+
+    expect(screen.queryByRole('complementary', { name: 'Attached workflows' })).toBeNull();
+    expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-1');
+    expect(screen.getByRole('button', { name: 'Attach another workflow' })).toBeDefined();
+  });
+
+  it('shows the rail and focused detail for multiple runs', () => {
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-2' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    expect(screen.getByRole('complementary', { name: 'Attached workflows' })).toBeDefined();
+    expect(screen.getByText('First workflow')).toBeDefined();
+    expect(screen.getByText('Second workflow')).toBeDefined();
+    expect(screen.getAllByText('0/2 steps')).toHaveLength(2);
+    expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-2');
+  });
+
+  it('focuses a run when its rail card is clicked', () => {
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'run-2' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    fireEvent.click(screen.getByText('First workflow'));
+
+    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, 'run-1');
+  });
+
+  it('falls back to the first run when focus is stale', () => {
+    store.focusedWorkflowRunId = { [SESSION_ID]: 'missing-run' };
+    render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
+
+    expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-1');
+    expect(screen.getByText('First workflow').closest('button')?.getAttribute('aria-current')).toBe(
+      'true',
+    );
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,0 +1,132 @@
+import { Workflow as WorkflowIcon } from 'lucide-react';
+import type { Agent, Session, SessionId } from '@goodboy/types';
+import { Divider, ScrollFade } from '@goodboy/ui';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { useAttachedWorkflowRuns } from '../../../../workflows/useAttachedWorkflowRuns';
+import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
+import { WorkflowStartButton } from '../../../../workspace/components/WorkspacesSidebar/parts/WorkflowStartButton';
+import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
+import { PaneShell } from './PaneShell';
+import { WorkflowAttachButton } from './WorkflowAttachButton';
+import { WorkflowRailCard } from './WorkflowRailCard';
+
+type Props = {
+  readonly session: Session;
+};
+
+export const WorkflowsPane = ({ session }: Props) => {
+  const sessionId = session.id as SessionId;
+  const attachedRuns = useAttachedWorkflowRuns({ session });
+  const phaseRuns = useAppStore(
+    (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
+  );
+  const focusedWorkflowRunId = useAppStore(
+    (state) => state.focusedWorkflowRunId[sessionId] ?? null,
+  );
+  const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
+  const selectedRun =
+    attachedRuns.find(({ run }) => run.id === focusedWorkflowRunId) ?? attachedRuns[0] ?? null;
+  const agentsByRunId = new Map<string, Agent[]>();
+  for (const agent of phaseRuns) {
+    if (agent.workflowRunId == null || agent.stepId == null || agent.parentAgentId != null) {
+      continue;
+    }
+    const agents = agentsByRunId.get(agent.workflowRunId) ?? [];
+    agents.push(agent);
+    agentsByRunId.set(agent.workflowRunId, agents);
+  }
+  const workflowNameByRunId = new Map(
+    attachedRuns.map(({ run, workflow }) => [run.id, workflowKindName(workflow)]),
+  );
+
+  if (attachedRuns.length === 0) {
+    return (
+      <PaneShell
+        title="Workflows"
+        description="Sequences of agents that drive this session toward its goal."
+        width="3xl"
+      >
+        <WorkflowStartButton sessionId={sessionId} variant="empty" />
+      </PaneShell>
+    );
+  }
+  if (attachedRuns.length === 1 && selectedRun != null) {
+    return (
+      <PaneShell
+        title="Workflows"
+        description="Sequences of agents that drive this session toward its goal."
+        actions={<WorkflowAttachButton sessionId={sessionId} placement="header" />}
+        width="3xl"
+      >
+        <AgentsSection
+          task={session}
+          only="workflows"
+          workflowRunId={selectedRun.run.id}
+          workflowVariant="detail"
+          showWorkflowAttach={false}
+        />
+      </PaneShell>
+    );
+  }
+  if (selectedRun == null) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex shrink-0 items-center gap-3 px-6 py-4">
+        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+          <WorkflowIcon size={16} aria-hidden className="text-accent" />
+        </span>
+        <div className="flex flex-col gap-0.5">
+          <h1 className="text-xl font-semibold leading-snug text-foreground">Workflows</h1>
+          <p className="text-sm text-muted-foreground">
+            Sequences of agents that drive this session toward its goal.
+          </p>
+        </div>
+      </div>
+      <Divider />
+      <div className="flex min-h-0 flex-1">
+        <aside className="flex w-60 shrink-0 flex-col" aria-label="Attached workflows">
+          <ScrollFade className="min-h-0 flex-1">
+            <ul className="flex flex-col gap-1 p-3">
+              {attachedRuns.map(({ run, workflow }) => {
+                const predecessorName = run.chainAfterId
+                  ? (workflowNameByRunId.get(run.chainAfterId) ?? 'previous')
+                  : 'previous';
+                return (
+                  <li key={run.id}>
+                    <WorkflowRailCard
+                      run={run}
+                      workflow={workflow}
+                      agents={agentsByRunId.get(run.id) ?? EMPTY_ARRAY}
+                      predecessorName={predecessorName}
+                      isSelected={run.id === selectedRun.run.id}
+                      onSelect={() => setFocusedWorkflowRun(sessionId, run.id)}
+                    />
+                  </li>
+                );
+              })}
+            </ul>
+          </ScrollFade>
+          <Divider />
+          <div className="p-3">
+            <WorkflowAttachButton sessionId={sessionId} placement="rail" />
+          </div>
+        </aside>
+        <Divider orientation="vertical" />
+        <ScrollFade className="min-w-0 flex-1" viewportClassName="px-6 py-5" fadeSize={24}>
+          <div className="mx-auto w-full max-w-3xl motion-safe:animate-studio-in">
+            <AgentsSection
+              task={session}
+              only="workflows"
+              workflowRunId={selectedRun.run.id}
+              workflowVariant="detail"
+              showWorkflowAttach={false}
+            />
+          </div>
+        </ScrollFade>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -20,6 +20,7 @@ const base = (
   studio: null,
   selectedAgentName: null,
   overlayHomeLens: null,
+  suppressAgentTail: false,
   focusedWorkflowName: null,
   focusedPlanTitle: null,
   lensLabel,
@@ -88,6 +89,22 @@ describe('buildSessionBreadcrumb', () => {
     crumbs[1]!.onClick!();
     expect(h.toWorkflowsList).toHaveBeenCalledOnce();
     expect(h.toLens).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the workflow agent tail when the workflow strip is present', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base(
+        {
+          selectedAgentName: 'scout-1',
+          overlayHomeLens: 'workflows',
+          suppressAgentTail: true,
+        },
+        h,
+      ),
+    );
+    expect(labels(crumbs)).toEqual(['Overview']);
+    expect(last(crumbs)?.onClick).toBeUndefined();
   });
 
   it('degrades a workflows lens with no focused run to a two-crumb leaf trail', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -13,6 +13,7 @@ export type SessionBreadcrumbInput = {
   studio: SessionStudio | null;
   selectedAgentName: string | null;
   overlayHomeLens: LensKind | null;
+  suppressAgentTail: boolean;
   focusedWorkflowName: string | null;
   focusedPlanTitle: string | null;
   lensLabel: (lens: LensKind) => string;
@@ -32,6 +33,7 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
     studio,
     selectedAgentName,
     overlayHomeLens,
+    suppressAgentTail,
     focusedWorkflowName,
     focusedPlanTitle,
     lensLabel,
@@ -73,6 +75,10 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
       { id: 'pr', label: lensLabel('pr'), onClick: () => handlers.toLens('pr') },
       { id: 'mr', label: 'Merge request' },
     ]);
+  }
+
+  if (suppressAgentTail && selectedAgentName != null && overlayHomeLens != null) {
+    return sealLast([overview]);
   }
 
   if (selectedAgentName != null && overlayHomeLens != null) {

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -23,6 +23,7 @@ type Props = {
 const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly label: string }> = [
   { combo: ['⌘', 'K'], label: 'command palette' },
   { combo: ['⌘', 'N'], label: 'new session' },
+  { combo: ['⌘', 'B'], label: 'toggle sessions sidebar' },
   { combo: ['⌘', '1', '..', '9'], label: 'jump to workspace 1 to 9' },
   { combo: ['⌘', '['], label: 'back (lens history)' },
   { combo: ['⌘', ']'], label: 'forward (lens history)' },

--- a/apps/desktop/src/features/workflows/useAttachedWorkflowRuns.ts
+++ b/apps/desktop/src/features/workflows/useAttachedWorkflowRuns.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import type { Session, Workflow } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../store';
+
+type Params = {
+  readonly session: Session;
+};
+
+export const useAttachedWorkflowRuns = ({ session }: Params) => {
+  const phaseTemplates = useAppStore(
+    (state) =>
+      state.phaseTemplates[session.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+  const sessionWorkflows = useAppStore(
+    (state) => state.sessionWorkflows[session.id] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
+  );
+
+  return useMemo(() => {
+    const workflowById = new Map<string, Workflow>();
+    for (const workflow of phaseTemplates) {
+      workflowById.set(workflow.id, workflow);
+    }
+    for (const workflow of sessionWorkflows) {
+      workflowById.set(workflow.id, workflow);
+    }
+
+    return [...session.workflowRuns]
+      .sort((first, second) => first.ordinal - second.ordinal)
+      .flatMap((run) => {
+        const workflow = workflowById.get(run.workflowId) ?? null;
+        return workflow == null ? [] : [{ run, workflow }];
+      });
+  }, [session.workflowRuns, phaseTemplates, sessionWorkflows]);
+};

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -11,6 +11,7 @@ const { state } = vi.hoisted(() => ({
     sessionExternalTasks: {} as Record<string, unknown>,
     bulkUnarchiveTask: vi.fn(async () => undefined),
     bulkDeleteTask: vi.fn(async () => undefined),
+    setSessionsSidebarCollapsed: vi.fn(),
   },
 }));
 
@@ -91,6 +92,7 @@ function clickCheckbox(index: number): HTMLElement {
 beforeEach(() => {
   state.bulkUnarchiveTask.mockClear();
   state.bulkDeleteTask.mockClear();
+  state.setSessionsSidebarCollapsed.mockClear();
   state.sessionExternalTasks = {};
 });
 
@@ -106,6 +108,12 @@ describe('SessionActivityBar, baseline', () => {
   it('renders empty-state copy when no sessions in active tab', () => {
     renderBar([]);
     expect(screen.getByText(/no sessions yet/i)).toBeDefined();
+  });
+
+  it('collapses the sessions sidebar from the header button', () => {
+    renderBar([]);
+    fireEvent.click(screen.getByRole('button', { name: 'hide sessions' }));
+    expect(state.setSessionsSidebarCollapsed).toHaveBeenCalledWith(true);
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -1,6 +1,14 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Archive, Check, ChevronRight, Plus, RotateCcw, Trash2 } from 'lucide-react';
-import { Button, cn, ScrollArea, StatusDot } from '@goodboy/ui';
+import {
+  Archive,
+  Check,
+  ChevronRight,
+  PanelLeftClose,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { Button, cn, ScrollArea, StatusDot, Tooltip } from '@goodboy/ui';
 import type {
   Session,
   SessionGroupKey,
@@ -74,6 +82,7 @@ export const SessionActivityBar = ({
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<SessionId>>(new Set());
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const bulkUnarchiveTask = useAppStore((s) => s.bulkUnarchiveTask);
+  const setSessionsSidebarCollapsed = useAppStore((s) => s.setSessionsSidebarCollapsed);
 
   const prefs = useSessionViewPrefs(workspaceId);
 
@@ -155,6 +164,16 @@ export const SessionActivityBar = ({
                 Archived
               </button>
               <SessionViewMenu workspaceId={workspaceId} />
+              <Tooltip content="hide sessions (⌘B)" side="bottom">
+                <button
+                  type="button"
+                  onClick={() => setSessionsSidebarCollapsed(true)}
+                  aria-label="hide sessions"
+                  className="inline-flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
+                >
+                  <PanelLeftClose size={13} aria-hidden />
+                </button>
+              </Tooltip>
             </div>
           </div>
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -82,7 +82,11 @@ vi.mock('./AgentRow', () => ({
 vi.mock('./WorkflowStartButton', () => ({
   WorkflowStartButton: () => <div data-testid="wf-start" />,
 }));
-vi.mock('./WorkflowStepRow', () => ({ WorkflowStepRow: () => null }));
+vi.mock('./WorkflowStepRow', () => ({
+  WorkflowStepRow: ({ run }: { run: Agent }) => (
+    <div data-testid={`workflow-step-${run.id}`}>{run.name}</div>
+  ),
+}));
 vi.mock('./ResolveCluster', () => ({ ResolveCluster: () => null }));
 vi.mock('./ScoutSubtree', () => ({ ScoutSubtree: () => null }));
 vi.mock('./ClusterChildRow', () => ({
@@ -399,6 +403,24 @@ describe('AgentsSection collapse defaults', () => {
     const childRow = screen.getByTestId('cluster-child-child-1');
     expect(childRow.textContent).toBe('cluster child');
     expect(childRow.dataset.selected).toBe('true');
+  });
+
+  it('renders a workflow-bound child only inside its parent subtree', () => {
+    h.state.selectedAgentId = { [SESSION_ID]: 'child-1' as AgentId };
+    renderWorkflowWith([
+      buildAgent({
+        id: 'child-1' as AgentId,
+        name: 'parallel branch',
+        parentAgentId: 'wf-1' as AgentId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+        stepId: 'step-1' as StepId,
+      }),
+    ]);
+
+    expect(screen.queryByTestId('workflow-step-wf-1')).not.toBeNull();
+    expect(screen.queryByTestId('workflow-step-child-1')).toBeNull();
+    expect(screen.queryByTestId('cluster-child-child-1')).not.toBeNull();
+    expect(screen.queryByTestId('agent-row')).toBeNull();
   });
 
   it('picking an agent selects it and reveals the chat (full-width swap trigger)', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -85,7 +85,13 @@ vi.mock('./WorkflowStartButton', () => ({
 vi.mock('./WorkflowStepRow', () => ({ WorkflowStepRow: () => null }));
 vi.mock('./ResolveCluster', () => ({ ResolveCluster: () => null }));
 vi.mock('./ScoutSubtree', () => ({ ScoutSubtree: () => null }));
-vi.mock('./ClusterChildRow', () => ({ ClusterChildRow: () => null }));
+vi.mock('./ClusterChildRow', () => ({
+  ClusterChildRow: ({ child, isSelected }: { child: Agent; isSelected: boolean }) => (
+    <div data-testid={`cluster-child-${child.id}`} data-selected={isSelected}>
+      {child.name}
+    </div>
+  ),
+}));
 vi.mock('./WorkflowKillButton', () => ({ WorkflowKillButton: () => null }));
 vi.mock('../../../../scripts/components/ScriptsSection', () => ({
   ScriptsSection: () => <div data-testid="scripts" />,
@@ -377,6 +383,22 @@ describe('AgentsSection collapse defaults', () => {
     ]);
 
     expect(screen.getByTitle('3 agent replies to review').textContent).toContain('3');
+  });
+
+  it('selecting a cluster child expands its container subtree', () => {
+    h.state.selectedAgentId = { [SESSION_ID]: 'child-1' as AgentId };
+    renderWorkflowWith([
+      buildAgent({
+        id: 'child-1' as AgentId,
+        name: 'cluster child',
+        parentAgentId: 'wf-1' as AgentId,
+        workflowRunId: 'run-1' as WorkflowRunId,
+      }),
+    ]);
+
+    const childRow = screen.getByTestId('cluster-child-child-1');
+    expect(childRow.textContent).toBe('cluster child');
+    expect(childRow.dataset.selected).toBe('true');
   });
 
   it('picking an agent selects it and reveals the chat (full-width swap trigger)', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -242,7 +242,7 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
   const agentsByRunId = useMemo(() => {
     const map = new Map<string, Agent[]>();
     for (const r of sorted) {
-      if (r.stepId == null || r.workflowRunId == null) {
+      if (r.parentAgentId != null || r.stepId == null || r.workflowRunId == null) {
         continue;
       }
       const bucket = map.get(r.workflowRunId) ?? [];

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { EmptyState, SectionHeader, cn } from '@goodboy/ui';
 import { ArrowUpRight, CheckCheck, Layers } from 'lucide-react';
@@ -207,6 +207,38 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
   }, []);
 
   const sorted = useMemo(() => [...phaseRuns].sort((a, b) => a.ordinal - b.ordinal), [phaseRuns]);
+  useEffect(() => {
+    if (selectedAgentId == null) {
+      return;
+    }
+    const agentsById = new Map(sorted.map((agent) => [agent.id, agent]));
+    const ancestorIds: AgentId[] = [];
+    const visited = new Set<AgentId>([selectedAgentId]);
+    let agent = agentsById.get(selectedAgentId) ?? null;
+
+    while (agent?.parentAgentId != null) {
+      const parent = agentsById.get(agent.parentAgentId) ?? null;
+      if (parent == null || visited.has(parent.id)) {
+        break;
+      }
+      ancestorIds.push(parent.id);
+      visited.add(parent.id);
+      agent = parent;
+    }
+    if (ancestorIds.length === 0) {
+      return;
+    }
+    setClusterExpand((previous) => {
+      if (ancestorIds.every((id) => previous.get(id) === true)) {
+        return previous;
+      }
+      const next = new Map(previous);
+      for (const id of ancestorIds) {
+        next.set(id, true);
+      }
+      return next;
+    });
+  }, [selectedAgentId, sorted]);
   const agentsByRunId = useMemo(() => {
     const map = new Map<string, Agent[]>();
     for (const r of sorted) {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -13,7 +13,6 @@ import type {
   ProviderRunId,
   Session,
   TelemetryRecord,
-  Workflow,
   WorkflowRun,
   WorkflowRunId,
 } from '@goodboy/types';
@@ -32,6 +31,7 @@ import { PendingResolutionsStrip } from '../../../../../features/context/compone
 import { computeLatestTelemetryByAgentId } from '../../../../../features/session/agent-row-format';
 import { classifyAgent, type AgentKind } from '../../../../../features/session/agent-kind';
 import { formatError } from '../../../../../shared/lib/errors';
+import { useAttachedWorkflowRuns } from '../../../../workflows/useAttachedWorkflowRuns';
 import { SectionToggle } from './SectionToggle';
 import { PlanReadySuggestion } from './PlanReadySuggestion';
 import { ResolveCluster } from './ResolveCluster';
@@ -45,9 +45,18 @@ import { pluralize, workflowKindName, type WorkflowBlockReason } from '../lib';
 type AgentsSectionProps = {
   task: Session;
   only?: 'workflows' | 'agents' | 'scripts' | 'resolve';
+  workflowRunId?: WorkflowRunId;
+  workflowVariant?: 'sidebar' | 'detail';
+  showWorkflowAttach?: boolean;
 };
 
-export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
+export const AgentsSection = ({
+  task,
+  only,
+  workflowRunId,
+  workflowVariant = 'sidebar',
+  showWorkflowAttach = true,
+}: AgentsSectionProps) => {
   const showWorkflows = only == null || only === 'workflows';
   const showAgents = only == null || only === 'agents';
   const showScripts = only == null || only === 'scripts';
@@ -157,24 +166,7 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
   const forceAdvanceWorkflowStep = useAppStore((s) => s.forceAdvanceWorkflowStep);
   const renameAgent = useAppStore((s) => s.renameAgent);
   const deleteAgent = useAppStore((s) => s.deleteAgent);
-  const phaseTemplates = useAppStore(
-    (s) => s.phaseTemplates[task.workspaceId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
-  );
-  const sessionWorkflows = useAppStore(
-    (s) => s.sessionWorkflows[task.id] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
-  );
-  const attachedRuns = useMemo<ReadonlyArray<{ run: WorkflowRun; workflow: Workflow }>>(() => {
-    const byId = new Map<string, Workflow>();
-    for (const w of phaseTemplates) byId.set(w.id, w);
-    for (const w of sessionWorkflows) byId.set(w.id, w);
-    return [...task.workflowRuns]
-      .sort((a, b) => a.ordinal - b.ordinal)
-      .map((run) => {
-        const workflow = byId.get(run.workflowId);
-        return workflow ? { run, workflow } : null;
-      })
-      .filter((e): e is { run: WorkflowRun; workflow: Workflow } => e !== null);
-  }, [task.workflowRuns, phaseTemplates, sessionWorkflows]);
+  const attachedRuns = useAttachedWorkflowRuns({ session: task });
   const discardWorkflow = useAppStore((s) => s.discardWorkflow);
   const reorderSessionWorkflows = useAppStore((s) => s.reorderSessionWorkflows);
   const setWorkflowRunAutoRun = useAppStore((s) => s.setWorkflowRunAutoRun);
@@ -659,6 +651,10 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
   };
 
   const hasAnyWorkflow = attachedRuns.length > 0;
+  const visibleWorkflowRuns =
+    workflowRunId == null
+      ? attachedRuns
+      : attachedRuns.filter(({ run }) => run.id === workflowRunId);
 
   const wfExpanded = forceExpanded || workflowExpanded;
   const agExpanded = forceExpanded || agentsExpanded;
@@ -687,12 +683,14 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
             ) : (
               <>
                 <div className={cn('flex flex-col', forceExpanded ? 'gap-3' : 'gap-0.5')}>
-                  {attachedRuns.map(({ run, workflow }, index) => (
+                  {visibleWorkflowRuns.map(({ run, workflow }) => (
                     <WorkflowRow
                       key={run.id}
                       run={run}
                       workflow={workflow}
-                      index={index}
+                      index={attachedRuns.findIndex(
+                        ({ run: candidate }) => candidate.id === run.id,
+                      )}
                       task={task}
                       attachedRuns={attachedRuns}
                       agentsByRunId={agentsByRunId}
@@ -703,6 +701,7 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
                       workflowExpand={workflowExpand}
                       workflowNameByRunId={workflowNameByRunId}
                       forceExpanded={forceExpanded}
+                      variant={workflowVariant}
                       toggleWorkflowExpand={toggleWorkflowExpand}
                       startWorkflowRun={startWorkflowRun}
                       setWorkflowRunAutoRun={setWorkflowRunAutoRun}
@@ -730,7 +729,9 @@ export const AgentsSection = ({ task, only }: AgentsSectionProps) => {
                     />
                   ))}
                 </div>
-                <WorkflowStartButton sessionId={task.id} variant="attach" />
+                {showWorkflowAttach ? (
+                  <WorkflowStartButton sessionId={task.id} variant="attach" />
+                ) : null}
               </>
             )
           ) : (

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -1,13 +1,9 @@
 import { Fragment, type Dispatch, type SetStateAction } from 'react';
 import { cn } from '@goodboy/ui';
 import {
-  Ban,
-  Check,
   ChevronDown,
   ChevronRight,
   ChevronUp,
-  Link2,
-  Pause,
   Play,
   Workflow as WorkflowIcon,
   Zap,
@@ -38,6 +34,7 @@ import { WorkflowStepRow } from './WorkflowStepRow';
 import { ScoutSubtree } from './ScoutSubtree';
 import { ClusterChildRow } from './ClusterChildRow';
 import { WorkflowKillButton } from './WorkflowKillButton';
+import { WorkflowRunStatus } from './WorkflowRunStatus';
 
 type Props = {
   readonly run: WorkflowRun;
@@ -53,6 +50,7 @@ type Props = {
   readonly workflowExpand: Readonly<Record<string, boolean>> | undefined;
   readonly workflowNameByRunId: ReadonlyMap<string, string>;
   readonly forceExpanded: boolean;
+  readonly variant?: 'sidebar' | 'detail';
   readonly toggleWorkflowExpand: AppStore['toggleWorkflowExpand'];
   readonly startWorkflowRun: AppStore['startWorkflowRun'];
   readonly setWorkflowRunAutoRun: AppStore['setWorkflowRunAutoRun'];
@@ -93,6 +91,7 @@ export const WorkflowRow = ({
   workflowExpand,
   workflowNameByRunId,
   forceExpanded,
+  variant = 'sidebar',
   toggleWorkflowExpand,
   startWorkflowRun,
   setWorkflowRunAutoRun,
@@ -130,72 +129,88 @@ export const WorkflowRow = ({
   const done = wfAgents.filter((a) => a.status === 'completed' || a.status === 'skipped').length;
   const isCompleted = !isDiscarded && total > 0 && done >= total;
   const unreadCount = countUnread(wfAgents);
-  const expanded =
-    focusedWorkflowRunId != null
+  const isDetail = variant === 'detail';
+  const expanded = isDetail
+    ? true
+    : focusedWorkflowRunId != null
       ? run.id === focusedWorkflowRunId
       : (workflowExpand?.[run.id] ?? (!isDiscarded && (!isCompleted || unreadCount > 0)));
   const hasStarted = wfAgents.length > 0;
   const isQueuedManual = !isDiscarded && run.triggerMode === 'manual' && !hasStarted;
-  const isQueuedAfter = !isDiscarded && run.triggerMode === 'after_run' && !hasStarted;
   const predecessorName = run.chainAfterId
     ? (workflowNameByRunId.get(run.chainAfterId) ?? 'previous')
     : 'previous';
   return (
-    <div className={cn('flex flex-col', forceExpanded && 'gap-1.5', isDiscarded && 'opacity-70')}>
-      <div className="flex items-center gap-0.5">
-        <button
-          type="button"
-          onClick={() => toggleWorkflowExpand(task.id, run.id, expanded)}
-          title={workflow.name || name}
-          aria-expanded={expanded}
-          aria-label={`${expanded ? 'collapse' : 'expand'} ${name} workflow`}
-          className="flex min-w-0 flex-1 items-center gap-1.5 rounded py-1 pl-1 pr-1.5 text-left transition-colors hover:bg-muted/50"
-        >
-          {expanded ? (
-            <ChevronDown size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
-          ) : (
-            <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
-          )}
-          {forceExpanded ? (
-            <WorkflowIcon size={13} aria-hidden className="shrink-0 text-accent" />
-          ) : null}
-          <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-            {name}
-          </span>
-          {unreadCount > 0 ? (
-            <span
-              className="inline-flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1.5 py-0.5 text-[10px] font-medium text-warning"
-              title={`${unreadCount} agent ${unreadCount === 1 ? 'reply' : 'replies'} to review`}
-            >
-              <span aria-hidden className="size-1.5 rounded-full bg-warning" />
-              {unreadCount}
+    <div
+      className={cn(
+        'flex flex-col',
+        isDetail ? 'gap-4' : forceExpanded && 'gap-1.5',
+        isDiscarded && 'opacity-70',
+      )}
+    >
+      <div className={cn('flex gap-2', isDetail ? 'items-start' : 'items-center gap-0.5')}>
+        {isDetail ? (
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-accent/10">
+              <WorkflowIcon size={17} aria-hidden className="text-accent" />
             </span>
-          ) : null}
-          {isDiscarded ? (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              <Ban size={10} aria-hidden /> discarded
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="truncate text-base font-semibold text-foreground">{name}</h2>
+                <WorkflowRunStatus
+                  run={run}
+                  workflow={workflow}
+                  agents={wfAgents}
+                  predecessorName={predecessorName}
+                />
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {done}/{total} steps
+              </span>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => toggleWorkflowExpand(task.id, run.id, expanded)}
+            title={workflow.name || name}
+            aria-expanded={expanded}
+            aria-label={`${expanded ? 'collapse' : 'expand'} ${name} workflow`}
+            className="flex min-w-0 flex-1 items-center gap-1.5 rounded py-1 pl-1 pr-1.5 text-left transition-colors hover:bg-muted/50"
+          >
+            {expanded ? (
+              <ChevronDown size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
+            ) : (
+              <ChevronRight size={12} aria-hidden className="shrink-0 text-muted-foreground/60" />
+            )}
+            {forceExpanded ? (
+              <WorkflowIcon size={13} aria-hidden className="shrink-0 text-accent" />
+            ) : null}
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+              {name}
             </span>
-          ) : isCompleted ? (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded bg-success/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-success">
-              <Check size={10} aria-hidden /> completed
-            </span>
-          ) : isQueuedManual ? (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-              <Pause size={10} aria-hidden /> queued (manual)
-            </span>
-          ) : isQueuedAfter ? (
-            <span
-              className="inline-flex max-w-[10rem] shrink-0 items-center gap-1 truncate rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
-              title={`after ${predecessorName}`}
-            >
-              <Link2 size={10} aria-hidden /> after {predecessorName}
-            </span>
-          ) : total > 0 ? (
-            <span className="shrink-0 font-mono text-[10px] text-muted-foreground/50">
-              {done}/{total}
-            </span>
-          ) : null}
-        </button>
+            {unreadCount > 0 ? (
+              <span
+                className="inline-flex shrink-0 items-center gap-1 rounded bg-warning/15 px-1.5 py-0.5 text-[10px] font-medium text-warning"
+                title={`${unreadCount} agent ${unreadCount === 1 ? 'reply' : 'replies'} to review`}
+              >
+                <span aria-hidden className="size-1.5 rounded-full bg-warning" />
+                {unreadCount}
+              </span>
+            ) : null}
+            <WorkflowRunStatus
+              run={run}
+              workflow={workflow}
+              agents={wfAgents}
+              predecessorName={predecessorName}
+            />
+            {total > 0 ? (
+              <span className="shrink-0 font-mono text-[10px] text-muted-foreground/50">
+                {done}/{total}
+              </span>
+            ) : null}
+          </button>
+        )}
         {!isDiscarded && !isCompleted && (
           <div className="flex shrink-0 items-center">
             {isQueuedManual ? (
@@ -259,7 +274,12 @@ export const WorkflowRow = ({
       </div>
       {expanded ? (
         wfAgents.length > 0 ? (
-          <div className={cn('flex flex-col gap-1 pb-1', forceExpanded ? 'pl-1' : 'pl-3')}>
+          <div
+            className={cn(
+              'flex flex-col gap-1 pb-1',
+              isDetail ? null : forceExpanded ? 'pl-1' : 'pl-3',
+            )}
+          >
             {wfAgents.map((run, index) => {
               const isActionable = run.stepId === actionableStepId && run.status === 'pending';
               const kind = agentKindOverride[run.id] ?? inferAgentKindFromName(run.name);
@@ -360,13 +380,13 @@ export const WorkflowRow = ({
             })}
           </div>
         ) : (
-          <p className="pb-1 pl-3 text-2xs text-muted-foreground/60">
+          <p className={cn('pb-1 text-2xs text-muted-foreground/60', !isDetail && 'pl-3')}>
             No agents yet for this workflow.
           </p>
         )
       ) : null}
       {expanded && !isDiscarded && wfBlockReason === 'failed-step' ? (
-        <div className={cn('pb-1', forceExpanded ? 'pl-1' : 'pl-3')}>
+        <div className={cn('pb-1', !isDetail && (forceExpanded ? 'pl-1' : 'pl-3'))}>
           <WorkflowNextStepCta
             workflow={workflow}
             runs={wfAgents}
@@ -376,7 +396,7 @@ export const WorkflowRow = ({
         </div>
       ) : null}
       {expanded ? (
-        <div className="pb-1 pl-3">
+        <div className={cn('pb-1', !isDetail && 'pl-3')}>
           <GoalAttachmentsStrip owner={{ type: 'workflow_run', id: run.id }} />
         </div>
       ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRunStatus.tsx
@@ -1,0 +1,71 @@
+import { Ban, Check, Link2, Pause } from 'lucide-react';
+import type { Agent, Workflow, WorkflowRun } from '@goodboy/types';
+import { StatusDot, cn } from '@goodboy/ui';
+
+type Props = {
+  readonly run: WorkflowRun;
+  readonly workflow: Workflow;
+  readonly agents: ReadonlyArray<Agent>;
+  readonly predecessorName: string;
+};
+
+export const WorkflowRunStatus = ({ run, workflow, agents, predecessorName }: Props) => {
+  const completedSteps = agents.filter(
+    (agent) => agent.status === 'completed' || agent.status === 'skipped',
+  ).length;
+  const isDiscarded = run.discardedAt != null;
+  const isCompleted =
+    !isDiscarded && workflow.steps.length > 0 && completedSteps >= workflow.steps.length;
+  const isRunning = agents.some((agent) => agent.status === 'running');
+  const hasStarted = agents.length > 0;
+  const isQueuedManual = !isDiscarded && run.triggerMode === 'manual' && !hasStarted;
+  const isQueuedAfter = !isDiscarded && run.triggerMode === 'after_run' && !hasStarted;
+
+  const baseClass =
+    'inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide';
+
+  if (isDiscarded) {
+    return (
+      <span className={cn(baseClass, 'bg-muted text-muted-foreground')}>
+        <Ban size={10} aria-hidden />
+        Discarded
+      </span>
+    );
+  }
+  if (isCompleted) {
+    return (
+      <span className={cn(baseClass, 'bg-success/10 text-success')}>
+        <Check size={10} aria-hidden />
+        Completed
+      </span>
+    );
+  }
+  if (isRunning) {
+    return (
+      <span className={cn(baseClass, 'bg-info/10 text-info')}>
+        <StatusDot tone="info" size="sm" pulsing />
+        Running
+      </span>
+    );
+  }
+  if (isQueuedManual) {
+    return (
+      <span className={cn(baseClass, 'bg-muted text-muted-foreground')}>
+        <Pause size={10} aria-hidden />
+        Queued
+      </span>
+    );
+  }
+  if (isQueuedAfter) {
+    return (
+      <span
+        className={cn(baseClass, 'max-w-40 truncate bg-muted text-muted-foreground')}
+        title={`after ${predecessorName}`}
+      >
+        <Link2 size={10} aria-hidden />
+        After {predecessorName}
+      </span>
+    );
+  }
+  return <span className={cn(baseClass, 'bg-accent/10 text-accent')}>Ready</span>;
+};

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -4,6 +4,7 @@ export const STORAGE_KEYS = {
   theme: `${PREFIX}theme`,
   pricingSortKey: `${PREFIX}pricing-sort-key`,
   diffSidebarCollapsed: `${PREFIX}diff-sidebar-collapsed`,
+  sessionsSidebarCollapsed: `${PREFIX}sessions-sidebar-collapsed`,
 } as const;
 
 export const STORAGE_PREFIXES = {

--- a/apps/desktop/src/store/parallel-turn.ts
+++ b/apps/desktop/src/store/parallel-turn.ts
@@ -305,6 +305,7 @@ export const runParallelBranch = async (
     await invokeAgentInsert({
       sessionId: session.id,
       stepId: def.id,
+      parentAgentId: orchestratingAgentId,
       ordinal: def.ordinal,
       name: def.name,
       status: 'running',

--- a/apps/desktop/src/store/selectors.test.ts
+++ b/apps/desktop/src/store/selectors.test.ts
@@ -34,6 +34,7 @@ const createRecord = ({ kind, estimatedCostUsd }: Params): TelemetryRecord =>
 type AgentParams = {
   readonly id: AgentId;
   readonly kind?: string;
+  readonly parentAgentId?: AgentId;
   readonly workflowRunId?: WorkflowRunId;
   readonly stepId?: StepId;
   readonly lastFinishedAt?: string;
@@ -42,6 +43,7 @@ type AgentParams = {
 const createAgent = ({
   id,
   kind,
+  parentAgentId,
   workflowRunId,
   stepId,
   lastFinishedAt = '2026-07-21T10:00:00.000Z',
@@ -53,6 +55,7 @@ const createAgent = ({
     name: 'agent',
     status: 'completed',
     kind,
+    parentAgentId,
     workflowRunId,
     stepId,
     lastFinishedAt,
@@ -92,6 +95,31 @@ describe('useSessionUnreadLens', () => {
           kind: 'resolver',
           workflowRunId: 'workflow-1' as WorkflowRunId,
           stepId: 'step-1' as StepId,
+        }),
+      ],
+    };
+
+    const { result } = renderHook(() => useSessionUnreadLens(SESSION_ID));
+
+    expect(result.current).toBe('workflows');
+  });
+
+  it('routes a cluster child reply through its workflow-step parent', () => {
+    const parentId = 'parent' as AgentId;
+    store.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        createAgent({
+          id: parentId,
+          kind: 'implementer',
+          workflowRunId: 'workflow-1' as WorkflowRunId,
+          stepId: 'step-1' as StepId,
+          lastFinishedAt: '2026-07-21T09:00:00.000Z',
+        }),
+        createAgent({
+          id: AGENT_ID,
+          kind: 'scout',
+          parentAgentId: parentId,
+          workflowRunId: 'workflow-1' as WorkflowRunId,
         }),
       ],
     };

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { worktreeChangedFiles } from '../features/worktree/worktree';
 import {
+  agentHomeLens,
   classifyAgent,
+  resolveRootAgent,
   selectNonResolverStandaloneAgents,
   type AgentKind,
 } from '../features/session/agent-kind';
@@ -478,13 +480,12 @@ export const useSessionUnreadLens = (sessionId: SessionId): SessionUnreadLens =>
     if (unreadAgent == null) {
       return null;
     }
-    if (unreadAgent.workflowRunId != null && unreadAgent.stepId != null) {
-      return 'workflows';
+    const rootAgent = resolveRootAgent({ agents: phaseRuns, agentId: unreadAgent.id });
+    if (rootAgent == null) {
+      return null;
     }
-    if (classifyAgent(unreadAgent, agentKindOverride[unreadAgent.id] ?? null) === 'resolver') {
-      return 'resolve';
-    }
-    return 'agents';
+    const kind = classifyAgent(rootAgent, agentKindOverride[rootAgent.id] ?? null);
+    return agentHomeLens(rootAgent, kind);
   }, [phaseRuns, selectedAgentId, isCurrentSession, agentKindOverride]);
 };
 

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -1,4 +1,5 @@
 import { getSessionViewPrefs } from './getSessionViewPrefs';
+import { sessionsSidebarStorage } from './sessionsSidebarStorage';
 import { setSessionGroup } from './setSessionGroup';
 import { setSessionSort } from './setSessionSort';
 import {
@@ -20,6 +21,7 @@ export type { SessionStudio, LensKind, LensHistory } from './types';
 
 export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice => {
   return {
+    sessionsSidebarCollapsed: sessionsSidebarStorage.read(),
     sessionViewPrefs: {},
     activeLens: {},
     lensHistory: {},
@@ -27,6 +29,15 @@ export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice
     sessionStudio: {},
     workflowExpand: {},
     focusedWorkflowRunId: {},
+    setSessionsSidebarCollapsed: (next) => {
+      sessionsSidebarStorage.write(next);
+      set({ sessionsSidebarCollapsed: next });
+    },
+    toggleSessionsSidebar: () => {
+      const next = !get().sessionsSidebarCollapsed;
+      sessionsSidebarStorage.write(next);
+      set({ sessionsSidebarCollapsed: next });
+    },
     getSessionViewPrefs: getSessionViewPrefs(set, get),
     setSessionSort: setSessionSort(set, get),
     setSessionGroup: setSessionGroup(set, get),

--- a/apps/desktop/src/store/slices/session-view/sessionsSidebar.test.ts
+++ b/apps/desktop/src/store/slices/session-view/sessionsSidebar.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+import { createSessionViewSlice } from './index';
+import type { SessionViewSlice } from './types';
+
+const localStorageMock = {
+  getItem: vi.fn<(key: string) => string | null>(() => null),
+  setItem: vi.fn<(key: string, value: string) => void>(() => undefined),
+};
+
+const createSliceHarness = () => {
+  let slice: SessionViewSlice;
+  const set = (update: unknown): void => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (state: SessionViewSlice) => Partial<SessionViewSlice>)(slice)
+        : (update as Partial<SessionViewSlice>);
+    slice = { ...slice, ...patch };
+  };
+  const get = (): SessionViewSlice => slice;
+  slice = createSessionViewSlice(set as never, get as never);
+  return { getState: get };
+};
+
+beforeEach(() => {
+  localStorageMock.getItem.mockReset();
+  localStorageMock.getItem.mockReturnValue(null);
+  localStorageMock.setItem.mockReset();
+  vi.stubGlobal('localStorage', localStorageMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sessions sidebar state', () => {
+  it('defaults to expanded without a persisted preference', () => {
+    const store = createSliceHarness();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(false);
+  });
+
+  it('reads the persisted collapsed preference', () => {
+    localStorageMock.getItem.mockReturnValue('1');
+    const store = createSliceHarness();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+  });
+
+  it('sets and persists the collapsed state', () => {
+    const store = createSliceHarness();
+    store.getState().setSessionsSidebarCollapsed(true);
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      STORAGE_KEYS.sessionsSidebarCollapsed,
+      '1',
+    );
+  });
+
+  it('toggles and persists the collapsed state', () => {
+    const store = createSliceHarness();
+    store.getState().toggleSessionsSidebar();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      STORAGE_KEYS.sessionsSidebarCollapsed,
+      '1',
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/session-view/sessionsSidebarStorage.ts
+++ b/apps/desktop/src/store/slices/session-view/sessionsSidebarStorage.ts
@@ -1,0 +1,23 @@
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+
+type SessionsSidebarStorage = {
+  readonly read: () => boolean;
+  readonly write: (collapsed: boolean) => void;
+};
+
+export const sessionsSidebarStorage: SessionsSidebarStorage = {
+  read: () => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.sessionsSidebarCollapsed) === '1';
+    } catch {
+      return false;
+    }
+  },
+  write: (collapsed) => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.sessionsSidebarCollapsed, collapsed ? '1' : '0');
+    } catch {
+      return;
+    }
+  },
+};

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -75,6 +75,7 @@ export type LensHistory = {
 };
 
 type SessionViewSliceState = {
+  readonly sessionsSidebarCollapsed: boolean;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -85,6 +86,8 @@ type SessionViewSliceState = {
 };
 
 type SessionViewSliceActions = {
+  setSessionsSidebarCollapsed(next: boolean): void;
+  toggleSessionsSidebar(): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;

--- a/apps/desktop/src/store/store.parallel.test.ts
+++ b/apps/desktop/src/store/store.parallel.test.ts
@@ -304,11 +304,18 @@ describe('sendTurn, parallel agents branch', () => {
     invokeParallelPhaseRunSpawnSpy.mockResolvedValue([]);
     const insertedPhaseRuns: Agent[] = [];
     phaseRunInsertSpy.mockImplementation(
-      async (args: { stepId: string; providerRunId: string; ordinal: number; name: string }) => {
+      async (args: {
+        stepId: string;
+        parentAgentId: AgentId;
+        providerRunId: string;
+        ordinal: number;
+        name: string;
+      }) => {
         const row: Agent = {
           id: `phase-run-${args.stepId}` as AgentId,
           sessionId: SESSION_ID,
           stepId: args.stepId as StepId,
+          parentAgentId: args.parentAgentId,
           ordinal: args.ordinal,
           name: args.name,
           status: 'running',
@@ -391,6 +398,14 @@ describe('sendTurn, parallel agents branch', () => {
 
     expect(parallelPhaseGroupUpdateCompletedAtSpy).toHaveBeenCalledOnce();
     expect(phaseRunInsertSpy).toHaveBeenCalledTimes(2);
+    expect(phaseRunInsertSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ parentAgentId: 'agent-1' }),
+    );
+    expect(phaseRunInsertSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ parentAgentId: 'agent-1' }),
+    );
     expect(phaseRunUpdateStatusSpy).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -277,6 +277,7 @@ export type AppState = UpdaterState & {
   readonly sessionNudges: Readonly<Record<SessionId, SessionNudge | null>>;
   readonly sessionLoading: Readonly<Record<SessionId, SessionLoadingFlags>>;
   readonly boardReady: boolean;
+  readonly sessionsSidebarCollapsed: boolean;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -693,6 +694,8 @@ export type AppActions = {
   runPlan(sessionId: SessionId, planId: PlanId): Promise<void>;
   dismissSessionNudge(sessionId: SessionId, outcome?: 'accepted' | 'dismissed'): Promise<void>;
   acceptSessionNudgeHandoff(sessionId: SessionId): Promise<void>;
+  setSessionsSidebarCollapsed(next: boolean): void;
+  toggleSessionsSidebar(): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;
@@ -798,6 +801,7 @@ export const initialState: AppState = {
   openQuestionScrollTarget: null,
   sessionLoading: {},
   boardReady: true,
+  sessionsSidebarCollapsed: false,
   sessionViewPrefs: {},
   activeLens: {},
   lensHistory: {},


### PR DESCRIPTION
## Problem
The Workflows lens rendered the sidebar list as a full page, and opening a workflow agent's chat added a redundant w-72 left panel showing the same list again. Two panels for one navigation concept, visually cluttered and unintuitive.

## Change
**Workflow agent chat goes full-width.** The left overlay panel is removed for workflow-home agents. The breadcrumb row becomes the flow of reference: a workflow stepper strip with the workflow chip (click = back to Workflows lens, run focused) and one pill per step (`1 Scout / 2 Plan / ...`) showing live status (done / running / failed / pending). Clicking a pill jumps to that step's chat; steps with clusters get an `n/m` badge that opens a popover listing the cluster children (click = open that child's chat). Agents/resolve overlays keep their panel (resolve depends on it for fan-out).

**Workflows lens redesigned:**
- 0 runs: existing empty state.
- 1 run: no list, the workflow detail renders directly full-width; "Attach another workflow" moves to a compact header action.
- 2+ runs: Plan Studio pattern, left rail of compact run cards (name, status chip, step progress, running indicator, after-chain label) + full detail of the focused run.

The detail body reuses the existing WorkflowRow/WorkflowStepRow/cluster subtree via a new `detail` variant (no collapsible card chrome). The attached-runs derivation is extracted into `useAttachedWorkflowRuns` shared by AgentsSection, WorkflowsPane and SessionWorkspace.

## Collapsible sessions sidebar
- `cmd+B` toggles the sessions sidebar (VSCode precedent), listed in the shortcuts help panel.
- Collapse button in the SESSIONS header; reopen button at the far left of the session top bar while collapsed.
- Global flag persisted to localStorage, restored on launch; reuses AppShell leftHidden (board view untouched).

## Stacked on #939
Uses `resolveRootAgent` from the home-lens fix. Retarget to main after #939 merges.

## Verification
- typecheck green
- desktop suite: 237 files, 2158 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
