### PR TITLE
feat: reviewable PR data layer (mine vs others)

### DIFF
--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -221,6 +221,14 @@ pub async fn gitlab_fetch_assigned_issues(
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct GitlabMrAuthor {
+    pub username: String,
+    pub name: String,
+    #[serde(rename = "avatarUrl", alias = "avatar_url", default)]
+    pub avatar_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct GitlabMergeRequest {
     pub id: i64,
     pub iid: i64,
@@ -243,6 +251,10 @@ pub struct GitlabMergeRequest {
     pub merge_status: Option<String>,
     #[serde(rename = "updatedAt", alias = "updated_at", default)]
     pub updated_at: String,
+    #[serde(default)]
+    pub author: Option<GitlabMrAuthor>,
+    #[serde(default)]
+    pub reviewers: Option<Vec<GitlabMrAuthor>>,
 }
 
 #[tauri::command]
@@ -256,6 +268,23 @@ pub async fn gitlab_fetch_assigned_mrs(
         &host,
         &token,
         "/merge_requests?scope=assigned_to_me&state=opened&order_by=updated_at&per_page=50",
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn gitlab_fetch_project_mrs(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<Vec<GitlabMergeRequest>, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let encoded = encode_project_path(&project_path);
+    get_json(
+        &host,
+        &token,
+        &format!("/projects/{encoded}/merge_requests?state=opened&per_page=100"),
     )
     .await
 }
@@ -401,6 +430,48 @@ mod tests {
         assert!(mr.draft);
         assert_eq!(mr.merge_status.as_deref(), Some("can_be_merged"));
         assert_eq!(mr.updated_at, "2026-07-22T10:00:00Z");
+    }
+
+    #[test]
+    fn merge_request_deserializes_author_and_reviewers() {
+        let raw = r#"{
+            "id": 9,
+            "iid": 2,
+            "project_id": 3,
+            "title": "wip",
+            "description": null,
+            "state": "opened",
+            "web_url": "https://gitlab.com/acme/web/-/merge_requests/2",
+            "source_branch": "ak/feat-x",
+            "target_branch": "main",
+            "author": { "username": "alice", "name": "Alice", "avatar_url": "https://gitlab.com/a.png" },
+            "reviewers": [{ "username": "bob", "name": "Bob" }]
+        }"#;
+        let mr: GitlabMergeRequest = serde_json::from_str(raw).unwrap();
+        let author = mr.author.unwrap();
+        assert_eq!(author.username, "alice");
+        assert_eq!(author.avatar_url.as_deref(), Some("https://gitlab.com/a.png"));
+        let reviewers = mr.reviewers.unwrap();
+        assert_eq!(reviewers[0].username, "bob");
+        assert!(reviewers[0].avatar_url.is_none());
+    }
+
+    #[test]
+    fn merge_request_defaults_missing_author_and_reviewers_to_none() {
+        let raw = r#"{
+            "id": 9,
+            "iid": 2,
+            "project_id": 3,
+            "title": "wip",
+            "description": null,
+            "state": "opened",
+            "web_url": "https://gitlab.com/acme/web/-/merge_requests/2",
+            "source_branch": "ak/feat-x",
+            "target_branch": "main"
+        }"#;
+        let mr: GitlabMergeRequest = serde_json::from_str(raw).unwrap();
+        assert!(mr.author.is_none());
+        assert!(mr.reviewers.is_none());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -236,6 +236,7 @@ pub fn run() {
       gitlab::gitlab_disconnect,
       gitlab::gitlab_fetch_assigned_issues,
       gitlab::gitlab_fetch_assigned_mrs,
+      gitlab::gitlab_fetch_project_mrs,
       gitlab::gitlab_mr_for_branch,
       gitlab::gitlab_create_mr,
       gitlab::gitlab_merge_mr,

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -51,6 +51,12 @@ export type GitlabMergeStatus =
   | 'cannot_be_merged_recheck'
   | null;
 
+export type GitlabMrAuthor = {
+  username: string;
+  name: string;
+  avatarUrl: string | null;
+};
+
 export type GitlabMergeRequest = {
   id: number;
   iid: number;
@@ -65,6 +71,8 @@ export type GitlabMergeRequest = {
   hasConflicts: boolean;
   mergeStatus: GitlabMergeStatus;
   updatedAt: string;
+  author?: GitlabMrAuthor | null;
+  reviewers?: ReadonlyArray<GitlabMrAuthor> | null;
 };
 
 export const gitlabFetchAssignedMrs = async (
@@ -72,6 +80,18 @@ export const gitlabFetchAssignedMrs = async (
   host: string,
 ): Promise<GitlabMergeRequest[]> => {
   return invoke<GitlabMergeRequest[]>('gitlab_fetch_assigned_mrs', { workspaceId, host });
+};
+
+export const gitlabFetchProjectMrs = async (
+  workspaceId: WorkspaceId,
+  host: string,
+  projectPath: string,
+): Promise<GitlabMergeRequest[]> => {
+  return invoke<GitlabMergeRequest[]>('gitlab_fetch_project_mrs', {
+    workspaceId,
+    host,
+    projectPath,
+  });
 };
 
 export type GitlabMergeStatusTone = 'success' | 'danger' | 'muted';

--- a/apps/desktop/src/store/slices/review-prs/index.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RepoPullRequest } from '@goodboy/core';
+import type {
+  GitlabWorkspaceIntegration,
+  IsoDateTime,
+  Workspace,
+  WorkspaceId,
+  WorkspaceIntegrationId,
+} from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+import type { AppStore } from '../../store';
+import type { SetFn } from './types';
+import { createReviewPrsSlice, selectReviewPrs } from './index';
+
+const { detectRepoSlugSpy, listOpenPrsForRepoSpy, gitlabFetchProjectMrsSpy } = vi.hoisted(() => ({
+  detectRepoSlugSpy: vi.fn(),
+  listOpenPrsForRepoSpy: vi.fn(),
+  gitlabFetchProjectMrsSpy: vi.fn(),
+}));
+
+vi.mock('@goodboy/core', () => ({
+  detectRepoSlug: detectRepoSlugSpy,
+  listOpenPrsForRepo: listOpenPrsForRepoSpy,
+}));
+
+vi.mock('../../../features/github/github', () => ({
+  tauriGhRunner: { run: vi.fn(async () => ({ stdout: '', stderr: '', exitCode: 0 })) },
+}));
+
+vi.mock('../../../features/integrations/gitlab/client', () => ({
+  gitlabFetchProjectMrs: gitlabFetchProjectMrsSpy,
+}));
+
+vi.mock('../../../features/worktree/worktree', () => ({
+  worktreeRemoteUrl: vi.fn(async () => 'git@gitlab.com:acme/web.git'),
+}));
+
+const WS_ID = 'workspace-1' as WorkspaceId;
+const NOW = '2026-07-23T00:00:00.000Z' as IsoDateTime;
+
+const buildWorkspace = (): Workspace => {
+  return {
+    id: WS_ID,
+    name: 'ws',
+    rootPath: '/tmp/repo',
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastAccessedAt: NOW,
+  };
+};
+
+const buildGitlabIntegration = (): GitlabWorkspaceIntegration => {
+  return {
+    id: 'wi-1' as WorkspaceIntegrationId,
+    workspaceId: WS_ID,
+    provider: 'gitlab',
+    credentialKey: 'k',
+    config: { userName: 'nbro', userId: '1', host: 'https://gitlab.com' },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+};
+
+const buildRepoPr = (overrides: Partial<RepoPullRequest>): RepoPullRequest => {
+  return {
+    number: 1,
+    title: 'PR',
+    url: 'https://github.com/org/repo/pull/1',
+    state: 'open',
+    mergeable: true,
+    checks: null,
+    baseBranch: 'main',
+    headBranch: 'feature',
+    isDraft: false,
+    reviewDecision: null,
+    body: '',
+    updatedAt: '2026-01-01T00:00:00Z',
+    mergeQueue: null,
+    author: 'alice',
+    reviewRequestLogins: [],
+    ...overrides,
+  };
+};
+
+const buildMr = (overrides: Partial<GitlabMergeRequest>): GitlabMergeRequest => {
+  return {
+    id: 1,
+    iid: 10,
+    projectId: 3,
+    title: 'MR',
+    description: null,
+    state: 'opened',
+    webUrl: 'https://gitlab.com/acme/web/-/merge_requests/10',
+    sourceBranch: 'feat-x',
+    targetBranch: 'main',
+    draft: false,
+    hasConflicts: false,
+    mergeStatus: null,
+    updatedAt: '2026-01-02T00:00:00Z',
+    author: { username: 'other', name: 'Other', avatarUrl: null },
+    reviewers: null,
+    ...overrides,
+  };
+};
+
+type Harness = {
+  slice: ReturnType<typeof createReviewPrsSlice>;
+  getState: () => AppStore;
+};
+
+const buildHarness = (initial: Record<string, unknown>): Harness => {
+  let state = {
+    reviewPrs: {},
+    workspaces: [buildWorkspace()],
+    workspaceIntegrations: {},
+    githubStatus: null,
+    ...initial,
+  } as unknown as AppStore;
+  const get = () => state;
+  const set: SetFn = (p) => {
+    const patch = typeof p === 'function' ? p(state) : p;
+    state = { ...state, ...patch };
+  };
+  return { slice: createReviewPrsSlice(set, get), getState: get };
+};
+
+describe('review-prs slice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    detectRepoSlugSpy.mockResolvedValue(null);
+    listOpenPrsForRepoSpy.mockResolvedValue([]);
+    gitlabFetchProjectMrsSpy.mockResolvedValue([]);
+  });
+
+  it('classifies github PRs as mine or review-requested case-insensitively', async () => {
+    detectRepoSlugSpy.mockResolvedValue('org/repo');
+    listOpenPrsForRepoSpy.mockResolvedValue([
+      buildRepoPr({ number: 1, author: 'me' }),
+      buildRepoPr({ number: 2, author: 'other', reviewRequestLogins: ['ME'] }),
+    ]);
+    const { slice, getState } = buildHarness({
+      githubStatus: { available: true, mode: 'gh-cli', user: 'Me' },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    const result = selectReviewPrs(WS_ID)(getState());
+    const mine = result.items.find((p) => p.number === 1);
+    const other = result.items.find((p) => p.number === 2);
+    expect(mine?.mine).toBe(true);
+    expect(other?.mine).toBe(false);
+    expect(other?.reviewRequested).toBe(true);
+    expect(other?.authorAvatarUrl).toBe('https://github.com/other.png');
+  });
+
+  it('maps gitlab MR states and classifies by integration userName', async () => {
+    gitlabFetchProjectMrsSpy.mockResolvedValue([
+      buildMr({ iid: 1, state: 'opened', draft: true }),
+      buildMr({
+        iid: 2,
+        state: 'opened',
+        author: { username: 'nbro', name: 'N', avatarUrl: 'https://gitlab.com/n.png' },
+      }),
+      buildMr({ iid: 3, state: 'merged' }),
+      buildMr({ iid: 4, state: 'closed', reviewers: [{ username: 'nbro', name: 'N', avatarUrl: null }] }),
+    ]);
+    const { slice, getState } = buildHarness({
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    const result = selectReviewPrs(WS_ID)(getState());
+    const byIid = new Map(result.items.map((p) => [p.number, p]));
+    expect(result.items.map((p) => p.state).sort()).toEqual(
+      ['closed', 'draft', 'merged', 'open'].sort(),
+    );
+    expect(byIid.get(2)?.mine).toBe(true);
+    expect(byIid.get(2)?.authorAvatarUrl).toBe('https://gitlab.com/n.png');
+    expect(byIid.get(1)?.mine).toBe(false);
+    expect(byIid.get(4)?.reviewRequested).toBe(true);
+  });
+
+  it('keeps github results when the gitlab provider fails', async () => {
+    detectRepoSlugSpy.mockResolvedValue('org/repo');
+    listOpenPrsForRepoSpy.mockResolvedValue([buildRepoPr({ number: 7 })]);
+    gitlabFetchProjectMrsSpy.mockRejectedValue(new Error('gitlab down'));
+    const { slice, getState } = buildHarness({
+      githubStatus: { available: true, mode: 'gh-cli', user: 'me' },
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    const result = selectReviewPrs(WS_ID)(getState());
+    expect(result.items.map((p) => p.id)).toEqual(['github:7']);
+    expect(result.error).toContain('gitlab down');
+    expect(result.loading).toBe(false);
+  });
+
+  it('merges both providers sorted by updatedAt descending', async () => {
+    detectRepoSlugSpy.mockResolvedValue('org/repo');
+    listOpenPrsForRepoSpy.mockResolvedValue([
+      buildRepoPr({ number: 1, updatedAt: '2026-01-01T00:00:00Z' }),
+    ]);
+    gitlabFetchProjectMrsSpy.mockResolvedValue([
+      buildMr({ iid: 2, updatedAt: '2026-03-01T00:00:00Z' }),
+    ]);
+    const { slice, getState } = buildHarness({
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await slice.refreshReviewPrs(WS_ID);
+    const result = selectReviewPrs(WS_ID)(getState());
+    expect(result.items.map((p) => p.id)).toEqual(['gitlab:2', 'github:1']);
+    expect(result.fetchedAt).not.toBeNull();
+  });
+
+  it('selectReviewPrs falls back to an empty idle state', () => {
+    const { getState } = buildHarness({});
+    const result = selectReviewPrs('missing-ws' as WorkspaceId)(getState());
+    expect(result).toEqual({ items: [], loading: false, error: null, fetchedAt: null });
+  });
+});

--- a/apps/desktop/src/store/slices/review-prs/index.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.ts
@@ -1,0 +1,11 @@
+import { refreshReviewPrs } from './refreshReviewPrs';
+import type { GetFn, SetFn } from './types';
+
+export const createReviewPrsSlice = (set: SetFn, get: GetFn) => {
+  return {
+    refreshReviewPrs: refreshReviewPrs(set, get),
+  };
+};
+
+export { selectReviewPrs } from './selectReviewPrs';
+export type { ReviewPrsState } from './types';

--- a/apps/desktop/src/store/slices/review-prs/mapGithubPr.ts
+++ b/apps/desktop/src/store/slices/review-prs/mapGithubPr.ts
@@ -1,0 +1,27 @@
+import type { RepoPullRequest } from '@goodboy/core';
+import type { ReviewablePr } from '@goodboy/types';
+
+type Params = {
+  pr: RepoPullRequest;
+  currentUser: string | null;
+};
+
+export const mapGithubPr = ({ pr, currentUser }: Params): ReviewablePr => {
+  const login = currentUser != null && currentUser !== '' ? currentUser.toLowerCase() : null;
+  return {
+    id: `github:${pr.number}`,
+    provider: 'github',
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    author: pr.author,
+    authorAvatarUrl: pr.author !== '' ? `https://github.com/${pr.author}.png` : null,
+    mine: login != null && pr.author.toLowerCase() === login,
+    reviewRequested: login != null && pr.reviewRequestLogins.some((l) => l.toLowerCase() === login),
+    state: pr.state,
+    baseBranch: pr.baseBranch,
+    headBranch: pr.headBranch,
+    isDraft: pr.isDraft,
+    updatedAt: pr.updatedAt,
+  };
+};

--- a/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
+++ b/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
@@ -1,0 +1,40 @@
+import type { PullRequestStateKind, ReviewablePr } from '@goodboy/types';
+import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/client';
+
+type Params = {
+  mr: GitlabMergeRequest;
+  currentUserName: string;
+};
+
+const deriveState = ({ mr }: { mr: GitlabMergeRequest }): PullRequestStateKind => {
+  if (mr.state === 'merged') {
+    return 'merged';
+  }
+  if (mr.state === 'closed' || mr.state === 'locked') {
+    return 'closed';
+  }
+  if (mr.draft) {
+    return 'draft';
+  }
+  return 'open';
+};
+
+export const mapGitlabMr = ({ mr, currentUserName }: Params): ReviewablePr => {
+  const author = mr.author?.username ?? '';
+  return {
+    id: `gitlab:${mr.iid}`,
+    provider: 'gitlab',
+    number: mr.iid,
+    title: mr.title,
+    url: mr.webUrl,
+    author,
+    authorAvatarUrl: mr.author?.avatarUrl ?? null,
+    mine: author !== '' && author === currentUserName,
+    reviewRequested: (mr.reviewers ?? []).some((r) => r.username === currentUserName),
+    state: deriveState({ mr }),
+    baseBranch: mr.targetBranch,
+    headBranch: mr.sourceBranch,
+    isDraft: mr.draft,
+    updatedAt: mr.updatedAt,
+  };
+};

--- a/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
+++ b/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
@@ -1,0 +1,81 @@
+import { detectRepoSlug, listOpenPrsForRepo } from '@goodboy/core';
+import type { GitlabWorkspaceIntegration, ReviewablePr, WorkspaceId } from '@goodboy/types';
+import { tauriGhRunner } from '../../../features/github/github';
+import { gitlabFetchProjectMrs } from '../../../features/integrations/gitlab/client';
+import { worktreeRemoteUrl } from '../../../features/worktree/worktree';
+import { formatError } from '../../../shared/lib/errors';
+import { projectPathFromRemoteUrl } from '../../../shared/lib/remoteHost';
+import { mapGithubPr } from './mapGithubPr';
+import { mapGitlabMr } from './mapGitlabMr';
+import type { GetFn, SetFn } from './types';
+
+export const refreshReviewPrs = (set: SetFn, get: GetFn) => {
+  return async (workspaceId: WorkspaceId) => {
+    if (get().reviewPrs[workspaceId]?.loading) {
+      return;
+    }
+    const workspace = get().workspaces.find((w) => w.id === workspaceId);
+    if (workspace == null) {
+      return;
+    }
+    set((state) => ({
+      reviewPrs: {
+        ...state.reviewPrs,
+        [workspaceId]: {
+          items: state.reviewPrs[workspaceId]?.items ?? [],
+          loading: true,
+          error: null,
+          fetchedAt: state.reviewPrs[workspaceId]?.fetchedAt ?? null,
+        },
+      },
+    }));
+    const items: ReviewablePr[] = [];
+    const errors: string[] = [];
+    try {
+      const slug = await detectRepoSlug(tauriGhRunner, workspace.rootPath, workspaceId);
+      if (slug != null) {
+        const prs = await listOpenPrsForRepo(tauriGhRunner, slug, {
+          cwd: workspace.rootPath,
+          workspaceId,
+        });
+        const currentUser = get().githubStatus?.user ?? null;
+        items.push(...prs.map((pr) => mapGithubPr({ pr, currentUser })));
+      }
+    } catch (err) {
+      errors.push(formatError(err));
+    }
+    const integration = (get().workspaceIntegrations[workspaceId] ?? []).find(
+      (i): i is GitlabWorkspaceIntegration => i.provider === 'gitlab',
+    );
+    if (integration != null) {
+      try {
+        const remoteUrl = await worktreeRemoteUrl(workspace.rootPath);
+        const projectPath = projectPathFromRemoteUrl(remoteUrl);
+        if (projectPath != null) {
+          const mrs = await gitlabFetchProjectMrs(
+            workspaceId,
+            integration.config.host,
+            projectPath,
+          );
+          items.push(
+            ...mrs.map((mr) => mapGitlabMr({ mr, currentUserName: integration.config.userName })),
+          );
+        }
+      } catch (err) {
+        errors.push(formatError(err));
+      }
+    }
+    items.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    set((state) => ({
+      reviewPrs: {
+        ...state.reviewPrs,
+        [workspaceId]: {
+          items,
+          loading: false,
+          error: errors.length > 0 ? errors.join('; ') : null,
+          fetchedAt: new Date().toISOString(),
+        },
+      },
+    }));
+  };
+};

--- a/apps/desktop/src/store/slices/review-prs/selectReviewPrs.ts
+++ b/apps/desktop/src/store/slices/review-prs/selectReviewPrs.ts
@@ -1,0 +1,14 @@
+import type { WorkspaceId } from '@goodboy/types';
+import type { AppStore } from '../../store';
+import type { ReviewPrsState } from './types';
+
+const EMPTY_STATE: ReviewPrsState = {
+  items: [],
+  loading: false,
+  error: null,
+  fetchedAt: null,
+};
+
+export const selectReviewPrs = (workspaceId: WorkspaceId) => {
+  return (state: AppStore): ReviewPrsState => state.reviewPrs[workspaceId] ?? EMPTY_STATE;
+};

--- a/apps/desktop/src/store/slices/review-prs/types.ts
+++ b/apps/desktop/src/store/slices/review-prs/types.ts
@@ -1,0 +1,10 @@
+import type { ReviewablePr } from '@goodboy/types';
+
+export type ReviewPrsState = {
+  readonly items: ReadonlyArray<ReviewablePr>;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly fetchedAt: string | null;
+};
+
+export type { GetFn, SetFn } from '../../slice-types';

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -72,6 +72,7 @@ import { createDiffCommentsSlice } from './slices/diff-comments';
 import { createAttachmentsSlice } from './slices/attachments';
 import { createGithubSlice } from './slices/github';
 import { createGitlabMrSlice } from './slices/gitlab-mr';
+import { createReviewPrsSlice } from './slices/review-prs';
 import { createIntegrationsSlice } from './slices/integrations';
 import { createSidebarSlice } from './slices/sidebar';
 import type { PanelSection } from './slices/sidebar/types';
@@ -410,6 +411,7 @@ export type AppActions = {
     sessionId: SessionId,
     opts?: { force?: boolean; silent?: boolean },
   ): Promise<void>;
+  refreshReviewPrs(workspaceId: WorkspaceId): Promise<void>;
   createMrForSession(
     sessionId: SessionId,
     opts?: { title?: string; description?: string; targetBranch?: string; draft?: boolean },
@@ -581,6 +583,7 @@ export const initialState: AppState = {
   githubStatus: null,
   sessionGithub: {},
   sessionGitlabMr: {},
+  reviewPrs: {},
   sessionPendingResolutions: {},
   volatilePermissionAllows: new Set<string>(),
   agentModelOverride: {},
@@ -625,6 +628,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   ...createAttachmentsSlice(set, get),
   ...createGithubSlice(set, get),
   ...createGitlabMrSlice(set, get),
+  ...createReviewPrsSlice(set, get),
   ...createIntegrationsSlice(set, get),
   ...createSidebarSlice(set, get),
   ...createSessionViewSlice(set, get),

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -57,6 +57,7 @@ import type { DraftAttachment } from './slices/agents/setAgentAttachments';
 import type { AgentQueuedTurn } from './slices/agents/setAgentQueue';
 import type { ProviderSpendEntry } from './slices/budget';
 import type { ProviderLifecycleMap } from './slices/providers';
+import type { ReviewPrsState } from './slices/review-prs/types';
 import type { LensHistory, LensKind, SessionStudio } from './slices/session-view';
 import type { PanelSection } from './slices/sidebar/types';
 import type { UpdaterState } from './slices/updater/state';
@@ -216,6 +217,7 @@ export type AppState = UpdaterState & {
   readonly githubStatus: GhTokenStatus | null;
   readonly sessionGithub: Readonly<Record<SessionId, SessionGithubState>>;
   readonly sessionGitlabMr: Readonly<Record<SessionId, SessionGitlabMrState>>;
+  readonly reviewPrs: Readonly<Record<WorkspaceId, ReviewPrsState>>;
   readonly sessionPendingResolutions: Readonly<Record<SessionId, ReadonlyArray<PendingResolution>>>;
   readonly volatilePermissionAllows: ReadonlySet<string>;
   readonly agentModelOverride: Readonly<Record<AgentId, string>>;

--- a/packages/core/src/github/__tests__/repo-prs.test.ts
+++ b/packages/core/src/github/__tests__/repo-prs.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GhRunner } from '../gh';
+import { listOpenPrsForRepo } from '../repo-prs';
+
+function makeRunner(result: { stdout: string; stderr: string; exitCode: number }): GhRunner {
+  return { run: vi.fn().mockResolvedValue(result) };
+}
+
+function makeJsonRunner(data: unknown): GhRunner {
+  return makeRunner({ stdout: JSON.stringify(data), stderr: '', exitCode: 0 });
+}
+
+const BASE_RAW = {
+  number: 1,
+  title: 'PR title',
+  url: 'https://github.com/org/repo/pull/1',
+  state: 'OPEN' as const,
+  isDraft: false,
+  mergeable: 'MERGEABLE' as const,
+  baseRefName: 'main',
+  headRefName: 'feature',
+  reviewDecision: null as null,
+  statusCheckRollup: null as null,
+  updatedAt: '2024-01-01T00:00:00Z',
+  body: null as null,
+  autoMergeRequest: null as Record<string, unknown> | null,
+  author: { login: 'alice' } as { login?: string | null } | null,
+  reviewRequests: null as ReadonlyArray<{ login?: string | null }> | null,
+};
+
+describe('listOpenPrsForRepo', () => {
+  it('maps author login and review request logins', async () => {
+    const pr = {
+      ...BASE_RAW,
+      author: { login: 'alice' },
+      reviewRequests: [{ login: 'bob' }, { login: 'carol' }],
+    };
+    const runner = makeJsonRunner([pr]);
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result[0]?.author).toBe('alice');
+    expect(result[0]?.reviewRequestLogins).toEqual(['bob', 'carol']);
+    expect(result[0]?.state).toBe('open');
+    expect(result[0]?.baseBranch).toBe('main');
+  });
+
+  it('derives draft state from isDraft like the branch resolver', async () => {
+    const pr = { ...BASE_RAW, isDraft: true };
+    const runner = makeJsonRunner([pr]);
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result[0]?.state).toBe('draft');
+    expect(result[0]?.isDraft).toBe(true);
+  });
+
+  it('sorts results by updatedAt descending', async () => {
+    const prs = [
+      { ...BASE_RAW, number: 1, updatedAt: '2024-01-01T00:00:00Z' },
+      { ...BASE_RAW, number: 2, updatedAt: '2024-06-01T00:00:00Z' },
+    ];
+    const runner = makeJsonRunner(prs);
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result.map((p) => p.number)).toEqual([2, 1]);
+  });
+
+  it('returns empty author for bot or missing author', async () => {
+    const prs = [
+      { ...BASE_RAW, number: 1, author: null },
+      { ...BASE_RAW, number: 2, author: {} },
+    ];
+    const runner = makeJsonRunner(prs);
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result.map((p) => p.author)).toEqual(['', '']);
+  });
+
+  it('drops review requests without a login', async () => {
+    const pr = { ...BASE_RAW, reviewRequests: [{ login: 'bob' }, {}, { login: null }] };
+    const runner = makeJsonRunner([pr]);
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result[0]?.reviewRequestLogins).toEqual(['bob']);
+  });
+
+  it('returns [] when the gh cli fails', async () => {
+    const runner = makeRunner({ stdout: '', stderr: 'no auth', exitCode: 1 });
+    const result = await listOpenPrsForRepo(runner, 'org/repo');
+    expect(result).toEqual([]);
+  });
+
+  it('re-throws non-GhCliError errors', async () => {
+    const runner: GhRunner = {
+      run: vi.fn().mockRejectedValue(new TypeError('network error')),
+    };
+    await expect(listOpenPrsForRepo(runner, 'org/repo')).rejects.toBeInstanceOf(TypeError);
+  });
+});

--- a/packages/core/src/github/index.ts
+++ b/packages/core/src/github/index.ts
@@ -18,6 +18,8 @@ export {
   resolvePrForBranch,
 } from './resolver';
 
+export { listOpenPrsForRepo, type RepoPullRequest } from './repo-prs';
+
 export { fetchPrDiff, parseUnifiedDiff } from './diff';
 
 export { fetchPrDetail } from './details';

--- a/packages/core/src/github/repo-prs.ts
+++ b/packages/core/src/github/repo-prs.ts
@@ -1,0 +1,53 @@
+import type { PullRequestState } from '@goodboy/types';
+import type { GhRunner } from './gh';
+import { GhCliError, runJson } from './gh';
+import { PR_FIELDS, toPullRequestState, type RawPullRequest } from './resolver';
+
+const REPO_PR_FIELDS = [...PR_FIELDS, 'author', 'reviewRequests'] as const;
+
+type RawRepoPullRequest = RawPullRequest & {
+  author: { login?: string | null } | null;
+  reviewRequests: ReadonlyArray<{ login?: string | null }> | null;
+};
+
+export type RepoPullRequest = PullRequestState & {
+  author: string;
+  reviewRequestLogins: ReadonlyArray<string>;
+};
+
+export const listOpenPrsForRepo = async (
+  runner: GhRunner,
+  repo: string,
+  opts: { cwd?: string; token?: string; workspaceId?: string } = {},
+): Promise<ReadonlyArray<RepoPullRequest>> => {
+  const args = [
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--state',
+    'open',
+    '--limit',
+    '100',
+    '--json',
+    REPO_PR_FIELDS.join(','),
+  ];
+  let raw: ReadonlyArray<RawRepoPullRequest>;
+  try {
+    raw = await runJson<ReadonlyArray<RawRepoPullRequest>>(runner, args, opts);
+  } catch (err) {
+    if (err instanceof GhCliError) {
+      return [];
+    }
+    throw err;
+  }
+  return [...raw]
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .map((pr) => ({
+      ...toPullRequestState(pr),
+      author: pr.author?.login ?? '',
+      reviewRequestLogins: (pr.reviewRequests ?? [])
+        .map((r) => r.login ?? '')
+        .filter((login) => login !== ''),
+    }));
+};

--- a/packages/core/src/github/resolver.ts
+++ b/packages/core/src/github/resolver.ts
@@ -2,7 +2,7 @@ import type { LinkedIssue, PullRequestState, PullRequestStateKind } from '@goodb
 import type { GhRunner } from './gh';
 import { GhCliError, runJson } from './gh';
 
-const PR_FIELDS = [
+export const PR_FIELDS = [
   'number',
   'title',
   'url',
@@ -18,7 +18,7 @@ const PR_FIELDS = [
   'autoMergeRequest',
 ] as const;
 
-type RawPullRequest = {
+export type RawPullRequest = {
   number: number;
   title: string;
   url: string;
@@ -95,7 +95,7 @@ function deriveMergeable(raw: RawPullRequest): boolean | null {
   return null;
 }
 
-function toPullRequestState(raw: RawPullRequest): PullRequestState {
+export const toPullRequestState = (raw: RawPullRequest): PullRequestState => {
   const reviewMap: Record<string, PullRequestState['reviewDecision']> = {
     APPROVED: 'approved',
     CHANGES_REQUESTED: 'changes_requested',
@@ -116,7 +116,7 @@ function toPullRequestState(raw: RawPullRequest): PullRequestState {
     updatedAt: raw.updatedAt,
     mergeQueue: raw.autoMergeRequest != null ? { position: null } : null,
   };
-}
+};
 
 export const resolvePrForBranch = async (
   runner: GhRunner,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -255,6 +255,7 @@ export {
   getPrForBranch,
   invalidatePrCache,
   listAssignedIssues,
+  listOpenPrsForRepo,
   listPrsForBranch,
   addReviewThreadReply,
   parseLinkedIssuesFromBody,
@@ -270,6 +271,7 @@ export {
   type PostedThreadReply,
   type PrCacheDeps,
   type PrCacheStore,
+  type RepoPullRequest,
   type ResolvedThread,
 } from './github';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -197,3 +197,4 @@ export type {
   PullRequestState,
   PullRequestStateKind,
 } from './github';
+export type { ReviewablePr, ReviewablePrProvider } from './review-pr';

--- a/packages/types/src/review-pr.ts
+++ b/packages/types/src/review-pr.ts
@@ -1,0 +1,20 @@
+import type { PullRequestStateKind } from './github';
+
+export type ReviewablePrProvider = 'github' | 'gitlab';
+
+export type ReviewablePr = {
+  id: string;
+  provider: ReviewablePrProvider;
+  number: number;
+  title: string;
+  url: string;
+  author: string;
+  authorAvatarUrl: string | null;
+  mine: boolean;
+  reviewRequested: boolean;
+  state: PullRequestStateKind;
+  baseBranch: string;
+  headBranch: string;
+  isDraft: boolean;
+  updatedAt: string;
+};


### PR DESCRIPTION
## Obiettivo
Fondamenta per fare review delle PR degli altri: fetch repo-wide delle PR/MR aperte con autore e classificazione mine/others, dietro un tipo provider-neutro.

Prima area dello stack **PR review** (5 PR). Da NON mergiare finché lo stack non è completo.

## Cosa
- `ReviewablePr` in `packages/types`: tipo neutro (github/gitlab) con `author`, `mine`, `reviewRequested`, `state`, branches.
- `listOpenPrsForRepo` (core): `gh pr list` repo-wide con `author` + `reviewRequests`.
- Rust `gitlab_fetch_project_mrs` + `GitlabMrAuthor`: MR di progetto con payload autore.
- Slice `review-prs`: `refreshReviewPrs` mappa entrambi i provider nel tipo neutro, classifica `mine` confrontando con l'identità connessa (GhTokenStatus.user / gitlab config.userName). Fallimento di un provider non azzera l'altro.

## MUST NOT (verificati)
- `sweepGithub` session-bound e gate `boardReady` invariati.
- Nessun framework provider generico: seam = tipo neutro + due impl.

## Test
typecheck types/core/desktop + 36 core + 75 desktop (review-prs/github/gitlab) + 13 rust, verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)