### PR TITLE
feat: github/gitlab work management dashboards

### DIFF
--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -241,6 +241,23 @@ pub struct GitlabMergeRequest {
     pub has_conflicts: bool,
     #[serde(rename = "mergeStatus", alias = "merge_status", default)]
     pub merge_status: Option<String>,
+    #[serde(rename = "updatedAt", alias = "updated_at", default)]
+    pub updated_at: String,
+}
+
+#[tauri::command]
+pub async fn gitlab_fetch_assigned_mrs(
+    workspace_id: String,
+    host: String,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<Vec<GitlabMergeRequest>, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    get_json(
+        &host,
+        &token,
+        "/merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&per_page=50",
+    )
+    .await
 }
 
 #[tauri::command]
@@ -375,13 +392,15 @@ mod tests {
             "target_branch": "main",
             "draft": true,
             "has_conflicts": false,
-            "merge_status": "can_be_merged"
+            "merge_status": "can_be_merged",
+            "updated_at": "2026-07-22T10:00:00Z"
         }"#;
         let mr: GitlabMergeRequest = serde_json::from_str(raw).unwrap();
         assert_eq!(mr.iid, 2);
         assert_eq!(mr.source_branch, "ak/feat-x");
         assert!(mr.draft);
         assert_eq!(mr.merge_status.as_deref(), Some("can_be_merged"));
