### PR TITLE
fix: model coherence in workflow builder + agent title rewrite

### DIFF
--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.test.tsx
@@ -103,6 +103,7 @@ vi.mock('../ModelSelect', () => ({
   ),
 }));
 
+import { PlannerClient } from '@goodboy/core';
 import { WorkflowBuilderView } from './index';
 
 const session: Session = {
@@ -673,5 +674,69 @@ describe('WorkflowBuilderView (no-presets empty state)', () => {
     fireEvent.click(screen.getByRole('button', { name: /^preset$/i }));
     fireEvent.click(screen.getByRole('button', { name: /describe your own/i }));
     expect(screen.getByPlaceholderText(/describe the process/i)).toBeDefined();
+  });
+});
+
+describe('WorkflowBuilderView (planner model picker)', () => {
+  it('default shows the resolved model name as recommended (not cheap-tier string)', async () => {
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+    const modelBtn = screen.getByRole('button', { name: /^model:auto$/i });
+    expect(modelBtn.dataset['recommendedModel']).toBe('claude-haiku-4-5');
+    expect(screen.queryByText(/cheap-tier/i)).toBeNull();
+  });
+
+  it('PlannerClient receives resolved model when Auto is selected', async () => {
+    mockPlan.mockResolvedValue({ output: PLAN_FIXTURE });
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+    fireEvent.change(screen.getByPlaceholderText(/describe the process/i), {
+      target: { value: 'do something' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+    await waitFor(() => screen.getByText('Ready'));
+
+    expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'anthropic', model: 'claude-haiku-4-5' }),
+    );
+  });
+
+  it('picking a concrete provider+model makes PlannerClient receive it', async () => {
+    mockPlan.mockResolvedValue({ output: PLAN_FIXTURE });
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+
+    const plannerProviderBtn = screen.getByRole('button', { name: /^provider:default$/i });
+    fireEvent.click(plannerProviderBtn);
+
+    const plannerModelBtn = screen.getByRole('button', { name: /^model:auto$/i });
+    fireEvent.click(plannerModelBtn);
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the process/i), {
+      target: { value: 'do something' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+    await waitFor(() => screen.getByText('Ready'));
+
+    expect(vi.mocked(PlannerClient)).toHaveBeenCalledWith(
+      expect.objectContaining({ providerId: 'cursor', model: 'claude-opus-4-6' }),
+    );
+  });
+
+  it('planner model picker does not write workspace overrides', async () => {
+    mockPlan.mockResolvedValue({ output: PLAN_FIXTURE });
+    render(<WorkflowBuilderView session={session} onClose={vi.fn()} />);
+    goToApproach();
+
+    const plannerProviderBtn = screen.getByRole('button', { name: /^provider:default$/i });
+    fireEvent.click(plannerProviderBtn);
+
+    fireEvent.change(screen.getByPlaceholderText(/describe the process/i), {
+      target: { value: 'do something' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /generate plan/i }));
+    await waitFor(() => screen.getByText('Ready'));
+
+    expect(storeState.workspaceOverrides).toEqual({});
   });
 });

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -53,6 +53,8 @@ import type {
 import { ROLE_LABEL, ROLE_TO_KIND, inferAgentKindFromName, type AgentKind } from '../../agent-kind';
 import { AgentAvatar } from '../../../../shared/components/AgentAvatar';
 import { WorkflowStepCard } from '../WorkflowStepCard';
+import { ProviderSelect } from '../ProviderSelect';
+import { ModelSelect } from '../ModelSelect';
 import { type EffortLevel, clampEffort } from '../../../chat/utils/chat-constants';
 import { useWorkflowDrag } from '../../../workflows/hooks/useWorkflowDrag';
 import { StepFlowConnector } from '../../../workflows/components/WorkflowStudio/StepFlowConnector';
@@ -214,6 +216,8 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [stage, setStage] = useState<Stage>(() => initialStage(initialDraft));
+  const [plannerProviderOverride, setPlannerProviderOverride] = useState<ProviderId | ''>('');
+  const [plannerModelOverride, setPlannerModelOverride] = useState('');
 
   const providerId =
     providers.find((p) => p.id === session.providerOverride)?.id ??
@@ -223,6 +227,22 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     const connected = providers.filter((p) => p.connection === 'connected').map((p) => p.id);
     return connected.length > 0 ? connected : [providerId];
   }, [providers, providerId]);
