### PR TITLE
feat(desktop): slot history side panel and shareable copy

### DIFF
--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useRef, useState } from 'react';
+import { Check, Copy, RotateCcw, X } from 'lucide-react';
+import { Divider, Markdown, ScrollFade, cn } from '@goodboy/ui';
+import type { ContextSlotHistoryEntry } from '@goodboy/types';
+
+type HistoryEntryProps = {
+  readonly entry: ContextSlotHistoryEntry;
+  readonly renderAsMarkdown: boolean;
+  readonly expanded: boolean;
+  readonly onToggle: () => void;
+  readonly onRestore: (entry: ContextSlotHistoryEntry) => void;
+};
+
+const HistoryEntry = ({
+  entry,
+  renderAsMarkdown,
+  expanded,
+  onToggle,
+  onRestore,
+}: HistoryEntryProps) => {
+  const [entryCopied, setEntryCopied] = useState(false);
+  const copyTimer = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current !== null) {
+        window.clearTimeout(copyTimer.current);
+      }
+    },
+    [],
+  );
+
+  const copyEntry = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(entry.value);
+    } catch {
+      return;
+    }
+    setEntryCopied(true);
+    if (copyTimer.current !== null) {
+      window.clearTimeout(copyTimer.current);
+    }
+    copyTimer.current = window.setTimeout(() => setEntryCopied(false), 1500);
+  };
+
+  return (
+    <li className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle p-3">
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            'rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide',
+            entry.author === 'user' ? 'bg-accent/10 text-accent' : 'bg-info/10 text-info',
+          )}
+        >
+          {entry.author === 'user' ? 'you' : 'agent'}
+        </span>
+        <span className="text-2xs text-muted-foreground">{formatRelative(entry.createdAt)}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={(e) => void copyEntry(e)}
+            title={entryCopied ? 'copied' : 'copy this version'}
+            aria-label="copy this version"
+            className="rounded-sm p-0.5 text-muted-foreground/60 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            {entryCopied ? <Check size={11} aria-hidden /> : <Copy size={11} aria-hidden />}
+          </button>
+          <button
+            type="button"
+            onClick={() => onRestore(entry)}
+            title="restore this version"
+            aria-label="restore"
+            className="flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <RotateCcw size={10} aria-hidden />
+            restore
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className="text-left"
+        aria-expanded={expanded}
+        aria-label={expanded ? 'collapse entry' : 'expand entry'}
+      >
+        {expanded ? (
+          <div className="rounded text-xs leading-relaxed text-foreground">
+            {renderAsMarkdown ? (
+              <Markdown text={entry.value} className="text-xs" />
+            ) : (
+              <p className="whitespace-pre-wrap">{entry.value}</p>
+            )}
+          </div>
+        ) : renderAsMarkdown ? (
+          <div className="text-xs leading-relaxed text-foreground line-clamp-3">
+            <Markdown text={entry.value} className="text-xs" />
+          </div>
+        ) : (
+          <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground line-clamp-3">
+            {entry.value}
+          </p>
+        )}
+      </button>
+    </li>
+  );
+};
+
+type Props = {
+  readonly label: string;
+  readonly renderAsMarkdown: boolean;
+  readonly entries: ReadonlyArray<ContextSlotHistoryEntry>;
+  readonly onRestore: (entry: ContextSlotHistoryEntry) => void;
+  readonly onClose: () => void;
+};
+
+export const SlotHistoryPanel = ({
+  label,
+  renderAsMarkdown,
+  entries,
+  onRestore,
+  onClose,
+}: Props) => {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  return (
+    <div className="flex w-80 shrink-0 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
+        <span className="text-xs font-medium text-foreground">history: {label}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="close history panel"
+          className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      </div>
+      <Divider />
+      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
+        {entries.length === 0 ? (
+          <p className="text-xs italic text-muted-foreground">no history yet</p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {entries.map((entry) => (
+              <HistoryEntry
+                key={entry.id}
+                entry={entry}
+                renderAsMarkdown={renderAsMarkdown}
+                expanded={expandedId === entry.id}
+                onToggle={() => setExpandedId((prev) => (prev === entry.id ? null : entry.id))}
+                onRestore={onRestore}
+              />
+            ))}
+          </ul>
+        )}
+      </ScrollFade>
+    </div>
+  );
+};
+
+const formatRelative = (iso: string): string => {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) {
+    return 'just now';
+  }
+  if (mins < 60) {
+    return `${mins}m ago`;
+  }
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) {
+    return `${hrs}h ago`;
+  }
+  return `${Math.floor(hrs / 24)}d ago`;
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.test.tsx
@@ -1,0 +1,357 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Session } from '@goodboy/types';
+
+const writeText = vi.fn(async () => undefined);
+
+type StoreSlot = { key: string; value: string; enabled: boolean };
+type LoadingFlags = {
+  agents: boolean;
+  transcript: boolean;
+  telemetry: boolean;
+  slots: boolean;
+  plans: boolean;
+  summary: boolean;
+};
+type SummarizerStatus = {
+  status: string;
+  lastUpdate: null;
+  error: null;
+  lastUsage: null;
+  lastAttempt: null;
+};
+type HistoryEntry = { id: string; key: string; value: string; author: string; createdAt: string };
+type OpenQuestion = {
+  id: string;
+  sessionId: string;
+  text: string;
+  status: string;
+  userAnswer: string | null;
+  suggestedAnswers: string[];
+  createdAt: string;
+};
+
+const { store } = vi.hoisted(() => {
+  return {
+    store: {
+      sessionSlots: {
+        'session-1': [
+          { key: 'goal', value: 'ship the feature', enabled: true },
+          { key: 'decisions', value: 'use tailwind', enabled: true },
+          { key: 'last_output_summary', value: '**Status**: done', enabled: true },
+        ],
+      } as Record<string, StoreSlot[]>,
+      sessionLoading: {
+        'session-1': {
+          agents: false,
+          transcript: false,
+          telemetry: false,
+          slots: false,
+          plans: false,
+          summary: false,
+        },
+      } as Record<string, LoadingFlags>,
+      summarizerStatus: {
+        'session-1': {
+          status: 'idle',
+          lastUpdate: null,
+          error: null,
+          lastUsage: null,
+          lastAttempt: null,
+        },
+      } as Record<string, SummarizerStatus>,
+      slotHistory: {
+        'session-1': {
+          goal: [
+            {
+              id: 'h1',
+              key: 'goal',
+              value: 'old goal text',
+              author: 'user',
+              createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+            },
+            {
+              id: 'h2',
+              key: 'goal',
+              value: 'agent wrote this',
+              author: 'summarizer',
+              createdAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+            },
+          ],
+          last_output_summary: [
+            {
+              id: 'sh1',
+              key: 'last_output_summary',
+              value: 'previous summary',
+              author: 'summarizer',
+              createdAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+            },
+          ],
+        },
+      } as Record<string, Record<string, HistoryEntry[]>>,
+      sessionOpenQuestions: {
+        'session-1': [
+          {
+            id: 'q1',
+            sessionId: 'session-1',
+            text: 'what is the deadline?',
+            status: 'open',
+            userAnswer: null,
+            suggestedAnswers: [],
+            createdAt: new Date().toISOString(),
+          },
+          {
+            id: 'q2',
+            sessionId: 'session-1',
+            text: 'already answered',
+            status: 'answered',
+            userAnswer: 'yes',
+            suggestedAnswers: [],
+            createdAt: new Date().toISOString(),
+          },
+        ],
+      } as Record<string, OpenQuestion[]>,
+      upsertSessionSlot: vi.fn(),
+      loadSlotHistory: vi.fn().mockResolvedValue(undefined),
+      loadSessionOpenQuestions: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+});
+
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
+  useSessionSlots: (sessionId: string) => store.sessionSlots[sessionId] ?? [],
+  useSessionLoading: (sessionId: string) =>
+    store.sessionLoading[sessionId] ?? {
+      agents: false,
+      transcript: false,
+      telemetry: false,
+      slots: false,
+      plans: false,
+      summary: false,
+    },
+  useSummarizerStatus: (sessionId: string) =>
+    store.summarizerStatus[sessionId] ?? {
+      status: 'idle',
+      lastUpdate: null,
+      error: null,
+      lastUsage: null,
+      lastAttempt: null,
+    },
+  useSlotHistory: (sessionId: string, key: string) => store.slotHistory[sessionId]?.[key] ?? [],
+  useSessionOpenQuestions: (sessionId: string) => store.sessionOpenQuestions[sessionId] ?? [],
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    Markdown: ({ text }: { text: string }) => <span data-testid="markdown">{text}</span>,
+  };
+});
+
+vi.mock('../../../../context/components/ContextPanel/strips/GoalAttachmentsStrip', () => ({
+  GoalAttachmentsStrip: () => null,
+}));
+
+import { SlotPane } from './SlotPane';
+
+const SESSION = {
+  id: 'session-1',
+  workspaceId: 'workspace-1',
+  workflowRuns: [],
+} as unknown as Session;
+
+beforeEach(() => {
+  store.upsertSessionSlot = vi.fn();
+  store.loadSlotHistory = vi.fn().mockResolvedValue(undefined);
+  store.loadSessionOpenQuestions = vi.fn().mockResolvedValue(undefined);
+  writeText.mockReset();
+  writeText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { writeText },
+  });
+});
+
+afterEach(cleanup);
+
+describe('SlotPane', () => {
+  describe('history panel', () => {
+    it('opens history panel (not a dialog) when history button clicked', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+
+      const historyBtn = screen.getByRole('button', { name: /view history for goal/i });
+      fireEvent.click(historyBtn);
+
+      expect(screen.queryByRole('dialog')).toBeNull();
+      expect(screen.getByText('history: Goal')).toBeDefined();
+    });
+
+    it('lists history entries with author labels and relative timestamps', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      expect(screen.getByText('you')).toBeDefined();
+      expect(screen.getByText('agent')).toBeDefined();
+      expect(screen.getByText('5m ago')).toBeDefined();
+      expect(screen.getByText('1h ago')).toBeDefined();
+    });
+
+    it('closes history panel when close button clicked', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+      expect(screen.getByText('history: Goal')).toBeDefined();
+
+      fireEvent.click(screen.getByRole('button', { name: /close history panel/i }));
+      expect(screen.queryByText('history: Goal')).toBeNull();
+    });
+
+    it('calls loadSlotHistory on open', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      expect(store.loadSlotHistory).toHaveBeenCalledWith('session-1', 'goal');
+    });
+  });
+
+  describe('restore', () => {
+    it('calls upsertSessionSlot and closes panel on restore', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      const restoreButtons = screen.getAllByRole('button', { name: /^restore$/i });
+      const first = restoreButtons[0];
+      if (first != null) {
+        fireEvent.click(first);
+      }
+
+      expect(store.upsertSessionSlot).toHaveBeenCalledWith('session-1', 'goal', 'old goal text');
+      expect(screen.queryByText('history: Goal')).toBeNull();
+    });
+  });
+
+  describe('copy button', () => {
+    it('copies slot value to clipboard for non-summary panes', async () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      const copyBtn = screen.getByRole('button', { name: /^copy$/i });
+      fireEvent.click(copyBtn);
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith('ship the feature');
+      });
+    });
+
+    it('copies per-entry value from history entry copy button', async () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      const entryButtons = screen.getAllByRole('button', { name: /copy this version/i });
+      const first = entryButtons[0];
+      if (first != null) {
+        fireEvent.click(first);
+      }
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith('old goal text');
+      });
+    });
+
+    it('composes shareable document for last_output_summary including goal, summary, decisions, open questions', async () => {
+      render(<SlotPane session={SESSION} slotKey="last_output_summary" />);
+
+      const copyBtn = screen.getByRole('button', { name: /copy shareable summary/i });
+      fireEvent.click(copyBtn);
+
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalled();
+      });
+
+      const written = (writeText.mock.calls as unknown as [string[]][])[0]?.[0] ?? '';
+      expect(written).toContain('## Goal');
+      expect(written).toContain('ship the feature');
+      expect(written).toContain('## Session summary');
+      expect(written).toContain('**Status**: done');
+      expect(written).toContain('## Decisions');
+      expect(written).toContain('use tailwind');
+      expect(written).toContain('## Open questions');
+      expect(written).toContain('what is the deadline?');
+      expect(written).not.toContain('already answered');
+    });
+
+    it('loads open questions for the summary pane so the shareable document is complete', () => {
+      render(<SlotPane session={SESSION} slotKey="last_output_summary" />);
+
+      expect(store.loadSessionOpenQuestions).toHaveBeenCalledWith('session-1');
+    });
+
+    it('does not load open questions for non-summary panes', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      expect(store.loadSessionOpenQuestions).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('expand/collapse entry', () => {
+    it('expands entry on click and collapses on second click', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      const expandButtons = screen.getAllByRole('button', { name: /expand entry/i });
+      expect(expandButtons.length).toBeGreaterThan(0);
+      const first = expandButtons[0];
+      if (first != null) {
+        fireEvent.click(first);
+      }
+
+      expect(screen.getByRole('button', { name: /collapse entry/i })).toBeDefined();
+
+      fireEvent.click(screen.getByRole('button', { name: /collapse entry/i }));
+      expect(screen.getAllByRole('button', { name: /expand entry/i }).length).toBeGreaterThan(0);
+    });
+
+    it('collapses the expanded entry when another entry is expanded', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      fireEvent.click(screen.getByRole('button', { name: /view history for goal/i }));
+
+      const expandButtons = screen.getAllByRole('button', { name: /expand entry/i });
+      expect(expandButtons.length).toBe(2);
+      const [first, second] = expandButtons;
+      if (first != null && second != null) {
+        fireEvent.click(first);
+        expect(screen.getAllByRole('button', { name: /collapse entry/i }).length).toBe(1);
+        fireEvent.click(second);
+      }
+
+      expect(screen.getAllByRole('button', { name: /collapse entry/i }).length).toBe(1);
+      expect(screen.getAllByRole('button', { name: /expand entry/i }).length).toBe(1);
+    });
+  });
+
+  describe('history toggle', () => {
+    it('closes the panel when the history button is clicked again', () => {
+      render(<SlotPane session={SESSION} slotKey="goal" />);
+
+      const historyBtn = screen.getByRole('button', { name: /view history for goal/i });
+      fireEvent.click(historyBtn);
+      expect(screen.getByText('history: Goal')).toBeDefined();
+
+      fireEvent.click(historyBtn);
+      expect(screen.queryByText('history: Goal')).toBeNull();
+    });
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -1,17 +1,19 @@
-import { useEffect, useMemo, useState } from 'react';
-import { CheckSquare, FileText, History, RotateCcw, Target } from 'lucide-react';
-import { Button, Dialog, EmptyState, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, CheckSquare, Copy, FileText, History, Target } from 'lucide-react';
+import { Button, Divider, EmptyState, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
 import type { LucideIcon } from 'lucide-react';
-import type { ContextSlotHistoryEntry, Session, SessionId } from '@goodboy/types';
+import type { Session, SessionId } from '@goodboy/types';
 import {
   useAppStore,
   useSessionLoading,
+  useSessionOpenQuestions,
   useSessionSlots,
   useSlotHistory,
   useSummarizerStatus,
 } from '../../../../../store';
 import { GoalAttachmentsStrip } from '../../../../context/components/ContextPanel/strips/GoalAttachmentsStrip';
 import { PaneShell } from './PaneShell';
+import { SlotHistoryPanel } from './SlotHistoryPanel';
 
 type SlotKey = 'goal' | 'decisions' | 'last_output_summary';
 
@@ -55,19 +57,21 @@ const SLOT_EMPTY_DESCRIPTION: Record<SlotKey, string> = {
 
 const MARKDOWN_SLOTS: ReadonlySet<SlotKey> = new Set<SlotKey>(['decisions', 'last_output_summary']);
 
-type SlotPaneProps = {
+type Props = {
   readonly session: Session;
   readonly slotKey: SlotKey;
 };
 
-export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
+export const SlotPane = ({ session, slotKey }: Props) => {
   const sessionId = session.id as SessionId;
   const slots = useSessionSlots(sessionId);
   const loading = useSessionLoading(sessionId);
   const summarizer = useSummarizerStatus(sessionId);
   const upsertSessionSlot = useAppStore((s) => s.upsertSessionSlot);
   const loadSlotHistory = useAppStore((s) => s.loadSlotHistory);
+  const loadSessionOpenQuestions = useAppStore((s) => s.loadSessionOpenQuestions);
   const history = useSlotHistory(sessionId, slotKey);
+  const openQuestions = useSessionOpenQuestions(sessionId);
 
   const slot = useMemo(() => slots.find((s) => s.key === slotKey), [slots, slotKey]);
   const value = slot?.value ?? '';
@@ -78,211 +82,240 @@ export const SlotPane = ({ session, slotKey }: SlotPaneProps) => {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [valueCopied, setValueCopied] = useState(false);
+  const copyTimer = useRef<number | null>(null);
 
   useEffect(() => {
-    if (!editing) setDraft(value);
+    if (!editing) {
+      setDraft(value);
+    }
   }, [value, editing]);
+
+  useEffect(() => {
+    if (slotKey === 'last_output_summary') {
+      void loadSessionOpenQuestions(sessionId);
+    }
+  }, [slotKey, sessionId, loadSessionOpenQuestions]);
+
+  useEffect(
+    () => () => {
+      if (copyTimer.current !== null) {
+        window.clearTimeout(copyTimer.current);
+      }
+    },
+    [],
+  );
 
   const commit = () => {
     setEditing(false);
-    if (draft !== value) void upsertSessionSlot(sessionId, slotKey, draft);
+    if (draft !== value) {
+      void upsertSessionSlot(sessionId, slotKey, draft);
+    }
   };
 
   const startEditing = () => {
-    if (isSummarizing) return;
+    if (isSummarizing) {
+      return;
+    }
     setEditing(true);
   };
 
-  const openHistory = () => {
+  const toggleHistory = () => {
+    if (historyOpen) {
+      setHistoryOpen(false);
+      return;
+    }
     void loadSlotHistory(sessionId, slotKey);
     setHistoryOpen(true);
   };
 
+  const buildShareableDocument = (): string => {
+    const goalSlot = slots.find((s) => s.key === 'goal');
+    const decisionsSlot = slots.find((s) => s.key === 'decisions');
+    const summarySlot = slots.find((s) => s.key === 'last_output_summary');
+
+    const parts: string[] = [];
+
+    if (goalSlot?.value) {
+      parts.push(`## Goal\n\n${goalSlot.value}`);
+    }
+
+    if (summarySlot?.value) {
+      parts.push(`## Session summary\n\n${summarySlot.value}`);
+    }
+
+    if (decisionsSlot?.value) {
+      parts.push(`## Decisions\n\n${decisionsSlot.value}`);
+    }
+
+    const openOnly = openQuestions.filter((q) => q.status === 'open');
+    if (openOnly.length > 0) {
+      const items = openOnly.map((q) => `- ${q.text}`).join('\n');
+      parts.push(`## Open questions\n\n${items}`);
+    }
+
+    return parts.join('\n\n');
+  };
+
+  const copyValue = async () => {
+    const text = slotKey === 'last_output_summary' ? buildShareableDocument() : value;
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      return;
+    }
+    setValueCopied(true);
+    if (copyTimer.current !== null) {
+      window.clearTimeout(copyTimer.current);
+    }
+    copyTimer.current = window.setTimeout(() => setValueCopied(false), 1500);
+  };
+
   return (
-    <PaneShell
-      title={SLOT_TITLE[slotKey]}
-      description={SLOT_DESCRIPTION[slotKey]}
-      actions={
-        <>
-          {history.length > 0 ? (
-            <button
-              type="button"
-              onClick={openHistory}
-              title="View history"
-              aria-label={`view history for ${SLOT_TITLE[slotKey]}`}
-              className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-            >
-              <History size={15} aria-hidden />
-            </button>
-          ) : null}
-        </>
-      }
-    >
-      <>
-        {slot === undefined && loading.slots ? (
-          <div className="flex flex-col gap-2">
-            <div className="h-4 w-full rounded bg-muted/50" />
-            <div className="h-4 w-3/4 rounded bg-muted/50" />
-          </div>
-        ) : editing ? (
-          <Textarea
-            autoFocus
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commit}
-            onKeyDown={(e) => {
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setDraft(value);
-                setEditing(false);
-              }
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                commit();
-              }
-            }}
-            className="font-mono text-sm"
-            autoGrow
-            maxRows={24}
-          />
-        ) : !hasValue ? (
-          <EmptyState
-            bordered
-            tone={SLOT_TONE[slotKey]}
-            icon={SLOT_ICON[slotKey]}
-            title={SLOT_EMPTY_CTA[slotKey]}
-            description={SLOT_EMPTY_DESCRIPTION[slotKey]}
-            action={
-              <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
-                Add
-              </Button>
-            }
-          />
-        ) : renderAsMarkdown ? (
-          <div
-            role={isSummarizing ? undefined : 'button'}
-            tabIndex={isSummarizing ? -1 : 0}
-            onClick={startEditing}
-            onKeyDown={(e) => {
-              if (isSummarizing) return;
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                setEditing(true);
-              }
-            }}
-            className={cn(
-              'rounded-lg leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_code]:break-all [&_pre]:whitespace-pre-wrap [&_pre]:break-all',
-              isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
-            )}
-          >
-            <Markdown text={value} className="text-sm text-foreground" />
-          </div>
-        ) : (
-          <button
-            type="button"
-            onClick={startEditing}
-            disabled={isSummarizing}
-            className={cn(
-              'whitespace-pre-wrap break-words rounded-lg text-left text-base font-medium leading-relaxed text-foreground transition-colors',
-              isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
-            )}
-          >
-            {value}
-          </button>
-        )}
-
-        {slotKey === 'goal' ? (
-          <GoalAttachmentsStrip owner={{ type: 'session', id: sessionId }} />
-        ) : null}
-
-        <SlotHistoryDialog
-          label={SLOT_TITLE[slotKey]}
-          renderAsMarkdown={renderAsMarkdown}
-          open={historyOpen}
-          entries={history}
-          onRestore={(entry) => {
-            void upsertSessionSlot(sessionId, slotKey, entry.value);
-            setHistoryOpen(false);
-          }}
-          onClose={() => setHistoryOpen(false)}
-        />
-      </>
-    </PaneShell>
-  );
-};
-
-type SlotHistoryDialogProps = {
-  readonly label: string;
-  readonly renderAsMarkdown: boolean;
-  readonly open: boolean;
-  readonly entries: ReadonlyArray<ContextSlotHistoryEntry>;
-  readonly onRestore: (entry: ContextSlotHistoryEntry) => void;
-  readonly onClose: () => void;
-};
-
-const SlotHistoryDialog = ({
-  label,
-  renderAsMarkdown,
-  open,
-  entries,
-  onRestore,
-  onClose,
-}: SlotHistoryDialogProps) => (
-  <Dialog open={open} onClose={onClose} title={`history: ${label}`} size="xl">
-    {entries.length === 0 ? (
-      <p className="text-xs text-muted-foreground italic">no history yet</p>
-    ) : (
-      <ul className="flex flex-col gap-4">
-        {entries.map((entry) => (
-          <li
-            key={entry.id}
-            className="flex flex-col gap-1.5 rounded-md border border-border-soft bg-subtle p-3"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <span
+    <div className="flex h-full min-h-0">
+      <div className="min-h-0 flex-1">
+        <PaneShell
+          title={SLOT_TITLE[slotKey]}
+          description={SLOT_DESCRIPTION[slotKey]}
+          actions={
+            <>
+              {hasValue ? (
+                <button
+                  type="button"
+                  onClick={() => void copyValue()}
+                  title={
+                    valueCopied
+                      ? 'copied'
+                      : slotKey === 'last_output_summary'
+                        ? 'copy shareable summary'
+                        : 'copy'
+                  }
+                  aria-label={
+                    valueCopied
+                      ? 'copied'
+                      : slotKey === 'last_output_summary'
+                        ? 'copy shareable summary'
+                        : 'copy'
+                  }
+                  className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+                >
+                  {valueCopied ? <Check size={15} aria-hidden /> : <Copy size={15} aria-hidden />}
+                </button>
+              ) : null}
+              {history.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={toggleHistory}
+                  title="view history"
+                  aria-label={`view history for ${SLOT_TITLE[slotKey]}`}
+                  className={cn(
+                    'rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
+                    historyOpen && 'bg-foreground/5 text-foreground',
+                  )}
+                >
+                  <History size={15} aria-hidden />
+                </button>
+              ) : null}
+            </>
+          }
+        >
+          <>
+            {slot === undefined && loading.slots ? (
+              <div className="flex flex-col gap-2">
+                <div className="h-4 w-full rounded bg-muted/50" />
+                <div className="h-4 w-3/4 rounded bg-muted/50" />
+              </div>
+            ) : editing ? (
+              <Textarea
+                autoFocus
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                onBlur={commit}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    setDraft(value);
+                    setEditing(false);
+                  }
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                    e.preventDefault();
+                    commit();
+                  }
+                }}
+                className="font-mono text-sm"
+                autoGrow
+                maxRows={24}
+              />
+            ) : !hasValue ? (
+              <EmptyState
+                bordered
+                tone={SLOT_TONE[slotKey]}
+                icon={SLOT_ICON[slotKey]}
+                title={SLOT_EMPTY_CTA[slotKey]}
+                description={SLOT_EMPTY_DESCRIPTION[slotKey]}
+                action={
+                  <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
+                    Add
+                  </Button>
+                }
+              />
+            ) : renderAsMarkdown ? (
+              <div
+                role={isSummarizing ? undefined : 'button'}
+                tabIndex={isSummarizing ? -1 : 0}
+                onClick={startEditing}
+                onKeyDown={(e) => {
+                  if (isSummarizing) {
+                    return;
+                  }
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    setEditing(true);
+                  }
+                }}
                 className={cn(
-                  'rounded-full px-2 py-0.5 text-2xs uppercase tracking-wide',
-                  entry.author === 'user' ? 'bg-accent/10 text-accent' : 'bg-info/10 text-info',
+                  'rounded-lg leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_code]:break-all [&_pre]:whitespace-pre-wrap [&_pre]:break-all',
+                  isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
                 )}
               >
-                {entry.author === 'user' ? 'you' : 'agent'}
-              </span>
-              <span className="text-2xs text-muted-foreground">
-                {formatRelative(entry.createdAt)}
-              </span>
-              <button
-                type="button"
-                onClick={() => onRestore(entry)}
-                title="restore this version"
-                aria-label="restore"
-                className="ml-auto flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-2xs text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                <RotateCcw size={10} aria-hidden />
-                restore
-              </button>
-            </div>
-            {renderAsMarkdown ? (
-              <div className="max-h-40 overflow-hidden text-xs leading-relaxed text-foreground">
-                <Markdown text={entry.value} className="text-xs" />
+                <Markdown text={value} className="text-sm text-foreground" />
               </div>
             ) : (
-              <p className="whitespace-pre-wrap text-xs leading-relaxed text-foreground line-clamp-4">
-                {entry.value}
-              </p>
+              <button
+                type="button"
+                onClick={startEditing}
+                disabled={isSummarizing}
+                className={cn(
+                  'whitespace-pre-wrap break-words rounded-lg text-left text-base font-medium leading-relaxed text-foreground transition-colors',
+                  isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
+                )}
+              >
+                {value}
+              </button>
             )}
-          </li>
-        ))}
-      </ul>
-    )}
-  </Dialog>
-);
 
