### PR TITLE
feat(desktop): hover-only rail hints, back-to-board shortcut, board sizing

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -712,6 +712,9 @@ export const App = () => {
   useKeyboardShortcut('cmd+shift+u', () => goToLens('last_output_summary'), {
     ignoreInInputs: false,
   });
+  useKeyboardShortcut('cmd+shift+escape', () => void setCurrentSession(null), {
+    ignoreInInputs: false,
+  });
   useKeyboardShortcut('cmd+1', () => selectWorkspaceByIndex(0), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+2', () => selectWorkspaceByIndex(1), { ignoreInInputs: false });
   useKeyboardShortcut('cmd+3', () => selectWorkspaceByIndex(2), { ignoreInInputs: false });

--- a/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
+++ b/apps/desktop/src/__tests__/keyboard/lens-shortcuts.test.tsx
@@ -153,4 +153,14 @@ describe('App lens shortcuts', () => {
 
     expect(setActiveLens.mock.calls).toEqual(expected.map(([, lens]) => ['session-1', lens]));
   });
+
+  it('returns to the board on cmd+shift+escape', () => {
+    render(<App />);
+
+    act(() => {
+      shortcutHandlers.get('cmd+shift+escape')?.();
+    });
+
+    expect(state.setCurrentSession).toHaveBeenCalledWith(null);
+  });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -289,7 +289,7 @@ export const LensColumn = ({
           </span>
           <KbdPill
             aria-hidden
-            className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] opacity-60"
+            className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60"
           >
             ⌘⇧O
           </KbdPill>
@@ -378,12 +378,7 @@ export const LensColumn = ({
                   {shortcut != null ? (
                     <KbdPill
                       aria-hidden
-                      className={cn(
-                        'pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] transition-opacity',
-                        hasBadge
-                          ? 'opacity-0 group-hover:opacity-60 group-focus-visible:opacity-60'
-                          : 'opacity-60',
-                      )}
+                      className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px] opacity-0 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60"
                     >
                       {shortcut}
                     </KbdPill>

--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -46,6 +46,7 @@ const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly lab
   { combo: ['⌘', '⇧', 'H'], label: 'jump to GitHub or GitLab' },
   { combo: ['⌘', '⇧', 'E'], label: 'jump to decisions' },
   { combo: ['⌘', '⇧', 'U'], label: 'jump to session summary' },
+  { combo: ['⌘', '⇧', '⎋'], label: 'back to board' },
   { combo: ['⌘', '↵'], label: 'send message (queue if running)' },
   { combo: ['⌘', '⇧', 'A'], label: 'archive current session' },
   { combo: ['⌘', '.'], label: 'delete current session' },

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.tsx
@@ -185,11 +185,14 @@ export const SessionActivityBar = ({
               onClick={onNewSession}
               aria-label="create new session"
               title="new session"
-              className="mb-1 w-full justify-center gap-1.5 px-2 text-xs"
+              className="group mb-1 w-full justify-center gap-1.5 px-2 text-xs"
             >
               <Plus size={13} aria-hidden />
               New
-              <KbdPill aria-hidden className="h-4 min-w-4 px-1 text-[9px]">
+              <KbdPill
+                aria-hidden
+                className="h-4 min-w-4 px-1 text-[9px] opacity-0 transition-opacity group-hover:opacity-100"
+              >
                 ⌘N
               </KbdPill>
             </Button>

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageColumn/index.tsx
@@ -75,7 +75,7 @@ export const StageColumn = ({
   );
 
   return (
-    <div className={cn('flex min-h-0 shrink-0 flex-col gap-3 w-72')}>
+    <div className={cn('flex min-h-0 w-[17rem] min-w-[13.5rem] flex-col gap-3')}>
       {view.collapsible ? (
         <button
           type="button"

--- a/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/index.tsx
@@ -22,12 +22,12 @@ const SKELETON_COLUMNS = [3, 2, 2, 1, 2];
 
 const BoardSkeleton = () => (
   <div
-    className="flex min-h-0 flex-1 gap-4 overflow-x-hidden"
+    className="mx-auto flex min-h-0 w-fit max-w-full flex-1 gap-4 overflow-x-hidden"
     role="status"
     aria-label="Loading board"
   >
     {SKELETON_COLUMNS.map((cards, col) => (
-      <div key={col} className="flex min-h-0 w-72 shrink-0 flex-col gap-3">
+      <div key={col} className="flex min-h-0 w-[17rem] min-w-[13.5rem] flex-col gap-3">
         <Skeleton className="h-4 w-24 rounded-full" />
         <div className="flex flex-col gap-2">
           {Array.from({ length: cards }).map((_, i) => (
@@ -109,27 +109,29 @@ export const StageBoard = ({ workspaceId, sessions, onCreateSession }: Props) =>
           </div>
         </div>
       ) : (
-        <div className="flex min-h-0 flex-1 gap-4 overflow-x-auto">
-          {STAGES.map((stage) => (
+        <div className="flex min-h-0 flex-1 overflow-x-auto">
+          <div className="mx-auto flex min-h-0 w-fit max-w-full gap-4">
+            {STAGES.map((stage) => (
+              <StageColumn
+                key={stage}
+                spec={{ kind: 'stage', stage }}
+                sessions={byStage.get(stage) ?? EMPTY_ARRAY}
+                nav={nav}
+                onArchive={onArchive}
+                onDelete={onDelete}
+                onRestore={nav.restore}
+              />
+            ))}
             <StageColumn
-              key={stage}
-              spec={{ kind: 'stage', stage }}
-              sessions={byStage.get(stage) ?? EMPTY_ARRAY}
+              key="archived"
+              spec={{ kind: 'archived' }}
+              sessions={archived}
               nav={nav}
               onArchive={onArchive}
               onDelete={onDelete}
               onRestore={nav.restore}
             />
-          ))}
-          <StageColumn
-            key="archived"
-            spec={{ kind: 'archived' }}
-            sessions={archived}
-            nav={nav}
-            onArchive={onArchive}
-            onDelete={onDelete}
-            onRestore={nav.restore}
-          />
+          </div>
         </div>
       )}
 

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react';
 import { Kanban } from 'lucide-react';
+import { KbdPill } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -50,10 +51,16 @@ export const WorkspacesSidebar = () => {
             type="button"
             onClick={() => void setCurrentSession(null)}
             aria-label="back to board"
-            className="w-full flex items-center justify-center gap-1.5 rounded-md bg-accent/10 px-2 py-1.5 text-xs font-semibold text-accent ring-1 ring-accent/20 motion-safe:transition-colors hover:bg-accent/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+            className="group relative w-full flex items-center justify-center gap-1.5 rounded-md bg-accent/10 px-2 py-1.5 text-xs font-semibold text-accent ring-1 ring-accent/20 motion-safe:transition-colors hover:bg-accent/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
           >
             <Kanban size={14} aria-hidden />
             Board
+            <KbdPill
+              aria-hidden
+              className="pointer-events-none absolute right-2 top-1/2 h-4 min-w-4 -translate-y-1/2 px-1 text-[9px] opacity-0 transition-opacity group-hover:opacity-100"
+            >
+              ⌘⇧⎋
+            </KbdPill>
           </button>
         </div>
       ) : null}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SessionsRail.tsx
@@ -18,7 +18,7 @@ export const SessionsRail = () => {
           <PanelLeftOpen size={15} aria-hidden />
         </button>
       </Tooltip>
-      <Tooltip content="back to board" side="right">
+      <Tooltip content="back to board · ⌘⇧⎋" side="right">
         <button
           type="button"
           onClick={() => void setCurrentSession(null)}


### PR DESCRIPTION
## What

- shortcut hints (KbdPill) on rail/sidebar rows now show only on hover/focus of their row; session-panel hints stay hover-only
- new shortcut cmd+shift+escape: back to board from any session (works with collapsed sidebar; hint on Board button + tooltip)
- board columns: fixed equal width for all columns expanded or collapsed (17rem, min 13.5rem), column group centered on wide screens, horizontal scroll only below min total

## Tests

- lens-shortcuts test extended (cmd+shift+escape returns to board)
- StageBoard suite green (19 tests), pnpm typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)