### PR TITLE
fix: single clickable pr status + always-visible card actions

### DIFF
--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type {
   PullRequestState,
   Session,
@@ -133,7 +133,7 @@ describe('StageBoardCard layout', () => {
 });
 
 describe('StageBoardCard linked request', () => {
-  it('always renders a no pull request icon in the title row', () => {
+  it('always renders a no pull request icon in the title row when no PR exists', () => {
     render(<StageBoardCard session={session} nav={nav} />);
     const icon = screen.getByLabelText('No pull request');
     const titleRow = screen.getByText(session.goal).closest('[data-tooltip]')?.parentElement;
@@ -141,12 +141,33 @@ describe('StageBoardCard linked request', () => {
     expect(titleRow?.contains(icon)).toBe(true);
   });
 
-  it('renders the GitHub pull request state and number', () => {
+  it('renders a clickable GitHub PR button that calls nav.openGithub', () => {
     state.sessionGithub = { [SESSION_ID]: { pr: pullRequest } };
     render(<StageBoardCard session={session} nav={nav} />);
-    const icon = screen.getByLabelText('Draft · #9484');
-    expect(icon.getAttribute('title')).toBe('Draft · #9484');
+    const btn = screen.getByLabelText('Draft · #9484, open in GitHub');
+    expect(btn.tagName).toBe('BUTTON');
+    fireEvent.click(btn);
+    expect(nav.openGithub).toHaveBeenCalledWith(session);
     expect(screen.queryByLabelText('No pull request')).toBeNull();
+  });
+
+  it('renders a clickable GitLab MR button that dispatches the studio event', () => {
+    state.sessionGitlabMr = {
+      [SESSION_ID]: { mr: mergeRequest({ state: 'opened' }) },
+    };
+    const dispatched: Event[] = [];
+    window.addEventListener('goodboy:open-gitlab-studio', (e) => dispatched.push(e));
+    render(<StageBoardCard session={session} nav={nav} />);
+    const btn = screen.getByLabelText('Merge request !12 · open, open in GitLab');
+    fireEvent.click(btn);
+    expect(dispatched).toHaveLength(1);
+    window.removeEventListener('goodboy:open-gitlab-studio', (e) => dispatched.push(e));
+  });
+
+  it('does not render a clickable button when state is none', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    expect(screen.queryByLabelText(/open in GitHub/)).toBeNull();
+    expect(screen.queryByLabelText(/open in GitLab/)).toBeNull();
   });
 
   it.each([
@@ -160,9 +181,24 @@ describe('StageBoardCard linked request', () => {
       [SESSION_ID]: { mr: mergeRequest({ state: mrState, draft }) },
     };
     render(<StageBoardCard session={session} nav={nav} />);
-    const title = `Merge request !12 · ${expected}`;
-    const icon = screen.getByLabelText(title);
-    expect(icon.getAttribute('title')).toBe(title);
+    const title = `Merge request !12 · ${expected}, open in GitLab`;
+    const btn = screen.getByLabelText(title);
+    expect(btn.tagName).toBe('BUTTON');
+  });
+});
+
+describe('StageBoardCard actions visibility', () => {
+  it('renders static actions without opacity-0 class', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const archiveBtn = screen.getByLabelText('archive');
+    const actionsContainer = archiveBtn.closest('span.mt-auto');
+    expect(actionsContainer?.className).not.toContain('opacity-0');
+  });
+
+  it('renders action buttons with hover color classes', () => {
+    render(<StageBoardCard session={session} nav={nav} />);
+    const deleteBtn = screen.getByLabelText('delete');
+    expect(deleteBtn.className).toContain('hover:text-danger');
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -18,7 +18,8 @@ import {
   useSessionStageInfo,
 } from '../../../../../store';
 import { CostBadge } from '../../../../providers/components/CostBadge';
-import { PullRequestChip } from '../../../../github/components/PullRequestChip';
+import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
+import { IntegrationGlyph } from '../../../../integrations/components/IntegrationGlyph';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
@@ -51,10 +52,32 @@ export const StageBoardCard = memo(function StageBoardCard({
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[id] ?? EMPTY_ARRAY);
   const agentCount = useNonResolverStandaloneAgents(id).length;
   const worktreePath = useAppStore((s) => s.sessionWorktrees[id]?.[0] ?? null);
-  const dynamicActions = useDynamicActions(session, nav, stage, reason);
+  const dynamicActions = useDynamicActions(session, nav, stage);
   const sessionCost = useSessionCost(id);
 
   const linkedRequest = getLinkedRequest({ pullRequest, mergeRequest });
+  const isGitlab = mergeRequest != null && pullRequest == null;
+  const hasLinkedRequest = linkedRequest.state !== 'none';
+
+  const prMeta = pullRequestMeta(linkedRequest.state);
+  const prLabel =
+    linkedRequest.title ??
+    prMeta.label +
+      (linkedRequest.number !== undefined
+        ? isGitlab
+          ? ` · !${linkedRequest.number}`
+          : ` · #${linkedRequest.number}`
+        : '');
+  const prTooltip = prLabel + (isGitlab ? ', open in GitLab' : ', open in GitHub');
+
+  const handlePrClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isGitlab) {
+      window.dispatchEvent(new CustomEvent('goodboy:open-gitlab-studio'));
+    } else {
+      nav.openGithub(session);
+    }
+  };
 
   return (
     <button
@@ -78,13 +101,33 @@ export const StageBoardCard = memo(function StageBoardCard({
             </span>
           </Tooltip>
           <span className="inline-flex h-5 shrink-0 items-center">
-            <PullRequestChip
-              state={linkedRequest.state}
-              variant="icon"
-              number={linkedRequest.number}
-              iconSize={12}
-              title={linkedRequest.title}
-            />
+            {hasLinkedRequest ? (
+              <Tooltip content={prTooltip} side="top">
+                <button
+                  type="button"
+                  aria-label={prTooltip}
+                  onClick={handlePrClick}
+                  className="inline-flex shrink-0 items-center gap-0.5 rounded-sm transition-colors hover:bg-muted"
+                >
+                  <IntegrationGlyph provider={isGitlab ? 'gitlab' : 'github'} size="xs" />
+                  <PullRequestChip
+                    state={linkedRequest.state}
+                    variant="icon"
+                    number={linkedRequest.number}
+                    iconSize={12}
+                    title={linkedRequest.title}
+                  />
+                </button>
+              </Tooltip>
+            ) : (
+              <PullRequestChip
+                state={linkedRequest.state}
+                variant="icon"
+                number={linkedRequest.number}
+                iconSize={12}
+                title={linkedRequest.title}
+              />
+            )}
           </span>
         </span>
 
@@ -125,25 +168,25 @@ export const StageBoardCard = memo(function StageBoardCard({
               <CardAction
                 key={action.key}
                 icon={action.icon}
-                color={action.color}
+                hoverColor={action.color}
                 label={action.label}
                 onClick={action.onClick}
               />
             ))}
           </span>
         )}
-        <span className="mt-auto flex flex-col items-end gap-0.5 opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100">
+        <span className="mt-auto flex flex-col items-end gap-0.5">
           {archived ? (
             <span className="flex gap-0.5">
               <CardAction
                 icon={RotateCcw}
-                color="text-primary"
+                hoverColor="text-primary"
                 label="restore"
                 onClick={() => onRestore?.(session)}
               />
               <CardAction
                 icon={Trash2}
-                color="text-danger"
+                hoverColor="text-danger"
                 label="delete"
                 onClick={() => onDelete?.(session)}
               />
@@ -153,14 +196,14 @@ export const StageBoardCard = memo(function StageBoardCard({
               <span className="flex gap-0.5">
                 <CardAction
                   icon={Code}
-                  color="text-muted-foreground"
+                  hoverColor="text-muted-foreground"
                   label="open in editor"
                   onClick={() => nav.openIDE(session)}
                   disabled={!worktreePath}
                 />
                 <CardAction
                   icon={SquareTerminal}
-                  color="text-muted-foreground"
+                  hoverColor="text-muted-foreground"
                   label="open terminal"
                   onClick={() => nav.openTerminal(session)}
                 />
@@ -168,13 +211,13 @@ export const StageBoardCard = memo(function StageBoardCard({
               <span className="flex gap-0.5">
                 <CardAction
                   icon={Archive}
-                  color="text-muted-foreground"
+                  hoverColor="text-muted-foreground"
                   label="archive"
                   onClick={() => onArchive?.(session)}
                 />
                 <CardAction
                   icon={Trash2}
-                  color="text-danger"
+                  hoverColor="text-danger"
                   label="delete"
                   onClick={() => onDelete?.(session)}
                 />
@@ -187,15 +230,24 @@ export const StageBoardCard = memo(function StageBoardCard({
   );
 });
 
+const ACTION_HOVER: Record<string, string> = {
+  'text-primary': 'hover:text-primary',
+  'text-danger': 'hover:text-danger',
+  'text-warning': 'hover:text-warning',
+  'text-info': 'hover:text-info',
+  'text-success': 'hover:text-success',
+  'text-muted-foreground': 'hover:text-muted-foreground',
+};
+
 type CardActionProps = {
   readonly icon: LucideIcon;
-  readonly color: string;
+  readonly hoverColor: string;
   readonly label: string;
   readonly onClick: () => void;
   readonly disabled?: boolean;
 };
 
-const CardAction = ({ icon: Icon, color, label, onClick, disabled }: CardActionProps) => {
+const CardAction = ({ icon: Icon, hoverColor, label, onClick, disabled }: CardActionProps) => {
   return (
     <Tooltip content={label} side="top">
       <button
@@ -206,9 +258,12 @@ const CardAction = ({ icon: Icon, color, label, onClick, disabled }: CardActionP
           e.stopPropagation();
           onClick();
         }}
-        className="inline-flex size-7 items-center justify-center rounded-md transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-40"
+        className={cn(
+          'inline-flex size-7 items-center justify-center rounded-md text-muted-foreground/50 transition-colors hover:bg-muted disabled:pointer-events-none disabled:opacity-40',
+          ACTION_HOVER[hoverColor] ?? hoverColor,
+        )}
       >
-        <Icon size={14} className={color} aria-hidden />
+        <Icon size={14} aria-hidden />
       </button>
     </Tooltip>
   );

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.test.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.test.ts
@@ -56,35 +56,27 @@ afterEach(() => vi.clearAllMocks());
 
 describe('useDynamicActions', () => {
   it('yields no actions for an idle building session', () => {
-    const { result } = renderHook(() =>
-      useDynamicActions(sessionWith(), nav, 'building', 'no PR yet'),
-    );
+    const { result } = renderHook(() => useDynamicActions(sessionWith(), nav, 'building'));
     expect(result.current).toHaveLength(0);
   });
 
   it('surfaces an open-questions action that routes to the questions lens', () => {
     state.sessionOpenQuestions = { 'sess-1': [{ status: 'open' }, { status: 'answered' }] };
-    const { result } = renderHook(() =>
-      useDynamicActions(sessionWith(), nav, 'attention', '1 open question'),
-    );
+    const { result } = renderHook(() => useDynamicActions(sessionWith(), nav, 'attention'));
     const action = result.current.find((a) => a.key === 'questions');
     expect(action?.label).toBe('1 open question');
     action?.onClick();
     expect(nav.openQuestions).toHaveBeenCalledWith(sessionWith());
   });
 
-  it('surfaces a github action only for PR attention', () => {
-    const { result } = renderHook(() =>
-      useDynamicActions(sessionWith(), nav, 'attention', 'PR #9 approved, ready to merge'),
-    );
-    expect(result.current.some((a) => a.key === 'github')).toBe(true);
+  it('does not produce a github action for PR attention', () => {
+    const { result } = renderHook(() => useDynamicActions(sessionWith(), nav, 'attention'));
+    expect(result.current.some((a) => a.key === 'github')).toBe(false);
   });
 
   it('surfaces an unread action when the session has unread replies', () => {
     state.hasUnread = true;
-    const { result } = renderHook(() =>
-      useDynamicActions(sessionWith(), nav, 'attention', 'unread agent reply'),
-    );
+    const { result } = renderHook(() => useDynamicActions(sessionWith(), nav, 'attention'));
     expect(result.current.some((a) => a.key === 'unread')).toBe(true);
   });
 
@@ -92,7 +84,7 @@ describe('useDynamicActions', () => {
     pickNextMock.mockReturnValue({ id: 'step-1' });
     state.sessionWorkflows = { 'sess-1': [{ id: 'wf-1' }] };
     const session = sessionWith([{ id: 'run-1', workflowId: 'wf-1' }]);
-    const { result } = renderHook(() => useDynamicActions(session, nav, 'building', 'no PR yet'));
+    const { result } = renderHook(() => useDynamicActions(session, nav, 'building'));
     expect(result.current.some((a) => a.key === 'run')).toBe(true);
   });
 
@@ -100,9 +92,7 @@ describe('useDynamicActions', () => {
     pickNextMock.mockReturnValue({ id: 'step-1' });
     state.sessionWorkflows = { 'sess-1': [{ id: 'wf-1' }] };
     const session = sessionWith([{ id: 'run-1', workflowId: 'wf-1' }]);
-    const { result } = renderHook(() =>
-      useDynamicActions(session, nav, 'running', 'agent running'),
-    );
+    const { result } = renderHook(() => useDynamicActions(session, nav, 'running'));
     expect(result.current.some((a) => a.key === 'run')).toBe(false);
   });
 });

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.ts
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/useDynamicActions/index.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { GitPullRequest, HelpCircle, MessageSquare, Play, type LucideIcon } from 'lucide-react';
+import { HelpCircle, MessageSquare, Play, type LucideIcon } from 'lucide-react';
 import type {
   Agent,
   OpenQuestion,
@@ -29,7 +29,6 @@ export const useDynamicActions = (
   session: Session,
   nav: BoardNavigation,
   stage: SessionStageInfo['stage'],
-  reason: string,
 ): ReadonlyArray<DynamicAction> => {
   const id = session.id as SessionId;
   const openQuestions = useAppStore((s) => s.sessionOpenQuestions[id] ?? EMPTY_QUESTIONS);
@@ -76,15 +75,6 @@ export const useDynamicActions = (
         onClick: () => nav.openQuestions(session),
       });
     }
-    if (stage === 'attention' && reason.startsWith('PR')) {
-      actions.push({
-        key: 'github',
-        icon: GitPullRequest,
-        color: 'text-info',
-        label: 'Open PR',
-        onClick: () => nav.openGithub(session),
-      });
-    }
     if (hasUnread) {
       actions.push({
         key: 'unread',
@@ -95,5 +85,5 @@ export const useDynamicActions = (
       });
     }
     return actions;
-  }, [session, nav, stage, reason, openQuestions, workflows, runs, hasUnread]);
+  }, [session, nav, stage, openQuestions, workflows, runs, hasUnread]);
 };


### PR DESCRIPTION
## What

- **One PR signal per card**: the `Open PR` dynamic action is gone; the top-right status element is now the CTA. It combines the provider glyph (GitHub/GitLab) with the state icon, is clickable (opens GitHub studio / GitLab studio), and keeps the full tooltip (`Approved · #9304, open in GitHub`, `!12` wording for MRs). `none` state stays a muted non-clickable dashed circle.
- **Actions always visible**: editor/terminal/archive/delete (and restore) no longer hide behind card hover. Idle state is neutral muted; each button takes its accent color on its own hover (static Tailwind class map, no runtime string building).
- Fixed card height and MR state mapping untouched; `deriveSessionStage` untouched.

## Verification

Typecheck green; desktop suite 2362 green (rebased on main post #970/#971 and re-verified). Updated tests assert: no github dynamic action, clickable status per provider, no `opacity-0` gating, hover accent classes.

Area C2 of 3, closes the polish batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)