### PR TITLE
refactor(desktop): two-layer workflow stepper, quieter transcript

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/TranscriptRows.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import { Divider } from '@goodboy/ui';
 import type { AgentId, OpenQuestion, SessionId } from '@goodboy/types';
 import type { TranscriptRow } from '../../utils/cluster-operations';
 import type { ThinkingContext } from '../../utils/thinking-context';
@@ -60,13 +59,6 @@ export const TranscriptRows = ({
       const at = row.item.at;
       const day = dayKey(at);
       const dayChanged = day !== lastDay;
-      if (idx > 0 && !dayChanged) {
-        out.push(
-          <li key={`turn-${row.key}`}>
-            <Divider />
-          </li>,
-        );
-      }
       if (dayChanged) {
         out.push(
           <li key={`day-${day}-${idx}`} className="flex justify-center">

--- a/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
+++ b/apps/desktop/src/features/chat/components/OperationsCluster/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { ChevronRight, Layers } from 'lucide-react';
+import { Layers } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { AgentId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../utils/transcript-items';
@@ -79,14 +79,6 @@ export const OperationsCluster = ({
           running != null && 'animate-border-pulse',
         )}
       >
-        <ChevronRight
-          size={11}
-          aria-hidden
-          className={cn(
-            'shrink-0 text-muted-foreground/60 motion-safe:transition-transform',
-            open && 'rotate-90',
-          )}
-        />
         <Layers size={11} aria-hidden className={cn('shrink-0', accent.icon)} />
         <span className={cn('font-medium', accent.text)}>operations</span>
         <span

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -96,8 +96,8 @@ vi.mock('./parts/PaneShell', () => ({
 vi.mock('./hooks/useSelectedAgentHome', () => ({
   useSelectedAgentHome: () => hooks.agentHome,
 }));
-vi.mock('./parts/WorkflowStrip', () => ({
-  WorkflowStrip: () => <div data-testid="workflow-strip" />,
+vi.mock('./parts/WorkflowStepper', () => ({
+  WorkflowStepper: () => <div data-testid="workflow-stepper" />,
 }));
 
 import { SessionWorkspace } from './index';
@@ -133,9 +133,9 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('SessionWorkspace agent overlay', () => {
-  it('uses the full overlay width and workflow strip for workflow agents', () => {
+  it('uses the full overlay width and workflow stepper for workflow agents', () => {
     const { container } = render(<SessionWorkspace session={session} isActive />);
-    expect(screen.getByTestId('workflow-strip')).toBeDefined();
+    expect(screen.getByTestId('workflow-stepper')).toBeDefined();
     expect(screen.getByTestId('chat-view')).toBeDefined();
     expect(container.querySelector('.w-72')).toBeNull();
     expect(screen.queryByTestId('agents-section')).toBeNull();
@@ -149,7 +149,7 @@ describe('SessionWorkspace agent overlay', () => {
   it('keeps the agents-home overlay panel unchanged', () => {
     hooks.agentHome = 'agents';
     const { container } = render(<SessionWorkspace session={session} isActive />);
-    expect(screen.queryByTestId('workflow-strip')).toBeNull();
+    expect(screen.queryByTestId('workflow-stepper')).toBeNull();
     expect(container.querySelector('.w-72')).not.toBeNull();
     expect(screen.getByTestId('agents-section').getAttribute('data-home')).toBe('agents');
     expect(screen.getByRole('button', { name: 'Agents' })).toBeDefined();
@@ -162,6 +162,44 @@ describe('SessionWorkspace agent overlay', () => {
 });
 
 describe('SessionWorkspace workflow breadcrumb', () => {
+  it('uses the selected workflow agent run name in the overlay breadcrumb', () => {
+    const workflowAgent = {
+      ...selectedAgent,
+      stepId: 'step-1',
+      workflowRunId: 'run-1',
+    } as Agent;
+    store.selectedAgentId = { [SESSION_ID]: workflowAgent.id };
+    store.sessionPhaseRuns = { [SESSION_ID]: [workflowAgent] };
+    store.phaseTemplates = {
+      'workspace-1': [
+        {
+          id: 'workflow-1',
+          name: 'Release flow',
+          steps: [],
+        },
+      ],
+    };
+    const workflowSession = {
+      ...session,
+      workflowRuns: [
+        {
+          id: 'run-1',
+          workflowId: 'workflow-1',
+          ordinal: 0,
+          currentStep: 0,
+          autoRun: true,
+          triggerMode: 'immediate',
+        },
+      ],
+    } as unknown as Session;
+
+    render(<SessionWorkspace session={workflowSession} isActive />);
+
+    expect(screen.getByTestId('breadcrumb').textContent).toBe(
+      'Overview / Workflows / Release flow',
+    );
+  });
+
   it('uses the visible workflow name when the only run is not explicitly focused', () => {
     store.activeLens = { [SESSION_ID]: 'workflows' };
     store.selectedAgentId = {};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -29,9 +29,10 @@ import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
 import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
 import { buildSessionBreadcrumb } from './sessionBreadcrumb';
-import { WorkflowStrip } from './parts/WorkflowStrip';
+import { WorkflowStepper } from './parts/WorkflowStepper';
 import { WorkflowsPane } from './parts/WorkflowsPane';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
+import { resolveRootAgent } from '../../agent-kind';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -117,6 +118,17 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
         : null,
     [phaseRuns, selectedAgentId],
   );
+  const stripWorkflowName = useMemo(() => {
+    if (selectedAgentId == null) {
+      return null;
+    }
+    const rootAgent = resolveRootAgent({ agents: phaseRuns, agentId: selectedAgentId });
+    if (rootAgent?.workflowRunId == null) {
+      return null;
+    }
+    const attachedRun = attachedWorkflowRuns.find(({ run }) => run.id === rootAgent.workflowRunId);
+    return attachedRun == null ? null : workflowKindName(attachedRun.workflow);
+  }, [attachedWorkflowRuns, phaseRuns, selectedAgentId]);
   const focusedWorkflowName = useMemo(() => {
     const focusedRun = attachedWorkflowRuns.find(({ run }) => run.id === focusedWorkflowRunId);
     const visibleRun = focusedRun ?? (lens === 'workflows' ? attachedWorkflowRuns[0] : null);
@@ -135,6 +147,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
         selectedAgentName,
         overlayHomeLens: overlayHome,
         suppressAgentTail: showWorkflowStrip,
+        stripWorkflowName,
         focusedWorkflowName,
         focusedPlanTitle,
         lensLabel: (l) => LENS_LABEL[l],
@@ -157,6 +170,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
       selectedAgentName,
       overlayHome,
       showWorkflowStrip,
+      stripWorkflowName,
       focusedWorkflowName,
       focusedPlanTitle,
       sessionId,
@@ -180,16 +194,23 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   return (
     <div className="flex h-full w-full flex-col">
       <SessionTopBar session={session} />
-      <div className="flex min-w-0 shrink-0 items-center gap-2 px-6 py-2.5">
+      <div
+        className={cn(
+          'flex min-w-0 shrink-0 items-center px-6',
+          showWorkflowStrip ? 'pb-1 pt-2.5' : 'py-2.5',
+        )}
+      >
         <AppBreadcrumb crumbs={crumbs} />
-        {showWorkflowStrip && selectedAgentId != null ? (
-          <WorkflowStrip
+      </div>
+      {showWorkflowStrip && selectedAgentId != null ? (
+        <div className="flex min-w-0 shrink-0 items-center px-6 pb-2">
+          <WorkflowStepper
             sessionId={sessionId}
             session={session}
             selectedAgentId={selectedAgentId}
           />
-        ) : null}
-      </div>
+        </div>
+      ) : null}
       <Divider />
       <div className="flex min-h-0 flex-1">
         <div className="flex w-60 shrink-0 flex-col bg-background">

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStepper.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStepper.test.tsx
@@ -19,8 +19,6 @@ type Store = {
   phaseTemplates: Record<string, ReadonlyArray<Workflow>>;
   sessionWorkflows: Record<string, ReadonlyArray<Workflow>>;
   selectAgent: ReturnType<typeof vi.fn>;
-  setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
-  setActiveLens: ReturnType<typeof vi.fn>;
 };
 
 const { store } = vi.hoisted(() => ({
@@ -29,8 +27,6 @@ const { store } = vi.hoisted(() => ({
     phaseTemplates: {},
     sessionWorkflows: {},
     selectAgent: vi.fn(async () => undefined),
-    setFocusedWorkflowRun: vi.fn(),
-    setActiveLens: vi.fn(),
   } as Store,
 }));
 
@@ -39,7 +35,7 @@ vi.mock('../../../../../store', () => ({
   useAppStore: <T,>(selector: (state: Store) => T) => selector(store),
 }));
 
-import { WorkflowStrip } from './WorkflowStrip';
+import { WorkflowStepper } from './WorkflowStepper';
 
 const NOW = '2026-07-21T00:00:00.000Z' as IsoDateTime;
 const SESSION_ID = 'session-1' as SessionId;
@@ -134,16 +130,18 @@ beforeEach(() => {
   store.sessionWorkflows = {};
   store.selectAgent.mockReset();
   store.selectAgent.mockResolvedValue(undefined);
-  store.setFocusedWorkflowRun.mockReset();
-  store.setActiveLens.mockReset();
 });
 
 afterEach(cleanup);
 
-describe('WorkflowStrip', () => {
+describe('WorkflowStepper', () => {
   it('maps statuses and accents the selected child parent step', () => {
     render(
-      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+      <WorkflowStepper
+        sessionId={SESSION_ID}
+        session={session}
+        selectedAgentId={selectedChild.id}
+      />,
     );
 
     expect(screen.getByLabelText('Plan status: completed')).toBeDefined();
@@ -154,14 +152,16 @@ describe('WorkflowStrip', () => {
     expect(screen.getByRole('button', { name: '2 Build' }).getAttribute('aria-current')).toBe(
       'step',
     );
-    expect(screen.getByRole('button', { name: '2 Build' }).parentElement?.className).toContain(
-      'bg-primary/10',
-    );
+    expect(screen.getByRole('button', { name: '2 Build' }).className).toContain('font-medium');
   });
 
   it('selects an available step root and keeps pending steps inert', () => {
     render(
-      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+      <WorkflowStepper
+        sessionId={SESSION_ID}
+        session={session}
+        selectedAgentId={selectedChild.id}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: '1 Plan' }));
@@ -179,7 +179,11 @@ describe('WorkflowStrip', () => {
 
   it('opens clusters, marks the selected child, and selects another child', () => {
     render(
-      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
+      <WorkflowStepper
+        sessionId={SESSION_ID}
+        session={session}
+        selectedAgentId={selectedChild.id}
+      />,
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'clusters 1/2 for Build' }));
@@ -191,16 +195,6 @@ describe('WorkflowStrip', () => {
     expect(store.selectAgent).toHaveBeenCalledWith(SESSION_ID, runningChild.id);
   });
 
-  it('opens the workflow lens at the focused run from the workflow chip', () => {
-    render(
-      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={selectedChild.id} />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Release flow' }));
-    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, RUN_ID);
-    expect(store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'workflows');
-  });
-
   it('renders nothing for a non-workflow agent', () => {
     const standalone = createAgent({
       id: 'standalone',
@@ -210,7 +204,7 @@ describe('WorkflowStrip', () => {
     });
     store.sessionPhaseRuns = { [SESSION_ID]: [standalone] };
     const { container } = render(
-      <WorkflowStrip sessionId={SESSION_ID} session={session} selectedAgentId={standalone.id} />,
+      <WorkflowStepper sessionId={SESSION_ID} session={session} selectedAgentId={standalone.id} />,
     );
     expect(container.innerHTML).toBe('');
   });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStepper.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/WorkflowStepper.tsx
@@ -1,11 +1,10 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, Workflow as WorkflowIcon } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import type { Agent, AgentId, Session, SessionId, Workflow } from '@goodboy/types';
 import { Popover, cn } from '@goodboy/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { resolveRootAgent } from '../../../agent-kind';
-import { workflowKindName } from '../../../../workspace/components/WorkspacesSidebar/lib';
 import { WorkflowStripStatus } from './WorkflowStripStatus';
 
 const POPOVER_WIDTH = 224;
@@ -17,7 +16,7 @@ type Props = {
   readonly selectedAgentId: AgentId;
 };
 
-export const WorkflowStrip = ({ sessionId, session, selectedAgentId }: Props) => {
+export const WorkflowStepper = ({ sessionId, session, selectedAgentId }: Props) => {
   const phaseRuns = useAppStore(
     (state) => state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>),
   );
@@ -29,8 +28,6 @@ export const WorkflowStrip = ({ sessionId, session, selectedAgentId }: Props) =>
     (state) => state.sessionWorkflows[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Workflow>),
   );
   const selectAgent = useAppStore((state) => state.selectAgent);
-  const setFocusedWorkflowRun = useAppStore((state) => state.setFocusedWorkflowRun);
-  const setActiveLens = useAppStore((state) => state.setActiveLens);
   const [openClusterRootId, setOpenClusterRootId] = useState<AgentId | null>(null);
   const [popoverPosition, setPopoverPosition] = useState<Readonly<{
     top: number;
@@ -86,21 +83,11 @@ export const WorkflowStrip = ({ sessionId, session, selectedAgentId }: Props) =>
       className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto whitespace-nowrap"
       aria-label="workflow steps"
     >
-      <button
-        type="button"
-        onClick={() => {
-          setFocusedWorkflowRun(sessionId, run.id);
-          setActiveLens(sessionId, 'workflows');
-        }}
-        className="flex shrink-0 items-center gap-1.5 rounded-lg border border-border-soft bg-subtle px-2 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-      >
-        <WorkflowIcon size={12} aria-hidden className="shrink-0 text-accent" />
-        <span className="max-w-40 truncate">{workflowKindName(workflow)}</span>
-      </button>
       {workflow.steps.map((step, index) => {
         const stepRoot = stepRoots.get(step.id) ?? null;
         const isPending = stepRoot == null || stepRoot.status === 'pending';
         const isCurrent = stepRoot?.id === rootAgent.id;
+        const isFailed = stepRoot?.status === 'failed';
         const clusterChildren =
           stepRoot == null
             ? EMPTY_ARRAY
@@ -110,68 +97,70 @@ export const WorkflowStrip = ({ sessionId, session, selectedAgentId }: Props) =>
         ).length;
 
         return (
-          <div
-            key={step.id}
-            className={cn(
-              'flex shrink-0 items-center rounded-lg border text-xs transition-colors',
-              isCurrent
-                ? 'border-primary/40 bg-primary/10 text-foreground ring-1 ring-primary/20'
-                : isPending
-                  ? 'border-border-soft/60 bg-subtle/50 text-muted-foreground/60'
-                  : 'border-border-soft bg-subtle text-muted-foreground hover:bg-muted hover:text-foreground',
-            )}
-          >
-            <button
-              type="button"
-              disabled={isPending}
-              aria-current={isCurrent ? 'step' : undefined}
-              aria-label={`${index + 1} ${step.name}`}
-              onClick={() => {
-                if (stepRoot == null || isPending) {
-                  return;
-                }
-                void selectAgent(sessionId, stepRoot.id);
-              }}
-              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-default"
-            >
-              <span className="text-2xs font-semibold tabular-nums text-muted-foreground">
-                {index + 1}
-              </span>
-              <WorkflowStripStatus
-                status={stepRoot?.status ?? null}
-                label={step.name}
-                variant="pill"
-              />
-              <span>{step.name}</span>
-            </button>
-            {stepRoot != null && clusterChildren.length > 0 ? (
+          <div key={step.id} className="flex shrink-0 items-center gap-1.5">
+            {index > 0 ? (
+              <ChevronRight size={11} aria-hidden className="shrink-0 text-muted-foreground/30" />
+            ) : null}
+            <div className="flex items-center gap-1">
               <button
                 type="button"
-                aria-haspopup="menu"
-                aria-expanded={openClusterRootId === stepRoot.id}
-                aria-label={`clusters ${completedChildren}/${clusterChildren.length} for ${step.name}`}
-                onClick={(event) => {
-                  if (openClusterRootId === stepRoot.id) {
-                    setOpenClusterRootId(null);
-                    setPopoverPosition(null);
+                disabled={isPending}
+                aria-current={isCurrent ? 'step' : undefined}
+                aria-label={`${index + 1} ${step.name}`}
+                onClick={() => {
+                  if (stepRoot == null || isPending) {
                     return;
                   }
-                  const rect = event.currentTarget.getBoundingClientRect();
-                  setOpenClusterRootId(stepRoot.id);
-                  setPopoverPosition({
-                    top: rect.bottom + 6,
-                    left: Math.max(
-                      POPOVER_EDGE_INSET,
-                      Math.min(rect.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH),
-                    ),
-                  });
+                  void selectAgent(sessionId, stepRoot.id);
                 }}
-                className="flex items-center gap-1 rounded-lg px-1.5 py-1 text-2xs font-medium tabular-nums text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                className={cn(
+                  'flex items-center gap-1.5 rounded-sm text-left text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-default',
+                  isCurrent && !isPending && 'font-medium',
+                  isPending
+                    ? 'text-muted-foreground/40'
+                    : isFailed
+                      ? 'text-danger hover:text-danger/80'
+                      : isCurrent
+                        ? 'text-foreground hover:text-foreground'
+                        : 'text-muted-foreground hover:text-foreground',
+                )}
               >
-                {completedChildren}/{clusterChildren.length}
-                <ChevronDown size={10} aria-hidden />
+                <WorkflowStripStatus
+                  status={stepRoot?.status ?? null}
+                  label={step.name}
+                  variant="pill"
+                />
+                <span>{step.name}</span>
               </button>
-            ) : null}
+              {stepRoot != null && clusterChildren.length > 0 ? (
+                <button
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded={openClusterRootId === stepRoot.id}
+                  aria-label={`clusters ${completedChildren}/${clusterChildren.length} for ${step.name}`}
+                  onClick={(event) => {
+                    if (openClusterRootId === stepRoot.id) {
+                      setOpenClusterRootId(null);
+                      setPopoverPosition(null);
+                      return;
+                    }
+                    const rect = event.currentTarget.getBoundingClientRect();
+                    setOpenClusterRootId(stepRoot.id);
+                    setPopoverPosition({
+                      top: rect.bottom + 6,
+                      left: Math.max(
+                        POPOVER_EDGE_INSET,
+                        Math.min(rect.right - POPOVER_WIDTH, window.innerWidth - POPOVER_WIDTH),
+                      ),
+                    });
+                  }}
+                  className="flex items-center gap-1 rounded-sm text-2xs font-medium tabular-nums text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+                >
+                  {completedChildren}/{clusterChildren.length}
+                  <ChevronDown size={10} aria-hidden />
+                </button>
+              ) : null}
+            </div>
           </div>
         );
       })}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.test.ts
@@ -21,6 +21,7 @@ const base = (
   selectedAgentName: null,
   overlayHomeLens: null,
   suppressAgentTail: false,
+  stripWorkflowName: null,
   focusedWorkflowName: null,
   focusedPlanTitle: null,
   lensLabel,
@@ -91,7 +92,26 @@ describe('buildSessionBreadcrumb', () => {
     expect(h.toLens).not.toHaveBeenCalled();
   });
 
-  it('suppresses the workflow agent tail when the workflow strip is present', () => {
+  it('replaces the workflow agent tail with the workflow name when the stepper is present', () => {
+    const h = makeHandlers();
+    const crumbs = buildSessionBreadcrumb(
+      base(
+        {
+          selectedAgentName: 'scout-1',
+          overlayHomeLens: 'workflows',
+          suppressAgentTail: true,
+          stripWorkflowName: 'Release flow',
+        },
+        h,
+      ),
+    );
+    expect(labels(crumbs)).toEqual(['Overview', 'Workflows', 'Release flow']);
+    expect(crumbs[0]?.onClick).toBeDefined();
+    expect(crumbs[1]?.onClick).toBeDefined();
+    expect(crumbs[2]?.onClick).toBeUndefined();
+  });
+
+  it('falls back to the workflow list when the stepper workflow name is unavailable', () => {
     const h = makeHandlers();
     const crumbs = buildSessionBreadcrumb(
       base(

--- a/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/sessionBreadcrumb.ts
@@ -14,6 +14,7 @@ export type SessionBreadcrumbInput = {
   selectedAgentName: string | null;
   overlayHomeLens: LensKind | null;
   suppressAgentTail: boolean;
+  stripWorkflowName: string | null;
   focusedWorkflowName: string | null;
   focusedPlanTitle: string | null;
   lensLabel: (lens: LensKind) => string;
@@ -34,6 +35,7 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
     selectedAgentName,
     overlayHomeLens,
     suppressAgentTail,
+    stripWorkflowName,
     focusedWorkflowName,
     focusedPlanTitle,
     lensLabel,
@@ -77,7 +79,10 @@ export const buildSessionBreadcrumb = (input: SessionBreadcrumbInput): Breadcrum
     ]);
   }
 
-  if (suppressAgentTail && selectedAgentName != null && overlayHomeLens != null) {
+  if (suppressAgentTail) {
+    if (stripWorkflowName != null) {
+      return [overview, workflowsList, { id: 'workflow-run', label: stripWorkflowName }];
+    }
     return [overview, workflowsList];
   }
 


### PR DESCRIPTION
Follow-up on #944/#945 from screenshot review.

## Changes
1. **Two-layer workflow header**: layer 1 is the plain app breadcrumb, now ending with the workflow name (`Overview > Workflows > <name>`); layer 2 is a text-based stepper (`Survey > Plan > Implement > Test`), replacing the bordered chip+pill strip. Steps are plain text with status glyphs and chevron separators (same visual language as the breadcrumb): current = foreground medium, completed = muted clickable, pending = faint non-clickable, failed = danger. Cluster steps keep a compact `n/m` dropdown to pick the sub-agent (existing popover reused). WorkflowStrip renamed to WorkflowStepper.
2. **Transcript noise**: removed the chevron expander to the left of `operations` rows (whole row is still the toggle) and removed the divider between user turns (day chips stay).

## Verification
- pnpm typecheck green
- pnpm --filter desktop test: 245 files, 2215 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)