### PR TITLE
feat: linear/sentry dashboards + integration connection gating

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -226,6 +226,8 @@ pub fn run() {
       linear::linear_connect,
       linear::linear_disconnect,
       linear::linear_fetch_assigned_issues,
+      linear::linear_fetch_issue,
+      linear::linear_fetch_issue_comments,
       sentry::sentry_connect,
       sentry::sentry_disconnect,
       sentry::sentry_fetch_issues,

--- a/apps/desktop/src-tauri/src/linear.rs
+++ b/apps/desktop/src-tauri/src/linear.rs
@@ -153,6 +153,22 @@ pub struct LinearIssueTeam {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct LinearIssuePerson {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinearIssueProject {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinearIssueLabel {
+    pub name: String,
+    pub color: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LinearAttachment {
     pub id: String,
     pub title: Option<String>,
@@ -168,6 +184,11 @@ pub struct LinearAttachmentNodes {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct LinearIssueLabelNodes {
+    pub nodes: Vec<LinearIssueLabel>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct LinearIssue {
     pub id: String,
     pub identifier: String,
@@ -176,6 +197,12 @@ pub struct LinearIssue {
     pub url: String,
     pub state: LinearIssueState,
     pub team: LinearIssueTeam,
+    pub priority: Option<i64>,
+    #[serde(rename = "priorityLabel")]
+    pub priority_label: Option<String>,
+    pub assignee: Option<LinearIssuePerson>,
+    pub project: Option<LinearIssueProject>,
+    pub labels: LinearIssueLabelNodes,
     #[serde(rename = "updatedAt")]
     pub updated_at: String,
     #[serde(rename = "branchName")]
@@ -194,10 +221,68 @@ query AssignedIssues($filter: IssueFilter!) {
       url
       state { name type }
       team { key }
+      priority
+      priorityLabel
+      assignee { name }
+      project { name }
+      labels { nodes { name color } }
       updatedAt
       branchName
       attachments(first: 10) {
         nodes { id title url sourceType metadata }
+      }
+    }
+  }
+}
+"#;
+
+const ISSUE_QUERY: &str = r#"
+query Issue($issueId: String!) {
+  issue(id: $issueId) {
+    id
+    identifier
+    title
+    description
+    url
+    state { name type }
+    team { key }
+    priority
+    priorityLabel
+    assignee { name }
+    project { name }
+    labels { nodes { name color } }
+    updatedAt
+    branchName
+    attachments(first: 10) {
+      nodes { id title url sourceType metadata }
+    }
+  }
+}
+"#;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinearCommentUser {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LinearIssueComment {
+    pub id: String,
+    pub body: String,
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    pub user: Option<LinearCommentUser>,
+}
+
+const ISSUE_COMMENTS_QUERY: &str = r#"
+query IssueComments($issueId: String!) {
+  issue(id: $issueId) {
+    comments {
+      nodes {
+        id
+        body
+        createdAt
+        user { name }
       }
     }
   }
@@ -246,6 +331,45 @@ pub async fn linear_fetch_assigned_issues(
     Ok(resp.issues.nodes)
 }
 
+#[tauri::command]
+pub async fn linear_fetch_issue(
+    workspace_id: String,
+    issue_id: String,
+    cache: State<'_, LinearTokenCache>,
+) -> Result<LinearIssue, LinearError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let resp: IssueResponse = graphql(
+        &token,
+        ISSUE_QUERY,
+        Some(serde_json::json!({ "issueId": issue_id })),
+    )
+    .await?;
+    resp.issue
+        .ok_or_else(|| LinearError::InvalidShape("missing issue".into()))
+}
+
+#[tauri::command]
+pub async fn linear_fetch_issue_comments(
+    workspace_id: String,
+    issue_id: String,
+    cache: State<'_, LinearTokenCache>,
+) -> Result<Vec<LinearIssueComment>, LinearError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let resp: IssueCommentsResponse = graphql(
+        &token,
+        ISSUE_COMMENTS_QUERY,
+        Some(serde_json::json!({ "issueId": issue_id })),
+    )
+    .await?;
+    let mut comments = resp
+        .issue
+        .ok_or_else(|| LinearError::InvalidShape("missing issue".into()))?
+        .comments
+        .nodes;
+    comments.sort_by(|a, b| a.created_at.cmp(&b.created_at));
+    Ok(comments)
+}
+
 #[derive(Deserialize)]
 struct ViewerResponse {
     viewer: LinearViewer,
@@ -259,4 +383,19 @@ struct Nodes<T> {
 #[derive(Deserialize)]
 struct IssuesResponse {
     issues: Nodes<LinearIssue>,
+}
+
+#[derive(Deserialize)]
+struct IssueResponse {
+    issue: Option<LinearIssue>,
+}
+
+#[derive(Deserialize)]
+struct IssueComments {
+    comments: Nodes<LinearIssueComment>,
+}
+
+#[derive(Deserialize)]
+struct IssueCommentsResponse {
+    issue: Option<IssueComments>,
 }

--- a/apps/desktop/src-tauri/src/sentry.rs
+++ b/apps/desktop/src-tauri/src/sentry.rs
@@ -134,10 +134,26 @@ pub struct SentryStackFrame {
 }
 
 #[derive(Serialize)]
+pub struct SentryTag {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+pub struct SentryBreadcrumb {
+    pub category: Option<String>,
+    pub message: Option<String>,
+    pub level: Option<String>,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Serialize)]
 pub struct SentryIssueDetail {
     pub title: Option<String>,
     pub culprit: Option<String>,
     pub frames: Vec<SentryStackFrame>,
+    pub tags: Vec<SentryTag>,
+    pub breadcrumbs: Vec<SentryBreadcrumb>,
 }
 
 fn read_config(workspace_id: &str, cache: &SentryTokenCache) -> Result<SentryConfig, SentryError> {
@@ -209,6 +225,63 @@ fn extract_frames(event: &serde_json::Value) -> Vec<SentryStackFrame> {
         }
     }
     Vec::new()
+}
+
+fn extract_tags(event: &serde_json::Value) -> Vec<SentryTag> {
+    event
+        .get("tags")
+        .and_then(|value| value.as_array())
+        .map(|tags| {
+            tags.iter()
+                .filter_map(|tag| {
+                    let key = tag.get("key").and_then(|value| value.as_str())?;
+                    let value = tag.get("value").and_then(|value| value.as_str())?;
+                    Some(SentryTag {
+                        key: key.to_string(),
+                        value: value.to_string(),
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn extract_breadcrumbs(event: &serde_json::Value) -> Vec<SentryBreadcrumb> {
+    event
+        .get("entries")
+        .and_then(|value| value.as_array())
+        .and_then(|entries| {
+            entries.iter().find(|entry| {
+                entry.get("type").and_then(|value| value.as_str()) == Some("breadcrumbs")
+            })
+        })
+        .and_then(|entry| entry.get("data"))
+        .and_then(|data| data.get("values"))
+        .and_then(|values| values.as_array())
+        .map(|breadcrumbs| {
+            breadcrumbs
+                .iter()
+                .map(|breadcrumb| SentryBreadcrumb {
+                    category: breadcrumb
+                        .get("category")
+                        .and_then(|value| value.as_str())
+                        .map(String::from),
+                    message: breadcrumb
+                        .get("message")
+                        .and_then(|value| value.as_str())
+                        .map(String::from),
+                    level: breadcrumb
+                        .get("level")
+                        .and_then(|value| value.as_str())
+                        .map(String::from),
+                    timestamp: breadcrumb
+                        .get("timestamp")
+                        .and_then(|value| value.as_str())
+                        .map(String::from),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 #[tauri::command]
@@ -313,6 +386,8 @@ pub async fn sentry_fetch_issue_detail(
         title,
         culprit,
         frames: extract_frames(&event),
+        tags: extract_tags(&event),
+        breadcrumbs: extract_breadcrumbs(&event),
     })
 }
 
@@ -365,5 +440,32 @@ mod tests {
     fn extract_frames_empty_without_entries() {
         let event = serde_json::json!({ "title": "x" });
         assert!(extract_frames(&event).is_empty());
+    }
+
+    #[test]
+    fn extracts_tags_and_breadcrumbs() {
+        let event = serde_json::json!({
+            "tags": [
+                { "key": "release", "value": "web@1.2.3" },
+                { "key": "environment", "value": "production" }
+            ],
+            "entries": [{
+                "type": "breadcrumbs",
+                "data": {
+                    "values": [{
+                        "category": "http",
+                        "message": "GET /api/items",
+                        "level": "info",
+                        "timestamp": "2026-07-23T10:00:00Z"
+                    }]
+                }
+            }]
+        });
+        let tags = extract_tags(&event);
+        let breadcrumbs = extract_breadcrumbs(&event);
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].key, "release");
+        assert_eq!(breadcrumbs.len(), 1);
+        assert_eq!(breadcrumbs[0].message.as_deref(), Some("GET /api/items"));
     }
 }

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
 
@@ -19,21 +19,18 @@ type IssueDetailProps = {
 
 const h = vi.hoisted(() => ({
   refetch: vi.fn(),
+  remoteKind: 'github' as 'github' | null,
+  useGithubIssues: vi.fn(),
 }));
 
 vi.mock('./useGithubInbox', () => ({ useGithubInbox: () => [] }));
 vi.mock('./useGithubIssues', () => ({
-  useGithubIssues: () => ({
-    groups: [{ key: 'open', label: 'Open', rows: [{ issue: ISSUE, sessionId: null }] }],
-    loading: false,
-    error: null,
-    refetch: h.refetch,
-  }),
+  useGithubIssues: h.useGithubIssues,
 }));
 vi.mock('./InboxList', () => ({ InboxList: () => <div>Pull request inbox</div> }));
 vi.mock('./PrDetailPanel', () => ({ PrDetailPanel: () => <div>Pull request detail</div> }));
 vi.mock('../../../worktree/useRemoteHostKind', () => ({
-  useRemoteHostKind: () => 'github',
+  useRemoteHostKind: () => h.remoteKind,
 }));
 vi.mock('./GithubIssueDetailPanel', () => ({
   GithubIssueDetailPanel: ({ issue }: IssueDetailProps) => (
@@ -70,10 +67,21 @@ const renderStudio = () =>
 
 afterEach(() => {
   cleanup();
+  h.remoteKind = 'github';
   h.refetch.mockClear();
+  h.useGithubIssues.mockReset();
 });
 
 describe('GitHubStudio', () => {
+  beforeEach(() => {
+    h.useGithubIssues.mockReturnValue({
+      groups: [{ key: 'open', label: 'Open', rows: [{ issue: ISSUE, sessionId: null }] }],
+      loading: false,
+      error: null,
+      refetch: h.refetch,
+    });
+  });
+
   it('keeps pull requests selected by default', () => {
     renderStudio();
 
@@ -98,5 +106,19 @@ describe('GitHubStudio', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Refresh issues' }));
 
     expect(h.refetch).toHaveBeenCalledOnce();
+  });
+
+  it('renders a neutral disconnected state without a connect action', () => {
+    h.remoteKind = null;
+    renderStudio();
+
+    expect(screen.getByText('No GitHub remote')).toBeDefined();
+    expect(screen.getByText('This workspace does not have a GitHub remote.')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Connect' })).toBeNull();
+    expect(h.useGithubIssues).toHaveBeenCalledWith({
+      workspaceId: 'workspace-1',
+      rootPath: '/repo',
+      isEnabled: false,
+    });
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -32,6 +32,9 @@ vi.mock('./useGithubIssues', () => ({
 }));
 vi.mock('./InboxList', () => ({ InboxList: () => <div>Pull request inbox</div> }));
 vi.mock('./PrDetailPanel', () => ({ PrDetailPanel: () => <div>Pull request detail</div> }));
+vi.mock('../../../worktree/useRemoteHostKind', () => ({
+  useRemoteHostKind: () => 'github',
+}));
 vi.mock('./GithubIssueDetailPanel', () => ({
   GithubIssueDetailPanel: ({ issue }: IssueDetailProps) => (
     <div>{issue?.title ?? 'No issue detail'}</div>

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -10,6 +10,9 @@ import { useGithubInbox } from './useGithubInbox';
 import { useGithubIssues } from './useGithubIssues';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+import { ConnectIntegrationEmptyState } from '../../../integrations/ConnectIntegrationEmptyState';
+import { resolveIntegrationConnection } from '../../../integrations/connection';
+import { useRemoteHostKind } from '../../../worktree/useRemoteHostKind';
 
 type Tab = 'pull-requests' | 'issues';
 
@@ -40,7 +43,14 @@ export const GitHubStudio = ({
   onClose,
 }: Props) => {
   const groups = useGithubInbox();
-  const issues = useGithubIssues({ workspaceId, rootPath });
+  const remoteKind = useRemoteHostKind(workspaceId);
+  const isConnected = resolveIntegrationConnection({
+    provider: 'github',
+    integrations: [],
+    remoteKind,
+    externalTasks: [],
+  }).isConnected;
+  const issues = useGithubIssues({ workspaceId, rootPath, isEnabled: isConnected });
   const [focused, setFocused] = useState<SessionId | null>(initialSessionId);
   const [focusedIssue, setFocusedIssue] = useState<GithubIssue | null>(null);
   const [tab, setTab] = useState<Tab>(initialIssueExternalId == null ? 'pull-requests' : 'issues');
@@ -106,28 +116,34 @@ export const GitHubStudio = ({
       workspaceName={workspaceName}
       closeLabel="close github studio"
       headerAccessory={
-        <div className="flex items-center gap-2">
-          <StudioTabs ariaLabel="GitHub work" tabs={TABS} value={tab} onChange={setTab} />
-          <button
-            type="button"
-            onClick={issues.refetch}
-            disabled={issues.loading}
-            title="Refresh issues"
-            aria-label="Refresh issues"
-            className={cn(
-              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-              'text-muted-foreground transition-colors',
-              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-            )}
-          >
-            <RefreshCw size={13} aria-hidden />
-          </button>
-        </div>
+        isConnected ? (
+          <div className="flex items-center gap-2">
+            <StudioTabs ariaLabel="GitHub work" tabs={TABS} value={tab} onChange={setTab} />
+            <button
+              type="button"
+              onClick={issues.refetch}
+              disabled={issues.loading}
+              title="Refresh issues"
+              aria-label="Refresh issues"
+              className={cn(
+                'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+                'text-muted-foreground transition-colors',
+                'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+              )}
+            >
+              <RefreshCw size={13} aria-hidden />
+            </button>
+          </div>
+        ) : null
       }
       onClose={onClose}
     >
       {(requestClose) =>
-        tab === 'pull-requests' ? (
+        !isConnected ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <ConnectIntegrationEmptyState name="GitHub" />
+          </div>
+        ) : tab === 'pull-requests' ? (
           <>
             <ScrollFade className="w-72 shrink-0" fadeSize={24}>
               <InboxList groups={groups} focusedSessionId={focused} onSelect={setFocused} />

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -10,9 +10,9 @@ import { useGithubInbox } from './useGithubInbox';
 import { useGithubIssues } from './useGithubIssues';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
-import { ConnectIntegrationEmptyState } from '../../../integrations/ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../../integrations/connection';
 import { useRemoteHostKind } from '../../../worktree/useRemoteHostKind';
+import { MissingGithubRemoteEmptyState } from '../MissingGithubRemoteEmptyState';
 
 type Tab = 'pull-requests' | 'issues';
 
@@ -141,7 +141,7 @@ export const GitHubStudio = ({
       {(requestClose) =>
         !isConnected ? (
           <div className="flex min-h-0 flex-1 items-center justify-center">
-            <ConnectIntegrationEmptyState name="GitHub" />
+            <MissingGithubRemoteEmptyState />
           </div>
         ) : tab === 'pull-requests' ? (
           <>

--- a/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/useGithubIssues.ts
@@ -28,6 +28,7 @@ type BranchParams = {
 type HookParams = {
   readonly workspaceId: WorkspaceId;
   readonly rootPath: string;
+  readonly isEnabled?: boolean;
 };
 
 type Result = Readonly<{
@@ -61,13 +62,23 @@ export const buildGithubIssueGroups = ({
   return rows.length === 0 ? [] : [{ key: 'open', label: 'Open', rows }];
 };
 
-export const useGithubIssues = ({ workspaceId, rootPath }: HookParams): Result => {
+export const useGithubIssues = ({
+  workspaceId,
+  rootPath,
+  isEnabled = true,
+}: HookParams): Result => {
   const externalTasks = useAppStore((state) => state.sessionExternalTasks);
   const [issues, setIssues] = useState<ReadonlyArray<GithubIssue>>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const fetchIssues = useCallback(async () => {
+    if (!isEnabled) {
+      setIssues([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -82,7 +93,7 @@ export const useGithubIssues = ({ workspaceId, rootPath }: HookParams): Result =
     } finally {
       setLoading(false);
     }
-  }, [rootPath, workspaceId]);
+  }, [isEnabled, rootPath, workspaceId]);
 
   useEffect(() => {
     void fetchIssues();

--- a/apps/desktop/src/features/github/components/MissingGithubRemoteEmptyState.tsx
+++ b/apps/desktop/src/features/github/components/MissingGithubRemoteEmptyState.tsx
@@ -1,0 +1,15 @@
+import { EmptyState } from '@goodboy/ui';
+import { GitBranch } from 'lucide-react';
+
+type Props = {
+  readonly compact?: boolean;
+};
+
+export const MissingGithubRemoteEmptyState = ({ compact = false }: Props) => (
+  <EmptyState
+    icon={GitBranch}
+    title="No GitHub remote"
+    description="This workspace does not have a GitHub remote."
+    className={compact ? 'py-5' : undefined}
+  />
+);

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.test.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.test.tsx
@@ -1,0 +1,33 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectIntegrationEmptyState } from './ConnectIntegrationEmptyState';
+
+const PROVIDERS = [
+  ['linear', 'Linear'],
+  ['sentry', 'Sentry'],
+  ['gitlab', 'GitLab'],
+] as const;
+
+afterEach(cleanup);
+
+describe('ConnectIntegrationEmptyState', () => {
+  it.each(PROVIDERS)('opens workspace integration settings for %s', (provider, name) => {
+    const workspaceSettingsListener = vi.fn();
+    const appSettingsListener = vi.fn();
+    window.addEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
+    window.addEventListener('goodboy:open-settings', appSettingsListener);
+
+    render(<ConnectIntegrationEmptyState provider={provider} />);
+    expect(screen.getByText(`Connect ${name}`)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    expect(workspaceSettingsListener).toHaveBeenCalledOnce();
+    expect((workspaceSettingsListener.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({
+      section: 'integrations',
+    });
+    expect(appSettingsListener).not.toHaveBeenCalled();
+
+    window.removeEventListener('goodboy:open-workspace-settings', workspaceSettingsListener);
+    window.removeEventListener('goodboy:open-settings', appSettingsListener);
+  });
+});

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
@@ -1,0 +1,28 @@
+import { Button, EmptyState } from '@goodboy/ui';
+import { Plug } from 'lucide-react';
+
+type Props = {
+  readonly name: string;
+  readonly compact?: boolean;
+};
+
+export const ConnectIntegrationEmptyState = ({ name, compact = false }: Props) => (
+  <EmptyState
+    icon={Plug}
+    title={`Connect ${name}`}
+    description={`Connect ${name} in Settings to use this integration.`}
+    className={compact ? 'py-5' : undefined}
+    action={
+      <Button
+        size="sm"
+        onClick={() =>
+          window.dispatchEvent(
+            new CustomEvent('goodboy:open-settings', { detail: { section: 'integrations' } }),
+          )
+        }
+      >
+        Connect
+      </Button>
+    }
+  />
+);

--- a/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
+++ b/apps/desktop/src/features/integrations/ConnectIntegrationEmptyState.tsx
@@ -2,22 +2,30 @@ import { Button, EmptyState } from '@goodboy/ui';
 import { Plug } from 'lucide-react';
 
 type Props = {
-  readonly name: string;
+  readonly provider: 'linear' | 'sentry' | 'gitlab';
   readonly compact?: boolean;
 };
 
-export const ConnectIntegrationEmptyState = ({ name, compact = false }: Props) => (
+const PROVIDER_NAMES: Record<Props['provider'], string> = {
+  linear: 'Linear',
+  sentry: 'Sentry',
+  gitlab: 'GitLab',
+};
+
+export const ConnectIntegrationEmptyState = ({ provider, compact = false }: Props) => (
   <EmptyState
     icon={Plug}
-    title={`Connect ${name}`}
-    description={`Connect ${name} in Settings to use this integration.`}
+    title={`Connect ${PROVIDER_NAMES[provider]}`}
+    description={`Connect ${PROVIDER_NAMES[provider]} in Settings to use this integration.`}
     className={compact ? 'py-5' : undefined}
     action={
       <Button
         size="sm"
         onClick={() =>
           window.dispatchEvent(
-            new CustomEvent('goodboy:open-settings', { detail: { section: 'integrations' } }),
+            new CustomEvent('goodboy:open-workspace-settings', {
+              detail: { section: 'integrations' },
+            }),
           )
         }
       >

--- a/apps/desktop/src/features/integrations/connection.test.ts
+++ b/apps/desktop/src/features/integrations/connection.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  SessionExternalTask,
+  WorkspaceIntegration,
+  WorkspaceIntegrationProvider,
+} from '@goodboy/types';
+import { resolveIntegrationConnection } from './connection';
+
+type IntegrationParams = {
+  readonly provider: WorkspaceIntegrationProvider;
+};
+
+type TaskParams = {
+  readonly provider: SessionExternalTask['provider'];
+};
+
+const integration = ({ provider }: IntegrationParams): WorkspaceIntegration =>
+  ({ provider }) as WorkspaceIntegration;
+
+const task = ({ provider }: TaskParams): SessionExternalTask =>
+  ({ provider }) as SessionExternalTask;
+
+describe('resolveIntegrationConnection', () => {
+  it('distinguishes connected, linked-only, and unavailable integrations', () => {
+    const connected = resolveIntegrationConnection({
+      provider: 'linear',
+      integrations: [integration({ provider: 'linear' })],
+      remoteKind: 'other',
+      externalTasks: [],
+    });
+    const linkedOnly = resolveIntegrationConnection({
+      provider: 'sentry',
+      integrations: [],
+      remoteKind: 'other',
+      externalTasks: [task({ provider: 'sentry' })],
+    });
+    const unavailable = resolveIntegrationConnection({
+      provider: 'gitlab',
+      integrations: [],
+      remoteKind: 'github',
+      externalTasks: [],
+    });
+
+    expect({ connected, linkedOnly, unavailable }).toEqual({
+      connected: { isConnected: true, isAvailable: true },
+      linkedOnly: { isConnected: false, isAvailable: true },
+      unavailable: { isConnected: false, isAvailable: false },
+    });
+  });
+
+  it('uses workspace remotes for pull request and GitHub availability', () => {
+    const github = resolveIntegrationConnection({
+      provider: 'github',
+      integrations: [],
+      remoteKind: 'github',
+      externalTasks: [],
+    });
+    const gitlabPr = resolveIntegrationConnection({
+      provider: 'pr',
+      integrations: [integration({ provider: 'gitlab' })],
+      remoteKind: 'gitlab',
+      externalTasks: [],
+    });
+
+    expect({ github, gitlabPr }).toEqual({
+      github: { isConnected: true, isAvailable: true },
+      gitlabPr: { isConnected: true, isAvailable: true },
+    });
+  });
+});

--- a/apps/desktop/src/features/integrations/connection.ts
+++ b/apps/desktop/src/features/integrations/connection.ts
@@ -1,0 +1,67 @@
+import type {
+  SessionExternalTask,
+  SessionExternalTaskProvider,
+  WorkspaceIntegration,
+} from '@goodboy/types';
+import type { RemoteHostKind } from '../../shared/lib/remoteHost';
+
+type Provider = SessionExternalTaskProvider | 'pr';
+
+type Params = {
+  readonly provider: Provider;
+  readonly integrations: ReadonlyArray<WorkspaceIntegration>;
+  readonly remoteKind: RemoteHostKind | null;
+  readonly externalTasks: ReadonlyArray<SessionExternalTask>;
+};
+
+type Result = {
+  readonly isConnected: boolean;
+  readonly isAvailable: boolean;
+};
+
+export const resolveIntegrationConnection = ({
+  provider,
+  integrations,
+  remoteKind,
+  externalTasks,
+}: Params): Result => {
+  const hasLinear = integrations.some((integration) => integration.provider === 'linear');
+  const hasSentry = integrations.some((integration) => integration.provider === 'sentry');
+  const hasGitlab = integrations.some((integration) => integration.provider === 'gitlab');
+  const hasGithubRemote = remoteKind === 'github';
+  const hasGitlabRemote = remoteKind === 'gitlab';
+
+  let isConnected: boolean;
+  let hasLinkedTask: boolean;
+
+  switch (provider) {
+    case 'linear':
+      isConnected = hasLinear;
+      hasLinkedTask = externalTasks.some((task) => task.provider === 'linear');
+      break;
+    case 'sentry':
+      isConnected = hasSentry;
+      hasLinkedTask = externalTasks.some((task) => task.provider === 'sentry');
+      break;
+    case 'gitlab':
+      isConnected = hasGitlab;
+      hasLinkedTask = externalTasks.some((task) => task.provider === 'gitlab');
+      break;
+    case 'github':
+      isConnected = hasGithubRemote;
+      hasLinkedTask = externalTasks.some((task) => task.provider === 'github');
+      break;
+    case 'pr':
+      isConnected = hasGithubRemote || (hasGitlabRemote && hasGitlab);
+      hasLinkedTask = externalTasks.some(
+        (task) => task.provider === 'github' || task.provider === 'gitlab',
+      );
+      break;
+    default: {
+      const unreachable: never = provider;
+      return unreachable;
+    }
+  }
+
+  return { isConnected, isAvailable: isConnected || hasLinkedTask };
+};

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { WorkspaceId } from '@goodboy/types';
 
@@ -19,17 +19,17 @@ const MR = {
   updatedAt: '2026-07-22T10:00:00Z',
 };
 
+const h = vi.hoisted(() => ({
+  isConnected: true,
+  useGitlabIssues: vi.fn(),
+  useGitlabMrs: vi.fn(),
+}));
+
 vi.mock('./useGitlabIssues', () => ({
-  useGitlabIssues: () => ({ groups: [], loading: false, error: null, refetch: vi.fn() }),
+  useGitlabIssues: h.useGitlabIssues,
 }));
 vi.mock('./useGitlabMrs', () => ({
-  useGitlabMrs: () => ({
-    groups: [{ key: 'acme/web', label: 'acme/web', rows: [MR] }],
-    host: 'https://gitlab.com',
-    loading: false,
-    error: null,
-    refetch: vi.fn(),
-  }),
+  useGitlabMrs: h.useGitlabMrs,
 }));
 vi.mock('./IssueInbox', () => ({ IssueInbox: () => <div>Issue inbox</div> }));
 vi.mock('./IssueDetailPanel', () => ({ IssueDetailPanel: () => <div>Issue detail</div> }));
@@ -40,7 +40,7 @@ vi.mock('../../../../store', () => ({
     selector: (state: { workspaceIntegrations: Record<string, Array<{ provider: string }>> }) => T,
   ) =>
     selector({
-      workspaceIntegrations: { 'workspace-1': [{ provider: 'gitlab' }] },
+      workspaceIntegrations: h.isConnected ? { 'workspace-1': [{ provider: 'gitlab' }] } : {},
     }),
 }));
 vi.mock('../../../../shared/components/StudioShell', () => ({
@@ -60,7 +60,28 @@ vi.mock('../../../../shared/components/StudioShell', () => ({
 
 import { GitlabStudio } from './index';
 
-afterEach(cleanup);
+beforeEach(() => {
+  h.isConnected = true;
+  h.useGitlabIssues.mockReturnValue({
+    groups: [],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  h.useGitlabMrs.mockReturnValue({
+    groups: [{ key: 'acme/web', label: 'acme/web', rows: [MR] }],
+    host: 'https://gitlab.com',
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  h.useGitlabIssues.mockReset();
+  h.useGitlabMrs.mockReset();
+});
 
 describe('GitlabStudio', () => {
   it('keeps issues selected by default', () => {
@@ -90,5 +111,16 @@ describe('GitlabStudio', () => {
     expect(screen.getByText('acme/web')).toBeDefined();
     expect(screen.getByText('Add merge request dashboard')).toBeDefined();
     expect(screen.getByText('Merge request detail')).toBeDefined();
+  });
+
+  it('renders the disconnected state and disables both data hooks', () => {
+    h.isConnected = false;
+    const workspaceId = 'workspace-1' as WorkspaceId;
+    render(<GitlabStudio workspaceId={workspaceId} workspaceName="Goodboy" onClose={vi.fn()} />);
+
+    expect(screen.getByText('Connect GitLab')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeDefined();
+    expect(h.useGitlabIssues).toHaveBeenCalledWith({ workspaceId, isEnabled: false });
+    expect(h.useGitlabMrs).toHaveBeenCalledWith({ workspaceId, isEnabled: false });
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
@@ -34,6 +34,15 @@ vi.mock('./useGitlabMrs', () => ({
 vi.mock('./IssueInbox', () => ({ IssueInbox: () => <div>Issue inbox</div> }));
 vi.mock('./IssueDetailPanel', () => ({ IssueDetailPanel: () => <div>Issue detail</div> }));
 vi.mock('./MrDetailPanel', () => ({ MrDetailPanel: () => <div>Merge request detail</div> }));
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(
+    selector: (state: { workspaceIntegrations: Record<string, Array<{ provider: string }>> }) => T,
+  ) =>
+    selector({
+      workspaceIntegrations: { 'workspace-1': [{ provider: 'gitlab' }] },
+    }),
+}));
 vi.mock('../../../../shared/components/StudioShell', () => ({
   StudioShell: ({
     headerAccessory,

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -3,6 +3,9 @@ import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
+import { resolveIntegrationConnection } from '../../connection';
 import { IssueInbox } from './IssueInbox';
 import { IssueDetailPanel } from './IssueDetailPanel';
 import { MrDetailPanel } from './MrDetailPanel';
@@ -27,6 +30,15 @@ type Props = {
 };
 
 export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClose }: Props) => {
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const isConnected = resolveIntegrationConnection({
+    provider: 'gitlab',
+    integrations,
+    remoteKind: null,
+    externalTasks: EMPTY_ARRAY,
+  }).isConnected;
   const { groups, loading, error, refetch } = useGitlabIssues(workspaceId);
   const mergeRequests = useGitlabMrs({ workspaceId });
   const [focused, setFocused] = useState<GitlabIssue | null>(null);
@@ -88,28 +100,34 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
       workspaceName={workspaceName}
       closeLabel="close gitlab studio"
       headerAccessory={
-        <div className="flex items-center gap-2">
-          <StudioTabs ariaLabel="GitLab work" tabs={TABS} value={tab} onChange={setTab} />
-          <button
-            type="button"
-            onClick={tab === 'issues' ? refetch : mergeRequests.refetch}
-            disabled={tab === 'issues' ? loading : mergeRequests.loading}
-            title={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
-            aria-label={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
-            className={cn(
-              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-              'text-muted-foreground transition-colors',
-              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-            )}
-          >
-            <RefreshCw size={13} aria-hidden />
-          </button>
-        </div>
+        isConnected ? (
+          <div className="flex items-center gap-2">
+            <StudioTabs ariaLabel="GitLab work" tabs={TABS} value={tab} onChange={setTab} />
+            <button
+              type="button"
+              onClick={tab === 'issues' ? refetch : mergeRequests.refetch}
+              disabled={tab === 'issues' ? loading : mergeRequests.loading}
+              title={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
+              aria-label={tab === 'issues' ? 'Refresh issues' : 'Refresh merge requests'}
+              className={cn(
+                'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+                'text-muted-foreground transition-colors',
+                'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+              )}
+            >
+              <RefreshCw size={13} aria-hidden />
+            </button>
+          </div>
+        ) : null
       }
       onClose={onClose}
     >
       {(requestClose) =>
-        tab === 'issues' ? (
+        !isConnected ? (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <ConnectIntegrationEmptyState name="GitLab" />
+          </div>
+        ) : tab === 'issues' ? (
           <>
             <div className="w-72 shrink-0">
               <IssueInbox

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -39,8 +39,11 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
     remoteKind: null,
     externalTasks: EMPTY_ARRAY,
   }).isConnected;
-  const { groups, loading, error, refetch } = useGitlabIssues(workspaceId);
-  const mergeRequests = useGitlabMrs({ workspaceId });
+  const { groups, loading, error, refetch } = useGitlabIssues({
+    workspaceId,
+    isEnabled: isConnected,
+  });
+  const mergeRequests = useGitlabMrs({ workspaceId, isEnabled: isConnected });
   const [focused, setFocused] = useState<GitlabIssue | null>(null);
   const [focusedMr, setFocusedMr] = useState<GitlabMergeRequest | null>(null);
   const [tab, setTab] = useState<Tab>('issues');
@@ -125,7 +128,7 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
       {(requestClose) =>
         !isConnected ? (
           <div className="flex min-h-0 flex-1 items-center justify-center">
-            <ConnectIntegrationEmptyState name="GitLab" />
+            <ConnectIntegrationEmptyState provider="gitlab" />
           </div>
         ) : tab === 'issues' ? (
           <>

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabIssues.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabIssues.test.ts
@@ -1,12 +1,39 @@
-import { describe, expect, it } from 'vitest';
-import type { Session, SessionExternalTask, SessionId } from '@goodboy/types';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
 import {
   buildIssueGroups,
   gitlabBranchSlug,
   projectPathFromIssue,
   resolveIssueSessions,
+  useGitlabIssues,
 } from './useGitlabIssues';
-import type { GitlabIssue } from '../client';
+import { gitlabFetchAssignedIssues, type GitlabIssue } from '../client';
+
+const h = vi.hoisted(() => ({
+  sessionExternalTasks: {},
+  sessionBranches: {},
+  workspaceIntegrations: {
+    'workspace-1': [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+  },
+}));
+
+vi.mock('../client', () => ({
+  gitlabFetchAssignedIssues: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  useSessions: () => [],
+  useAppStore: <T>(
+    selector: (state: {
+      sessionExternalTasks: typeof h.sessionExternalTasks;
+      sessionBranches: typeof h.sessionBranches;
+      workspaceIntegrations: typeof h.workspaceIntegrations;
+    }) => T,
+  ) => selector(h),
+}));
+
+const fetchAssignedIssues = vi.mocked(gitlabFetchAssignedIssues);
 
 function makeIssue(overrides: Partial<GitlabIssue> = {}): GitlabIssue {
   return {
@@ -28,6 +55,12 @@ function makeIssue(overrides: Partial<GitlabIssue> = {}): GitlabIssue {
 function session(id: string): Session {
   return { id: id as SessionId } as Session;
 }
+
+beforeEach(() => {
+  fetchAssignedIssues.mockReset();
+});
+
+afterEach(cleanup);
 
 describe('projectPathFromIssue', () => {
   it('returns the namespace before the #iid', () => {
@@ -122,5 +155,17 @@ describe('resolveIssueSessions', () => {
     const branches = { s1: 'kay/42-fix-login' };
     const map = resolveIssueSessions([issue], [session('s1'), session('s2')], branches, tasks);
     expect(map.get('101')).toBe('s2');
+  });
+});
+
+describe('useGitlabIssues', () => {
+  it('does not fetch assigned issues when disabled', () => {
+    const { result } = renderHook(() =>
+      useGitlabIssues({ workspaceId: 'workspace-1' as WorkspaceId, isEnabled: false }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.groups).toEqual([]);
+    expect(fetchAssignedIssues).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabIssues.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabIssues.ts
@@ -116,7 +116,12 @@ export type UseGitlabIssues = {
   readonly refetch: () => void;
 };
 
-export const useGitlabIssues = (workspaceId: WorkspaceId): UseGitlabIssues => {
+type HookParams = {
+  readonly workspaceId: WorkspaceId;
+  readonly isEnabled?: boolean;
+};
+
+export const useGitlabIssues = ({ workspaceId, isEnabled = true }: HookParams): UseGitlabIssues => {
   const sessions = useSessions();
   const sessionExternalTasks = useAppStore((s) => s.sessionExternalTasks);
   const sessionBranches = useAppStore((s) => s.sessionBranches);
@@ -131,6 +136,12 @@ export const useGitlabIssues = (workspaceId: WorkspaceId): UseGitlabIssues => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchIssues = useCallback(async () => {
+    if (!isEnabled) {
+      setIssues([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
     if (!host) {
       setIssues([]);
       return;
@@ -145,7 +156,7 @@ export const useGitlabIssues = (workspaceId: WorkspaceId): UseGitlabIssues => {
     } finally {
       setLoading(false);
     }
-  }, [workspaceId, host]);
+  }, [workspaceId, host, isEnabled]);
 
   useEffect(() => {
     void fetchIssues();

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.test.ts
@@ -1,6 +1,26 @@
-import { describe, expect, it } from 'vitest';
-import type { GitlabMergeRequest } from '../../client';
-import { buildGitlabMrGroups, projectPathFromMrUrl } from './index';
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { gitlabFetchAssignedMrs, type GitlabMergeRequest } from '../../client';
+import { buildGitlabMrGroups, projectPathFromMrUrl, useGitlabMrs } from './index';
+
+const h = vi.hoisted(() => ({
+  workspaceIntegrations: {
+    'workspace-1': [{ provider: 'gitlab', config: { host: 'https://gitlab.com' } }],
+  },
+}));
+
+vi.mock('../../client', () => ({
+  gitlabFetchAssignedMrs: vi.fn(),
+}));
+
+vi.mock('../../../../../store', () => ({
+  useAppStore: <T>(
+    selector: (state: { workspaceIntegrations: typeof h.workspaceIntegrations }) => T,
+  ) => selector(h),
+}));
+
+const fetchAssignedMrs = vi.mocked(gitlabFetchAssignedMrs);
 
 type Params = {
   readonly overrides?: Partial<GitlabMergeRequest>;
@@ -22,6 +42,12 @@ const makeMr = ({ overrides = {} }: Params = {}): GitlabMergeRequest => ({
   updatedAt: '2026-07-22T10:00:00Z',
   ...overrides,
 });
+
+beforeEach(() => {
+  fetchAssignedMrs.mockReset();
+});
+
+afterEach(cleanup);
 
 describe('useGitlabMrs helpers', () => {
   it('groups merge requests by project and sorts each group newest first', () => {
@@ -57,5 +83,17 @@ describe('useGitlabMrs helpers', () => {
         mrs: [makeMr({ overrides: { webUrl: 'not a URL' } })],
       })[0]?.label,
     ).toBe('Merge requests');
+  });
+});
+
+describe('useGitlabMrs', () => {
+  it('does not fetch assigned merge requests when disabled', () => {
+    const { result } = renderHook(() =>
+      useGitlabMrs({ workspaceId: 'workspace-1' as WorkspaceId, isEnabled: false }),
+    );
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.groups).toEqual([]);
+    expect(fetchAssignedMrs).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/useGitlabMrs/index.ts
@@ -15,6 +15,7 @@ type Params = {
 
 type HookParams = {
   readonly workspaceId: WorkspaceId;
+  readonly isEnabled?: boolean;
 };
 
 type GroupsParams = {
@@ -57,7 +58,7 @@ export const buildGitlabMrGroups = ({ mrs }: GroupsParams): ReadonlyArray<Gitlab
     }));
 };
 
-export const useGitlabMrs = ({ workspaceId }: HookParams): Result => {
+export const useGitlabMrs = ({ workspaceId, isEnabled = true }: HookParams): Result => {
   const host = useAppStore((state) => {
     const integration = state.workspaceIntegrations[workspaceId]?.find(
       (candidate): candidate is GitlabWorkspaceIntegration => candidate.provider === 'gitlab',
@@ -69,6 +70,12 @@ export const useGitlabMrs = ({ workspaceId }: HookParams): Result => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchMrs = useCallback(async () => {
+    if (!isEnabled) {
+      setMrs([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
     if (host == null) {
       setMrs([]);
       return;
@@ -82,7 +89,7 @@ export const useGitlabMrs = ({ workspaceId }: HookParams): Result => {
     } finally {
       setLoading(false);
     }
-  }, [host, workspaceId]);
+  }, [host, isEnabled, workspaceId]);
 
   useEffect(() => {
     void fetchMrs();

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import type { LinearIssue } from '../client';
+
+vi.mock('../useLinearIssueComments', () => ({
+  useLinearIssueComments: () => ({
+    comments: [
+      {
+        id: 'comment-1',
+        body: 'The fix is ready for review.',
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        user: { name: 'Ada Lovelace' },
+      },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+import { LinearIssueDetail } from '.';
+
+const ISSUE: LinearIssue = {
+  id: 'issue-1',
+  identifier: 'GB-42',
+  title: 'Improve linked issue detail',
+  description: '**Full** description',
+  url: 'https://linear.app/goodboy/issue/GB-42',
+  state: { name: 'In Progress', type: 'started' },
+  team: { key: 'GB' },
+  priority: 1,
+  priorityLabel: 'Urgent',
+  assignee: { name: 'Grace Hopper' },
+  project: { name: 'Desktop' },
+  labels: { nodes: [{ name: 'UI', color: '#5e6ad2' }] },
+  updatedAt: '2026-07-23T10:00:00Z',
+};
+
+afterEach(cleanup);
+
+describe('LinearIssueDetail', () => {
+  it('renders issue metadata, markdown, and comments', () => {
+    render(<LinearIssueDetail issue={ISSUE} workspaceId={'workspace-1' as WorkspaceId} />);
+
+    expect(screen.getByLabelText('Priority: Urgent')).toBeDefined();
+    expect(screen.getByText('Assigned to Grace Hopper')).toBeDefined();
+    expect(screen.getByText('Full')).toBeDefined();
+    expect(screen.getByText('Ada Lovelace')).toBeDefined();
+    expect(screen.getByText('The fix is ready for review.')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -1,0 +1,148 @@
+import { EmptyState, Markdown, SectionHeader, Skeleton, cn } from '@goodboy/ui';
+import { ExternalLink, GitPullRequest, MessageSquare } from 'lucide-react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import { issuePullRequests, type LinearIssue } from '../client';
+import { priorityTone } from '../priorityTone';
+import { prStatusTone } from '../prStatusTone';
+import { useLinearIssueComments } from '../useLinearIssueComments';
+
+type Props = {
+  readonly issue: LinearIssue;
+  readonly workspaceId: WorkspaceId;
+};
+
+export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
+  const { comments, isLoading, error } = useLinearIssueComments({
+    workspaceId,
+    issueId: issue.id,
+  });
+  const linkedPrs = issuePullRequests(issue);
+  const priorityLabel = issue.priorityLabel ?? 'No priority';
+
+  return (
+    <article className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            aria-label={`Priority: ${priorityLabel}`}
+            className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground"
+          >
+            <span
+              aria-hidden
+              className={cn('size-2 rounded-full', priorityTone({ priority: issue.priority }))}
+            />
+            {priorityLabel}
+          </span>
+          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+            {issue.identifier}
+          </span>
+          <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+            {issue.state.name}
+          </span>
+          <span className="flex-1" />
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Open in Linear <ExternalLink size={11} aria-hidden />
+          </a>
+        </div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {issue.assignee != null ? <span>Assigned to {issue.assignee.name}</span> : null}
+          {issue.project != null ? <span>Project: {issue.project.name}</span> : null}
+        </div>
+        {(issue.labels?.nodes.length ?? 0) > 0 ? (
+          <div aria-label="Labels" className="flex flex-wrap items-center gap-2">
+            {issue.labels?.nodes.map((label) => (
+              <span
+                key={`${label.name}-${label.color}`}
+                className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground"
+              >
+                <span
+                  aria-hidden
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: label.color }}
+                />
+                {label.name}
+              </span>
+            )) ?? null}
+          </div>
+        ) : null}
+        {linkedPrs.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-1.5">
+            {linkedPrs.map((pr) => (
+              <a
+                key={pr.number}
+                href={pr.url}
+                target="_blank"
+                rel="noreferrer"
+                title={pr.url}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80',
+                  prStatusTone({ status: pr.status }),
+                )}
+              >
+                <GitPullRequest size={11} aria-hidden />#{pr.number}
+                {pr.status != null ? <span className="opacity-70">· {pr.status}</span> : null}
+              </a>
+            ))}
+          </div>
+        ) : null}
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <SectionHeader label="description" />
+        {issue.description != null && issue.description !== '' ? (
+          <Markdown text={issue.description} className="text-sm leading-relaxed" />
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No description.</p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <SectionHeader label="comments" />
+        {isLoading ? (
+          <div role="status" aria-label="Loading comments" className="flex flex-col gap-4">
+            {[0, 1, 2].map((row) => (
+              <div key={row} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+                <Skeleton className="h-3 w-28 rounded" />
+                <Skeleton className="h-3 w-full rounded" />
+                <Skeleton className="h-3 w-2/3 rounded" />
+              </div>
+            ))}
+          </div>
+        ) : error != null ? (
+          <p className="text-sm text-danger">{error}</p>
+        ) : comments.length === 0 ? (
+          <EmptyState
+            icon={MessageSquare}
+            title="No comments"
+            description="This issue has no comments yet."
+            className="py-5"
+          />
+        ) : (
+          <div className="flex flex-col gap-3">
+            {comments.map((comment) => {
+              const relativeDate = formatRelativeDuration(comment.createdAt);
+              return (
+                <div key={comment.id} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+                  <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      {comment.user?.name ?? 'Unknown author'}
+                    </span>
+                    {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
+                  </div>
+                  <Markdown text={comment.body} className="text-sm leading-relaxed" />
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    </article>
+  );
+};

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -1,19 +1,8 @@
 import { useEffect, useState } from 'react';
-import {
-  Button,
-  Divider,
-  EmptyState,
-  Input,
-  Markdown,
-  SectionHeader,
-  StatusDot,
-  Textarea,
-  cn,
-} from '@goodboy/ui';
+import { Button, EmptyState, Input, SectionHeader, StatusDot, Textarea, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
-  ExternalLink,
   GitBranch,
   GitPullRequest,
   MessagesSquare,
@@ -37,6 +26,7 @@ import { useBranchConflict } from '../../../worktree/useBranchConflict';
 import { ghPrHeadBranch } from '../../../github/github';
 import { goalFromIssue } from '../goal-from-issue';
 import { issuePullRequests, type LinearIssue } from '../client';
+import { LinearIssueDetail } from '../LinearIssueDetail';
 
 type BranchMode = 'pr' | 'fresh';
 
@@ -69,21 +59,6 @@ function branchSlugFor(issue: LinearIssue): string {
     }
   }
   return slugify(issue.title);
-}
-
-function prStatusTone(status: string | null): string {
-  switch (status?.toLowerCase()) {
-    case 'merged':
-      return 'border-primary/40 bg-primary/10 text-primary';
-    case 'open':
-      return 'border-success/40 bg-success/10 text-success';
-    case 'draft':
-      return 'border-border-soft bg-muted/50 text-muted-foreground';
-    case 'closed':
-      return 'border-danger/40 bg-danger/10 text-danger';
-    default:
-      return 'border-border-soft bg-muted/40 text-muted-foreground';
-  }
 }
 
 export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
@@ -234,52 +209,8 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     }
   };
 
-  const linkedPrs = issuePullRequests(issue);
-
   return (
     <div className="flex h-full flex-col">
-      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-            {issue.identifier}
-          </span>
-          <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
-            {issue.state.name}
-          </span>
-          <span className="flex-1" />
-          <a
-            href={issue.url}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Open in Linear <ExternalLink size={11} aria-hidden />
-          </a>
-        </div>
-        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
-        {linkedPrs.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1.5">
-            {linkedPrs.map((pr) => (
-              <a
-                key={pr.number}
-                href={pr.url}
-                target="_blank"
-                rel="noreferrer"
-                title={pr.url}
-                className={cn(
-                  'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80',
-                  prStatusTone(pr.status),
-                )}
-              >
-                <GitPullRequest size={11} aria-hidden />#{pr.number}
-                {pr.status ? <span className="opacity-70">· {pr.status}</span> : null}
-              </a>
-            ))}
-          </div>
-        )}
-      </div>
-      <Divider />
-
       <div className="min-h-0 flex-1">
         <ScrollFade
           className="mx-auto h-full max-w-3xl"
@@ -287,14 +218,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
           fadeSize={24}
         >
           <div className="flex flex-col gap-8">
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="description" />
-              {issue.description ? (
-                <Markdown text={issue.description} className="text-sm leading-relaxed" />
-              ) : (
-                <p className="text-sm italic text-muted-foreground/60">No description.</p>
-              )}
-            </section>
+            <LinearIssueDetail issue={issue} workspaceId={workspaceId} />
 
             <section className="flex flex-col gap-3">
               <SectionHeader label="launch session" />

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { cn, EmptyState, ScrollFade, SectionHeader, Skeleton } from '@goodboy/ui';
 import { GitPullRequest, Inbox, MessagesSquare, Search } from 'lucide-react';
 import { issuePullRequests, type LinearIssue } from '../client';
+import { priorityTone } from '../priorityTone';
 import type { LinearGroupKey, LinearIssueGroup } from './useLinearIssues';
 
 type Props = {
@@ -10,14 +11,6 @@ type Props = {
   readonly onSelect: (issue: LinearIssue) => void;
   readonly loading: boolean;
   readonly error: string | null;
-};
-
-const STATE_DOT: Record<LinearGroupKey, string> = {
-  started: 'bg-primary',
-  unstarted: 'bg-info',
-  backlog: 'bg-muted-foreground/50',
-  triage: 'bg-warning',
-  other: 'bg-muted-foreground/40',
 };
 
 export const IssueInbox = ({ groups, focusedIssueId, onSelect, loading, error }: Props) => {
@@ -114,8 +107,11 @@ export const IssueInbox = ({ groups, focusedIssueId, onSelect, loading, error }:
                           )}
                         >
                           <span
-                            aria-hidden
-                            className={cn('size-1.5 shrink-0 rounded-full', STATE_DOT[group.key])}
+                            aria-label={`Priority: ${row.issue.priorityLabel ?? 'No priority'}`}
+                            className={cn(
+                              'size-1.5 shrink-0 rounded-full',
+                              priorityTone({ priority: row.issue.priority }),
+                            )}
                           />
                           <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
                             {row.issue.identifier}

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueInbox.tsx
@@ -3,7 +3,7 @@ import { cn, EmptyState, ScrollFade, SectionHeader, Skeleton } from '@goodboy/ui
 import { GitPullRequest, Inbox, MessagesSquare, Search } from 'lucide-react';
 import { issuePullRequests, type LinearIssue } from '../client';
 import { priorityTone } from '../priorityTone';
-import type { LinearGroupKey, LinearIssueGroup } from './useLinearIssues';
+import type { LinearIssueGroup } from './useLinearIssues';
 
 type Props = {
   readonly groups: ReadonlyArray<LinearIssueGroup>;

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: { workspaceIntegrations: Record<string, never[]> }) => T) =>
+    selector({ workspaceIntegrations: {} }),
+}));
+
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({ children }: { children: (requestClose: () => void) => ReactNode }) => (
+    <div>{children(vi.fn())}</div>
+  ),
+}));
+
+vi.mock('./useLinearIssues', () => ({
+  useLinearIssues: () => ({
+    groups: [],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+import { LinearStudio } from '.';
+
+afterEach(cleanup);
+
+describe('LinearStudio', () => {
+  it('shows the connection state when Linear is disconnected', () => {
+    render(
+      <LinearStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Connect Linear')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -120,7 +120,7 @@ export const LinearStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
           </>
         ) : (
           <div className="flex min-h-0 flex-1 items-center justify-center">
-            <ConnectIntegrationEmptyState name="Linear" />
+            <ConnectIntegrationEmptyState provider="linear" />
           </div>
         )
       }

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -3,6 +3,9 @@ import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
+import { resolveIntegrationConnection } from '../../connection';
 import { IssueInbox } from './IssueInbox';
 import { IssueDetailPanel } from './IssueDetailPanel';
 import { useLinearIssues } from './useLinearIssues';
@@ -16,7 +19,16 @@ type Props = {
 };
 
 export const LinearStudio = ({ workspaceId, workspaceName, initialIssueId, onClose }: Props) => {
-  const { groups, loading, error, refetch } = useLinearIssues(workspaceId);
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const isConnected = resolveIntegrationConnection({
+    provider: 'linear',
+    integrations,
+    remoteKind: null,
+    externalTasks: EMPTY_ARRAY,
+  }).isConnected;
+  const { groups, loading, error, refetch } = useLinearIssues(workspaceId, isConnected);
   const [focused, setFocused] = useState<LinearIssue | null>(null);
 
   useEffect(() => {
@@ -64,46 +76,54 @@ export const LinearStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
       workspaceName={workspaceName}
       closeLabel="close linear studio"
       headerAccessory={
-        <button
-          type="button"
-          onClick={refetch}
-          disabled={loading}
-          title="Refresh issues"
-          aria-label="Refresh issues"
-          className={cn(
-            'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-            'text-muted-foreground transition-colors',
-            'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-            loading && 'animate-border-pulse',
-          )}
-        >
-          <RefreshCw size={13} aria-hidden />
-        </button>
+        isConnected ? (
+          <button
+            type="button"
+            onClick={refetch}
+            disabled={loading}
+            title="Refresh issues"
+            aria-label="Refresh issues"
+            className={cn(
+              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+              'text-muted-foreground transition-colors',
+              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+              loading && 'animate-border-pulse',
+            )}
+          >
+            <RefreshCw size={13} aria-hidden />
+          </button>
+        ) : null
       }
       onClose={onClose}
     >
-      {(requestClose) => (
-        <>
-          <div className="w-72 shrink-0">
-            <IssueInbox
-              groups={groups}
-              focusedIssueId={focused?.id ?? null}
-              onSelect={setFocused}
-              loading={loading}
-              error={error}
-            />
+      {(requestClose) =>
+        isConnected ? (
+          <>
+            <div className="w-72 shrink-0">
+              <IssueInbox
+                groups={groups}
+                focusedIssueId={focused?.id ?? null}
+                onSelect={setFocused}
+                loading={loading}
+                error={error}
+              />
+            </div>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <IssueDetailPanel
+                issue={focused}
+                sessionId={focusedRow?.sessionId ?? null}
+                workspaceId={workspaceId}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <ConnectIntegrationEmptyState name="Linear" />
           </div>
-          <Divider orientation="vertical" />
-          <div className="min-h-0 flex-1">
-            <IssueDetailPanel
-              issue={focused}
-              sessionId={focusedRow?.sessionId ?? null}
-              workspaceId={workspaceId}
-              onClose={requestClose}
-            />
-          </div>
-        </>
-      )}
+        )
+      }
     </StudioShell>
   );
 };

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/useLinearIssues.ts
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/useLinearIssues.ts
@@ -146,7 +146,7 @@ export type UseLinearIssues = {
   readonly refetch: () => void;
 };
 
-export const useLinearIssues = (workspaceId: WorkspaceId): UseLinearIssues => {
+export const useLinearIssues = (workspaceId: WorkspaceId, isEnabled = true): UseLinearIssues => {
   const sessions = useSessions();
   const sessionExternalTasks = useAppStore((s) => s.sessionExternalTasks);
   const sessionBranches = useAppStore((s) => s.sessionBranches);
@@ -156,6 +156,12 @@ export const useLinearIssues = (workspaceId: WorkspaceId): UseLinearIssues => {
   const [error, setError] = useState<string | null>(null);
 
   const fetchIssues = useCallback(async () => {
+    if (!isEnabled) {
+      setIssues([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -166,7 +172,7 @@ export const useLinearIssues = (workspaceId: WorkspaceId): UseLinearIssues => {
     } finally {
       setLoading(false);
     }
-  }, [workspaceId]);
+  }, [isEnabled, workspaceId]);
 
   useEffect(() => {
     void fetchIssues();

--- a/apps/desktop/src/features/integrations/linear/client.test.ts
+++ b/apps/desktop/src/features/integrations/linear/client.test.ts
@@ -1,5 +1,18 @@
-import { describe, expect, it } from 'vitest';
-import { issuePullRequests, type LinearAttachment, type LinearIssue } from './client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import type { WorkspaceId } from '@goodboy/types';
+import {
+  issuePullRequests,
+  linearFetchIssue,
+  linearFetchIssueComments,
+  type LinearAttachment,
+  type LinearIssue,
+} from './client';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const mockInvoke = vi.mocked(invoke);
 
 function makeIssue(attachments: LinearAttachment[] | undefined): LinearIssue {
   return {
@@ -10,10 +23,19 @@ function makeIssue(attachments: LinearAttachment[] | undefined): LinearIssue {
     url: 'https://linear.app/serenis/issue/SER-1',
     state: { name: 'In Progress', type: 'started' },
     team: { key: 'SER' },
+    priority: 2,
+    priorityLabel: 'High',
+    assignee: { name: 'Ada' },
+    project: { name: 'Desktop' },
+    labels: { nodes: [{ name: 'Bug', color: '#ff0000' }] },
     updatedAt: '2026-05-21T10:00:00Z',
     ...(attachments ? { attachments: { nodes: attachments } } : {}),
   };
 }
+
+afterEach(() => {
+  mockInvoke.mockReset();
+});
 
 function attachment(overrides: Partial<LinearAttachment>): LinearAttachment {
   return {
@@ -77,5 +99,19 @@ describe('issuePullRequests', () => {
       makeIssue([attachment({ url: 'https://github.com/acme/web/pull/2', metadata: { foo: 1 } })]),
     );
     expect(noStatus?.status).toBeNull();
+  });
+});
+
+describe('Linear issue requests', () => {
+  it('forwards issue ids to detail and comments commands', async () => {
+    mockInvoke.mockResolvedValueOnce(makeIssue([])).mockResolvedValueOnce([]);
+
+    await linearFetchIssue({ workspaceId: WORKSPACE_ID, issueId: 'issue-42' });
+    await linearFetchIssueComments({ workspaceId: WORKSPACE_ID, issueId: 'issue-42' });
+
+    expect(mockInvoke.mock.calls).toEqual([
+      ['linear_fetch_issue', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
+      ['linear_fetch_issue_comments', { workspaceId: WORKSPACE_ID, issueId: 'issue-42' }],
+    ]);
   });
 });

--- a/apps/desktop/src/features/integrations/linear/client.ts
+++ b/apps/desktop/src/features/integrations/linear/client.ts
@@ -16,6 +16,11 @@ type LinearIssueState = {
   type: string;
 };
 
+export type LinearIssueLabel = {
+  name: string;
+  color: string;
+};
+
 export type LinearAttachment = {
   id: string;
   title: string | null;
@@ -32,9 +37,26 @@ export type LinearIssue = {
   url: string;
   state: LinearIssueState;
   team: { key: string };
+  priority?: number | null;
+  priorityLabel?: string | null;
+  assignee?: { name: string } | null;
+  project?: { name: string } | null;
+  labels?: { nodes: ReadonlyArray<LinearIssueLabel> };
   updatedAt: string;
   branchName?: string;
   attachments?: { nodes: ReadonlyArray<LinearAttachment> };
+};
+
+export type LinearIssueComment = {
+  id: string;
+  body: string;
+  createdAt: string;
+  user: { name: string } | null;
+};
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string;
 };
 
 export type LinearLinkedPr = {
@@ -94,4 +116,15 @@ export const linearFetchAssignedIssues = async (
     workspaceId,
     teamId: teamId ?? null,
   });
+};
+
+export const linearFetchIssue = async ({ workspaceId, issueId }: Params): Promise<LinearIssue> => {
+  return invoke<LinearIssue>('linear_fetch_issue', { workspaceId, issueId });
+};
+
+export const linearFetchIssueComments = async ({
+  workspaceId,
+  issueId,
+}: Params): Promise<LinearIssueComment[]> => {
+  return invoke<LinearIssueComment[]>('linear_fetch_issue_comments', { workspaceId, issueId });
 };

--- a/apps/desktop/src/features/integrations/linear/prStatusTone.ts
+++ b/apps/desktop/src/features/integrations/linear/prStatusTone.ts
@@ -1,0 +1,18 @@
+type Params = {
+  readonly status: string | null;
+};
+
+export const prStatusTone = ({ status }: Params): string => {
+  switch (status?.toLowerCase()) {
+    case 'merged':
+      return 'border-primary/40 bg-primary/10 text-primary';
+    case 'open':
+      return 'border-success/40 bg-success/10 text-success';
+    case 'draft':
+      return 'border-border-soft bg-muted/50 text-muted-foreground';
+    case 'closed':
+      return 'border-danger/40 bg-danger/10 text-danger';
+    default:
+      return 'border-border-soft bg-muted/40 text-muted-foreground';
+  }
+};

--- a/apps/desktop/src/features/integrations/linear/priorityTone.ts
+++ b/apps/desktop/src/features/integrations/linear/priorityTone.ts
@@ -1,0 +1,15 @@
+const PRIORITY_TONES: Readonly<Record<number, string>> = {
+  1: 'bg-danger',
+  2: 'bg-warning',
+  3: 'bg-info',
+  4: 'bg-muted-foreground/50',
+};
+
+type Params = {
+  readonly priority: number | null | undefined;
+};
+
+export const priorityTone = ({ priority }: Params): string =>
+  priority == null
+    ? 'bg-muted-foreground/30'
+    : (PRIORITY_TONES[priority] ?? 'bg-muted-foreground/30');

--- a/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssue.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../shared/lib/errors';
+import { linearFetchIssue, type LinearIssue } from './client';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string;
+};
+
+type Result = {
+  readonly issue: LinearIssue | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const useLinearIssue = ({ workspaceId, issueId }: Params): Result => {
+  const [issue, setIssue] = useState<LinearIssue | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+    setIssue(null);
+    setError(null);
+    setIsLoading(true);
+    linearFetchIssue({ workspaceId, issueId })
+      .then((nextIssue) => {
+        if (isCancelled) {
+          return;
+        }
+        setIssue(nextIssue);
+      })
+      .catch((fetchError: unknown) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(formatError(fetchError));
+      })
+      .finally(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [issueId, workspaceId]);
+
+  return { issue, isLoading, error };
+};

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { useLinearIssueComments } from './useLinearIssueComments';
+
+const fetchComments = vi.hoisted(() => vi.fn());
+
+vi.mock('./client', () => ({
+  linearFetchIssueComments: fetchComments,
+}));
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+afterEach(() => {
+  cleanup();
+  fetchComments.mockReset();
+});
+
+describe('useLinearIssueComments', () => {
+  it('loads comments when the selected issue changes', async () => {
+    fetchComments
+      .mockResolvedValueOnce([
+        {
+          id: 'comment-1',
+          body: 'First comment',
+          createdAt: '2026-07-23T10:00:00Z',
+          user: { name: 'Ada' },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    const { result, rerender } = renderHook(
+      ({ issueId }: { issueId: string | null }) =>
+        useLinearIssueComments({ workspaceId: WORKSPACE_ID, issueId }),
+      { initialProps: { issueId: 'issue-1' } },
+    );
+
+    await waitFor(() => expect(result.current.comments).toHaveLength(1));
+    rerender({ issueId: 'issue-2' });
+    await waitFor(() => expect(fetchComments).toHaveBeenCalledTimes(2));
+
+    expect(fetchComments.mock.calls).toEqual([
+      [{ workspaceId: WORKSPACE_ID, issueId: 'issue-1' }],
+      [{ workspaceId: WORKSPACE_ID, issueId: 'issue-2' }],
+    ]);
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
+++ b/apps/desktop/src/features/integrations/linear/useLinearIssueComments.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../shared/lib/errors';
+import { linearFetchIssueComments, type LinearIssueComment } from './client';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string | null;
+};
+
+type Result = {
+  readonly comments: ReadonlyArray<LinearIssueComment>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const useLinearIssueComments = ({ workspaceId, issueId }: Params): Result => {
+  const [comments, setComments] = useState<ReadonlyArray<LinearIssueComment>>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setComments([]);
+    setError(null);
+    if (issueId == null) {
+      setIsLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsLoading(true);
+    linearFetchIssueComments({ workspaceId, issueId })
+      .then((nextComments) => {
+        if (isCancelled) {
+          return;
+        }
+        setComments(nextComments);
+      })
+      .catch((fetchError: unknown) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(formatError(fetchError));
+      })
+      .finally(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [issueId, workspaceId]);
+
+  return { comments, isLoading, error };
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SentryIssueDetail } from '.';
+
+afterEach(cleanup);
+
+describe('SentryIssueDetail', () => {
+  it('surfaces event tags and keeps breadcrumbs collapsed', () => {
+    render(
+      <SentryIssueDetail
+        identifier="GOODBOY-42"
+        title="Request failed"
+        culprit="api/items"
+        level="error"
+        permalink="https://sentry.io/issues/42"
+        detail={{
+          title: 'TypeError: request failed',
+          culprit: 'api/items',
+          frames: [],
+          tags: [
+            { key: 'release', value: 'desktop@1.2.3' },
+            { key: 'environment', value: 'production' },
+          ],
+          breadcrumbs: [
+            {
+              category: 'http',
+              message: 'GET /api/items',
+              level: 'info',
+              timestamp: '2026-07-23T10:00:00Z',
+            },
+          ],
+        }}
+        isLoading={false}
+        error={null}
+      />,
+    );
+
+    expect(screen.getByText(/desktop@1.2.3/)).toBeDefined();
+    expect(screen.getByText(/production/)).toBeDefined();
+    expect(screen.getByText('Breadcrumbs (1)').parentElement?.hasAttribute('open')).toBe(false);
+    expect(screen.getByText('GET /api/items')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -1,0 +1,148 @@
+import { SectionHeader, Skeleton, cn } from '@goodboy/ui';
+import { ExternalLink, Layers } from 'lucide-react';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import type { SentryIssueDetail as Detail } from '../client';
+import { levelTone } from '../levelTone';
+
+type Props = {
+  readonly identifier: string;
+  readonly title: string;
+  readonly culprit: string | null;
+  readonly level: string | null;
+  readonly permalink: string | null;
+  readonly detail: Detail | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+const VISIBLE_TAGS = new Set(['release', 'environment']);
+
+export const SentryIssueDetail = ({
+  identifier,
+  title,
+  culprit,
+  level,
+  permalink,
+  detail,
+  isLoading,
+  error,
+}: Props) => {
+  const visibleTags = detail?.tags?.filter((tag) => VISIBLE_TAGS.has(tag.key)) ?? [];
+  const frames = detail?.frames ?? [];
+  const breadcrumbs = detail?.breadcrumbs ?? [];
+
+  return (
+    <article className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={cn(
+              'shrink-0 rounded border px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide',
+              levelTone({ level }),
+            )}
+          >
+            {level ?? 'error'}
+          </span>
+          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+            {identifier}
+          </span>
+          <span className="flex-1" />
+          {permalink != null && permalink !== '' ? (
+            <a
+              href={permalink}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Open in Sentry <ExternalLink size={11} aria-hidden />
+            </a>
+          ) : null}
+        </div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">
+          {detail?.title ?? title}
+        </h2>
+        {detail?.culprit != null || culprit != null ? (
+          <span className="truncate font-mono text-2xs text-muted-foreground">
+            {detail?.culprit ?? culprit}
+          </span>
+        ) : null}
+        {visibleTags.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {visibleTags.map((tag) => (
+              <span
+                key={tag.key}
+                className="rounded-md border border-border-soft bg-muted/30 px-2 py-1 text-2xs text-muted-foreground"
+              >
+                {tag.key}: <span className="text-foreground">{tag.value}</span>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </header>
+
+      <section className="flex flex-col gap-3">
+        <SectionHeader
+          label="stack trace"
+          icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
+        />
+        {isLoading ? (
+          <div
+            role="status"
+            aria-label="Loading latest event"
+            className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/40 p-3"
+          >
+            {['w-3/4', 'w-1/2', 'w-2/3', 'w-5/6', 'w-2/5', 'w-3/5'].map((width) => (
+              <Skeleton key={width} className={cn('h-2.5 rounded', width)} />
+            ))}
+          </div>
+        ) : error != null ? (
+          <p className="text-sm text-danger">{error}</p>
+        ) : frames.length > 0 ? (
+          <pre className="overflow-x-auto rounded-lg border border-border-soft bg-subtle/40 p-3 font-mono text-2xs leading-relaxed text-muted-foreground">
+            {frames
+              .map(
+                (frame) =>
+                  `${frame.in_app ? '› ' : '  '}${frame.function ?? '?'} (${frame.filename ?? '?'}${
+                    frame.line_no != null ? `:${frame.line_no}` : ''
+                  })`,
+              )
+              .join('\n')}
+          </pre>
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No stack trace available.</p>
+        )}
+      </section>
+
+      {!isLoading && error == null && breadcrumbs.length > 0 ? (
+        <details className="rounded-lg border border-border-soft bg-muted/10">
+          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-foreground">
+            Breadcrumbs ({breadcrumbs.length})
+          </summary>
+          <div className="flex flex-col gap-2 px-3 pb-3">
+            {breadcrumbs.map((breadcrumb, index) => {
+              const relativeDate =
+                breadcrumb.timestamp == null ? '' : formatRelativeDuration(breadcrumb.timestamp);
+              return (
+                <div
+                  key={`${breadcrumb.timestamp ?? 'breadcrumb'}-${index}`}
+                  className="flex flex-col gap-1 rounded-md bg-muted/30 p-2"
+                >
+                  <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+                    <span className="font-medium text-foreground">
+                      {breadcrumb.category ?? 'event'}
+                    </span>
+                    {breadcrumb.level != null ? <span>{breadcrumb.level}</span> : null}
+                    {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
+                  </div>
+                  {breadcrumb.message != null ? (
+                    <span className="text-xs text-muted-foreground">{breadcrumb.message}</span>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </details>
+      ) : null}
+    </article>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import type { SentryIssue } from '../client';
+import { sentryFetchIssueDetail } from '../client';
+import { IssueDetailPanel } from './IssueDetailPanel';
+
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  loadSetting: vi.fn(async () => null),
+  showToast: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (state: {
+      createSession: typeof h.createSession;
+      loadSetting: typeof h.loadSetting;
+    }) => T,
+  ) => selector({ createSession: h.createSession, loadSetting: h.loadSetting }),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+
+vi.mock('../client', () => ({
+  sentryFetchIssueDetail: vi.fn(),
+}));
+
+const fetchIssueDetail = vi.mocked(sentryFetchIssueDetail);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+type IssueParams = {
+  readonly id: string;
+  readonly title: string;
+  readonly shortId: string;
+};
+
+const makeIssue = ({ id, title, shortId }: IssueParams): SentryIssue => ({
+  id,
+  shortId,
+  title,
+  culprit: null,
+  level: 'error',
+  status: 'unresolved',
+  count: '1',
+  userCount: 1,
+  firstSeen: null,
+  lastSeen: null,
+  permalink: null,
+  metadata: null,
+});
+
+beforeEach(() => {
+  fetchIssueDetail.mockReset();
+  h.loadSetting.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('IssueDetailPanel', () => {
+  it('does not regenerate a switched issue goal from stale detail after a failed fetch', async () => {
+    const firstIssue = makeIssue({
+      id: 'issue-1',
+      title: 'First issue',
+      shortId: 'GB-1',
+    });
+    const secondIssue = makeIssue({
+      id: 'issue-2',
+      title: 'Second issue',
+      shortId: 'GB-2',
+    });
+    fetchIssueDetail.mockResolvedValueOnce({
+      title: 'First issue',
+      culprit: null,
+      frames: [
+        {
+          filename: 'src/first.ts',
+          function: 'firstFrame',
+          line_no: 42,
+          in_app: true,
+        },
+      ],
+    });
+
+    const { rerender } = render(
+      <IssueDetailPanel
+        issue={firstIssue}
+        sessionId={null}
+        workspaceId={WORKSPACE_ID}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      const goal = screen.getByRole('textbox', { name: 'Session goal' }) as HTMLTextAreaElement;
+      expect(goal.value).toContain('firstFrame');
+    });
+
+    fetchIssueDetail.mockRejectedValueOnce(new Error('request failed'));
+    rerender(
+      <IssueDetailPanel
+        issue={secondIssue}
+        sessionId={null}
+        workspaceId={WORKSPACE_ID}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('request failed')).toBeDefined());
+    const goal = screen.getByRole('textbox', { name: 'Session goal' }) as HTMLTextAreaElement;
+    expect(goal.value).toBe('[GB-2] Second issue');
+    expect(goal.value).not.toContain('firstFrame');
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -1,23 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import {
-  Button,
-  Divider,
-  EmptyState,
-  Input,
-  SectionHeader,
-  Skeleton,
-  Textarea,
-  cn,
-} from '@goodboy/ui';
-import {
-  ArrowRight,
-  ExternalLink,
-  GitBranch,
-  Layers,
-  MessagesSquare,
-  MousePointerClick,
-  Target,
-} from 'lucide-react';
+import { Button, EmptyState, Input, SectionHeader, Textarea } from '@goodboy/ui';
+import { ArrowRight, GitBranch, MessagesSquare, MousePointerClick, Target } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { ScrollFade } from '@goodboy/ui';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
@@ -31,7 +14,9 @@ import { sanitizeBranchSlug } from '../../../../shared/utils/sanitizeBranchSlug'
 import { slugifyBranch } from '../../../../shared/utils/slugifyBranch';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
 import { goalFromSentry } from '../goal-from-sentry';
-import { sentryFetchIssueDetail, type SentryIssue, type SentryIssueDetail } from '../client';
+import type { SentryIssue } from '../client';
+import { SentryIssueDetail } from '../SentryIssueDetail';
+import { useSentryIssueDetail } from '../useSentryIssueDetail';
 
 type Props = {
   readonly issue: SentryIssue | null;
@@ -51,17 +36,6 @@ const sanitizePrefix = (input: string): string => sanitizeBranchPrefix({ input }
 
 const isValidBranchSlug = (slug: string): boolean => validateBranchSlug({ slug });
 
-const LEVEL_TONE: Record<string, string> = {
-  fatal: 'border-danger/40 bg-danger/10 text-danger',
-  error: 'border-danger/40 bg-danger/10 text-danger',
-  warning: 'border-warning/40 bg-warning/10 text-warning',
-  info: 'border-info/40 bg-info/10 text-info',
-  debug: 'border-border-soft bg-muted/40 text-muted-foreground',
-};
-
-const levelTone = (level: string | null): string =>
-  LEVEL_TONE[level?.toLowerCase() ?? ''] ?? 'border-border-soft bg-muted/40 text-muted-foreground';
-
 export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Props) => {
   const createSession = useAppStore((s) => s.createSession);
   const loadSetting = useAppStore((s) => s.loadSetting);
@@ -70,9 +44,14 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   const [goal, setGoal] = useState('');
   const [branchSlug, setBranchSlug] = useState('');
   const [branchPrefix, setBranchPrefix] = useState(DEFAULT_BRANCH_PREFIX);
-  const [detail, setDetail] = useState<SentryIssueDetail | null>(null);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [detailError, setDetailError] = useState<string | null>(null);
+  const {
+    detail,
+    isLoading: detailLoading,
+    error: detailError,
+  } = useSentryIssueDetail({
+    workspaceId,
+    issueId: issue?.id ?? null,
+  });
   const [setupWorkflow, setSetupWorkflow] = useState(() => {
     try {
       return localStorage.getItem('goodboy:new-session-setup-workflow') !== '0';
@@ -92,44 +71,19 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     lastGenRef.current = initial;
     setGoal(initial);
     setBranchSlug(slugify(issue.title));
-    setDetail(null);
-    setDetailError(null);
     setError(null);
     setBusy(false);
   }, [issue]);
 
   useEffect(() => {
-    if (!issue) {
+    if (issue == null || detail == null) {
       return;
     }
-    let cancelled = false;
-    setDetailLoading(true);
-    setDetailError(null);
-    sentryFetchIssueDetail(workspaceId, issue.id)
-      .then((d) => {
-        if (cancelled) {
-          return;
-        }
-        setDetail(d);
-        const regenerated = goalFromSentry(issue, d);
-        const prevGen = lastGenRef.current;
-        lastGenRef.current = regenerated;
-        setGoal((cur) => (cur === prevGen ? regenerated : cur));
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setDetailError(formatError(err));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setDetailLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [issue, workspaceId]);
+    const regenerated = goalFromSentry(issue, detail);
+    const previousGenerated = lastGenRef.current;
+    lastGenRef.current = regenerated;
+    setGoal((current) => (current === previousGenerated ? regenerated : current));
+  }, [detail, issue]);
 
   useEffect(() => {
     void loadSetting(settingBranchPrefix(workspaceId)).then((value) => {
@@ -196,44 +150,8 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     }
   };
 
-  const frames = detail?.frames ?? [];
-
   return (
     <div className="flex h-full flex-col">
-      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
-        <div className="flex items-center gap-2">
-          <span
-            className={cn(
-              'shrink-0 rounded border px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide',
-              levelTone(issue.level),
-            )}
-          >
-            {issue.level ?? 'error'}
-          </span>
-          {issue.shortId ? (
-            <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-              {issue.shortId}
-            </span>
-          ) : null}
-          <span className="flex-1" />
-          {issue.permalink ? (
-            <a
-              href={issue.permalink}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-            >
-              Open in Sentry <ExternalLink size={11} aria-hidden />
-            </a>
-          ) : null}
-        </div>
-        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
-        {issue.culprit ? (
-          <span className="truncate font-mono text-2xs text-muted-foreground">{issue.culprit}</span>
-        ) : null}
-      </div>
-      <Divider />
-
       <div className="min-h-0 flex-1">
         <ScrollFade
           className="mx-auto h-full max-w-3xl"
@@ -241,38 +159,16 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
           fadeSize={24}
         >
           <div className="flex flex-col gap-8">
-            <section className="flex flex-col gap-3">
-              <SectionHeader
-                label="stack trace"
-                icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
-              />
-              {detailLoading ? (
-                <div
-                  role="status"
-                  aria-label="Loading latest event"
-                  className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/40 p-3"
-                >
-                  {['w-3/4', 'w-1/2', 'w-2/3', 'w-5/6', 'w-2/5', 'w-3/5'].map((w, i) => (
-                    <Skeleton key={i} className={cn('h-2.5 rounded', w)} />
-                  ))}
-                </div>
-              ) : detailError ? (
-                <p className="text-sm text-danger">{detailError}</p>
-              ) : frames.length > 0 ? (
-                <pre className="overflow-x-auto rounded-lg border border-border-soft bg-subtle/40 p-3 font-mono text-2xs leading-relaxed text-muted-foreground">
-                  {frames
-                    .map(
-                      (f) =>
-                        `${f.in_app ? '› ' : '  '}${f.function ?? '?'} (${f.filename ?? '?'}${
-                          f.line_no != null ? `:${f.line_no}` : ''
-                        })`,
-                    )
-                    .join('\n')}
-                </pre>
-              ) : (
-                <p className="text-sm italic text-muted-foreground/60">No stack trace available.</p>
-              )}
-            </section>
+            <SentryIssueDetail
+              identifier={issue.shortId ?? issue.id}
+              title={issue.title}
+              culprit={issue.culprit}
+              level={issue.level}
+              permalink={issue.permalink}
+              detail={detail}
+              isLoading={detailLoading}
+              error={detailError}
+            />
 
             <section className="flex flex-col gap-3">
               <SectionHeader label="launch session" />

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -76,7 +76,7 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
   }, [issue]);
 
   useEffect(() => {
-    if (issue == null || detail == null) {
+    if (issue == null || detail == null || detail.issueId !== issue.id) {
       return;
     }
     const regenerated = goalFromSentry(issue, detail);

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.test.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  useSentryIssues: vi.fn(() => ({
+    rows: [],
+    loadMore: vi.fn(),
+    hasMore: false,
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: { workspaceIntegrations: Record<string, never[]> }) => T) =>
+    selector({ workspaceIntegrations: {} }),
+}));
+
+vi.mock('../../../../shared/components/StudioShell', () => ({
+  StudioShell: ({ children }: { children: (requestClose: () => void) => ReactNode }) => (
+    <div>{children(vi.fn())}</div>
+  ),
+}));
+
+vi.mock('./useSentryIssues', () => ({
+  useSentryIssues: h.useSentryIssues,
+}));
+
+import { SentryStudio } from '.';
+
+afterEach(() => {
+  cleanup();
+  h.useSentryIssues.mockClear();
+});
+
+describe('SentryStudio', () => {
+  it('renders the disconnected state without fetching issues', () => {
+    const workspaceId = 'workspace-1' as WorkspaceId;
+    render(<SentryStudio workspaceId={workspaceId} workspaceName="Goodboy" onClose={vi.fn()} />);
+
+    expect(screen.getByText('Connect Sentry')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeDefined();
+    expect(h.useSentryIssues).toHaveBeenCalledWith(workspaceId, false);
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cn, Divider } from '@goodboy/ui';
-import { RefreshCw, X } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
-import { useStudioOverlay } from '../../../../shared/hooks/useStudioOverlay';
+import { StudioShell } from '../../../../shared/components/StudioShell';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
+import { resolveIntegrationConnection } from '../../connection';
 import { IssueInbox } from './IssueInbox';
 import { IssueDetailPanel } from './IssueDetailPanel';
 import { useSentryIssues } from './useSentryIssues';
@@ -16,9 +19,20 @@ type Props = {
 };
 
 export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClose }: Props) => {
-  const { rows, loadMore, hasMore, loading, error, refetch } = useSentryIssues(workspaceId);
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const isConnected = resolveIntegrationConnection({
+    provider: 'sentry',
+    integrations,
+    remoteKind: null,
+    externalTasks: EMPTY_ARRAY,
+  }).isConnected;
+  const { rows, loadMore, hasMore, loading, error, refetch } = useSentryIssues(
+    workspaceId,
+    isConnected,
+  );
   const [focused, setFocused] = useState<SentryIssue | null>(null);
-  const { closing, requestClose } = useStudioOverlay(onClose);
 
   useEffect(() => {
     if (focused !== null) {
@@ -43,80 +57,68 @@ export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
   );
 
   return (
-    <div
-      className={cn(
-        'fixed inset-0 z-50 flex flex-col bg-background',
-        closing ? 'motion-safe:animate-studio-out' : 'motion-safe:animate-studio-in',
-      )}
-    >
-      <header className="flex shrink-0 items-center gap-3 px-6 py-3">
+    <StudioShell
+      glyph={
         <span className="flex size-8 items-center justify-center rounded-lg bg-provider-sentry/10">
           <span className="flex size-4 items-center justify-center rounded-sm bg-provider-sentry text-[9px] font-bold text-white">
             S
           </span>
         </span>
-        <div className="flex min-w-0 flex-col">
-          <div className="flex items-center gap-2">
-            <h1 className="text-sm font-semibold text-foreground">Sentry</h1>
-            <span className="rounded bg-warning/20 px-1 py-px text-[8px] font-semibold uppercase leading-none tracking-wide text-warning">
-              beta
-            </span>
+      }
+      title="Sentry"
+      workspaceName={workspaceName}
+      closeLabel="close sentry studio"
+      headerAccessory={
+        isConnected ? (
+          <button
+            type="button"
+            onClick={refetch}
+            disabled={loading}
+            title="Refresh issues"
+            aria-label="Refresh issues"
+            className={cn(
+              'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
+              'text-muted-foreground transition-colors',
+              'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
+              loading && 'animate-border-pulse',
+            )}
+          >
+            <RefreshCw size={13} aria-hidden />
+          </button>
+        ) : null
+      }
+      onClose={onClose}
+    >
+      {(requestClose) =>
+        isConnected ? (
+          <>
+            <div className="w-72 shrink-0">
+              <IssueInbox
+                rows={rows}
+                focusedIssueId={focused?.id ?? null}
+                onSelect={setFocused}
+                onLoadMore={loadMore}
+                hasMore={hasMore}
+                loading={loading}
+                error={error}
+              />
+            </div>
+            <Divider orientation="vertical" />
+            <div className="min-h-0 flex-1">
+              <IssueDetailPanel
+                issue={focused}
+                sessionId={focusedRow?.sessionId ?? null}
+                workspaceId={workspaceId}
+                onClose={requestClose}
+              />
+            </div>
+          </>
+        ) : (
+          <div className="flex min-h-0 flex-1 items-center justify-center">
+            <ConnectIntegrationEmptyState name="Sentry" />
           </div>
-          <span className="truncate text-2xs text-muted-foreground">{workspaceName}</span>
-        </div>
-        <div className="flex-1" />
-        <button
-          type="button"
-          onClick={refetch}
-          disabled={loading}
-          title="Refresh issues"
-          aria-label="Refresh issues"
-          className={cn(
-            'inline-flex items-center justify-center rounded-md border border-border-soft p-1.5',
-            'text-muted-foreground transition-colors',
-            'hover:border-border hover:bg-muted/50 hover:text-foreground disabled:opacity-50',
-            loading && 'animate-border-pulse',
-          )}
-        >
-          <RefreshCw size={13} aria-hidden />
-        </button>
-        <button
-          type="button"
-          onClick={requestClose}
-          className={cn(
-            'inline-flex items-center gap-1.5 rounded-md border border-danger/40 bg-danger/10 px-3 py-1.5',
-            'text-xs font-semibold text-danger transition-colors',
-            'hover:border-danger/60 hover:bg-danger/15',
-          )}
-          aria-label="close sentry studio"
-        >
-          <X size={13} aria-hidden /> Done
-        </button>
-      </header>
-      <Divider />
-
-      <div className="flex min-h-0 flex-1">
-        <div className="w-72 shrink-0">
-          <IssueInbox
-            rows={rows}
-            focusedIssueId={focused?.id ?? null}
-            onSelect={setFocused}
-            onLoadMore={loadMore}
-            hasMore={hasMore}
-            loading={loading}
-            error={error}
-          />
-        </div>
-        <Divider orientation="vertical" />
-        <div className="min-h-0 flex-1">
-          <IssueDetailPanel
-            issue={focused}
-            sessionId={focusedRow?.sessionId ?? null}
-            workspaceId={workspaceId}
-            onClose={requestClose}
-          />
-        </div>
-      </div>
-    </div>
+        )
+      }
+    </StudioShell>
   );
 };

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
@@ -115,7 +115,7 @@ export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
           </>
         ) : (
           <div className="flex min-h-0 flex-1 items-center justify-center">
-            <ConnectIntegrationEmptyState name="Sentry" />
+            <ConnectIntegrationEmptyState provider="sentry" />
           </div>
         )
       }

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.ts
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/useSentryIssues.ts
@@ -53,7 +53,7 @@ export type UseSentryIssues = {
   readonly refetch: () => void;
 };
 
-export const useSentryIssues = (workspaceId: WorkspaceId): UseSentryIssues => {
+export const useSentryIssues = (workspaceId: WorkspaceId, isEnabled = true): UseSentryIssues => {
   const sessionExternalTasks = useAppStore((s) => s.sessionExternalTasks);
   const [issues, setIssues] = useState<ReadonlyArray<SentryIssue>>([]);
   const [cursor, setCursor] = useState<string | null>(null);
@@ -63,6 +63,14 @@ export const useSentryIssues = (workspaceId: WorkspaceId): UseSentryIssues => {
 
   const load = useCallback(
     async (nextCursor: string | null, reset: boolean) => {
+      if (!isEnabled) {
+        setIssues([]);
+        setCursor(null);
+        setHasMore(false);
+        setLoading(false);
+        setError(null);
+        return;
+      }
       setLoading(true);
       setError(null);
       try {
@@ -76,7 +84,7 @@ export const useSentryIssues = (workspaceId: WorkspaceId): UseSentryIssues => {
         setLoading(false);
       }
     },
-    [workspaceId],
+    [isEnabled, workspaceId],
   );
 
   useEffect(() => {

--- a/apps/desktop/src/features/integrations/sentry/client.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.test.ts
@@ -62,7 +62,13 @@ describe('sentryFetchIssues', () => {
 
 describe('sentryFetchIssueDetail', () => {
   it('invokes sentry_fetch_issue_detail with issue id', async () => {
-    mockInvoke.mockResolvedValue({ title: null, culprit: null, frames: [] });
+    mockInvoke.mockResolvedValue({
+      title: null,
+      culprit: null,
+      frames: [],
+      tags: [],
+      breadcrumbs: [],
+    });
     await sentryFetchIssueDetail(WS, 'issue-9');
     expect(mockInvoke).toHaveBeenCalledWith('sentry_fetch_issue_detail', {
       workspaceId: WS,

--- a/apps/desktop/src/features/integrations/sentry/client.ts
+++ b/apps/desktop/src/features/integrations/sentry/client.ts
@@ -44,10 +44,24 @@ export type SentryStackFrame = {
   in_app: boolean;
 };
 
+export type SentryTag = {
+  key: string;
+  value: string;
+};
+
+export type SentryBreadcrumb = {
+  category: string | null;
+  message: string | null;
+  level: string | null;
+  timestamp: string | null;
+};
+
 export type SentryIssueDetail = {
   title: string | null;
   culprit: string | null;
   frames: SentryStackFrame[];
+  tags?: SentryTag[];
+  breadcrumbs?: SentryBreadcrumb[];
 };
 
 export const sentryConnect = async (

--- a/apps/desktop/src/features/integrations/sentry/levelTone.ts
+++ b/apps/desktop/src/features/integrations/sentry/levelTone.ts
@@ -1,0 +1,14 @@
+const LEVEL_TONES: Readonly<Record<string, string>> = {
+  fatal: 'border-danger/40 bg-danger/10 text-danger',
+  error: 'border-danger/40 bg-danger/10 text-danger',
+  warning: 'border-warning/40 bg-warning/10 text-warning',
+  info: 'border-info/40 bg-info/10 text-info',
+  debug: 'border-border-soft bg-muted/40 text-muted-foreground',
+};
+
+type Params = {
+  readonly level: string | null;
+};
+
+export const levelTone = ({ level }: Params): string =>
+  LEVEL_TONES[level?.toLowerCase() ?? ''] ?? 'border-border-soft bg-muted/40 text-muted-foreground';

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.test.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.test.ts
@@ -1,0 +1,58 @@
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceId } from '@goodboy/types';
+import { sentryFetchIssueDetail } from './client';
+import { useSentryIssueDetail } from './useSentryIssueDetail';
+
+vi.mock('./client', () => ({
+  sentryFetchIssueDetail: vi.fn(),
+}));
+
+const fetchIssueDetail = vi.mocked(sentryFetchIssueDetail);
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const DETAIL = {
+  title: 'First issue',
+  culprit: 'handleRequest',
+  frames: [
+    {
+      filename: 'src/first.ts',
+      function: 'handleRequest',
+      line_no: 42,
+      in_app: true,
+    },
+  ],
+};
+
+beforeEach(() => {
+  fetchIssueDetail.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('useSentryIssueDetail', () => {
+  it('returns the issue id associated with the fetched detail', async () => {
+    fetchIssueDetail.mockResolvedValueOnce(DETAIL);
+    const { result } = renderHook(() =>
+      useSentryIssueDetail({ workspaceId: WORKSPACE_ID, issueId: 'issue-1' }),
+    );
+
+    await waitFor(() => expect(result.current.detail?.issueId).toBe('issue-1'));
+    expect(result.current.detail).toMatchObject(DETAIL);
+  });
+
+  it('clears previous detail when the next issue fetch fails', async () => {
+    fetchIssueDetail.mockResolvedValueOnce(DETAIL);
+    const { result, rerender } = renderHook(
+      ({ issueId }: { issueId: string }) =>
+        useSentryIssueDetail({ workspaceId: WORKSPACE_ID, issueId }),
+      { initialProps: { issueId: 'issue-1' } },
+    );
+    await waitFor(() => expect(result.current.detail?.issueId).toBe('issue-1'));
+
+    fetchIssueDetail.mockRejectedValueOnce(new Error('request failed'));
+    rerender({ issueId: 'issue-2' });
+
+    await waitFor(() => expect(result.current.error).toBe('request failed'));
+    expect(result.current.detail).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
@@ -8,14 +8,18 @@ type Params = {
   readonly issueId: string | null;
 };
 
+type Detail = SentryIssueDetail & {
+  readonly issueId: string;
+};
+
 type Result = {
-  readonly detail: SentryIssueDetail | null;
+  readonly detail: Detail | null;
   readonly isLoading: boolean;
   readonly error: string | null;
 };
 
 export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result => {
-  const [detail, setDetail] = useState<SentryIssueDetail | null>(null);
+  const [detail, setDetail] = useState<Detail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +38,7 @@ export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result =
         if (isCancelled) {
           return;
         }
-        setDetail(nextDetail);
+        setDetail({ ...nextDetail, issueId });
       })
       .catch((fetchError: unknown) => {
         if (isCancelled) {

--- a/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
+++ b/apps/desktop/src/features/integrations/sentry/useSentryIssueDetail.ts
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatError } from '../../../shared/lib/errors';
+import { sentryFetchIssueDetail, type SentryIssueDetail } from './client';
+
+type Params = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string | null;
+};
+
+type Result = {
+  readonly detail: SentryIssueDetail | null;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const useSentryIssueDetail = ({ workspaceId, issueId }: Params): Result => {
+  const [detail, setDetail] = useState<SentryIssueDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setDetail(null);
+    setError(null);
+    if (issueId == null) {
+      setIsLoading(false);
+      return;
+    }
+
+    let isCancelled = false;
+    setIsLoading(true);
+    sentryFetchIssueDetail(workspaceId, issueId)
+      .then((nextDetail) => {
+        if (isCancelled) {
+          return;
+        }
+        setDetail(nextDetail);
+      })
+      .catch((fetchError: unknown) => {
+        if (isCancelled) {
+          return;
+        }
+        setError(formatError(fetchError));
+      })
+      .finally(() => {
+        if (isCancelled) {
+          return;
+        }
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [issueId, workspaceId]);
+
+  return { detail, isLoading, error };
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -316,13 +316,25 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 ) : null}
                 {lens === 'pr' ? <PrPane session={session} /> : null}
                 {lens === 'linear' ? (
-                  <IntegrationPane sessionId={sessionId} provider="linear" />
+                  <IntegrationPane
+                    sessionId={sessionId}
+                    workspaceId={session.workspaceId}
+                    provider="linear"
+                  />
                 ) : null}
                 {lens === 'sentry' ? (
-                  <IntegrationPane sessionId={sessionId} provider="sentry" />
+                  <IntegrationPane
+                    sessionId={sessionId}
+                    workspaceId={session.workspaceId}
+                    provider="sentry"
+                  />
                 ) : null}
                 {lens === 'gitlab_issues' ? (
-                  <IntegrationPane sessionId={sessionId} provider="gitlab" />
+                  <IntegrationPane
+                    sessionId={sessionId}
+                    workspaceId={session.workspaceId}
+                    provider="gitlab"
+                  />
                 ) : null}
                 {lens === 'files' ? (
                   <FilesPane

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/LinearTaskDetail.tsx
@@ -1,0 +1,33 @@
+import { Skeleton } from '@goodboy/ui';
+import type { WorkspaceId } from '@goodboy/types';
+import { LinearIssueDetail } from '../../../../../integrations/linear/LinearIssueDetail';
+import { useLinearIssue } from '../../../../../integrations/linear/useLinearIssue';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string;
+};
+
+export const LinearTaskDetail = ({ workspaceId, issueId }: Props) => {
+  const { issue, isLoading, error } = useLinearIssue({ workspaceId, issueId });
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-label="Loading Linear issue" className="flex flex-col gap-3 py-2">
+        <Skeleton className="h-4 w-2/3 rounded" />
+        <Skeleton className="h-3 w-full rounded" />
+        <Skeleton className="h-3 w-3/4 rounded" />
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return <p className="text-sm text-danger">{error}</p>;
+  }
+
+  if (issue == null) {
+    return null;
+  }
+
+  return <LinearIssueDetail issue={issue} workspaceId={workspaceId} />;
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/SentryTaskDetail.tsx
@@ -1,0 +1,28 @@
+import type { SessionExternalTask, WorkspaceId } from '@goodboy/types';
+import { SentryIssueDetail } from '../../../../../integrations/sentry/SentryIssueDetail';
+import { useSentryIssueDetail } from '../../../../../integrations/sentry/useSentryIssueDetail';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly task: SessionExternalTask;
+};
+
+export const SentryTaskDetail = ({ workspaceId, task }: Props) => {
+  const { detail, isLoading, error } = useSentryIssueDetail({
+    workspaceId,
+    issueId: task.externalId,
+  });
+
+  return (
+    <SentryIssueDetail
+      identifier={task.identifier}
+      title={task.title}
+      culprit={null}
+      level={null}
+      permalink={task.url}
+      detail={detail}
+      isLoading={isLoading}
+      error={error}
+    />
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -68,6 +68,15 @@ const TASK: SessionExternalTask = {
   url: 'https://linear.app/goodboy/issue/GB-42/refactor-integration-storage',
   createdAt: CREATED_AT,
 };
+const SENTRY_TASK: SessionExternalTask = {
+  sessionId: SESSION_ID,
+  provider: 'sentry',
+  externalId: '12345',
+  identifier: 'GOODBOY-5',
+  title: 'Request failed',
+  url: 'https://sentry.io/organizations/goodboy/issues/12345/',
+  createdAt: CREATED_AT,
+};
 
 beforeEach(() => {
   h.store.sessionExternalTasks = { [SESSION_ID]: [TASK] };
@@ -163,7 +172,7 @@ describe('IntegrationPane', () => {
     h.store.sessionExternalTasks = {};
     h.store.workspaceIntegrations = {};
     const listener = vi.fn();
-    window.addEventListener('goodboy:open-settings', listener);
+    window.addEventListener('goodboy:open-workspace-settings', listener);
 
     render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
@@ -171,6 +180,27 @@ describe('IntegrationPane', () => {
     expect(screen.queryByRole('textbox', { name: 'Linear issue URL' })).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
     expect(listener).toHaveBeenCalledOnce();
-    window.removeEventListener('goodboy:open-settings', listener);
+    expect((listener.mock.calls[0]?.[0] as CustomEvent).detail).toEqual({
+      section: 'integrations',
+    });
+    window.removeEventListener('goodboy:open-workspace-settings', listener);
   });
+
+  it.each([
+    ['linear', TASK, 'Linear detail GB-42'],
+    ['sentry', SENTRY_TASK, 'Sentry detail 12345'],
+  ] as const)(
+    'keeps linked %s rows without rendering live detail while disconnected',
+    (provider, task, detailText) => {
+      h.store.sessionExternalTasks = { [SESSION_ID]: [task] };
+      h.store.workspaceIntegrations = {};
+
+      render(
+        <IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider={provider} />,
+      );
+
+      expect(screen.getByText(task.title)).toBeDefined();
+      expect(screen.queryByText(detailText)).toBeNull();
+    },
+  );
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.test.tsx
@@ -3,10 +3,11 @@
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { IsoDateTime, SessionExternalTask, SessionId } from '@goodboy/types';
+import type { IsoDateTime, SessionExternalTask, SessionId, WorkspaceId } from '@goodboy/types';
 
 type Store = {
   readonly sessionExternalTasks: Readonly<Record<string, ReadonlyArray<SessionExternalTask>>>;
+  readonly workspaceIntegrations: Readonly<Record<string, ReadonlyArray<{ provider: string }>>>;
   readonly linkSessionExternalTask: ReturnType<typeof vi.fn>;
   readonly unlinkSessionExternalTask: ReturnType<typeof vi.fn>;
 };
@@ -18,6 +19,7 @@ type Props = {
 const h = vi.hoisted(() => ({
   store: {
     sessionExternalTasks: {},
+    workspaceIntegrations: {},
     linkSessionExternalTask: vi.fn(async () => undefined),
     unlinkSessionExternalTask: vi.fn(async () => undefined),
   },
@@ -33,6 +35,20 @@ vi.mock('../../../../../../shared/lib/editor', () => ({
   openUrl: h.openUrl,
 }));
 
+vi.mock('../../../../../worktree/useRemoteHostKind', () => ({
+  useRemoteHostKind: () => 'github',
+}));
+
+vi.mock('./LinearTaskDetail', () => ({
+  LinearTaskDetail: ({ issueId }: { issueId: string }) => <div>Linear detail {issueId}</div>,
+}));
+
+vi.mock('./SentryTaskDetail', () => ({
+  SentryTaskDetail: ({ task }: { task: SessionExternalTask }) => (
+    <div>Sentry detail {task.externalId}</div>
+  ),
+}));
+
 vi.mock('../PaneShell', () => ({
   PaneShell: ({ children }: Props) => <div>{children}</div>,
 }));
@@ -41,6 +57,7 @@ import { IntegrationPane } from '.';
 import { parseIntegrationTaskUrl } from './parseIntegrationTaskUrl';
 
 const SESSION_ID = 'session-1' as SessionId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
 const CREATED_AT = '2026-07-22T12:00:00.000Z' as IsoDateTime;
 const TASK: SessionExternalTask = {
   sessionId: SESSION_ID,
@@ -54,6 +71,9 @@ const TASK: SessionExternalTask = {
 
 beforeEach(() => {
   h.store.sessionExternalTasks = { [SESSION_ID]: [TASK] };
+  h.store.workspaceIntegrations = {
+    [WORKSPACE_ID]: [{ provider: 'linear' }, { provider: 'sentry' }],
+  };
   h.store.linkSessionExternalTask.mockClear();
   h.store.unlinkSessionExternalTask.mockClear();
   h.openUrl.mockClear();
@@ -96,9 +116,10 @@ describe('parseIntegrationTaskUrl', () => {
 
 describe('IntegrationPane', () => {
   it('opens and unlinks every provider task shown for the session', async () => {
-    render(<IntegrationPane sessionId={SESSION_ID} provider="linear" />);
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
     expect(screen.getByText('Refactor integration storage')).toBeDefined();
+    expect(screen.getByText('Linear detail GB-42')).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'open GB-42' }));
     expect(h.openUrl).toHaveBeenCalledWith(TASK.url);
     fireEvent.click(screen.getByRole('button', { name: 'unlink GB-42' }));
@@ -108,7 +129,7 @@ describe('IntegrationPane', () => {
   });
 
   it('links a pasted provider URL', async () => {
-    render(<IntegrationPane sessionId={SESSION_ID} provider="linear" />);
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Linear issue URL' }), {
       target: { value: 'https://linear.app/goodboy/issue/GB-99/new-link' },
@@ -126,15 +147,30 @@ describe('IntegrationPane', () => {
     });
   });
 
-  it('shows the empty state and opens the provider studio', () => {
+  it('keeps the link form as the connected empty state and opens the provider studio', () => {
     h.store.sessionExternalTasks = {};
     const listener = vi.fn();
     window.addEventListener('goodboy:open-sentry-studio', listener);
-    render(<IntegrationPane sessionId={SESSION_ID} provider="sentry" />);
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="sentry" />);
 
-    expect(screen.getByText('No Sentry issues linked yet.')).toBeDefined();
+    expect(screen.getByRole('textbox', { name: 'Sentry issue URL' })).toBeDefined();
     fireEvent.click(screen.getByRole('button', { name: 'Open Sentry studio' }));
     expect(listener).toHaveBeenCalledOnce();
     window.removeEventListener('goodboy:open-sentry-studio', listener);
+  });
+
+  it('shows a connect action instead of the link form when disconnected', () => {
+    h.store.sessionExternalTasks = {};
+    h.store.workspaceIntegrations = {};
+    const listener = vi.fn();
+    window.addEventListener('goodboy:open-settings', listener);
+
+    render(<IntegrationPane sessionId={SESSION_ID} workspaceId={WORKSPACE_ID} provider="linear" />);
+
+    expect(screen.getByText('Connect Linear')).toBeDefined();
+    expect(screen.queryByRole('textbox', { name: 'Linear issue URL' })).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+    expect(listener).toHaveBeenCalledOnce();
+    window.removeEventListener('goodboy:open-settings', listener);
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -1,15 +1,26 @@
 import { useMemo, useState, type FormEvent } from 'react';
 import { ExternalLink, Link2, Unlink } from 'lucide-react';
-import type { IsoDateTime, SessionExternalTaskProvider, SessionId } from '@goodboy/types';
-import { Button, Input } from '@goodboy/ui';
+import type {
+  IsoDateTime,
+  SessionExternalTaskProvider,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { Button, Divider, Input } from '@goodboy/ui';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../../store';
 import { formatError } from '../../../../../../shared/lib/errors';
 import { openUrl } from '../../../../../../shared/lib/editor';
+import { ConnectIntegrationEmptyState } from '../../../../../integrations/ConnectIntegrationEmptyState';
+import { resolveIntegrationConnection } from '../../../../../integrations/connection';
+import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { PaneShell } from '../PaneShell';
+import { LinearTaskDetail } from './LinearTaskDetail';
 import { parseIntegrationTaskUrl } from './parseIntegrationTaskUrl';
+import { SentryTaskDetail } from './SentryTaskDetail';
 
 type Props = {
   readonly sessionId: SessionId;
+  readonly workspaceId: WorkspaceId;
   readonly provider: SessionExternalTaskProvider;
 };
 
@@ -25,7 +36,7 @@ const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
   github: { label: 'GitHub', studioEvent: 'goodboy:open-github-studio' },
 };
 
-export const IntegrationPane = ({ sessionId, provider }: Props) => {
+export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => {
   const [url, setUrl] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [isLinking, setIsLinking] = useState(false);
@@ -35,11 +46,21 @@ export const IntegrationPane = ({ sessionId, provider }: Props) => {
   );
   const linkSessionExternalTask = useAppStore((state) => state.linkSessionExternalTask);
   const unlinkSessionExternalTask = useAppStore((state) => state.unlinkSessionExternalTask);
+  const integrations = useAppStore(
+    (state) => state.workspaceIntegrations[workspaceId] ?? EMPTY_ARRAY,
+  );
+  const remoteKind = useRemoteHostKind(workspaceId);
   const tasks = useMemo(
     () => externalTasks.filter((task) => task.provider === provider),
     [externalTasks, provider],
   );
   const meta = PROVIDER_META[provider];
+  const connection = resolveIntegrationConnection({
+    provider,
+    integrations,
+    remoteKind,
+    externalTasks,
+  });
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -71,15 +92,46 @@ export const IntegrationPane = ({ sessionId, provider }: Props) => {
       width="3xl"
     >
       <div className="flex flex-col gap-3">
-        {tasks.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No {meta.label} issues linked yet.</p>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {tasks.map((task) => (
-              <div
-                key={task.externalId}
-                className="flex items-center gap-3 rounded-lg bg-muted/35 p-3"
+        {connection.isConnected ? (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+            <label
+              htmlFor={`${provider}-issue-url`}
+              className="text-xs font-medium text-foreground"
+            >
+              Issue URL
+            </label>
+            <div className="flex items-center gap-2">
+              <Input
+                id={`${provider}-issue-url`}
+                value={url}
+                onChange={(event) => setUrl(event.target.value)}
+                placeholder={`Paste a ${meta.label} issue URL`}
+                aria-label={`${meta.label} issue URL`}
+              />
+              <Button type="submit" size="sm" disabled={isLinking}>
+                <Link2 size={13} aria-hidden />
+                Link
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => window.dispatchEvent(new CustomEvent(meta.studioEvent))}
               >
+                Open {meta.label} studio
+              </Button>
+            </div>
+            {error != null ? <p className="text-xs text-danger">{error}</p> : null}
+          </form>
+        ) : (
+          <ConnectIntegrationEmptyState name={meta.label} compact />
+        )}
+
+        {tasks.length > 0 ? <Divider /> : null}
+        <div className="flex flex-col gap-5">
+          {tasks.map((task, index) => (
+            <div key={task.externalId} className="flex flex-col gap-5">
+              {index > 0 ? <Divider /> : null}
+              <div className="flex items-center gap-3 rounded-lg bg-muted/35 p-3">
                 <button
                   type="button"
                   onClick={() => void openUrl(task.url)}
@@ -111,36 +163,15 @@ export const IntegrationPane = ({ sessionId, provider }: Props) => {
                   Unlink
                 </Button>
               </div>
-            ))}
-          </div>
-        )}
-
-        <form onSubmit={handleSubmit} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
-          <label htmlFor={`${provider}-issue-url`} className="text-xs font-medium text-foreground">
-            Issue URL
-          </label>
-          <div className="flex items-center gap-2">
-            <Input
-              id={`${provider}-issue-url`}
-              value={url}
-              onChange={(event) => setUrl(event.target.value)}
-              placeholder={`Paste a ${meta.label} issue URL`}
-              aria-label={`${meta.label} issue URL`}
-            />
-            <Button type="submit" size="sm" disabled={isLinking}>
-              <Link2 size={13} aria-hidden />
-              Link
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              onClick={() => window.dispatchEvent(new CustomEvent(meta.studioEvent))}
-            >
-              Open {meta.label} studio
-            </Button>
-          </div>
-          {error != null ? <p className="text-xs text-danger">{error}</p> : null}
-        </form>
+              {provider === 'linear' ? (
+                <LinearTaskDetail workspaceId={workspaceId} issueId={task.externalId} />
+              ) : null}
+              {provider === 'sentry' ? (
+                <SentryTaskDetail workspaceId={workspaceId} task={task} />
+              ) : null}
+            </div>
+          ))}
+        </div>
       </div>
     </PaneShell>
   );

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/IntegrationPane/index.tsx
@@ -12,6 +12,7 @@ import { formatError } from '../../../../../../shared/lib/errors';
 import { openUrl } from '../../../../../../shared/lib/editor';
 import { ConnectIntegrationEmptyState } from '../../../../../integrations/ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../../../../integrations/connection';
+import { MissingGithubRemoteEmptyState } from '../../../../../github/components/MissingGithubRemoteEmptyState';
 import { useRemoteHostKind } from '../../../../../worktree/useRemoteHostKind';
 import { PaneShell } from '../PaneShell';
 import { LinearTaskDetail } from './LinearTaskDetail';
@@ -122,8 +123,10 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
             </div>
             {error != null ? <p className="text-xs text-danger">{error}</p> : null}
           </form>
+        ) : provider === 'github' ? (
+          <MissingGithubRemoteEmptyState compact />
         ) : (
-          <ConnectIntegrationEmptyState name={meta.label} compact />
+          <ConnectIntegrationEmptyState provider={provider} compact />
         )}
 
         {tasks.length > 0 ? <Divider /> : null}
@@ -163,10 +166,10 @@ export const IntegrationPane = ({ sessionId, workspaceId, provider }: Props) => 
                   Unlink
                 </Button>
               </div>
-              {provider === 'linear' ? (
+              {connection.isConnected && provider === 'linear' ? (
                 <LinearTaskDetail workspaceId={workspaceId} issueId={task.externalId} />
               ) : null}
-              {provider === 'sentry' ? (
+              {connection.isConnected && provider === 'sentry' ? (
                 <SentryTaskDetail workspaceId={workspaceId} task={task} />
               ) : null}
             </div>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -77,7 +77,9 @@ beforeEach(() => {
   hooks.planCount = 0;
   hooks.questionCount = 0;
   store.sessionExternalTasks = {};
-  store.workspaceIntegrations = {};
+  store.workspaceIntegrations = {
+    'workspace-1': [{ provider: 'linear' }, { provider: 'sentry' }],
+  };
   store.sessionLoading['session-1'] = { agents: false, plans: false };
   store.sessionOpenQuestions = { 'session-1': [] };
 });
@@ -227,7 +229,7 @@ describe('LensColumn', () => {
     expect(screen.getByRole('button', { name: 'Questions' }).textContent).not.toContain('2');
   });
 
-  it('shows provider counts and hides GitLab issues on a GitLab remote', () => {
+  it('shows provider counts and keeps connected GitLab issues reachable', () => {
     store.workspaceIntegrations = {
       'workspace-1': [{ provider: 'gitlab' }],
     };
@@ -266,6 +268,26 @@ describe('LensColumn', () => {
     );
 
     expect(screen.getByRole('button', { name: 'GitLab' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'GitLab issues 1' })).toBeDefined();
+  });
+
+  it('hides disconnected integration rows without linked tasks', () => {
+    remote.kind = 'other';
+    store.workspaceIntegrations = {};
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'Linear' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Sentry' })).toBeNull();
     expect(screen.queryByRole('button', { name: /GitLab issues/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'GitHub' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../../../../store';
 import type { LensKind } from '../../../../../store';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
+import { resolveIntegrationConnection } from '../../../../integrations/connection';
 import { resolveAttentionLens, selectOpenQuestions } from '../../SessionOverviewPane/lib';
 
 type LensColumnProps = {
@@ -96,10 +97,8 @@ export const LensColumn = ({
   const unreadLens = useSessionUnreadLens(sessionId);
   const remoteKind = useRemoteHostKind(session.workspaceId);
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
-  const hasGitlabIntegration = useAppStore((s) =>
-    (s.workspaceIntegrations[session.workspaceId] ?? EMPTY_ARRAY).some(
-      (integration) => integration.provider === 'gitlab',
-    ),
+  const workspaceIntegrations = useAppStore(
+    (s) => s.workspaceIntegrations[session.workspaceId] ?? EMPTY_ARRAY,
   );
 
   const isResolver = useMemo(
@@ -158,7 +157,76 @@ export const LensColumn = ({
   const sentryCount = externalTasks.filter((task) => task.provider === 'sentry').length;
   const gitlabCount = externalTasks.filter((task) => task.provider === 'gitlab').length;
   const isGitlabRemote = remoteKind === 'gitlab';
-  const shouldShowGitlabIssues = remoteKind != null && !isGitlabRemote && hasGitlabIntegration;
+  const prConnection = resolveIntegrationConnection({
+    provider: 'pr',
+    integrations: workspaceIntegrations,
+    remoteKind,
+    externalTasks,
+  });
+  const linearConnection = resolveIntegrationConnection({
+    provider: 'linear',
+    integrations: workspaceIntegrations,
+    remoteKind,
+    externalTasks,
+  });
+  const sentryConnection = resolveIntegrationConnection({
+    provider: 'sentry',
+    integrations: workspaceIntegrations,
+    remoteKind,
+    externalTasks,
+  });
+  const gitlabConnection = resolveIntegrationConnection({
+    provider: 'gitlab',
+    integrations: workspaceIntegrations,
+    remoteKind,
+    externalTasks,
+  });
+  const integrationRows: ReadonlyArray<LensRow> = [
+    ...(prConnection.isAvailable
+      ? [
+          {
+            kind: 'pr',
+            label: isGitlabRemote ? 'GitLab' : 'GitHub',
+            icon: isGitlabRemote ? GitFork : GitBranch,
+            tone: 'accent',
+            dot: hasPr ? 'running' : undefined,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(linearConnection.isAvailable
+      ? [
+          {
+            kind: 'linear',
+            label: 'Linear',
+            icon: ListTodo,
+            tone: 'primary',
+            count: linearCount,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(sentryConnection.isAvailable
+      ? [
+          {
+            kind: 'sentry',
+            label: 'Sentry',
+            icon: Bug,
+            tone: 'warning',
+            count: sentryCount,
+          } satisfies LensRow,
+        ]
+      : []),
+    ...(gitlabConnection.isAvailable
+      ? [
+          {
+            kind: 'gitlab_issues',
+            label: 'GitLab issues',
+            icon: GitFork,
+            tone: 'accent',
+            count: gitlabCount,
+          } satisfies LensRow,
+        ]
+      : []),
+  ];
 
   const groups: ReadonlyArray<LensGroup> = [
     {
@@ -232,28 +300,7 @@ export const LensColumn = ({
     },
     {
       label: 'Integrations',
-      rows: [
-        {
-          kind: 'pr',
-          label: isGitlabRemote ? 'GitLab' : 'GitHub',
-          icon: isGitlabRemote ? GitFork : GitBranch,
-          tone: 'accent',
-          dot: hasPr ? 'running' : undefined,
-        },
-        { kind: 'linear', label: 'Linear', icon: ListTodo, tone: 'primary', count: linearCount },
-        { kind: 'sentry', label: 'Sentry', icon: Bug, tone: 'warning', count: sentryCount },
-        ...(shouldShowGitlabIssues
-          ? [
-              {
-                kind: 'gitlab_issues',
-                label: 'GitLab issues',
-                icon: GitFork,
-                tone: 'accent',
-                count: gitlabCount,
-              } satisfies LensRow,
-            ]
-          : []),
-      ],
+      rows: integrationRows,
     },
     {
       label: 'Infra',


### PR DESCRIPTION
## What

Integrations become real dashboards, and unconnected integrations never look available.

- **Linear**: issue query enriched (priority, assignee, project, labels), new `linear_fetch_issue` and `linear_fetch_issue_comments` commands; studio detail shows metadata, markdown description and a lazy-loaded comments thread; inbox rows get priority indicators.
- **Sentry**: studio migrated to the shared StudioShell anatomy; detail surfaces tags (release/environment), breadcrumbs and stack frames extracted from the existing latest-event call (no new HTTP).
- **Shared detail components** (`LinearIssueDetail`, `SentryIssueDetail`) render both in the studios and in the session lenses: the in-session Linear/Sentry panes now show the full linked-task detail under the link/unlink form (direct fetch by id, race-guarded).
- **Connection gating** (all providers, future-proof): pure `connection.ts` helper; lens rows hidden unless connected or already-linked; panes and studios show a provider-aware Connect empty state that navigates to the right settings surface; disconnected studios fire zero fetches; GitHub's no-remote case gets accurate copy instead of a dead CTA.

## Verification

- Typecheck green; suites green: desktop 2330, core 810, db 84, ui 12; cargo 90.
- Adversarial review: fixes applied (dead-end Connect navigation, GitLab fetch behind empty state, Sentry stale-goal race, misleading GitHub CTA, disconnected-state tests).
- Untouched: workspace_integrations schema, connect dialogs, polling policy, resolve flows, deriveSessionStage.

Area D of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)