### PR TITLE
feat(resolve): spawn hints + fix|analyze mode picker

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -129,7 +129,7 @@ describe('spawn-from-comment', () => {
 
   it('keeps the omitted and explicit fix-mode prompts byte-identical', () => {
     const omitted = buildCommentAgentArgs(makeComment(), PR).initialPrompt;
-    const explicit = buildCommentAgentArgs(makeComment(), PR, {}, [], 'fix').initialPrompt;
+    const explicit = buildCommentAgentArgs(makeComment(), PR, { mode: 'fix' }).initialPrompt;
     expect(omitted).toBe(explicit);
     expect(omitted).toBe(
       [
@@ -143,8 +143,27 @@ describe('spawn-from-comment', () => {
     );
   });
 
+  it('keeps omitted, empty and whitespace-only hint prompts byte-identical', () => {
+    const omitted = buildCommentAgentArgs(makeComment(), PR).initialPrompt;
+    const empty = buildCommentAgentArgs(makeComment(), PR, { hint: '' }).initialPrompt;
+    const whitespace = buildCommentAgentArgs(makeComment(), PR, { hint: '  \n\t ' }).initialPrompt;
+    expect(empty).toBe(omitted);
+    expect(whitespace).toBe(omitted);
+  });
+
+  it('appends trimmed operator notes to the kickoff prompt', () => {
+    const args = buildCommentAgentArgs(makeComment(), PR, {
+      hint: '  Use the existing helper.\nAvoid schema changes.  ',
+    });
+    expect(args.initialPrompt).toContain(
+      'Comment URL: https://github.com/o/r/pull/9108#discussion_r1\n\nOperator notes:\nUse the existing helper.\nAvoid schema changes.',
+    );
+  });
+
   it('appends the read-only analysis contract in analyze mode', () => {
-    const args = buildCommentAgentArgs(makeComment({ threadId: 'PRRT_7' }), PR, {}, [], 'analyze');
+    const args = buildCommentAgentArgs(makeComment({ threadId: 'PRRT_7' }), PR, {
+      mode: 'analyze',
+    });
     expect(args.mode).toBe('analyze');
     expect(args.initialPrompt).toContain('do not modify or commit any file');
     expect(args.initialPrompt).toContain(

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -27,9 +27,16 @@ type Params = {
   readonly pr: PullRequestState;
   readonly replies: ReadonlyArray<PrComment>;
   readonly mode?: ResolveMode;
+  readonly hint?: string;
 };
 
-const buildCommentAgentPrompt = ({ comment: c, pr, replies, mode = 'fix' }: Params): string => {
+const buildCommentAgentPrompt = ({
+  comment: c,
+  pr,
+  replies,
+  mode = 'fix',
+  hint = '',
+}: Params): string => {
   const lines: Array<string> = [];
   lines.push(`Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`);
   if (c.source === 'review' && c.path) {
@@ -69,6 +76,12 @@ const buildCommentAgentPrompt = ({ comment: c, pr, replies, mode = 'fix' }: Para
     lines.push('Use verdict="wontfix" instead when the comment is not worth fixing.');
     lines.push('The summary must be one paragraph of plain text with no double quotes.');
   }
+  const operatorNotes = hint.trim();
+  if (operatorNotes.length > 0) {
+    lines.push('');
+    lines.push('Operator notes:');
+    lines.push(operatorNotes);
+  }
   return lines.join('\n');
 };
 
@@ -88,6 +101,8 @@ export type ResolveModelChoice = {
   readonly provider?: ProviderId;
   readonly model?: string;
   readonly effort?: EffortLevel;
+  readonly mode?: ResolveMode;
+  readonly hint?: string;
 };
 
 export const buildCommentAgentArgs = (
@@ -95,16 +110,16 @@ export const buildCommentAgentArgs = (
   pr: PullRequestState,
   choice: ResolveModelChoice = {},
   replies: ReadonlyArray<PrComment> = [],
-  mode: ResolveMode = 'fix',
 ): CommentAgentArgs => {
   const defaults = AGENT_KIND_DEFAULTS.resolver;
+  const mode = choice.mode ?? 'fix';
   return {
     name: buildCommentAgentTitle(c),
     kind: 'resolver',
     model: choice.model ?? defaults.model,
     ...(choice.provider !== undefined && { provider: choice.provider }),
     effort: choice.effort ?? defaults.effort,
-    initialPrompt: buildCommentAgentPrompt({ comment: c, pr, replies, mode }),
+    initialPrompt: buildCommentAgentPrompt({ comment: c, pr, replies, mode, hint: choice.hint }),
     ...(c.source === 'review' && c.threadId ? { sourceThreadId: c.threadId } : {}),
     sourceCommentUrl: c.url,
     ...(mode !== 'fix' && { mode }),

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { PrComment } from '@goodboy/types';
+import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
 import type { CommentThread } from '../../../comment-threads';
 
 const h = vi.hoisted(() => ({
@@ -76,7 +77,7 @@ describe('ResolveBoard', () => {
   });
 
   it('spawns a single comment via its Resolve button', () => {
-    const onSpawnOne = vi.fn();
+    const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
         threads={[thread({ id: 'c1' })]}
@@ -90,6 +91,77 @@ describe('ResolveBoard', () => {
     });
     expect(onSpawnOne).toHaveBeenCalledTimes(1);
     expect(onSpawnOne.mock.calls[0]?.[0]?.head?.id).toBe('c1');
+    expect(onSpawnOne.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ mode: 'fix', hint: '' }),
+    );
+  });
+
+  it('applies mode and hint to a single resolver', () => {
+    const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
+    render(
+      <ResolveBoard
+        threads={[thread({ id: 'c1' })]}
+        onSpawnOne={onSpawnOne}
+        onSpawnBatch={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve with/i }));
+    });
+    act(() => {
+      fireEvent.change(screen.getByRole('combobox', { name: /Resolver mode/i }), {
+        target: { value: 'analyze' },
+      });
+      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
+        target: { value: 'Avoid schema changes.' },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /^Resolve$/i }));
+    });
+    expect(onSpawnOne.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Avoid schema changes.' }),
+    );
+  });
+
+  it('shares mode and hint across every resolver in a batch', () => {
+    const onSpawnBatch =
+      vi.fn<
+        (
+          threads: ReadonlyArray<CommentThread>,
+          choiceById: Readonly<Record<string, ResolveModelChoice>>,
+        ) => void
+      >();
+    render(
+      <ResolveBoard
+        threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={onSpawnBatch}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+    });
+    act(() => {
+      fireEvent.change(screen.getByRole('combobox', { name: /Resolver mode/i }), {
+        target: { value: 'analyze' },
+      });
+      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
+        target: { value: 'Keep the public API stable.' },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Spawn resolver for 2 comments/i }));
+    });
+    const choices = onSpawnBatch.mock.calls[0]?.[1];
+    expect(choices?.c1).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+    );
+    expect(choices?.c2).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+    );
   });
 
   it('renders the head comment plus its replies as context', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -20,7 +20,7 @@ import { shortModelWithVersion } from '../../../../session/agent-row-format';
 import { ProviderSelect } from '../../../../session/components/ProviderSelect';
 import { ModelSelect } from '../../../../session/components/ModelSelect';
 import { EffortSelect } from '../../../../session/components/EffortSelect';
-import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
+import type { ResolveMode, ResolveModelChoice } from '../../../../chat/spawn-from-comment';
 import type { CommentThread } from '../../../comment-threads';
 import {
   ResolverStateBadge,
@@ -59,6 +59,8 @@ export const ResolveBoard = ({
   const [configById, setConfigById] = useState<Readonly<Record<string, CardConfig>>>({});
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
   const [overrideOpen, setOverrideOpen] = useState(false);
+  const [mode, setMode] = useState<ResolveMode>('fix');
+  const [hint, setHint] = useState('');
 
   const getConfig = (id: string): CardConfig => configById[id] ?? DEFAULT_CONFIG;
   const patchConfig = (id: string, next: CardConfig) =>
@@ -103,7 +105,7 @@ export const ResolveBoard = ({
     setDeselected(allSelected ? new Set(selectable.map((t) => t.head.id)) : new Set());
 
   const choiceById: Record<string, ResolveModelChoice> = Object.fromEntries(
-    threads.map((t) => [t.head.id, getConfig(t.head.id)]),
+    threads.map((t) => [t.head.id, { ...getConfig(t.head.id), mode, hint }]),
   );
 
   return (
@@ -128,7 +130,7 @@ export const ResolveBoard = ({
           <button
             type="button"
             onClick={() => setOverrideOpen((v) => !v)}
-            title="apply one provider/model/effort to every comment"
+            title="apply one resolver configuration to every comment"
             className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-xs transition-colors hover:bg-muted/50"
           >
             <Sliders size={12} aria-hidden className="text-muted-foreground" />
@@ -143,8 +145,12 @@ export const ResolveBoard = ({
               className="absolute right-0 top-8 z-20 w-64"
               title="Apply to all comments"
               config={aggregate === 'mixed' ? DEFAULT_CONFIG : aggregate}
+              mode={mode}
+              hint={hint}
               connectedProviders={connectedProviders}
               onChange={(next) => applyToAll(next)}
+              onMode={setMode}
+              onHint={setHint}
               footer={
                 <button
                   type="button"
@@ -180,7 +186,11 @@ export const ResolveBoard = ({
               connectedProviders={connectedProviders}
               onToggle={() => toggle(t.head.id)}
               onConfig={(next) => patchConfig(t.head.id, next)}
-              onResolve={() => onSpawnOne(t, getConfig(t.head.id))}
+              onResolve={() => onSpawnOne(t, { ...getConfig(t.head.id), mode, hint })}
+              mode={mode}
+              hint={hint}
+              onMode={setMode}
+              onHint={setHint}
               onOpenResolver={onOpenResolver}
               onOpenThread={
                 t.head.threadId ? () => onOpenThread(t.head.threadId as string) : undefined
@@ -202,6 +212,10 @@ function ResolveCard({
   onToggle,
   onConfig,
   onResolve,
+  mode,
+  hint,
+  onMode,
+  onHint,
   onOpenResolver,
   onOpenThread,
 }: {
@@ -213,6 +227,10 @@ function ResolveCard({
   onToggle: () => void;
   onConfig: (next: CardConfig) => void;
   onResolve: () => void;
+  mode: ResolveMode;
+  hint: string;
+  onMode: (next: ResolveMode) => void;
+  onHint: (next: string) => void;
   onOpenResolver?: (agentId: AgentId) => void;
   onOpenThread?: () => void;
 }) {
@@ -309,8 +327,12 @@ function ResolveCard({
                       className="absolute left-0 top-8 z-20 w-60"
                       title="Resolve with"
                       config={config}
+                      mode={mode}
+                      hint={hint}
                       connectedProviders={connectedProviders}
                       onChange={onConfig}
+                      onMode={onMode}
+                      onHint={onHint}
                       footer={
                         <button
                           type="button"
@@ -358,15 +380,23 @@ function ConfigPanel({
   className,
   title,
   config,
+  mode,
+  hint,
   connectedProviders,
   onChange,
+  onMode,
+  onHint,
   footer,
 }: {
   className?: string;
   title: string;
   config: CardConfig;
+  mode: ResolveMode;
+  hint: string;
   connectedProviders: ReadonlyArray<ProviderId>;
   onChange: (next: CardConfig) => void;
+  onMode: (next: ResolveMode) => void;
+  onHint: (next: string) => void;
   footer?: ReactNode;
 }) {
   const onProvider = (next: ProviderId | '') => {
@@ -405,6 +435,36 @@ function ConfigPanel({
         value={config.effort}
         onChange={onEffort}
         disabled={false}
+      />
+      <div className="relative">
+        <select
+          aria-label="Resolver mode"
+          value={mode}
+          onChange={(event) => {
+            const nextMode = event.target.value;
+            if (nextMode !== 'fix' && nextMode !== 'analyze') {
+              return;
+            }
+            onMode(nextMode);
+          }}
+          className="w-full appearance-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 pr-7 text-xs text-foreground transition-colors hover:border-border hover:bg-muted/50"
+        >
+          <option value="fix">Fix</option>
+          <option value="analyze">Analyze</option>
+        </select>
+        <ChevronDown
+          size={11}
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+      </div>
+      <textarea
+        aria-label="Resolver hint"
+        value={hint}
+        onChange={(event) => onHint(event.target.value)}
+        rows={2}
+        placeholder="Optional notes for the resolver: how to fix, what to avoid..."
+        className="w-full resize-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
       />
       {footer}
     </div>

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -6,10 +6,13 @@ import type {
   IsoDateTime,
   PlanId,
   PlanWithCount,
+  PrComment,
+  PullRequestState,
   Session,
   SessionId,
   WorkspaceId,
 } from '@goodboy/types';
+import { buildCommentAgentArgs } from '../../../features/chat/spawn-from-comment';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
@@ -58,6 +61,35 @@ const TWO_CLUSTERS: ReadonlyArray<ImplementationCluster> = [
   { title: 'a', instructions: 'i1' },
   { title: 'b', instructions: 'i2' },
 ];
+
+const PR = {
+  number: 9108,
+  title: 'resolve: foo',
+  url: 'https://github.com/o/r/pull/9108',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'kay/foo',
+  isDraft: false,
+  reviewDecision: 'changes_requested',
+  body: '',
+  updatedAt: '2026-05-15T00:00:00Z',
+} satisfies PullRequestState;
+
+const COMMENT = {
+  id: 'review-1',
+  author: 'alice',
+  authorAvatarUrl: null,
+  body: 'this should use a helper',
+  createdAt: '2026-05-15T10:00:00Z',
+  url: 'https://github.com/o/r/pull/9108#discussion_r1',
+  source: 'review',
+  path: 'src/foo.ts',
+  line: 42,
+  resolved: false,
+  threadId: 'PRRT_7',
+} satisfies PrComment;
 
 function makePlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   return {
@@ -121,13 +153,18 @@ function buildHarness(plans: ReadonlyArray<PlanWithCount>) {
     agentProviderOverride: {},
     agentEffortOverride: {},
     agentKindOverride: {},
+    pendingResolverKickoff: {},
     sendTurn,
   };
-  const set = vi.fn();
   const get = (() => state) as unknown as Parameters<typeof spawnAgent>[1];
+  const set = vi.fn((update: Parameters<Parameters<typeof spawnAgent>[0]>[0]) => {
+    const patch = typeof update === 'function' ? update(get()) : update;
+    Object.assign(state, patch);
+  });
   return {
+    getState: get,
     sendTurn,
-    spawn: spawnAgent(set as unknown as Parameters<typeof spawnAgent>[0], get),
+    spawn: spawnAgent(set, get),
   };
 }
 
@@ -188,6 +225,25 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
     expect(sendTurn).toHaveBeenCalledTimes(1);
     expect(sendTurn.mock.calls[0]?.[0]?.content).toContain('fix the typo in README');
+  });
+
+  it('stores mode instructions and hint for a deferred batch resolver', async () => {
+    const { getState, sendTurn, spawn } = buildHarness([]);
+    const args = buildCommentAgentArgs(COMMENT, PR, {
+      mode: 'analyze',
+      hint: 'Avoid schema changes.',
+    });
+
+    await spawn(SESSION_ID, {
+      kindOverride: 'resolver',
+      initialPrompt: args.initialPrompt,
+      deferKickoff: true,
+    });
+
+    const kickoff = getState().pendingResolverKickoff[INSERTED_ID];
+    expect(kickoff).toContain('Analysis mode: do not modify or commit any file.');
+    expect(kickoff).toContain('Operator notes:\nAvoid schema changes.');
+    expect(sendTurn).not.toHaveBeenCalled();
   });
 
   it('consumes the plan on ad-hoc fan-out so a re-spawn cannot fan out again', async () => {


### PR DESCRIPTION
ResolveBoard ConfigPanel gains a free-text operator-notes hint and a fix|analyze mode picker (default fix), applied to single and batch spawn. Hint appended to the kickoff in a delimited section; empty hint keeps the prompt byte-identical. Both survive deferKickoff.

Stacked PR 2/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)