-function formatRelative(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
-}
+            {slotKey === 'goal' ? (
+              <GoalAttachmentsStrip owner={{ type: 'session', id: sessionId }} />
+            ) : null}
+          </>
+        </PaneShell>
+      </div>
+
+      {historyOpen ? (
+        <>
+          <Divider orientation="vertical" />
+          <SlotHistoryPanel
+            label={SLOT_TITLE[slotKey]}
+            renderAsMarkdown={renderAsMarkdown}
+            entries={history}
+            onRestore={(entry) => {
+              void upsertSessionSlot(sessionId, slotKey, entry.value);
+              setHistoryOpen(false);
+            }}
+            onClose={() => setHistoryOpen(false)}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+};


### PR DESCRIPTION
## What

- Replaces the slot history modal (SlotHistoryDialog) with a right-side panel inside SlotPane: fixed-width column, scrollable list via ScrollFade, short entries (author badge you/agent, relative timestamp, 3-line preview). Clicking an entry expands it in place to full content; expanding another collapses the first; restore preserved per entry. The History button now toggles the panel.
- Copy actions via navigator.clipboard: pane-header copy (raw markdown of the slot), per-version copy in the history panel, check-icon feedback with proper timer cleanup on unmount.
- The Session summary pane copies a full shareable document instead: Goal + Session summary + Decisions + open-status Open questions, ready to paste. Open questions are loaded on pane mount so the document is complete regardless of navigation path.

## Why

The old modal clipped every entry at 160px with no scroll, making history unusable, and sharing the session context required manual text selection. With the structured summary from #973 the composed document is a paste-ready handoff.

## Tests

New SlotPane.test.tsx (13 tests): panel open/close/toggle, entries with author labels and timestamps, restore, single-expand behavior, clipboard copy for slot/entry, shareable document composition (includes open questions, excludes answered), open-questions loading scoped to the summary pane. Desktop 2382 passed, typecheck 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)