+
+  const resolvedPlanTaskModel = useMemo(
+    () => resolveTaskModel('plan_generation', workspaceOverrides?.taskModels, providerId),
+    [workspaceOverrides, providerId],
+  );
+
+  const plannerEffectiveProviderId: ProviderId =
+    plannerProviderOverride !== '' ? plannerProviderOverride : resolvedPlanTaskModel.providerId;
+
+  const plannerRecommendedModel = useMemo(
+    () =>
+      plannerProviderOverride !== ''
+        ? resolveTaskModel('plan_generation', null, plannerProviderOverride).model
+        : resolvedPlanTaskModel.model,
+    [plannerProviderOverride, resolvedPlanTaskModel],
+  );
 
   const basePreset = useMemo(
     () => (basePresetId ? (presets.find((t) => t.id === basePresetId) ?? null) : null),
@@ -493,11 +513,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
     setBasePresetId(null);
     setPlanning(true);
     try {
-      const taskModel = resolveTaskModel(
-        'plan_generation',
-        workspaceOverrides?.taskModels,
-        providerId,
-      );
+      const effectiveModel =
+        plannerModelOverride !== '' ? plannerModelOverride : plannerRecommendedModel;
+      const taskModel = { providerId: plannerEffectiveProviderId, model: effectiveModel };
       const client = new PlannerClient({ ...taskModel, invokeFn: invoke });
       const result = await client.plan({ process });
       setPlan(result.output);
@@ -923,10 +941,29 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                             </div>
                           </div>
                         </div>
-                        <div className="flex justify-end px-1">
-                          <span className="text-2xs text-muted-foreground/60">
-                            cheap-tier · {providerId}
-                          </span>
+                        <div className="flex justify-end gap-2 px-1">
+                          <div className="w-28">
+                            <ProviderSelect
+                              value={plannerProviderOverride}
+                              providers={candidateProviders}
+                              onChange={(v) => {
+                                setPlannerProviderOverride(v as ProviderId | '');
+                                setPlannerModelOverride('');
+                              }}
+                              disabled={blocked}
+                              recommended={resolvedPlanTaskModel.providerId}
+                            />
+                          </div>
+                          <div className="w-36">
+                            <ModelSelect
+                              provider={plannerEffectiveProviderId}
+                              value={plannerModelOverride}
+                              onChange={setPlannerModelOverride}
+                              disabled={blocked}
+                              allowAuto
+                              recommendedModel={plannerRecommendedModel}
+                            />
+                          </div>
                         </div>
                       </div>
                     )}

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.test.ts
@@ -33,7 +33,8 @@ type HarnessParams = {
 const createHarness = ({
   agentName = 'agent 1',
   titleUserEdited = false,
-}: HarnessParams = {}): Harness => {
+  agentOrdinal = 0,
+}: HarnessParams & { agentOrdinal?: number } = {}): Harness => {
   const session = {
     id: SESSION_ID,
     workspaceId: WORKSPACE_ID,
@@ -44,7 +45,7 @@ const createHarness = ({
   const agent = {
     id: AGENT_ID,
     sessionId: SESSION_ID,
-    ordinal: 0,
+    ordinal: agentOrdinal,
     name: agentName,
     status: 'pending',
   } satisfies Agent;
@@ -174,6 +175,75 @@ describe('applyHeuristicTitle', () => {
       expect.objectContaining({ sessionId: SESSION_ID }),
     );
     expect(emitNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('null-heuristic prompt: AI title replaces placeholder agent name', async () => {
+    invokeMock.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'Fix login crash' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const harness = createHarness({ agentName: 'agent 2', agentOrdinal: 1 });
+
+    await applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'fix it',
+    });
+
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe('Fix login crash');
+    expect(harness.read().sessions[0]?.goal).toBe('original goal');
+    expect(invokeMock).toHaveBeenCalledOnce();
+  });
+
+  it('null-heuristic prompt + AI failure: leaves agent N and emits info notification', async () => {
+    invokeMock.mockRejectedValue(new Error('model offline'));
+    const emitNotification = vi.fn(async () => undefined);
+    const harness = createHarness({ agentName: 'agent 2', agentOrdinal: 1 });
+    const baseGet = harness.get;
+    const get = () => ({ ...baseGet(), emitNotification }) as ReturnType<typeof harness.get>;
+
+    await applyHeuristicTitle({
+      set: harness.set,
+      get,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'fix it',
+    });
+
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe('agent 2');
+    expect(emitNotification).toHaveBeenCalledWith(
+      'title-generation',
+      'info',
+      'agent title generation failed',
+      expect.stringContaining('model offline'),
+      expect.objectContaining({ sessionId: SESSION_ID }),
+    );
+  });
+
+  it('non-founding agent gets AI name but session goal is untouched', async () => {
+    invokeMock.mockResolvedValue({
+      stdout: JSON.stringify({ result: 'Refactor auth module' }),
+      stderr: '',
+      exitCode: 0,
+    });
+    const harness = createHarness({
+      agentName: 'agent 3',
+      agentOrdinal: 2,
+      titleUserEdited: false,
+    });
+
+    await applyHeuristicTitle({
+      ...harness,
+      sessionId: SESSION_ID,
+      agentId: AGENT_ID,
+      prompt: 'Refactor the auth module to use tokens',
+    });
+
+    expect(harness.read().sessionPhaseRuns[SESSION_ID]?.[0]?.name).toBe('Refactor auth module');
+    expect(harness.read().sessions[0]?.goal).toBe('original goal');
+    expect(renameSessionMock).not.toHaveBeenCalled();
   });
 
   it('skips rename when the agent name is not a placeholder', async () => {

--- a/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
+++ b/apps/desktop/src/store/slices/turn/applyHeuristicTitle/index.ts
@@ -91,9 +91,6 @@ export const applyHeuristicTitle = async ({
 }: Params): Promise<void> => {
   try {
     const heuristicTitle = heuristicAgentTitle(prompt);
-    if (heuristicTitle == null) {
-      return;
-    }
 
     const session = get().sessions.find((candidate) => candidate.id === sessionId);
     if (session == null) {
@@ -108,17 +105,20 @@ export const applyHeuristicTitle = async ({
     const canRenameSession = isFoundingAgent && !session.titleUserEdited;
     const titleNow = new Date().toISOString() as IsoDateTime;
 
-    if (canRenameSession) {
-      set((state) => ({
-        sessions: state.sessions.map((candidate) =>
-          candidate.id === sessionId ? { ...candidate, goal: heuristicTitle } : candidate,
-        ),
-      }));
-      await renameSessionInDb(tauriDatabase, sessionId, heuristicTitle, titleNow, false);
+    if (heuristicTitle != null) {
+      if (canRenameSession) {
+        set((state) => ({
+          sessions: state.sessions.map((candidate) =>
+            candidate.id === sessionId ? { ...candidate, goal: heuristicTitle } : candidate,
+          ),
+        }));
+        await renameSessionInDb(tauriDatabase, sessionId, heuristicTitle, titleNow, false);
+      }
+      if (canRenameAgent) {
+        await get().renameAgent(sessionId, agentId, heuristicTitle);
+      }
     }
-    if (canRenameAgent) {
-      await get().renameAgent(sessionId, agentId, heuristicTitle);
-    }
+
     if (!canRenameSession && !canRenameAgent) {
       return;
     }
@@ -152,14 +152,22 @@ export const applyHeuristicTitle = async ({
     const currentAgent = (get().sessionPhaseRuns[sessionId] ?? []).find(
       (candidate) => candidate.id === agentId,
     );
-    const shouldRenameSession =
+    const placeholderOrHeuristic = heuristicTitle ?? /^(agent|puppy) \d+$/i;
+    const sessionMatchesPlaceholder =
       canRenameSession &&
       currentSession?.titleUserEdited === false &&
-      currentSession.goal === heuristicTitle;
-    const shouldRenameAgent = canRenameAgent && currentAgent?.name === heuristicTitle;
+      (heuristicTitle != null
+        ? currentSession.goal === heuristicTitle
+        : placeholderOrHeuristic instanceof RegExp &&
+          placeholderOrHeuristic.test(currentSession?.goal ?? ''));
+    const agentMatchesPlaceholder =
+      canRenameAgent &&
+      (heuristicTitle != null
+        ? currentAgent?.name === heuristicTitle
+        : currentAgent?.name != null && /^(agent|puppy) \d+$/i.test(currentAgent.name));
     const generatedAt = new Date().toISOString() as IsoDateTime;
 
-    if (shouldRenameSession) {
+    if (sessionMatchesPlaceholder) {
       set((state) => ({
         sessions: state.sessions.map((candidate) =>
           candidate.id === sessionId ? { ...candidate, goal: generatedTitle } : candidate,
@@ -167,7 +175,7 @@ export const applyHeuristicTitle = async ({
       }));
       await renameSessionInDb(tauriDatabase, sessionId, generatedTitle, generatedAt, false);
     }
-    if (shouldRenameAgent) {
+    if (agentMatchesPlaceholder) {
       await get().renameAgent(sessionId, agentId, generatedTitle);
     }
   } catch {}


### PR DESCRIPTION
## What

- **Workflow builder told lies**: the plan step showed a hardcoded `cheap-tier · <provider>` note regardless of the configured `plan_generation` task model. Now it shows the actually resolved provider + model and is editable inline (connected-provider select + ModelSelect with Auto), one-shot for that plan run; workspace preferences are never written from here.
- **Hand-spawned agents never got AI titles**: root cause was an early return in `applyHeuristicTitle` when the heuristic extractor yielded null (short or stop-word-only prompts), which skipped the AI generation phase entirely. Eligibility is now computed first; AI titling runs for any placeholder-named agent even with a null heuristic. Non-founding agents get only the agent name renamed, session goal untouched; user renames mid-flight still win; failures still emit the diagnosable info notification from #970.

## Verification

Typecheck green; suites green: desktop 2365 (+7 new tests: reproduction, null-heuristic AI success/failure, non-founding goal untouched, builder resolved-model display, planner override wiring, no-prefs-written), core 810, db 84, ui 12.

Area B2 of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)