### PR TITLE
fix(ui): strip html comments and raw tags in markdown

### DIFF
--- a/packages/ui/src/__tests__/Markdown.test.tsx
+++ b/packages/ui/src/__tests__/Markdown.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { Markdown } from '../components/Markdown';
+
+afterEach(cleanup);
+
+const textOf = (markdown: string): string => {
+  const { container } = render(<Markdown text={markdown} />);
+  return container.textContent ?? '';
+};
+
+describe('Markdown html handling', () => {
+  it('drops single-line html comments', () => {
+    const out = textOf('before <!-- BUGBOT_BUG_ID: abc123 --> after');
+    expect(out).toContain('before');
+    expect(out).toContain('after');
+    expect(out).not.toContain('BUGBOT_BUG_ID');
+  });
+
+  it('drops multi-line html comments and their inner content', () => {
+    const out = textOf(
+      [
+        '<!-- LOCATIONS START',
+        'src/app/useFlow.tsx#L221-L235',
+        'LOCATIONS END -->',
+        'visible',
+      ].join('\n'),
+    );
+    expect(out).not.toContain('LOCATIONS');
+    expect(out).not.toContain('useFlow.tsx');
+    expect(out).toContain('visible');
+  });
+
+  it('strips raw html tags but keeps surrounding prose', () => {
+    const out = textOf(
+      'The flow re-upserts <div><a href="x"><picture></picture></a></div> the answer',
+    );
+    expect(out).toContain('The flow re-upserts');
+    expect(out).toContain('the answer');
+    expect(out).not.toContain('<div>');
+    expect(out).not.toContain('picture');
+    expect(out).not.toContain('href');
+  });
+
+  it('preserves context markers that look like tags', () => {
+    const { container } = render(<Markdown text="see <<ctx-goal>> now" />);
+    expect(container.textContent).toContain('goal');
+    expect(container.textContent).not.toContain('<<');
+  });
+
+  it('keeps html inside fenced code blocks intact', () => {
+    const out = textOf(['```tsx', 'const x = <div>hi</div>;', '```'].join('\n'));
+    expect(out).toContain('<div>hi</div>');
+  });
+
+  it('keeps html inside inline code intact', () => {
+    const out = textOf('use the `<Foo />` component');
+    expect(out).toContain('<Foo />');
+  });
+
+  it('leaves an unterminated comment as literal text', () => {
+    const out = textOf('trailing <!-- never closed');
+    expect(out).toContain('<!-- never closed');
+  });
+
+  it('converts nbsp entities to spaces', () => {
+    const out = textOf('a&nbsp;b');
+    expect(out).toContain('a b');
+  });
+});

--- a/packages/ui/src/components/Markdown.tsx
+++ b/packages/ui/src/components/Markdown.tsx
@@ -144,6 +144,75 @@ function parseAlign(divider: string): ReadonlyArray<CellAlign> {
   });
 }
 
+const isTagNameStart = (ch: string | undefined): boolean =>
+  ch !== undefined && ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'));
+
+const stripHtml = (input: string): string => {
+  let out = '';
+  let i = 0;
+  let inFence = false;
+  const n = input.length;
+
+  while (i < n) {
+    const atLineStart = i === 0 || input[i - 1] === '\n';
+    if (atLineStart && input.startsWith('```', i)) {
+      const lineEnd = input.indexOf('\n', i);
+      const end = lineEnd === -1 ? n : lineEnd;
+      out += input.slice(i, end);
+      i = end;
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      out += input[i];
+      i++;
+      continue;
+    }
+
+    const ch = input[i];
+
+    if (ch === '`') {
+      const end = input.indexOf('`', i + 1);
+      if (end !== -1) {
+        out += input.slice(i, end + 1);
+        i = end + 1;
+        continue;
+      }
+    }
+
+    if (ch === '<' && input.startsWith('<!--', i)) {
+      const end = input.indexOf('-->', i + 4);
+      if (end !== -1) {
+        i = end + 3;
+        continue;
+      }
+    }
+
+    if (ch === '<' && input[i + 1] === '<') {
+      out += '<<';
+      i += 2;
+      continue;
+    }
+
+    if (ch === '<') {
+      const slashed = input[i + 1] === '/';
+      const nameStart = slashed ? input[i + 2] : input[i + 1];
+      if (isTagNameStart(nameStart)) {
+        const end = input.indexOf('>', i + 1);
+        if (end !== -1) {
+          i = end + 1;
+          continue;
+        }
+      }
+    }
+
+    out += ch;
+    i++;
+  }
+
+  return out.replace(/&nbsp;/g, ' ');
+};
+
 function parseBlocks(input: string): ReadonlyArray<Block> {
   const lines = input.replace(/\r\n/g, '\n').split('\n');
   const blocks: Block[] = [];
@@ -633,7 +702,7 @@ function renderBlock(block: Block, idx: number): ReactNode {
 }
 
 export const Markdown = ({ text, className }: MarkdownProps) => {
-  const blocks = parseBlocks(text);
+  const blocks = parseBlocks(stripHtml(text));
   return (
     <div className={cn('flex flex-col gap-2 text-sm text-foreground/85', className)}>
       {blocks.map(renderBlock)}


### PR DESCRIPTION
## Problem

Bot PR review comments (e.g. Cursor Bugbot) embed HTML comments (`<!-- DESCRIPTION START -->`, `<!-- BUGBOT_BUG_ID: ... -->`, `<!-- LOCATIONS ... -->`) and raw HTML markup (`<div><a><picture><source/><img/></a></div>`). GitHub hides the comments and renders the HTML; Goodboy's custom markdown parser showed all of it as literal noise, making the comment unreadable.

## Fix

`stripHtml` preprocess before `parseBlocks`, a single linear `indexOf` scanner (ReDoS-safe, same approach as the marker-parsing hardening):

- drops HTML comments (single and multi-line, incl. their inner content, matching GitHub)
- strips HTML open/close/self-closing tags
- **preserves** fenced code blocks, inline code spans, and `<< >>` context markers
- decodes `&nbsp;`

Applied in the shared `Markdown` component so every caller (PR conversation, comment thread rows, transcript) benefits. Raw HTML was never rendered before, only shown as noise, so removing it is strictly an improvement with no rendering regression.

## Tests

8 new tests in `Markdown.test.tsx`: comment stripping (single/multi-line), tag stripping with prose preserved, marker preservation, fenced + inline code untouched, unterminated comment left literal, nbsp decode. Full `@goodboy/ui` suite green (20/20), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)