### PR TITLE
feat(desktop): sessions mini-rail, persistent lens column, regroup

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -807,7 +807,8 @@ export const App = () => {
             />
           ) : undefined
         }
-        leftHidden={!currentSession || sessionsSidebarCollapsed}
+        leftHidden={!currentSession}
+        leftCollapsed={sessionsSidebarCollapsed}
         leftSidebar={hasWorkspaces ? <WorkspacesSidebar /> : undefined}
         main={
           <div className="relative h-full w-full">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Agent, Session } from '@goodboy/types';
 import type { LensKind } from '../../../../store';
 
@@ -79,7 +79,13 @@ vi.mock('../../../../app/components/AppBreadcrumb', () => ({
 vi.mock('../SessionOverviewPane', () => ({ SessionOverviewPane: () => null }));
 vi.mock('./parts/SessionStudioLayer', () => ({ SessionStudioLayer: () => null }));
 vi.mock('./parts/SessionTopBar', () => ({ SessionTopBar: () => null }));
-vi.mock('./parts/LensColumn', () => ({ LensColumn: () => null }));
+vi.mock('./parts/LensColumn', () => ({
+  LensColumn: ({ onSelectOverview }: { onSelectOverview: () => void }) => (
+    <button type="button" onClick={onSelectOverview}>
+      Overview
+    </button>
+  ),
+}));
 vi.mock('./parts/QuestionsPane', () => ({ QuestionsPane: () => null }));
 vi.mock('./parts/SlotPane', () => ({ SlotPane: () => null }));
 vi.mock('./parts/PrPane', () => ({ PrPane: () => null }));
@@ -185,5 +191,17 @@ describe('SessionWorkspace workflow breadcrumb', () => {
     render(<SessionWorkspace session={workflowSession} isActive />);
 
     expect(screen.getByTestId('breadcrumb').textContent).toBe('Overview / Workflows / refactor');
+  });
+});
+
+describe('SessionWorkspace overview', () => {
+  it('keeps the lens column visible and selects Overview', () => {
+    store.activeLens = { [SESSION_ID]: null };
+    store.selectedAgentId = {};
+
+    render(<SessionWorkspace session={session} isActive />);
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+
+    expect(store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, null);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -107,7 +107,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const showStudio = studio != null;
   const showAgentOverlay = selectedAgentId != null && !showStudio;
   const showLens = selectedAgentId == null && !showStudio;
-  const onBareOverview = showLens && lens === null;
   const overlayHome = agentHome ?? 'agents';
   const showWorkflowStrip = showAgentOverlay && overlayHome === 'workflows';
 
@@ -193,19 +192,16 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
       </div>
       <Divider />
       <div className="flex min-h-0 flex-1">
-        {onBareOverview ? null : (
-          <>
-            <div className="flex w-60 shrink-0 flex-col bg-background">
-              <LensColumn
-                session={session}
-                activeLens={lens}
-                onSelect={onSelectLens}
-                filesCount={filesTouched.count}
-              />
-            </div>
-            <Divider orientation="vertical" />
-          </>
-        )}
+        <div className="flex w-60 shrink-0 flex-col bg-background">
+          <LensColumn
+            session={session}
+            activeLens={lens}
+            onSelectOverview={onSelectOverview}
+            onSelect={onSelectLens}
+            filesCount={filesTouched.count}
+          />
+        </div>
+        <Divider orientation="vertical" />
         <div className="relative flex min-w-0 flex-1 flex-col">
           <div className="relative min-h-0 flex-1">
             {showLens ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Session } from '@goodboy/types';
+
+const { store } = vi.hoisted(() => ({
+  store: {
+    agentKindOverride: {},
+    sessionPhaseRuns: {},
+    scriptRuns: {},
+    terminalSessions: {},
+    sessionGithub: {},
+    sessionGitlabMr: {},
+    sessionPendingResolutions: {},
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
+  useNonResolverStandaloneAgents: () => [],
+  useSessionOpenQuestions: () => [],
+  useSessionPlans: () => [],
+  useSessionStageInfo: () => ({ stage: 'done' as const, reason: 'idle' }),
+  useSessionUnreadLens: () => null,
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import { LensColumn } from './LensColumn';
+
+const SESSION = {
+  id: 'session-1',
+  workflowRuns: [],
+} as unknown as Session;
+
+afterEach(cleanup);
+
+describe('LensColumn', () => {
+  it('renders active Overview and selects it', () => {
+    const onSelectOverview = vi.fn();
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={onSelectOverview}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    const overview = screen.getByRole('button', { name: 'Overview' });
+    expect(overview.getAttribute('aria-current')).toBe('page');
+    fireEvent.click(overview);
+    expect(onSelectOverview).toHaveBeenCalledOnce();
+  });
+
+  it('orders the regrouped lens sections and rows', () => {
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens="agents"
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(
+      screen
+        .getAllByText(/^(Work|Changes|Artifacts|Context|Infra)$/)
+        .map((heading) => heading.textContent),
+    ).toEqual(['Work', 'Changes', 'Artifacts', 'Context', 'Infra']);
+    expect(screen.getAllByRole('button').map((button) => button.textContent?.trim())).toEqual([
+      'Overview',
+      'Workflows',
+      'Agents',
+      'Resolve',
+      'Questions',
+      'Diff',
+      'Pull request',
+      'Plans',
+      'Scripts',
+      'Goal',
+      'Decisions',
+      'Session summary',
+      'Terminal',
+    ]);
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -8,6 +8,7 @@ import {
   FileDiff,
   FileText,
   GitPullRequest,
+  LayoutDashboard,
   Layers,
   MessageSquareReply,
   SquareTerminal,
@@ -33,6 +34,7 @@ import { resolveAttentionLens, selectOpenQuestions } from '../../SessionOverview
 type LensColumnProps = {
   readonly session: Session;
   readonly activeLens: LensKind | null;
+  readonly onSelectOverview: () => void;
   readonly onSelect: (lens: LensKind) => void;
   readonly filesCount: number;
 };
@@ -52,7 +54,13 @@ type LensGroup = {
   readonly rows: ReadonlyArray<LensRow>;
 };
 
-export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensColumnProps) => {
+export const LensColumn = ({
+  session,
+  activeLens,
+  onSelectOverview,
+  onSelect,
+  filesCount,
+}: LensColumnProps) => {
   const sessionId = session.id as SessionId;
   const openCount = selectOpenQuestions(useSessionOpenQuestions(sessionId)).length;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
@@ -113,26 +121,6 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
     (s) => (s.sessionPendingResolutions[sessionId]?.length ?? 0) > 0,
   );
 
-  const contextRows: ReadonlyArray<LensRow> = [
-    { kind: 'goal', label: 'Goal', icon: Target, tone: 'primary' },
-    { kind: 'decisions', label: 'Decisions', icon: CheckCheck, tone: 'success' },
-    { kind: 'last_output_summary', label: 'Session summary', icon: Activity, tone: 'info' },
-    {
-      kind: 'pr',
-      label: 'Pull request',
-      icon: GitPullRequest,
-      tone: 'accent',
-      dot: hasPr ? 'running' : undefined,
-    },
-    {
-      kind: 'questions',
-      label: 'Questions',
-      icon: CircleHelp,
-      tone: 'warning',
-      count: openCount,
-    },
-  ];
-
   const groups: ReadonlyArray<LensGroup> = [
     {
       label: 'Work',
@@ -168,7 +156,26 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
           dot: attentionLens === 'resolve' || unreadLens === 'resolve' ? 'attention' : undefined,
           secondaryDot: hasPendingBatch,
         },
+        {
+          kind: 'questions',
+          label: 'Questions',
+          icon: CircleHelp,
+          tone: 'warning',
+          count: openCount,
+        },
+      ],
+    },
+    {
+      label: 'Changes',
+      rows: [
         { kind: 'files', label: 'Diff', icon: FileDiff, tone: 'info', count: filesCount },
+        {
+          kind: 'pr',
+          label: 'Pull request',
+          icon: GitPullRequest,
+          tone: 'accent',
+          dot: hasPr ? 'running' : undefined,
+        },
       ],
     },
     {
@@ -180,7 +187,11 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
     },
     {
       label: 'Context',
-      rows: contextRows,
+      rows: [
+        { kind: 'goal', label: 'Goal', icon: Target, tone: 'primary' },
+        { kind: 'decisions', label: 'Decisions', icon: CheckCheck, tone: 'success' },
+        { kind: 'last_output_summary', label: 'Session summary', icon: Activity, tone: 'info' },
+      ],
     },
     {
       label: 'Infra',
@@ -199,6 +210,37 @@ export const LensColumn = ({ session, activeLens, onSelect, filesCount }: LensCo
   return (
     <ScrollFade className="min-h-0 flex-1">
       <nav className="flex flex-col gap-4 px-2 py-3">
+        <button
+          type="button"
+          onClick={onSelectOverview}
+          aria-current={activeLens === null ? 'page' : undefined}
+          className={cn(
+            'flex items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
+            activeLens === null
+              ? 'bg-foreground/[0.06] text-foreground'
+              : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              'flex size-5 shrink-0 items-center justify-center rounded-md ring-1 transition-colors',
+              tintClasses('neutral').bg,
+              tintClasses('neutral').ring,
+            )}
+          >
+            <LayoutDashboard size={12} aria-hidden className={tintClasses('neutral').icon} />
+          </span>
+          <span
+            className={cn(
+              'min-w-0 flex-1 truncate text-[13px]',
+              activeLens === null && 'font-medium',
+            )}
+          >
+            Overview
+          </span>
+        </button>
         {groups.map((group) => (
           <div key={group.label} className="flex flex-col gap-0.5">
             <span className="px-2 pb-1 text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground/60">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.test.tsx
@@ -1,19 +1,8 @@
 // @vitest-environment happy-dom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
-
-const { state } = vi.hoisted(() => ({
-  state: {
-    sessionsSidebarCollapsed: false,
-    setSessionsSidebarCollapsed: vi.fn(),
-  },
-}));
-
-vi.mock('../../../../../store', () => ({
-  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
-}));
 
 vi.mock('../../../../workspace/components/SessionDetailPanel', () => ({
   SessionDetailPanel: () => <div>session details</div>,
@@ -23,23 +12,11 @@ import { SessionTopBar } from './SessionTopBar';
 
 const SESSION = { goal: 'test session' } as Session;
 
-beforeEach(() => {
-  state.sessionsSidebarCollapsed = false;
-  state.setSessionsSidebarCollapsed.mockClear();
-});
-
 afterEach(cleanup);
 
 describe('SessionTopBar', () => {
-  it('does not render the reopen button while the sessions sidebar is visible', () => {
+  it('renders the session details', () => {
     render(<SessionTopBar session={SESSION} />);
-    expect(screen.queryByRole('button', { name: 'show sessions' })).toBeNull();
-  });
-
-  it('reopens the sessions sidebar from an open session', () => {
-    state.sessionsSidebarCollapsed = true;
-    render(<SessionTopBar session={SESSION} />);
-    fireEvent.click(screen.getByRole('button', { name: 'show sessions' }));
-    expect(state.setSessionsSidebarCollapsed).toHaveBeenCalledWith(false);
+    expect(screen.getByText('session details')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionTopBar.tsx
@@ -1,7 +1,5 @@
-import { PanelLeftOpen } from 'lucide-react';
-import { Divider, Tooltip, cn } from '@goodboy/ui';
+import { Divider } from '@goodboy/ui';
 import type { Session } from '@goodboy/types';
-import { useAppStore } from '../../../../../store';
 import { SessionDetailPanel } from '../../../../workspace/components/SessionDetailPanel';
 
 type SessionTopBarProps = {
@@ -9,29 +7,9 @@ type SessionTopBarProps = {
 };
 
 export const SessionTopBar = ({ session }: SessionTopBarProps) => {
-  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
-  const setSessionsSidebarCollapsed = useAppStore((s) => s.setSessionsSidebarCollapsed);
-
   return (
     <>
-      <div
-        className={cn(
-          'flex w-full items-center gap-3 bg-background pr-3',
-          sessionsSidebarCollapsed && 'pl-2',
-        )}
-      >
-        {sessionsSidebarCollapsed ? (
-          <Tooltip content="show sessions (⌘B)" side="bottom">
-            <button
-              type="button"
-              onClick={() => setSessionsSidebarCollapsed(false)}
-              aria-label="show sessions"
-              className="inline-flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground motion-safe:transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-            >
-              <PanelLeftOpen size={13} aria-hidden />
-            </button>
-          </Tooltip>
-        ) : null}
+      <div className="flex w-full items-center gap-3 bg-background pr-3">
         <div className="min-w-0 flex-1">
           <SessionDetailPanel
             session={session}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.test.tsx
@@ -7,6 +7,7 @@ const { state, currentWorkspace } = vi.hoisted(() => ({
     workspaceIntegrations: {} as Record<string, ReadonlyArray<unknown>>,
     archivedSessions: {} as Record<string, ReadonlyArray<unknown>>,
     providers: [] as ReadonlyArray<{ connection: string }>,
+    sessionsSidebarCollapsed: false,
     setCurrentSession: vi.fn(),
     loadArchivedSessions: vi.fn(),
   },

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -11,11 +11,13 @@ import {
 import { WorkspaceLinkDialog } from '../WorkspaceLinkDialog';
 import { SessionActivityBar } from '../SessionActivityBar';
 import { NoWorkspaceEmpty } from './parts/NoWorkspaceEmpty';
+import { SessionsRail } from './parts/SessionsRail';
 
 export const WorkspacesSidebar = () => {
   const currentWorkspace = useCurrentWorkspace();
   const sessions = useSessions();
   const currentSession = useCurrentSession();
+  const sessionsSidebarCollapsed = useAppStore((s) => s.sessionsSidebarCollapsed);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
   const onSelectSession = useCallback(
     (id: SessionId) => {
@@ -35,6 +37,10 @@ export const WorkspacesSidebar = () => {
     }
     void loadArchivedSessions(currentWorkspace.id);
   }, [currentWorkspace, loadArchivedSessions]);
+
+  if (sessionsSidebarCollapsed && currentSession != null) {
+    return <SessionsRail />;
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col">

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    toggleSessionsSidebar: vi.fn(),
+    setCurrentSession: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+import { SessionsRail } from './SessionsRail';
+
+beforeEach(() => {
+  state.toggleSessionsSidebar.mockClear();
+  state.setCurrentSession.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('SessionsRail', () => {
+  it('renders the three collapsed sidebar actions', () => {
+    render(<SessionsRail />);
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('expands the sessions sidebar', () => {
+    render(<SessionsRail />);
+    fireEvent.click(screen.getByRole('button', { name: 'show sessions' }));
+    expect(state.toggleSessionsSidebar).toHaveBeenCalledOnce();
+  });
+
+  it('returns to the board', () => {
+    render(<SessionsRail />);
+    fireEvent.click(screen.getByRole('button', { name: 'back to board' }));
+    expect(state.setCurrentSession).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.tsx
@@ -1,0 +1,43 @@
+import { Kanban, PanelLeftOpen, Plus } from 'lucide-react';
+import { Tooltip } from '@goodboy/ui';
+import { useAppStore } from '../../../../../store';
+
+export const SessionsRail = () => {
+  const toggleSessionsSidebar = useAppStore((s) => s.toggleSessionsSidebar);
+  const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+
+  return (
+    <div className="flex w-full flex-col items-center gap-1 pt-2">
+      <Tooltip content="show sessions (⌘B)" side="right">
+        <button
+          type="button"
+          onClick={toggleSessionsSidebar}
+          aria-label="show sessions"
+          className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        >
+          <PanelLeftOpen size={15} aria-hidden />
+        </button>
+      </Tooltip>
+      <Tooltip content="back to board" side="right">
+        <button
+          type="button"
+          onClick={() => void setCurrentSession(null)}
+          aria-label="back to board"
+          className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        >
+          <Kanban size={15} aria-hidden />
+        </button>
+      </Tooltip>
+      <Tooltip content="new session" side="right">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent('goodboy:new-session'))}
+          aria-label="new session"
+          className="inline-flex items-center justify-center rounded-md p-1.5 text-muted-foreground motion-safe:transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+        >
+          <Plus size={15} aria-hidden />
+        </button>
+      </Tooltip>
+    </div>
+  );
+};

--- a/packages/ui/src/components/AppShell.tsx
+++ b/packages/ui/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ export type AppShellProps = {
   footer?: ReactNode;
   leftSidebar?: ReactNode;
   leftHidden?: boolean;
+  leftCollapsed?: boolean;
   main: ReactNode;
   rightSidebar: ReactNode;
   rightSidebarCollapsed?: boolean;
@@ -18,6 +19,7 @@ const LEFT_SIDEBAR_MIN = 260;
 const LEFT_SIDEBAR_MAX = 640;
 const LEFT_SIDEBAR_DEFAULT = 340;
 const LEFT_SIDEBAR_STORAGE_KEY = 'goodboy:left-sidebar-width:v2';
+const LEFT_RAIL_WIDTH = 44;
 
 const RIGHT_SIDEBAR_MIN = 260;
 const RIGHT_SIDEBAR_MAX = 560;
@@ -43,6 +45,7 @@ function readPersistedWidth(key: string, def: number, min: number, max: number):
 function buildLayout(opts: {
   collapsed: boolean;
   leftHidden: boolean;
+  leftCollapsed: boolean;
   hasLeftSidebar: boolean;
   hasRightSidebar: boolean;
   hasFooter: boolean;
@@ -56,6 +59,7 @@ function buildLayout(opts: {
   const {
     collapsed,
     leftHidden,
+    leftCollapsed,
     hasLeftSidebar,
     hasRightSidebar,
     hasFooter,
@@ -84,8 +88,8 @@ function buildLayout(opts: {
     };
   }
 
-  const leftCol = leftHidden ? '0px' : `${leftWidthPx}px`;
-  const handleCol = leftHidden ? '0px' : '6px';
+  const leftCol = leftHidden ? '0px' : leftCollapsed ? `${LEFT_RAIL_WIDTH}px` : `${leftWidthPx}px`;
+  const handleCol = leftHidden || leftCollapsed ? '0px' : '6px';
   if (!hasRightSidebar) {
     return {
       templateAreas: hasFooter
@@ -112,6 +116,7 @@ export const AppShell = ({
   footer,
   leftSidebar,
   leftHidden = false,
+  leftCollapsed = false,
   main,
   rightSidebar,
   rightSidebarCollapsed = false,
@@ -121,6 +126,7 @@ export const AppShell = ({
   const hasFooter = footer != null;
   const hasLeftSidebar = leftSidebar != null;
   const hasRightSidebar = rightSidebar !== null && rightSidebar !== undefined;
+  const isLeftResizeDisabled = leftHidden || leftCollapsed;
   const [leftWidth, setLeftWidth] = useState<number>(() =>
     readPersistedWidth(
       LEFT_SIDEBAR_STORAGE_KEY,
@@ -225,6 +231,7 @@ export const AppShell = ({
   const layout = buildLayout({
     collapsed: rightSidebarCollapsed,
     leftHidden,
+    leftCollapsed,
     hasLeftSidebar,
     hasRightSidebar,
     hasFooter,
@@ -266,16 +273,16 @@ export const AppShell = ({
             role="separator"
             aria-orientation="vertical"
             aria-label="resize left sidebar"
-            tabIndex={leftHidden ? -1 : 0}
-            onMouseDown={leftHidden ? undefined : startDrag('left')}
-            onKeyDown={leftHidden ? undefined : onLeftKeyDown}
+            tabIndex={isLeftResizeDisabled ? -1 : 0}
+            onMouseDown={isLeftResizeDisabled ? undefined : startDrag('left')}
+            onKeyDown={isLeftResizeDisabled ? undefined : onLeftKeyDown}
             className={cn(
               'group relative select-none overflow-hidden',
-              leftHidden ? 'pointer-events-none' : 'cursor-col-resize',
+              isLeftResizeDisabled ? 'pointer-events-none' : 'cursor-col-resize',
             )}
             style={{ gridArea: 'lhandle' }}
           >
-            {!leftHidden && (
+            {!isLeftResizeDisabled && (
               <div className="pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-gradient-to-b from-transparent via-border-soft to-transparent transition-colors group-hover:via-border group-focus-visible:via-primary" />
             )}
           </div>


### PR DESCRIPTION
Session nav follow-up from screenshot review.

## Changes
1. **Sessions mini-rail**: cmd+B collapse no longer voids the left column. AppShell gains additive `leftCollapsed` (44px rail, resize handle disabled, VSCode activity-bar precedent). Rail actions: show sessions (⌘B), back to board, new session. Floating reopen button removed from SessionTopBar. Board view unchanged (column fully hidden there).
2. **Lens column always visible**: the w-60 session detail sidebar no longer disappears on bare overview; new **Overview** entry at the top (active when no lens selected).
3. **Menu regroup**: Work (Workflows, Agents, Resolve, Questions), Changes (Diff, Pull request), Artifacts (Plans, Scripts), Context (Goal, Decisions, Session summary), Infra (Terminal). Questions is actionable work; Diff+PR pair up as SCM-style Changes.

## Verification
- pnpm typecheck green (5 packages)
- pnpm --filter desktop test: 245 files, 2214 tests green
- pnpm --filter @goodboy/ui test: 20 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)