### PR TITLE
fix(desktop): polish workflow nav crumbs, chat dedup, pane header

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
+const chatBreadcrumbMock = vi.hoisted(() => vi.fn());
+
 const { state, openQuestions, answeredQuestions, transcriptItems } = vi.hoisted(() => ({
   openQuestions: { current: [] as ReadonlyArray<unknown> },
   answeredQuestions: { current: [] as ReadonlyArray<unknown> },
@@ -65,7 +67,10 @@ vi.mock('../AuthRequiredCallout', () => ({
 }));
 
 vi.mock('../ChatBreadcrumb', () => ({
-  ChatBreadcrumb: () => null,
+  ChatBreadcrumb: (props: unknown) => {
+    chatBreadcrumbMock(props);
+    return null;
+  },
 }));
 
 vi.mock('../ChatInput', () => ({
@@ -119,6 +124,7 @@ beforeEach(() => {
   state.loadSessionOpenQuestions.mockClear();
   state.loadSessionAnsweredQuestions.mockClear();
   state.clearOpenQuestionScroll.mockClear();
+  chatBreadcrumbMock.mockClear();
   openQuestions.current = [];
   answeredQuestions.current = [];
   transcriptItems.current = [];
@@ -131,6 +137,11 @@ describe('ChatView', () => {
   it('renders without throwing on an empty session', () => {
     const { container } = render(<ChatView session={session} />);
     expect(container.firstChild).not.toBeNull();
+  });
+
+  it('does not render the breadcrumb when it is hidden', () => {
+    render(<ChatView session={session} hideBreadcrumb />);
+    expect(chatBreadcrumbMock).not.toHaveBeenCalled();
   });
 
   it('loads open and answered questions on mount', () => {

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -47,11 +47,12 @@ import { TranscriptSkeleton } from './parts/TranscriptSkeleton';
 type ChatViewProps = {
   session: Session;
   isActive?: boolean;
+  hideBreadcrumb?: boolean;
 };
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
+export const ChatView = ({ session, isActive = true, hideBreadcrumb = false }: ChatViewProps) => {
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[session.id] ?? null,
   ) as AgentId | null;
@@ -395,7 +396,7 @@ export const ChatView = ({ session, isActive = true }: ChatViewProps) => {
 
   return (
     <div className="flex h-full flex-col">
-      <ChatBreadcrumb session={session} />
+      {!hideBreadcrumb && <ChatBreadcrumb session={session} />}
       <div ref={fadeHostRef} className="relative flex min-h-0 flex-1 flex-col">
         <ScrollFade
           className="flex-1"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -287,7 +287,11 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   </>
                 )}
                 <div className="min-h-0 min-w-0 flex-1">
-                  <ChatView session={session} isActive={isActive && selectedAgentId != null} />
+                  <ChatView
+                    session={session}
+                    isActive={isActive && selectedAgentId != null}
+                    hideBreadcrumb={showWorkflowStrip}
+                  />
                 </div>
               </div>
             ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.test.tsx
@@ -132,6 +132,7 @@ describe('WorkflowsPane', () => {
   it('shows one full detail without a rail and puts attach in the header', () => {
     render(<WorkflowsPane session={buildSession({ runIds: ['run-1'] })} />);
 
+    expect(screen.queryByTestId('pane-shell')).toBeNull();
     expect(screen.queryByRole('complementary', { name: 'Attached workflows' })).toBeNull();
     expect(screen.getByTestId('workflow-detail').getAttribute('data-run-id')).toBe('run-1');
     expect(screen.getByRole('button', { name: 'Attach another workflow' })).toBeDefined();
@@ -142,6 +143,9 @@ describe('WorkflowsPane', () => {
     render(<WorkflowsPane session={buildSession({ runIds: ['run-1', 'run-2'] })} />);
 
     expect(screen.getByRole('complementary', { name: 'Attached workflows' })).toBeDefined();
+    expect(screen.queryByTestId('pane-shell')).toBeNull();
+    expect(screen.getByText('Workflows')).toBeDefined();
+    expect(screen.getByText('2')).toBeDefined();
     expect(screen.getByText('First workflow')).toBeDefined();
     expect(screen.getByText('Second workflow')).toBeDefined();
     expect(screen.getAllByText('0/2 steps')).toHaveLength(2);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowsPane.tsx
@@ -1,4 +1,3 @@
-import { Workflow as WorkflowIcon } from 'lucide-react';
 import type { Agent, Session, SessionId } from '@goodboy/types';
 import { Divider, ScrollFade } from '@goodboy/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
@@ -52,20 +51,24 @@ export const WorkflowsPane = ({ session }: Props) => {
   }
   if (attachedRuns.length === 1 && selectedRun != null) {
     return (
-      <PaneShell
-        title="Workflows"
-        description="Sequences of agents that drive this session toward its goal."
-        actions={<WorkflowAttachButton sessionId={sessionId} placement="header" />}
-        width="3xl"
-      >
-        <AgentsSection
-          task={session}
-          only="workflows"
-          workflowRunId={selectedRun.run.id}
-          workflowVariant="detail"
-          showWorkflowAttach={false}
-        />
-      </PaneShell>
+      <ScrollFade className="h-full" viewportClassName="px-6 py-5" fadeSize={24}>
+        <div className="mx-auto flex max-w-3xl flex-col gap-5 motion-safe:animate-studio-in">
+          <div className="flex items-start gap-3">
+            <div className="min-w-0 flex-1">
+              <AgentsSection
+                task={session}
+                only="workflows"
+                workflowRunId={selectedRun.run.id}
+                workflowVariant="detail"
+                showWorkflowAttach={false}
+              />
+            </div>
+            <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+              <WorkflowAttachButton sessionId={sessionId} placement="header" />
+            </div>
+          </div>
+        </div>
+      </ScrollFade>
     );
   }
   if (selectedRun == null) {
@@ -74,22 +77,14 @@ export const WorkflowsPane = ({ session }: Props) => {
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
-      <div className="flex shrink-0 items-center gap-3 px-6 py-4">
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-accent/10">
-          <WorkflowIcon size={16} aria-hidden className="text-accent" />
-        </span>
-        <div className="flex flex-col gap-0.5">
-          <h1 className="text-xl font-semibold leading-snug text-foreground">Workflows</h1>
-          <p className="text-sm text-muted-foreground">
-            Sequences of agents that drive this session toward its goal.
-          </p>
-        </div>
-      </div>
-      <Divider />
       <div className="flex min-h-0 flex-1">
         <aside className="flex w-60 shrink-0 flex-col" aria-label="Attached workflows">
+          <div className="flex shrink-0 items-center justify-between gap-2 px-3 pt-3 text-2xs font-semibold uppercase tracking-wide text-muted-foreground/70">
+            <span>Workflows</span>
+            <span className="tabular-nums">{attachedRuns.length}</span>
+          </div>
           <ScrollFade className="min-h-0 flex-1">
-            <ul className="flex flex-col gap-1 p-3">
+            <ul className="flex flex-col gap-1 px-3 pb-3 pt-2">
               {attachedRuns.map(({ run, workflow }) => {
                 const predecessorName = run.chainAfterId
                   ? (workflowNameByRunId.get(run.chainAfterId) ?? 'previous')

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -103,8 +103,9 @@ describe('buildSessionBreadcrumb', () => {
         h,
       ),
     );
-    expect(labels(crumbs)).toEqual(['Overview']);
-    expect(last(crumbs)?.onClick).toBeUndefined();
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows']);
+    expect(crumbs[0]?.onClick).toBeDefined();
+    expect(crumbs[1]?.onClick).toBeDefined();
   });
 
   it('degrades a workflows lens with no focused run to a two-crumb leaf trail', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -78,7 +78,7 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
   }
 
   if (suppressAgentTail && selectedAgentName != null && overlayHomeLens != null) {
-    return sealLast([overview]);
+    return [overview, workflowsList];
   }
 
   if (selectedAgentName != null && overlayHomeLens != null) {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -156,7 +156,9 @@ export const WorkflowRow = ({
             </span>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <div className="flex flex-wrap items-center gap-2">
-                <h2 className="truncate text-base font-semibold text-foreground">{name}</h2>
+                <h2 className="truncate text-xl font-semibold leading-snug text-foreground">
+                  {name}
+                </h2>
                 <WorkflowRunStatus
                   run={run}
                   workflow={workflow}


### PR DESCRIPTION
Follow-up polish on the workflow nav overhaul (#942), from screenshot review.

## Fixes
1. **Stepper strip breadcrumb**: the strip trail was `Overview | <workflow> | steps`, missing the Workflows lens segment. Now `Overview > Workflows` (both clickable) precedes the workflow chip.
2. **Duplicate breadcrumb + parent CTA in workflow chat**: ChatView always rendered ChatBreadcrumb (workspace > session > workflow n/m, plus the go-to-parent button). Redundant under the stepper strip, which already carries workflow/step/cluster navigation. New `hideBreadcrumb` prop on ChatView, passed when the strip is shown. Agents-home chats unchanged.
3. **Workflows pane header**: dropped the generic "Workflows" h1 + description that triplicated info already in the app breadcrumb and the run detail card. The detail card header (icon, name, status, n/m steps, controls) is promoted to page-header scale; single-run keeps the attach button top-right; multi-run rail gets a slim uppercase header with run count.

## Verification
- pnpm typecheck green
- pnpm --filter desktop test: 243 files, 2209 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)