### PR TITLE
fix: unified integration icons + uniform stage board cards

### DIFF
--- a/apps/desktop/src/app/components/AppFooter/index.tsx
+++ b/apps/desktop/src/app/components/AppFooter/index.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
-import { DollarSign, GitPullRequest, Layers, Plug } from 'lucide-react';
+import { DollarSign, Layers, Plug } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import { useAppStore } from '../../../store';
+import { IntegrationGlyph } from '../../../features/integrations/components/IntegrationGlyph';
 
 type FooterButtonProps = {
   icon: ReactNode;
@@ -68,7 +69,7 @@ export const AppFooter = ({
       <div className="flex items-center gap-0.5">
         {!gitlabEnabled ? (
           <FooterButton
-            icon={<GitPullRequest size={12} aria-hidden />}
+            icon={<IntegrationGlyph provider="github" size="xs" />}
             label="GitHub"
             title="review and act on pull requests across this workspace"
             onClick={onOpenGithub}
@@ -77,11 +78,7 @@ export const AppFooter = ({
         ) : null}
         {gitlabEnabled ? (
           <FooterButton
-            icon={
-              <span className="flex size-3 items-center justify-center rounded-[3px] bg-provider-gitlab text-[7px] font-bold text-white">
-                G
-              </span>
-            }
+            icon={<IntegrationGlyph provider="gitlab" size="xs" />}
             label="GitLab"
             title="launch a session from a GitLab issue"
             onClick={onOpenGitlab}
@@ -90,11 +87,7 @@ export const AppFooter = ({
         ) : null}
         {linearEnabled ? (
           <FooterButton
-            icon={
-              <span className="flex size-3 items-center justify-center rounded-[3px] bg-provider-linear text-[7px] font-bold text-white">
-                L
-              </span>
-            }
+            icon={<IntegrationGlyph provider="linear" size="xs" />}
             label="Linear"
             title="launch a session from a Linear issue"
             onClick={onOpenLinear}
@@ -103,11 +96,7 @@ export const AppFooter = ({
         ) : null}
         {sentryEnabled ? (
           <FooterButton
-            icon={
-              <span className="flex size-3 items-center justify-center rounded-[3px] bg-provider-sentry text-[7px] font-bold text-white">
-                S
-              </span>
-            }
+            icon={<IntegrationGlyph provider="sentry" size="xs" />}
             label="Sentry"
             title="launch a session from a Sentry issue"
             onClick={onOpenSentry}

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cn, Divider, ScrollFade } from '@goodboy/ui';
-import { GitPullRequest, RefreshCw } from 'lucide-react';
+import { RefreshCw } from 'lucide-react';
 import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
 import { InboxList } from './InboxList';
 import { IssueInbox } from './IssueInbox';
@@ -10,6 +10,7 @@ import { useGithubInbox } from './useGithubInbox';
 import { useGithubIssues } from './useGithubIssues';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+import { IntegrationGlyph } from '../../../integrations/components/IntegrationGlyph';
 import { resolveIntegrationConnection } from '../../../integrations/connection';
 import { useRemoteHostKind } from '../../../worktree/useRemoteHostKind';
 import { MissingGithubRemoteEmptyState } from '../MissingGithubRemoteEmptyState';
@@ -111,7 +112,7 @@ export const GitHubStudio = ({
 
   return (
     <StudioShell
-      icon={GitPullRequest}
+      glyph={<IntegrationGlyph provider="github" framed />}
       title="GitHub"
       workspaceName={workspaceName}
       closeLabel="close github studio"

--- a/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.test.tsx
@@ -28,6 +28,14 @@ describe('PullRequestChip', () => {
     expect(screen.getByText('#7')).toBeDefined();
     expect(screen.queryByText('Draft')).toBeNull();
   });
+
+  it('renders the none state as a muted dashed icon', () => {
+    render(<PullRequestChip state="none" />);
+    const icon = screen.getByLabelText('No pull request');
+    expect(icon.getAttribute('title')).toBe('No pull request');
+    expect(icon.className).toContain('text-muted-foreground/50');
+    expect(icon.querySelector('.lucide-circle-dashed')).not.toBeNull();
+  });
 });
 
 describe('pullRequestMeta', () => {
@@ -35,5 +43,6 @@ describe('pullRequestMeta', () => {
     expect(pullRequestMeta('open').label).toBe('In review');
     expect(pullRequestMeta('queued').label).toBe('Queued');
     expect(pullRequestMeta('closed').label).toBe('Closed');
+    expect(pullRequestMeta('none').label).toBe('No pull request');
   });
 });

--- a/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
+++ b/apps/desktop/src/features/github/components/PullRequestChip/index.tsx
@@ -1,5 +1,6 @@
 import {
   Check,
+  CircleDashed,
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
@@ -16,7 +17,15 @@ type PrStateMeta = {
   readonly bgClass: string;
 };
 
-const PR_META: Record<PullRequestStateKind, PrStateMeta> = {
+type PullRequestChipState = PullRequestStateKind | 'none';
+
+const PR_META: Record<PullRequestChipState, PrStateMeta> = {
+  none: {
+    icon: CircleDashed,
+    label: 'No pull request',
+    textClass: 'text-muted-foreground/50',
+    bgClass: 'bg-muted/20',
+  },
   draft: {
     icon: GitPullRequestDraft,
     label: 'Draft',
@@ -55,18 +64,19 @@ const PR_META: Record<PullRequestStateKind, PrStateMeta> = {
   },
 };
 
-export const pullRequestMeta = (state: PullRequestStateKind): PrStateMeta => {
+export const pullRequestMeta = (state: PullRequestChipState): PrStateMeta => {
   return PR_META[state];
 };
 
 type Variant = 'icon' | 'compact' | 'badge';
 
 type Props = {
-  readonly state: PullRequestStateKind;
+  readonly state: PullRequestChipState;
   readonly variant?: Variant;
   readonly number?: number;
   readonly iconSize?: number;
   readonly className?: string;
+  readonly title?: string;
 };
 
 export const PullRequestChip = ({
@@ -75,15 +85,17 @@ export const PullRequestChip = ({
   number,
   iconSize,
   className,
+  title,
 }: Props) => {
   const meta = PR_META[state];
   const Icon = meta.icon;
+  const description = title ?? meta.label + (number !== undefined ? ` · #${number}` : '');
 
   if (variant === 'icon') {
     return (
       <span
-        title={meta.label + (number !== undefined ? ` · #${number}` : '')}
-        aria-label={meta.label + (number !== undefined ? ` (#${number})` : '')}
+        title={description}
+        aria-label={description}
         className={cn('inline-flex shrink-0', meta.textClass, className)}
       >
         <Icon size={iconSize ?? 10} aria-hidden />

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import type { SessionExternalTask, SessionExternalTaskProvider } from '@goodboy/types';
+import { IntegrationGlyph } from '../IntegrationGlyph';
 
 type Props = {
   task: SessionExternalTask;
@@ -12,8 +13,6 @@ type Props = {
 
 type ProviderMeta = {
   label: string;
-  glyph: string;
-  glyphClasses: string;
   colorClasses: string;
   studioEvent: string;
 };
@@ -21,32 +20,24 @@ type ProviderMeta = {
 const PROVIDER_META: Record<SessionExternalTaskProvider, ProviderMeta> = {
   linear: {
     label: 'Linear',
-    glyph: 'L',
-    glyphClasses: 'bg-provider-linear text-white',
     colorClasses:
       'border-provider-linear/30 bg-provider-linear/5 text-provider-linear hover:border-provider-linear/60 hover:bg-provider-linear/10',
     studioEvent: 'goodboy:open-linear-studio',
   },
   sentry: {
     label: 'Sentry',
-    glyph: 'S',
-    glyphClasses: 'bg-provider-sentry text-white',
     colorClasses:
       'border-provider-sentry/30 bg-provider-sentry/5 text-provider-sentry hover:border-provider-sentry/60 hover:bg-provider-sentry/10',
     studioEvent: 'goodboy:open-sentry-studio',
   },
   gitlab: {
     label: 'GitLab',
-    glyph: 'G',
-    glyphClasses: 'bg-provider-gitlab text-white',
     colorClasses:
       'border-provider-gitlab/30 bg-provider-gitlab/5 text-provider-gitlab hover:border-provider-gitlab/60 hover:bg-provider-gitlab/10',
     studioEvent: 'goodboy:open-gitlab-studio',
   },
   github: {
     label: 'GitHub',
-    glyph: 'GH',
-    glyphClasses: 'bg-provider-github text-white',
     colorClasses:
       'border-provider-github/30 bg-provider-github/5 text-provider-github hover:border-provider-github/60 hover:bg-provider-github/10',
     studioEvent: 'goodboy:open-github-studio',
@@ -64,16 +55,7 @@ export const ExternalTaskChip = ({
   const tooltip = `${task.identifier}: ${task.title}`;
   const isRow = appearance === 'row';
 
-  const glyph = (
-    <span
-      className={cn(
-        'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-[9px] font-bold',
-        meta.glyphClasses,
-      )}
-    >
-      {meta.glyph}
-    </span>
-  );
+  const glyph = <IntegrationGlyph provider={task.provider} />;
 
   if (variant === 'icon') {
     return (

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -1,0 +1,67 @@
+import { cn } from '@goodboy/ui';
+
+export type IntegrationGlyphProvider = 'github' | 'gitlab' | 'linear' | 'sentry';
+
+const GLYPH: Record<IntegrationGlyphProvider, string> = {
+  github: 'GH',
+  gitlab: 'G',
+  linear: 'L',
+  sentry: 'S',
+};
+
+const BADGE_STYLE: Record<IntegrationGlyphProvider, string> = {
+  github: 'bg-provider-github',
+  gitlab: 'bg-provider-gitlab',
+  linear: 'bg-provider-linear',
+  sentry: 'bg-provider-sentry',
+};
+
+const FRAME_STYLE: Record<IntegrationGlyphProvider, string> = {
+  github: 'bg-provider-github/10',
+  gitlab: 'bg-provider-gitlab/10',
+  linear: 'bg-provider-linear/10',
+  sentry: 'bg-provider-sentry/10',
+};
+
+const SIZE: Record<'xs' | 'sm', string> = {
+  xs: 'size-3 text-[7px]',
+  sm: 'size-4 text-[9px]',
+};
+
+type Props = {
+  readonly provider: IntegrationGlyphProvider;
+  readonly size?: 'xs' | 'sm';
+  readonly framed?: boolean;
+  readonly className?: string;
+};
+
+export const IntegrationGlyph = ({ provider, size = 'sm', framed = false, className }: Props) => {
+  const badge = (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-sm font-bold text-white',
+        SIZE[size],
+        BADGE_STYLE[provider],
+        !framed && className,
+      )}
+    >
+      {GLYPH[provider]}
+    </span>
+  );
+
+  if (!framed) {
+    return badge;
+  }
+
+  return (
+    <span
+      className={cn(
+        'flex size-8 shrink-0 items-center justify-center rounded-lg',
+        FRAME_STYLE[provider],
+        className,
+      )}
+    >
+      {badge}
+    </span>
+  );
+};

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -3,6 +3,7 @@ import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { IntegrationGlyph } from '../../components/IntegrationGlyph';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../connection';
@@ -92,13 +93,7 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
 
   return (
     <StudioShell
-      glyph={
-        <span className="flex size-8 items-center justify-center rounded-lg bg-provider-gitlab/10">
-          <span className="flex size-4 items-center justify-center rounded-sm bg-provider-gitlab text-[9px] font-bold text-white">
-            G
-          </span>
-        </span>
-      }
+      glyph={<IntegrationGlyph provider="gitlab" framed />}
       title="GitLab"
       workspaceName={workspaceName}
       closeLabel="close gitlab studio"

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/index.tsx
@@ -3,6 +3,7 @@ import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { IntegrationGlyph } from '../../components/IntegrationGlyph';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../connection';
@@ -65,13 +66,7 @@ export const LinearStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
 
   return (
     <StudioShell
-      glyph={
-        <span className="flex size-8 items-center justify-center rounded-lg bg-provider-linear/10">
-          <span className="flex size-4 items-center justify-center rounded-sm bg-provider-linear text-[9px] font-bold text-white">
-            L
-          </span>
-        </span>
-      }
+      glyph={<IntegrationGlyph provider="linear" framed />}
       title="Linear"
       workspaceName={workspaceName}
       closeLabel="close linear studio"

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/index.tsx
@@ -3,6 +3,7 @@ import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
+import { IntegrationGlyph } from '../../components/IntegrationGlyph';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
 import { ConnectIntegrationEmptyState } from '../../ConnectIntegrationEmptyState';
 import { resolveIntegrationConnection } from '../../connection';
@@ -58,13 +59,7 @@ export const SentryStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
 
   return (
     <StudioShell
-      glyph={
-        <span className="flex size-8 items-center justify-center rounded-lg bg-provider-sentry/10">
-          <span className="flex size-4 items-center justify-center rounded-sm bg-provider-sentry text-[9px] font-bold text-white">
-            S
-          </span>
-        </span>
-      }
+      glyph={<IntegrationGlyph provider="sentry" framed />}
       title="Sentry"
       workspaceName={workspaceName}
       closeLabel="close sentry studio"

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -123,8 +123,10 @@ describe('LensColumn', () => {
     ).toEqual(['Work', 'Artifacts', 'Context', 'Integrations', 'Infra']);
     expect(
       screen.getAllByRole('button').map((button) => {
-        const shortcut = button.querySelector('kbd')?.textContent ?? '';
-        return button.textContent?.replace(shortcut, '').trim();
+        const clone = button.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll('[aria-hidden="true"]').forEach((node) => node.remove());
+        const shortcut = clone.querySelector('kbd')?.textContent ?? '';
+        return clone.textContent?.replace(shortcut, '').trim();
       }),
     ).toEqual([
       'Overview',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -3,16 +3,12 @@ import type { LucideIcon } from 'lucide-react';
 import {
   Activity,
   Bot,
-  Bug,
   CheckCheck,
   CircleHelp,
   FileDiff,
   FileText,
-  GitBranch,
-  GitFork,
   LayoutDashboard,
   Layers,
-  ListTodo,
   MessageSquareReply,
   SquareTerminal,
   Target,
@@ -34,6 +30,10 @@ import {
 import type { LensKind } from '../../../../../store';
 import { useRemoteHostKind } from '../../../../worktree/useRemoteHostKind';
 import { resolveIntegrationConnection } from '../../../../integrations/connection';
+import {
+  IntegrationGlyph,
+  type IntegrationGlyphProvider,
+} from '../../../../integrations/components/IntegrationGlyph';
 import { resolveAttentionLens, selectOpenQuestions } from '../../SessionOverviewPane/lib';
 
 type LensColumnProps = {
@@ -47,7 +47,8 @@ type LensColumnProps = {
 type LensRow = {
   readonly kind: LensKind;
   readonly label: string;
-  readonly icon: LucideIcon;
+  readonly icon?: LucideIcon;
+  readonly glyph?: IntegrationGlyphProvider;
   readonly tone: Tone;
   readonly count?: number;
   readonly isCountLoading?: boolean;
@@ -187,7 +188,7 @@ export const LensColumn = ({
           {
             kind: 'pr',
             label: isGitlabRemote ? 'GitLab' : 'GitHub',
-            icon: isGitlabRemote ? GitFork : GitBranch,
+            glyph: isGitlabRemote ? 'gitlab' : 'github',
             tone: 'accent',
             dot: hasPr ? 'running' : undefined,
           } satisfies LensRow,
@@ -198,7 +199,7 @@ export const LensColumn = ({
           {
             kind: 'linear',
             label: 'Linear',
-            icon: ListTodo,
+            glyph: 'linear',
             tone: 'primary',
             count: linearCount,
           } satisfies LensRow,
@@ -209,7 +210,7 @@ export const LensColumn = ({
           {
             kind: 'sentry',
             label: 'Sentry',
-            icon: Bug,
+            glyph: 'sentry',
             tone: 'warning',
             count: sentryCount,
           } satisfies LensRow,
@@ -220,7 +221,7 @@ export const LensColumn = ({
           {
             kind: 'gitlab_issues',
             label: 'GitLab issues',
-            icon: GitFork,
+            glyph: 'gitlab',
             tone: 'accent',
             count: gitlabCount,
           } satisfies LensRow,
@@ -383,16 +384,22 @@ export const LensColumn = ({
                       : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
                   )}
                 >
-                  <span
-                    aria-hidden
-                    className={cn(
-                      'flex size-5 shrink-0 items-center justify-center rounded-md ring-1 transition-colors',
-                      tintClasses(row.tone).bg,
-                      tintClasses(row.tone).ring,
-                    )}
-                  >
-                    <row.icon size={12} aria-hidden className={tintClasses(row.tone).icon} />
-                  </span>
+                  {row.glyph ? (
+                    <span aria-hidden className="flex size-5 shrink-0 items-center justify-center">
+                      <IntegrationGlyph provider={row.glyph} />
+                    </span>
+                  ) : row.icon ? (
+                    <span
+                      aria-hidden
+                      className={cn(
+                        'flex size-5 shrink-0 items-center justify-center rounded-md ring-1 transition-colors',
+                        tintClasses(row.tone).bg,
+                        tintClasses(row.tone).ring,
+                      )}
+                    >
+                      <row.icon size={12} aria-hidden className={tintClasses(row.tone).icon} />
+                    </span>
+                  ) : null}
                   <span
                     className={cn(
                       'min-w-0 flex-1 truncate text-[13px]',

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/getLinkedRequest.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/getLinkedRequest.ts
@@ -1,0 +1,53 @@
+import type { PullRequestState, PullRequestStateKind } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../../integrations/gitlab/client';
+
+type Params = {
+  readonly pullRequest: PullRequestState | null;
+  readonly mergeRequest: GitlabMergeRequest | null;
+};
+
+type LinkedRequest = {
+  readonly state: PullRequestStateKind | 'none';
+  readonly number?: number;
+  readonly title?: string;
+};
+
+type MergeRequestStateParams = Pick<GitlabMergeRequest, 'draft' | 'state'>;
+
+const getMergeRequestState = ({ draft, state }: MergeRequestStateParams): PullRequestStateKind => {
+  if (draft) {
+    return 'draft';
+  }
+
+  switch (state) {
+    case 'opened':
+    case 'open':
+      return 'open';
+    case 'merged':
+      return 'merged';
+    case 'closed':
+      return 'closed';
+    default:
+      return 'open';
+  }
+};
+
+export const getLinkedRequest = ({ pullRequest, mergeRequest }: Params): LinkedRequest => {
+  if (pullRequest != null) {
+    return {
+      state: pullRequest.state,
+      number: pullRequest.number,
+    };
+  }
+
+  if (mergeRequest != null) {
+    const state = getMergeRequestState(mergeRequest);
+    return {
+      state,
+      number: mergeRequest.iid,
+      title: `Merge request !${mergeRequest.iid} · ${state}`,
+    };
+  }
+
+  return { state: 'none' };
+};

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -1,0 +1,196 @@
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type {
+  PullRequestState,
+  Session,
+  SessionExternalTask,
+  SessionId,
+  SessionStage,
+} from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../../integrations/gitlab/client';
+import type { BoardNavigation } from '../useBoardNavigation';
+
+const { state, hooks } = vi.hoisted(() => ({
+  state: {
+    sessionGithub: {} as Record<string, { pr: PullRequestState | null }>,
+    sessionGitlabMr: {} as Record<string, { mr: GitlabMergeRequest | null }>,
+    sessionExternalTasks: {} as Record<string, ReadonlyArray<SessionExternalTask>>,
+    sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+  },
+  hooks: {
+    stage: 'building' as SessionStage,
+    reason: 'no PR yet',
+    agents: [] as ReadonlyArray<unknown>,
+    cost: 0,
+  },
+}));
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: [] as readonly never[],
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+  useNonResolverStandaloneAgents: () => hooks.agents,
+  useSessionCost: () => hooks.cost,
+  useSessionStageInfo: () => ({ stage: hooks.stage, reason: hooks.reason }),
+}));
+
+vi.mock('./useDynamicActions', () => ({
+  useDynamicActions: () => [],
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    StatusDot: () => <span data-testid="status-dot" />,
+    Tooltip: ({ content, children }: { content: string; children: ReactElement }) => (
+      <span data-tooltip={content}>{children}</span>
+    ),
+  };
+});
+
+import { StageBoardCard } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+
+const nav = {
+  selectCard: vi.fn(),
+  openAgent: vi.fn(),
+  openTerminal: vi.fn(),
+  openIDE: vi.fn(),
+  openQuestions: vi.fn(),
+  openWorkflows: vi.fn(),
+  openGithub: vi.fn(),
+  restore: vi.fn(),
+} satisfies BoardNavigation;
+
+const session = {
+  id: SESSION_ID,
+  goal: 'Keep every board card compact',
+  workflowRuns: [],
+} as unknown as Session;
+
+const pullRequest = {
+  number: 9484,
+  state: 'draft',
+} as unknown as PullRequestState;
+
+type MergeRequestParams = {
+  readonly state: string;
+  readonly draft?: boolean;
+};
+
+const mergeRequest = ({
+  state: mergeRequestState,
+  draft = false,
+}: MergeRequestParams): GitlabMergeRequest =>
+  ({
+    iid: 12,
+    state: mergeRequestState,
+    draft,
+  }) as GitlabMergeRequest;
+
+const externalTask = {
+  sessionId: SESSION_ID,
+  provider: 'linear',
+  externalId: 'linear-1',
+  identifier: 'GB-123',
+  title: 'Compact board cards',
+} as SessionExternalTask;
+
+beforeEach(() => {
+  state.sessionGithub = {};
+  state.sessionGitlabMr = {};
+  state.sessionExternalTasks = {};
+  state.sessionWorktrees = {};
+  hooks.reason = 'no PR yet';
+  hooks.agents = [];
+  hooks.cost = 0;
+});
+
+afterEach(cleanup);
+
+describe('StageBoardCard layout', () => {
+  it('uses fixed card and title slots while always rendering the footer row', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const card = screen.getAllByRole('button')[0];
+    const title = screen.getByText(session.goal);
+    const footer = title.closest('[data-tooltip]')?.parentElement?.nextElementSibling;
+    expect(card?.className).toContain('h-[7.25rem]');
+    expect(title.className).toContain('line-clamp-2');
+    expect(title.className).toContain('min-h-10');
+    expect(footer?.className).toContain('flex-nowrap');
+    expect(footer?.className).toContain('min-h-5');
+  });
+
+  it('keeps the reason in the title tooltip without rendering a status dot or reason line', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const tooltip = screen.getByText(session.goal).closest('[data-tooltip]');
+    expect(tooltip?.getAttribute('data-tooltip')).toBe(`${session.goal} · no PR yet`);
+    expect(screen.queryByTestId('status-dot')).toBeNull();
+    expect(screen.queryByText('no PR yet')).toBeNull();
+  });
+});
+
+describe('StageBoardCard linked request', () => {
+  it('always renders a no pull request icon in the title row', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const icon = screen.getByLabelText('No pull request');
+    const titleRow = screen.getByText(session.goal).closest('[data-tooltip]')?.parentElement;
+    expect(icon.getAttribute('title')).toBe('No pull request');
+    expect(titleRow?.contains(icon)).toBe(true);
+  });
+
+  it('renders the GitHub pull request state and number', () => {
+    state.sessionGithub = { [SESSION_ID]: { pr: pullRequest } };
+    render(<StageBoardCard session={session} nav={nav} />);
+    const icon = screen.getByLabelText('Draft · #9484');
+    expect(icon.getAttribute('title')).toBe('Draft · #9484');
+    expect(screen.queryByLabelText('No pull request')).toBeNull();
+  });
+
+  it.each([
+    ['opened', false, 'open'],
+    ['open', false, 'open'],
+    ['opened', true, 'draft'],
+    ['merged', false, 'merged'],
+    ['closed', false, 'closed'],
+  ])('maps GitLab %s with draft %s to %s', (mrState, draft, expected) => {
+    state.sessionGitlabMr = {
+      [SESSION_ID]: { mr: mergeRequest({ state: mrState, draft }) },
+    };
+    render(<StageBoardCard session={session} nav={nav} />);
+    const title = `Merge request !12 · ${expected}`;
+    const icon = screen.getByLabelText(title);
+    expect(icon.getAttribute('title')).toBe(title);
+  });
+});
+
+describe('StageBoardCard footer', () => {
+  it('renders compact agents, glyph-only external tasks, cost, and auto metadata in order', () => {
+    hooks.stage = 'running';
+    hooks.agents = [{}, {}];
+    hooks.cost = 1.25;
+    state.sessionExternalTasks = { [SESSION_ID]: [externalTask] };
+    const autoSession = {
+      ...session,
+      workflowRuns: [{ autoRun: true }],
+    } as unknown as Session;
+    render(<StageBoardCard session={autoSession} nav={nav} />);
+    const agents = screen.getByLabelText('2 agents');
+    const task = screen.getByLabelText('GB-123 from Linear');
+    const cost = document.querySelector('[title="session spend: $1.25 (excludes summarizer)"]');
+    const auto = screen.getByText('auto');
+    const footer = agents.closest('[data-tooltip]')?.parentElement;
+    expect(agents.querySelector('.lucide-bot')).not.toBeNull();
+    expect(screen.queryByText('GB-123')).toBeNull();
+    expect(cost).not.toBeNull();
+    expect(auto).toBeDefined();
+    expect(Array.from(footer?.children ?? [])).toEqual([
+      agents.closest('[data-tooltip]'),
+      task,
+      cost,
+      auto,
+    ]);
+  });
+});

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -1,6 +1,14 @@
 import { memo } from 'react';
-import { Archive, Code, RotateCcw, SquareTerminal, Trash2, type LucideIcon } from 'lucide-react';
-import { Chip, cn, StatusDot, Tooltip } from '@goodboy/ui';
+import {
+  Archive,
+  Bot,
+  Code,
+  RotateCcw,
+  SquareTerminal,
+  Trash2,
+  type LucideIcon,
+} from 'lucide-react';
+import { Chip, cn, Tooltip } from '@goodboy/ui';
 import type { Session, SessionId } from '@goodboy/types';
 import {
   EMPTY_ARRAY,
@@ -9,12 +17,11 @@ import {
   useSessionCost,
   useSessionStageInfo,
 } from '../../../../../store';
-import { SESSION_STAGE_META, STAGE_TONE } from '../../../../session/session-stage';
 import { CostBadge } from '../../../../providers/components/CostBadge';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
-import { pluralize } from '../../WorkspacesSidebar/lib';
 import type { BoardNavigation } from '../useBoardNavigation';
+import { getLinkedRequest } from './getLinkedRequest';
 import { useDynamicActions } from './useDynamicActions';
 
 type StageBoardCardProps = {
@@ -39,15 +46,15 @@ export const StageBoardCard = memo(function StageBoardCard({
   const isAutoMode =
     stage === 'running' && session.workflowRuns.some((r) => r.autoRun && !r.discardedAt);
 
-  const prState = useAppStore((s) => s.sessionGithub[id]?.pr?.state ?? null);
-  const prNumber = useAppStore((s) => s.sessionGithub[id]?.pr?.number);
+  const pullRequest = useAppStore((s) => s.sessionGithub[id]?.pr ?? null);
+  const mergeRequest = useAppStore((s) => s.sessionGitlabMr[id]?.mr ?? null);
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[id] ?? EMPTY_ARRAY);
   const agentCount = useNonResolverStandaloneAgents(id).length;
   const worktreePath = useAppStore((s) => s.sessionWorktrees[id]?.[0] ?? null);
   const dynamicActions = useDynamicActions(session, nav, stage, reason);
   const sessionCost = useSessionCost(id);
 
-  const stageMeta = SESSION_STAGE_META[stage];
+  const linkedRequest = getLinkedRequest({ pullRequest, mergeRequest });
 
   return (
     <button
@@ -55,7 +62,7 @@ export const StageBoardCard = memo(function StageBoardCard({
       data-archived={archived || undefined}
       onClick={() => nav.selectCard(session)}
       className={cn(
-        'group flex min-h-[7.25rem] shrink-0 gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
+        'group flex h-[7.25rem] min-h-[7.25rem] shrink-0 gap-2 rounded-lg border bg-muted/40 p-3 text-left text-foreground/70 shadow-sm transition-colors hover:bg-muted/60 hover:text-foreground',
         stage === 'running'
           ? 'border-info/50'
           : stage === 'attention'
@@ -64,53 +71,51 @@ export const StageBoardCard = memo(function StageBoardCard({
       )}
     >
       <span className="flex min-w-0 flex-1 flex-col gap-2">
-        <span className="flex items-start gap-2">
-          <span className="inline-flex h-5 shrink-0 items-center">
-            <StatusDot
-              tone={isAutoMode ? 'danger' : STAGE_TONE[stage]}
-              size="sm"
-              pulsing={stage === 'running'}
-              ariaLabel={stageMeta.label}
-            />
-          </span>
+        <span className="flex min-h-10 items-start gap-2">
           <Tooltip content={`${session.goal}${reason ? ` · ${reason}` : ''}`} side="top">
-            <span className="line-clamp-2 min-w-0 flex-1 text-sm font-medium leading-snug">
+            <span className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-snug">
               {session.goal}
             </span>
           </Tooltip>
+          <span className="inline-flex h-5 shrink-0 items-center">
+            <PullRequestChip
+              state={linkedRequest.state}
+              variant="icon"
+              number={linkedRequest.number}
+              iconSize={12}
+              title={linkedRequest.title}
+            />
+          </span>
         </span>
 
-        {reason && <span className="truncate text-2xs text-muted-foreground">{reason}</span>}
-
-        {(sessionCost > 0 ||
-          prState != null ||
-          externalTasks.length > 0 ||
-          agentCount > 0 ||
-          isAutoMode) && (
-          <span className="flex flex-wrap items-center gap-1.5">
-            {sessionCost > 0 && (
-              <CostBadge
-                value={sessionCost}
-                title={`session spend: $${sessionCost.toFixed(2)} (excludes summarizer)`}
-                className="text-2xs font-medium tabular-nums text-muted-foreground"
-              />
-            )}
-            {prState && (
-              <PullRequestChip state={prState} variant="icon" number={prNumber} iconSize={12} />
-            )}
-            {externalTasks.map((task) => (
-              <ExternalTaskChip
-                key={`${task.provider}:${task.externalId}`}
-                task={task}
-                variant="badge"
-              />
-            ))}
-            {agentCount > 0 && (
-              <Chip tone="neutral" size="sm" shape="pill" label={pluralize(agentCount, 'agent')} />
-            )}
-            {isAutoMode && <Chip tone="danger" size="sm" label="auto" />}
-          </span>
-        )}
+        <span className="mt-auto flex min-h-5 flex-nowrap items-center gap-1.5 overflow-hidden">
+          {agentCount > 0 && (
+            <Tooltip content={`${agentCount} agents`} side="top">
+              <span
+                aria-label={`${agentCount} agents`}
+                className="inline-flex shrink-0 items-center gap-1 text-2xs text-muted-foreground"
+              >
+                <Bot size={12} aria-hidden />
+                <span className="tabular-nums">{agentCount}</span>
+              </span>
+            </Tooltip>
+          )}
+          {externalTasks.map((task) => (
+            <ExternalTaskChip
+              key={`${task.provider}:${task.externalId}`}
+              task={task}
+              variant="icon"
+            />
+          ))}
+          {sessionCost > 0 && (
+            <CostBadge
+              value={sessionCost}
+              title={`session spend: $${sessionCost.toFixed(2)} (excludes summarizer)`}
+              className="shrink-0 text-2xs font-medium tabular-nums text-muted-foreground"
+            />
+          )}
+          {isAutoMode && <Chip tone="danger" size="sm" label="auto" className="shrink-0" />}
+        </span>
       </span>
 
       <span className="-mr-1 flex shrink-0 flex-col items-end gap-1">


### PR DESCRIPTION
## What

**Integration icons, one system.** New shared `IntegrationGlyph` (brand-colored letter badge for GitHub/GitLab/Linear/Sentry) replaces the three divergent icon systems: footer buttons (GitHub used a lucide `GitPullRequest`), GitHub Studio header (same), session lens rows (generic `GitBranch`/`GitFork`/`ListTodo`/`Bug`), and the inline glyphs duplicated in each studio header and ExternalTaskChip.

**Stage board cards, uniform and compact.**
- Fixed card height with reserved slots: title always 2 lines, footer always present.
- Status dot removed (the column already says the stage); running/attention border tint kept; `auto` chip kept.
- Reason line removed from the body (still in the title tooltip). Stage engine untouched.
- PR/MR state is now a single icon top-right, always present: none (dashed), draft, in review, approved, queued, merged, closed; GitLab MRs map onto the same set with `!iid` wording.
- Footer compacted: agents as `bot icon + N`, linked tasks as glyph-only chips, cost badge, no wrap.

## Verification

Typecheck green; desktop suite 2341 green (chip none-state, MR mapping, uniform layout, glyph rendering covered). Verified live against a prod DB copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)