### PR TITLE
chore(repo): bump to 0.1.29

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goodboy/desktop",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "goodboy-desktop"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goodboy-desktop"
-version = "0.1.28"
+version = "0.1.29"
 description = "Goodboy desktop app"
 authors = ["Amin Khayam"]
 license = "MIT"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Goodboy",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "identifier": "com.goodboy.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodboy",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "description": "AI workspace orchestrator. Local-first, provider-agnostic.",
   "license": "MIT",


### PR DESCRIPTION
Version bump 0.1.28 → 0.1.29 across all four runbook locations + Cargo.lock crate entry.

Release contents (since v0.1.28, 74 commits): features #951-#974 (resolve story flow, session skeletons, task models + provider defaults, github/gitlab/linear/sentry dashboards, integration gating, contextual workflow header, actionable notifications, structured summary + consolidated decisions, slot history panel) plus safe dependency bumps (#914/#925/#930/#931/#932/#933/#915).

No regressions: all constituent PRs merged through required CI; main HEAD green on ci + rust + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)