### PR TITLE
feat(desktop): session detail skeleton on first open

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -18,6 +18,7 @@ type Store = {
   resolverState: Record<string, 'awaiting' | 'committed' | 'wontfix' | 'analyzed'>;
   agentTurnState: Record<string, unknown>;
   agentKindOverride: Record<string, unknown>;
+  sessionLoading: Record<string, { agents: boolean; plans: boolean }>;
   setActiveLens: ReturnType<typeof vi.fn>;
   setSessionStudio: ReturnType<typeof vi.fn>;
   setFocusedWorkflowRun: ReturnType<typeof vi.fn>;
@@ -41,6 +42,7 @@ const { store, hooks } = vi.hoisted(() => ({
     resolverState: {},
     agentTurnState: {},
     agentKindOverride: {},
+    sessionLoading: {},
     setActiveLens: vi.fn(),
     setSessionStudio: vi.fn(),
     setFocusedWorkflowRun: vi.fn(),
@@ -88,7 +90,9 @@ vi.mock('../../../../app/components/AppBreadcrumb', () => ({
     <div data-testid="breadcrumb">{crumbs.map((crumb) => crumb.label).join(' / ')}</div>
   ),
 }));
-vi.mock('../SessionOverviewPane', () => ({ SessionOverviewPane: () => null }));
+vi.mock('../SessionOverviewPane', () => ({
+  SessionOverviewPane: () => <div role="region" aria-label="Session overview" />,
+}));
 vi.mock('./parts/SessionStudioLayer', () => ({ SessionStudioLayer: () => null }));
 vi.mock('./parts/SessionTopBar', () => ({ SessionTopBar: () => null }));
 vi.mock('./parts/LensColumn', () => ({
@@ -150,6 +154,7 @@ beforeEach(() => {
   store.resolverState = {};
   store.agentTurnState = {};
   store.agentKindOverride = {};
+  store.sessionLoading = {};
   store.setActiveLens.mockReset();
   hooks.agentHome = 'workflows';
 });
@@ -307,6 +312,39 @@ describe('SessionWorkspace workflow breadcrumb', () => {
 });
 
 describe('SessionWorkspace overview', () => {
+  it('renders the overview skeleton while key session data is loading', () => {
+    store.activeLens = { [SESSION_ID]: null };
+    store.selectedAgentId = {};
+    store.sessionLoading = { [SESSION_ID]: { agents: true, plans: false } };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByRole('status', { name: 'Loading session overview' })).toBeDefined();
+    expect(screen.queryByRole('region', { name: 'Session overview' })).toBeNull();
+  });
+
+  it('keeps the overview skeleton visible while plans are loading', () => {
+    store.activeLens = { [SESSION_ID]: null };
+    store.selectedAgentId = {};
+    store.sessionLoading = { [SESSION_ID]: { agents: false, plans: true } };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByRole('status', { name: 'Loading session overview' })).toBeDefined();
+    expect(screen.queryByRole('region', { name: 'Session overview' })).toBeNull();
+  });
+
+  it('renders cached overview content immediately when key loads are done', () => {
+    store.activeLens = { [SESSION_ID]: null };
+    store.selectedAgentId = {};
+    store.sessionLoading = { [SESSION_ID]: { agents: false, plans: false } };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByRole('region', { name: 'Session overview' })).toBeDefined();
+    expect(screen.queryByRole('status', { name: 'Loading session overview' })).toBeNull();
+  });
+
   it('keeps the lens column visible and selects Overview', () => {
     store.activeLens = { [SESSION_ID]: null };
     store.selectedAgentId = {};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -37,6 +37,7 @@ import { resolveRootAgent } from '../../agent-kind';
 import { ForceResolveAction } from '../ForceResolveAction';
 import { canForceResolve } from '../ForceResolveAction/canForceResolve';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
+import { SessionOverviewSkeleton } from './parts/SessionOverviewSkeleton';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -83,6 +84,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId[sessionId] ?? null);
   const attachedWorkflowRuns = useAttachedWorkflowRuns({ session });
   const plans = useSessionPlans(sessionId);
+  const sessionLoading = useAppStore((s) => s.sessionLoading[sessionId]);
 
   useEffect(() => {
     if (activeLens === undefined) {
@@ -106,6 +108,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   }, [isActive, workingDir, sessionId, filesTouched.count, reconcileSessionBranch]);
 
   const lens: LensKind | null = activeLens ?? null;
+  const isOverviewLoading = sessionLoading?.agents === true || sessionLoading?.plans === true;
   const onSelectLens = (next: LensKind) => {
     setActiveLens(sessionId, next);
   };
@@ -237,7 +240,11 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
             {showLens ? (
               <div className="absolute inset-0 z-0">
                 {lens === null ? (
-                  <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
+                  isOverviewLoading ? (
+                    <SessionOverviewSkeleton />
+                  ) : (
+                    <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
+                  )
                 ) : null}
                 {lens === 'questions' ? <QuestionsPane session={session} /> : null}
                 {lens === 'plans' ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -109,6 +109,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
 
   const lens: LensKind | null = activeLens ?? null;
   const isOverviewLoading = sessionLoading?.agents === true || sessionLoading?.plans === true;
+  const isFreshOverviewLayout = session.workflowRuns.every((run) => run.discardedAt != null);
   const onSelectLens = (next: LensKind) => {
     setActiveLens(sessionId, next);
   };
@@ -241,7 +242,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
               <div className="absolute inset-0 z-0">
                 {lens === null ? (
                   isOverviewLoading ? (
-                    <SessionOverviewSkeleton />
+                    <SessionOverviewSkeleton isFreshLayout={isFreshOverviewLayout} />
                   ) : (
                     <SessionOverviewPane session={session} onSelectLens={onSelectLens} />
                   )

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
-const { remote, store } = vi.hoisted(() => ({
+const { hooks, remote, store } = vi.hoisted(() => ({
+  hooks: { agentCount: 0, planCount: 0, questionCount: 0 },
   remote: { kind: 'github' as 'github' | 'gitlab' | 'other' | null },
   store: {
     agentKindOverride: {},
@@ -16,15 +17,30 @@ const { remote, store } = vi.hoisted(() => ({
     sessionPendingResolutions: {},
     sessionExternalTasks: {},
     workspaceIntegrations: {},
+    sessionLoading: {
+      'session-1': { agents: false, plans: false },
+    },
   },
 }));
 
 vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
-  useNonResolverStandaloneAgents: () => [],
-  useSessionOpenQuestions: () => [],
-  useSessionPlans: () => [],
+  useNonResolverStandaloneAgents: () =>
+    Array.from({ length: hooks.agentCount }, (_, index) => ({
+      id: `agent-${index}`,
+      status: 'running',
+    })),
+  useSessionOpenQuestions: () =>
+    Array.from({ length: hooks.questionCount }, (_, index) => ({
+      id: `question-${index}`,
+      status: 'open',
+    })),
+  useSessionPlans: () =>
+    Array.from({ length: hooks.planCount }, (_, index) => ({
+      id: `plan-${index}`,
+      status: 'active',
+    })),
   useSessionStageInfo: () => ({ stage: 'done' as const, reason: 'idle' }),
   useSessionUnreadLens: () => null,
 }));
@@ -51,8 +67,12 @@ const SESSION = {
 
 beforeEach(() => {
   remote.kind = 'github';
+  hooks.agentCount = 0;
+  hooks.planCount = 0;
+  hooks.questionCount = 0;
   store.sessionExternalTasks = {};
   store.workspaceIntegrations = {};
+  store.sessionLoading['session-1'] = { agents: false, plans: false };
 });
 
 afterEach(cleanup);
@@ -131,6 +151,52 @@ describe('LensColumn', () => {
       '⌘⇧D',
     );
     expect(screen.getByRole('button', { name: 'Linear' }).querySelector('kbd')).toBeNull();
+  });
+
+  it('reserves loading badges while keeping rows selectable', () => {
+    const onSelect = vi.fn();
+    hooks.agentCount = 3;
+    hooks.planCount = 2;
+    hooks.questionCount = 1;
+    store.sessionLoading['session-1'] = { agents: true, plans: true };
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={onSelect}
+        filesCount={0}
+      />,
+    );
+
+    const agents = screen.getByRole('button', { name: 'Agents' });
+    expect(screen.getByTestId('lens-count-loading-agents')).toBeDefined();
+    expect(screen.getByTestId('lens-count-loading-questions')).toBeDefined();
+    expect(screen.getByTestId('lens-count-loading-plans')).toBeDefined();
+    expect(agents.textContent).not.toContain('3');
+    fireEvent.click(agents);
+    expect(onSelect).toHaveBeenCalledWith('agents');
+  });
+
+  it('shows loaded agent and plan counts', () => {
+    hooks.agentCount = 3;
+    hooks.planCount = 2;
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Agents 3' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Plans 2' })).toBeDefined();
+    expect(screen.queryByTestId('lens-count-loading-agents')).toBeNull();
+    expect(screen.queryByTestId('lens-count-loading-plans')).toBeNull();
   });
 
   it('shows provider counts and hides GitLab issues on a GitLab remote', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -4,24 +4,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@goodboy/types';
 
-const { hooks, remote, store } = vi.hoisted(() => ({
-  hooks: { agentCount: 0, planCount: 0, questionCount: 0 },
-  remote: { kind: 'github' as 'github' | 'gitlab' | 'other' | null },
-  store: {
-    agentKindOverride: {},
-    sessionPhaseRuns: {},
-    scriptRuns: {},
-    terminalSessions: {},
-    sessionGithub: {},
-    sessionGitlabMr: {},
-    sessionPendingResolutions: {},
-    sessionExternalTasks: {},
-    workspaceIntegrations: {},
-    sessionLoading: {
-      'session-1': { agents: false, plans: false },
+const { hooks, remote, store } = vi.hoisted(() => {
+  const sessionOpenQuestions: Record<string, ReadonlyArray<unknown>> = {
+    'session-1': [],
+  };
+  return {
+    hooks: { agentCount: 0, planCount: 0, questionCount: 0 },
+    remote: { kind: 'github' as 'github' | 'gitlab' | 'other' | null },
+    store: {
+      agentKindOverride: {},
+      sessionPhaseRuns: {},
+      scriptRuns: {},
+      terminalSessions: {},
+      sessionGithub: {},
+      sessionGitlabMr: {},
+      sessionPendingResolutions: {},
+      sessionExternalTasks: {},
+      workspaceIntegrations: {},
+      sessionLoading: {
+        'session-1': { agents: false, plans: false },
+      },
+      sessionOpenQuestions,
     },
-  },
-}));
+  };
+});
 
 vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
@@ -73,6 +79,7 @@ beforeEach(() => {
   store.sessionExternalTasks = {};
   store.workspaceIntegrations = {};
   store.sessionLoading['session-1'] = { agents: false, plans: false };
+  store.sessionOpenQuestions = { 'session-1': [] };
 });
 
 afterEach(cleanup);
@@ -159,6 +166,7 @@ describe('LensColumn', () => {
     hooks.planCount = 2;
     hooks.questionCount = 1;
     store.sessionLoading['session-1'] = { agents: true, plans: true };
+    store.sessionOpenQuestions = {};
 
     render(
       <LensColumn
@@ -182,6 +190,7 @@ describe('LensColumn', () => {
   it('shows loaded agent and plan counts', () => {
     hooks.agentCount = 3;
     hooks.planCount = 2;
+    hooks.questionCount = 1;
 
     render(
       <LensColumn
@@ -195,8 +204,27 @@ describe('LensColumn', () => {
 
     expect(screen.getByRole('button', { name: 'Agents 3' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'Plans 2' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Questions 1' })).toBeDefined();
     expect(screen.queryByTestId('lens-count-loading-agents')).toBeNull();
     expect(screen.queryByTestId('lens-count-loading-plans')).toBeNull();
+  });
+
+  it('keeps the question badge loading until questions resolve', () => {
+    hooks.questionCount = 2;
+    store.sessionOpenQuestions = {};
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.getByTestId('lens-count-loading-questions')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Questions' }).textContent).not.toContain('2');
   });
 
   it('shows provider counts and hides GitLab issues on a GitLab remote', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -88,6 +88,7 @@ export const LensColumn = ({
   const loading = useAppStore((s) => s.sessionLoading[sessionId]);
   const areAgentsLoading = loading?.agents === true;
   const arePlansLoading = loading?.plans === true;
+  const areQuestionsLoading = useAppStore((s) => s.sessionOpenQuestions[sessionId] === undefined);
   const openCount = selectOpenQuestions(useSessionOpenQuestions(sessionId)).length;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
@@ -202,7 +203,7 @@ export const LensColumn = ({
           icon: CircleHelp,
           tone: 'warning',
           count: openCount,
-          isCountLoading: areAgentsLoading,
+          isCountLoading: areQuestionsLoading,
         },
         { kind: 'files', label: 'Diff', icon: FileDiff, tone: 'info', count: filesCount },
       ],

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -18,7 +18,7 @@ import {
   Target,
   Terminal,
 } from 'lucide-react';
-import { KbdPill, ScrollFade, StatusDot, cn, tintClasses } from '@goodboy/ui';
+import { KbdPill, ScrollFade, Skeleton, StatusDot, cn, tintClasses } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type { Agent, Session, SessionId } from '@goodboy/types';
 import { classifyAgent, isStandaloneAgent } from '../../../../session/agent-kind';
@@ -49,6 +49,7 @@ type LensRow = {
   readonly icon: LucideIcon;
   readonly tone: Tone;
   readonly count?: number;
+  readonly isCountLoading?: boolean;
   readonly dot?: 'attention' | 'running';
   readonly secondaryDot?: boolean;
 };
@@ -84,6 +85,9 @@ export const LensColumn = ({
   filesCount,
 }: LensColumnProps) => {
   const sessionId = session.id as SessionId;
+  const loading = useAppStore((s) => s.sessionLoading[sessionId]);
+  const areAgentsLoading = loading?.agents === true;
+  const arePlansLoading = loading?.plans === true;
   const openCount = selectOpenQuestions(useSessionOpenQuestions(sessionId)).length;
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
@@ -174,6 +178,7 @@ export const LensColumn = ({
           icon: Bot,
           tone: 'primary',
           count: nonResolverStandalone.length,
+          isCountLoading: areAgentsLoading,
           dot:
             attentionLens === 'agents' || unreadLens === 'agents'
               ? 'attention'
@@ -187,6 +192,7 @@ export const LensColumn = ({
           icon: MessageSquareReply,
           tone: 'success',
           count: openResolvers,
+          isCountLoading: areAgentsLoading,
           dot: attentionLens === 'resolve' || unreadLens === 'resolve' ? 'attention' : undefined,
           secondaryDot: hasPendingBatch,
         },
@@ -196,6 +202,7 @@ export const LensColumn = ({
           icon: CircleHelp,
           tone: 'warning',
           count: openCount,
+          isCountLoading: areAgentsLoading,
         },
         { kind: 'files', label: 'Diff', icon: FileDiff, tone: 'info', count: filesCount },
       ],
@@ -203,7 +210,14 @@ export const LensColumn = ({
     {
       label: 'Artifacts',
       rows: [
-        { kind: 'plans', label: 'Plans', icon: FileText, tone: 'success', count: activePlans },
+        {
+          kind: 'plans',
+          label: 'Plans',
+          icon: FileText,
+          tone: 'success',
+          count: activePlans,
+          isCountLoading: arePlansLoading,
+        },
         { kind: 'scripts', label: 'Scripts', icon: Terminal, tone: 'info', count: runningScripts },
       ],
     },
@@ -303,6 +317,7 @@ export const LensColumn = ({
               const active = activeLens === row.kind;
               const shortcut = LENS_SHORTCUTS[row.kind];
               const hasBadge =
+                row.isCountLoading === true ||
                 (row.count != null && row.count > 0) ||
                 row.dot != null ||
                 row.secondaryDot === true;
@@ -347,7 +362,11 @@ export const LensColumn = ({
                           'min-w-10 justify-end group-hover:opacity-0 group-focus-visible:opacity-0',
                       )}
                     >
-                      {row.count != null && row.count > 0 ? (
+                      {row.isCountLoading === true ? (
+                        <span data-testid={`lens-count-loading-${row.kind}`}>
+                          <Skeleton className="h-4 w-6 rounded-full" />
+                        </span>
+                      ) : row.count != null && row.count > 0 ? (
                         <span className="flex shrink-0 items-center gap-1.5">
                           {row.secondaryDot ? <StatusDot tone="accent" size="sm" /> : null}
                           {row.dot === 'running' ? (

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
@@ -1,0 +1,60 @@
+import { ScrollFade, Skeleton, SkeletonText } from '@goodboy/ui';
+
+const ACTIVITY_ROWS = [0, 1];
+const LINKED_WORK_ROWS = [0, 1];
+
+export const SessionOverviewSkeleton = () => {
+  return (
+    <ScrollFade className="h-full" viewportClassName="px-8 py-7" fadeSize={24}>
+      <div
+        className="mx-auto flex max-w-3xl flex-col gap-6"
+        role="status"
+        aria-label="Loading session overview"
+      >
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <Skeleton className="size-2.5 rounded-full" />
+            <Skeleton className="h-3 w-24 rounded-full" />
+          </div>
+          <Skeleton className="h-7 w-3/5" />
+          <SkeletonText className="max-w-xl" lines={2} />
+          <div className="flex flex-wrap items-center gap-2">
+            <Skeleton className="h-6 w-24 rounded-md" />
+            <Skeleton className="h-6 w-32 rounded-md" />
+            <Skeleton className="h-6 w-16 rounded-md" />
+            <Skeleton className="h-3 w-20 rounded-full" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-12 rounded-full" />
+          <div className="grid grid-cols-2 gap-2">
+            <Skeleton className="h-11 w-full rounded-lg" />
+            <Skeleton className="h-11 w-full rounded-lg" />
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-3 w-16 rounded-full" />
+          <div className="flex flex-col gap-2">
+            {ACTIVITY_ROWS.map((row) => (
+              <Skeleton key={row} className="h-16 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between gap-2 px-0.5">
+            <Skeleton className="h-3 w-24 rounded-full" />
+            <Skeleton className="h-6 w-14 rounded-md" />
+          </div>
+          <div className="flex flex-col gap-2">
+            {LINKED_WORK_ROWS.map((row) => (
+              <Skeleton key={row} className="h-12 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+      </div>
+    </ScrollFade>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SessionOverviewSkeleton.tsx
@@ -3,7 +3,11 @@ import { ScrollFade, Skeleton, SkeletonText } from '@goodboy/ui';
 const ACTIVITY_ROWS = [0, 1];
 const LINKED_WORK_ROWS = [0, 1];
 
-export const SessionOverviewSkeleton = () => {
+type Props = {
+  readonly isFreshLayout: boolean;
+};
+
+export const SessionOverviewSkeleton = ({ isFreshLayout }: Props) => {
   return (
     <ScrollFade className="h-full" viewportClassName="px-8 py-7" fadeSize={24}>
       <div
@@ -17,7 +21,7 @@ export const SessionOverviewSkeleton = () => {
             <Skeleton className="h-3 w-24 rounded-full" />
           </div>
           <Skeleton className="h-7 w-3/5" />
-          <SkeletonText className="max-w-xl" lines={2} />
+          <Skeleton className="h-5 w-2/3" />
           <div className="flex flex-wrap items-center gap-2">
             <Skeleton className="h-6 w-24 rounded-md" />
             <Skeleton className="h-6 w-32 rounded-md" />
@@ -26,22 +30,40 @@ export const SessionOverviewSkeleton = () => {
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-3 w-12 rounded-full" />
-          <div className="grid grid-cols-2 gap-2">
-            <Skeleton className="h-11 w-full rounded-lg" />
-            <Skeleton className="h-11 w-full rounded-lg" />
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Skeleton className="h-3 w-16 rounded-full" />
+        {isFreshLayout ? (
           <div className="flex flex-col gap-2">
-            {ACTIVITY_ROWS.map((row) => (
-              <Skeleton key={row} className="h-16 w-full rounded-lg" />
-            ))}
+            <Skeleton className="h-3 w-12 rounded-full" />
+            <div className="flex flex-col gap-3 rounded-lg bg-muted/20 p-4">
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-3 w-20 rounded-full" />
+                <Skeleton className="h-5 w-36" />
+                <SkeletonText lines={2} />
+              </div>
+              <div className="flex flex-col gap-2">
+                <Skeleton className="h-14 w-full rounded-lg" />
+                <Skeleton className="h-14 w-full rounded-lg" />
+              </div>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex flex-col gap-6">
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-3 w-12 rounded-full" />
+              <div className="grid grid-cols-2 gap-2">
+                <Skeleton className="h-11 w-full rounded-lg" />
+                <Skeleton className="h-11 w-full rounded-lg" />
+              </div>
+            </div>
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-3 w-16 rounded-full" />
+              <div className="flex flex-col gap-2">
+                {ACTIVITY_ROWS.map((row) => (
+                  <Skeleton key={row} className="h-16 w-full rounded-lg" />
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
 
         <div className="flex flex-col gap-2">
           <div className="flex items-center justify-between gap-2 px-0.5">


### PR DESCRIPTION
## Problem

Clicking a session card on the board mounts SessionWorkspace immediately but empty: currentSessionId flips synchronously while agents/plans/telemetry load fire-and-forget, so the overview renders blank then re-renders in cascade. Perceived freeze, badge counts jump 0 to N.

## Fix

- SessionOverviewSkeleton (SessionWorkspace/parts): layout-mirroring skeleton gated on existing `sessionLoading[id].agents || plans` flags, only when `lens === null`
- LensColumn: badge counts show a small skeleton pill while agents load, rows stay clickable
- flags are already cache-aware (setCurrentSession builds them from cache state), so revisited sessions render full detail instantly, never a skeleton flash
- no new store flags, setCurrentSession/StageBoard/boardReady untouched

## Verification

- typecheck 5/5 packages
- full desktop suite 2278/2278 green (3 new gate tests + 3 new LensColumn badge tests)
- adversarial review: all 8 MUSTs pass, no functional findings

Stacked on #961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)