### PR TITLE
feat(desktop): collapsible sessions sidebar with cmd+b toggle

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -77,6 +77,8 @@ export const App = () => {
   const hasWorkspaces = workspaces.length > 0;
   const currentWorkspace = useCurrentWorkspace();
   const currentSession = useCurrentSession();
+  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
+  const toggleSessionsSidebar = useAppStore((s) => s.toggleSessionsSidebar);
   const hasLinear = useAppStore((s) =>
     (s.workspaceIntegrations?.[currentWorkspace?.id ?? ('' as WorkspaceId)] ?? []).some(
       (i) => i.provider === 'linear',
@@ -686,6 +688,7 @@ export const App = () => {
   useKeyboardShortcut('cmd+k', () => openPalette());
   useKeyboardShortcut('cmd+o', () => setSwitcherOpen(true));
   useKeyboardShortcut('cmd+n', openNewSession, { ignoreInInputs: false });
+  useKeyboardShortcut('cmd+b', toggleSessionsSidebar, { ignoreInInputs: false });
   useKeyboardShortcut('cmd+[', () => navigateLens(-1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+]', () => navigateLens(1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+shift+[', () => navigateSession(-1), { ignoreInInputs: false });
@@ -804,7 +807,7 @@ export const App = () => {
             />
           ) : undefined
         }
-        leftHidden={!currentSession}
+        leftHidden={!currentSession || sessionsSidebarCollapsed}
         leftSidebar={hasWorkspaces ? <WorkspacesSidebar /> : undefined}
         main={
           <div className="relative h-full w-full">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Session } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    sessionsSidebarCollapsed: false,
+    setSessionsSidebarCollapsed: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../workspace/components/SessionDetailPanel', () => ({
+  SessionDetailPanel: () => <div>session details</div>,
+}));
+
+import { SessionTopBar } from './SessionTopBar';
+
+const SESSION = { goal: 'test session' } as Session;
+
+beforeEach(() => {
+  state.sessionsSidebarCollapsed = false;
+  state.setSessionsSidebarCollapsed.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionTopBar', () => {
+  it('does not render the reopen button while the sessions sidebar is visible', () => {
+    render(<SessionTopBar session={SESSION} />);
+    expect(screen.queryByRole('button', { name: 'show sessions' })).toBeNull();
+  });
+
+  it('reopens the sessions sidebar from an open session', () => {
+    state.sessionsSidebarCollapsed = true;
+    render(<SessionTopBar session={SESSION} />);
+    fireEvent.click(screen.getByRole('button', { name: 'show sessions' }));
+    expect(state.setSessionsSidebarCollapsed).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
@@ -1,5 +1,7 @@
-import { Divider } from '@goodboy/ui';
+import { PanelLeftOpen } from 'lucide-react';
+import { Divider, Tooltip, cn } from '@goodboy/ui';
 import type { Session } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
 import { SessionDetailPanel } from '../../../../workspace/components/SessionDetailPanel';
 
 type SessionTopBarProps = {
@@ -7,9 +9,29 @@ type SessionTopBarProps = {
 };
 
 export const SessionTopBar = ({ session }: SessionTopBarProps) => {
+  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
+  const setSessionsSidebarCollapsed = useAppStore((s) => s.setSessionsSidebarCollapsed);
+
   return (
     <>
-      <div className="flex w-full items-center gap-3 bg-background pr-3">
+      <div
+        className={cn(
+          'flex w-full items-center gap-3 bg-background pr-3',
+          sessionsSidebarCollapsed && 'pl-2',
+        )}
+      >
+        {sessionsSidebarCollapsed ? (
+          <Tooltip content="show sessions (⌘B)" side="bottom">
+            <button
+              type="button"
+              onClick={() => setSessionsSidebarCollapsed(false)}
+              aria-label="show sessions"
+              className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            >
+              <PanelLeftOpen size={13} aria-hidden />
+            </button>
+          </Tooltip>
+        ) : null}
         <div className="min-w-0 flex-1">
           <SessionDetailPanel
             session={session}

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -23,6 +23,7 @@ type Props = {
 const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly label: string }> = [
   { combo: ['⌘', 'K'], label: 'command palette' },
   { combo: ['⌘', 'N'], label: 'new session' },
+  { combo: ['⌘', 'B'], label: 'toggle sessions sidebar' },
   { combo: ['⌘', '1', '..', '9'], label: 'jump to workspace 1 to 9' },
   { combo: ['⌘', '['], label: 'back (lens history)' },
   { combo: ['⌘', ']'], label: 'forward (lens history)' },

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -11,6 +11,7 @@ const { state } = vi.hoisted(() => ({
     sessionExternalTasks: {} as Record<string, unknown>,
     bulkUnarchiveTask: vi.fn(async () => undefined),
     bulkDeleteTask: vi.fn(async () => undefined),
+    setSessionsSidebarCollapsed: vi.fn(),
   },
 }));
 
@@ -91,6 +92,7 @@ function clickCheckbox(index: number): HTMLElement {
 beforeEach(() => {
   state.bulkUnarchiveTask.mockClear();
   state.bulkDeleteTask.mockClear();
+  state.setSessionsSidebarCollapsed.mockClear();
   state.sessionExternalTasks = {};
 });
 
@@ -106,6 +108,12 @@ describe('SessionActivityBar, baseline', () => {
   it('renders empty-state copy when no sessions in active tab', () => {
     renderBar([]);
     expect(screen.getByText(/no sessions yet/i)).toBeDefined();
+  });
+
+  it('collapses the sessions sidebar from the header button', () => {
+    renderBar([]);
+    fireEvent.click(screen.getByRole('button', { name: 'hide sessions' }));
+    expect(state.setSessionsSidebarCollapsed).toHaveBeenCalledWith(true);
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -1,6 +1,14 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { Archive, Check, ChevronRight, Plus, RotateCcw, Trash2 } from 'lucide-react';
-import { Button, cn, ScrollArea, StatusDot } from '@goodboy/ui';
+import {
+  Archive,
+  Check,
+  ChevronRight,
+  PanelLeftClose,
+  Plus,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react';
+import { Button, cn, ScrollArea, StatusDot, Tooltip } from '@goodboy/ui';
 import type {
   Session,
   SessionGroupKey,
@@ -74,6 +82,7 @@ export const SessionActivityBar = ({
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<SessionId>>(new Set());
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
   const bulkUnarchiveTask = useAppStore((s) => s.bulkUnarchiveTask);
+  const setSessionsSidebarCollapsed = useAppStore((s) => s.setSessionsSidebarCollapsed);
 
   const prefs = useSessionViewPrefs(workspaceId);
 
@@ -155,6 +164,16 @@ export const SessionActivityBar = ({
                 Archived
               </button>
               <SessionViewMenu workspaceId={workspaceId} />
+              <Tooltip content="hide sessions (⌘B)" side="bottom">
+                <button
+                  type="button"
+                  onClick={() => setSessionsSidebarCollapsed(true)}
+                  aria-label="hide sessions"
+                  className="inline-flex shrink-0 items-center justify-center rounded p-1 text-muted-foreground/70 motion-safe:transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/40"
+                >
+                  <PanelLeftClose size={13} aria-hidden />
+                </button>
+              </Tooltip>
             </div>
           </div>
 

--- a/apps/desktop/src/shared/lib/storage-keys.ts
+++ b/apps/desktop/src/shared/lib/storage-keys.ts
@@ -4,6 +4,7 @@ export const STORAGE_KEYS = {
   theme: `${PREFIX}theme`,
   pricingSortKey: `${PREFIX}pricing-sort-key`,
   diffSidebarCollapsed: `${PREFIX}diff-sidebar-collapsed`,
+  sessionsSidebarCollapsed: `${PREFIX}sessions-sidebar-collapsed`,
 } as const;
 
 export const STORAGE_PREFIXES = {

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -1,4 +1,5 @@
 import { getSessionViewPrefs } from './getSessionViewPrefs';
+import { sessionsSidebarStorage } from './sessionsSidebarStorage';
 import { setSessionGroup } from './setSessionGroup';
 import { setSessionSort } from './setSessionSort';
 import {
@@ -20,6 +21,7 @@ export type { SessionStudio, LensKind, LensHistory } from './types';
 
 export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice => {
   return {
+    sessionsSidebarCollapsed: sessionsSidebarStorage.read(),
     sessionViewPrefs: {},
     activeLens: {},
     lensHistory: {},
@@ -27,6 +29,15 @@ export const createSessionViewSlice = (set: SetFn, get: GetFn): SessionViewSlice
     sessionStudio: {},
     workflowExpand: {},
     focusedWorkflowRunId: {},
+    setSessionsSidebarCollapsed: (next) => {
+      sessionsSidebarStorage.write(next);
+      set({ sessionsSidebarCollapsed: next });
+    },
+    toggleSessionsSidebar: () => {
+      const next = !get().sessionsSidebarCollapsed;
+      sessionsSidebarStorage.write(next);
+      set({ sessionsSidebarCollapsed: next });
+    },
     getSessionViewPrefs: getSessionViewPrefs(set, get),
     setSessionSort: setSessionSort(set, get),
     setSessionGroup: setSessionGroup(set, get),

--- a/apps/desktop/src/store/slices/session-view/sessionsSidebar.test.ts
+++ b/apps/desktop/src/store/slices/session-view/sessionsSidebar.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+import { createSessionViewSlice } from './index';
+import type { SessionViewSlice } from './types';
+
+const localStorageMock = {
+  getItem: vi.fn<(key: string) => string | null>(() => null),
+  setItem: vi.fn<(key: string, value: string) => void>(() => undefined),
+};
+
+const createSliceHarness = () => {
+  let slice: SessionViewSlice;
+  const set = (update: unknown): void => {
+    const patch =
+      typeof update === 'function'
+        ? (update as (state: SessionViewSlice) => Partial<SessionViewSlice>)(slice)
+        : (update as Partial<SessionViewSlice>);
+    slice = { ...slice, ...patch };
+  };
+  const get = (): SessionViewSlice => slice;
+  slice = createSessionViewSlice(set as never, get as never);
+  return { getState: get };
+};
+
+beforeEach(() => {
+  localStorageMock.getItem.mockReset();
+  localStorageMock.getItem.mockReturnValue(null);
+  localStorageMock.setItem.mockReset();
+  vi.stubGlobal('localStorage', localStorageMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sessions sidebar state', () => {
+  it('defaults to expanded without a persisted preference', () => {
+    const store = createSliceHarness();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(false);
+  });
+
+  it('reads the persisted collapsed preference', () => {
+    localStorageMock.getItem.mockReturnValue('1');
+    const store = createSliceHarness();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+  });
+
+  it('sets and persists the collapsed state', () => {
+    const store = createSliceHarness();
+    store.getState().setSessionsSidebarCollapsed(true);
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      STORAGE_KEYS.sessionsSidebarCollapsed,
+      '1',
+    );
+  });
+
+  it('toggles and persists the collapsed state', () => {
+    const store = createSliceHarness();
+    store.getState().toggleSessionsSidebar();
+    expect(store.getState().sessionsSidebarCollapsed).toBe(true);
+    expect(localStorageMock.setItem).toHaveBeenCalledWith(
+      STORAGE_KEYS.sessionsSidebarCollapsed,
+      '1',
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/session-view/sessionsSidebarStorage.ts
+++ b/apps/desktop/src/store/slices/session-view/sessionsSidebarStorage.ts
@@ -1,0 +1,23 @@
+import { STORAGE_KEYS } from '../../../shared/lib/storage-keys';
+
+type SessionsSidebarStorage = {
+  readonly read: () => boolean;
+  readonly write: (collapsed: boolean) => void;
+};
+
+export const sessionsSidebarStorage: SessionsSidebarStorage = {
+  read: () => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.sessionsSidebarCollapsed) === '1';
+    } catch {
+      return false;
+    }
+  },
+  write: (collapsed) => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.sessionsSidebarCollapsed, collapsed ? '1' : '0');
+    } catch {
+      return;
+    }
+  },
+};

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -75,6 +75,7 @@ export type LensHistory = {
 };
 
 type SessionViewSliceState = {
+  readonly sessionsSidebarCollapsed: boolean;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -85,6 +86,8 @@ type SessionViewSliceState = {
 };
 
 type SessionViewSliceActions = {
+  setSessionsSidebarCollapsed(next: boolean): void;
+  toggleSessionsSidebar(): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -277,6 +277,7 @@ export type AppState = UpdaterState & {
   readonly sessionNudges: Readonly<Record<SessionId, SessionNudge | null>>;
   readonly sessionLoading: Readonly<Record<SessionId, SessionLoadingFlags>>;
   readonly boardReady: boolean;
+  readonly sessionsSidebarCollapsed: boolean;
   readonly sessionViewPrefs: Readonly<Record<WorkspaceId, SessionViewPrefs>>;
   readonly activeLens: Readonly<Record<SessionId, LensKind | null>>;
   readonly lensHistory: Readonly<Record<SessionId, LensHistory>>;
@@ -693,6 +694,8 @@ export type AppActions = {
   runPlan(sessionId: SessionId, planId: PlanId): Promise<void>;
   dismissSessionNudge(sessionId: SessionId, outcome?: 'accepted' | 'dismissed'): Promise<void>;
   acceptSessionNudgeHandoff(sessionId: SessionId): Promise<void>;
+  setSessionsSidebarCollapsed(next: boolean): void;
+  toggleSessionsSidebar(): void;
   getSessionViewPrefs(workspaceId: WorkspaceId): SessionViewPrefs;
   setSessionSort(workspaceId: WorkspaceId, sort: SessionSortKey): void;
   setSessionGroup(workspaceId: WorkspaceId, group: SessionGroupKey): void;
@@ -798,6 +801,7 @@ export const initialState: AppState = {
   openQuestionScrollTarget: null,
   sessionLoading: {},
   boardReady: true,
+  sessionsSidebarCollapsed: false,
   sessionViewPrefs: {},
   activeLens: {},
   lensHistory: {},


### PR DESCRIPTION
## Problem
The sessions sidebar always occupies its full width in session view. When working inside one session it wastes horizontal space with no way to dismiss it.

## Change
- `cmd+B` toggles the sessions sidebar (VSCode precedent; `cmd+shift+B` was taken, `cmd+B` was free). Listed in the shortcuts help panel.
- Collapse button (PanelLeftClose) in the SESSIONS header row of SessionActivityBar.
- Reopen button (PanelLeftOpen) at the far left of the session top bar, rendered only while a session is open with the sidebar collapsed, tooltip shows the shortcut.
- State is global, persisted to localStorage (`goodboy:sessions-sidebar-collapsed`, same pattern as the diff sidebar flag) and restored on launch.
- Reuses AppShell's existing `leftHidden` mechanism (animated grid columns, resize handle suppression): `leftHidden = !currentSession || sessionsSidebarCollapsed`. Board view is untouched (sidebar was already hidden there).

## Verification
- typecheck green
- desktop suite: 235 files, 2141 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)