### PR TITLE
feat: actionable notifications for auxiliary AI operations

### DIFF
--- a/apps/desktop/src/app/components/Toast/index.tsx
+++ b/apps/desktop/src/app/components/Toast/index.tsx
@@ -4,6 +4,11 @@ import { cn } from '@goodboy/ui';
 
 export type ToastKind = 'info' | 'warning' | 'error' | 'success';
 
+export type ToastAction = {
+  readonly label: string;
+  readonly onClick: () => void;
+};
+
 export type ToastItem = {
   readonly id: string;
   readonly kind: ToastKind;
@@ -11,12 +16,14 @@ export type ToastItem = {
   readonly title?: string;
   readonly context?: string;
   readonly persist?: boolean;
+  readonly action?: ToastAction;
 };
 
 export type ShowToastOptions = {
   readonly title?: string;
   readonly context?: string;
   readonly persist?: boolean;
+  readonly action?: ToastAction;
 };
 
 type ToastContextValue = {
@@ -48,6 +55,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
         title: opts?.title,
         context: opts?.context,
         persist: opts?.persist,
+        action: opts?.action,
       },
     ]);
   }, []);
@@ -215,6 +223,18 @@ function ToastCard({ toast, onDismiss }: ToastCardProps) {
           ) : null}
           {toast.context ? (
             <p className="mt-1.5 line-clamp-2 text-2xs text-muted-foreground/70">{toast.context}</p>
+          ) : null}
+          {toast.action != null ? (
+            <button
+              type="button"
+              className="mt-1.5 rounded px-1.5 py-0.5 text-2xs font-medium text-foreground/80 ring-1 ring-inset ring-foreground/20 hover:bg-muted hover:text-foreground"
+              onClick={() => {
+                toast.action!.onClick();
+                onDismiss(toast.id);
+              }}
+            >
+              {toast.action.label}
+            </button>
           ) : null}
         </div>
         <button

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { resolveTaskModel } from '@goodboy/core';
 import type { Notification } from '@goodboy/db';
 
 const { state } = vi.hoisted(() => ({
@@ -10,12 +11,19 @@ const { state } = vi.hoisted(() => ({
     loadNotifications: vi.fn(async () => undefined),
     markNotificationsRead: vi.fn(async () => undefined),
     clearNotifications: vi.fn(async () => undefined),
+    retrySummarizer: vi.fn(),
+    retryStepSummary: vi.fn(async () => undefined),
+    summarizerStatus: {} as Record<string, unknown>,
+    sessions: [] as ReadonlyArray<unknown>,
+    providers: [] as ReadonlyArray<{ id: string; connection: string }>,
   },
 }));
 
-vi.mock('../../../../store', () => ({
-  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
-}));
+vi.mock('../../../../store', () => {
+  const useAppStore = <T,>(selector: (s: typeof state) => T) => selector(state);
+  (useAppStore as unknown as { getState: () => typeof state }).getState = () => state;
+  return { useAppStore };
+});
 
 import { NotificationCenter } from './index';
 
@@ -24,6 +32,11 @@ beforeEach(() => {
   state.loadNotifications = vi.fn(async () => undefined);
   state.markNotificationsRead = vi.fn(async () => undefined);
   state.clearNotifications = vi.fn(async () => undefined);
+  state.retrySummarizer = vi.fn();
+  state.retryStepSummary = vi.fn(async () => undefined);
+  state.summarizerStatus = {};
+  state.sessions = [];
+  state.providers = [];
 });
 afterEach(cleanup);
 
@@ -65,5 +78,91 @@ describe('NotificationCenter', () => {
     ];
     render(<NotificationCenter />);
     expect(screen.getByRole('button', { name: /^notifications, 1 unread$/i })).toBeDefined();
+  });
+
+  it('retry with picker dispatches retryStepSummary with the selected override', async () => {
+    state.providers = [{ id: 'anthropic', connection: 'connected' }];
+    state.sessions = [
+      {
+        id: 'session-1',
+        providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+      },
+    ];
+    state.notifications = [
+      {
+        id: 'n1',
+        read: true,
+        severity: 'warning',
+        kind: 'summarizer-degraded',
+        title: 'step summary degraded',
+        body: 'anthropic/haiku: boom',
+        ts: new Date().toISOString(),
+        sessionId: 'session-1',
+        workspaceId: null,
+        action: { kind: 'retry-step-summary', sessionId: 'session-1', agentId: 'agent-1' },
+      } as unknown as Notification,
+    ];
+
+    render(<NotificationCenter />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /retry with/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /confirm retry with selected model/i }));
+    });
+
+    const expected = resolveTaskModel('summarizer', null, 'anthropic');
+    expect(state.retryStepSummary).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      agentId: 'agent-1',
+      taskModelOverride: expected,
+    });
+  });
+
+  it('retry with picker dispatches retrySummarizer with the selected override', async () => {
+    state.providers = [{ id: 'anthropic', connection: 'connected' }];
+    state.sessions = [
+      {
+        id: 'session-2',
+        providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+      },
+    ];
+    state.summarizerStatus = {
+      'session-2': { status: 'error', lastAttempt: { turnInput: 'in', turnOutput: 'out' } },
+    };
+    state.notifications = [
+      {
+        id: 'n2',
+        read: true,
+        severity: 'error',
+        kind: 'error',
+        title: 'summarizer failed',
+        body: 'anthropic: boom',
+        ts: new Date().toISOString(),
+        sessionId: 'session-2',
+        workspaceId: null,
+        action: { kind: 'retry-summarizer', sessionId: 'session-2' },
+      } as unknown as Notification,
+    ];
+
+    render(<NotificationCenter />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /notifications/i }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /retry with/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /confirm retry with selected model/i }));
+    });
+
+    const expected = resolveTaskModel('summarizer', null, 'anthropic');
+    expect(state.retrySummarizer).toHaveBeenCalledWith('session-2', expected);
+    expect(screen.queryByRole('button', { name: /confirm retry with selected model/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Bell, CheckCircle, AlertCircle, AlertTriangle, Info, Trash2 } from 'lucide-react';
-import { Divider, Popover, ScrollFade, Tooltip, cn } from '@goodboy/ui';
+import { Divider, Popover, ScrollFade, Select, Tooltip, cn } from '@goodboy/ui';
 import { Fragment } from 'react';
-import type { Notification, NotificationSeverity } from '@goodboy/db';
+import { useShallow } from 'zustand/react/shallow';
+import type { Notification, NotificationAction, NotificationSeverity } from '@goodboy/db';
+import { PROVIDER_CAPABILITIES, resolveTaskModel } from '@goodboy/core';
+import type { ProviderId, TaskModelPreference } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
+import { mapNotificationAction } from '../NotificationToastBridge';
+import { PROVIDER_LABEL } from '../../../chat/utils/chat-constants';
+import { ModelSelect } from '../../../session/components/ModelSelect';
 
 function severityIcon(severity: NotificationSeverity, size = 13) {
   switch (severity) {
@@ -210,6 +216,9 @@ type NotificationItemProps = {
 };
 
 function NotificationItem({ notification: n }: NotificationItemProps) {
+  const store = useAppStore.getState();
+  const action = n.action != null ? mapNotificationAction(n.action, store) : undefined;
+  const [pickerOpen, setPickerOpen] = useState(false);
   return (
     <li className={cn('flex items-start gap-2 px-3 py-2.5', !n.read && 'bg-muted/40')}>
       <span className={cn('mt-0.5 shrink-0', severityClass(n.severity))}>
@@ -223,7 +232,107 @@ function NotificationItem({ notification: n }: NotificationItemProps) {
           </p>
         )}
         <p className="mt-0.5 text-2xs text-muted-foreground/70">{relativeTime(n.ts)}</p>
+        {action != null ? (
+          <div className="mt-1 flex items-center gap-1.5">
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-2xs font-medium text-foreground/80 ring-1 ring-inset ring-foreground/20 hover:bg-muted hover:text-foreground"
+              onClick={action.onClick}
+            >
+              {action.label}
+            </button>
+            <button
+              type="button"
+              className="rounded px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() => setPickerOpen((v) => !v)}
+            >
+              Retry with…
+            </button>
+          </div>
+        ) : null}
+        {action != null && pickerOpen && n.action != null ? (
+          <RetryWithPicker action={n.action} onDone={() => setPickerOpen(false)} />
+        ) : null}
       </div>
     </li>
+  );
+}
+
+type RetryWithPickerProps = {
+  readonly action: NotificationAction;
+  readonly onDone: () => void;
+};
+
+function RetryWithPicker({ action, onDone }: RetryWithPickerProps) {
+  const connectedProviderIds = useAppStore(
+    useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
+  );
+  const sessionProvider = useAppStore(
+    (s) => s.sessions.find((x) => x.id === action.sessionId)?.providerPreference.defaultProvider,
+  );
+  const availableProviderIds = connectedProviderIds.filter(
+    (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
+  );
+  const initialProvider =
+    sessionProvider != null && availableProviderIds.includes(sessionProvider)
+      ? sessionProvider
+      : availableProviderIds[0];
+  const [providerId, setProviderId] = useState<ProviderId | undefined>(initialProvider);
+  const [model, setModel] = useState('');
+  if (providerId == null) {
+    return null;
+  }
+  const recommendedModel = resolveTaskModel('summarizer', null, providerId).model;
+  const dispatch = () => {
+    const override: TaskModelPreference =
+      model === '' ? resolveTaskModel('summarizer', null, providerId) : { providerId, model };
+    const store = useAppStore.getState();
+    if (action.kind === 'retry-summarizer') {
+      store.retrySummarizer(action.sessionId, override);
+    } else {
+      void store.retryStepSummary({
+        sessionId: action.sessionId,
+        agentId: action.agentId,
+        taskModelOverride: override,
+      });
+    }
+    onDone();
+  };
+  return (
+    <div className="mt-1.5 flex items-center gap-1.5">
+      <Select
+        size="sm"
+        aria-label="retry provider"
+        value={providerId}
+        onChange={(event) => {
+          setProviderId(event.target.value as ProviderId);
+          setModel('');
+        }}
+      >
+        {availableProviderIds.map((candidate) => (
+          <option key={candidate} value={candidate}>
+            {PROVIDER_LABEL[candidate]}
+          </option>
+        ))}
+      </Select>
+      <div className="min-w-0 flex-1">
+        <ModelSelect
+          provider={providerId}
+          value={model}
+          onChange={setModel}
+          disabled={false}
+          allowAuto
+          recommendedModel={recommendedModel}
+        />
+      </div>
+      <button
+        type="button"
+        className="rounded px-1.5 py-0.5 text-2xs font-medium text-foreground/80 ring-1 ring-inset ring-foreground/20 hover:bg-muted hover:text-foreground"
+        onClick={dispatch}
+        aria-label="confirm retry with selected model"
+      >
+        Retry
+      </button>
+    </div>
   );
 }

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.test.ts
@@ -24,6 +24,7 @@ function notif(over: NotifOverride): Notification {
     sessionId: over.sessionId ?? null,
     workspaceId: over.workspaceId ?? null,
     read: false,
+    action: null,
   };
 }
 

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef } from 'react';
-import type { Notification } from '@goodboy/db';
+import type { Notification, NotificationAction } from '@goodboy/db';
 import type { Session, Workspace } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
-import { useToast } from '../../../../app/components/Toast';
+import { useToast, type ToastAction } from '../../../../app/components/Toast';
 
 export const pickFreshFailures = (
   notifications: ReadonlyArray<Notification>,
@@ -43,6 +43,36 @@ export const notificationContext = (
   return parts.length > 0 ? parts.join(' · ') : undefined;
 };
 
+export const mapNotificationAction = (
+  action: NotificationAction,
+  store: ReturnType<typeof useAppStore.getState>,
+): ToastAction | undefined => {
+  if (action.kind === 'retry-summarizer') {
+    const { sessionId } = action;
+    const lastAttempt = store.summarizerStatus[sessionId]?.lastAttempt;
+    if (lastAttempt == null) {
+      return undefined;
+    }
+    return {
+      label: 'Retry',
+      onClick: () => {
+        store.retrySummarizer(sessionId);
+      },
+    };
+  }
+  if (action.kind === 'retry-step-summary') {
+    const { sessionId, agentId } = action;
+    return {
+      label: 'Retry',
+      onClick: () => {
+        void store.retryStepSummary({ sessionId, agentId });
+      },
+    };
+  }
+  const _exhaustive: never = action;
+  return undefined;
+};
+
 export const NotificationToastBridge = () => {
   const notifications = useAppStore((s) => s.notifications);
   const sessions = useAppStore((s) => s.sessions);
@@ -54,10 +84,13 @@ export const NotificationToastBridge = () => {
 
   useEffect(() => {
     for (const n of pickFreshFailures(notifications, seen.current, mountedAt.current)) {
+      const store = useAppStore.getState();
+      const toastAction = n.action != null ? mapNotificationAction(n.action, store) : undefined;
       showToast(n.severity === 'error' ? 'error' : 'warning', n.body ?? '', {
         title: n.title,
         context: notificationContext(n, sessions, workspaces),
         persist: n.severity === 'error',
+        action: toastAction,
       });
     }
   }, [notifications, sessions, workspaces, showToast]);

--- a/apps/desktop/src/features/notifications/components/NotificationToastBridge/notificationAction.test.ts
+++ b/apps/desktop/src/features/notifications/components/NotificationToastBridge/notificationAction.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotificationAction } from '@goodboy/db';
+import type { AgentId, SessionId } from '@goodboy/types';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+
+import { mapNotificationAction } from './';
+
+const retrySummarizerSpy = vi.fn();
+const retryStepSummarySpy = vi.fn(async () => undefined);
+
+type FakeStore = {
+  summarizerStatus: Record<
+    string,
+    { lastAttempt?: { turnInput: string; turnOutput: string } } | undefined
+  >;
+  retrySummarizer: typeof retrySummarizerSpy;
+  retryStepSummary: typeof retryStepSummarySpy;
+};
+
+function buildStore(overrides: Partial<FakeStore> = {}): FakeStore {
+  return {
+    summarizerStatus: {},
+    retrySummarizer: retrySummarizerSpy,
+    retryStepSummary: retryStepSummarySpy,
+    ...overrides,
+  };
+}
+
+describe('mapNotificationAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retry-summarizer: returns undefined when lastAttempt is missing', () => {
+    const action: NotificationAction = { kind: 'retry-summarizer', sessionId: SESSION_ID };
+    const store = buildStore({ summarizerStatus: { [SESSION_ID]: undefined } });
+    const result = mapNotificationAction(action, store as never);
+    expect(result).toBeUndefined();
+  });
+
+  it('retry-summarizer: returns action with Retry label when lastAttempt exists', () => {
+    const lastAttempt = { turnInput: 'user prompt', turnOutput: 'agent reply' };
+    const action: NotificationAction = { kind: 'retry-summarizer', sessionId: SESSION_ID };
+    const store = buildStore({ summarizerStatus: { [SESSION_ID]: { lastAttempt } } });
+    const toastAction = mapNotificationAction(action, store as never);
+    expect(toastAction?.label).toBe('Retry');
+  });
+
+  it('retry-summarizer: onClick calls retrySummarizer with sessionId', () => {
+    const lastAttempt = { turnInput: 'user prompt', turnOutput: 'agent reply' };
+    const action: NotificationAction = { kind: 'retry-summarizer', sessionId: SESSION_ID };
+    const store = buildStore({ summarizerStatus: { [SESSION_ID]: { lastAttempt } } });
+    const toastAction = mapNotificationAction(action, store as never);
+    toastAction?.onClick();
+    expect(retrySummarizerSpy).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('retry-step-summary: returns action with Retry label', () => {
+    const action: NotificationAction = {
+      kind: 'retry-step-summary',
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+    };
+    const store = buildStore();
+    const toastAction = mapNotificationAction(action, store as never);
+    expect(toastAction?.label).toBe('Retry');
+  });
+
+  it('retry-step-summary: onClick calls retryStepSummary with correct params', () => {
+    const action: NotificationAction = {
+      kind: 'retry-step-summary',
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+    };
+    const store = buildStore();
+    const toastAction = mapNotificationAction(action, store as never);
+    toastAction?.onClick();
+    expect(retryStepSummarySpy).toHaveBeenCalledWith({ sessionId: SESSION_ID, agentId: AGENT_ID });
+  });
+});

--- a/apps/desktop/src/store/slices/notifications/emitNotification.ts
+++ b/apps/desktop/src/store/slices/notifications/emitNotification.ts
@@ -1,6 +1,7 @@
 import {
   insertNotification,
   type Notification,
+  type NotificationAction,
   type NotificationKind,
   type NotificationSeverity,
 } from '@goodboy/db';
@@ -11,6 +12,7 @@ import type { SetFn } from './types';
 type Params = {
   sessionId?: SessionId;
   workspaceId?: WorkspaceId;
+  action?: NotificationAction;
 };
 
 export const emitNotification = (set: SetFn) => {
@@ -31,6 +33,7 @@ export const emitNotification = (set: SetFn) => {
       sessionId: opts?.sessionId ?? null,
       workspaceId: opts?.workspaceId ?? null,
       read: false,
+      action: opts?.action ?? null,
     };
     await insertNotification(tauriDatabase, n);
     set((state) => ({ notifications: [n, ...state.notifications] }));

--- a/apps/desktop/src/store/slices/notifications/index.test.ts
+++ b/apps/desktop/src/store/slices/notifications/index.test.ts
@@ -529,6 +529,22 @@ describe('store contract', () => {
       expect(insertNotificationSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('emitNotification persists action payload to DB', async () => {
+      const store = await getStore();
+      await store
+        .getState()
+        .emitNotification('error', 'error', 'summarizer failed', 'anthropic: timeout', {
+          sessionId: SESSION_ID,
+          action: { kind: 'retry-summarizer', sessionId: SESSION_ID },
+        });
+      const ns = store.getState().notifications;
+      expect(ns[0]?.action).toEqual({ kind: 'retry-summarizer', sessionId: SESSION_ID });
+      expect(insertNotificationSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ action: { kind: 'retry-summarizer', sessionId: SESSION_ID } }),
+      );
+    });
+
     it('markNotificationsRead flips read=true on all entries', async () => {
       const store = await getStore();
       store.setState({

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
@@ -151,6 +151,31 @@ describe('applyHeuristicTitle', () => {
     );
   });
 
+  it('emits info notification when AI title generation fails', async () => {
+    invokeMock.mockRejectedValue(new Error('model offline'));
+    const emitNotification = vi.fn(async () => undefined);
+    const harness = createHarness();
+    const baseGet = harness.get;
+    const get = () => ({ ...baseGet(), emitNotification }) as ReturnType<typeof harness.get>;
+
+    await applyHeuristicTitle({
+      set: harness.set,
+      get,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Implement a secure authentication flow',
+    });
+
+    expect(emitNotification).toHaveBeenCalledWith(
+      'title-generation',
+      'info',
+      'agent title generation failed',
+      expect.stringContaining('model offline'),
+      expect.objectContaining({ sessionId: SESSION_ID }),
+    );
+    expect(emitNotification).toHaveBeenCalledTimes(1);
+  });
+
   it('skips rename when the agent name is not a placeholder', async () => {
     const harness = createHarness({
       agentName: 'Existing agent title',

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
@@ -2,6 +2,8 @@ import { invoke } from '@tauri-apps/api/core';
 import { getDefaultBinary, resolveTaskModel } from '@goodboy/core';
 import { renameSession as renameSessionInDb } from '@goodboy/db';
 import type { AgentId, IsoDateTime, SessionId, TaskModelPreference } from '@goodboy/types';
+import { shortModel } from '../../../../features/session/agent-row-format';
+import { formatError } from '../../../../shared/lib/errors';
 import { heuristicAgentTitle } from '../../../../shared/lib/agent-title-heuristic';
 import { tauriDatabase } from '../../../../shared/lib/db';
 import type { GetFn, SetFn } from '../types';
@@ -126,7 +128,22 @@ export const applyHeuristicTitle = async ({
       get().workspaceOverrides?.[session.workspaceId]?.taskModels,
       session.providerPreference.defaultProvider,
     );
-    const generatedTitle = await generateAgentTitle({ prompt, ...taskModel });
+
+    let generatedTitle: string;
+    try {
+      generatedTitle = await generateAgentTitle({ prompt, ...taskModel });
+    } catch (titleErr) {
+      const modelLabel = `${taskModel.providerId}/${shortModel(taskModel.model)}`;
+      void get().emitNotification(
+        'title-generation',
+        'info',
+        'agent title generation failed',
+        `${modelLabel}: ${formatError(titleErr)}`,
+        { sessionId },
+      );
+      return;
+    }
+
     if (generatedTitle.length === 0) {
       return;
     }

--- a/apps/desktop/src/store/slices/turn/retrySummarizer.ts
+++ b/apps/desktop/src/store/slices/turn/retrySummarizer.ts
@@ -1,9 +1,9 @@
-import type { SessionId } from '@goodboy/types';
+import type { SessionId, TaskModelPreference } from '@goodboy/types';
 import { enqueueSummarizer } from '../../turn-helpers';
 import type { GetFn, SetFn } from './types';
 
 export const retrySummarizer = (set: SetFn, get: GetFn) => {
-  return (sessionId: SessionId) => {
+  return (sessionId: SessionId, taskModelOverride?: TaskModelPreference) => {
     const status = get().summarizerStatus[sessionId];
     if (!status || status.status === 'running') {
       return;
@@ -17,6 +17,7 @@ export const retrySummarizer = (set: SetFn, get: GetFn) => {
       sessionId,
       status.lastAttempt.turnInput,
       status.lastAttempt.turnOutput,
+      taskModelOverride,
     );
   };
 };

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
 }));
 
-import { finalizeWorkflowStep } from './finalizeWorkflowStep';
+import { finalizeWorkflowStep, degradedNotifiedAgents } from './finalizeWorkflowStep';
 
 const SESSION_ID = 'session-1' as SessionId;
 const AGENT_ID = 'agent-1' as AgentId;
@@ -102,6 +102,7 @@ describe('finalizeWorkflowStep output summary', () => {
   beforeEach(() => {
     invokeAgentListSpy.mockResolvedValue([{ ...agent, status: 'completed' }]);
     invokeAgentUpdateStatusSpy.mockResolvedValue({ ...agent, status: 'completed' });
+    degradedNotifiedAgents.clear();
   });
 
   afterEach(() => {
@@ -141,7 +142,19 @@ describe('finalizeWorkflowStep output summary', () => {
     const expectedSummary = `${'h'.repeat(1500)}\n...\n${'t'.repeat(400)}`;
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     summarizeStepOutputSpy.mockRejectedValue(new Error('provider unavailable'));
-    const finalize = buildHarness();
+    const state = {
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      sessions: [session],
+      refreshUnreadWorkspaces: vi.fn(),
+      emitNotification: vi.fn(),
+      sendTurn: vi.fn(),
+    };
+    const set = vi.fn();
+    const get = (() => state) as unknown as Parameters<typeof finalizeWorkflowStep>[1];
+    const finalize = finalizeWorkflowStep(
+      set as unknown as Parameters<typeof finalizeWorkflowStep>[0],
+      get,
+    );
 
     await finalize(SESSION_ID, AGENT_ID, assistantText, false, { force: true });
 
@@ -152,6 +165,37 @@ describe('finalizeWorkflowStep output summary', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[step-output] summarization failed, using deterministic fallback: provider unavailable',
     );
+    expect(state.emitNotification).toHaveBeenCalledWith(
+      'summarizer-degraded',
+      'warning',
+      expect.stringContaining('Implement'),
+      expect.stringContaining('provider unavailable'),
+      expect.objectContaining({ sessionId: SESSION_ID }),
+    );
+  });
+
+  it('emits degraded notification only once per agent (dedup)', async () => {
+    const assistantText = 'short output';
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    summarizeStepOutputSpy.mockRejectedValue(new Error('timeout'));
+    const state = {
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      sessions: [session],
+      refreshUnreadWorkspaces: vi.fn(),
+      emitNotification: vi.fn(),
+      sendTurn: vi.fn(),
+    };
+    const set = vi.fn();
+    const get = (() => state) as unknown as Parameters<typeof finalizeWorkflowStep>[1];
+    const finalize = finalizeWorkflowStep(
+      set as unknown as Parameters<typeof finalizeWorkflowStep>[0],
+      get,
+    );
+
+    await finalize(SESSION_ID, AGENT_ID, assistantText, false, { force: true });
+    await finalize(SESSION_ID, AGENT_ID, assistantText, false, { force: true });
+
+    expect(state.emitNotification).toHaveBeenCalledTimes(1);
   });
 
   it('uses the fallback when summarization exceeds 15 seconds', async () => {

--- a/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
+++ b/apps/desktop/src/store/slices/workflows/finalizeWorkflowStep.ts
@@ -6,6 +6,7 @@ import {
   resolveTaskModel,
 } from '@goodboy/core';
 import { updateSessionWorkflowStep } from '@goodboy/db';
+import { shortModel } from '../../../features/session/agent-row-format';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
 import { composeStepBoundary } from '../../kickoff';
@@ -16,6 +17,7 @@ import type { GetFn, SetFn } from './types';
 const MAX_CONTINUE = 1;
 
 const continueAttempts = new Map<string, number>();
+export const degradedNotifiedAgents = new Set<AgentId>();
 
 const nowIso = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
 
@@ -90,17 +92,32 @@ export const finalizeWorkflowStep = (set: SetFn, get: GetFn) => {
 
     continueAttempts.delete(agentId);
     const session = get().sessions.find((candidate) => candidate.id === sessionId);
-    const outputSummary =
-      session == null
-        ? fallbackStepOutputSummary({ output: assistantText })
-        : await summarizeAgentOutput({
-            output: assistantText,
-            taskModel: resolveTaskModel(
-              'summarizer',
-              get().workspaceOverrides?.[session.workspaceId]?.taskModels,
-              session.providerPreference.defaultProvider,
-            ),
-          });
+    let outputSummary: string;
+    if (session == null) {
+      outputSummary = fallbackStepOutputSummary({ output: assistantText });
+    } else {
+      const taskModel = resolveTaskModel(
+        'summarizer',
+        get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+        session.providerPreference.defaultProvider,
+      );
+      const result = await summarizeAgentOutput({ output: assistantText, taskModel });
+      outputSummary = result.summary;
+      if (result.degraded && !degradedNotifiedAgents.has(agentId)) {
+        degradedNotifiedAgents.add(agentId);
+        const modelLabel = `${taskModel.providerId}/${shortModel(taskModel.model)}`;
+        void get().emitNotification(
+          'summarizer-degraded',
+          'warning',
+          `step summary degraded: ${agent.name}`,
+          `${modelLabel}: ${result.error ?? 'summarization failed'}`,
+          {
+            sessionId,
+            action: { kind: 'retry-step-summary', sessionId, agentId },
+          },
+        );
+      }
+    }
     await invokeAgentUpdateStatus(agentId, {
       status: 'completed',
       outputSummary,

--- a/apps/desktop/src/store/slices/workflows/index.ts
+++ b/apps/desktop/src/store/slices/workflows/index.ts
@@ -1,5 +1,6 @@
 import { activateWorkflowAgent } from './activateWorkflowAgent';
 import { advanceClusterImplementation } from './clusterImplementation';
+import { retryStepSummary } from './retryStepSummary';
 import { attachWorkflowToSession } from './attachWorkflowToSession';
 import { deleteStepDef } from './deleteStepDef';
 import { deleteWorkflow } from './deleteWorkflow';
@@ -46,5 +47,6 @@ export const createWorkflowsSlice = (set: SetFn, get: GetFn) => {
     skipStuckStepAndAdvance: skipStuckStepAndAdvance(set, get),
     advanceScoutTree: advanceScoutTree(set, get),
     maybeAutoAdvanceWorkflow: maybeAutoAdvanceWorkflow(set, get),
+    retryStepSummary: retryStepSummary(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, IsoDateTime, Session, SessionId, WorkspaceId } from '@goodboy/types';
+
+const { invokeAgentUpdateStatusSpy, summarizeStepOutputSpy } = vi.hoisted(() => ({
+  invokeAgentUpdateStatusSpy: vi.fn(),
+  summarizeStepOutputSpy: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+vi.mock('@goodboy/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/core')>();
+  return { ...actual, summarizeStepOutput: summarizeStepOutputSpy };
+});
+
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
+}));
+
+import { retryStepSummary } from './retryStepSummary';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const NOW = '2026-07-23T00:00:00.000Z' as IsoDateTime;
+
+const agent: Agent = {
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'Implement',
+  status: 'completed',
+};
+
+const session: Session = {
+  id: SESSION_ID,
+  workspaceId: WORKSPACE_ID,
+  goal: 'implement the change',
+  state: { kind: 'idle', lastActivityAt: NOW },
+  contextSlots: [],
+  providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: true },
+  permissionMode: 'default',
+  workflowRuns: [],
+  autoRun: false,
+  titleUserEdited: false,
+  createdAt: NOW,
+  updatedAt: NOW,
+};
+
+type State = {
+  sessions: ReadonlyArray<Session>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<Agent>>;
+  transcripts: Record<string, ReadonlyArray<{ kind: string; delta?: string }>>;
+  workspaceOverrides: Record<string, unknown>;
+};
+
+const buildHarness = (stateOverrides: Partial<State> = {}) => {
+  const state: State = {
+    sessions: [session],
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    transcripts: {
+      [AGENT_ID]: [
+        { kind: 'assistant_text', delta: 'implemented the feature' },
+        { kind: 'assistant_text', delta: ' with tests' },
+      ],
+    },
+    workspaceOverrides: {},
+    ...stateOverrides,
+  };
+  const set = vi.fn();
+  const get = (() => state) as unknown as Parameters<ReturnType<typeof retryStepSummary>>[0];
+  return retryStepSummary(
+    set as unknown as Parameters<typeof retryStepSummary>[0],
+    get as unknown as Parameters<typeof retryStepSummary>[1],
+  );
+};
+
+describe('retryStepSummary', () => {
+  beforeEach(() => {
+    invokeAgentUpdateStatusSpy.mockResolvedValue({ ...agent });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updates outputSummary from LLM result', async () => {
+    summarizeStepOutputSpy.mockResolvedValue('implemented the feature with tests');
+    const retry = buildHarness();
+
+    await retry({ sessionId: SESSION_ID, agentId: AGENT_ID });
+
+    expect(invokeAgentUpdateStatusSpy).toHaveBeenCalledWith(
+      AGENT_ID,
+      expect.objectContaining({
+        status: 'completed',
+        outputSummary: 'implemented the feature with tests',
+      }),
+    );
+  });
+
+  it('updates store sessionPhaseRuns with new outputSummary', async () => {
+    summarizeStepOutputSpy.mockResolvedValue('new summary');
+    const set = vi.fn();
+    const state: State = {
+      sessions: [session],
+      sessionPhaseRuns: { [SESSION_ID]: [agent] },
+      transcripts: { [AGENT_ID]: [{ kind: 'assistant_text', delta: 'output' }] },
+      workspaceOverrides: {},
+    };
+    const get = (() => state) as unknown as Parameters<typeof retryStepSummary>[1];
+    const retry = retryStepSummary(set as unknown as Parameters<typeof retryStepSummary>[0], get);
+
+    await retry({ sessionId: SESSION_ID, agentId: AGENT_ID });
+
+    expect(set).toHaveBeenCalledWith(expect.any(Function));
+    const updater = set.mock.calls[0]?.[0] as ((s: typeof state) => typeof state) | undefined;
+    const nextState = updater?.(state);
+    expect(nextState?.sessionPhaseRuns[SESSION_ID]?.[0]?.outputSummary).toBe('new summary');
+  });
+
+  it('uses provided taskModelOverride instead of resolved model', async () => {
+    summarizeStepOutputSpy.mockResolvedValue('override result');
+    const retry = buildHarness();
+
+    await retry({
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      taskModelOverride: { providerId: 'anthropic', model: 'claude-haiku-4-5' },
+    });
+
+    expect(summarizeStepOutputSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'anthropic', model: 'claude-haiku-4-5' }),
+    );
+  });
+
+  it('returns early when session is not found', async () => {
+    const retry = buildHarness({ sessions: [] });
+
+    await retry({ sessionId: SESSION_ID, agentId: AGENT_ID });
+
+    expect(invokeAgentUpdateStatusSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns early when agent is not found', async () => {
+    const retry = buildHarness({ sessionPhaseRuns: { [SESSION_ID]: [] } });
+
+    await retry({ sessionId: SESSION_ID, agentId: AGENT_ID });
+
+    expect(invokeAgentUpdateStatusSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
+++ b/apps/desktop/src/store/slices/workflows/retryStepSummary.ts
@@ -1,0 +1,53 @@
+import { resolveTaskModel } from '@goodboy/core';
+import { fallbackStepOutputSummary } from '@goodboy/core';
+import type { AgentId, SessionId, TaskModelPreference } from '@goodboy/types';
+import { invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
+import { summarizeAgentOutput } from '../../summarizeAgentOutput';
+import type { GetFn, SetFn } from './types';
+
+type Params = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly taskModelOverride?: TaskModelPreference;
+};
+
+export const retryStepSummary = (set: SetFn, get: GetFn) => {
+  return async ({ sessionId, agentId, taskModelOverride }: Params): Promise<void> => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    const agents = get().sessionPhaseRuns[sessionId] ?? [];
+    const agent = agents.find((a) => a.id === agentId);
+
+    if (session == null || agent == null) {
+      return;
+    }
+
+    const transcriptEvents = get().transcripts[agentId] ?? [];
+    const assistantDeltas = transcriptEvents
+      .filter((e) => e.kind === 'assistant_text')
+      .map((e) => (e.kind === 'assistant_text' ? e.delta : ''));
+    const assistantText =
+      assistantDeltas.length > 0
+        ? assistantDeltas.join('')
+        : fallbackStepOutputSummary({ output: '' });
+
+    const taskModel =
+      taskModelOverride ??
+      resolveTaskModel(
+        'summarizer',
+        get().workspaceOverrides?.[session.workspaceId]?.taskModels,
+        session.providerPreference.defaultProvider,
+      );
+
+    const result = await summarizeAgentOutput({ output: assistantText, taskModel });
+    await invokeAgentUpdateStatus(agentId, { status: 'completed', outputSummary: result.summary });
+
+    set((state) => ({
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((a) =>
+          a.id === agentId ? { ...a, outputSummary: result.summary } : a,
+        ),
+      },
+    }));
+  };
+};

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -3,6 +3,7 @@ import { type FileConflict, type SlotKey } from '@goodboy/core';
 import {
   type SessionConfigUpdate,
   type AgentConfigUpdate,
+  type NotificationAction,
   type NotificationKind,
   type NotificationSeverity,
 } from '@goodboy/db';
@@ -48,6 +49,7 @@ import type {
   SessionViewPrefs,
   SessionSortKey,
   SessionGroupKey,
+  TaskModelPreference,
 } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { resolveSettings } from '@goodboy/core';
@@ -252,7 +254,7 @@ export type AppActions = {
     onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
   }): Promise<void>;
   cancelCurrentTurn(sessionId: SessionId): Promise<void>;
-  retrySummarizer(sessionId: SessionId): void;
+  retrySummarizer(sessionId: SessionId, taskModelOverride?: TaskModelPreference): void;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
   loadSessionTelemetry(sessionId: SessionId): Promise<void>;
   loadSessionSlots(sessionId: SessionId): Promise<void>;
@@ -461,8 +463,13 @@ export type AppActions = {
     severity: NotificationSeverity,
     title: string,
     body?: string,
-    opts?: { sessionId?: SessionId; workspaceId?: WorkspaceId },
+    opts?: { sessionId?: SessionId; workspaceId?: WorkspaceId; action?: NotificationAction },
   ): Promise<void>;
+  retryStepSummary(params: {
+    sessionId: SessionId;
+    agentId: AgentId;
+    taskModelOverride?: TaskModelPreference;
+  }): Promise<void>;
   markNotificationsRead(): Promise<void>;
   clearNotifications(): Promise<void>;
   loadSessionOpenQuestions(sessionId: SessionId): Promise<void>;

--- a/apps/desktop/src/store/summarizeAgentOutput.ts
+++ b/apps/desktop/src/store/summarizeAgentOutput.ts
@@ -10,7 +10,16 @@ type Params = {
   readonly taskModel: TaskModelPreference;
 };
 
-export const summarizeAgentOutput = async ({ output, taskModel }: Params): Promise<string> => {
+export type SummarizeAgentOutputResult = {
+  readonly summary: string;
+  readonly degraded: boolean;
+  readonly error?: string;
+};
+
+export const summarizeAgentOutput = async ({
+  output,
+  taskModel,
+}: Params): Promise<SummarizeAgentOutputResult> => {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const timeout = new Promise<never>((_resolve, reject) => {
     timeoutId = setTimeout(
@@ -20,15 +29,15 @@ export const summarizeAgentOutput = async ({ output, taskModel }: Params): Promi
   });
 
   try {
-    return await Promise.race([
+    const summary = await Promise.race([
       summarizeStepOutput({ ...taskModel, invokeFn: invoke, output }),
       timeout,
     ]);
+    return { summary, degraded: false };
   } catch (error) {
-    console.warn(
-      `[step-output] summarization failed, using deterministic fallback: ${formatError(error)}`,
-    );
-    return fallbackStepOutputSummary({ output });
+    const message = formatError(error);
+    console.warn(`[step-output] summarization failed, using deterministic fallback: ${message}`);
+    return { summary: fallbackStepOutputSummary({ output }), degraded: true, error: message };
   } finally {
     if (timeoutId !== null) {
       clearTimeout(timeoutId);

--- a/apps/desktop/src/store/summarizerNotifications.test.ts
+++ b/apps/desktop/src/store/summarizerNotifications.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IsoDateTime, SessionId, WorkspaceId } from '@goodboy/types';
+
+vi.mock('../features/chat/turn', () => ({
+  runTurn: vi.fn(),
+  cancelTurn: vi.fn(),
+  encodeAuthRequiredMessage: () => '',
+  isAuthErrorMessage: () => false,
+}));
+
+vi.mock('../features/permissions/permissions', () => ({
+  invokePermissionRuleList: vi.fn(async () => []),
+  invokePermissionAuditInsert: vi.fn(async () => ({})),
+  invokeAuditRetryEnqueue: vi.fn(),
+  invokeAuditRetryDrain: vi.fn(async () => []),
+  invokeAuditRetryUpdate: vi.fn(),
+  invokeAuditRetryDelete: vi.fn(),
+  useEffectivePermissionRules: () => [],
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => () => undefined),
+}));
+
+vi.mock('../shared/lib/db', () => ({
+  runDbMigrations: vi.fn(async () => undefined),
+  wipeDb: vi.fn(async () => undefined),
+  tauriDatabase: { execute: vi.fn(), select: vi.fn() },
+}));
+
+vi.mock('../features/providers/providers', () => ({
+  buildProviderList: () => [{ id: 'anthropic', binary: 'claude', connection: 'connected' }],
+  checkProviderAuth: vi.fn(async () => ({ state: 'connected', identity: 'test' })),
+  getCursorStatus: vi.fn(async () => null),
+  getCodexStatus: vi.fn(async () => null),
+  getProviderStatus: vi.fn(async () => null),
+}));
+
+vi.mock('../features/providers/routing', () => ({
+  resolveProviderForTurn: vi.fn(async () => ({
+    selectedProvider: 'anthropic',
+    selectedModel: 'claude-3-5-sonnet-latest',
+    reason: 'preference',
+  })),
+}));
+
+vi.mock('../features/budget/budget', () => ({
+  invokeBudgetRuleList: vi.fn(async () => []),
+  invokeBudgetRuleUpsert: vi.fn(),
+  invokeBudgetRuleDelete: vi.fn(),
+  invokeBudgetAlertsList: vi.fn(async () => []),
+  invokeBudgetAlertDismiss: vi.fn(),
+  invokeSessionBudgetGet: vi.fn(),
+  invokeSessionBudgetSet: vi.fn(),
+  invokeCheckProviderBudget: vi.fn(),
+}));
+
+vi.mock('../features/skills/skills', () => ({
+  invokeSkillList: vi.fn(async () => []),
+  invokeSkillUpsert: vi.fn(),
+  invokeSkillDelete: vi.fn(),
+  invokeSkillRescan: vi.fn(),
+  resolveSkillInvocation: vi.fn(),
+}));
+
+vi.mock('../features/workflows/workflows', () => ({
+  invokeWorkflowList: vi.fn(async () => []),
+  invokeWorkflowUpsert: vi.fn(),
+  invokeWorkflowDelete: vi.fn(),
+  invokeAgentList: vi.fn(async () => []),
+  invokeAgentInsert: vi.fn(),
+  invokeAgentUpdateStatus: vi.fn(),
+  invokeAgentSetKind: vi.fn(async () => undefined),
+  invokeAgentSetVerbosity: vi.fn(async () => undefined),
+  invokeAgentMarkViewed: vi.fn(async () => undefined),
+  invokeAgentSetProviderSessionId: vi.fn(async () => undefined),
+  invokeWorkspacesWithUnread: vi.fn(async () => []),
+}));
+
+vi.mock('../features/worktree/worktree', () => ({
+  createWorktree: vi.fn(),
+  removeWorktree: vi.fn(),
+}));
+
+vi.mock('../shared/lib/repo', () => ({
+  validateGitRepo: vi.fn(),
+}));
+
+vi.mock('../features/providers/provider-pricing', () => ({
+  parseProviderPricingConfig: vi.fn(() => null),
+  getCodexPriceOverride: vi.fn(() => null),
+  refreshPricingTable: vi.fn(() => Promise.resolve()),
+}));
+
+const summarizeSpy = vi.fn();
+
+vi.mock('@goodboy/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/core')>();
+  return {
+    ...actual,
+    Summarizer: class {
+      summarize() {
+        return summarizeSpy();
+      }
+    },
+  };
+});
+
+const insertNotificationSpy = vi.fn(async () => undefined);
+
+vi.mock('@goodboy/db', () => ({
+  getSetting: vi.fn(async () => null),
+  setSetting: vi.fn(async () => undefined),
+  insertMessage: vi.fn(async () => undefined),
+  insertProviderRun: vi.fn(async () => undefined),
+  insertSession: vi.fn(async () => undefined),
+  insertSessionWorktree: vi.fn(async () => undefined),
+  insertTelemetry: vi.fn(async () => undefined),
+  insertWorkspace: vi.fn(async () => undefined),
+  disconnectWorkspace: vi.fn(async () => undefined),
+  reconnectWorkspace: vi.fn(async () => undefined),
+  touchWorkspaceLastAccessed: vi.fn(async () => undefined),
+  findWorkspaceByRootPath: vi.fn(async () => null),
+  upsertSessionExternalTask: vi.fn(async () => undefined),
+  deleteSessionExternalTask: vi.fn(async () => undefined),
+  listExternalTasksForWorkspace: vi.fn(async () => []),
+  listContextSlotsForSession: vi.fn(async () => []),
+  insertContextSlotHistory: vi.fn(async () => undefined),
+  listContextSlotHistory: vi.fn(async () => []),
+  listMessagesForAgent: vi.fn(async () => []),
+  listMessagesForSession: vi.fn(async () => []),
+  listTurnEventsForAgent: vi.fn(async () => []),
+  listTurnEventsForSession: vi.fn(async () => []),
+  listAgentRunIdsForSession: vi.fn(async () => new Map()),
+  listSessionsForWorkspace: vi.fn(async () => []),
+  listArchivedSessionsForWorkspace: vi.fn(async () => []),
+  listTelemetryForSession: vi.fn(async () => []),
+  listWorkspaces: vi.fn(async () => []),
+  listWorktreesForSession: vi.fn(async () => []),
+  listWorktreesForSessions: vi.fn(async () => new Map()),
+  listAgentsForSessions: vi.fn(async () => new Map()),
+  deleteWorktreesForSession: vi.fn(async () => undefined),
+  updateSessionWorktreeBranch: vi.fn(async () => undefined),
+  listAllSessionWorktrees: vi.fn(async () => []),
+  renameSession: vi.fn(async () => undefined),
+  deleteSession: vi.fn(async () => undefined),
+  archiveSession: vi.fn(async () => undefined),
+  unarchiveSession: vi.fn(async () => undefined),
+  updateSessionConfig: vi.fn(async () => undefined),
+  updateAgentConfig: vi.fn(async () => undefined),
+  summarizeSessionTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceTelemetry: vi.fn(async () => null),
+  summarizeWorkspaceProviderTelemetry: vi.fn(async () => []),
+  updateProviderRunStatus: vi.fn(async () => undefined),
+  updateSessionPermissionMode: vi.fn(async () => undefined),
+  updateSessionAutoRun: vi.fn(async () => undefined),
+  updateSessionTitleUserEdited: vi.fn(async () => undefined),
+  updateSessionState: vi.fn(async () => undefined),
+  attachWorkflowToSession: vi.fn(async () => undefined),
+  detachWorkflowFromSession: vi.fn(async () => undefined),
+  updateWorkflowOrder: vi.fn(async () => undefined),
+  updateSessionWorkflowStep: vi.fn(async () => undefined),
+  listWorkspaceScripts: vi.fn(async () => []),
+  upsertWorkspaceScript: vi.fn(async () => undefined),
+  deleteWorkspaceScript: vi.fn(async () => undefined),
+  upsertContextSlot: vi.fn(async () => undefined),
+  listOpenQuestionsForSession: vi.fn(async () => []),
+  insertNudgeEvent: vi.fn(async () => undefined),
+  updateNudgeEventOutcome: vi.fn(async () => undefined),
+  insertNotification: insertNotificationSpy,
+  listNotifications: vi.fn(async () => []),
+  markAllNotificationsRead: vi.fn(async () => undefined),
+  clearAllNotifications: vi.fn(async () => undefined),
+  listDiffCommentsForSession: vi.fn(async () => []),
+  insertDiffComment: vi.fn(async () => undefined),
+  resolveDiffComment: vi.fn(async () => undefined),
+  reopenDiffComment: vi.fn(async () => undefined),
+  consumeDiffComments: vi.fn(async () => undefined),
+  deleteDiffComment: vi.fn(async () => undefined),
+  listIntegrationsForWorkspace: vi.fn(async () => []),
+  upsertWorkspaceIntegration: vi.fn(async () => undefined),
+  deleteWorkspaceIntegration: vi.fn(async () => undefined),
+  insertOpenQuestion: vi.fn(async () => undefined),
+  markOpenQuestionsResolvedByText: vi.fn(async () => 0),
+  listResolvedQuestionTextsForSession: vi.fn(async () => []),
+  insertTurnEvent: vi.fn(async () => undefined),
+  insertTurnEventsBatch: vi.fn(async () => undefined),
+  getGithubPrCache: vi.fn(async () => null),
+  upsertGithubPrCache: vi.fn(async () => undefined),
+  deleteGithubPrCache: vi.fn(async () => undefined),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async () => null),
+}));
+
+const SESSION_ID = 'session-notif-test' as SessionId;
+const WORKSPACE_ID = 'ws-notif-test' as WorkspaceId;
+const NOW = '2026-07-23T00:00:00.000Z' as IsoDateTime;
+
+describe('summarizer notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertNotificationSpy.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('success notification body includes provider/shortModel', async () => {
+    summarizeSpy.mockResolvedValue({
+      delta: { upserts: [] },
+      usage: { inputTokens: 10, outputTokens: 5, cachedInputTokens: 0, estimatedCostUsd: 0 },
+      model: 'claude-haiku-4-5',
+      nextActions: [],
+    });
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues } = await import('./turn-helpers');
+
+    summarizerQueues.delete(SESSION_ID);
+    useAppStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          goal: 'test',
+          state: { kind: 'idle', lastActivityAt: NOW },
+          contextSlots: [],
+          providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+          permissionMode: 'bypassPermissions' as const,
+          autoRun: false,
+          titleUserEdited: false,
+          workflowRuns: [],
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+      sessionSlots: {},
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'user input',
+      'agent output',
+    );
+
+    await vi.waitFor(() => expect(insertNotificationSpy).toHaveBeenCalled(), { timeout: 5000 });
+
+    type NotifCall = [unknown, Record<string, unknown>];
+    const calls = insertNotificationSpy.mock.calls as unknown as NotifCall[];
+    const call = calls.find((c) => c[1].kind === 'summarizer-success');
+    expect(call).not.toBeUndefined();
+    const n = call?.[1] ?? {};
+    expect(n.body).toMatch(/^via anthropic\//);
+    expect(n.body as string).toContain('haiku');
+  });
+
+  it('failure notification body includes provider and error, carries retry action', async () => {
+    summarizeSpy.mockRejectedValue(new Error('model overloaded'));
+
+    const { useAppStore } = await import('./store');
+    const { enqueueSummarizer, summarizerQueues } = await import('./turn-helpers');
+
+    summarizerQueues.delete(SESSION_ID);
+    useAppStore.setState({
+      sessions: [
+        {
+          id: SESSION_ID,
+          workspaceId: WORKSPACE_ID,
+          goal: 'test',
+          state: { kind: 'idle', lastActivityAt: NOW },
+          contextSlots: [],
+          providerPreference: { defaultProvider: 'anthropic', allowTurnOverride: false },
+          permissionMode: 'bypassPermissions' as const,
+          autoRun: false,
+          titleUserEdited: false,
+          workflowRuns: [],
+          createdAt: NOW,
+          updatedAt: NOW,
+        },
+      ],
+      sessionSlots: {},
+      summarizerStatus: {},
+      workspaces: [
+        { id: WORKSPACE_ID, name: 'ws', rootPath: '/tmp', createdAt: NOW, updatedAt: NOW },
+      ],
+    });
+
+    enqueueSummarizer(
+      useAppStore.setState,
+      useAppStore.getState,
+      SESSION_ID,
+      'user input',
+      'agent output',
+    );
+
+    await vi.waitFor(() => expect(insertNotificationSpy).toHaveBeenCalled(), { timeout: 5000 });
+
+    type NotifCall = [unknown, Record<string, unknown>];
+    const calls = insertNotificationSpy.mock.calls as unknown as NotifCall[];
+    const call = calls.find((c) => c[1].severity === 'error');
+    expect(call).not.toBeUndefined();
+    const n = call?.[1] ?? {};
+    expect(n.body as string).toContain('anthropic');
+    expect(n.body as string).toContain('model overloaded');
+    expect(n.action).toEqual({ kind: 'retry-summarizer', sessionId: SESSION_ID });
+  });
+});

--- a/apps/desktop/src/store/turn-helpers.ts
+++ b/apps/desktop/src/store/turn-helpers.ts
@@ -9,6 +9,7 @@ import {
   type ExtractedHandoff,
   type SlotKey,
 } from '@goodboy/core';
+import { shortModel } from '../features/session/agent-row-format';
 import {
   insertNudgeEvent,
   insertProviderRun,
@@ -34,6 +35,7 @@ import type {
   PlanWithCount,
   ProviderRunId,
   SessionId,
+  TaskModelPreference,
   TelemetryRecord,
   TelemetryRecordId,
   WorkflowRunId,
@@ -95,6 +97,7 @@ type SummarizerQueueEntry = {
   readonly turnInput: string;
   readonly turnOutput: string;
   readonly oversizeRetried: boolean;
+  readonly taskModelOverride?: TaskModelPreference;
 };
 
 type SummarizerTaskQueue = {
@@ -170,18 +173,31 @@ export const enqueueSummarizer = (
   sessionId: SessionId,
   turnInput: string,
   turnOutput: string,
+  taskModelOverride?: TaskModelPreference,
 ): void => {
   enqueueSummarizerEntry({
     set,
     get,
     sessionId,
-    entry: { turnInput, turnOutput, oversizeRetried: false },
+    entry: {
+      turnInput,
+      turnOutput,
+      oversizeRetried: false,
+      ...(taskModelOverride && { taskModelOverride }),
+    },
   });
 };
 
 const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<void> => {
   const { turnInput, turnOutput } = entry;
   const now = (): IsoDateTime => new Date().toISOString() as IsoDateTime;
+
+  const session = get().sessions.find((s) => s.id === sessionId);
+  if (!session) {
+    return;
+  }
+  const providerId =
+    entry.taskModelOverride?.providerId ?? session.providerPreference.defaultProvider;
 
   set((state) => {
     const prev = state.summarizerStatus[sessionId];
@@ -200,13 +216,11 @@ const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<vo
   });
 
   try {
-    const session = get().sessions.find((s) => s.id === sessionId);
-    if (!session) {
-      return;
-    }
-
-    const providerId = session.providerPreference.defaultProvider;
-    const summarizer = new Summarizer({ providerId, invokeFn: invoke });
+    const summarizer = new Summarizer({
+      providerId,
+      invokeFn: invoke,
+      ...(entry.taskModelOverride && { model: entry.taskModelOverride.model }),
+    });
     const prevSlots = get().sessionSlots[sessionId] ?? [];
     const slotValueSnapshot = new Map(prevSlots.map((slot) => [slot.key, slot.value]));
     const ghPr = get().sessionGithub[sessionId]?.pr ?? null;
@@ -365,9 +379,16 @@ const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<vo
       },
       providerSpendBreakdown: buildProviderSpendBreakdown(providerSummaries, budgetRules),
     }));
-    void get().emitNotification('summarizer-success', 'info', 'context summarized', undefined, {
-      sessionId,
-    });
+    const successModel = `${providerId}/${shortModel(result.model)}`;
+    void get().emitNotification(
+      'summarizer-success',
+      'info',
+      'context summarized',
+      `via ${successModel}`,
+      {
+        sessionId,
+      },
+    );
   } catch (err) {
     const message = formatError(err);
     if (import.meta.env.DEV) {
@@ -388,9 +409,16 @@ const runSummarizer = async ({ set, get, sessionId, entry }: Params): Promise<vo
         },
       };
     });
-    void get().emitNotification('error', 'error', 'summarizer failed', message, {
-      sessionId,
-    });
+    void get().emitNotification(
+      'error',
+      'error',
+      'summarizer failed',
+      `${providerId}: ${message}`,
+      {
+        sessionId,
+        action: { kind: 'retry-summarizer', sessionId },
+      },
+    );
   }
 };
 

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -37,6 +37,7 @@ type InvokeFn = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
 export type SummarizerDeps = {
   readonly providerId: ProviderId;
   readonly binary?: string;
+  readonly model?: string;
   readonly invokeFn: InvokeFn;
 };
 
@@ -75,7 +76,7 @@ export class Summarizer {
   constructor(deps: SummarizerDeps) {
     this.providerId = deps.providerId;
     this.binary = deps.binary ?? getDefaultBinary(deps.providerId);
-    this.model = getCheapModel(deps.providerId);
+    this.model = deps.model ?? getCheapModel(deps.providerId);
     this.invokeFn = deps.invokeFn;
   }
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -183,6 +183,7 @@ export {
   markAllNotificationsRead,
   clearAllNotifications,
   type Notification,
+  type NotificationAction,
   type NotificationKind,
   type NotificationSeverity,
 } from './queries/notification';

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -71,6 +71,7 @@ import { m070StepLibraryExampleOnly } from './m070-step-library-example-only';
 import { m071SessionExternalTaskMultipleLinks } from './m071-session-external-task-multiple-links';
 import { m072TaskModels } from './m072-task-models';
 import { m073SessionExternalTaskGithubProvider } from './m073-session-external-task-github-provider';
+import { m074NotificationAction } from './m074-notification-action';
 
 export type Migration = {
   readonly version: number;
@@ -151,4 +152,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 71, sql: m071SessionExternalTaskMultipleLinks },
   { version: 72, sql: m072TaskModels },
   { version: 73, sql: m073SessionExternalTaskGithubProvider },
+  { version: 74, sql: m074NotificationAction },
 ];

--- a/packages/db/src/migrations/m074-notification-action.ts
+++ b/packages/db/src/migrations/m074-notification-action.ts
@@ -1,0 +1,3 @@
+export const m074NotificationAction = `
+ALTER TABLE notifications ADD COLUMN action TEXT;
+`;

--- a/packages/db/src/queries/notification.ts
+++ b/packages/db/src/queries/notification.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, SessionId, WorkspaceId } from '@goodboy/types';
+import type { AgentId, IsoDateTime, SessionId, WorkspaceId } from '@goodboy/types';
 import type { Database } from '../client';
 
 export type NotificationSeverity = 'success' | 'info' | 'warning' | 'error';
@@ -6,11 +6,21 @@ export type NotificationKind =
   | 'session-created'
   | 'session-deleted'
   | 'summarizer-success'
+  | 'summarizer-degraded'
   | 'agent-auto-spawn'
   | 'pr-created'
   | 'workspace-deleted'
   | 'boundary-drift'
+  | 'title-generation'
   | 'error';
+
+export type NotificationAction =
+  | { readonly kind: 'retry-summarizer'; readonly sessionId: SessionId }
+  | {
+      readonly kind: 'retry-step-summary';
+      readonly sessionId: SessionId;
+      readonly agentId: AgentId;
+    };
 
 export type Notification = {
   readonly id: string;
@@ -22,6 +32,7 @@ export type Notification = {
   readonly sessionId: SessionId | null;
   readonly workspaceId: WorkspaceId | null;
   readonly read: boolean;
+  readonly action: NotificationAction | null;
 };
 
 type NotificationRow = {
@@ -34,7 +45,23 @@ type NotificationRow = {
   session_id: string | null;
   workspace_id: string | null;
   read: number;
+  action: string | null;
 };
+
+function parseAction(raw: string | null): NotificationAction | null {
+  if (raw == null) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as NotificationAction;
+  } catch {
+    return null;
+  }
+}
+
+function serializeAction(action: NotificationAction | null): string | null {
+  return action != null ? JSON.stringify(action) : null;
+}
 
 function toNotification(row: NotificationRow): Notification {
   return {
@@ -47,13 +74,14 @@ function toNotification(row: NotificationRow): Notification {
     sessionId: row.session_id ? (row.session_id as SessionId) : null,
     workspaceId: row.workspace_id ? (row.workspace_id as WorkspaceId) : null,
     read: row.read !== 0,
+    action: parseAction(row.action),
   };
 }
 
 export const insertNotification = async (db: Database, n: Notification): Promise<void> => {
   await db.execute(
-    `INSERT INTO notifications (id, ts, kind, title, body, severity, session_id, workspace_id, read)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    `INSERT INTO notifications (id, ts, kind, title, body, severity, session_id, workspace_id, read, action)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       n.id,
       n.ts,
@@ -64,6 +92,7 @@ export const insertNotification = async (db: Database, n: Notification): Promise
       n.sessionId ?? null,
       n.workspaceId ?? null,
       n.read ? 1 : 0,
+      serializeAction(n.action),
     ],
   );
 };


### PR DESCRIPTION
## What

Auxiliary AI operations become observable and recoverable. A broken summarizer silently degrades the shared context (the core of the product); now failures are explicit and retryable.

- **Notification actions** (m074 `action` JSON column, serializable kind+payload, no callbacks in DB): toasts and the notification center render action buttons.
- **Context summarizer**: failure notification includes the resolved provider/model and the error, and carries **Retry** (re-enqueues the last attempt). In the notification center a **Retry with…** control opens a compact connected-provider + model picker and re-runs with a one-shot override (workspace preferences untouched). Success body says `via <provider>/<model>`.
- **Step-output summaries**: falling back to head+tail truncation is no longer silent: one deduped warning per agent with the attempted model and a retry action; `retryStepSummary` re-summarizes and updates the agent's `outputSummary` (override supported).
- **AI title generation** failures emit a diagnosable info notification (provider/model + error), no toast noise; heuristic fallback unchanged.

## Verification

- Typecheck green; suites green: desktop 2358, core 810, db 84, ui 12.
- Fences respected: summarizer stays non-blocking (#461), queue coalescing/conflict/oversize logic untouched (summarizer-queue suite green unmodified).

Area A2 of 3 (notifications → model coherence → card polish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)