### PR TITLE
feat(desktop): PR draft card model/provider/effort + hints

### DIFF
--- a/apps/desktop/src/features/chat/spawn-from-comment.test.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.test.ts
@@ -129,7 +129,7 @@ describe('spawn-from-comment', () => {
 
   it('keeps the omitted and explicit fix-mode prompts byte-identical', () => {
     const omitted = buildCommentAgentArgs(makeComment(), PR).initialPrompt;
-    const explicit = buildCommentAgentArgs(makeComment(), PR, {}, [], 'fix').initialPrompt;
+    const explicit = buildCommentAgentArgs(makeComment(), PR, { mode: 'fix' }).initialPrompt;
     expect(omitted).toBe(explicit);
     expect(omitted).toBe(
       [
@@ -143,8 +143,27 @@ describe('spawn-from-comment', () => {
     );
   });
 
+  it('keeps omitted, empty and whitespace-only hint prompts byte-identical', () => {
+    const omitted = buildCommentAgentArgs(makeComment(), PR).initialPrompt;
+    const empty = buildCommentAgentArgs(makeComment(), PR, { hint: '' }).initialPrompt;
+    const whitespace = buildCommentAgentArgs(makeComment(), PR, { hint: '  \n\t ' }).initialPrompt;
+    expect(empty).toBe(omitted);
+    expect(whitespace).toBe(omitted);
+  });
+
+  it('appends trimmed operator notes to the kickoff prompt', () => {
+    const args = buildCommentAgentArgs(makeComment(), PR, {
+      hint: '  Use the existing helper.\nAvoid schema changes.  ',
+    });
+    expect(args.initialPrompt).toContain(
+      'Comment URL: https://github.com/o/r/pull/9108#discussion_r1\n\nOperator notes:\nUse the existing helper.\nAvoid schema changes.',
+    );
+  });
+
   it('appends the read-only analysis contract in analyze mode', () => {
-    const args = buildCommentAgentArgs(makeComment({ threadId: 'PRRT_7' }), PR, {}, [], 'analyze');
+    const args = buildCommentAgentArgs(makeComment({ threadId: 'PRRT_7' }), PR, {
+      mode: 'analyze',
+    });
     expect(args.mode).toBe('analyze');
     expect(args.initialPrompt).toContain('do not modify or commit any file');
     expect(args.initialPrompt).toContain(

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -27,9 +27,16 @@ type Params = {
   readonly pr: PullRequestState;
   readonly replies: ReadonlyArray<PrComment>;
   readonly mode?: ResolveMode;
+  readonly hint?: string;
 };
 
-const buildCommentAgentPrompt = ({ comment: c, pr, replies, mode = 'fix' }: Params): string => {
+const buildCommentAgentPrompt = ({
+  comment: c,
+  pr,
+  replies,
+  mode = 'fix',
+  hint = '',
+}: Params): string => {
   const lines: Array<string> = [];
   lines.push(`Context: PR #${pr.number} on branch \`${pr.headBranch}\`.`);
   if (c.source === 'review' && c.path) {
@@ -69,6 +76,12 @@ const buildCommentAgentPrompt = ({ comment: c, pr, replies, mode = 'fix' }: Para
     lines.push('Use verdict="wontfix" instead when the comment is not worth fixing.');
     lines.push('The summary must be one paragraph of plain text with no double quotes.');
   }
+  const operatorNotes = hint.trim();
+  if (operatorNotes.length > 0) {
+    lines.push('');
+    lines.push('Operator notes:');
+    lines.push(operatorNotes);
+  }
   return lines.join('\n');
 };
 
@@ -88,6 +101,8 @@ export type ResolveModelChoice = {
   readonly provider?: ProviderId;
   readonly model?: string;
   readonly effort?: EffortLevel;
+  readonly mode?: ResolveMode;
+  readonly hint?: string;
 };
 
 export const buildCommentAgentArgs = (
@@ -95,16 +110,16 @@ export const buildCommentAgentArgs = (
   pr: PullRequestState,
   choice: ResolveModelChoice = {},
   replies: ReadonlyArray<PrComment> = [],
-  mode: ResolveMode = 'fix',
 ): CommentAgentArgs => {
   const defaults = AGENT_KIND_DEFAULTS.resolver;
+  const mode = choice.mode ?? 'fix';
   return {
     name: buildCommentAgentTitle(c),
     kind: 'resolver',
     model: choice.model ?? defaults.model,
     ...(choice.provider !== undefined && { provider: choice.provider }),
     effort: choice.effort ?? defaults.effort,
-    initialPrompt: buildCommentAgentPrompt({ comment: c, pr, replies, mode }),
+    initialPrompt: buildCommentAgentPrompt({ comment: c, pr, replies, mode, hint: choice.hint }),
     ...(c.source === 'review' && c.threadId ? { sourceThreadId: c.threadId } : {}),
     sourceCommentUrl: c.url,
     ...(mode !== 'fix' && { mode }),

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { SessionId } from '@goodboy/types';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+
+type SpawnAgent = (
+  sessionId: SessionId,
+  args: Readonly<Record<string, unknown>>,
+) => Promise<string>;
+
+type Store = {
+  readonly createPrForSession: ReturnType<typeof vi.fn>;
+  readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
+  readonly selectAgent: ReturnType<typeof vi.fn>;
+  readonly setCurrentSession: ReturnType<typeof vi.fn>;
+  readonly sessionBranches: Record<string, string>;
+  readonly sessions: ReadonlyArray<{ id: SessionId; workspaceId: string }>;
+  readonly workspaces: ReadonlyArray<{ id: string; rootPath: string }>;
+};
+
+type ConfigProps = {
+  readonly value: AgentSpawnConfigValue;
+  readonly onChange: (value: AgentSpawnConfigValue) => void;
+  readonly disabled: boolean;
+};
+
+const h = vi.hoisted(() => ({
+  config: {
+    provider: 'codex',
+    model: 'gpt-5.4-mini',
+    effort: 'medium',
+    hint: 'Keep the public API stable.',
+  } satisfies AgentSpawnConfigValue,
+  store: {
+    createPrForSession: vi.fn(async () => undefined),
+    spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-2'),
+    selectAgent: vi.fn(async () => undefined),
+    setCurrentSession: vi.fn(async () => undefined),
+    sessionBranches: { 'session-2': 'ak/card-config' },
+    sessions: [{ id: 'session-2' as SessionId, workspaceId: 'workspace-1' }],
+    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+  } satisfies Store,
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
+}));
+
+vi.mock('../../github', () => ({
+  ghBaseBranches: vi.fn(async () => ({ defaultBranch: 'main', branches: ['main'] })),
+}));
+
+vi.mock('../../../session/components/AgentSpawnConfig', () => ({
+  AgentSpawnConfig: ({ value, onChange, disabled }: ConfigProps) => (
+    <div>
+      <button type="button" disabled={disabled} onClick={() => onChange(h.config)}>
+        Choose agent config
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => onChange({ ...value, hint: ' \n\t ' })}
+      >
+        Set whitespace hint
+      </button>
+    </div>
+  ),
+}));
+
+import { CreatePrPanel } from './CreatePrPanel';
+
+const SESSION_ID = 'session-2' as SessionId;
+
+beforeEach(() => {
+  h.store.spawnAgent.mockClear();
+  h.store.selectAgent.mockClear();
+  h.store.setCurrentSession.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('CreatePrPanel', () => {
+  it('spawns a PR agent with the chosen config and operator notes', async () => {
+    const onStudioClose = vi.fn();
+    render(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={onStudioClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    const args = h.store.spawnAgent.mock.calls[0]![1];
+    expect(args).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.4-mini',
+      effort: 'medium',
+    });
+    expect(args.initialPrompt).toContain(
+      '\n\nOperator notes:\n---\nKeep the public API stable.\n---',
+    );
+    await waitFor(() => expect(onStudioClose).toHaveBeenCalledOnce());
+  });
+
+  it('preserves the legacy prompt and routing for a whitespace-only hint', async () => {
+    render(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Set whitespace hint' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    const args = h.store.spawnAgent.mock.calls[0]![1];
+    expect(args).not.toHaveProperty('provider');
+    expect(args).toMatchObject({ model: 'claude-haiku-4-5', effort: 'low' });
+    expect(args.initialPrompt).toBe(
+      [
+        `Open a GitHub pull request for this session's branch.`,
+        `- Write a clear, conventional title and a concise description from the committed changes.`,
+        `- Session goal: "Refactor PR cards".`,
+        `- If this project defines a PR-creation skill, command, or template (look under .claude/), follow it.`,
+        `- Open it as a draft PR.`,
+        `Then run \`gh pr create\` to open it and report the PR URL.`,
+      ].join('\n'),
+    );
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -3,7 +3,10 @@ import type { SessionId } from '@goodboy/types';
 import { Button, cn, Input, ScrollFade, SectionHeader, Textarea } from '@goodboy/ui';
 import { ArrowRight, GitBranch, Sparkles } from 'lucide-react';
 import { ghBaseBranches } from '../../github';
-import { AGENT_KIND_DEFAULTS } from '../../../session/agent-kind';
+import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
+import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
 import { useAppStore } from '../../../../store';
 
 type Props = {
@@ -42,6 +45,7 @@ export const CreatePrPanel = ({
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
 
   useEffect(() => {
     if (!workspaceRoot) {
@@ -100,9 +104,10 @@ export const CreatePrPanel = ({
       ].join('\n');
       const agentId = await spawnAgent(sessionId, {
         name: 'open pull request',
-        initialPrompt: prompt,
-        model: AGENT_KIND_DEFAULTS.generic.model,
-        effort: AGENT_KIND_DEFAULTS.generic.effort,
+        initialPrompt: appendOperatorNotes({ prompt, hint: agentConfig.hint }),
+        model: agentConfig.model,
+        ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
+        effort: agentConfig.effort,
       });
       await setCurrentSession(sessionId);
       await selectAgent(sessionId, agentId);
@@ -171,6 +176,11 @@ export const CreatePrPanel = ({
                 ))}
               </datalist>
             </div>
+            <AgentSpawnConfig
+              value={agentConfig}
+              onChange={setAgentConfig}
+              disabled={busy !== null}
+            />
             <div className="flex items-center gap-3 pt-1">
               <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
                 <input

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { PrComment } from '@goodboy/types';
+import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
 import type { CommentThread } from '../../../comment-threads';
 
 const h = vi.hoisted(() => ({
@@ -76,7 +77,7 @@ describe('ResolveBoard', () => {
   });
 
   it('spawns a single comment via its Resolve button', () => {
-    const onSpawnOne = vi.fn();
+    const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
         threads={[thread({ id: 'c1' })]}
@@ -90,6 +91,77 @@ describe('ResolveBoard', () => {
     });
     expect(onSpawnOne).toHaveBeenCalledTimes(1);
     expect(onSpawnOne.mock.calls[0]?.[0]?.head?.id).toBe('c1');
+    expect(onSpawnOne.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ mode: 'fix', hint: '' }),
+    );
+  });
+
+  it('applies mode and hint to a single resolver', () => {
+    const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
+    render(
+      <ResolveBoard
+        threads={[thread({ id: 'c1' })]}
+        onSpawnOne={onSpawnOne}
+        onSpawnBatch={vi.fn()}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve with/i }));
+    });
+    act(() => {
+      fireEvent.change(screen.getByRole('combobox', { name: /Resolver mode/i }), {
+        target: { value: 'analyze' },
+      });
+      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
+        target: { value: 'Avoid schema changes.' },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /^Resolve$/i }));
+    });
+    expect(onSpawnOne.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Avoid schema changes.' }),
+    );
+  });
+
+  it('shares mode and hint across every resolver in a batch', () => {
+    const onSpawnBatch =
+      vi.fn<
+        (
+          threads: ReadonlyArray<CommentThread>,
+          choiceById: Readonly<Record<string, ResolveModelChoice>>,
+        ) => void
+      >();
+    render(
+      <ResolveBoard
+        threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
+        onSpawnOne={vi.fn()}
+        onSpawnBatch={onSpawnBatch}
+        onOpenThread={vi.fn()}
+      />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Resolve all with/i }));
+    });
+    act(() => {
+      fireEvent.change(screen.getByRole('combobox', { name: /Resolver mode/i }), {
+        target: { value: 'analyze' },
+      });
+      fireEvent.change(screen.getByRole('textbox', { name: /Resolver hint/i }), {
+        target: { value: 'Keep the public API stable.' },
+      });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /Spawn resolver for 2 comments/i }));
+    });
+    const choices = onSpawnBatch.mock.calls[0]?.[1];
+    expect(choices?.c1).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+    );
+    expect(choices?.c2).toEqual(
+      expect.objectContaining({ mode: 'analyze', hint: 'Keep the public API stable.' }),
+    );
   });
 
   it('renders the head comment plus its replies as context', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -20,7 +20,7 @@ import { shortModelWithVersion } from '../../../../session/agent-row-format';
 import { ProviderSelect } from '../../../../session/components/ProviderSelect';
 import { ModelSelect } from '../../../../session/components/ModelSelect';
 import { EffortSelect } from '../../../../session/components/EffortSelect';
-import type { ResolveModelChoice } from '../../../../chat/spawn-from-comment';
+import type { ResolveMode, ResolveModelChoice } from '../../../../chat/spawn-from-comment';
 import type { CommentThread } from '../../../comment-threads';
 import {
   ResolverStateBadge,
@@ -59,6 +59,8 @@ export const ResolveBoard = ({
   const [configById, setConfigById] = useState<Readonly<Record<string, CardConfig>>>({});
   const [deselected, setDeselected] = useState<ReadonlySet<string>>(new Set());
   const [overrideOpen, setOverrideOpen] = useState(false);
+  const [mode, setMode] = useState<ResolveMode>('fix');
+  const [hint, setHint] = useState('');
 
   const getConfig = (id: string): CardConfig => configById[id] ?? DEFAULT_CONFIG;
   const patchConfig = (id: string, next: CardConfig) =>
@@ -103,7 +105,7 @@ export const ResolveBoard = ({
     setDeselected(allSelected ? new Set(selectable.map((t) => t.head.id)) : new Set());
 
   const choiceById: Record<string, ResolveModelChoice> = Object.fromEntries(
-    threads.map((t) => [t.head.id, getConfig(t.head.id)]),
+    threads.map((t) => [t.head.id, { ...getConfig(t.head.id), mode, hint }]),
   );
 
   return (
@@ -128,7 +130,7 @@ export const ResolveBoard = ({
           <button
             type="button"
             onClick={() => setOverrideOpen((v) => !v)}
-            title="apply one provider/model/effort to every comment"
+            title="apply one resolver configuration to every comment"
             className="inline-flex items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1 text-xs transition-colors hover:bg-muted/50"
           >
             <Sliders size={12} aria-hidden className="text-muted-foreground" />
@@ -143,8 +145,12 @@ export const ResolveBoard = ({
               className="absolute right-0 top-8 z-20 w-64"
               title="Apply to all comments"
               config={aggregate === 'mixed' ? DEFAULT_CONFIG : aggregate}
+              mode={mode}
+              hint={hint}
               connectedProviders={connectedProviders}
               onChange={(next) => applyToAll(next)}
+              onMode={setMode}
+              onHint={setHint}
               footer={
                 <button
                   type="button"
@@ -180,7 +186,11 @@ export const ResolveBoard = ({
               connectedProviders={connectedProviders}
               onToggle={() => toggle(t.head.id)}
               onConfig={(next) => patchConfig(t.head.id, next)}
-              onResolve={() => onSpawnOne(t, getConfig(t.head.id))}
+              onResolve={() => onSpawnOne(t, { ...getConfig(t.head.id), mode, hint })}
+              mode={mode}
+              hint={hint}
+              onMode={setMode}
+              onHint={setHint}
               onOpenResolver={onOpenResolver}
               onOpenThread={
                 t.head.threadId ? () => onOpenThread(t.head.threadId as string) : undefined
@@ -202,6 +212,10 @@ function ResolveCard({
   onToggle,
   onConfig,
   onResolve,
+  mode,
+  hint,
+  onMode,
+  onHint,
   onOpenResolver,
   onOpenThread,
 }: {
@@ -213,6 +227,10 @@ function ResolveCard({
   onToggle: () => void;
   onConfig: (next: CardConfig) => void;
   onResolve: () => void;
+  mode: ResolveMode;
+  hint: string;
+  onMode: (next: ResolveMode) => void;
+  onHint: (next: string) => void;
   onOpenResolver?: (agentId: AgentId) => void;
   onOpenThread?: () => void;
 }) {
@@ -309,8 +327,12 @@ function ResolveCard({
                       className="absolute left-0 top-8 z-20 w-60"
                       title="Resolve with"
                       config={config}
+                      mode={mode}
+                      hint={hint}
                       connectedProviders={connectedProviders}
                       onChange={onConfig}
+                      onMode={onMode}
+                      onHint={onHint}
                       footer={
                         <button
                           type="button"
@@ -358,15 +380,23 @@ function ConfigPanel({
   className,
   title,
   config,
+  mode,
+  hint,
   connectedProviders,
   onChange,
+  onMode,
+  onHint,
   footer,
 }: {
   className?: string;
   title: string;
   config: CardConfig;
+  mode: ResolveMode;
+  hint: string;
   connectedProviders: ReadonlyArray<ProviderId>;
   onChange: (next: CardConfig) => void;
+  onMode: (next: ResolveMode) => void;
+  onHint: (next: string) => void;
   footer?: ReactNode;
 }) {
   const onProvider = (next: ProviderId | '') => {
@@ -405,6 +435,36 @@ function ConfigPanel({
         value={config.effort}
         onChange={onEffort}
         disabled={false}
+      />
+      <div className="relative">
+        <select
+          aria-label="Resolver mode"
+          value={mode}
+          onChange={(event) => {
+            const nextMode = event.target.value;
+            if (nextMode !== 'fix' && nextMode !== 'analyze') {
+              return;
+            }
+            onMode(nextMode);
+          }}
+          className="w-full appearance-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 pr-7 text-xs text-foreground transition-colors hover:border-border hover:bg-muted/50"
+        >
+          <option value="fix">Fix</option>
+          <option value="analyze">Analyze</option>
+        </select>
+        <ChevronDown
+          size={11}
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+        />
+      </div>
+      <textarea
+        aria-label="Resolver hint"
+        value={hint}
+        onChange={(event) => onHint(event.target.value)}
+        rows={2}
+        placeholder="Optional notes for the resolver: how to fix, what to avoid..."
+        className="w-full resize-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
       />
       {footer}
     </div>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { SessionId } from '@goodboy/types';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+
+type SpawnAgent = (
+  sessionId: SessionId,
+  args: Readonly<Record<string, unknown>>,
+) => Promise<string>;
+
+type Store = {
+  readonly sessions: ReadonlyArray<{ id: SessionId; goal: string }>;
+  readonly sessionGitlabMr: Record<string, unknown>;
+  readonly sessionBranches: Record<string, string>;
+  readonly refreshSessionMr: ReturnType<typeof vi.fn>;
+  readonly createMrForSession: ReturnType<typeof vi.fn>;
+  readonly mergeMrForSession: ReturnType<typeof vi.fn>;
+  readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
+  readonly selectAgent: ReturnType<typeof vi.fn>;
+  readonly setCurrentSession: ReturnType<typeof vi.fn>;
+};
+
+type ConfigProps = {
+  readonly onChange: (value: AgentSpawnConfigValue) => void;
+  readonly disabled: boolean;
+};
+
+const h = vi.hoisted(() => ({
+  config: {
+    provider: 'gemini',
+    model: 'gemini-3.5-flash',
+    effort: 'low',
+    hint: 'Mention the rollout order.',
+  } satisfies AgentSpawnConfigValue,
+  showToast: vi.fn(),
+  store: {
+    sessions: [{ id: 'session-3' as SessionId, goal: 'Prepare the GitLab release' }],
+    sessionGitlabMr: {},
+    sessionBranches: { 'session-3': 'ak/gitlab-release' },
+    refreshSessionMr: vi.fn(async () => undefined),
+    createMrForSession: vi.fn(async () => undefined),
+    mergeMrForSession: vi.fn(async () => undefined),
+    spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-3'),
+    selectAgent: vi.fn(async () => undefined),
+    setCurrentSession: vi.fn(async () => undefined),
+  } satisfies Store,
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+
+vi.mock('../../../session/components/AgentSpawnConfig', () => ({
+  AgentSpawnConfig: ({ onChange, disabled }: ConfigProps) => (
+    <button type="button" disabled={disabled} onClick={() => onChange(h.config)}>
+      Choose agent config
+    </button>
+  ),
+}));
+
+import { MrDetailPanel } from './MrDetailPanel';
+
+const SESSION_ID = 'session-3' as SessionId;
+
+beforeEach(() => {
+  h.store.refreshSessionMr.mockClear();
+  h.store.spawnAgent.mockClear();
+  h.store.selectAgent.mockClear();
+  h.store.setCurrentSession.mockClear();
+  h.showToast.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('MrDetailPanel', () => {
+  it('spawns an MR agent with the chosen config and operator notes', async () => {
+    const onClose = vi.fn();
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    const args = h.store.spawnAgent.mock.calls[0]![1];
+    expect(args).toMatchObject({
+      provider: 'gemini',
+      model: 'gemini-3.5-flash',
+      effort: 'low',
+    });
+    expect(args.initialPrompt).toContain(
+      '\n\nOperator notes:\n---\nMention the rollout order.\n---',
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -12,7 +12,10 @@ import {
 } from 'lucide-react';
 import type { SessionId } from '@goodboy/types';
 import { ScrollFade } from '@goodboy/ui';
-import { AGENT_KIND_DEFAULTS } from '../../../session/agent-kind';
+import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
+import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
@@ -57,6 +60,7 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   const [targetBranch, setTargetBranch] = useState('main');
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | 'merge' | null>(null);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
 
   useEffect(() => {
     void refreshSessionMr(sessionId, { silent: true });
@@ -115,9 +119,10 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
       ].join('\n');
       const agentId = await spawnAgent(sessionId, {
         name: 'open merge request',
-        initialPrompt: prompt,
-        model: AGENT_KIND_DEFAULTS.generic.model,
-        effort: AGENT_KIND_DEFAULTS.generic.effort,
+        initialPrompt: appendOperatorNotes({ prompt, hint: agentConfig.hint }),
+        model: agentConfig.model,
+        ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
+        effort: agentConfig.effort,
       });
       await setCurrentSession(sessionId);
       await selectAgent(sessionId, agentId);
@@ -289,6 +294,11 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
                     aria-label="Target branch"
                   />
                 </div>
+                <AgentSpawnConfig
+                  value={agentConfig}
+                  onChange={setAgentConfig}
+                  disabled={busy !== null}
+                />
                 <div className="flex items-center gap-3 pt-1">
                   <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
                     <input

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/AgentSpawnConfigValue.ts
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/AgentSpawnConfigValue.ts
@@ -1,0 +1,8 @@
+import type { ModelEffort, ProviderId } from '@goodboy/types';
+
+export type AgentSpawnConfigValue = {
+  readonly provider: ProviderId | '';
+  readonly model: string;
+  readonly effort: ModelEffort;
+  readonly hint: string;
+};

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/defaultAgentSpawnConfig.ts
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/defaultAgentSpawnConfig.ts
@@ -1,0 +1,9 @@
+import { AGENT_KIND_DEFAULTS } from '../../agent-kind';
+import type { AgentSpawnConfigValue } from './AgentSpawnConfigValue';
+
+export const DEFAULT_AGENT_SPAWN_CONFIG = {
+  provider: '',
+  model: AGENT_KIND_DEFAULTS.generic.model,
+  effort: AGENT_KIND_DEFAULTS.generic.effort,
+  hint: '',
+} satisfies AgentSpawnConfigValue;

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.test.tsx
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ProviderId } from '@goodboy/types';
+import type { AgentSpawnConfigValue } from './AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from './defaultAgentSpawnConfig';
+
+type Store = {
+  readonly providers: ReadonlyArray<{
+    readonly id: ProviderId;
+    readonly connection: string;
+  }>;
+};
+
+const h = vi.hoisted(() => ({
+  providers: [
+    { id: 'anthropic', connection: 'connected' },
+    { id: 'codex', connection: 'connected' },
+  ] satisfies Store['providers'],
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) => selector({ providers: h.providers }),
+}));
+
+import { AgentSpawnConfig } from './index';
+
+afterEach(cleanup);
+
+describe('AgentSpawnConfig', () => {
+  it('keeps defaults compact and updates provider, model, effort, and hint', () => {
+    const onChange = vi.fn<(value: AgentSpawnConfigValue) => void>();
+    const view = render(
+      <AgentSpawnConfig value={DEFAULT_AGENT_SPAWN_CONFIG} onChange={onChange} disabled={false} />,
+    );
+
+    expect(screen.queryByRole('textbox', { name: 'Agent hint' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /Agent settings/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Default$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Codex$/i }));
+    const providerValue = onChange.mock.calls[0]![0];
+    expect(providerValue).toEqual({
+      provider: 'codex',
+      model: 'gpt-5.6',
+      effort: 'low',
+      hint: '',
+    });
+
+    view.rerender(<AgentSpawnConfig value={providerValue} onChange={onChange} disabled={false} />);
+    fireEvent.click(screen.getByRole('button', { name: /^GPT-5\.6$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^GPT-5\.4 Mini$/i }));
+    const modelValue = onChange.mock.calls[1]![0];
+    expect(modelValue.model).toBe('gpt-5.4-mini');
+
+    view.rerender(<AgentSpawnConfig value={modelValue} onChange={onChange} disabled={false} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Low$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Medium$/i }));
+    const effortValue = onChange.mock.calls[2]![0];
+    expect(effortValue.effort).toBe('medium');
+
+    view.rerender(<AgentSpawnConfig value={effortValue} onChange={onChange} disabled={false} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Agent hint' }), {
+      target: { value: 'Emphasize the migration path.' },
+    });
+    expect(onChange.mock.calls[3]![0].hint).toBe('Emphasize the migration path.');
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/index.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { getDefaultTurnModel, getModelProvider } from '@goodboy/core';
+import type { ProviderId } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { ChevronDown, Sliders } from 'lucide-react';
+import {
+  EFFORT_LABEL,
+  PROVIDER_LABEL,
+  clampEffort,
+  modelEffortLevels,
+} from '../../../chat/utils/chat-constants';
+import { shortModelWithVersion } from '../../agent-row-format';
+import { useAppStore } from '../../../../store';
+import { EffortSelect } from '../EffortSelect';
+import { ModelSelect } from '../ModelSelect';
+import { ProviderSelect } from '../ProviderSelect';
+import type { AgentSpawnConfigValue } from './AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from './defaultAgentSpawnConfig';
+
+type Props = {
+  readonly value: AgentSpawnConfigValue;
+  readonly onChange: (value: AgentSpawnConfigValue) => void;
+  readonly disabled: boolean;
+  readonly className?: string;
+};
+
+export const AgentSpawnConfig = ({ value, onChange, disabled, className }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const connectedProviders = useAppStore(
+    useShallow((state) =>
+      state.providers.filter((provider) => provider.connection === 'connected').map(({ id }) => id),
+    ),
+  );
+  const defaultModelProvider = getModelProvider(DEFAULT_AGENT_SPAWN_CONFIG.model) ?? 'anthropic';
+  const modelProvider =
+    value.provider !== ''
+      ? value.provider
+      : (getModelProvider(value.model) ?? defaultModelProvider);
+
+  const onProvider = (provider: ProviderId | '') => {
+    if (provider === '') {
+      onChange({ ...value, ...DEFAULT_AGENT_SPAWN_CONFIG, hint: value.hint });
+      return;
+    }
+    const model =
+      provider === defaultModelProvider
+        ? DEFAULT_AGENT_SPAWN_CONFIG.model
+        : getDefaultTurnModel(provider);
+    onChange({
+      ...value,
+      provider,
+      model,
+      effort: clampEffort(model, DEFAULT_AGENT_SPAWN_CONFIG.effort),
+    });
+  };
+
+  const onModel = (model: string) => {
+    onChange({ ...value, model, effort: clampEffort(model, value.effort) });
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-2', className)}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        disabled={disabled}
+        aria-expanded={isOpen}
+        className="inline-flex w-full items-center gap-1.5 rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/50 disabled:opacity-50"
+      >
+        <Sliders size={12} aria-hidden className="shrink-0 text-muted-foreground" />
+        <span className="text-muted-foreground">Agent settings</span>
+        <span className="min-w-0 flex-1 truncate font-medium text-foreground">
+          {value.provider === '' ? 'Session routing' : PROVIDER_LABEL[value.provider]} ·{' '}
+          {shortModelWithVersion(value.model)}
+          {modelEffortLevels(value.model) != null ? ` · ${EFFORT_LABEL[value.effort]}` : ''}
+        </span>
+        <ChevronDown
+          size={11}
+          aria-hidden
+          className={cn(
+            'shrink-0 text-muted-foreground transition-transform',
+            isOpen && 'rotate-180',
+          )}
+        />
+      </button>
+      {isOpen ? (
+        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-background p-2 text-left">
+          <ProviderSelect
+            value={value.provider}
+            providers={connectedProviders}
+            onChange={onProvider}
+            disabled={disabled || connectedProviders.length === 0}
+          />
+          <ModelSelect
+            provider={modelProvider}
+            value={value.model}
+            onChange={onModel}
+            disabled={disabled}
+          />
+          <EffortSelect
+            model={value.model}
+            value={value.effort}
+            onChange={(effort) => onChange({ ...value, effort })}
+            disabled={disabled}
+          />
+          <textarea
+            aria-label="Agent hint"
+            value={value.hint}
+            onChange={(event) => onChange({ ...value, hint: event.target.value })}
+            rows={2}
+            disabled={disabled}
+            placeholder="Optional notes for the agent: what to emphasize, what to avoid..."
+            className="w-full resize-none rounded-md border border-border-soft bg-subtle px-2 py-1.5 text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none disabled:opacity-50"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
+
+type SpawnAgent = (
+  sessionId: SessionId,
+  args: Readonly<Record<string, unknown>>,
+) => Promise<string>;
+
+type Store = {
+  readonly sessionGithub: Record<string, unknown>;
+  readonly refreshSessionPr: ReturnType<typeof vi.fn>;
+  readonly createPrForSession: ReturnType<typeof vi.fn>;
+  readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
+  readonly selectAgent: ReturnType<typeof vi.fn>;
+  readonly setActiveLens: ReturnType<typeof vi.fn>;
+  readonly sessionBranches: Record<string, string>;
+};
+
+type ConfigProps = {
+  readonly value: AgentSpawnConfigValue;
+  readonly onChange: (value: AgentSpawnConfigValue) => void;
+  readonly disabled: boolean;
+};
+
+const h = vi.hoisted(() => ({
+  config: {
+    provider: 'codex',
+    model: 'gpt-5.4',
+    effort: 'high',
+    hint: 'Call out the migration risk.',
+  } satisfies AgentSpawnConfigValue,
+  store: {
+    sessionGithub: {},
+    refreshSessionPr: vi.fn(),
+    createPrForSession: vi.fn(async () => undefined),
+    spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-1'),
+    selectAgent: vi.fn(async () => undefined),
+    setActiveLens: vi.fn(),
+    sessionBranches: { 'session-1': 'ak/refactor-auth' },
+  } satisfies Store,
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
+}));
+
+vi.mock('../../../../worktree/useRemoteHostKind', () => ({
+  useRemoteHostKind: () => 'github',
+}));
+
+vi.mock('../../AgentSpawnConfig', () => ({
+  AgentSpawnConfig: ({ onChange, disabled }: ConfigProps) => (
+    <button type="button" disabled={disabled} onClick={() => onChange(h.config)}>
+      Choose agent config
+    </button>
+  ),
+}));
+
+import { PrPane } from './PrPane';
+
+const DATE = '2026-07-22T10:00:00.000Z' as IsoDateTime;
+const SESSION_ID = 'session-1' as SessionId;
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: 'workspace-1' as WorkspaceId,
+  goal: 'Refactor authentication',
+  state: { kind: 'idle', lastActivityAt: DATE },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'bypassPermissions',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: DATE,
+  updatedAt: DATE,
+};
+
+beforeEach(() => {
+  h.store.createPrForSession.mockClear();
+  h.store.spawnAgent.mockClear();
+  h.store.selectAgent.mockClear();
+  h.store.setActiveLens.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('PrPane', () => {
+  it('spawns a draft agent with the chosen config and operator notes', async () => {
+    render(<PrPane session={session} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Choose agent config' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    const args = h.store.spawnAgent.mock.calls[0]![1];
+    expect(args).toMatchObject({ provider: 'codex', model: 'gpt-5.4', effort: 'high' });
+    expect(args.initialPrompt).toContain(
+      '\n\nOperator notes:\n---\nCall out the migration risk.\n---',
+    );
+    expect(h.store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'agents');
+  });
+
+  it('keeps quick draft on createPrForSession without spawning an agent', async () => {
+    render(<PrPane session={session} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Quick draft' }));
+
+    await waitFor(() =>
+      expect(h.store.createPrForSession).toHaveBeenCalledWith(SESSION_ID, { draft: true }),
+    );
+    expect(h.store.spawnAgent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -16,7 +16,10 @@ import type { PrCheckRun, Session, SessionId } from '@goodboy/types';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
 import { GitlabMrStrip } from '../../../../context/components/ContextPanel/strips/GitlabMrStrip';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
-import { AGENT_KIND_DEFAULTS } from '../../../agent-kind';
+import { appendOperatorNotes } from '../../../utils/appendOperatorNotes';
+import { AgentSpawnConfig } from '../../AgentSpawnConfig';
+import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../AgentSpawnConfig/defaultAgentSpawnConfig';
 import { useAppStore } from '../../../../../store';
 import { PaneShell } from './PaneShell';
 
@@ -56,6 +59,7 @@ const GithubPrCard = ({ session }: { session: Session }) => {
 
   const [busy, setBusy] = useState<'draft' | 'ai' | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
 
   const openStudio = () =>
     window.dispatchEvent(new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }));
@@ -88,9 +92,10 @@ const GithubPrCard = ({ session }: { session: Session }) => {
       ].join('\n');
       const agentId = await spawnAgent(sessionId, {
         name: 'open pull request',
-        initialPrompt: prompt,
-        model: AGENT_KIND_DEFAULTS.generic.model,
-        effort: AGENT_KIND_DEFAULTS.generic.effort,
+        initialPrompt: appendOperatorNotes({ prompt, hint: agentConfig.hint }),
+        model: agentConfig.model,
+        ...(agentConfig.provider !== '' && { provider: agentConfig.provider }),
+        effort: agentConfig.effort,
       });
       setActiveLens(sessionId, 'agents');
       await selectAgent(sessionId, agentId);
@@ -125,6 +130,12 @@ const GithubPrCard = ({ session }: { session: Session }) => {
             </span>
           ) : null}
         </div>
+        <AgentSpawnConfig
+          value={agentConfig}
+          onChange={setAgentConfig}
+          disabled={busy !== null}
+          className="w-full max-w-sm"
+        />
         <div className="flex flex-col items-stretch gap-2 pt-1 sm:flex-row sm:items-center">
           <button
             type="button"

--- a/apps/desktop/src/features/session/utils/appendOperatorNotes.test.ts
+++ b/apps/desktop/src/features/session/utils/appendOperatorNotes.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { appendOperatorNotes } from './appendOperatorNotes';
+
+describe('appendOperatorNotes', () => {
+  it('keeps the original prompt byte-identical for a whitespace-only hint', () => {
+    const prompt = 'Open a draft pull request.\nThen report the URL.';
+    expect(appendOperatorNotes({ prompt, hint: ' \n\t ' })).toBe(prompt);
+  });
+
+  it('appends trimmed notes in a trailing delimited section', () => {
+    expect(
+      appendOperatorNotes({ prompt: 'Open a draft pull request.', hint: '  Focus on API. ' }),
+    ).toBe('Open a draft pull request.\n\nOperator notes:\n---\nFocus on API.\n---');
+  });
+});

--- a/apps/desktop/src/features/session/utils/appendOperatorNotes.ts
+++ b/apps/desktop/src/features/session/utils/appendOperatorNotes.ts
@@ -1,0 +1,12 @@
+type Params = {
+  readonly prompt: string;
+  readonly hint: string;
+};
+
+export const appendOperatorNotes = ({ prompt, hint }: Params): string => {
+  const notes = hint.trim();
+  if (notes.length === 0) {
+    return prompt;
+  }
+  return [prompt, '', 'Operator notes:', '---', notes, '---'].join('\n');
+};

--- a/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.test.ts
@@ -6,10 +6,13 @@ import type {
   IsoDateTime,
   PlanId,
   PlanWithCount,
+  PrComment,
+  PullRequestState,
   Session,
   SessionId,
   WorkspaceId,
 } from '@goodboy/types';
+import { buildCommentAgentArgs } from '../../../features/chat/spawn-from-comment';
 
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
 vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
@@ -58,6 +61,35 @@ const TWO_CLUSTERS: ReadonlyArray<ImplementationCluster> = [
   { title: 'a', instructions: 'i1' },
   { title: 'b', instructions: 'i2' },
 ];
+
+const PR = {
+  number: 9108,
+  title: 'resolve: foo',
+  url: 'https://github.com/o/r/pull/9108',
+  state: 'open',
+  mergeable: true,
+  checks: 'success',
+  baseBranch: 'main',
+  headBranch: 'kay/foo',
+  isDraft: false,
+  reviewDecision: 'changes_requested',
+  body: '',
+  updatedAt: '2026-05-15T00:00:00Z',
+} satisfies PullRequestState;
+
+const COMMENT = {
+  id: 'review-1',
+  author: 'alice',
+  authorAvatarUrl: null,
+  body: 'this should use a helper',
+  createdAt: '2026-05-15T10:00:00Z',
+  url: 'https://github.com/o/r/pull/9108#discussion_r1',
+  source: 'review',
+  path: 'src/foo.ts',
+  line: 42,
+  resolved: false,
+  threadId: 'PRRT_7',
+} satisfies PrComment;
 
 function makePlan(overrides: Partial<PlanWithCount> = {}): PlanWithCount {
   return {
@@ -121,13 +153,18 @@ function buildHarness(plans: ReadonlyArray<PlanWithCount>) {
     agentProviderOverride: {},
     agentEffortOverride: {},
     agentKindOverride: {},
+    pendingResolverKickoff: {},
     sendTurn,
   };
-  const set = vi.fn();
   const get = (() => state) as unknown as Parameters<typeof spawnAgent>[1];
+  const set = vi.fn((update: Parameters<Parameters<typeof spawnAgent>[0]>[0]) => {
+    const patch = typeof update === 'function' ? update(get()) : update;
+    Object.assign(state, patch);
+  });
   return {
+    getState: get,
     sendTurn,
-    spawn: spawnAgent(set as unknown as Parameters<typeof spawnAgent>[0], get),
+    spawn: spawnAgent(set, get),
   };
 }
 
@@ -188,6 +225,25 @@ describe('spawnAgent ad-hoc cluster fan-out', () => {
     expect(fanOutClustersSpy).not.toHaveBeenCalled();
     expect(sendTurn).toHaveBeenCalledTimes(1);
     expect(sendTurn.mock.calls[0]?.[0]?.content).toContain('fix the typo in README');
+  });
+
+  it('stores mode instructions and hint for a deferred batch resolver', async () => {
+    const { getState, sendTurn, spawn } = buildHarness([]);
+    const args = buildCommentAgentArgs(COMMENT, PR, {
+      mode: 'analyze',
+      hint: 'Avoid schema changes.',
+    });
+
+    await spawn(SESSION_ID, {
+      kindOverride: 'resolver',
+      initialPrompt: args.initialPrompt,
+      deferKickoff: true,
+    });
+
+    const kickoff = getState().pendingResolverKickoff[INSERTED_ID];
+    expect(kickoff).toContain('Analysis mode: do not modify or commit any file.');
+    expect(kickoff).toContain('Operator notes:\nAvoid schema changes.');
+    expect(sendTurn).not.toHaveBeenCalled();
   });
 
   it('consumes the plan on ad-hoc fan-out so a re-spawn cannot fan out again', async () => {


### PR DESCRIPTION
Shared AgentSpawnConfig on the Draft-with-an-agent flow in PrPane, CreatePrPanel and GitLab MrDetailPanel: provider/model/effort pickers + optional hint. Defaults unchanged (generic haiku/low). Quick-draft path untouched.

Stacked PR 3/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)