### PR TITLE
feat: contextual workflow header + agents/resolve status counts

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -26,6 +26,12 @@ type Store = {
   reconcileSessionBranch: ReturnType<typeof vi.fn>;
 };
 
+type PaneShellMockProps = {
+  readonly title: string;
+  readonly meta?: React.ReactNode;
+  readonly children: React.ReactNode;
+};
+
 const { store, hooks } = vi.hoisted(() => ({
   store: {
     activeLens: {},
@@ -107,7 +113,13 @@ vi.mock('./parts/SlotPane', () => ({ SlotPane: () => null }));
 vi.mock('./parts/PrPane', () => ({ PrPane: () => null }));
 vi.mock('./parts/FilesPane', () => ({ FilesPane: () => null }));
 vi.mock('./parts/PaneShell', () => ({
-  PaneShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PaneShell: ({ title, meta, children }: PaneShellMockProps) => (
+    <div>
+      <h1>{title}</h1>
+      {meta ? <span data-testid={`pane-meta-${title.toLowerCase()}`}>{meta}</span> : null}
+      {children}
+    </div>
+  ),
 }));
 vi.mock('./hooks/useSelectedAgentHome', () => ({
   useSelectedAgentHome: () => hooks.agentHome,
@@ -199,6 +211,47 @@ describe('SessionWorkspace agent overlay', () => {
     );
   });
 
+  it('shows linked workflow context outside the workflows lens and focuses its run', () => {
+    const linkedAgent = {
+      ...selectedAgent,
+      stepId: undefined,
+      workflowRunId: 'run-1',
+    } as Agent;
+    store.selectedAgentId = { [SESSION_ID]: linkedAgent.id };
+    store.sessionPhaseRuns = { [SESSION_ID]: [linkedAgent] };
+    store.phaseTemplates = {
+      'workspace-1': [
+        {
+          id: 'workflow-1',
+          name: 'Release flow',
+          steps: [],
+        },
+      ],
+    };
+    hooks.agentHome = 'agents';
+    const workflowSession = {
+      ...session,
+      workflowRuns: [
+        {
+          id: 'run-1',
+          workflowId: 'workflow-1',
+          ordinal: 0,
+          currentStep: 0,
+          autoRun: true,
+          triggerMode: 'immediate',
+        },
+      ],
+    } as unknown as Session;
+
+    render(<SessionWorkspace session={workflowSession} isActive />);
+
+    expect(screen.queryByTestId('workflow-stepper')).toBeNull();
+    expect(screen.getByText('Part of').textContent).toBe('Part of Release flow');
+    fireEvent.click(screen.getByRole('button', { name: 'Release flow' }));
+    expect(store.setFocusedWorkflowRun).toHaveBeenCalledWith(SESSION_ID, 'run-1');
+    expect(store.setActiveLens).toHaveBeenCalledWith(SESSION_ID, 'workflows');
+  });
+
   it('shows the force resolve action in a markerless resolver header', () => {
     const standaloneResolver = {
       ...selectedAgent,
@@ -237,6 +290,88 @@ describe('SessionWorkspace agent overlay', () => {
         .getAllByTestId('divider')
         .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
     ).toHaveLength(2);
+  });
+});
+
+describe('SessionWorkspace pane metadata', () => {
+  it('summarizes standalone agent statuses', () => {
+    store.activeLens = { [SESSION_ID]: 'agents' };
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        { ...selectedAgent, stepId: undefined, workflowRunId: undefined },
+        {
+          ...selectedAgent,
+          id: 'agent-2',
+          name: 'Done agent',
+          status: 'completed',
+          stepId: undefined,
+          workflowRunId: undefined,
+        } as Agent,
+        {
+          ...selectedAgent,
+          id: 'agent-3',
+          name: 'Failed agent',
+          status: 'failed',
+          stepId: undefined,
+          workflowRunId: undefined,
+        } as Agent,
+      ],
+    };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('pane-meta-agents').textContent).toBe('1 running, 1 done, 1 failed');
+  });
+
+  it('summarizes queued and resolved resolver statuses', () => {
+    store.activeLens = { [SESSION_ID]: 'resolve' };
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        {
+          ...selectedAgent,
+          id: 'resolver-queued',
+          name: 'Queued resolver',
+          kind: 'resolver',
+          status: 'pending',
+          stepId: undefined,
+          workflowRunId: undefined,
+          sourceThreadId: 'thread-queued',
+        } as Agent,
+        {
+          ...selectedAgent,
+          id: 'resolver-resolved',
+          name: 'Resolved resolver',
+          kind: 'resolver',
+          status: 'completed',
+          stepId: undefined,
+          workflowRunId: undefined,
+          sourceThreadId: 'thread-resolved',
+        } as Agent,
+      ],
+    };
+    store.sessionGithub = {
+      [SESSION_ID]: {
+        detail: {
+          comments: [{ threadId: 'thread-resolved', resolved: true }],
+        },
+      },
+    };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('pane-meta-resolve').textContent).toBe('1 queued, 1 resolved');
+  });
+
+  it('hides metadata when all displayed counts are zero', () => {
+    store.activeLens = { [SESSION_ID]: 'agents' };
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [] };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.queryByTestId('pane-meta-agents')).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -33,11 +33,12 @@ import { ChatWorkflowHeader } from './parts/ChatWorkflowHeader';
 import { WorkflowsPane } from './parts/WorkflowsPane';
 import { IntegrationPane } from './parts/IntegrationPane';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
-import { resolveRootAgent } from '../../agent-kind';
+import { isStandaloneAgent, resolveRootAgent } from '../../agent-kind';
 import { ForceResolveAction } from '../ForceResolveAction';
 import { canForceResolve } from '../ForceResolveAction/canForceResolve';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
 import { SessionOverviewSkeleton } from './parts/SessionOverviewSkeleton';
+import { ChatWorkflowContext } from './parts/ChatWorkflowContext';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
@@ -124,10 +125,53 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     () => phaseRuns.find((agent) => agent.id === selectedAgentId) ?? null,
     [phaseRuns, selectedAgentId],
   );
+  const selectedRootAgent = useMemo(() => {
+    if (selectedAgentId == null) {
+      return null;
+    }
+    return resolveRootAgent({ agents: phaseRuns, agentId: selectedAgentId });
+  }, [phaseRuns, selectedAgentId]);
   const selectedAgentName = selectedAgent?.name ?? (selectedAgentId != null ? 'Agent' : null);
-  const showWorkflowStrip = showAgentOverlay && selectedAgent?.workflowRunId != null;
+  const selectedWorkflowRunId = selectedRootAgent?.workflowRunId ?? null;
+  const showWorkflowStrip =
+    showAgentOverlay && overlayHome === 'workflows' && selectedWorkflowRunId != null;
   const selectedThreadId = selectedAgent?.sourceThreadId ?? null;
   const resolverIndex = useResolverIndex(sessionId);
+  const resolverAgentIds = useMemo(
+    () => new Set(resolverIndex.links.map(({ agent }) => agent.id)),
+    [resolverIndex],
+  );
+  const standaloneAgents = useMemo(
+    () => phaseRuns.filter((agent) => isStandaloneAgent(agent) && !resolverAgentIds.has(agent.id)),
+    [phaseRuns, resolverAgentIds],
+  );
+  const agentCounts = useMemo(
+    () => ({
+      running: standaloneAgents.filter((agent) => agent.status === 'running').length,
+      done: standaloneAgents.filter(
+        (agent) => agent.status === 'completed' || agent.status === 'skipped',
+      ).length,
+      failed: standaloneAgents.filter((agent) => agent.status === 'failed').length,
+    }),
+    [standaloneAgents],
+  );
+  const resolverCounts = useMemo(
+    () => ({
+      queued: resolverIndex.links.filter(({ status }) => status === 'pending').length,
+      resolved: resolverIndex.links.filter(({ status }) => status === 'resolved').length,
+    }),
+    [resolverIndex],
+  );
+  const agentsMeta =
+    agentCounts.running === 0 && agentCounts.done === 0 && agentCounts.failed === 0
+      ? undefined
+      : `${agentCounts.running} running, ${agentCounts.done} done${
+          agentCounts.failed > 0 ? `, ${agentCounts.failed} failed` : ''
+        }`;
+  const resolveMeta =
+    resolverCounts.queued === 0 && resolverCounts.resolved === 0
+      ? undefined
+      : `${resolverCounts.queued} queued, ${resolverCounts.resolved} resolved`;
   const selectedResolverLink =
     selectedThreadId == null ? undefined : resolverIndex.byThreadId.get(selectedThreadId);
   const selectedResolverStatus =
@@ -146,16 +190,12 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
       turnState: selectedTurnState,
     });
   const stripWorkflowName = useMemo(() => {
-    if (selectedAgentId == null) {
+    if (selectedWorkflowRunId == null) {
       return null;
     }
-    const rootAgent = resolveRootAgent({ agents: phaseRuns, agentId: selectedAgentId });
-    if (rootAgent?.workflowRunId == null) {
-      return null;
-    }
-    const attachedRun = attachedWorkflowRuns.find(({ run }) => run.id === rootAgent.workflowRunId);
+    const attachedRun = attachedWorkflowRuns.find(({ run }) => run.id === selectedWorkflowRunId);
     return attachedRun == null ? null : workflowKindName(attachedRun.workflow);
-  }, [attachedWorkflowRuns, phaseRuns, selectedAgentId]);
+  }, [attachedWorkflowRuns, selectedWorkflowRunId]);
   const focusedWorkflowName = useMemo(() => {
     const focusedRun = attachedWorkflowRuns.find(({ run }) => run.id === focusedWorkflowRunId);
     const visibleRun = focusedRun ?? (lens === 'workflows' ? attachedWorkflowRuns[0] : null);
@@ -256,6 +296,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <PaneShell
                     title="Resolve"
                     description="Resolver agents spawned from pull request comments and diff selections."
+                    meta={resolveMeta}
                     width="3xl"
                   >
                     <AgentsSection task={session} only="resolve" />
@@ -294,6 +335,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <PaneShell
                     title="Agents"
                     description="Agents you spawn by hand to work this session."
+                    meta={agentsMeta}
                     width="3xl"
                   >
                     <AgentsSection task={session} only="agents" />
@@ -335,6 +377,17 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                           sessionId={sessionId}
                           session={session}
                           selectedAgentId={selectedAgentId}
+                        />
+                      ) : showAgentOverlay &&
+                        overlayHome !== 'workflows' &&
+                        selectedWorkflowRunId != null &&
+                        stripWorkflowName != null ? (
+                        <ChatWorkflowContext
+                          workflowName={stripWorkflowName}
+                          onOpenWorkflow={() => {
+                            setFocusedWorkflowRun(sessionId, selectedWorkflowRunId);
+                            setActiveLens(sessionId, 'workflows');
+                          }}
                         />
                       ) : showForceResolveHeader &&
                         selectedAgent != null &&

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowContext.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowContext.tsx
@@ -1,0 +1,25 @@
+import { Divider } from '@goodboy/ui';
+
+type Props = {
+  readonly workflowName: string;
+  readonly onOpenWorkflow: () => void;
+};
+
+export const ChatWorkflowContext = ({ workflowName, onOpenWorkflow }: Props) => (
+  <>
+    <div className="flex h-[var(--chat-header-h)] shrink-0 items-center px-3 text-2xs text-muted-foreground">
+      <span className="min-w-0 truncate">
+        Part of{' '}
+        <button
+          type="button"
+          onClick={onOpenWorkflow}
+          className="font-medium text-muted-foreground transition-colors hover:text-foreground"
+          title={workflowName}
+        >
+          {workflowName}
+        </button>
+      </span>
+    </div>
+    <Divider className="shrink-0" />
+  </>
+);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PaneShell.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PaneShell.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react';
 import { cn, ScrollFade } from '@goodboy/ui';
 
-type PaneShellProps = {
+type Props = {
   readonly title: string;
   readonly description?: string;
+  readonly meta?: ReactNode;
   readonly actions?: ReactNode;
   readonly width?: '2xl' | '3xl';
   readonly children: ReactNode;
@@ -17,15 +18,21 @@ const WIDTH: Record<'2xl' | '3xl', string> = {
 export const PaneShell = ({
   title,
   description,
+  meta,
   actions,
   width = '2xl',
   children,
-}: PaneShellProps) => (
+}: Props) => (
   <ScrollFade className="h-full" viewportClassName="px-6 py-5" fadeSize={24}>
     <div className={cn('mx-auto flex flex-col gap-5 motion-safe:animate-studio-in', WIDTH[width])}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex flex-col gap-1">
-          <h1 className="text-xl font-semibold leading-snug text-foreground">{title}</h1>
+          <div className="flex items-baseline gap-2">
+            <h1 className="text-xl font-semibold leading-snug text-foreground">{title}</h1>
+            {meta ? (
+              <span className="text-xs tabular-nums text-muted-foreground">{meta}</span>
+            ) : null}
+          </div>
           {description ? <p className="text-sm text-muted-foreground">{description}</p> : null}
         </div>
         {actions ? (

--- a/apps/desktop/src/features/session/resolver-linkage.ts
+++ b/apps/desktop/src/features/session/resolver-linkage.ts
@@ -10,6 +10,7 @@ export type ResolverLink = {
 };
 
 export type ResolverIndex = {
+  readonly links: ReadonlyArray<ResolverLink>;
   readonly byThreadId: Map<string, ResolverLink>;
   readonly byCommentUrl: Map<string, ResolverLink>;
   readonly byDiffAgentId: Map<AgentId, ResolverLink>;
@@ -23,11 +24,12 @@ export const buildResolverIndex = (
     statusOf: (agent: Agent) => ResolverStatus;
   },
 ): ResolverIndex => {
+  const links = resolvers.map((agent) => ({ agent, status: args.statusOf(agent) }));
   const byThreadId = new Map<string, ResolverLink>();
   const byCommentUrl = new Map<string, ResolverLink>();
   const byDiffAgentId = new Map<AgentId, ResolverLink>();
-  for (const agent of resolvers) {
-    const link: ResolverLink = { agent, status: args.statusOf(agent) };
+  for (const link of links) {
+    const { agent } = link;
     if (agent.sourceThreadId != null) {
       if (!byThreadId.has(agent.sourceThreadId)) {
         byThreadId.set(agent.sourceThreadId, link);
@@ -42,7 +44,7 @@ export const buildResolverIndex = (
     }
     byDiffAgentId.set(agent.id, link);
   }
-  return { byThreadId, byCommentUrl, byDiffAgentId };
+  return { links, byThreadId, byCommentUrl, byDiffAgentId };
 };
 
 export const resolverForComment = (

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -33,7 +33,7 @@ type Props = {
   readonly onDelete: () => void;
 };
 
-export function AgentRow({
+export const AgentRow = ({
   run,
   kind,
   index,
@@ -50,7 +50,7 @@ export function AgentRow({
   onRenameCommit,
   onRenameCancel,
   onDelete,
-}: Props) {
+}: Props) => {
   const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
   const titleParts = [
     `agent ${run.ordinal + 1}`,
@@ -140,9 +140,10 @@ export function AgentRow({
         ) : (
           <span
             className={cn(
-              'line-clamp-1 flex-1 text-left text-2xs font-medium',
+              'min-w-0 flex-1 truncate text-left text-2xs font-medium',
               isSelected ? 'text-foreground' : 'text-muted-foreground',
             )}
+            title={run.name}
           >
             {run.name}
           </span>
@@ -213,4 +214,4 @@ export function AgentRow({
       </div>
     </li>
   );
-}
+};

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
@@ -108,7 +108,9 @@ export const ResolveClusterRow = ({
         <span className="tabular-nums text-muted-foreground/50">
           {index + 1}/{total}
         </span>
-        <span className="min-w-0 flex-1 truncate text-left">{agent.name}</span>
+        <span className="min-w-0 flex-1 truncate text-left" title={agent.name}>
+          {agent.name}
+        </span>
         <ResolverStateBadge state={resolverBadgeState(status)} />
         {canJump ? (
           <button


### PR DESCRIPTION
## What

- **Workflow stepper only where it belongs**: the full stepper now renders only when the agent overlay was opened from the Workflows lens. Opening a workflow-bound agent from Agents/Resolve shows a minimal `Part of <workflow>` text link that navigates to the focused run, instead of the stale full stepper of an old run.
- **Agents / Resolve pane headers** gain muted status counts (`N running, N done[, N failed]` / `N queued, N resolved`), derived from data already in the store, hidden when all zero. Uniform `meta` slot on PaneShell.
- **Agent names**: CSS truncate + full-name hover title in agent rows; no JS truncation.

## Verification

- Typecheck green, full suite green: desktop 2292, core 809, db 83, ui 12.
- Untouched by design: breadcrumb building, workflow advancement (finalize/skip), root-agent routing, lens grouping.

Area B of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)