+        assert_eq!(mr.updated_at, "2026-07-22T10:00:00Z");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -233,6 +233,7 @@ pub fn run() {
       gitlab::gitlab_connect,
       gitlab::gitlab_disconnect,
       gitlab::gitlab_fetch_assigned_issues,
+      gitlab::gitlab_fetch_assigned_mrs,
       gitlab::gitlab_mr_for_branch,
       gitlab::gitlab_create_mr,
       gitlab::gitlab_merge_mr,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -125,6 +125,7 @@ export const App = () => {
   const [githubStudioSession, setGithubStudioSession] = useState<SessionId | null>(null);
   const [githubStudioPrNumber, setGithubStudioPrNumber] = useState<number | null>(null);
   const [githubStudioThreadId, setGithubStudioThreadId] = useState<string | null>(null);
+  const [githubStudioIssueId, setGithubStudioIssueId] = useState<string | null>(null);
   const [budgetStudioOpen, setBudgetStudioOpen] = useState(false);
   const [budgetStudioScope, setBudgetStudioScope] = useState<BudgetScope | undefined>(undefined);
   const setSessionStudio = useAppStore((s) => s.setSessionStudio);
@@ -187,7 +188,12 @@ export const App = () => {
     };
     const onOpenGithubStudio = (event: Event) => {
       const detail = (
-        event as CustomEvent<{ sessionId?: SessionId; prNumber?: number; threadId?: string }>
+        event as CustomEvent<{
+          sessionId?: SessionId;
+          prNumber?: number;
+          threadId?: string;
+          issueExternalId?: string;
+        }>
       ).detail;
       setWorkflowStudioOpen(false);
       setProviderStudioOpen(false);
@@ -202,6 +208,7 @@ export const App = () => {
       setGithubStudioSession(detail?.sessionId ?? null);
       setGithubStudioPrNumber(detail?.prNumber ?? null);
       setGithubStudioThreadId(detail?.threadId ?? null);
+      setGithubStudioIssueId(detail?.issueExternalId ?? null);
       setGithubStudioOpen(true);
     };
     const onOpenPlanStudio = (event: Event) => {
@@ -796,6 +803,7 @@ export const App = () => {
               onOpenGithub={() => {
                 closeAllStudios();
                 setGithubStudioSession(currentSession?.id ?? null);
+                setGithubStudioIssueId(null);
                 setGithubStudioOpen(true);
               }}
               onOpenLinear={() => {
@@ -913,10 +921,13 @@ export const App = () => {
       ) : null}
       {githubStudioOpen && currentWorkspace ? (
         <GitHubStudio
+          workspaceId={currentWorkspace.id}
+          rootPath={currentWorkspace.rootPath}
           workspaceName={currentWorkspace.name}
           initialSessionId={githubStudioSession}
           initialPrNumber={githubStudioPrNumber}
           initialThreadId={githubStudioThreadId}
+          initialIssueExternalId={githubStudioIssueId}
           onClose={() => setGithubStudioOpen(false)}
         />
       ) : null}

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { GithubIssue, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(async () => ({
+    session: { id: 'session-42', goal: 'GitHub issue #42: Add issue dashboard' },
+  })),
+  loadSetting: vi.fn(async () => null),
+  showToast: vi.fn(),
+  store: {
+    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (
+      state: typeof h.store & {
+        createSession: typeof h.createSession;
+        loadSetting: typeof h.loadSetting;
+      },
+    ) => T,
+  ) => selector({ ...h.store, createSession: h.createSession, loadSetting: h.loadSetting }),
+}));
+vi.mock('../../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+vi.mock('../../../../worktree/useBranchConflict', () => ({ useBranchConflict: () => null }));
+vi.mock('../../../../worktree/worktree', () => ({ removeWorktree: vi.fn() }));
+
+import { GithubIssueDetailPanel } from './index';
+
+const ISSUE: GithubIssue = {
+  number: 42,
+  title: 'Add issue dashboard',
+  body: 'Show assigned issues in GitHub Studio.',
+  url: 'https://github.com/goodboy/goodboy/issues/42',
+  state: 'OPEN',
+  labels: ['feature'],
+  updatedAt: '2026-07-22T10:00:00Z',
+};
+
+beforeEach(() => {
+  h.createSession.mockClear();
+  h.loadSetting.mockClear();
+  h.showToast.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('GithubIssueDetailPanel', () => {
+  it('launches a session linked to the selected GitHub issue', async () => {
+    render(
+      <GithubIssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('textbox', { name: 'Session goal' }) as HTMLTextAreaElement).value,
+      ).toBe('GitHub issue #42: Add issue dashboard\n\nShow assigned issues in GitHub Studio.'),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Launch session' }));
+
+    await waitFor(() => expect(h.createSession).toHaveBeenCalledOnce());
+    expect(h.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-1',
+        branchSlug: '42-add-issue-dashboard',
+        externalTask: {
+          provider: 'github',
+          externalId: '42',
+          identifier: '#42',
+          url: ISSUE.url,
+          title: ISSUE.title,
+        },
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useState } from 'react';
+import {
+  Button,
+  Divider,
+  EmptyState,
+  Input,
+  Markdown,
+  ScrollFade,
+  SectionHeader,
+  Textarea,
+} from '@goodboy/ui';
+import {
+  AlertTriangle,
+  ArrowRight,
+  ExternalLink,
+  GitBranch,
+  MessagesSquare,
+  MousePointerClick,
+} from 'lucide-react';
+import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
+import { useToast } from '../../../../../app/components/Toast';
+import { OpenSessionButton } from '../../../../../shared/components/OpenSessionButton';
+import { BaseBranchGuide } from '../../../../../shared/components/BaseBranchGuide';
+import { formatError, isMissingBaseRefError } from '../../../../../shared/lib/errors';
+import { isValidBranchSlug } from '../../../../../shared/utils/isValidBranchSlug';
+import { sanitizeBranchPrefix } from '../../../../../shared/utils/sanitizeBranchPrefix';
+import { sanitizeBranchSlug } from '../../../../../shared/utils/sanitizeBranchSlug';
+import { useAppStore } from '../../../../../store';
+import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../../settings/settings';
+import { removeWorktree } from '../../../../worktree/worktree';
+import { useBranchConflict } from '../../../../worktree/useBranchConflict';
+import { goalFromIssue } from '../../../goal-from-issue';
+import { githubBranchSlug } from '../useGithubIssues';
+
+type Props = {
+  readonly issue: GithubIssue | null;
+  readonly sessionId: SessionId | null;
+  readonly workspaceId: WorkspaceId;
+  readonly onClose: () => void;
+};
+
+type LaunchParams = {
+  readonly eraseWorktreePath?: string;
+};
+
+export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
+  const createSession = useAppStore((state) => state.createSession);
+  const loadSetting = useAppStore((state) => state.loadSetting);
+  const rootPath = useAppStore(
+    (state) => state.workspaces.find((workspace) => workspace.id === workspaceId)?.rootPath ?? null,
+  );
+  const { showToast } = useToast();
+  const [goal, setGoal] = useState('');
+  const [branchSlug, setBranchSlug] = useState('');
+  const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const prefix = sanitizeBranchPrefix({ input: branchPrefix }) || DEFAULT_BRANCH_PREFIX;
+  const isBranchValid = isValidBranchSlug({ slug: branchSlug });
+  const fullBranch = isBranchValid ? `${prefix}/${branchSlug.trim()}` : null;
+  const conflict = useBranchConflict(fullBranch, rootPath);
+  const branchSessionId = conflict?.kind === 'session' ? conflict.sessionId : null;
+  const conflictPath = conflict?.kind === 'worktree' ? conflict.path : null;
+
+  useEffect(() => {
+    if (issue == null) {
+      return;
+    }
+    setGoal(goalFromIssue({ issue }));
+    setBranchSlug(githubBranchSlug({ issue }));
+    setError(null);
+    setBusy(false);
+  }, [issue]);
+
+  useEffect(() => {
+    void loadSetting(settingBranchPrefix(workspaceId)).then((value) => {
+      setBranchPrefix(value ?? DEFAULT_BRANCH_PREFIX);
+    });
+  }, [loadSetting, workspaceId]);
+
+  if (issue == null) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <EmptyState
+          icon={MousePointerClick}
+          title="No issue selected"
+          description="Pick an issue to see its details and launch a session."
+        />
+      </div>
+    );
+  }
+
+  const openableSessionId = sessionId ?? branchSessionId;
+  const isMissingBase = error != null && isMissingBaseRefError(error);
+  const isBlockedByConflict = conflictPath != null;
+  const canLaunch = goal.trim() !== '' && isBranchValid && !busy && !isBlockedByConflict;
+
+  const launch = async ({ eraseWorktreePath }: LaunchParams) => {
+    setError(null);
+    setBusy(true);
+    try {
+      if (eraseWorktreePath != null && rootPath != null) {
+        await removeWorktree(rootPath, eraseWorktreePath);
+      }
+      const { session } = await createSession({
+        workspaceId,
+        goal,
+        branchPrefix: prefix,
+        branchSlug: branchSlug.trim() || undefined,
+        externalTask: {
+          provider: 'github',
+          externalId: String(issue.number),
+          identifier: `#${issue.number}`,
+          url: issue.url,
+          title: issue.title,
+        },
+      });
+      showToast('success', `Session created: ${session.goal}`);
+      onClose();
+    } catch (launchError) {
+      setError(formatError(launchError));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+            #{issue.number}
+          </span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+            {issue.state.toLowerCase()}
+          </span>
+          <span className="flex-1" />
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Open in GitHub <ExternalLink size={11} aria-hidden />
+          </a>
+        </div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
+        {issue.labels.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {issue.labels.map((label) => (
+              <span
+                key={label}
+                className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
+              >
+                {label}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+      <Divider />
+      <div className="flex min-h-0 flex-1 justify-center">
+        <ScrollFade
+          className="h-full w-full max-w-3xl"
+          viewportClassName="px-10 py-8"
+          fadeSize={24}
+        >
+          <div className="flex flex-col gap-8">
+            <section className="flex flex-col gap-3">
+              <SectionHeader label="description" />
+              {issue.body.trim() !== '' ? (
+                <Markdown text={issue.body} className="text-sm leading-relaxed" />
+              ) : (
+                <p className="text-sm italic text-muted-foreground/60">No description.</p>
+              )}
+            </section>
+            <section className="flex flex-col gap-3">
+              <SectionHeader label="launch session" />
+              {openableSessionId != null ? (
+                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+                    <MessagesSquare size={15} className="text-success" aria-hidden />
+                  </span>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <span className="text-sm font-medium text-foreground">
+                      Session already launched
+                    </span>
+                    <span className="truncate text-2xs text-muted-foreground">
+                      {sessionId != null
+                        ? 'A session is linked to this issue.'
+                        : 'A session is already on this branch.'}
+                    </span>
+                  </div>
+                  <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+                  <div className="flex flex-col gap-1.5">
+                    <SectionHeader label="Goal" />
+                    <Textarea
+                      value={goal}
+                      onChange={(event) => setGoal(event.target.value)}
+                      autoGrow
+                      minRows={3}
+                      maxRows={10}
+                      disabled={busy}
+                      aria-label="Session goal"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-1.5">
+                    <SectionHeader
+                      label="Branch"
+                      icon={<GitBranch size={13} aria-hidden className="text-success" />}
+                    />
+                    <div className="flex items-center gap-1.5">
+                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                        {prefix + '/'}
+                      </span>
+                      <Input
+                        value={branchSlug}
+                        onChange={(event) =>
+                          setBranchSlug(
+                            sanitizeBranchSlug({ input: event.target.value, maxLength: 48 }),
+                          )
+                        }
+                        placeholder="branch-slug"
+                        className="h-8 flex-1 font-mono text-sm"
+                        disabled={busy}
+                        aria-label="Branch slug"
+                      />
+                    </div>
+                    {conflictPath != null ? (
+                      <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
+                        <AlertTriangle size={12} aria-hidden className="shrink-0 text-warning" />
+                        <span>This branch is already checked out in another worktree.</span>
+                      </div>
+                    ) : null}
+                  </div>
+                  {isMissingBase ? <BaseBranchGuide /> : null}
+                  <div className="flex items-center gap-3">
+                    {error != null && !isMissingBase ? (
+                      <span className="text-xs text-danger">{error}</span>
+                    ) : null}
+                    <span className="flex-1" />
+                    <Button
+                      variant={isBlockedByConflict ? 'danger' : undefined}
+                      onClick={() => void launch({ eraseWorktreePath: conflictPath ?? undefined })}
+                      disabled={isBlockedByConflict ? busy || goal.trim() === '' : !canLaunch}
+                    >
+                      {busy
+                        ? 'Launching…'
+                        : isBlockedByConflict
+                          ? 'Erase worktree & launch'
+                          : 'Launch session'}
+                      {!busy ? <ArrowRight size={13} aria-hidden /> : null}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
+        </ScrollFade>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/IssueInbox.tsx
@@ -1,0 +1,155 @@
+import { useMemo, useState } from 'react';
+import { cn, EmptyState, ScrollFade, SectionHeader, Skeleton } from '@goodboy/ui';
+import { Inbox, MessagesSquare, Search } from 'lucide-react';
+import type { GithubIssue } from '@goodboy/types';
+import type { GithubIssueGroup } from './useGithubIssues';
+
+type Props = {
+  readonly groups: ReadonlyArray<GithubIssueGroup>;
+  readonly focusedIssueNumber: number | null;
+  readonly onSelect: (issue: GithubIssue) => void;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+type DateParams = {
+  readonly iso: string;
+};
+
+const shortDate = ({ iso }: DateParams): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+export const IssueInbox = ({ groups, focusedIssueNumber, onSelect, loading, error }: Props) => {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (normalized === '') {
+      return groups;
+    }
+    return groups
+      .map((group) => ({
+        ...group,
+        rows: group.rows.filter(
+          (row) =>
+            `#${row.issue.number}`.includes(normalized) ||
+            row.issue.title.toLowerCase().includes(normalized),
+        ),
+      }))
+      .filter((group) => group.rows.length > 0);
+  }, [groups, query]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-3 pb-2">
+        <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-2.5 focus-within:border-primary">
+          <Search size={13} aria-hidden className="shrink-0 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search issues…"
+            aria-label="Search GitHub issues"
+            autoComplete="off"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
+          />
+        </div>
+      </div>
+      {loading && groups.length === 0 ? (
+        <div
+          className="flex min-h-0 flex-1 flex-col gap-1 px-3 pb-3"
+          role="status"
+          aria-label="Loading issues"
+        >
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2.5 px-2.5 py-2">
+              <Skeleton className="size-1.5 shrink-0 rounded-full" />
+              <Skeleton className="h-3 w-8 shrink-0 rounded" />
+              <Skeleton className="h-3 flex-1 rounded" />
+            </div>
+          ))}
+        </div>
+      ) : error != null ? (
+        <div className="px-3 pb-3">
+          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={Inbox}
+            title={query.trim() === '' ? 'Inbox clear' : 'No matching issues'}
+            description={
+              query.trim() === ''
+                ? 'No open issues assigned to you.'
+                : 'Try a different search term.'
+            }
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+          <div className="flex flex-col gap-3 px-3 pb-3">
+            {filtered.map((group) => (
+              <div key={group.key} className="flex flex-col gap-1">
+                <SectionHeader
+                  className="px-1"
+                  label={group.label}
+                  action={
+                    <span className="text-2xs tabular-nums text-muted-foreground/50">
+                      {group.rows.length}
+                    </span>
+                  }
+                />
+                <ul className="flex flex-col gap-0.5">
+                  {group.rows.map((row) => {
+                    const isActive = row.issue.number === focusedIssueNumber;
+                    return (
+                      <li key={row.issue.number}>
+                        <button
+                          type="button"
+                          onClick={() => onSelect(row.issue)}
+                          title={row.issue.title}
+                          aria-current={isActive}
+                          className={cn(
+                            'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors',
+                            isActive
+                              ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                              : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                          )}
+                        >
+                          <span
+                            aria-hidden
+                            className="size-1.5 shrink-0 rounded-full bg-provider-github"
+                          />
+                          <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
+                            #{row.issue.number}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate text-xs">{row.issue.title}</span>
+                          <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
+                            {shortDate({ iso: row.issue.updatedAt })}
+                          </span>
+                          {row.sessionId != null ? (
+                            <MessagesSquare
+                              size={11}
+                              aria-label="session launched"
+                              className="shrink-0 text-success"
+                            />
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
+
+const ISSUE: GithubIssue = {
+  number: 42,
+  title: 'Add issue dashboard',
+  body: 'Show assigned issues.',
+  url: 'https://github.com/goodboy/goodboy/issues/42',
+  state: 'OPEN',
+  labels: ['feature'],
+  updatedAt: '2026-07-22T10:00:00Z',
+};
+
+type IssueDetailProps = {
+  readonly issue: GithubIssue | null;
+};
+
+vi.mock('./useGithubInbox', () => ({ useGithubInbox: () => [] }));
+vi.mock('./useGithubIssues', () => ({
+  useGithubIssues: () => ({
+    groups: [{ key: 'open', label: 'Open', rows: [{ issue: ISSUE, sessionId: null }] }],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock('./InboxList', () => ({ InboxList: () => <div>Pull request inbox</div> }));
+vi.mock('./PrDetailPanel', () => ({ PrDetailPanel: () => <div>Pull request detail</div> }));
+vi.mock('./GithubIssueDetailPanel', () => ({
+  GithubIssueDetailPanel: ({ issue }: IssueDetailProps) => (
+    <div>{issue?.title ?? 'No issue detail'}</div>
+  ),
+}));
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({
+    headerAccessory,
+    children,
+  }: {
+    headerAccessory?: ReactNode;
+    children: (requestClose: () => void) => ReactNode;
+  }) => (
+    <div>
+      {headerAccessory}
+      {children(vi.fn())}
+    </div>
+  ),
+}));
+
+import { GitHubStudio } from './index';
+
+const renderStudio = () =>
+  render(
+    <GitHubStudio
+      workspaceId={'workspace-1' as WorkspaceId}
+      rootPath="/repo"
+      workspaceName="Goodboy"
+      initialSessionId={'session-1' as SessionId}
+      onClose={vi.fn()}
+    />,
+  );
+
+afterEach(cleanup);
+
+describe('GitHubStudio', () => {
+  it('keeps pull requests selected by default', () => {
+    renderStudio();
+
+    expect(screen.getByRole('tab', { name: 'Pull requests' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByText('Pull request inbox')).toBeDefined();
+    expect(screen.getByText('Pull request detail')).toBeDefined();
+  });
+
+  it('renders grouped assigned issues in the issues tab', () => {
+    renderStudio();
+    fireEvent.click(screen.getByRole('tab', { name: 'Issues' }));
+
+    expect(screen.getByText('Open')).toBeDefined();
+    expect(screen.getAllByText('Add issue dashboard').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -17,13 +17,17 @@ type IssueDetailProps = {
   readonly issue: GithubIssue | null;
 };
 
+const h = vi.hoisted(() => ({
+  refetch: vi.fn(),
+}));
+
 vi.mock('./useGithubInbox', () => ({ useGithubInbox: () => [] }));
 vi.mock('./useGithubIssues', () => ({
   useGithubIssues: () => ({
     groups: [{ key: 'open', label: 'Open', rows: [{ issue: ISSUE, sessionId: null }] }],
     loading: false,
     error: null,
-    refetch: vi.fn(),
+    refetch: h.refetch,
   }),
 }));
 vi.mock('./InboxList', () => ({ InboxList: () => <div>Pull request inbox</div> }));
@@ -61,7 +65,10 @@ const renderStudio = () =>
     />,
   );
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  h.refetch.mockClear();
+});
 
 describe('GitHubStudio', () => {
   it('keeps pull requests selected by default', () => {
@@ -80,5 +87,13 @@ describe('GitHubStudio', () => {
 
     expect(screen.getByText('Open')).toBeDefined();
     expect(screen.getAllByText('Add issue dashboard').length).toBeGreaterThan(0);
+  });
+
+  it('renders an issues refresh button in the header', () => {
+    renderStudio();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh issues' }));
+
+    expect(h.refetch).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -1,29 +1,57 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Divider, ScrollFade } from '@goodboy/ui';
 import { GitPullRequest } from 'lucide-react';
-import type { SessionId } from '@goodboy/types';
+import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
 import { InboxList } from './InboxList';
+import { IssueInbox } from './IssueInbox';
 import { PrDetailPanel } from './PrDetailPanel';
+import { GithubIssueDetailPanel } from './GithubIssueDetailPanel';
 import { useGithubInbox } from './useGithubInbox';
+import { useGithubIssues } from './useGithubIssues';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+
+type Tab = 'pull-requests' | 'issues';
+
+const TABS: ReadonlyArray<StudioTab<Tab>> = [
+  { value: 'pull-requests', label: 'Pull requests' },
+  { value: 'issues', label: 'Issues' },
+];
 
 type Props = {
   readonly workspaceName: string;
+  readonly workspaceId: WorkspaceId;
+  readonly rootPath: string;
   readonly initialSessionId: SessionId | null;
   readonly initialPrNumber?: number | null;
   readonly initialThreadId?: string | null;
+  readonly initialIssueExternalId?: string | null;
   readonly onClose: () => void;
 };
 
 export const GitHubStudio = ({
   workspaceName,
+  workspaceId,
+  rootPath,
   initialSessionId,
   initialPrNumber = null,
   initialThreadId = null,
+  initialIssueExternalId = null,
   onClose,
 }: Props) => {
   const groups = useGithubInbox();
+  const issues = useGithubIssues({ workspaceId, rootPath });
   const [focused, setFocused] = useState<SessionId | null>(initialSessionId);
+  const [focusedIssue, setFocusedIssue] = useState<GithubIssue | null>(null);
+  const [tab, setTab] = useState<Tab>(initialIssueExternalId == null ? 'pull-requests' : 'issues');
+
+  useEffect(() => {
+    if (initialIssueExternalId == null) {
+      return;
+    }
+    setTab('issues');
+    setFocusedIssue(null);
+  }, [initialIssueExternalId]);
 
   useEffect(() => {
     if (focused !== null) {
@@ -35,6 +63,40 @@ export const GitHubStudio = ({
     }
   }, [focused, groups]);
 
+  useEffect(() => {
+    if (focusedIssue != null) {
+      return;
+    }
+    if (initialIssueExternalId != null) {
+      for (const group of issues.groups) {
+        const row = group.rows.find(
+          (candidate) => String(candidate.issue.number) === initialIssueExternalId,
+        );
+        if (row != null) {
+          setFocusedIssue(row.issue);
+          return;
+        }
+      }
+    }
+    const first = issues.groups[0]?.rows[0]?.issue ?? null;
+    if (first != null) {
+      setFocusedIssue(first);
+    }
+  }, [focusedIssue, initialIssueExternalId, issues.groups]);
+
+  const focusedIssueRow = useMemo(() => {
+    if (focusedIssue == null) {
+      return null;
+    }
+    for (const group of issues.groups) {
+      const row = group.rows.find((candidate) => candidate.issue.number === focusedIssue.number);
+      if (row != null) {
+        return row;
+      }
+    }
+    return null;
+  }, [focusedIssue, issues.groups]);
+
   const onInitialSession = focused === initialSessionId;
 
   return (
@@ -43,24 +105,50 @@ export const GitHubStudio = ({
       title="GitHub"
       workspaceName={workspaceName}
       closeLabel="close github studio"
+      headerAccessory={
+        <StudioTabs ariaLabel="GitHub work" tabs={TABS} value={tab} onChange={setTab} />
+      }
       onClose={onClose}
     >
-      {(requestClose) => (
-        <>
-          <ScrollFade className="w-72 shrink-0" fadeSize={24}>
-            <InboxList groups={groups} focusedSessionId={focused} onSelect={setFocused} />
-          </ScrollFade>
-          <Divider orientation="vertical" />
-          <div className="min-h-0 flex-1">
-            <PrDetailPanel
-              sessionId={focused}
-              initialPrNumber={onInitialSession ? initialPrNumber : null}
-              initialThreadId={onInitialSession ? initialThreadId : null}
-              onClose={requestClose}
-            />
-          </div>
-        </>
-      )}
+      {(requestClose) =>
+        tab === 'pull-requests' ? (
+          <>
+            <ScrollFade className="w-72 shrink-0" fadeSize={24}>
+              <InboxList groups={groups} focusedSessionId={focused} onSelect={setFocused} />
+            </ScrollFade>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <PrDetailPanel
+                sessionId={focused}
+                initialPrNumber={onInitialSession ? initialPrNumber : null}
+                initialThreadId={onInitialSession ? initialThreadId : null}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="w-72 shrink-0">
+              <IssueInbox
+                groups={issues.groups}
+                focusedIssueNumber={focusedIssue?.number ?? null}
+                onSelect={setFocusedIssue}
+                loading={issues.loading}
+                error={issues.error}
+              />
+            </div>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <GithubIssueDetailPanel
+                issue={focusedIssue}
+                sessionId={focusedIssueRow?.sessionId ?? null}
+                workspaceId={workspaceId}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        )
+      }
     </StudioShell>
   );
 };

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Divider, ScrollFade } from '@goodboy/ui';
-import { GitPullRequest } from 'lucide-react';
+import { cn, Divider, ScrollFade } from '@goodboy/ui';
+import { GitPullRequest, RefreshCw } from 'lucide-react';
 import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
 import { InboxList } from './InboxList';
 import { IssueInbox } from './IssueInbox';
@@ -106,7 +106,23 @@ export const GitHubStudio = ({
       workspaceName={workspaceName}
       closeLabel="close github studio"
       headerAccessory={
-        <StudioTabs ariaLabel="GitHub work" tabs={TABS} value={tab} onChange={setTab} />
+        <div className="flex items-center gap-2">
+          <StudioTabs ariaLabel="GitHub work" tabs={TABS} value={tab} onChange={setTab} />
+          <button
+            type="button"
+            onClick={issues.refetch}
+            disabled={issues.loading}
+            title="Refresh issues"
+            aria-label="Refresh issues"
+            className={cn(
+              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+              'text-muted-foreground transition-colors',
+              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+            )}
+          >
+            <RefreshCw size={13} aria-hidden />
+          </button>
+        </div>
       }
       onClose={onClose}
     >

--- a/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.test.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { GithubIssue, IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
+import { buildGithubIssueGroups } from './useGithubIssues';
+
+type IssueParams = {
+  readonly number: number;
+  readonly updatedAt: string;
+};
+
+type TaskParams = {
+  readonly sessionId: SessionId;
+  readonly externalId: string;
+  readonly provider?: SessionExternalTask['provider'];
+};
+
+const makeIssue = ({ number, updatedAt }: IssueParams): GithubIssue => ({
+  number,
+  title: `Issue ${number}`,
+  body: '',
+  url: `https://github.com/goodboy/goodboy/issues/${number}`,
+  state: 'OPEN',
+  labels: [],
+  updatedAt,
+});
+
+const makeTask = ({
+  sessionId,
+  externalId,
+  provider = 'github',
+}: TaskParams): SessionExternalTask => ({
+  sessionId,
+  provider,
+  externalId,
+  identifier: `#${externalId}`,
+  url: `https://github.com/goodboy/goodboy/issues/${externalId}`,
+  title: `Issue ${externalId}`,
+  createdAt: '2026-07-20T10:00:00Z' as IsoDateTime,
+});
+
+describe('buildGithubIssueGroups', () => {
+  it('maps GitHub issues to sessions and sorts newest first', () => {
+    const sessionId = 'session-1' as SessionId;
+    const groups = buildGithubIssueGroups({
+      issues: [
+        makeIssue({ number: 41, updatedAt: '2026-07-20T10:00:00Z' }),
+        makeIssue({ number: 42, updatedAt: '2026-07-22T10:00:00Z' }),
+        makeIssue({ number: 43, updatedAt: '2026-07-21T10:00:00Z' }),
+      ],
+      externalTasks: {
+        [sessionId]: [
+          makeTask({ sessionId, externalId: '42' }),
+          makeTask({ sessionId, externalId: '43', provider: 'gitlab' }),
+        ],
+      },
+    });
+
+    expect(groups[0]?.rows.map((row) => row.issue.number)).toEqual([42, 43, 41]);
+    expect(groups[0]?.rows.map((row) => row.sessionId)).toEqual([sessionId, null, null]);
+  });
+});

--- a/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
@@ -1,0 +1,97 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { detectRepoSlug } from '@goodboy/core';
+import type { GithubIssue, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
+import { slugifyBranch } from '../../../../shared/utils/slugifyBranch';
+import { useAppStore } from '../../../../store';
+import { ghAssignedIssues, tauriGhRunner } from '../../github';
+
+export type GithubIssueRow = Readonly<{
+  issue: GithubIssue;
+  sessionId: SessionId | null;
+}>;
+
+export type GithubIssueGroup = Readonly<{
+  key: string;
+  label: string;
+  rows: ReadonlyArray<GithubIssueRow>;
+}>;
+
+type GroupsParams = {
+  readonly issues: ReadonlyArray<GithubIssue>;
+  readonly externalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
+};
+
+type BranchParams = {
+  readonly issue: GithubIssue;
+};
+
+type HookParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly rootPath: string;
+};
+
+type Result = Readonly<{
+  groups: ReadonlyArray<GithubIssueGroup>;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}>;
+
+export const githubBranchSlug = ({ issue }: BranchParams): string =>
+  `${issue.number}-${slugifyBranch({ input: issue.title, maxLength: 48 })}`;
+
+export const buildGithubIssueGroups = ({
+  issues,
+  externalTasks,
+}: GroupsParams): ReadonlyArray<GithubIssueGroup> => {
+  const sessionIdByExternalId = new Map<string, SessionId>();
+  for (const [sessionId, tasks] of Object.entries(externalTasks)) {
+    for (const task of tasks) {
+      if (task.provider === 'github' && !sessionIdByExternalId.has(task.externalId)) {
+        sessionIdByExternalId.set(task.externalId, sessionId as SessionId);
+      }
+    }
+  }
+  const rows = [...issues]
+    .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+    .map((issue) => ({
+      issue,
+      sessionId: sessionIdByExternalId.get(String(issue.number)) ?? null,
+    }));
+  return rows.length === 0 ? [] : [{ key: 'open', label: 'Open', rows }];
+};
+
+export const useGithubIssues = ({ workspaceId, rootPath }: HookParams): Result => {
+  const externalTasks = useAppStore((state) => state.sessionExternalTasks);
+  const [issues, setIssues] = useState<ReadonlyArray<GithubIssue>>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchIssues = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const slug = await detectRepoSlug(tauriGhRunner, rootPath, workspaceId);
+      if (slug == null) {
+        setIssues([]);
+        return;
+      }
+      setIssues(await ghAssignedIssues(slug));
+    } catch (fetchError) {
+      setError(fetchError instanceof Error ? fetchError.message : String(fetchError));
+    } finally {
+      setLoading(false);
+    }
+  }, [rootPath, workspaceId]);
+
+  useEffect(() => {
+    void fetchIssues();
+  }, [fetchIssues]);
+
+  const groups = useMemo(
+    () => buildGithubIssueGroups({ issues, externalTasks }),
+    [externalTasks, issues],
+  );
+
+  return { groups, loading, error, refetch: () => void fetchIssues() };
+};

--- a/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
@@ -76,7 +76,7 @@ export const useGithubIssues = ({ workspaceId, rootPath }: HookParams): Result =
         setIssues([]);
         return;
       }
-      setIssues(await ghAssignedIssues(slug));
+      setIssues(await ghAssignedIssues(slug, { cwd: rootPath, workspaceId }));
     } catch (fetchError) {
       setError(fetchError instanceof Error ? fetchError.message : String(fetchError));
     } finally {

--- a/apps/desktop/src/features/github/github.ts
+++ b/apps/desktop/src/features/github/github.ts
@@ -113,8 +113,10 @@ export const ghPrsForBranch = async (
   return listPrsForBranch(tauriGhRunner, slug, branch, { cwd, workspaceId });
 };
 
-export const ghAssignedIssues = async (slug: string): Promise<ReadonlyArray<GithubIssue>> =>
-  listAssignedIssues(tauriGhRunner, slug);
+export const ghAssignedIssues = async (
+  slug: string,
+  opts: GhRunOptions = {},
+): Promise<ReadonlyArray<GithubIssue>> => listAssignedIssues(tauriGhRunner, slug, opts);
 
 export const ghPrDetailByNumber = async (
   cwd: string,

--- a/apps/desktop/src/features/github/github.ts
+++ b/apps/desktop/src/features/github/github.ts
@@ -1,7 +1,13 @@
 import { invoke } from '@tauri-apps/api/core';
-import { detectRepoSlug, fetchPrDetail, listPrsForBranch } from '@goodboy/core';
+import { detectRepoSlug, fetchPrDetail, listAssignedIssues, listPrsForBranch } from '@goodboy/core';
 import type { GhRunner, GhResult, GhRunOptions, PrCacheStore } from '@goodboy/core';
-import type { GhTokenStatus, GithubPrCacheEntry, PrDetail, PullRequestState } from '@goodboy/types';
+import type {
+  GhTokenStatus,
+  GithubIssue,
+  GithubPrCacheEntry,
+  PrDetail,
+  PullRequestState,
+} from '@goodboy/types';
 import {
   getGithubPrCache,
   upsertGithubPrCache,
@@ -106,6 +112,9 @@ export const ghPrsForBranch = async (
   }
   return listPrsForBranch(tauriGhRunner, slug, branch, { cwd, workspaceId });
 };
+
+export const ghAssignedIssues = async (slug: string): Promise<ReadonlyArray<GithubIssue>> =>
+  listAssignedIssues(tauriGhRunner, slug);
 
 export const ghPrDetailByNumber = async (
   cwd: string,

--- a/apps/desktop/src/features/github/goal-from-issue.ts
+++ b/apps/desktop/src/features/github/goal-from-issue.ts
@@ -1,0 +1,11 @@
+import type { GithubIssue } from '@goodboy/types';
+
+type Params = {
+  readonly issue: GithubIssue;
+};
+
+export const goalFromIssue = ({ issue }: Params): string => {
+  const reference = `GitHub issue #${issue.number}: ${issue.title}`;
+  const body = issue.body.trim();
+  return body === '' ? reference : `${reference}\n\n${body}`;
+};

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
@@ -65,6 +65,7 @@ describe('ExternalTaskChip, provider mapping', () => {
     { provider: 'linear', glyph: 'L', label: /Linear/i, event: 'goodboy:open-linear-studio' },
     { provider: 'sentry', glyph: 'S', label: /Sentry/i, event: 'goodboy:open-sentry-studio' },
     { provider: 'gitlab', glyph: 'G', label: /GitLab/i, event: 'goodboy:open-gitlab-studio' },
+    { provider: 'github', glyph: 'GH', label: /GitHub/i, event: 'goodboy:open-github-studio' },
   ];
 
   for (const { provider, glyph, label, event } of cases) {

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -43,6 +43,14 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
       'border-provider-gitlab/30 bg-provider-gitlab/5 text-provider-gitlab hover:border-provider-gitlab/60 hover:bg-provider-gitlab/10',
     studioEvent: 'goodboy:open-gitlab-studio',
   },
+  github: {
+    label: 'GitHub',
+    glyph: 'GH',
+    glyphClasses: 'bg-provider-github text-white',
+    colorClasses:
+      'border-provider-github/30 bg-provider-github/5 text-provider-github hover:border-provider-github/60 hover:bg-provider-github/10',
+    studioEvent: 'goodboy:open-github-studio',
+  },
 };
 
 export const ExternalTaskChip = ({

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { SessionId, TaskModelPreferences } from '@goodboy/types';
+import type { SessionId, TaskModelPreferences, WorkspaceId } from '@goodboy/types';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
+import type { GitlabMergeRequest } from '../client';
 
 type SpawnAgent = (
   sessionId: SessionId,
@@ -31,6 +32,11 @@ type ConfigProps = {
   readonly disabled: boolean;
 };
 
+type MrParams = {
+  readonly mergeStatus?: GitlabMergeRequest['mergeStatus'];
+  readonly webUrl?: string;
+};
+
 const h = vi.hoisted(() => ({
   config: {
     provider: 'gemini',
@@ -38,6 +44,7 @@ const h = vi.hoisted(() => ({
     effort: 'low',
     hint: 'Mention the rollout order.',
   } satisfies AgentSpawnConfigValue,
+  gitlabMergeMr: vi.fn(async () => undefined),
   showToast: vi.fn(),
   store: {
     sessions: [
@@ -68,6 +75,11 @@ vi.mock('../../../../app/components/Toast', () => ({
   useToast: () => ({ showToast: h.showToast }),
 }));
 
+vi.mock('../client', async () => {
+  const actual = await vi.importActual<typeof import('../client')>('../client');
+  return { ...actual, gitlabMergeMr: h.gitlabMergeMr };
+});
+
 vi.mock('../../../session/components/AgentSpawnConfig', () => ({
   AgentSpawnConfig: ({ onChange, disabled }: ConfigProps) => (
     <button type="button" disabled={disabled} onClick={() => onChange(h.config)}>
@@ -79,8 +91,29 @@ vi.mock('../../../session/components/AgentSpawnConfig', () => ({
 import { MrDetailPanel } from './MrDetailPanel';
 
 const SESSION_ID = 'session-3' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const makeMr = ({
+  mergeStatus = 'can_be_merged',
+  webUrl = 'https://gitlab.com/acme/web/-/merge_requests/4',
+}: MrParams = {}): GitlabMergeRequest => ({
+  id: 12,
+  iid: 4,
+  projectId: 3,
+  title: 'Add merge request dashboard',
+  description: null,
+  state: 'opened',
+  webUrl,
+  sourceBranch: 'ak/mr-dashboard',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus,
+  updatedAt: '2026-07-22T10:00:00Z',
+});
 
 beforeEach(() => {
+  h.gitlabMergeMr.mockClear();
   h.store.refreshSessionMr.mockClear();
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
@@ -126,5 +159,62 @@ describe('MrDetailPanel', () => {
       provider: 'codex',
       model: 'gpt-5.4-mini',
     });
+  });
+
+  it('merges a selected MR through the GitLab client', async () => {
+    const onClose = vi.fn();
+    const onRefresh = vi.fn();
+    render(
+      <MrDetailPanel
+        mr={makeMr()}
+        workspaceId={WORKSPACE_ID}
+        host="https://gitlab.com"
+        onRefresh={onRefresh}
+        onClose={onClose}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Merge request' }));
+
+    await waitFor(() =>
+      expect(h.gitlabMergeMr).toHaveBeenCalledWith(
+        WORKSPACE_ID,
+        'https://gitlab.com',
+        'acme/web',
+        4,
+      ),
+    );
+    expect(onRefresh).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('disables merge when GitLab reports cannot_be_merged', () => {
+    render(
+      <MrDetailPanel
+        mr={makeMr({ mergeStatus: 'cannot_be_merged' })}
+        workspaceId={WORKSPACE_ID}
+        host="https://gitlab.com"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      (screen.getByRole('button', { name: 'Merge request' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it('disables merge when the MR project path cannot be parsed', () => {
+    render(
+      <MrDetailPanel
+        mr={makeMr({ webUrl: 'not a URL' })}
+        workspaceId={WORKSPACE_ID}
+        host="https://gitlab.com"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      (screen.getByRole('button', { name: 'Merge request' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -10,7 +10,7 @@ import {
   RefreshCw,
   Sparkles,
 } from 'lucide-react';
-import type { SessionId } from '@goodboy/types';
+import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { ScrollFade } from '@goodboy/ui';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
@@ -19,10 +19,20 @@ import { taskModelAgentSpawnConfig } from '../../../session/components/AgentSpaw
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError } from '../../../../shared/lib/errors';
-import { humanizeMergeStatus, type GitlabMergeStatusTone } from '../client';
+import {
+  gitlabMergeMr,
+  humanizeMergeStatus,
+  type GitlabMergeRequest,
+  type GitlabMergeStatusTone,
+} from '../client';
+import { projectPathFromMrUrl } from './useGitlabMrs';
 
 type Props = {
-  readonly sessionId: SessionId;
+  readonly sessionId?: SessionId | null;
+  readonly mr?: GitlabMergeRequest | null;
+  readonly workspaceId?: WorkspaceId;
+  readonly host?: string | null;
+  readonly onRefresh?: () => void;
   readonly onClose: () => void;
 };
 
@@ -39,10 +49,23 @@ const MERGE_STATUS_STYLE: Record<GitlabMergeStatusTone, string> = {
   muted: 'bg-muted text-muted-foreground',
 };
 
-export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
-  const session = useAppStore((s) => s.sessions.find((x) => x.id === sessionId) ?? null);
-  const mrState = useAppStore((s) => s.sessionGitlabMr[sessionId]);
-  const branch = useAppStore((s) => s.sessionBranches[sessionId] ?? null);
+export const MrDetailPanel = ({
+  sessionId = null,
+  mr: selectedMr = null,
+  workspaceId,
+  host,
+  onRefresh,
+  onClose,
+}: Props) => {
+  const session = useAppStore((s) =>
+    sessionId == null ? null : (s.sessions.find((x) => x.id === sessionId) ?? null),
+  );
+  const mrState = useAppStore((s) =>
+    sessionId == null ? undefined : s.sessionGitlabMr[sessionId],
+  );
+  const sessionBranch = useAppStore((s) =>
+    sessionId == null ? null : (s.sessionBranches[sessionId] ?? null),
+  );
   const refreshSessionMr = useAppStore((s) => s.refreshSessionMr);
   const createMrForSession = useAppStore((s) => s.createMrForSession);
   const mergeMrForSession = useAppStore((s) => s.mergeMrForSession);
@@ -62,7 +85,8 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   );
   const { showToast } = useToast();
 
-  const mr = mrState?.mr ?? null;
+  const mr = selectedMr ?? mrState?.mr ?? null;
+  const branch = selectedMr?.sourceBranch ?? sessionBranch;
   const loading = mrState?.loading ?? false;
   const error = mrState?.error ?? null;
 
@@ -82,6 +106,9 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   }, [agentConfigUserTouched, resolvedAgentConfig]);
 
   useEffect(() => {
+    if (sessionId == null) {
+      return;
+    }
     void refreshSessionMr(sessionId, { silent: true });
   }, [sessionId, refreshSessionMr]);
 
@@ -89,7 +116,7 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
     setTitle(session?.goal ?? '');
   }, [session?.goal]);
 
-  if (!session) {
+  if (sessionId != null && session == null) {
     return (
       <div className="flex h-full items-center justify-center px-8">
         <EmptyState
@@ -101,8 +128,20 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
     );
   }
 
+  if (sessionId == null && mr == null) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <EmptyState
+          icon={MousePointerClick}
+          title="No merge request selected"
+          description="Pick a merge request to see its details."
+        />
+      </div>
+    );
+  }
+
   const onCreate = async () => {
-    if (busy !== null || title.trim().length === 0) {
+    if (sessionId == null || busy !== null || title.trim().length === 0) {
       return;
     }
     setBusy('create');
@@ -122,7 +161,7 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
   };
 
   const onCreateWithAi = async () => {
-    if (busy !== null) {
+    if (sessionId == null || session == null || busy !== null) {
       return;
     }
     setBusy('ai');
@@ -158,7 +197,12 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
     }
     setBusy('merge');
     try {
-      await mergeMrForSession(sessionId);
+      if (sessionId != null) {
+        await mergeMrForSession(sessionId);
+      } else if (mr != null && workspaceId != null && host != null) {
+        await gitlabMergeMr(workspaceId, host, projectPathFromMrUrl({ webUrl: mr.webUrl }), mr.iid);
+        onRefresh?.();
+      }
       showToast('success', 'Merge request merged');
       onClose();
     } catch (err) {
@@ -188,7 +232,13 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
         <span className="flex-1" />
         <button
           type="button"
-          onClick={() => void refreshSessionMr(sessionId, { force: true })}
+          onClick={() => {
+            if (sessionId != null) {
+              void refreshSessionMr(sessionId, { force: true });
+              return;
+            }
+            onRefresh?.();
+          }}
           disabled={loading}
           title={error ? `refresh failed: ${error}` : 'refresh merge request'}
           aria-label="refresh merge request"
@@ -258,7 +308,9 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
                   <span className="flex-1" />
                   <Button
                     onClick={() => void onMerge()}
-                    disabled={busy !== null || mr.hasConflicts}
+                    disabled={
+                      busy !== null || mr.hasConflicts || mr.mergeStatus === 'cannot_be_merged'
+                    }
                     className={busy === 'merge' ? 'animate-border-pulse' : undefined}
                   >
                     {busy === 'merge' ? (
@@ -273,7 +325,7 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
                 </div>
               ) : null}
             </div>
-          ) : (
+          ) : session != null && sessionId != null ? (
             <section className="flex flex-col gap-4">
               <SectionHeader label="create merge request" />
               <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
@@ -361,7 +413,7 @@ export const MrDetailPanel = ({ sessionId, onClose }: Props) => {
                 {error ? <span className="text-xs text-danger">{error}</span> : null}
               </div>
             </section>
-          )}
+          ) : null}
         </ScrollFade>
       </div>
     </div>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -86,6 +86,7 @@ export const MrDetailPanel = ({
   const { showToast } = useToast();
 
   const mr = selectedMr ?? mrState?.mr ?? null;
+  const mergeProjectPath = mr == null ? null : projectPathFromMrUrl({ webUrl: mr.webUrl });
   const branch = selectedMr?.sourceBranch ?? sessionBranch;
   const loading = mrState?.loading ?? false;
   const error = mrState?.error ?? null;
@@ -199,8 +200,8 @@ export const MrDetailPanel = ({
     try {
       if (sessionId != null) {
         await mergeMrForSession(sessionId);
-      } else if (mr != null && workspaceId != null && host != null) {
-        await gitlabMergeMr(workspaceId, host, projectPathFromMrUrl({ webUrl: mr.webUrl }), mr.iid);
+      } else if (mr != null && workspaceId != null && host != null && mergeProjectPath != null) {
+        await gitlabMergeMr(workspaceId, host, mergeProjectPath, mr.iid);
         onRefresh?.();
       }
       showToast('success', 'Merge request merged');
@@ -309,7 +310,10 @@ export const MrDetailPanel = ({
                   <Button
                     onClick={() => void onMerge()}
                     disabled={
-                      busy !== null || mr.hasConflicts || mr.mergeStatus === 'cannot_be_merged'
+                      busy !== null ||
+                      mr.hasConflicts ||
+                      mr.mergeStatus === 'cannot_be_merged' ||
+                      (sessionId == null && mergeProjectPath == null)
                     }
                     className={busy === 'merge' ? 'animate-border-pulse' : undefined}
                   >

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrInbox.tsx
@@ -1,0 +1,146 @@
+import { useMemo, useState } from 'react';
+import { cn, EmptyState, ScrollFade, SectionHeader, Skeleton } from '@goodboy/ui';
+import { GitMerge, Inbox, Search } from 'lucide-react';
+import type { GitlabMergeRequest } from '../client';
+import type { GitlabMrGroup } from './useGitlabMrs';
+
+type Props = {
+  readonly groups: ReadonlyArray<GitlabMrGroup>;
+  readonly focusedMrId: number | null;
+  readonly onSelect: (mr: GitlabMergeRequest) => void;
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+type DateParams = {
+  readonly iso: string;
+};
+
+const shortDate = ({ iso }: DateParams): string => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+};
+
+export const MrInbox = ({ groups, focusedMrId, onSelect, loading, error }: Props) => {
+  const [query, setQuery] = useState('');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (normalized === '') {
+      return groups;
+    }
+    return groups
+      .map((group) => ({
+        ...group,
+        rows: group.rows.filter(
+          (mr) => `!${mr.iid}`.includes(normalized) || mr.title.toLowerCase().includes(normalized),
+        ),
+      }))
+      .filter((group) => group.rows.length > 0);
+  }, [groups, query]);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="shrink-0 p-3 pb-2">
+        <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-background px-2.5 focus-within:border-primary">
+          <Search size={13} aria-hidden className="shrink-0 text-muted-foreground/60" />
+          <input
+            type="text"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search merge requests…"
+            aria-label="Search GitLab merge requests"
+            autoComplete="off"
+            className="min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground/50"
+          />
+        </div>
+      </div>
+      {loading && groups.length === 0 ? (
+        <div
+          className="flex min-h-0 flex-1 flex-col gap-1 px-3 pb-3"
+          role="status"
+          aria-label="Loading merge requests"
+        >
+          {Array.from({ length: 7 }).map((_, index) => (
+            <div key={index} className="flex items-center gap-2.5 px-2.5 py-2">
+              <Skeleton className="h-3 w-8 shrink-0 rounded" />
+              <Skeleton className="h-3 flex-1 rounded" />
+            </div>
+          ))}
+        </div>
+      ) : error != null ? (
+        <div className="px-3 pb-3">
+          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={Inbox}
+            title={query.trim() === '' ? 'Inbox clear' : 'No matching merge requests'}
+            description={
+              query.trim() === ''
+                ? 'No open merge requests assigned to you.'
+                : 'Try a different search term.'
+            }
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+          <div className="flex flex-col gap-3 px-3 pb-3">
+            {filtered.map((group) => (
+              <div key={group.key} className="flex flex-col gap-1">
+                <SectionHeader
+                  className="px-1"
+                  label={group.label}
+                  action={
+                    <span className="text-2xs tabular-nums text-muted-foreground/50">
+                      {group.rows.length}
+                    </span>
+                  }
+                />
+                <ul className="flex flex-col gap-0.5">
+                  {group.rows.map((mr) => {
+                    const isActive = mr.id === focusedMrId;
+                    return (
+                      <li key={mr.id}>
+                        <button
+                          type="button"
+                          onClick={() => onSelect(mr)}
+                          title={mr.title}
+                          aria-current={isActive}
+                          className={cn(
+                            'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left transition-colors',
+                            isActive
+                              ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                              : 'text-muted-foreground hover:bg-muted/40 hover:text-foreground',
+                          )}
+                        >
+                          <GitMerge
+                            size={12}
+                            aria-hidden
+                            className="shrink-0 text-provider-gitlab"
+                          />
+                          <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
+                            !{mr.iid}
+                          </span>
+                          <span className="min-w-0 flex-1 truncate text-xs">{mr.title}</span>
+                          <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
+                            {shortDate({ iso: mr.updatedAt })}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+
+const MR = {
+  id: 12,
+  iid: 4,
+  projectId: 3,
+  title: 'Add merge request dashboard',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/merge_requests/4',
+  sourceBranch: 'ak/mr-dashboard',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged' as const,
+  updatedAt: '2026-07-22T10:00:00Z',
+};
+
+vi.mock('./useGitlabIssues', () => ({
+  useGitlabIssues: () => ({ groups: [], loading: false, error: null, refetch: vi.fn() }),
+}));
+vi.mock('./useGitlabMrs', () => ({
+  useGitlabMrs: () => ({
+    groups: [{ key: 'acme/web', label: 'acme/web', rows: [MR] }],
+    host: 'https://gitlab.com',
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock('./IssueInbox', () => ({ IssueInbox: () => <div>Issue inbox</div> }));
+vi.mock('./IssueDetailPanel', () => ({ IssueDetailPanel: () => <div>Issue detail</div> }));
+vi.mock('./MrDetailPanel', () => ({ MrDetailPanel: () => <div>Merge request detail</div> }));
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({
+    headerAccessory,
+    children,
+  }: {
+    headerAccessory?: ReactNode;
+    children: (requestClose: () => void) => ReactNode;
+  }) => (
+    <div>
+      {headerAccessory}
+      {children(vi.fn())}
+    </div>
+  ),
+}));
+
+import { GitlabStudio } from './index';
+
+afterEach(cleanup);
+
+describe('GitlabStudio', () => {
+  it('keeps issues selected by default', () => {
+    render(
+      <GitlabStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Issues' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('Issue inbox')).toBeDefined();
+    expect(screen.getByText('Issue detail')).toBeDefined();
+  });
+
+  it('renders grouped assigned merge requests in the merge requests tab', () => {
+    render(
+      <GitlabStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Merge requests' }));
+
+    expect(screen.getByText('acme/web')).toBeDefined();
+    expect(screen.getByText('Add merge request dashboard')).toBeDefined();
+    expect(screen.getByText('Merge request detail')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -5,8 +5,19 @@ import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { IssueInbox } from './IssueInbox';
 import { IssueDetailPanel } from './IssueDetailPanel';
+import { MrDetailPanel } from './MrDetailPanel';
+import { MrInbox } from './MrInbox';
 import { useGitlabIssues } from './useGitlabIssues';
-import type { GitlabIssue } from '../client';
+import { useGitlabMrs } from './useGitlabMrs';
+import type { GitlabIssue, GitlabMergeRequest } from '../client';
+import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+
+type Tab = 'issues' | 'merge-requests';
+
+const TABS: ReadonlyArray<StudioTab<Tab>> = [
+  { value: 'issues', label: 'Issues' },
+  { value: 'merge-requests', label: 'Merge requests' },
+];
 
 type Props = {
   readonly workspaceId: WorkspaceId;
@@ -17,7 +28,10 @@ type Props = {
 
 export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClose }: Props) => {
   const { groups, loading, error, refetch } = useGitlabIssues(workspaceId);
+  const mergeRequests = useGitlabMrs({ workspaceId });
   const [focused, setFocused] = useState<GitlabIssue | null>(null);
+  const [focusedMr, setFocusedMr] = useState<GitlabMergeRequest | null>(null);
+  const [tab, setTab] = useState<Tab>('issues');
 
   useEffect(() => {
     if (focused !== null) {
@@ -37,6 +51,16 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
       setFocused(first);
     }
   }, [focused, groups, initialIssueId]);
+
+  useEffect(() => {
+    if (focusedMr != null) {
+      return;
+    }
+    const first = mergeRequests.groups[0]?.rows[0] ?? null;
+    if (first != null) {
+      setFocusedMr(first);
+    }
+  }, [focusedMr, mergeRequests.groups]);
 
   const focusedRow = useMemo(() => {
     if (!focused) {
@@ -64,45 +88,72 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
       workspaceName={workspaceName}
       closeLabel="close gitlab studio"
       headerAccessory={
-        <button
-          type="button"
-          onClick={refetch}
-          disabled={loading}
-          title="Refresh issues"
-          aria-label="Refresh issues"
-          className={cn(
-            'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-            'text-muted-foreground transition-colors',
-            'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-          )}
-        >
-          <RefreshCw size={13} aria-hidden />
-        </button>
+        <div className="flex items-center gap-2">
+          <StudioTabs ariaLabel="GitLab work" tabs={TABS} value={tab} onChange={setTab} />
+          <button
+            type="button"
+            onClick={tab === 'issues' ? refetch : mergeRequests.refetch}
+            disabled={tab === 'issues' ? loading : mergeRequests.loading}
+            title={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
+            aria-label={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
+            className={cn(
+              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+              'text-muted-foreground transition-colors',
+              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+            )}
+          >
+            <RefreshCw size={13} aria-hidden />
+          </button>
+        </div>
       }
       onClose={onClose}
     >
-      {(requestClose) => (
-        <>
-          <div className="w-72 shrink-0">
-            <IssueInbox
-              groups={groups}
-              focusedIssueId={focused?.id ?? null}
-              onSelect={setFocused}
-              loading={loading}
-              error={error}
-            />
-          </div>
-          <Divider orientation="vertical" />
-          <div className="min-h-0 flex-1">
-            <IssueDetailPanel
-              issue={focused}
-              sessionId={focusedRow?.sessionId ?? null}
-              workspaceId={workspaceId}
-              onClose={requestClose}
-            />
-          </div>
-        </>
-      )}
+      {(requestClose) =>
+        tab === 'issues' ? (
+          <>
+            <div className="w-72 shrink-0">
+              <IssueInbox
+                groups={groups}
+                focusedIssueId={focused?.id ?? null}
+                onSelect={setFocused}
+                loading={loading}
+                error={error}
+              />
+            </div>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <IssueDetailPanel
+                issue={focused}
+                sessionId={focusedRow?.sessionId ?? null}
+                workspaceId={workspaceId}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="w-72 shrink-0">
+              <MrInbox
+                groups={mergeRequests.groups}
+                focusedMrId={focusedMr?.id ?? null}
+                onSelect={setFocusedMr}
+                loading={mergeRequests.loading}
+                error={mergeRequests.error}
+              />
+            </div>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <MrDetailPanel
+                mr={focusedMr}
+                workspaceId={workspaceId}
+                host={mergeRequests.host}
+                onRefresh={mergeRequests.refetch}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        )
+      }
     </StudioShell>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { GitlabMergeRequest } from '../../client';
+import { buildGitlabMrGroups, projectPathFromMrUrl } from './index';
+
+type Params = {
+  readonly overrides?: Partial<GitlabMergeRequest>;
+};
+
+const makeMr = ({ overrides = {} }: Params = {}): GitlabMergeRequest => ({
+  id: 12,
+  iid: 4,
+  projectId: 3,
+  title: 'Add merge request dashboard',
+  description: null,
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/merge_requests/4',
+  sourceBranch: 'ak/mr-dashboard',
+  targetBranch: 'main',
+  draft: false,
+  hasConflicts: false,
+  mergeStatus: 'can_be_merged',
+  updatedAt: '2026-07-22T10:00:00Z',
+  ...overrides,
+});
+
+describe('useGitlabMrs helpers', () => {
+  it('groups merge requests by project and sorts each group newest first', () => {
+    const groups = buildGitlabMrGroups({
+      mrs: [
+        makeMr({ overrides: { id: 1, updatedAt: '2026-07-20T10:00:00Z' } }),
+        makeMr({ overrides: { id: 2, updatedAt: '2026-07-23T10:00:00Z' } }),
+        makeMr({
+          overrides: {
+            id: 3,
+            webUrl: 'https://gitlab.com/acme/api/-/merge_requests/8',
+          },
+        }),
+      ],
+    });
+
+    expect(groups.map((group) => group.key)).toEqual(['acme/api', 'acme/web']);
+    expect(groups[1]?.rows.map((mr) => mr.id)).toEqual([2, 1]);
+  });
+
+  it('extracts a nested project path from an MR URL', () => {
+    expect(
+      projectPathFromMrUrl({
+        webUrl: 'https://gitlab.com/group/subgroup/repo/-/merge_requests/9',
+      }),
+    ).toBe('group/subgroup/repo');
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
@@ -49,4 +49,13 @@ describe('useGitlabMrs helpers', () => {
       }),
     ).toBe('group/subgroup/repo');
   });
+
+  it('returns no project path for an unparseable MR URL', () => {
+    expect(projectPathFromMrUrl({ webUrl: 'not a URL' })).toBeNull();
+    expect(
+      buildGitlabMrGroups({
+        mrs: [makeMr({ overrides: { webUrl: 'not a URL' } })],
+      })[0]?.label,
+    ).toBe('Merge requests');
+  });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
@@ -29,21 +29,21 @@ type Result = Readonly<{
   refetch: () => void;
 }>;
 
-export const projectPathFromMrUrl = ({ webUrl }: Params): string => {
+export const projectPathFromMrUrl = ({ webUrl }: Params): string | null => {
   try {
     const marker = '/-/merge_requests/';
     const path = new URL(webUrl).pathname;
     const markerIndex = path.indexOf(marker);
     return markerIndex < 0 ? path.replace(/^\//, '') : path.slice(1, markerIndex);
   } catch {
-    return 'Merge requests';
+    return null;
   }
 };
 
 export const buildGitlabMrGroups = ({ mrs }: GroupsParams): ReadonlyArray<GitlabMrGroup> => {
   const buckets = new Map<string, GitlabMergeRequest[]>();
   for (const mr of mrs) {
-    const key = projectPathFromMrUrl({ webUrl: mr.webUrl });
+    const key = projectPathFromMrUrl({ webUrl: mr.webUrl }) ?? 'Merge requests';
     buckets.set(key, [...(buckets.get(key) ?? []), mr]);
   }
   return [...buckets.keys()]

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { GitlabWorkspaceIntegration, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../../store';
+import { gitlabFetchAssignedMrs, type GitlabMergeRequest } from '../../client';
+
+export type GitlabMrGroup = Readonly<{
+  key: string;
+  label: string;
+  rows: ReadonlyArray<GitlabMergeRequest>;
+}>;
+
+type Params = {
+  readonly webUrl: string;
+};
+
+type HookParams = {
+  readonly workspaceId: WorkspaceId;
+};
+
+type GroupsParams = {
+  readonly mrs: ReadonlyArray<GitlabMergeRequest>;
+};
+
+type Result = Readonly<{
+  groups: ReadonlyArray<GitlabMrGroup>;
+  host: string | null;
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}>;
+
+export const projectPathFromMrUrl = ({ webUrl }: Params): string => {
+  try {
+    const marker = '/-/merge_requests/';
+    const path = new URL(webUrl).pathname;
+    const markerIndex = path.indexOf(marker);
+    return markerIndex < 0 ? path.replace(/^\//, '') : path.slice(1, markerIndex);
+  } catch {
+    return 'Merge requests';
+  }
+};
+
+export const buildGitlabMrGroups = ({ mrs }: GroupsParams): ReadonlyArray<GitlabMrGroup> => {
+  const buckets = new Map<string, GitlabMergeRequest[]>();
+  for (const mr of mrs) {
+    const key = projectPathFromMrUrl({ webUrl: mr.webUrl });
+    buckets.set(key, [...(buckets.get(key) ?? []), mr]);
+  }
+  return [...buckets.keys()]
+    .sort((left, right) => left.localeCompare(right))
+    .map((key) => ({
+      key,
+      label: key,
+      rows: (buckets.get(key) ?? []).sort((left, right) =>
+        right.updatedAt.localeCompare(left.updatedAt),
+      ),
+    }));
+};
+
+export const useGitlabMrs = ({ workspaceId }: HookParams): Result => {
+  const host = useAppStore((state) => {
+    const integration = state.workspaceIntegrations[workspaceId]?.find(
+      (candidate): candidate is GitlabWorkspaceIntegration => candidate.provider === 'gitlab',
+    );
+    return integration?.config.host ?? null;
+  });
+  const [mrs, setMrs] = useState<ReadonlyArray<GitlabMergeRequest>>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchMrs = useCallback(async () => {
+    if (host == null) {
+      setMrs([]);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      setMrs(await gitlabFetchAssignedMrs(workspaceId, host));
+    } catch (fetchError) {
+      setError(fetchError instanceof Error ? fetchError.message : String(fetchError));
+    } finally {
+      setLoading(false);
+    }
+  }, [host, workspaceId]);
+
+  useEffect(() => {
+    void fetchMrs();
+  }, [fetchMrs]);
+
+  const groups = useMemo(() => buildGitlabMrGroups({ mrs }), [mrs]);
+  return { groups, host, loading, error, refetch: () => void fetchMrs() };
+};

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -64,6 +64,14 @@ export type GitlabMergeRequest = {
   draft: boolean;
   hasConflicts: boolean;
   mergeStatus: GitlabMergeStatus;
+  updatedAt: string;
+};
+
+export const gitlabFetchAssignedMrs = async (
+  workspaceId: WorkspaceId,
+  host: string,
+): Promise<GitlabMergeRequest[]> => {
+  return invoke<GitlabMergeRequest[]>('gitlab_fetch_assigned_mrs', { workspaceId, host });
 };
 
 export type GitlabMergeStatusTone = 'success' | 'danger' | 'muted';

--- a/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
+++ b/apps/desktop/src/features/session/components/SessionOverviewPane/LinkedWorkSection.tsx
@@ -18,12 +18,14 @@ const PROVIDER_LENS: Record<SessionExternalTaskProvider, LensKind> = {
   linear: 'linear',
   sentry: 'sentry',
   gitlab: 'gitlab_issues',
+  github: 'pr',
 };
 
 const PROVIDER_ORDER: Record<SessionExternalTaskProvider, number> = {
   linear: 0,
   sentry: 1,
   gitlab: 2,
+  github: 3,
 };
 
 export const LinkedWorkSection = ({ sessionId, onSelectLens }: Props) => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -22,6 +22,7 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
   linear: { label: 'Linear', studioEvent: 'goodboy:open-linear-studio' },
   sentry: { label: 'Sentry', studioEvent: 'goodboy:open-sentry-studio' },
   gitlab: { label: 'GitLab', studioEvent: 'goodboy:open-gitlab-studio' },
+  github: { label: 'GitHub', studioEvent: 'goodboy:open-github-studio' },
 };
 
 export const IntegrationPane = ({ sessionId, provider }: Props) => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.ts
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/parseIntegrationTaskUrl.ts
@@ -65,6 +65,15 @@ const parseGitlab = ({ segments }: ProviderParams): ProviderResult => {
   return { externalId: identifier, identifier };
 };
 
+const parseGithub = ({ segments }: ProviderParams): ProviderResult => {
+  const issueIndex = segments.findIndex((segment) => segment.toLowerCase() === 'issues');
+  const issueNumber = segments[issueIndex + 1];
+  if (issueIndex < 2 || issueNumber == null || issueNumber === '') {
+    return null;
+  }
+  return { externalId: issueNumber, identifier: `#${issueNumber}` };
+};
+
 const parseProvider = ({ provider, segments }: ParseProviderParams): ProviderResult => {
   switch (provider) {
     case 'linear':
@@ -73,6 +82,8 @@ const parseProvider = ({ provider, segments }: ParseProviderParams): ProviderRes
       return parseSentry({ segments });
     case 'gitlab':
       return parseGitlab({ segments });
+    case 'github':
+      return parseGithub({ segments });
     default: {
       const exhaustiveProvider: never = provider;
       return exhaustiveProvider;

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -4,6 +4,7 @@ import type {
   IsoDateTime,
   PullRequestState,
   Session,
+  SessionExternalTask,
   SessionId,
   TaskModelPreferences,
   WorkspaceId,
@@ -18,6 +19,7 @@ type SpawnAgent = (
 type Store = {
   sessionGithub: Record<string, unknown>;
   sessionGitlabMr: Record<string, unknown>;
+  sessionExternalTasks: Record<string, ReadonlyArray<SessionExternalTask>>;
   readonly refreshSessionPr: ReturnType<typeof vi.fn>;
   readonly createPrForSession: ReturnType<typeof vi.fn>;
   readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
@@ -43,6 +45,7 @@ const h = vi.hoisted(() => ({
   store: {
     sessionGithub: {},
     sessionGitlabMr: {},
+    sessionExternalTasks: {},
     refreshSessionPr: vi.fn(),
     createPrForSession: vi.fn(async () => undefined),
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-1'),
@@ -54,6 +57,7 @@ const h = vi.hoisted(() => ({
 }));
 
 vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: [],
   useAppStore: <T,>(selector: (state: Store) => T) => selector(h.store),
 }));
 
@@ -105,6 +109,7 @@ const session: Session = {
 beforeEach(() => {
   h.store.sessionGithub = {};
   h.store.sessionGitlabMr = {};
+  h.store.sessionExternalTasks = {};
   h.store.createPrForSession.mockClear();
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
@@ -133,6 +138,60 @@ describe('PrPane', () => {
     expect(listRow.getAttribute('aria-current')).toBe('true');
     expect(screen.getAllByText('Refactor authentication')).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'Open PR' })).toBeDefined();
+  });
+
+  it('shows PR status, linked issues, and code-host external tasks from stored state', () => {
+    h.store.sessionGithub = {
+      [SESSION_ID]: {
+        pr: PULL_REQUEST,
+        linkedIssues: [
+          {
+            number: 7,
+            title: 'Track auth rollout',
+            url: 'https://github.com/acme/goodboy/issues/7',
+            closes: true,
+          },
+        ],
+        detail: {
+          checks: [{ name: 'test', conclusion: 'success', detailsUrl: null, durationMs: 1200 }],
+          comments: [
+            {
+              id: 'comment-1',
+              author: 'reviewer',
+              authorAvatarUrl: null,
+              body: 'Please add a regression test.',
+              createdAt: DATE,
+              url: 'https://github.com/acme/goodboy/pull/42#discussion_r1',
+              source: 'review',
+              resolved: false,
+            },
+          ],
+        },
+        loading: false,
+        error: null,
+      },
+    };
+    h.store.sessionExternalTasks = {
+      [SESSION_ID]: [
+        {
+          sessionId: SESSION_ID,
+          provider: 'github',
+          externalId: '7',
+          identifier: '#7',
+          url: 'https://github.com/acme/goodboy/issues/7',
+          title: 'Track auth rollout',
+          createdAt: DATE,
+        },
+      ],
+    };
+
+    render(<PrPane session={session} />);
+
+    expect(screen.getByText('CI passing')).toBeDefined();
+    expect(screen.getByText('Review required')).toBeDefined();
+    expect(screen.getByText('1')).toBeDefined();
+    expect(screen.getByRole('link', { name: /#7 Track auth rollout/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: /open #7 in GitHub studio/i })).toBeDefined();
   });
 
   it('spawns a draft agent with the chosen config and operator notes', async () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -16,13 +16,14 @@ import {
 import { Eyebrow, cn } from '@goodboy/ui';
 import type { PrCheckRun, PullRequestStateKind, Session, SessionId } from '@goodboy/types';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
+import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import { GitlabMrStrip } from '../../../../context/components/ContextPanel/strips/GitlabMrStrip';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { appendOperatorNotes } from '../../../utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
 import { taskModelAgentSpawnConfig } from '../../AgentSpawnConfig/taskModelAgentSpawnConfig';
-import { useAppStore } from '../../../../../store';
+import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
 import { PaneShell } from './PaneShell';
 import { PrListRow } from './PrListRow';
 
@@ -112,6 +113,7 @@ const GithubPrCard = ({ session }: { session: Session }) => {
   const selectAgent = useAppStore((s) => s.selectAgent);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const branch = useAppStore((s) => s.sessionBranches[sessionId] ?? null);
+  const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
   const workspaceOverrides = useAppStore(
     (s) => s.workspaceOverrides?.[session.workspaceId] ?? null,
   );
@@ -125,6 +127,10 @@ const GithubPrCard = ({ session }: { session: Session }) => {
   );
   const pr = github?.pr ?? null;
   const detail = github?.detail ?? null;
+  const linkedIssues = github?.linkedIssues ?? [];
+  const codeHostTasks = externalTasks.filter(
+    (task) => task.provider === 'github' || task.provider === 'gitlab',
+  );
   const loading = github?.loading ?? false;
   const error = github?.error ?? null;
 
@@ -272,7 +278,7 @@ const GithubPrCard = ({ session }: { session: Session }) => {
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex items-center gap-2">
             <PullRequestChip state={pr.state} variant="badge" number={pr.number} iconSize={12} />
-            {ciState !== 'none' ? <CiBadge state={ciState} /> : null}
+            <CiBadge state={ciState} />
           </div>
           <h2 className="text-balance text-sm font-semibold leading-snug text-foreground">
             {pr.title}
@@ -288,15 +294,53 @@ const GithubPrCard = ({ session }: { session: Session }) => {
           <span className="text-muted-foreground/50">→</span>
           <span className="truncate">{pr.baseBranch}</span>
         </span>
-        {pr.reviewDecision ? <ReviewBadge decision={pr.reviewDecision} /> : null}
-        {unresolved > 0 ? (
-          <span className="inline-flex items-center gap-1">
-            <MessageSquare size={11} aria-hidden />
-            <span className="tabular-nums">{unresolved}</span>
-            <span>unresolved</span>
-          </span>
-        ) : null}
+        {pr.reviewDecision != null ? (
+          <ReviewBadge decision={pr.reviewDecision} />
+        ) : (
+          <span>No review decision</span>
+        )}
+        <span className="inline-flex items-center gap-1">
+          <MessageSquare size={11} aria-hidden />
+          <span className="tabular-nums">{unresolved}</span>
+          <span>unresolved</span>
+        </span>
       </div>
+
+      {linkedIssues.length > 0 ? (
+        <div className="flex flex-col gap-1.5">
+          <Eyebrow label="Linked issues" muted className="px-0.5 font-medium" />
+          <div className="flex flex-col gap-1">
+            {linkedIssues.map((issue) => (
+              <a
+                key={issue.url}
+                href={issue.url}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2 rounded-lg bg-muted/25 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+              >
+                <span className="shrink-0 font-mono">#{issue.number}</span>
+                <span className="min-w-0 flex-1 truncate">{issue.title ?? 'GitHub issue'}</span>
+                <ArrowUpRight size={12} aria-hidden className="shrink-0" />
+              </a>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {codeHostTasks.length > 0 ? (
+        <div className="flex flex-col gap-1.5">
+          <Eyebrow label="External tasks" muted className="px-0.5 font-medium" />
+          <div className="flex flex-col gap-1">
+            {codeHostTasks.map((task) => (
+              <ExternalTaskChip
+                key={`${task.provider}:${task.externalId}`}
+                task={task}
+                appearance="row"
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
 
       <button
         type="button"

--- a/apps/desktop/src/shared/components/StudioTabs.tsx
+++ b/apps/desktop/src/shared/components/StudioTabs.tsx
@@ -1,0 +1,42 @@
+import { cn } from '@goodboy/ui';
+
+export type StudioTab<T extends string> = Readonly<{
+  label: string;
+  value: T;
+}>;
+
+type Props<T extends string> = {
+  readonly ariaLabel: string;
+  readonly tabs: ReadonlyArray<StudioTab<T>>;
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+};
+
+export const StudioTabs = <T extends string>({ ariaLabel, tabs, value, onChange }: Props<T>) => (
+  <div
+    role="tablist"
+    aria-label={ariaLabel}
+    className="flex items-center gap-1 rounded-md bg-muted/50 p-1"
+  >
+    {tabs.map((tab) => {
+      const isActive = tab.value === value;
+      return (
+        <button
+          key={tab.value}
+          type="button"
+          role="tab"
+          aria-selected={isActive}
+          onClick={() => onChange(tab.value)}
+          className={cn(
+            'rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+            isActive
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {tab.label}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -44,6 +44,7 @@
   --color-provider-linear: oklch(0.57 0.16 277);
   --color-provider-sentry: oklch(0.55 0.18 320);
   --color-provider-gitlab: oklch(0.68 0.18 45);
+  --color-provider-github: oklch(0.68 0.02 260);
 
   /* Syntax palette for the diff viewer (dark). On-brand hues, readable on the
      charcoal canvas. Unmapped languages fall back to foreground (no token). */
@@ -255,6 +256,7 @@ html[data-theme='light'] {
   --color-provider-linear: oklch(0.5 0.16 277);
   --color-provider-sentry: oklch(0.48 0.18 320);
   --color-provider-gitlab: oklch(0.56 0.18 45);
+  --color-provider-github: oklch(0.42 0.03 260);
   --color-focus-ring: oklch(0.5 0.13 200 / 0.45);
   /* Syntax palette (light): same hues, lower L for contrast on the light canvas. */
   --color-syntax-keyword: oklch(0.48 0.17 300);

--- a/packages/core/src/github/__tests__/issues.test.ts
+++ b/packages/core/src/github/__tests__/issues.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { listAssignedIssues } from '../issues';
+
+describe('listAssignedIssues', () => {
+  it('lists open assigned issues and maps GitHub labels', async () => {
+    const run = vi.fn().mockResolvedValue({
+      stdout: JSON.stringify([
+        {
+          number: 42,
+          title: 'Add issue dashboard',
+          body: null,
+          url: 'https://github.com/goodboy/goodboy/issues/42',
+          state: 'OPEN',
+          labels: [{ name: 'feature' }, { name: 'desktop' }],
+          assignees: [{ login: 'octocat' }],
+          updatedAt: '2026-07-22T10:00:00Z',
+        },
+      ]),
+      stderr: '',
+      exitCode: 0,
+    });
+    const runner: GhRunner = { run };
+
+    const result = await listAssignedIssues(runner, 'goodboy/goodboy');
+
+    expect(run).toHaveBeenCalledWith(
+      [
+        'issue',
+        'list',
+        '--repo',
+        'goodboy/goodboy',
+        '--assignee',
+        '@me',
+        '--state',
+        'open',
+        '--limit',
+        '50',
+        '--json',
+        'number,title,body,url,state,labels,assignees,updatedAt',
+      ],
+      undefined,
+    );
+    expect(result).toEqual([
+      {
+        number: 42,
+        title: 'Add issue dashboard',
+        body: '',
+        url: 'https://github.com/goodboy/goodboy/issues/42',
+        state: 'OPEN',
+        labels: ['feature', 'desktop'],
+        updatedAt: '2026-07-22T10:00:00Z',
+      },
+    ]);
+  });
+});

--- a/packages/core/src/github/__tests__/issues.test.ts
+++ b/packages/core/src/github/__tests__/issues.test.ts
@@ -22,7 +22,10 @@ describe('listAssignedIssues', () => {
     });
     const runner: GhRunner = { run };
 
-    const result = await listAssignedIssues(runner, 'goodboy/goodboy');
+    const result = await listAssignedIssues(runner, 'goodboy/goodboy', {
+      cwd: '/repos/goodboy',
+      workspaceId: 'workspace-1',
+    });
 
     expect(run).toHaveBeenCalledWith(
       [
@@ -39,7 +42,10 @@ describe('listAssignedIssues', () => {
         '--json',
         'number,title,body,url,state,labels,assignees,updatedAt',
       ],
-      undefined,
+      {
+        cwd: '/repos/goodboy',
+        workspaceId: 'workspace-1',
+      },
     );
     expect(result).toEqual([
       {

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -22,6 +22,8 @@ export { fetchPrDiff, parseUnifiedDiff } from './diff';
 
 export { fetchPrDetail } from './details';
 
+export { listAssignedIssues } from './issues';
+
 export {
   addReviewThreadReply,
   resolveReviewThread,

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -1,5 +1,5 @@
 import type { GithubIssue } from '@goodboy/types';
-import type { GhRunner } from './gh';
+import type { GhRunner, GhRunOptions } from './gh';
 import { runJson } from './gh';
 
 const ISSUE_FIELDS = [
@@ -27,21 +27,26 @@ type RawGithubIssue = {
 export const listAssignedIssues = async (
   runner: GhRunner,
   repoSlug: string,
+  opts: GhRunOptions = {},
 ): Promise<ReadonlyArray<GithubIssue>> => {
-  const issues = await runJson<ReadonlyArray<RawGithubIssue>>(runner, [
-    'issue',
-    'list',
-    '--repo',
-    repoSlug,
-    '--assignee',
-    '@me',
-    '--state',
-    'open',
-    '--limit',
-    '50',
-    '--json',
-    ISSUE_FIELDS.join(','),
-  ]);
+  const issues = await runJson<ReadonlyArray<RawGithubIssue>>(
+    runner,
+    [
+      'issue',
+      'list',
+      '--repo',
+      repoSlug,
+      '--assignee',
+      '@me',
+      '--state',
+      'open',
+      '--limit',
+      '50',
+      '--json',
+      ISSUE_FIELDS.join(','),
+    ],
+    opts,
+  );
 
   return issues.map((issue) => ({
     number: issue.number,

--- a/packages/core/src/github/issues.ts
+++ b/packages/core/src/github/issues.ts
@@ -1,0 +1,55 @@
+import type { GithubIssue } from '@goodboy/types';
+import type { GhRunner } from './gh';
+import { runJson } from './gh';
+
+const ISSUE_FIELDS = [
+  'number',
+  'title',
+  'body',
+  'url',
+  'state',
+  'labels',
+  'assignees',
+  'updatedAt',
+] as const;
+
+type RawGithubIssue = {
+  number: number;
+  title: string;
+  body: string | null;
+  url: string;
+  state: string;
+  labels: ReadonlyArray<{ name: string }>;
+  assignees: ReadonlyArray<{ login: string }>;
+  updatedAt: string;
+};
+
+export const listAssignedIssues = async (
+  runner: GhRunner,
+  repoSlug: string,
+): Promise<ReadonlyArray<GithubIssue>> => {
+  const issues = await runJson<ReadonlyArray<RawGithubIssue>>(runner, [
+    'issue',
+    'list',
+    '--repo',
+    repoSlug,
+    '--assignee',
+    '@me',
+    '--state',
+    'open',
+    '--limit',
+    '50',
+    '--json',
+    ISSUE_FIELDS.join(','),
+  ]);
+
+  return issues.map((issue) => ({
+    number: issue.number,
+    title: issue.title,
+    body: issue.body ?? '',
+    url: issue.url,
+    state: issue.state,
+    labels: issue.labels.map((label) => label.name),
+    updatedAt: issue.updatedAt,
+  }));
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -254,6 +254,7 @@ export {
   fetchPrDiff,
   getPrForBranch,
   invalidatePrCache,
+  listAssignedIssues,
   listPrsForBranch,
   addReviewThreadReply,
   parseLinkedIssuesFromBody,

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -70,6 +70,7 @@ import { m069RefactorExampleOnly } from './m069-refactor-example-only';
 import { m070StepLibraryExampleOnly } from './m070-step-library-example-only';
 import { m071SessionExternalTaskMultipleLinks } from './m071-session-external-task-multiple-links';
 import { m072TaskModels } from './m072-task-models';
+import { m073SessionExternalTaskGithubProvider } from './m073-session-external-task-github-provider';
 
 export type Migration = {
   readonly version: number;
@@ -149,4 +150,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 70, sql: m070StepLibraryExampleOnly },
   { version: 71, sql: m071SessionExternalTaskMultipleLinks },
   { version: 72, sql: m072TaskModels },
+  { version: 73, sql: m073SessionExternalTaskGithubProvider },
 ];

--- a/packages/db/src/migrations/m073-session-external-task-github-provider.ts
+++ b/packages/db/src/migrations/m073-session-external-task-github-provider.ts
@@ -1,0 +1,31 @@
+export const m073SessionExternalTaskGithubProvider = `
+PRAGMA foreign_keys = OFF;
+
+DROP TABLE IF EXISTS session_external_tasks_new;
+
+CREATE TABLE session_external_tasks_new (
+  session_id TEXT NOT NULL,
+  provider TEXT NOT NULL CHECK (provider IN ('linear', 'sentry', 'gitlab', 'github')),
+  external_id TEXT NOT NULL,
+  identifier TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  created_at INTEGER NOT NULL,
+  UNIQUE (session_id, provider, external_id),
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+INSERT INTO session_external_tasks_new (session_id, provider, external_id, identifier, url, title, created_at)
+  SELECT session_id, provider, external_id, identifier, url, title, created_at
+  FROM session_external_tasks;
+
+DROP TABLE session_external_tasks;
+ALTER TABLE session_external_tasks_new RENAME TO session_external_tasks;
+
+DROP INDEX IF EXISTS idx_session_external_tasks_provider_external;
+CREATE INDEX idx_session_external_tasks_provider_external
+  ON session_external_tasks(provider, external_id);
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys = ON;
+`;

--- a/packages/db/src/queries/session-external-task.test.ts
+++ b/packages/db/src/queries/session-external-task.test.ts
@@ -164,4 +164,36 @@ describe('session_external_tasks queries', () => {
 
     expect(await listSessionExternalTasks({ db, sessionId })).toEqual([original]);
   });
+
+  it('preserves existing rows while allowing GitHub links', async () => {
+    const db = await seed({ throughVersion: 72 });
+    const gitlab = makeTask({
+      overrides: {
+        provider: 'gitlab',
+        externalId: 'gitlab-12',
+        identifier: '#12',
+        url: 'https://gitlab.com/goodboy/goodboy/-/issues/12',
+        title: 'Keep this link',
+      },
+    });
+    await upsertSessionExternalTask({ db, task: gitlab });
+    const migration = migrations.find((candidate) => candidate.version === 73);
+    if (migration == null) {
+      throw new Error('Migration 73 should exist');
+    }
+
+    await migrate(db, [migration]);
+    const github = makeTask({
+      overrides: {
+        provider: 'github',
+        externalId: '34',
+        identifier: '#34',
+        url: 'https://github.com/goodboy/goodboy/issues/34',
+        title: 'Add GitHub issues',
+      },
+    });
+    await upsertSessionExternalTask({ db, task: github });
+
+    expect(await listSessionExternalTasks({ db, sessionId })).toEqual([github, gitlab]);
+  });
 });

--- a/packages/types/src/github.ts
+++ b/packages/types/src/github.ts
@@ -11,6 +11,16 @@ export type GhTokenStatus = {
   scoped?: boolean;
 };
 
+export type GithubIssue = {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: string;
+  labels: ReadonlyArray<string>;
+  updatedAt: string;
+};
+
 export type PullRequestStateKind = 'draft' | 'open' | 'approved' | 'queued' | 'merged' | 'closed';
 
 export type PullRequestChecks = 'pending' | 'success' | 'failure' | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -181,6 +181,7 @@ export type {
   GhTokenMode,
   GhTokenStatus,
   GithubPrCacheEntry,
+  GithubIssue,
   LinkedIssue,
   PendingResolution,
   PrCheckConclusion,

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -158,7 +158,7 @@ export type WorkspaceIntegration =
   | SentryWorkspaceIntegration
   | GitlabWorkspaceIntegration;
 
-export type SessionExternalTaskProvider = 'linear' | 'sentry' | 'gitlab';
+export type SessionExternalTaskProvider = 'linear' | 'sentry' | 'gitlab' | 'github';
 
 export type SessionExternalTask = Readonly<{
   sessionId: SessionId;


### PR DESCRIPTION
## What

Goodboy as a work aggregator: both forges now offer the same anatomy, Issues and Pull/Merge requests, with launch-session-from-issue on both sides.

- **GitHub issues as first-class work**: migration m073 adds `github` to `session_external_tasks`; `gh issue list` data layer in core (workspace-scoped PAT support); ExternalTaskChip gets a GitHub variant.
- **GitHub Studio**: tabs Pull requests (unchanged) / Issues: searchable assigned-issue inbox + detail panel with prefilled goal, branch suggestion and Launch session (parity with GitLab's flow), refresh button, focus deep-link via `goodboy:open-github-studio`.
- **GitLab Studio**: tabs Issues (unchanged) / Merge requests: new `gitlab_fetch_assigned_mrs` rust command, MR inbox + reused MrDetailPanel (merge disabled on unparseable project path or `cannot_be_merged`).
- **PR lens enrichment**: checks, review decision, unresolved count, linked issues and linked external tasks, all from data already in the store (zero new fetches).
- Shared `StudioTabs` primitive keeps the two studios uniform.

## Verification

- Typecheck green; suites green: desktop 2308, core 810, db 84, ui 12; cargo 89.
- Adversarial review: 8/8 verified; fixes applied (PAT scoping on issue fetch, MR merge path fallback, dead refetch, test gaps).
- Untouched: deriveSessionStage, PullRequestState existing fields, resolve/batch-push flows.

Area C of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)