### PR TITLE
feat: user-configurable task models + provider defaults dashboard

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -922,6 +922,7 @@ export const App = () => {
       ) : null}
       {providerStudioOpen && currentWorkspace ? (
         <ProviderStudio
+          workspaceId={currentWorkspace.id}
           workspaceName={currentWorkspace.name}
           initialFocus={providerStudioFocus}
           initialAction={providerStudioAction}

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { SessionId } from '@goodboy/types';
+import type { SessionId, TaskModelPreferences } from '@goodboy/types';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 
 type SpawnAgent = (
@@ -16,6 +16,7 @@ type Store = {
   readonly sessionBranches: Record<string, string>;
   readonly sessions: ReadonlyArray<{ id: SessionId; workspaceId: string }>;
   readonly workspaces: ReadonlyArray<{ id: string; rootPath: string }>;
+  workspaceOverrides: Record<string, { readonly taskModels: TaskModelPreferences | null }>;
 };
 
 type ConfigProps = {
@@ -39,6 +40,7 @@ const h = vi.hoisted(() => ({
     sessionBranches: { 'session-2': 'ak/card-config' },
     sessions: [{ id: 'session-2' as SessionId, workspaceId: 'workspace-1' }],
     workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+    workspaceOverrides: {},
   } satisfies Store,
 }));
 
@@ -75,6 +77,7 @@ beforeEach(() => {
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
+  h.store.workspaceOverrides = {};
 });
 
 afterEach(cleanup);
@@ -135,5 +138,36 @@ describe('CreatePrPanel', () => {
         `Then run \`gh pr create\` to open it and report the PR URL.`,
       ].join('\n'),
     );
+  });
+
+  it('uses a workspace task model loaded after mount', async () => {
+    const { rerender } = render(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={vi.fn()}
+      />,
+    );
+    h.store.workspaceOverrides = {
+      'workspace-1': {
+        taskModels: { pr_draft: { providerId: 'codex', model: 'gpt-5.4-mini' } },
+      },
+    };
+    rerender(
+      <CreatePrPanel
+        sessionId={SESSION_ID}
+        defaultTitle="Refactor PR cards"
+        onCreated={vi.fn()}
+        onStudioClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    expect(h.store.spawnAgent.mock.calls[0]![1]).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.4-mini',
+    });
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.test.tsx
@@ -106,7 +106,7 @@ describe('CreatePrPanel', () => {
     await waitFor(() => expect(onStudioClose).toHaveBeenCalledOnce());
   });
 
-  it('preserves the legacy prompt and routing for a whitespace-only hint', async () => {
+  it('preserves the prompt for a whitespace-only hint', async () => {
     render(
       <CreatePrPanel
         sessionId={SESSION_ID}
@@ -120,8 +120,11 @@ describe('CreatePrPanel', () => {
 
     await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
     const args = h.store.spawnAgent.mock.calls[0]![1];
-    expect(args).not.toHaveProperty('provider');
-    expect(args).toMatchObject({ model: 'claude-haiku-4-5', effort: 'low' });
+    expect(args).toMatchObject({
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+    });
     expect(args.initialPrompt).toBe(
       [
         `Open a GitHub pull request for this session's branch.`,

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -6,7 +6,7 @@ import { ghBaseBranches } from '../../github';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
-import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
+import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpawnConfig/taskModelAgentSpawnConfig';
 import { useAppStore } from '../../../../store';
 
 type Props = {
@@ -36,7 +36,11 @@ export const CreatePrPanel = ({
     const ws = sess ? s.workspaces.find((w) => w.id === sess.workspaceId) : undefined;
     return ws?.rootPath ?? null;
   });
-  const workspaceId = useAppStore((s) => s.sessions.find((x) => x.id === sessionId)?.workspaceId);
+  const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId) ?? null);
+  const workspaceId = session?.workspaceId;
+  const workspaceOverrides = useAppStore((s) =>
+    workspaceId == null ? null : (s.workspaceOverrides?.[workspaceId] ?? null),
+  );
 
   const [title, setTitle] = useState(defaultTitle);
   const [body, setBody] = useState('');
@@ -45,7 +49,12 @@ export const CreatePrPanel = ({
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
+    taskModelAgentSpawnConfig({
+      preferences: workspaceOverrides?.taskModels,
+      defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+    }),
+  );
 
   useEffect(() => {
     if (!workspaceRoot) {

--- a/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/CreatePrPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { SessionId } from '@goodboy/types';
 import { Button, cn, Input, ScrollFade, SectionHeader, Textarea } from '@goodboy/ui';
 import { ArrowRight, GitBranch, Sparkles } from 'lucide-react';
@@ -41,6 +41,14 @@ export const CreatePrPanel = ({
   const workspaceOverrides = useAppStore((s) =>
     workspaceId == null ? null : (s.workspaceOverrides?.[workspaceId] ?? null),
   );
+  const resolvedAgentConfig = useMemo(
+    () =>
+      taskModelAgentSpawnConfig({
+        preferences: workspaceOverrides?.taskModels,
+        defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+      }),
+    [workspaceOverrides?.taskModels, session?.providerPreference?.defaultProvider],
+  );
 
   const [title, setTitle] = useState(defaultTitle);
   const [body, setBody] = useState('');
@@ -49,12 +57,15 @@ export const CreatePrPanel = ({
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
-    taskModelAgentSpawnConfig({
-      preferences: workspaceOverrides?.taskModels,
-      defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
-    }),
-  );
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(resolvedAgentConfig);
+  const [agentConfigUserTouched, setAgentConfigUserTouched] = useState(false);
+
+  useEffect(() => {
+    if (agentConfigUserTouched) {
+      return;
+    }
+    setAgentConfig(resolvedAgentConfig);
+  }, [agentConfigUserTouched, resolvedAgentConfig]);
 
   useEffect(() => {
     if (!workspaceRoot) {
@@ -187,7 +198,10 @@ export const CreatePrPanel = ({
             </div>
             <AgentSpawnConfig
               value={agentConfig}
-              onChange={setAgentConfig}
+              onChange={(value) => {
+                setAgentConfigUserTouched(true);
+                setAgentConfig(value);
+              }}
               disabled={busy !== null}
             />
             <div className="flex items-center gap-3 pt-1">

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { SessionId } from '@goodboy/types';
+import type { SessionId, TaskModelPreferences } from '@goodboy/types';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
 
 type SpawnAgent = (
@@ -9,7 +9,12 @@ type SpawnAgent = (
 ) => Promise<string>;
 
 type Store = {
-  readonly sessions: ReadonlyArray<{ id: SessionId; goal: string }>;
+  readonly sessions: ReadonlyArray<{
+    id: SessionId;
+    goal: string;
+    workspaceId: string;
+    providerPreference: { defaultProvider: 'anthropic'; allowTurnOverride: false };
+  }>;
   readonly sessionGitlabMr: Record<string, unknown>;
   readonly sessionBranches: Record<string, string>;
   readonly refreshSessionMr: ReturnType<typeof vi.fn>;
@@ -18,6 +23,7 @@ type Store = {
   readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
   readonly selectAgent: ReturnType<typeof vi.fn>;
   readonly setCurrentSession: ReturnType<typeof vi.fn>;
+  workspaceOverrides: Record<string, { readonly taskModels: TaskModelPreferences | null }>;
 };
 
 type ConfigProps = {
@@ -34,7 +40,14 @@ const h = vi.hoisted(() => ({
   } satisfies AgentSpawnConfigValue,
   showToast: vi.fn(),
   store: {
-    sessions: [{ id: 'session-3' as SessionId, goal: 'Prepare the GitLab release' }],
+    sessions: [
+      {
+        id: 'session-3' as SessionId,
+        goal: 'Prepare the GitLab release',
+        workspaceId: 'workspace-1',
+        providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+      },
+    ],
     sessionGitlabMr: {},
     sessionBranches: { 'session-3': 'ak/gitlab-release' },
     refreshSessionMr: vi.fn(async () => undefined),
@@ -43,6 +56,7 @@ const h = vi.hoisted(() => ({
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-3'),
     selectAgent: vi.fn(async () => undefined),
     setCurrentSession: vi.fn(async () => undefined),
+    workspaceOverrides: {},
   } satisfies Store,
 }));
 
@@ -72,6 +86,7 @@ beforeEach(() => {
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
   h.showToast.mockClear();
+  h.store.workspaceOverrides = {};
 });
 
 afterEach(cleanup);
@@ -94,5 +109,22 @@ describe('MrDetailPanel', () => {
       '\n\nOperator notes:\n---\nMention the rollout order.\n---',
     );
     await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+  });
+
+  it('uses a workspace task model loaded after mount', async () => {
+    const { rerender } = render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+    h.store.workspaceOverrides = {
+      'workspace-1': {
+        taskModels: { pr_draft: { providerId: 'codex', model: 'gpt-5.4-mini' } },
+      },
+    };
+    rerender(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    expect(h.store.spawnAgent.mock.calls[0]![1]).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.4-mini',
+    });
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -15,7 +15,7 @@ import { ScrollFade } from '@goodboy/ui';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
-import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../../session/components/AgentSpawnConfig/defaultAgentSpawnConfig';
+import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpawnConfig/taskModelAgentSpawnConfig';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
@@ -49,6 +49,9 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   const spawnAgent = useAppStore((s) => s.spawnAgent);
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setCurrentSession = useAppStore((s) => s.setCurrentSession);
+  const workspaceOverrides = useAppStore((s) =>
+    session == null ? null : (s.workspaceOverrides?.[session.workspaceId] ?? null),
+  );
   const { showToast } = useToast();
 
   const mr = mrState?.mr ?? null;
@@ -60,7 +63,12 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   const [targetBranch, setTargetBranch] = useState('main');
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | 'merge' | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
+    taskModelAgentSpawnConfig({
+      preferences: workspaceOverrides?.taskModels,
+      defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+    }),
+  );
 
   useEffect(() => {
     void refreshSessionMr(sessionId, { silent: true });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Button, Divider, EmptyState, Input, SectionHeader, Textarea, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
@@ -52,6 +52,14 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   const workspaceOverrides = useAppStore((s) =>
     session == null ? null : (s.workspaceOverrides?.[session.workspaceId] ?? null),
   );
+  const resolvedAgentConfig = useMemo(
+    () =>
+      taskModelAgentSpawnConfig({
+        preferences: workspaceOverrides?.taskModels,
+        defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
+      }),
+    [workspaceOverrides?.taskModels, session?.providerPreference?.defaultProvider],
+  );
   const { showToast } = useToast();
 
   const mr = mrState?.mr ?? null;
@@ -63,12 +71,15 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   const [targetBranch, setTargetBranch] = useState('main');
   const [draft, setDraft] = useState(true);
   const [busy, setBusy] = useState<'create' | 'ai' | 'merge' | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
-    taskModelAgentSpawnConfig({
-      preferences: workspaceOverrides?.taskModels,
-      defaultProviderId: session?.providerPreference?.defaultProvider ?? 'anthropic',
-    }),
-  );
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(resolvedAgentConfig);
+  const [agentConfigUserTouched, setAgentConfigUserTouched] = useState(false);
+
+  useEffect(() => {
+    if (agentConfigUserTouched) {
+      return;
+    }
+    setAgentConfig(resolvedAgentConfig);
+  }, [agentConfigUserTouched, resolvedAgentConfig]);
 
   useEffect(() => {
     void refreshSessionMr(sessionId, { silent: true });
@@ -304,7 +315,10 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
                 </div>
                 <AgentSpawnConfig
                   value={agentConfig}
-                  onChange={setAgentConfig}
+                  onChange={(value) => {
+                    setAgentConfigUserTouched(true);
+                    setAgentConfig(value);
+                  }}
                   disabled={busy !== null}
                 />
                 <div className="flex items-center gap-3 pt-1">

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -104,6 +104,7 @@ const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
         parallelEnabled: wsOverrides?.parallelEnabled ?? null,
         defaultVerbosity: verbosity,
         providerBindings: wsOverrides?.providerBindings ?? null,
+        taskModels: wsOverrides?.taskModels ?? null,
         scoutFanout,
         ...partial,
       });

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
@@ -1,0 +1,68 @@
+import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
+import type { AuxTaskId, ProviderId, TaskModelPreference } from '@goodboy/types';
+import { FieldRow, Select } from '@goodboy/ui';
+import { PROVIDER_LABEL } from '../../../../chat/utils/chat-constants';
+import { ModelSelect } from '../../../../session/components/ModelSelect';
+
+type Props = {
+  readonly task: AuxTaskId;
+  readonly label: string;
+  readonly help: string;
+  readonly preference: TaskModelPreference | null;
+  readonly defaultProviderId: ProviderId;
+  readonly connectedProviderIds: ReadonlyArray<ProviderId>;
+  readonly disabled: boolean;
+  readonly onChange: (preference: TaskModelPreference | null) => void;
+};
+
+export const TaskModelRow = ({
+  task,
+  label,
+  help,
+  preference,
+  defaultProviderId,
+  connectedProviderIds,
+  disabled,
+  onChange,
+}: Props) => {
+  const automatic = resolveTaskModel(task, null, defaultProviderId);
+  const providerId = preference?.providerId ?? automatic.providerId;
+  const model = preference?.model ?? '';
+  const availableProviderIds = connectedProviderIds.filter(
+    (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
+  );
+
+  return (
+    <FieldRow label={label} help={help}>
+      <div className="grid w-80 grid-cols-2 gap-2">
+        <Select
+          size="sm"
+          block
+          aria-label={`${label} provider`}
+          value={providerId}
+          disabled={disabled || availableProviderIds.length === 0}
+          onChange={(event) => {
+            const nextProviderId = event.target.value as ProviderId;
+            onChange(resolveTaskModel(task, null, nextProviderId));
+          }}
+        >
+          {availableProviderIds.map((candidate) => (
+            <option key={candidate} value={candidate}>
+              {PROVIDER_LABEL[candidate]}
+            </option>
+          ))}
+        </Select>
+        <ModelSelect
+          provider={providerId}
+          value={model}
+          onChange={(nextModel) =>
+            onChange(nextModel === '' ? null : { providerId, model: nextModel })
+          }
+          disabled={disabled}
+          allowAuto
+          recommendedModel={automatic.model}
+        />
+      </div>
+    </FieldRow>
+  );
+};

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/TaskModelRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
 import type { AuxTaskId, ProviderId, TaskModelPreference } from '@goodboy/types';
 import { FieldRow, Select } from '@goodboy/ui';
@@ -26,11 +27,17 @@ export const TaskModelRow = ({
   onChange,
 }: Props) => {
   const automatic = resolveTaskModel(task, null, defaultProviderId);
-  const providerId = preference?.providerId ?? automatic.providerId;
+  const preferredProviderId = preference?.providerId ?? automatic.providerId;
+  const [providerId, setProviderId] = useState(preferredProviderId);
   const model = preference?.model ?? '';
   const availableProviderIds = connectedProviderIds.filter(
     (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
   );
+  const recommendedModel = resolveTaskModel(task, null, providerId).model;
+
+  useEffect(() => {
+    setProviderId(preferredProviderId);
+  }, [preferredProviderId]);
 
   return (
     <FieldRow label={label} help={help}>
@@ -43,6 +50,10 @@ export const TaskModelRow = ({
           disabled={disabled || availableProviderIds.length === 0}
           onChange={(event) => {
             const nextProviderId = event.target.value as ProviderId;
+            setProviderId(nextProviderId);
+            if (preference == null) {
+              return;
+            }
             onChange(resolveTaskModel(task, null, nextProviderId));
           }}
         >
@@ -60,7 +71,7 @@ export const TaskModelRow = ({
           }
           disabled={disabled}
           allowAuto
-          recommendedModel={automatic.model}
+          recommendedModel={recommendedModel}
         />
       </div>
     </FieldRow>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { OverrideSettings } from '@goodboy/types';
+
+const { state } = vi.hoisted(() => ({
+  state: {
+    workspaceOverrides: {} as Record<string, OverrideSettings>,
+    providers: [
+      { id: 'anthropic', connection: 'connected' },
+      { id: 'cursor', connection: 'connected' },
+    ],
+    setWorkspaceOverrides: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../ProviderChip', () => ({
+  ProviderChip: ({
+    id,
+    selected,
+    disabled,
+    onClick,
+  }: {
+    id: string;
+    selected: boolean;
+    disabled: boolean;
+    onClick: () => void;
+  }) => (
+    <button type="button" aria-pressed={selected} disabled={disabled} onClick={onClick}>
+      {id}
+    </button>
+  ),
+}));
+
+vi.mock('../../../../session/components/ModelSelect', () => ({
+  ModelSelect: ({
+    value,
+    recommendedModel,
+    onChange,
+  }: {
+    value: string;
+    recommendedModel: string;
+    onChange: (model: string) => void;
+  }) => (
+    <button type="button" onClick={() => onChange('claude-sonnet-4-6')}>
+      {value === '' ? `${recommendedModel} recommended` : value}
+    </button>
+  ),
+}));
+
+const EMPTY_OVERRIDES: OverrideSettings = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+  taskModels: null,
+  scoutFanout: null,
+};
+
+beforeEach(() => {
+  state.workspaceOverrides = { 'ws-1': EMPTY_OVERRIDES };
+  state.setWorkspaceOverrides.mockClear();
+});
+
+afterEach(cleanup);
+
+import { DefaultsPanel } from './index';
+
+describe('DefaultsPanel', () => {
+  it('renders every task model row', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByText('Summaries')).toBeDefined();
+    expect(screen.getByText('Branch names')).toBeDefined();
+    expect(screen.getByText('Planning')).toBeDefined();
+    expect(screen.getByText('Agent titles')).toBeDefined();
+    expect(screen.getByText('PR and MR drafts')).toBeDefined();
+  });
+
+  it('shows the resolved model for automatic preferences', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getAllByText('claude-haiku-4-5 recommended')).toHaveLength(5);
+  });
+
+  it('persists a selected task model immediately', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+    fireEvent.click(screen.getAllByText('claude-haiku-4-5 recommended')[0]!);
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        taskModels: {
+          summarizer: { providerId: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { OverrideSettings } from '@goodboy/types';
+import { DefaultsPanel } from './index';
 
 const { state } = vi.hoisted(() => ({
   state: {
@@ -37,15 +38,21 @@ vi.mock('../../ProviderChip', () => ({
 
 vi.mock('../../../../session/components/ModelSelect', () => ({
   ModelSelect: ({
+    provider,
     value,
     recommendedModel,
     onChange,
   }: {
+    provider: string;
     value: string;
     recommendedModel: string;
     onChange: (model: string) => void;
   }) => (
-    <button type="button" onClick={() => onChange('claude-sonnet-4-6')}>
+    <button
+      type="button"
+      aria-label={`${provider} model`}
+      onClick={() => onChange('claude-sonnet-4-6')}
+    >
       {value === '' ? `${recommendedModel} recommended` : value}
     </button>
   ),
@@ -68,8 +75,6 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
-
-import { DefaultsPanel } from './index';
 
 describe('DefaultsPanel', () => {
   it('renders every task model row', () => {
@@ -97,6 +102,28 @@ describe('DefaultsPanel', () => {
       expect.objectContaining({
         taskModels: {
           summarizer: { providerId: 'anthropic', model: 'claude-sonnet-4-6' },
+        },
+      }),
+    );
+  });
+
+  it('keeps provider changes local while automatic is selected', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Summaries provider' }), {
+      target: { value: 'cursor' },
+    });
+
+    expect(state.setWorkspaceOverrides).not.toHaveBeenCalled();
+    const modelPicker = screen.getByRole('button', { name: 'cursor model' });
+
+    fireEvent.click(modelPicker);
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        taskModels: {
+          summarizer: { providerId: 'cursor', model: 'claude-sonnet-4-6' },
         },
       }),
     );

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -1,18 +1,17 @@
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
-import type { AuxTaskId, OverrideSettings, ProviderId, WorkspaceId } from '@goodboy/types';
+import type { AuxTaskId, OverrideSettings, WorkspaceId } from '@goodboy/types';
 import { Divider, FieldRow, ScrollFade, SectionHeader } from '@goodboy/ui';
 import { useShallow } from 'zustand/react/shallow';
 import { ProviderChip } from '../../ProviderChip';
 import { PROVIDER_LABEL } from '../../../../chat/utils/chat-constants';
 import { useAppStore } from '../../../../../store';
+import { PROVIDER_ORDER } from '../providerOrder';
 import { TaskModelRow } from './TaskModelRow';
 import { useDefaultsPersistence } from './useDefaultsPersistence';
 
 type Props = {
   readonly workspaceId: WorkspaceId;
 };
-
-const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 const TASKS: ReadonlyArray<{
   readonly id: AuxTaskId;
@@ -91,7 +90,7 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
           <section className="flex flex-col">
             <FieldRow label="Default provider" help="New sessions start on it and can override it.">
               <div className="flex flex-wrap justify-end gap-1">
-                {PROVIDER_OPTIONS.map((providerId) => (
+                {PROVIDER_ORDER.map((providerId) => (
                   <ProviderChip
                     key={providerId}
                     id={providerId}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -1,0 +1,142 @@
+import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
+import type { AuxTaskId, OverrideSettings, ProviderId, WorkspaceId } from '@goodboy/types';
+import { Divider, FieldRow, ScrollFade, SectionHeader } from '@goodboy/ui';
+import { useShallow } from 'zustand/react/shallow';
+import { ProviderChip } from '../../ProviderChip';
+import { PROVIDER_LABEL } from '../../../../chat/utils/chat-constants';
+import { useAppStore } from '../../../../../store';
+import { TaskModelRow } from './TaskModelRow';
+import { useDefaultsPersistence } from './useDefaultsPersistence';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+};
+
+const PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];
+
+const TASKS: ReadonlyArray<{
+  readonly id: AuxTaskId;
+  readonly label: string;
+  readonly help: string;
+}> = [
+  {
+    id: 'summarizer',
+    label: 'Summaries',
+    help: 'Condenses step output into short summaries',
+  },
+  {
+    id: 'branch_naming',
+    label: 'Branch names',
+    help: 'Generates branch slugs for new sessions',
+  },
+  {
+    id: 'plan_generation',
+    label: 'Planning',
+    help: 'Drafts plans and custom workflows',
+  },
+  {
+    id: 'agent_naming',
+    label: 'Agent titles',
+    help: 'Names agents from your first request',
+  },
+  {
+    id: 'pr_draft',
+    label: 'PR and MR drafts',
+    help: 'Default agent config when drafting pull requests',
+  },
+];
+
+const EMPTY_OVERRIDES: OverrideSettings = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+  taskModels: null,
+  scoutFanout: null,
+};
+
+export const DefaultsPanel = ({ workspaceId }: Props) => {
+  const workspaceOverrides = useAppStore(
+    (state) => state.workspaceOverrides?.[workspaceId] ?? null,
+  );
+  const connectedProviderIds = useAppStore(
+    useShallow((state) =>
+      state.providers
+        .filter((provider) => provider.connection === 'connected')
+        .map((provider) => provider.id),
+    ),
+  );
+  const overrides = workspaceOverrides ?? EMPTY_OVERRIDES;
+  const defaultProviderId =
+    overrides.defaultProviderId ?? DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider;
+
+  const { busy, error, persistOverrides, persistTaskModel } = useDefaultsPersistence({
+    workspaceId,
+    overrides,
+  });
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-col gap-0.5 px-8 py-4">
+        <h2 className="text-base font-semibold text-foreground">Defaults</h2>
+        <p className="text-2xs text-muted-foreground">
+          Choose provider defaults for this workspace and its auxiliary tasks.
+        </p>
+      </div>
+      <Divider />
+      <ScrollFade className="flex-1" fadeFrom="background">
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 py-6">
+          <section className="flex flex-col">
+            <FieldRow label="Default provider" help="New sessions start on it and can override it.">
+              <div className="flex flex-wrap justify-end gap-1">
+                {PROVIDER_OPTIONS.map((providerId) => (
+                  <ProviderChip
+                    key={providerId}
+                    id={providerId}
+                    selected={defaultProviderId === providerId}
+                    disabled={busy || !connectedProviderIds.includes(providerId)}
+                    onClick={() =>
+                      void persistOverrides({ partial: { defaultProviderId: providerId } })
+                    }
+                    trailing={
+                      connectedProviderIds.includes(providerId) ? null : (
+                        <span className="text-2xs uppercase tracking-wide text-warning">
+                          offline
+                        </span>
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            </FieldRow>
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <SectionHeader label="Task models" />
+            <div className="flex flex-col">
+              {TASKS.map((task, index) => (
+                <div key={task.id} className="flex flex-col">
+                  {index > 0 ? <Divider /> : null}
+                  <TaskModelRow
+                    task={task.id}
+                    label={task.label}
+                    help={task.help}
+                    preference={overrides.taskModels?.[task.id] ?? null}
+                    defaultProviderId={defaultProviderId}
+                    connectedProviderIds={connectedProviderIds}
+                    disabled={busy}
+                    onChange={(preference) => persistTaskModel({ task: task.id, preference })}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {error != null ? <p className="text-xs text-danger">{error}</p> : null}
+        </div>
+      </ScrollFade>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/useDefaultsPersistence.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/useDefaultsPersistence.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import type { AuxTaskId, OverrideSettings, TaskModelPreference, WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../../../shared/lib/errors';
+import { useAppStore } from '../../../../../store';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly overrides: OverrideSettings;
+};
+
+type PersistParams = {
+  readonly partial: Partial<OverrideSettings>;
+};
+
+type PersistTaskModelParams = {
+  readonly task: AuxTaskId;
+  readonly preference: TaskModelPreference | null;
+};
+
+export const useDefaultsPersistence = ({ workspaceId, overrides }: Params) => {
+  const setWorkspaceOverrides = useAppStore((state) => state.setWorkspaceOverrides);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const persistOverrides = async ({ partial }: PersistParams) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await setWorkspaceOverrides(workspaceId, { ...overrides, ...partial });
+    } catch (caught) {
+      setError(formatError(caught));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const persistTaskModel = ({ task, preference }: PersistTaskModelParams) => {
+    const taskModels = { ...(overrides.taskModels ?? {}) };
+    if (preference == null) {
+      delete taskModels[task];
+    }
+    if (preference != null) {
+      taskModels[task] = preference;
+    }
+    void persistOverrides({
+      partial: {
+        taskModels: Object.keys(taskModels).length > 0 ? taskModels : null,
+      },
+    });
+  };
+
+  return { busy, error, persistOverrides, persistTaskModel };
+};

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
@@ -2,11 +2,13 @@ import { cn } from '@goodboy/ui';
 import type { ProviderConnectionState, ProviderId } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
+import { SlidersHorizontal } from 'lucide-react';
 
 type Props = {
   readonly providers: ReadonlyArray<ProviderInfo>;
-  readonly focusedId: ProviderId | null;
+  readonly focusedId: ProviderId | 'defaults';
   readonly onSelect: (id: ProviderId) => void;
+  readonly onSelectDefaults: () => void;
 };
 
 const STATUS_DOT: Record<ProviderConnectionState, string> = {
@@ -23,52 +25,80 @@ const STATUS_LABEL: Record<ProviderConnectionState, string> = {
   error: 'error',
 };
 
-export const ProvidersRail = ({ providers, focusedId, onSelect }: Props) => {
+export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults }: Props) => {
   return (
-    <div className="flex flex-col gap-0.5 p-2">
-      {providers.map((p) => {
-        const id = p.id as ProviderId;
-        const Icon = PROVIDER_BRAND[id].icon;
-        const active = id === focusedId;
-        const subtitle =
-          p.connection === 'connected'
-            ? (p.identity ?? STATUS_LABEL.connected)
-            : STATUS_LABEL[p.connection];
-        return (
-          <button
-            key={id}
-            type="button"
-            onClick={() => onSelect(id)}
-            aria-current={active}
-            className={cn(
-              'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors',
-              active
-                ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
-                : 'text-muted-foreground hover:bg-muted/50',
-            )}
-          >
-            <span
-              className="flex size-7 shrink-0 items-center justify-center rounded-md"
-              style={{
-                backgroundColor: `color-mix(in oklch, ${brandColor(id)} 18%, transparent)`,
-                color: brandColor(id),
-              }}
-            >
-              <Icon size={15} aria-hidden />
-            </span>
-            <span className="flex min-w-0 flex-1 flex-col">
-              <span className="truncate text-sm font-medium lowercase text-foreground">
-                {p.label}
-              </span>
-              <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
-            </span>
-            <span
-              className={cn('size-2 shrink-0 rounded-full', STATUS_DOT[p.connection])}
-              aria-hidden
-            />
-          </button>
-        );
-      })}
+    <div className="flex flex-col gap-4 p-2">
+      <section className="flex flex-col gap-1">
+        <span className="px-2.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          Configuration
+        </span>
+        <button
+          type="button"
+          onClick={onSelectDefaults}
+          aria-current={focusedId === 'defaults'}
+          className={cn(
+            'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors',
+            focusedId === 'defaults'
+              ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+              : 'text-muted-foreground hover:bg-muted/50',
+          )}
+        >
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+            <SlidersHorizontal size={15} aria-hidden />
+          </span>
+          <span className="text-sm font-medium text-foreground">Defaults</span>
+        </button>
+      </section>
+      <section className="flex flex-col gap-1">
+        <span className="px-2.5 text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          Providers
+        </span>
+        <div className="flex flex-col gap-0.5">
+          {providers.map((p) => {
+            const id = p.id as ProviderId;
+            const Icon = PROVIDER_BRAND[id].icon;
+            const active = id === focusedId;
+            const subtitle =
+              p.connection === 'connected'
+                ? (p.identity ?? STATUS_LABEL.connected)
+                : STATUS_LABEL[p.connection];
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => onSelect(id)}
+                aria-current={active}
+                className={cn(
+                  'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors',
+                  active
+                    ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                    : 'text-muted-foreground hover:bg-muted/50',
+                )}
+              >
+                <span
+                  className="flex size-7 shrink-0 items-center justify-center rounded-md"
+                  style={{
+                    backgroundColor: `color-mix(in oklch, ${brandColor(id)} 18%, transparent)`,
+                    color: brandColor(id),
+                  }}
+                >
+                  <Icon size={15} aria-hidden />
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-sm font-medium lowercase text-foreground">
+                    {p.label}
+                  </span>
+                  <span className="truncate text-2xs text-muted-foreground">{subtitle}</span>
+                </span>
+                <span
+                  className={cn('size-2 shrink-0 rounded-full', STATUS_DOT[p.connection])}
+                  aria-hidden
+                />
+              </button>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
@@ -9,8 +9,7 @@ import { ProvidersRail } from './ProvidersRail';
 import { ProviderDetailPanel } from './ProviderDetailPanel';
 import { ProviderConnectPane } from './ProviderConnectPane';
 import { DefaultsPanel } from './DefaultsPanel';
-
-const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
+import { PROVIDER_ORDER } from './providerOrder';
 
 type Props = {
   readonly workspaceName: string;

--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Divider, ScrollFade } from '@goodboy/ui';
-import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
+import type { ProviderId, ProviderLifecycleAction, WorkspaceId } from '@goodboy/types';
 import { ProviderStudioIcon } from '../brand-icons';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
@@ -8,19 +8,27 @@ import { StudioShell } from '../../../../shared/components/StudioShell';
 import { ProvidersRail } from './ProvidersRail';
 import { ProviderDetailPanel } from './ProviderDetailPanel';
 import { ProviderConnectPane } from './ProviderConnectPane';
+import { DefaultsPanel } from './DefaultsPanel';
 
 const PROVIDER_ORDER: ProviderId[] = ['anthropic', 'cursor', 'codex', 'gemini'];
 
 type Props = {
   readonly workspaceName: string;
+  readonly workspaceId: WorkspaceId;
   readonly initialFocus?: ProviderId | null;
   readonly initialAction?: ProviderLifecycleAction | null;
   readonly onClose: () => void;
 };
 
-export const ProviderStudio = ({ workspaceName, initialFocus, initialAction, onClose }: Props) => {
+export const ProviderStudio = ({
+  workspaceName,
+  workspaceId,
+  initialFocus,
+  initialAction,
+  onClose,
+}: Props) => {
   const providers = useAppStore((s) => s.providers);
-  const [focused, setFocused] = useState<ProviderId | null>(initialFocus ?? null);
+  const [focused, setFocused] = useState<ProviderId | 'defaults'>(initialFocus ?? 'defaults');
   const [connectAction, setConnectAction] = useState<ProviderLifecycleAction | null>(
     initialFocus && initialAction ? initialAction : null,
   );
@@ -28,16 +36,6 @@ export const ProviderStudio = ({ workspaceName, initialFocus, initialAction, onC
   const ordered = PROVIDER_ORDER.map((id) => providers.find((p) => p.id === id)).filter(
     (p): p is ProviderInfo => p !== undefined,
   );
-
-  useEffect(() => {
-    if (focused !== null) {
-      return;
-    }
-    const first = ordered.find((p) => p.connection === 'connected')?.id ?? ordered[0]?.id ?? null;
-    if (first) {
-      setFocused(first);
-    }
-  }, [focused, ordered]);
 
   const selected = ordered.find((p) => p.id === focused) ?? null;
 
@@ -57,11 +55,21 @@ export const ProviderStudio = ({ workspaceName, initialFocus, initialAction, onC
       {() => (
         <>
           <ScrollFade className="w-72 shrink-0" fadeFrom="background">
-            <ProvidersRail providers={ordered} focusedId={focused} onSelect={onSelect} />
+            <ProvidersRail
+              providers={ordered}
+              focusedId={focused}
+              onSelect={onSelect}
+              onSelectDefaults={() => {
+                setConnectAction(null);
+                setFocused('defaults');
+              }}
+            />
           </ScrollFade>
           <Divider orientation="vertical" />
           <div className="min-h-0 flex-1">
-            {selected && connectAction ? (
+            {focused === 'defaults' ? (
+              <DefaultsPanel workspaceId={workspaceId} />
+            ) : selected && connectAction ? (
               <ProviderConnectPane
                 providerId={selected.id as ProviderId}
                 action={connectAction}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/providerOrder.ts
@@ -1,0 +1,3 @@
+import type { ProviderId } from '@goodboy/types';
+
+export const PROVIDER_ORDER: ReadonlyArray<ProviderId> = ['anthropic', 'cursor', 'codex', 'gemini'];

--- a/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.ts
+++ b/apps/desktop/src/features/session/components/AgentSpawnConfig/taskModelAgentSpawnConfig.ts
@@ -1,0 +1,23 @@
+import { resolveTaskModel } from '@goodboy/core';
+import type { ProviderId, TaskModelPreferences } from '@goodboy/types';
+import { clampEffort } from '../../../chat/utils/chat-constants';
+import type { AgentSpawnConfigValue } from './AgentSpawnConfigValue';
+import { DEFAULT_AGENT_SPAWN_CONFIG } from './defaultAgentSpawnConfig';
+
+type Params = {
+  readonly preferences: TaskModelPreferences | null | undefined;
+  readonly defaultProviderId: ProviderId;
+};
+
+export const taskModelAgentSpawnConfig = ({
+  preferences,
+  defaultProviderId,
+}: Params): AgentSpawnConfigValue => {
+  const taskModel = resolveTaskModel('pr_draft', preferences, defaultProviderId);
+  return {
+    ...DEFAULT_AGENT_SPAWN_CONFIG,
+    provider: taskModel.providerId,
+    model: taskModel.model,
+    effort: clampEffort(taskModel.model, DEFAULT_AGENT_SPAWN_CONFIG.effort),
+  };
+};

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -2,8 +2,8 @@ import { invoke } from '@tauri-apps/api/core';
 import { useEffect, useRef, useState } from 'react';
 import { Button, Divider, Input, ScrollFade, Skeleton, Textarea, cn } from '@goodboy/ui';
 import { AlertTriangle, GitBranch, Paperclip, Target, Wand2 } from 'lucide-react';
-import type { ProviderId, SessionId, WorkspaceId } from '@goodboy/types';
-import { CURSOR_AUTO_MODEL } from '@goodboy/core';
+import type { ProviderId, SessionId, TaskModelPreference, WorkspaceId } from '@goodboy/types';
+import { resolveTaskModel } from '@goodboy/core';
 import { AttachmentChip } from '../../../chat/components/ChatInput/parts/AttachmentChip';
 import { toAttachmentInput } from '../../../chat/components/ChatInput/lib';
 import { usePendingAttachments } from '../../../chat/components/ChatInput/hooks/usePendingAttachments';
@@ -81,24 +81,6 @@ type SummarizeTaskResult = {
   readonly exitCode: number | null;
 };
 
-function getCheapModel(providerId: ProviderId): string {
-  switch (providerId) {
-    case 'anthropic':
-      return 'claude-haiku-4-5';
-    case 'cursor':
-      return CURSOR_AUTO_MODEL;
-    case 'codex':
-      return 'gpt-5.4-mini';
-    case 'gemini':
-      return 'gemini-3.5-flash';
-    default: {
-      const _exhaustive: never = providerId;
-      void _exhaustive;
-      return 'claude-haiku-4-5';
-    }
-  }
-}
-
 function getDefaultBinary(providerId: ProviderId): string {
   switch (providerId) {
     case 'anthropic':
@@ -130,14 +112,17 @@ const EMPTY_LOCAL_BRANCHES: ReadonlyArray<LocalBranchInfo> = [];
 
 const isValidBranchSlug = (slug: string): boolean => validateBranchSlug({ slug });
 
-async function generateBranchSlug(goal: string, providerId: ProviderId): Promise<string> {
+async function generateBranchSlug(
+  goal: string,
+  { providerId, model }: TaskModelPreference,
+): Promise<string> {
   const systemPrompt =
     'You are a branch-name generator. Given a goal, output a kebab-case branch slug in English, max 5 words, descriptive (not first words of goal). Respond with ONLY the slug, nothing else.';
   const userMessage = `Goal: ${goal}`;
   const result = await invoke<SummarizeTaskResult>('summarize_session', {
     args: {
       providerId,
-      model: getCheapModel(providerId),
+      model,
       binary: getDefaultBinary(providerId),
       userMessage,
       systemPrompt,
@@ -174,6 +159,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
   const { showToast } = useToast();
   const settingKey = settingBranchPrefix(workspaceId);
   const workspace = useAppStore((s) => s.workspaces.find((w) => w.id === workspaceId));
+  const workspaceOverrides = useAppStore((s) => s.workspaceOverrides?.[workspaceId] ?? null);
 
   const [goal, setGoal] = useState('');
   const [branchSlug, setBranchSlug] = useState('');
@@ -204,7 +190,12 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
 
   const connectedProviders = providers.filter((p) => p.connection === 'connected');
   const noProviderConnected = providers.length > 0 && connectedProviders.length === 0;
-  const defaultProvider = pickDefaultProvider(new Set(connectedProviders.map((p) => p.id)));
+  const connectedProviderIds = new Set(connectedProviders.map((provider) => provider.id));
+  const workspaceDefaultProvider = workspaceOverrides?.defaultProviderId;
+  const defaultProvider =
+    workspaceDefaultProvider != null && connectedProviderIds.has(workspaceDefaultProvider)
+      ? workspaceDefaultProvider
+      : pickDefaultProvider(connectedProviderIds);
 
   useEffect(() => {
     void loadSetting(settingKey).then((value) => {
@@ -261,7 +252,10 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
       return;
     }
     setSlugGenerating(true);
-    generateBranchSlug(trimmed, defaultProvider)
+    generateBranchSlug(
+      trimmed,
+      resolveTaskModel('branch_naming', workspaceOverrides?.taskModels, defaultProvider),
+    )
       .then((slug) => {
         setBranchSlug(slug);
         setSlugTouched(true);

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Button, Divider, Input, ScrollFade, Skeleton, Textarea, cn } from '@goodboy/ui';
 import { AlertTriangle, GitBranch, Paperclip, Target, Wand2 } from 'lucide-react';
 import type { ProviderId, SessionId, TaskModelPreference, WorkspaceId } from '@goodboy/types';
-import { resolveTaskModel } from '@goodboy/core';
+import { getDefaultBinary, resolveTaskModel } from '@goodboy/core';
 import { AttachmentChip } from '../../../chat/components/ChatInput/parts/AttachmentChip';
 import { toAttachmentInput } from '../../../chat/components/ChatInput/lib';
 import { usePendingAttachments } from '../../../chat/components/ChatInput/hooks/usePendingAttachments';
@@ -80,24 +80,6 @@ type SummarizeTaskResult = {
   readonly stderr: string;
   readonly exitCode: number | null;
 };
-
-function getDefaultBinary(providerId: ProviderId): string {
-  switch (providerId) {
-    case 'anthropic':
-      return 'claude';
-    case 'cursor':
-      return 'cursor-agent';
-    case 'codex':
-      return 'codex';
-    case 'gemini':
-      return 'agy';
-    default: {
-      const _exhaustive: never = providerId;
-      void _exhaustive;
-      return 'claude';
-    }
-  }
-}
 
 const SLUG_MAX_LEN = 48;
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -5,6 +5,7 @@ import type {
   PullRequestState,
   Session,
   SessionId,
+  TaskModelPreferences,
   WorkspaceId,
 } from '@goodboy/types';
 import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
@@ -23,6 +24,7 @@ type Store = {
   readonly selectAgent: ReturnType<typeof vi.fn>;
   readonly setActiveLens: ReturnType<typeof vi.fn>;
   readonly sessionBranches: Record<string, string>;
+  workspaceOverrides: Record<string, { readonly taskModels: TaskModelPreferences | null }>;
 };
 
 type ConfigProps = {
@@ -47,6 +49,7 @@ const h = vi.hoisted(() => ({
     selectAgent: vi.fn(async () => undefined),
     setActiveLens: vi.fn(),
     sessionBranches: { 'session-1': 'ak/refactor-auth' },
+    workspaceOverrides: {},
   } satisfies Store,
 }));
 
@@ -106,6 +109,7 @@ beforeEach(() => {
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setActiveLens.mockClear();
+  h.store.workspaceOverrides = {};
 });
 
 afterEach(cleanup);
@@ -153,5 +157,22 @@ describe('PrPane', () => {
       expect(h.store.createPrForSession).toHaveBeenCalledWith(SESSION_ID, { draft: true }),
     );
     expect(h.store.spawnAgent).not.toHaveBeenCalled();
+  });
+
+  it('uses a workspace task model loaded after mount', async () => {
+    const { rerender } = render(<PrPane session={session} />);
+    h.store.workspaceOverrides = {
+      'workspace-1': {
+        taskModels: { pr_draft: { providerId: 'codex', model: 'gpt-5.4-mini' } },
+      },
+    };
+    rerender(<PrPane session={session} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Draft with an agent' }));
+
+    await waitFor(() => expect(h.store.spawnAgent).toHaveBeenCalledOnce());
+    expect(h.store.spawnAgent.mock.calls[0]![1]).toMatchObject({
+      provider: 'codex',
+      model: 'gpt-5.4-mini',
+    });
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   ArrowUpRight,
   CheckCircle2,
@@ -115,6 +115,14 @@ const GithubPrCard = ({ session }: { session: Session }) => {
   const workspaceOverrides = useAppStore(
     (s) => s.workspaceOverrides?.[session.workspaceId] ?? null,
   );
+  const resolvedAgentConfig = useMemo(
+    () =>
+      taskModelAgentSpawnConfig({
+        preferences: workspaceOverrides?.taskModels,
+        defaultProviderId: session.providerPreference.defaultProvider,
+      }),
+    [workspaceOverrides?.taskModels, session.providerPreference.defaultProvider],
+  );
   const pr = github?.pr ?? null;
   const detail = github?.detail ?? null;
   const loading = github?.loading ?? false;
@@ -122,12 +130,15 @@ const GithubPrCard = ({ session }: { session: Session }) => {
 
   const [busy, setBusy] = useState<'draft' | 'ai' | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
-    taskModelAgentSpawnConfig({
-      preferences: workspaceOverrides?.taskModels,
-      defaultProviderId: session.providerPreference.defaultProvider,
-    }),
-  );
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(resolvedAgentConfig);
+  const [agentConfigUserTouched, setAgentConfigUserTouched] = useState(false);
+
+  useEffect(() => {
+    if (agentConfigUserTouched) {
+      return;
+    }
+    setAgentConfig(resolvedAgentConfig);
+  }, [agentConfigUserTouched, resolvedAgentConfig]);
 
   const openStudio = () =>
     window.dispatchEvent(new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }));
@@ -200,7 +211,10 @@ const GithubPrCard = ({ session }: { session: Session }) => {
         </div>
         <AgentSpawnConfig
           value={agentConfig}
-          onChange={setAgentConfig}
+          onChange={(value) => {
+            setAgentConfigUserTouched(true);
+            setAgentConfig(value);
+          }}
           disabled={busy !== null}
           className="w-full max-w-sm"
         />

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -21,7 +21,7 @@ import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { appendOperatorNotes } from '../../../utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
-import { DEFAULT_AGENT_SPAWN_CONFIG } from '../../AgentSpawnConfig/defaultAgentSpawnConfig';
+import { taskModelAgentSpawnConfig } from '../../AgentSpawnConfig/taskModelAgentSpawnConfig';
 import { useAppStore } from '../../../../../store';
 import { PaneShell } from './PaneShell';
 import { PrListRow } from './PrListRow';
@@ -112,6 +112,9 @@ const GithubPrCard = ({ session }: { session: Session }) => {
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const branch = useAppStore((s) => s.sessionBranches[sessionId] ?? null);
+  const workspaceOverrides = useAppStore(
+    (s) => s.workspaceOverrides?.[session.workspaceId] ?? null,
+  );
   const pr = github?.pr ?? null;
   const detail = github?.detail ?? null;
   const loading = github?.loading ?? false;
@@ -119,7 +122,12 @@ const GithubPrCard = ({ session }: { session: Session }) => {
 
   const [busy, setBusy] = useState<'draft' | 'ai' | null>(null);
   const [createError, setCreateError] = useState<string | null>(null);
-  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(DEFAULT_AGENT_SPAWN_CONFIG);
+  const [agentConfig, setAgentConfig] = useState<AgentSpawnConfigValue>(() =>
+    taskModelAgentSpawnConfig({
+      preferences: workspaceOverrides?.taskModels,
+      defaultProviderId: session.providerPreference.defaultProvider,
+    }),
+  );
 
   const openStudio = () =>
     window.dispatchEvent(new CustomEvent('goodboy:open-github-session', { detail: { sessionId } }));

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -23,6 +23,7 @@ const {
   storeState: {
     phaseTemplates: {} as Record<string, ReadonlyArray<Workflow>>,
     sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    workspaceOverrides: {},
     workflowDrafts: {} as Record<string, WorkflowBuilderDraft | undefined>,
   },
 }));
@@ -43,6 +44,7 @@ vi.mock('../../../../store', () => {
     attachWorkflowToSession: mockAttach,
     phaseTemplates: storeState.phaseTemplates,
     sessionPhaseRuns: storeState.sessionPhaseRuns,
+    workspaceOverrides: storeState.workspaceOverrides,
     workflowDrafts: storeState.workflowDrafts,
     setWorkflowDraft,
     clearWorkflowDraft,

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -29,6 +29,7 @@ import {
   polishStepInstruction,
   polishWorkflowGoal,
   recommendedModelForRole,
+  resolveTaskModel,
   runsForWorkflowRun,
 } from '@goodboy/core';
 import type {
@@ -165,6 +166,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const providers = useAppStore(
     (s) => s.providers ?? (EMPTY_ARRAY as ReadonlyArray<never>),
   ) as ReadonlyArray<ProviderEntry>;
+  const workspaceOverrides = useAppStore(
+    (s) => s.workspaceOverrides?.[session.workspaceId] ?? null,
+  );
   const setWorkflowDraft = useAppStore((s) => s.setWorkflowDraft);
   const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const sessionSlots = useSessionSlots(session.id);
@@ -489,7 +493,12 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     setBasePresetId(null);
     setPlanning(true);
     try {
-      const client = new PlannerClient({ providerId, invokeFn: invoke });
+      const taskModel = resolveTaskModel(
+        'plan_generation',
+        workspaceOverrides?.taskModels,
+        providerId,
+      );
+      const client = new PlannerClient({ ...taskModel, invokeFn: invoke });
       const result = await client.plan({ process });
       setPlan(result.output);
       setSteps(stepsFromPlan(result.output));

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.test.tsx
@@ -80,30 +80,11 @@ describe('WorkspaceScopePanel', () => {
   it('renders the one-page fields without a nav rail', () => {
     render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
     expect(screen.getByLabelText(/branch prefix/i)).toBeDefined();
-    expect(screen.getByText(/default provider/i)).toBeDefined();
+    expect(screen.queryByText(/default provider/i)).toBeNull();
     expect(screen.getByText(/parallel scouts/i)).toBeDefined();
     expect(screen.getByText('Linear')).toBeDefined();
     expect(screen.getByText('GitHub')).toBeDefined();
     expect(screen.queryByRole('button', { name: /^general$/i })).toBeNull();
-  });
-
-  it('falls back to the global default provider when no override is set', () => {
-    render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
-    expect(screen.getByRole('button', { name: /claude/i }).getAttribute('aria-pressed')).toBe(
-      'true',
-    );
-    expect(screen.queryByRole('button', { name: /inherit global/i })).toBeNull();
-  });
-
-  it('persists a provider pick from a brand chip', () => {
-    state.providers = [{ id: 'cursor', connection: 'connected' }];
-    render(<WorkspaceScopePanel workspaceId={'ws-1' as never} requestClose={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: /cursor/i }));
-    expect(state.setWorkspaceOverrides).toHaveBeenCalledOnce();
-    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
-      'ws-1',
-      expect.objectContaining({ defaultProviderId: 'cursor' }),
-    );
   });
 
   it('shows the disconnect action with inline confirm', () => {

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -4,17 +4,13 @@ import type {
   GhTokenStatus,
   GitlabIntegrationConfig,
   LinearIntegrationConfig,
-  ProviderId,
   SentryIntegrationConfig,
   VerbosityLevel,
   WorkspaceId,
   WorkspaceIntegration,
 } from '@goodboy/types';
-import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { Button, FieldRow, ScrollFade, cn } from '@goodboy/ui';
 import { Check, GitBranch, Unplug } from 'lucide-react';
-import { PROVIDER_LABEL } from '../../../../features/chat/utils/chat-constants';
-import { ProviderChip } from '../../../../features/providers/components/ProviderChip';
 import { SkillsPanel } from '../../../../features/skills/components/SkillsPanel';
 import { ScriptsPanel } from '../../../../features/scripts';
 import { VerbositySelect } from '../../../../features/session/components/VerbositySelect';
@@ -36,22 +32,12 @@ type Props = {
   readonly requestClose: () => void;
 };
 
-const WORKSPACE_PROVIDER_OPTIONS: ReadonlyArray<ProviderId> = [
-  'anthropic',
-  'cursor',
-  'codex',
-  'gemini',
-];
-
 export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose }: Props) => {
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
   const disconnect = useAppStore((s) => s.deleteWorkspace);
   const wsOverrides = useAppStore((s) => s.workspaceOverrides[workspaceId] ?? null);
   const storeSetWorkspaceOverrides = useAppStore((s) => s.setWorkspaceOverrides);
-  const connectedProviderIds = useAppStore(
-    useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
-  );
   const { showToast } = useToast();
 
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
@@ -64,8 +50,6 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
   const anchorsRef = useRef<Record<string, HTMLDivElement | null>>({});
 
   const verbosity = wsOverrides?.defaultVerbosity ?? 'normal';
-  const defaultProvider =
-    wsOverrides?.defaultProviderId ?? DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider;
   const scoutFanout = wsOverrides?.scoutFanout ?? false;
 
   useEffect(() => {
@@ -85,7 +69,6 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
 
   const persistOverrides = async (
     partial: Partial<{
-      defaultProviderId: ProviderId | null;
       defaultVerbosity: VerbosityLevel;
       scoutFanout: boolean;
     }>,
@@ -101,6 +84,7 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
         parallelEnabled: wsOverrides?.parallelEnabled ?? null,
         defaultVerbosity: verbosity,
         providerBindings: wsOverrides?.providerBindings ?? null,
+        taskModels: wsOverrides?.taskModels ?? null,
         scoutFanout,
         ...partial,
       });
@@ -185,30 +169,6 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
                 )}
               />
               <span className="font-mono text-sm text-muted-foreground/40">/&lt;slug&gt;</span>
-            </div>
-          </FieldRow>
-
-          <FieldRow label="Default provider" help="New sessions start on it and can override it.">
-            <div className="flex flex-wrap justify-end gap-1">
-              {WORKSPACE_PROVIDER_OPTIONS.map((id) => (
-                <ProviderChip
-                  key={id}
-                  id={id}
-                  selected={defaultProvider === id}
-                  disabled={busy || !connectedProviderIds.includes(id)}
-                  onClick={() =>
-                    void persistOverrides(
-                      { defaultProviderId: id },
-                      `default provider set to ${PROVIDER_LABEL[id] ?? id}`,
-                    )
-                  }
-                  trailing={
-                    connectedProviderIds.includes(id) ? null : (
-                      <span className="text-2xs uppercase tracking-wide text-warning">offline</span>
-                    )
-                  }
-                />
-              ))}
             </div>
           </FieldRow>
 

--- a/apps/desktop/src/store/slices/overrides/index.ts
+++ b/apps/desktop/src/store/slices/overrides/index.ts
@@ -8,7 +8,7 @@ import type { GetFn, SetFn } from './types';
 export const createOverridesSlice = (set: SetFn, get: GetFn) => {
   return {
     loadWorkspaceOverrides: loadWorkspaceOverrides(set),
-    setWorkspaceOverrides: setWorkspaceOverrides(set),
+    setWorkspaceOverrides: setWorkspaceOverrides(set, get),
     setWorkspaceProviderBinding: setWorkspaceProviderBinding(set, get),
     loadSessionOverrides: loadSessionOverrides(set),
     setTaskOverrides: setTaskOverrides(set),

--- a/apps/desktop/src/store/slices/overrides/setWorkspaceOverrides.ts
+++ b/apps/desktop/src/store/slices/overrides/setWorkspaceOverrides.ts
@@ -1,12 +1,30 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { OverrideSettings, WorkspaceId } from '@goodboy/types';
-import type { SetFn } from './types';
+import type { GetFn, SetFn } from './types';
 
-export const setWorkspaceOverrides = (set: SetFn) => {
+export const setWorkspaceOverrides = (set: SetFn, get: GetFn) => {
   return async (workspaceId: WorkspaceId, overrides: OverrideSettings) => {
-    await invoke('set_workspace_overrides', { workspaceId, overrides });
+    const previous = get().workspaceOverrides[workspaceId];
     set((state) => ({
       workspaceOverrides: { ...state.workspaceOverrides, [workspaceId]: overrides },
     }));
+    try {
+      await invoke('set_workspace_overrides', { workspaceId, overrides });
+    } catch (error) {
+      set((state) => {
+        if (state.workspaceOverrides[workspaceId] !== overrides) {
+          return {};
+        }
+        const workspaceOverrides = { ...state.workspaceOverrides };
+        if (previous == null) {
+          delete workspaceOverrides[workspaceId];
+        }
+        if (previous != null) {
+          workspaceOverrides[workspaceId] = previous;
+        }
+        return { workspaceOverrides };
+      });
+      throw error;
+    }
   };
 };

--- a/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
+++ b/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
@@ -9,6 +9,7 @@ const EMPTY_OVERRIDE: OverrideSettings = {
   parallelEnabled: null,
   defaultVerbosity: null,
   providerBindings: null,
+  taskModels: null,
   scoutFanout: null,
 };
 

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, Session, SessionId, WorkspaceId } from '@goodboy/types';
+import type { AppStore } from '../../../store';
+import type { GetFn, SetFn } from '../types';
+import { applyHeuristicTitle } from './index';
+
+const { invokeMock, renameSessionMock } = vi.hoisted(() => ({
+  invokeMock: vi.fn(),
+  renameSessionMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: invokeMock }));
+
+vi.mock('@goodboy/db', () => ({ renameSession: renameSessionMock }));
+
+vi.mock('../../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+type Harness = {
+  readonly get: GetFn;
+  readonly set: SetFn;
+  readonly read: () => AppStore;
+};
+
+const createHarness = (): Harness => {
+  const session = {
+    id: SESSION_ID,
+    workspaceId: WORKSPACE_ID,
+    goal: 'original goal',
+    titleUserEdited: false,
+    providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+  } as unknown as Session;
+  const agent = {
+    id: AGENT_ID,
+    sessionId: SESSION_ID,
+    ordinal: 0,
+    name: 'agent 1',
+    status: 'pending',
+  } satisfies Agent;
+  let state = {
+    sessions: [session],
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    workspaceOverrides: {},
+  } as unknown as AppStore;
+  const set: SetFn = (update) => {
+    const partial = typeof update === 'function' ? update(state) : update;
+    state = { ...state, ...partial };
+  };
+  const renameAgent: AppStore['renameAgent'] = async (sessionId, agentId, name) => {
+    state = {
+      ...state,
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((candidate) =>
+          candidate.id === agentId ? { ...candidate, name } : candidate,
+        ),
+      },
+    };
+  };
+  state = { ...state, renameAgent };
+  return { get: () => state, set, read: () => state };
+};
+
+describe('applyHeuristicTitle', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    renameSessionMock.mockClear();
+  });
+
+  it('replaces eligible heuristic titles with the generated title', async () => {
+    invokeMock.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'Implement secure authentication flow' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const harness = createHarness();
+
+    await applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Implement a secure authentication flow',
+    });
+
+    expect(harness.read().sessions[0]?.goal).toBe('Implement secure authentication flow');
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe(
+      'Implement secure authentication flow',
+    );
+    expect(renameSessionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps user titles changed while generation is in flight', async () => {
+    let resolveInvoke: (value: unknown) => void = () => undefined;
+    const invokeResult = new Promise((resolve) => {
+      resolveInvoke = resolve;
+    });
+    invokeMock.mockReturnValue(invokeResult);
+    const harness = createHarness();
+    const pending = applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Implement a secure authentication flow',
+    });
+    await vi.waitFor(() => expect(invokeMock).toHaveBeenCalledOnce());
+    harness.set((state) => ({
+      sessions: state.sessions.map((session) =>
+        session.id === SESSION_ID
+          ? { ...session, goal: 'User session title', titleUserEdited: true }
+          : session,
+      ),
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [SESSION_ID]: (state.sessionPhaseRuns[SESSION_ID] ?? []).map((agent) =>
+          agent.id === AGENT_ID ? { ...agent, name: 'User agent title' } : agent,
+        ),
+      },
+    }));
+    resolveInvoke({ stdout: 'Generated title', stderr: '', exitCode: 0 });
+    await pending;
+
+    expect(harness.read().sessions[0]?.goal).toBe('User session title');
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe('User agent title');
+  });
+
+  it('keeps heuristic titles when generation fails', async () => {
+    invokeMock.mockRejectedValue(new Error('offline'));
+    const harness = createHarness();
+
+    await applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Implement a secure authentication flow',
+    });
+
+    expect(harness.read().sessions[0]?.goal).toBe('implement secure authentication');
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe(
+      'implement secure authentication',
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
@@ -25,19 +25,27 @@ type Harness = {
   readonly read: () => AppStore;
 };
 
-const createHarness = (): Harness => {
+type HarnessParams = {
+  readonly agentName?: string;
+  readonly titleUserEdited?: boolean;
+};
+
+const createHarness = ({
+  agentName = 'agent 1',
+  titleUserEdited = false,
+}: HarnessParams = {}): Harness => {
   const session = {
     id: SESSION_ID,
     workspaceId: WORKSPACE_ID,
     goal: 'original goal',
-    titleUserEdited: false,
+    titleUserEdited,
     providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
   } as unknown as Session;
   const agent = {
     id: AGENT_ID,
     sessionId: SESSION_ID,
     ordinal: 0,
-    name: 'agent 1',
+    name: agentName,
     status: 'pending',
   } satisfies Agent;
   let state = {
@@ -141,5 +149,50 @@ describe('applyHeuristicTitle', () => {
     expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe(
       'implement secure authentication',
     );
+  });
+
+  it('skips rename when the agent name is not a placeholder', async () => {
+    const harness = createHarness({
+      agentName: 'Existing agent title',
+      titleUserEdited: true,
+    });
+
+    await applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Implement a secure authentication flow',
+    });
+
+    expect(harness.read().sessions[0]?.goal).toBe('original goal');
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe('Existing agent title');
+    expect(invokeMock).not.toHaveBeenCalled();
+    expect(renameSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps heuristic titles when generation times out', async () => {
+    vi.useFakeTimers();
+    invokeMock.mockReturnValue(new Promise(() => undefined));
+    const harness = createHarness();
+
+    try {
+      const pending = applyHeuristicTitle({
+        ...harness,
+        sessionId: SESSION_ID,
+        agentId: AGENT_ID,
+        prompt: 'Implement a secure authentication flow',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(invokeMock).toHaveBeenCalledOnce();
+      await vi.advanceTimersByTimeAsync(15_000);
+      await expect(pending).resolves.toBeUndefined();
+
+      expect(harness.read().sessions[0]?.goal).toBe('implement secure authentication');
+      expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe(
+        'implement secure authentication',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
@@ -1,0 +1,157 @@
+import { invoke } from '@tauri-apps/api/core';
+import { getDefaultBinary, resolveTaskModel } from '@goodboy/core';
+import { renameSession as renameSessionInDb } from '@goodboy/db';
+import type { AgentId, IsoDateTime, SessionId, TaskModelPreference } from '@goodboy/types';
+import { heuristicAgentTitle } from '../../../../shared/lib/agent-title-heuristic';
+import { tauriDatabase } from '../../../../shared/lib/db';
+import type { GetFn, SetFn } from '../types';
+
+const TITLE_TIMEOUT_MS = 15_000;
+
+const TITLE_SYSTEM_PROMPT =
+  'Write a concise imperative title for the user request. Use at most 6 words and the same language as the request. Return plain text only with no quotes or punctuation wrapping.';
+
+type Params = {
+  readonly set: SetFn;
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly prompt: string;
+};
+
+type InvokeResult = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number | null;
+};
+
+type GenerateParams = TaskModelPreference &
+  Readonly<{
+    prompt: string;
+  }>;
+
+const parseTitle = ({ stdout }: InvokeResult): string => {
+  const raw = stdout.trim();
+  let text = raw;
+  try {
+    const parsed = JSON.parse(raw) as { result?: unknown };
+    if (typeof parsed.result === 'string') {
+      text = parsed.result;
+    }
+  } catch {
+    text = raw;
+  }
+  return text.trim().split(/\s+/).slice(0, 6).join(' ');
+};
+
+const generateAgentTitle = async ({
+  prompt,
+  providerId,
+  model,
+}: GenerateParams): Promise<string> => {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(
+      () => reject(new Error('agent title generation timed out')),
+      TITLE_TIMEOUT_MS,
+    );
+  });
+  try {
+    const result = await Promise.race([
+      invoke<InvokeResult>('summarize_session', {
+        args: {
+          providerId,
+          model,
+          binary: getDefaultBinary(providerId),
+          userMessage: prompt,
+          systemPrompt: TITLE_SYSTEM_PROMPT,
+        },
+      }),
+      timeout,
+    ]);
+    if ((result.exitCode ?? 0) !== 0) {
+      throw new Error(result.stderr);
+    }
+    return parseTitle(result);
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+  }
+};
+
+export const applyHeuristicTitle = async ({
+  set,
+  get,
+  sessionId,
+  agentId,
+  prompt,
+}: Params): Promise<void> => {
+  try {
+    const heuristicTitle = heuristicAgentTitle(prompt);
+    if (heuristicTitle == null) {
+      return;
+    }
+
+    const session = get().sessions.find((candidate) => candidate.id === sessionId);
+    if (session == null) {
+      return;
+    }
+
+    const agent = (get().sessionPhaseRuns[sessionId] ?? []).find(
+      (candidate) => candidate.id === agentId,
+    );
+    const canRenameAgent = agent != null && /^(agent|puppy) \d+$/i.test(agent.name);
+    const isFoundingAgent = agent?.ordinal === 0;
+    const canRenameSession = isFoundingAgent && !session.titleUserEdited;
+    const titleNow = new Date().toISOString() as IsoDateTime;
+
+    if (canRenameSession) {
+      set((state) => ({
+        sessions: state.sessions.map((candidate) =>
+          candidate.id === sessionId ? { ...candidate, goal: heuristicTitle } : candidate,
+        ),
+      }));
+      await renameSessionInDb(tauriDatabase, sessionId, heuristicTitle, titleNow, false);
+    }
+    if (canRenameAgent) {
+      await get().renameAgent(sessionId, agentId, heuristicTitle);
+    }
+    if (!canRenameSession && !canRenameAgent) {
+      return;
+    }
+
+    const taskModel = resolveTaskModel(
+      'agent_naming',
+      get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+      session.providerPreference.defaultProvider,
+    );
+    const generatedTitle = await generateAgentTitle({ prompt, ...taskModel });
+    if (generatedTitle.length === 0) {
+      return;
+    }
+
+    const currentSession = get().sessions.find((candidate) => candidate.id === sessionId);
+    const currentAgent = (get().sessionPhaseRuns[sessionId] ?? []).find(
+      (candidate) => candidate.id === agentId,
+    );
+    const shouldRenameSession =
+      canRenameSession &&
+      currentSession?.titleUserEdited === false &&
+      currentSession.goal === heuristicTitle;
+    const shouldRenameAgent = canRenameAgent && currentAgent?.name === heuristicTitle;
+    const generatedAt = new Date().toISOString() as IsoDateTime;
+
+    if (shouldRenameSession) {
+      set((state) => ({
+        sessions: state.sessions.map((candidate) =>
+          candidate.id === sessionId ? { ...candidate, goal: generatedTitle } : candidate,
+        ),
+      }));
+      await renameSessionInDb(tauriDatabase, sessionId, generatedTitle, generatedAt, false);
+    }
+    if (shouldRenameAgent) {
+      await get().renameAgent(sessionId, agentId, generatedTitle);
+    }
+  } catch {}
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -62,13 +62,13 @@ import { detectParallelGroup } from '../../parallel-turn';
 import { buildContextPreamble, buildPriorTurnsBlock, getModelContextWindow } from '../../preamble';
 import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import {
-  applyHeuristicTitle,
   buildGoalAttachmentsBlock,
   capturePlanFromTurn,
   emitTurnNudges,
   enqueueSummarizer,
   toRelPath,
 } from '../../turn-helpers';
+import { applyHeuristicTitle } from './applyHeuristicTitle';
 import { clusterBoundaryMarker, composeClusterBoundary } from '../workflows/clusterImplementation';
 import { completeResolvedAgent } from './completeResolvedAgent';
 import { resolvePhaseAgent } from './resolvePhaseAgent';
@@ -665,7 +665,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     }
 
     if (isFirstTurn && !agentRowEarly?.parentAgentId) {
-      void applyHeuristicTitle(set, get, sessionId, activeAgentId, content);
+      void applyHeuristicTitle({ set, get, sessionId, agentId: activeAgentId, prompt: content });
     }
 
     const rawEffort = phaseDefinition?.effort ?? get().agentEffortOverride[activeAgentId] ?? null;

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -122,6 +122,7 @@ describe('finalizeWorkflowStep output summary', () => {
 
     expect(summarizeStepOutputSpy).toHaveBeenCalledWith({
       providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
       invokeFn: expect.any(Function),
       output: 'raw assistant output',
     });

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -1,5 +1,10 @@
 import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
-import { extractMarkers, extractStepDone, fallbackStepOutputSummary } from '@goodboy/core';
+import {
+  extractMarkers,
+  extractStepDone,
+  fallbackStepOutputSummary,
+  resolveTaskModel,
+} from '@goodboy/core';
 import { updateSessionWorkflowStep } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
@@ -90,7 +95,11 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
         ? fallbackStepOutputSummary({ output: assistantText })
         : await summarizeAgentOutput({
             output: assistantText,
-            providerId: session.providerPreference.defaultProvider,
+            taskModel: resolveTaskModel(
+              'summarizer',
+              get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+              session.providerPreference.defaultProvider,
+            ),
           });
     await invokeAgentUpdateStatus(agentId, {
       status: 'completed',

--- a/apps/desktop/src/store/summarizeAgentOutput.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.ts
@@ -1,16 +1,16 @@
 import { invoke } from '@tauri-apps/api/core';
 import { fallbackStepOutputSummary, summarizeStepOutput } from '@goodboy/core';
-import type { ProviderId } from '@goodboy/types';
+import type { TaskModelPreference } from '@goodboy/types';
 import { formatError } from '../shared/lib/errors';
 
 const SUMMARY_TIMEOUT_MS = 15_000;
 
 type Params = {
   readonly output: string;
-  readonly providerId: ProviderId;
+  readonly taskModel: TaskModelPreference;
 };
 
-export const summarizeAgentOutput = async ({ output, providerId }: Params): Promise<string> => {
+export const summarizeAgentOutput = async ({ output, taskModel }: Params): Promise<string> => {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeout = new Promise<never>((_resolve, reject) => {
     timeoutId = setTimeout(
@@ -21,7 +21,7 @@ export const summarizeAgentOutput = async ({ output, providerId }: Params): Prom
 
   try {
     return await Promise.race([
-      summarizeStepOutput({ providerId, invokeFn: invoke, output }),
+      summarizeStepOutput({ ...taskModel, invokeFn: invoke, output }),
       timeout,
     ]);
   } catch (error) {

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -16,7 +16,6 @@ import {
   listContextSlotHistory,
   listContextSlotsForSession,
   listTelemetryForSession,
-  renameSession as renameSessionInDb,
   summarizeSessionTelemetry,
   summarizeWorkspaceProviderTelemetry,
   summarizeWorkspaceTelemetry,
@@ -47,7 +46,6 @@ import {
   listPlansForSession as invokeListPlansForSession,
   upsertPlan as invokeUpsertPlan,
 } from '../features/plans/plans';
-import { heuristicAgentTitle } from '../shared/lib/agent-title-heuristic';
 import { formatError } from '../shared/lib/errors';
 import { buildProviderSpendBreakdown } from './slices/budget';
 import type { SessionNudge } from './types';
@@ -515,42 +513,5 @@ export const emitTurnNudges = async (
     set((state) => ({
       sessionNudges: { ...state.sessionNudges, [sessionId]: nextNudge },
     }));
-  }
-};
-
-export const applyHeuristicTitle = async (
-  set: SetFn,
-  get: GetFn,
-  sessionId: SessionId,
-  agentId: AgentId,
-  prompt: string,
-): Promise<void> => {
-  try {
-    const title = heuristicAgentTitle(prompt);
-    if (!title) {
-      return;
-    }
-
-    const session = get().sessions.find((s) => s.id === sessionId);
-    if (!session) {
-      return;
-    }
-
-    const agentRecord = (get().sessionPhaseRuns[sessionId] ?? []).find((r) => r.id === agentId);
-    const agentNameEditable = agentRecord ? /^(agent|puppy) \d+$/i.test(agentRecord.name) : false;
-    const isFoundingAgent = agentRecord?.ordinal === 0;
-
-    const titleNow = new Date().toISOString() as IsoDateTime;
-    if (isFoundingAgent && !session.titleUserEdited) {
-      set((state) => ({
-        sessions: state.sessions.map((s) => (s.id === sessionId ? { ...s, goal: title } : s)),
-      }));
-      await renameSessionInDb(tauriDatabase, sessionId, title, titleNow, false);
-    }
-    if (agentNameEditable) {
-      await get().renameAgent(sessionId, agentId, title);
-    }
-  } catch {
-    // best-effort
   }
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -94,6 +94,10 @@ export {
 
 export { resolveModelForProvider } from './providers/model-map';
 
+export { resolveTaskModel } from './providers/task-models';
+
+export { getDefaultBinary } from './providers/cli-defaults';
+
 export { getModelDescriptor, getModelProvider } from './providers/model-display';
 
 export { assessTurnWeight, type TurnWeight } from './providers/turn-weight';

--- a/packages/core/src/planner/client.ts
+++ b/packages/core/src/planner/client.ts
@@ -1,6 +1,5 @@
 import type { ProviderId } from '@goodboy/types';
 import { computeCostUsd } from '../providers/claude/cost';
-import { PROVIDER_CAPABILITIES } from '../providers/capabilities';
 import { parsePlannerOutput } from './parser';
 import { PLANNER_SYSTEM_PROMPT, buildPlannerUserPrompt } from './prompt';
 import type { PlannerInput, PlannerOutput } from './types';
@@ -22,6 +21,7 @@ type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
 
 export type PlannerClientDeps = {
   readonly providerId: ProviderId;
+  readonly model: string;
   readonly binary?: string;
   readonly invokeFn: InvokeFn;
 };
@@ -60,7 +60,7 @@ export class PlannerClient {
   constructor(deps: PlannerClientDeps) {
     this.providerId = deps.providerId;
     this.binary = deps.binary ?? defaultBinary(deps.providerId);
-    this.model = cheapModel(deps.providerId);
+    this.model = deps.model;
     this.invokeFn = deps.invokeFn;
   }
 
@@ -91,11 +91,6 @@ export class PlannerClient {
     }
     return { text: stdout.trim(), usage: zeroUsage() };
   }
-}
-
-function cheapModel(providerId: ProviderId): string {
-  const caps = PROVIDER_CAPABILITIES[providerId];
-  return caps.models.find((m) => m.tier === 'cheap')?.id ?? caps.models[0]!.id;
 }
 
 function defaultBinary(providerId: ProviderId): string {

--- a/packages/core/src/planner/client.ts
+++ b/packages/core/src/planner/client.ts
@@ -1,5 +1,6 @@
 import type { ProviderId } from '@goodboy/types';
 import { computeCostUsd } from '../providers/claude/cost';
+import { getDefaultBinary } from '../providers/cli-defaults';
 import { parsePlannerOutput } from './parser';
 import { PLANNER_SYSTEM_PROMPT, buildPlannerUserPrompt } from './prompt';
 import type { PlannerInput, PlannerOutput } from './types';
@@ -59,7 +60,7 @@ export class PlannerClient {
 
   constructor(deps: PlannerClientDeps) {
     this.providerId = deps.providerId;
-    this.binary = deps.binary ?? defaultBinary(deps.providerId);
+    this.binary = deps.binary ?? getDefaultBinary(deps.providerId);
     this.model = deps.model;
     this.invokeFn = deps.invokeFn;
   }
@@ -90,23 +91,6 @@ export class PlannerClient {
       return extractClaudeJsonOutput(stdout, this.model);
     }
     return { text: stdout.trim(), usage: zeroUsage() };
-  }
-}
-
-function defaultBinary(providerId: ProviderId): string {
-  switch (providerId) {
-    case 'anthropic':
-      return 'claude';
-    case 'cursor':
-      return 'cursor-agent';
-    case 'codex':
-      return 'codex';
-    case 'gemini':
-      return 'agy';
-    default: {
-      const _exhaustive: never = providerId;
-      throw new Error(`unknown provider: ${_exhaustive}`);
-    }
   }
 }
 

--- a/packages/core/src/providers/task-models.test.ts
+++ b/packages/core/src/providers/task-models.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskModelPreferences } from '@goodboy/types';
+import { resolveTaskModel } from './task-models';
+
+describe('resolveTaskModel', () => {
+  it('returns a valid stored preference', () => {
+    const prefs: TaskModelPreferences = {
+      summarizer: { providerId: 'anthropic', model: 'claude-haiku-4-5' },
+    };
+
+    expect(resolveTaskModel('summarizer', prefs, 'codex')).toEqual({
+      providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
+    });
+  });
+
+  it('uses the default provider cheap model when no preference exists', () => {
+    expect(resolveTaskModel('branch_naming', null, 'anthropic')).toEqual({
+      providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
+    });
+  });
+
+  it('falls back when the stored model does not belong to its provider', () => {
+    const prefs: TaskModelPreferences = {
+      plan_generation: {
+        providerId: 'anthropic',
+        model: 'not-a-model',
+      },
+    };
+
+    expect(resolveTaskModel('plan_generation', prefs, 'anthropic')).toEqual({
+      providerId: 'anthropic',
+      model: 'claude-haiku-4-5',
+    });
+  });
+});

--- a/packages/core/src/providers/task-models.ts
+++ b/packages/core/src/providers/task-models.ts
@@ -1,0 +1,28 @@
+import type {
+  AuxTaskId,
+  ProviderId,
+  TaskModelPreference,
+  TaskModelPreferences,
+} from '@goodboy/types';
+import { PROVIDER_CAPABILITIES } from './capabilities';
+import { getCheapModel } from './cli-defaults';
+
+export const resolveTaskModel = (
+  task: AuxTaskId,
+  prefs: TaskModelPreferences | null | undefined,
+  defaultProviderId: ProviderId,
+): TaskModelPreference => {
+  const preference = prefs?.[task];
+  const isValid =
+    preference != null &&
+    PROVIDER_CAPABILITIES[preference.providerId]?.models.some(
+      (model) => model.id === preference.model,
+    );
+  if (isValid) {
+    return preference;
+  }
+  return {
+    providerId: defaultProviderId,
+    model: getCheapModel(defaultProviderId),
+  };
+};

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -19,6 +19,7 @@ const NULL_OVERRIDE: OverrideSettings = {
   parallelEnabled: null,
   defaultVerbosity: null,
   providerBindings: null,
+  taskModels: null,
   scoutFanout: null,
 };
 
@@ -39,6 +40,7 @@ describe('resolveSettings', () => {
       parallelEnabled: true,
       defaultVerbosity: 'verbose',
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({ global: GLOBAL, workspaceOverride: wsOverride });
@@ -57,6 +59,7 @@ describe('resolveSettings', () => {
       parallelEnabled: true,
       defaultVerbosity: null,
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({ global: GLOBAL, sessionOverride: sessOverride });
@@ -75,6 +78,7 @@ describe('resolveSettings', () => {
       parallelEnabled: false,
       defaultVerbosity: 'verbose',
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const sessOverride: OverrideSettings = {
@@ -84,6 +88,7 @@ describe('resolveSettings', () => {
       parallelEnabled: true,
       defaultVerbosity: null,
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({
@@ -106,6 +111,7 @@ describe('resolveSettings', () => {
       parallelEnabled: true,
       defaultVerbosity: 'verbose',
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const sessOverride: OverrideSettings = {
@@ -115,6 +121,7 @@ describe('resolveSettings', () => {
       parallelEnabled: null,
       defaultVerbosity: null,
       providerBindings: null,
+      taskModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({

--- a/packages/core/src/summarizer/step-output.test.ts
+++ b/packages/core/src/summarizer/step-output.test.ts
@@ -20,7 +20,12 @@ describe('summarizeStepOutput', () => {
       return { stdout: 'Implemented auth flow.\n- `src/auth.ts`', stderr: '', exitCode: 0 } as T;
     };
 
-    const result = await summarizeStepOutput({ providerId: 'cursor', invokeFn, output: 'raw' });
+    const result = await summarizeStepOutput({
+      providerId: 'cursor',
+      model: 'composer-2-fast',
+      invokeFn,
+      output: 'raw',
+    });
     const args = request?.['args'];
     const systemPrompt =
       typeof args === 'object' && args !== null && 'systemPrompt' in args
@@ -43,7 +48,12 @@ describe('summarizeStepOutput', () => {
     };
 
     await expect(
-      summarizeStepOutput({ providerId: 'anthropic', invokeFn, output: 'raw review' }),
+      summarizeStepOutput({
+        providerId: 'anthropic',
+        model: 'claude-haiku-4-5',
+        invokeFn,
+        output: 'raw review',
+      }),
     ).resolves.toBe('Review passed.\n- No blockers');
   });
 
@@ -53,7 +63,12 @@ describe('summarizeStepOutput', () => {
     };
 
     await expect(
-      summarizeStepOutput({ providerId: 'cursor', invokeFn, output: 'raw' }),
+      summarizeStepOutput({
+        providerId: 'cursor',
+        model: 'composer-2-fast',
+        invokeFn,
+        output: 'raw',
+      }),
     ).rejects.toBeInstanceOf(SummarizerParseError);
   });
 });

--- a/packages/core/src/summarizer/step-output.ts
+++ b/packages/core/src/summarizer/step-output.ts
@@ -1,4 +1,4 @@
-import { getCheapModel, getDefaultBinary } from '../providers/cli-defaults';
+import { getDefaultBinary } from '../providers/cli-defaults';
 import { SummarizerParseError, SummarizerSpawnError, type SummarizerDeps } from './client';
 
 const MAX_SUMMARY_LENGTH = 1200;
@@ -24,6 +24,10 @@ type Params = {
   readonly output: string;
 };
 
+type SummarizeParams = Params & {
+  readonly model: string;
+};
+
 type FallbackDetection = {
   readonly summary: string;
 };
@@ -39,11 +43,12 @@ export const summarizeStepOutput = async ({
   binary,
   invokeFn,
   output,
-}: Params & SummarizerDeps): Promise<string> => {
+  model,
+}: SummarizeParams & SummarizerDeps): Promise<string> => {
   const result = await invokeFn<OneShotResult>('summarize_session', {
     args: {
       providerId,
-      model: getCheapModel(providerId),
+      model,
       binary: binary ?? getDefaultBinary(providerId),
       userMessage: output,
       systemPrompt: STEP_OUTPUT_SYSTEM_PROMPT,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -69,6 +69,7 @@ import { m068ProviderRunsGeminiRepair } from './m068-provider-runs-gemini-repair
 import { m069RefactorExampleOnly } from './m069-refactor-example-only';
 import { m070StepLibraryExampleOnly } from './m070-step-library-example-only';
 import { m071SessionExternalTaskMultipleLinks } from './m071-session-external-task-multiple-links';
+import { m072TaskModels } from './m072-task-models';
 
 export type Migration = {
   readonly version: number;
@@ -147,4 +148,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 69, sql: m069RefactorExampleOnly },
   { version: 70, sql: m070StepLibraryExampleOnly },
   { version: 71, sql: m071SessionExternalTaskMultipleLinks },
+  { version: 72, sql: m072TaskModels },
 ];

--- a/packages/db/src/migrations/m072-task-models.ts
+++ b/packages/db/src/migrations/m072-task-models.ts
@@ -1,0 +1,3 @@
+export const m072TaskModels = `
+ALTER TABLE workspaces ADD COLUMN task_models TEXT;
+`;

--- a/packages/db/src/queries/settings-overrides.ts
+++ b/packages/db/src/queries/settings-overrides.ts
@@ -3,6 +3,7 @@ import type {
   ProviderBindings,
   ProviderId,
   SessionId,
+  TaskModelPreferences,
   VerbosityLevel,
   WorkflowId,
   WorkspaceId,
@@ -16,6 +17,7 @@ type WorkspaceOverrideRow = {
   parallel_enabled: number | null;
   default_verbosity: string | null;
   provider_bindings: string | null;
+  task_models: string | null;
   scout_fanout: number | null;
 };
 
@@ -42,6 +44,21 @@ function serializeBindings(bindings: ProviderBindings | null): string | null {
   return bindings && Object.keys(bindings).length > 0 ? JSON.stringify(bindings) : null;
 }
 
+function parseTaskModels(raw: string | null): TaskModelPreferences | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as TaskModelPreferences;
+  } catch {
+    return null;
+  }
+}
+
+function serializeTaskModels(taskModels: TaskModelPreferences | null): string | null {
+  return taskModels && Object.keys(taskModels).length > 0 ? JSON.stringify(taskModels) : null;
+}
+
 function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
   return {
     defaultProviderId: row.default_provider_id as ProviderId | null,
@@ -50,6 +67,7 @@ function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
     parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
     defaultVerbosity: row.default_verbosity as VerbosityLevel | null,
     providerBindings: parseBindings(row.provider_bindings),
+    taskModels: parseTaskModels(row.task_models),
     scoutFanout: row.scout_fanout === null ? null : row.scout_fanout !== 0,
   };
 }
@@ -62,6 +80,7 @@ function sessionRowToOverride(row: SessionOverrideRow): OverrideSettings {
     parallelEnabled: row.parallel_enabled === null ? null : row.parallel_enabled !== 0,
     defaultVerbosity: null,
     providerBindings: parseBindings(row.provider_bindings),
+    taskModels: null,
     scoutFanout: null,
   };
 }
@@ -71,7 +90,7 @@ export const getWorkspaceOverrides = async (
   workspaceId: WorkspaceId,
 ): Promise<OverrideSettings | null> => {
   const rows = await db.select<WorkspaceOverrideRow>(
-    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, scout_fanout
+    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, task_models, scout_fanout
      FROM workspaces WHERE id = ?`,
     [workspaceId],
   );
@@ -92,6 +111,7 @@ export const setWorkspaceOverrides = async (
          parallel_enabled = ?,
          default_verbosity = ?,
          provider_bindings = ?,
+         task_models = ?,
          scout_fanout = ?,
          updated_at = ?
      WHERE id = ?`,
@@ -102,6 +122,7 @@ export const setWorkspaceOverrides = async (
       overrides.parallelEnabled === null ? null : overrides.parallelEnabled ? 1 : 0,
       overrides.defaultVerbosity,
       serializeBindings(overrides.providerBindings),
+      serializeTaskModels(overrides.taskModels),
       overrides.scoutFanout === null ? null : overrides.scoutFanout ? 1 : 0,
       Date.now(),
       workspaceId,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -112,11 +112,14 @@ export type {
   Workflow,
 } from './workflow';
 export type {
+  AuxTaskId,
   GlobalSettings,
   OverrideSettings,
   ProviderBindings,
   ResolvedSettings,
   SettingsScope,
+  TaskModelPreference,
+  TaskModelPreferences,
   VerbosityLevel,
 } from './settings';
 export type { BranchCommit, DiffView, WorktreeDiffScope, WorktreeStatus } from './worktree';

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -5,6 +5,20 @@ export type VerbosityLevel = 'brief' | 'normal' | 'verbose';
 
 export type ProviderBindings = Partial<Record<ProviderId, string>>;
 
+export type AuxTaskId =
+  | 'summarizer'
+  | 'branch_naming'
+  | 'plan_generation'
+  | 'agent_naming'
+  | 'pr_draft';
+
+export type TaskModelPreference = Readonly<{
+  providerId: ProviderId;
+  model: string;
+}>;
+
+export type TaskModelPreferences = Readonly<Partial<Record<AuxTaskId, TaskModelPreference>>>;
+
 export type OverrideSettings = Readonly<{
   defaultProviderId: ProviderId | null;
   defaultWorkflowId: WorkflowId | null;
@@ -12,6 +26,7 @@ export type OverrideSettings = Readonly<{
   parallelEnabled: boolean | null;
   defaultVerbosity: VerbosityLevel | null;
   providerBindings: ProviderBindings | null;
+  taskModels: TaskModelPreferences | null;
   scoutFanout: boolean | null;
 }>;
 


### PR DESCRIPTION
## What

Users can now choose which provider/model runs each minor AI operation, from a single configuration dashboard inside Provider Studio.

- **Task model preferences** (`OverrideSettings.taskModels`, migration m072): per-workspace `provider+model` pin (or Auto) for `summarizer`, `branch_naming`, `plan_generation`, `agent_naming`, `pr_draft`.
- **Single resolver** `resolveTaskModel` in core, wired into every call site: step-output summarizer, branch slug generation, planner, PR/MR draft agent defaults. Deleted the planner's duplicate `cheapModel`.
- **AI agent titles**: agents named `agent N` get an immediate heuristic placeholder, then an AI-generated title via the `agent_naming` task model (silent fallback on error/timeout, user-edited names never touched).
- **Provider Studio → Defaults panel**: default provider chips (offline disabled), task model rows with Auto showing the resolved model. Provider config removed from Settings (single home now).

## Verification

- Typecheck green, full suite green: core 809, desktop 2288, db 83, ui 12.
- Adversarial review vs spec: 9/9 requirements verified; review fixes applied (late-overrides sync in PR/MR pickers, Auto semantics on provider change, dedup getDefaultBinary/provider order).

Area A of 5 (task models → agents/resolve UX → github/gitlab work mgmt → linear/sentry dashboards → docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)