### PR TITLE
fix(desktop): move workflow stepper into chat header slot

### DIFF
--- a/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.test.tsx
@@ -139,8 +139,9 @@ describe('ChatView', () => {
     expect(container.firstChild).not.toBeNull();
   });
 
-  it('does not render the breadcrumb when it is hidden', () => {
-    render(<ChatView session={session} hideBreadcrumb />);
+  it('renders a custom header instead of the breadcrumb', () => {
+    render(<ChatView session={session} header={<div data-testid="custom-header" />} />);
+    expect(screen.getByTestId('custom-header')).toBeDefined();
     expect(chatBreadcrumbMock).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/features/chat/components/ChatView/index.tsx
+++ b/apps/desktop/src/features/chat/components/ChatView/index.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import type { ReactNode } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { ArrowDown } from 'lucide-react';
 import type { AgentId, OpenQuestion, ProviderRunId, Session } from '@goodboy/types';
@@ -44,15 +45,15 @@ import { MARKER_ACCENT } from '../marker-accents';
 const neutralAccent = MARKER_ACCENT.neutral;
 import { TranscriptSkeleton } from './parts/TranscriptSkeleton';
 
-type ChatViewProps = {
-  session: Session;
-  isActive?: boolean;
-  hideBreadcrumb?: boolean;
+type Props = {
+  readonly session: Session;
+  readonly isActive?: boolean;
+  readonly header?: ReactNode;
 };
 
 const TERMINAL_STATUSES = new Set(['completed', 'failed', 'cancelled']);
 
-export const ChatView = ({ session, isActive = true, hideBreadcrumb = false }: ChatViewProps) => {
+export const ChatView = ({ session, isActive = true, header }: Props) => {
   const selectedAgentId = useAppStore(
     (s) => s.selectedAgentId[session.id] ?? null,
   ) as AgentId | null;
@@ -396,7 +397,7 @@ export const ChatView = ({ session, isActive = true, hideBreadcrumb = false }: C
 
   return (
     <div className="flex h-full flex-col">
-      {!hideBreadcrumb && <ChatBreadcrumb session={session} />}
+      {header !== undefined ? header : <ChatBreadcrumb session={session} />}
       <div ref={fadeHostRef} className="relative flex min-h-0 flex-1 flex-col">
         <ScrollFade
           className="flex-1"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -60,7 +60,9 @@ vi.mock('@goodboy/ui', async (importOriginal) => {
 });
 
 vi.mock('../../../chat/components/ChatView', () => ({
-  ChatView: () => <div data-testid="chat-view" />,
+  ChatView: ({ header }: { header?: React.ReactNode }) => (
+    <div data-testid="chat-view">{header}</div>
+  ),
 }));
 vi.mock('../../../terminal/components/TerminalDock', () => ({ TerminalDock: () => null }));
 vi.mock('../../../plans/components/PlanStudio', () => ({ PlanStudio: () => null }));
@@ -137,6 +139,9 @@ describe('SessionWorkspace agent overlay', () => {
     const { container } = render(<SessionWorkspace session={session} isActive />);
     expect(screen.getByTestId('workflow-stepper')).toBeDefined();
     expect(screen.getByTestId('chat-view')).toBeDefined();
+    expect(screen.getByTestId('chat-view').contains(screen.getByTestId('workflow-stepper'))).toBe(
+      true,
+    );
     expect(container.querySelector('.w-72')).toBeNull();
     expect(screen.queryByTestId('agents-section')).toBeNull();
     expect(

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -29,7 +29,7 @@ import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
 import { useSelectedAgentHome } from './hooks/useSelectedAgentHome';
 import { buildSessionBreadcrumb } from './sessionBreadcrumb';
-import { WorkflowStepper } from './parts/WorkflowStepper';
+import { ChatWorkflowHeader } from './parts/ChatWorkflowHeader';
 import { WorkflowsPane } from './parts/WorkflowsPane';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
 import { resolveRootAgent } from '../../agent-kind';
@@ -194,23 +194,9 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   return (
     <div className="flex h-full w-full flex-col">
       <SessionTopBar session={session} />
-      <div
-        className={cn(
-          'flex min-w-0 shrink-0 items-center px-6',
-          showWorkflowStrip ? 'pb-1 pt-2.5' : 'py-2.5',
-        )}
-      >
+      <div className="flex min-w-0 shrink-0 items-center px-6 py-2.5">
         <AppBreadcrumb crumbs={crumbs} />
       </div>
-      {showWorkflowStrip && selectedAgentId != null ? (
-        <div className="flex min-w-0 shrink-0 items-center px-6 pb-2">
-          <WorkflowStepper
-            sessionId={sessionId}
-            session={session}
-            selectedAgentId={selectedAgentId}
-          />
-        </div>
-      ) : null}
       <Divider />
       <div className="flex min-h-0 flex-1">
         <div className="flex w-60 shrink-0 flex-col bg-background">
@@ -307,7 +293,15 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <ChatView
                     session={session}
                     isActive={isActive && selectedAgentId != null}
-                    hideBreadcrumb={showWorkflowStrip}
+                    header={
+                      showWorkflowStrip && selectedAgentId != null ? (
+                        <ChatWorkflowHeader
+                          sessionId={sessionId}
+                          session={session}
+                          selectedAgentId={selectedAgentId}
+                        />
+                      ) : undefined
+                    }
                   />
                 </div>
               </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowHeader.tsx
@@ -1,0 +1,18 @@
+import type { AgentId, Session, SessionId } from '@goodboy/types';
+import { Divider } from '@goodboy/ui';
+import { WorkflowStepper } from './WorkflowStepper';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly session: Session;
+  readonly selectedAgentId: AgentId;
+};
+
+export const ChatWorkflowHeader = ({ sessionId, session, selectedAgentId }: Props) => (
+  <>
+    <div className="flex h-[var(--chat-header-h)] shrink-0 items-center px-3">
+      <WorkflowStepper sessionId={sessionId} session={session} selectedAgentId={selectedAgentId} />
+    </div>
+    <Divider className="shrink-0" />
+  </>
+);


### PR DESCRIPTION
Follow-up on #946: the stepper sat on a second row under the app breadcrumb, pushing session content down. It is chat-owned, so it now renders in ChatView's fixed-height header slot (`--chat-header-h` + divider, same shell ChatBreadcrumb uses), which was empty in workflow chats since #944. Net: no extra row, zero vertical shift, breadcrumb row back to a single compact line.

ChatView's `hideBreadcrumb` prop is replaced by a generic `header?: ReactNode` override; new ChatWorkflowHeader part wraps the stepper in the ChatBreadcrumb shell.

## Verification
- pnpm typecheck green
- pnpm --filter desktop test: 245 files, 2215 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)