### PR TITLE
feat(core): structured session summary and consolidated decisions

### DIFF
--- a/apps/desktop/src/store/preamble.test.ts
+++ b/apps/desktop/src/store/preamble.test.ts
@@ -65,7 +65,7 @@ describe('buildContextPreamble', () => {
       slot('files_touched', 'f'.repeat(1_600)),
       slot('decisions', 'd'.repeat(1_200)),
       slot('open_questions', 'q'.repeat(800)),
-      slot('last_output_summary', 's'.repeat(900)),
+      slot('last_output_summary', 's'.repeat(2_000)),
     ];
     buildContextPreamble(slots);
     expect(debug).toHaveBeenCalledWith(

--- a/packages/core/src/context/budgets.ts
+++ b/packages/core/src/context/budgets.ts
@@ -5,7 +5,7 @@ export const SLOT_BUDGETS = {
   decisions: 1_200,
   open_questions: 800,
   files_touched: 1_600,
-  last_output_summary: 900,
+  last_output_summary: 2_000,
 } satisfies Record<SlotKey, number>;
 
-export const PREAMBLE_SLOT_TOTAL_BUDGET = 5_600;
+export const PREAMBLE_SLOT_TOTAL_BUDGET = 6_100;

--- a/packages/core/src/summarizer/client.test.ts
+++ b/packages/core/src/summarizer/client.test.ts
@@ -3,7 +3,7 @@ import { Summarizer, type SummarizerDeps } from './client';
 import { SUMMARIZER_SYSTEM_PROMPT } from './prompt';
 
 describe('Summarizer client prompt', () => {
-  it('defines cumulative session summary, compaction, decisions, and goal rules', async () => {
+  it('defines structured summary, compaction, decisions, and goal rules', async () => {
     let request: Record<string, unknown> | undefined;
     const invokeFn: SummarizerDeps['invokeFn'] = async <T>(
       _cmd: string,
@@ -33,13 +33,34 @@ describe('Summarizer client prompt', () => {
     expect(systemPrompt).toBe(SUMMARIZER_SYSTEM_PROMPT);
     expect(systemPrompt).toContain('- last_output_summary (session summary)');
     expect(systemPrompt).toContain(
-      '- goal: 280\n- files_touched: 1600\n- decisions: 1200\n- open_questions: 800\n- last_output_summary: 900\n\nIf a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.',
+      '- goal: 280\n- files_touched: 1600\n- decisions: 1200\n- open_questions: 800\n- last_output_summary: 2000\n\nIf a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.',
     );
     expect(systemPrompt).toContain(
-      'When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.',
+      'For last_output_summary, compaction MUST preserve all four bold section labels; compress the content within each section, never drop a section.',
     );
     expect(systemPrompt).toContain(
-      'On every turn, REWORK the previous summary together with the latest assistant turn into a new summary covering what the session has accomplished so far, the current state, and what is in flight.',
+      'Per-slot format rules override these general rules: last_output_summary follows its four-section format above, and its Problem section is sentences, not bullets.',
+    );
+    expect(systemPrompt).toContain(
+      'A newer decision that reverses or contradicts an earlier one REPLACES it, so the emitted set must never contain two entries that contradict each other.',
+    );
+    expect(systemPrompt).toContain(
+      'when this slot changes, emit the ENTIRE set rewritten compactly, one line per decision',
+    );
+    expect(systemPrompt).toContain(
+      'a standard structured object with four fixed sections, in this exact order, each introduced by a bold label: `**Problem:**`, `**Learned:**`, `**State:**`, `**Next:**`',
+    );
+    expect(systemPrompt).toContain(
+      '**Problem:** why the session exists, the original problem or request, in one or two sentences. Sticky: write it once, then only sharpen or compress it.',
+    );
+    expect(systemPrompt).toContain(
+      '**Learned:** durable discoveries that changed the understanding or approach',
+    );
+    expect(systemPrompt).toContain(
+      '**State:** where the work is right now. Fully rewritten every pass.',
+    );
+    expect(systemPrompt).toContain(
+      '**Next:** what remains and what is in flight. Fully rewritten every pass.',
     );
     expect(systemPrompt).toContain(
       'Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.',

--- a/packages/core/src/summarizer/client.ts
+++ b/packages/core/src/summarizer/client.ts
@@ -196,6 +196,7 @@ function buildUserPrompt(input: SummarizeInput): string {
     'Assistant turn:',
     input.turnOutput,
     '',
+    'When decisions is included in upserts it must be the full rewritten set. Omitting a slot means it is unchanged.',
     'Return the JSON object now.',
   ].join('\n');
 }

--- a/packages/core/src/summarizer/prompt.ts
+++ b/packages/core/src/summarizer/prompt.ts
@@ -13,15 +13,20 @@ CONTEXT PRESERVATION (critical)
 Previous slot content is canonical memory. There is no "append" operation, every upsert REPLACES the slot, so when you change a slot you MUST emit the full merged value (previous content + new additions, with only items the latest turn invalidated removed).
 Never silently drop facts that are still valid. Per slot:
 - goal: the high-level intent of the session, the feature, refactor, or fix being built and why. Keep it stable. Change it only to sharpen or broaden that intent as it clarifies, never to log what just happened. It is NOT a status line. Never add completion markers (done, complete, "review passed", shipped), phase / cluster / step numbers, counts, file paths, or any description of the latest turn's actions. Those belong in last_output_summary or decisions. If the latest turn only reports progress and the underlying intent is unchanged, omit goal from the upserts. If the current goal value already carries status, progress, or per-turn detail, rewrite it down to the clean high-level intent. Never exceed two sentences. If the current value exceeds two sentences, rewrite it down to two sentences or fewer.
-- decisions: append new decisions to the existing list. When a new decision reverses or supersedes an earlier one, REPLACE the earlier entry with the final decision.
+- decisions: when this slot changes, emit the ENTIRE set rewritten compactly, one line per decision. Merge near-duplicate variants into a single entry. A newer decision that reverses or contradicts an earlier one REPLACES it, so the emitted set must never contain two entries that contradict each other. Consolidating is not deleting: every decision that is still valid MUST survive the rewrite. A marker pipeline may have appended raw or near-duplicate lines to the previous value between passes, so treat the previous value as unconsolidated input to fold into the clean set.
 - open_questions: drop only items the latest user turn explicitly resolves. Add new ones only when the assistant is blocked on the user.
 - files_touched: one path per line; append unique paths; never duplicate or drop prior paths unless a file was deleted.
-- last_output_summary: the rolling cumulative summary of the whole session. On every turn, REWORK the previous summary together with the latest assistant turn into a new summary covering what the session has accomplished so far, the current state, and what is in flight. REPLACE is the storage mechanism, so emit the full cumulative summary. Do not summarize only the latest turn and do not append a turn-by-turn log.
+- last_output_summary: a standard structured object with four fixed sections, in this exact order, each introduced by a bold label: \`**Problem:**\`, \`**Learned:**\`, \`**State:**\`, \`**Next:**\`. These are bold labels, not markdown headings. Every pass MUST emit all four sections, even when one is a single short line.
+  - **Problem:** why the session exists, the original problem or request, in one or two sentences. Sticky: write it once, then only sharpen or compress it. Never delete it and never turn it into a status line.
+  - **Learned:** durable discoveries that changed the understanding or approach, such as root causes found, constraints hit, and facts verified. Sticky: compress and merge over time, but never drop a discovery that still explains the current approach.
+  - **State:** where the work is right now. Fully rewritten every pass.
+  - **Next:** what remains and what is in flight. Fully rewritten every pass.
+  - If the previous value is unstructured legacy prose, restructure it into these four sections on the first pass, distributing the existing facts across them. Do not invent facts that are not already present or established by the latest turn.
 
 SLOT BUDGETS (hard maximum characters per emitted value)
 ${SLOT_KEYS.map((key) => `- ${key}: ${SLOT_BUDGETS[key]}`).join('\n')}
 
-If a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts.
+If a current or updated slot exceeds its budget, emit a compacted full value within the budget. Merge semantic duplicates, replace superseded decisions with the final decision, and keep the most recent and most relevant facts. For last_output_summary, compaction MUST preserve all four bold section labels; compress the content within each section, never drop a section.
 
 FORMATTING (critical, values render as markdown in the UI)
 Each value MUST be compact, well-structured markdown. Never write a wall of prose on one line.
@@ -34,6 +39,7 @@ Rules:
 - Do NOT wrap the value in code fences unless quoting actual code.
 - Exclude raw tool output and chat-style narration.
 - The "goal" slot is one tight high-level sentence (two at most). No bullets, no status, no progress, no per-turn detail.
+- Per-slot format rules override these general rules: last_output_summary follows its four-section format above, and its Problem section is sentences, not bullets.
 
 OUTPUT
 You MUST respond with a single JSON object and nothing else. No prose, no markdown wrapper, no code fences around the JSON.

--- a/packages/core/src/summarizer/round-trip.test.ts
+++ b/packages/core/src/summarizer/round-trip.test.ts
@@ -200,6 +200,93 @@ describe('synthetic context engine round-trip', () => {
     expect(slot?.value.length).toBe(50_000);
   });
 
+  it('preserves the four-section structure of last_output_summary across a rewrite', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_structured' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const prev = [
+      '**Problem:** auth middleware rejects valid tokens.',
+      '',
+      '**Learned:** clock skew between issuer and verifier.',
+      '',
+      '**State:** patch drafted.',
+      '',
+      '**Next:** add regression test.',
+    ].join('\n');
+    await engine.upsert(sessionId, 'last_output_summary', prev);
+
+    const merged = [
+      '**Problem:** auth middleware rejects valid tokens.',
+      '',
+      '**Learned:** clock skew between issuer and verifier; tolerance now configurable.',
+      '',
+      '**State:** patch merged, regression test green.',
+      '',
+      '**Next:** monitor staging for false rejects.',
+    ].join('\n');
+    const invokeFn = makeInvokeFnWithOutput(
+      JSON.stringify({ upserts: [{ key: 'last_output_summary', value: merged }] }),
+    );
+    const summarizer = new Summarizer({ providerId: 'cursor', invokeFn });
+
+    const before = await engine.load(sessionId);
+    const result = await summarizer.summarize({
+      prevSlots: before,
+      turnInput: 'ship it',
+      turnOutput: 'merged and tested',
+    });
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    const value = after.find((s) => s.key === 'last_output_summary')?.value ?? '';
+    expect(value).toContain('**Problem:** auth middleware rejects valid tokens.');
+    expect(value).toContain('**Learned:**');
+    expect(value).toContain('**State:** patch merged, regression test green.');
+    expect(value).toContain('**Next:** monitor staging for false rejects.');
+    expect(value.indexOf('**Problem:**')).toBeLessThan(value.indexOf('**Learned:**'));
+    expect(value.indexOf('**Learned:**')).toBeLessThan(value.indexOf('**State:**'));
+    expect(value.indexOf('**State:**')).toBeLessThan(value.indexOf('**Next:**'));
+  });
+
+  it('replaces decisions with the consolidated full set', async () => {
+    const db = makeDb();
+    await migrate(db);
+    const sessionId = 'sess_decisions' as SessionId;
+    await seedSession(db, sessionId);
+    const engine = new ContextEngine({ db });
+
+    const raw = [
+      '- use jwt for auth',
+      '- use jwt tokens for authentication',
+      '- store refresh token in sqlite',
+      '- do not store refresh token in sqlite',
+    ].join('\n');
+    await engine.upsert(sessionId, 'decisions', raw);
+
+    const consolidated = ['- use jwt for auth', '- keep refresh token in memory only'].join('\n');
+    const invokeFn = makeInvokeFnWithOutput(
+      JSON.stringify({ upserts: [{ key: 'decisions', value: consolidated }] }),
+    );
+    const summarizer = new Summarizer({ providerId: 'cursor', invokeFn });
+
+    const before = await engine.load(sessionId);
+    const result = await summarizer.summarize({
+      prevSlots: before,
+      turnInput: 'consolidate decisions',
+      turnOutput: 'done',
+    });
+    await applyDelta(engine, sessionId, result.delta.upserts);
+
+    const after = await engine.load(sessionId);
+    const value = after.find((s) => s.key === 'decisions')?.value ?? '';
+    expect(value).toBe(consolidated);
+    expect(value).not.toContain('use jwt tokens for authentication');
+    expect(value).not.toContain('store refresh token in sqlite');
+  });
+
   it('drops summarizer-suggested keys outside the known set', async () => {
     const db = makeDb();
     await migrate(db);


### PR DESCRIPTION
## What

Reworks the summarizer contract so shared context survives long sessions.

- `last_output_summary` becomes a standard four-section object with bold labels: **Problem** (sticky: why the session exists), **Learned** (sticky: durable discoveries), **State** and **Next** (rewritten every pass). Legacy prose gets restructured on the first pass without inventing facts. Compaction must preserve all four sections.
- `decisions` rule strengthened: when the slot changes the summarizer emits the entire set rewritten compactly, one line per decision, near-duplicates merged, newer decisions replace contradicting older ones, no contradictory pairs. Raw marker-appended lines are treated as unconsolidated input.
- Budgets: `last_output_summary` 900 to 2000, `PREAMBLE_SLOT_TOTAL_BUDGET` 5600 to 6100 (worst-case serialized total is 5963, so total-budget compaction never fires when slots sit at their caps).
- User prompt marks decisions upserts as full rewritten set; omitted slot means unchanged.

## Why

After many iterations the rolling summary loses the original problem and key discoveries, and the decisions slot accumulates conflicting near-duplicates that poison every agent preamble.

## Tests

- `client.test.ts` pins the new prompt rules (sections, sticky semantics, no-contradiction, budgets, format-precedence and compaction invariants).
- Two new round-trip tests (real ContextEngine, mocked model) prove structure preservation and decisions consolidation through the parse/upsert contract.
- core 812 passed, desktop 2369 passed, typecheck 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)