### PR TITLE
chore(repo): bump version to 0.1.28

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.27"
+version = "0.1.28"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Patch bump v0.1.27 → v0.1.28.

## Release gate (green)
- typecheck: 5/5 packages pass
- tests: 2215/2215 pass (245 files)
- no Rust changes in window → cargo test not required
- 12/13 PRs fully green; #938's single failing check is the known CI test-isolation flake (admin-merged), confirmed non-regressive by the aggregate run on current main

## PRs included since v0.1.27
- fix(desktop): move workflow stepper into chat header slot (#947)
- refactor(desktop): two-layer workflow stepper, quieter transcript (#946)
- feat(desktop): sessions mini-rail, persistent lens column, regroup (#945)
- fix(desktop): polish workflow nav crumbs, chat dedup, pane header (#944)
- refactor(desktop): chat coherence, tones, shell, typography (#941)
- refactor(core): workflow handoff chain, real step summaries, parallel merge (#938)
- refactor(core): shared context budgets, session tldr, writer coordination (#937)
- refactor(desktop): workflow nav overhaul, breadcrumb stepper + lens redesign (#942)
- fix(desktop): route cluster sub-agents to workflow lens (#939)
- feat(desktop): linked work section in session overview (#940)
- refactor(desktop): coherent session detail (nav, cta, counters, empty states, readability) (#936)
- fix(db): run migrations in crash-safe transactional segments (#935)
- fix(core): route cursor turns to role-selected models with cross-provider mapping (#934)