### PR TITLE
feat: local PR review sessions (read-only agent)

### DIFF
--- a/apps/desktop/src-tauri/src/gitlab.rs
+++ b/apps/desktop/src-tauri/src/gitlab.rs
@@ -343,6 +343,68 @@ pub async fn gitlab_create_mr(
     .await
 }
 
+#[derive(Debug, Deserialize)]
+pub struct GitlabMrChange {
+    pub old_path: String,
+    pub new_path: String,
+    #[serde(default)]
+    pub diff: String,
+    #[serde(default)]
+    pub new_file: bool,
+    #[serde(default)]
+    pub deleted_file: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitlabMrChanges {
+    #[serde(default)]
+    pub changes: Vec<GitlabMrChange>,
+}
+
+fn assemble_mr_diff(changes: &[GitlabMrChange]) -> String {
+    let mut out = String::new();
+    for change in changes {
+        out.push_str(&format!(
+            "diff --git a/{} b/{}\n",
+            change.old_path, change.new_path
+        ));
+        if change.new_file {
+            out.push_str("--- /dev/null\n");
+        } else {
+            out.push_str(&format!("--- a/{}\n", change.old_path));
+        }
+        if change.deleted_file {
+            out.push_str("+++ /dev/null\n");
+        } else {
+            out.push_str(&format!("+++ b/{}\n", change.new_path));
+        }
+        out.push_str(&change.diff);
+        if !change.diff.is_empty() && !change.diff.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    out
+}
+
+#[tauri::command]
+pub async fn gitlab_mr_diff(
+    workspace_id: String,
+    host: String,
+    project_path: String,
+    mr_iid: i64,
+    cache: State<'_, GitlabTokenCache>,
+) -> Result<String, GitlabError> {
+    let token = read_token(&workspace_id, &cache)?;
+    let encoded = encode_project_path(&project_path);
+    let payload: GitlabMrChanges = get_json(
+        &host,
+        &token,
+        &format!("/projects/{encoded}/merge_requests/{mr_iid}/changes"),
+    )
+    .await?;
+    Ok(assemble_mr_diff(&payload.changes))
+}
+
 #[tauri::command]
 pub async fn gitlab_merge_mr(
     workspace_id: String,
@@ -472,6 +534,42 @@ mod tests {
         let mr: GitlabMergeRequest = serde_json::from_str(raw).unwrap();
         assert!(mr.author.is_none());
         assert!(mr.reviewers.is_none());
+    }
+
+    #[test]
+    fn assemble_mr_diff_emits_git_headers_per_change() {
+        let changes = vec![
+            GitlabMrChange {
+                old_path: "src/a.ts".into(),
+                new_path: "src/a.ts".into(),
+                diff: "@@ -1 +1 @@\n-old\n+new\n".into(),
+                new_file: false,
+                deleted_file: false,
+            },
+            GitlabMrChange {
+                old_path: "src/b.ts".into(),
+                new_path: "src/b.ts".into(),
+                diff: "@@ -0,0 +1 @@\n+created".into(),
+                new_file: true,
+                deleted_file: false,
+            },
+            GitlabMrChange {
+                old_path: "src/c.ts".into(),
+                new_path: "src/c.ts".into(),
+                diff: "@@ -1 +0,0 @@\n-gone\n".into(),
+                new_file: false,
+                deleted_file: true,
+            },
+        ];
+        let out = assemble_mr_diff(&changes);
+        assert!(out.contains("diff --git a/src/a.ts b/src/a.ts\n--- a/src/a.ts\n+++ b/src/a.ts\n@@ -1 +1 @@\n-old\n+new\n"));
+        assert!(out.contains("diff --git a/src/b.ts b/src/b.ts\n--- /dev/null\n+++ b/src/b.ts\n@@ -0,0 +1 @@\n+created\n"));
+        assert!(out.contains("diff --git a/src/c.ts b/src/c.ts\n--- a/src/c.ts\n+++ /dev/null\n@@ -1 +0,0 @@\n-gone\n"));
+    }
+
+    #[test]
+    fn assemble_mr_diff_returns_empty_for_no_changes() {
+        assert_eq!(assemble_mr_diff(&[]), "");
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -240,6 +240,7 @@ pub fn run() {
       gitlab::gitlab_mr_for_branch,
       gitlab::gitlab_create_mr,
       gitlab::gitlab_merge_mr,
+      gitlab::gitlab_mr_diff,
     ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");

--- a/apps/desktop/src-tauri/src/worktree.rs
+++ b/apps/desktop/src-tauri/src/worktree.rs
@@ -65,6 +65,8 @@ pub struct CreateArgs {
     /// to derive the worktree directory name.
     #[serde(rename = "existingBranch", default)]
     pub existing_branch: Option<String>,
+    #[serde(rename = "fallbackRef", default)]
+    pub fallback_ref: Option<String>,
     /// Base branch to cut a new branch from. Defaults to `main`. The branch is
     /// always cut from `origin/<base>` (not the local copy) so a stale local
     /// `main` cannot leak unrelated commits into the new branch. Ignored when
@@ -192,19 +194,54 @@ pub fn worktree_create(args: CreateArgs) -> Result<CreatedWorktree, WorktreeErro
                 ],
             )?;
         } else {
-            let _ = git(&repo_path, &["fetch", "origin", name]);
-            git(
-                &repo_path,
-                &[
-                    "worktree",
-                    "add",
-                    "--track",
-                    "-b",
-                    name,
-                    worktree_path.to_string_lossy().as_ref(),
-                    &format!("origin/{name}"),
-                ],
-            )?;
+            let fallback_ref = args
+                .fallback_ref
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty());
+            let fetched = git(&repo_path, &["fetch", "origin", name]).is_ok();
+            let remote_exists = fetched
+                && git(
+                    &repo_path,
+                    &[
+                        "rev-parse",
+                        "--verify",
+                        "--quiet",
+                        &format!("refs/remotes/origin/{name}"),
+                    ],
+                )
+                .is_ok();
+            match fallback_ref {
+                Some(fallback) if !remote_exists => {
+                    git(
+                        &repo_path,
+                        &["fetch", "origin", &format!("{fallback}:{name}")],
+                    )?;
+                    git(
+                        &repo_path,
+                        &[
+                            "worktree",
+                            "add",
+                            worktree_path.to_string_lossy().as_ref(),
+                            name,
+                        ],
+                    )?;
+                }
+                _ => {
+                    git(
+                        &repo_path,
+                        &[
+                            "worktree",
+                            "add",
+                            "--track",
+                            "-b",
+                            name,
+                            worktree_path.to_string_lossy().as_ref(),
+                            &format!("origin/{name}"),
+                        ],
+                    )?;
+                }
+            }
         }
     } else {
         // Cut from `origin/<base>`, not the local checkout, so a stale or

--- a/apps/desktop/src/features/integrations/gitlab/client.ts
+++ b/apps/desktop/src/features/integrations/gitlab/client.ts
@@ -140,6 +140,20 @@ export const gitlabCreateMr = async (args: {
   return invoke<GitlabMergeRequest>('gitlab_create_mr', args);
 };
 
+export const gitlabMrDiff = async (
+  workspaceId: WorkspaceId,
+  host: string,
+  projectPath: string,
+  mrIid: number,
+): Promise<string> => {
+  return invoke<string>('gitlab_mr_diff', {
+    workspaceId,
+    host,
+    projectPath,
+    mrIid,
+  });
+};
+
 export const gitlabMergeMr = async (
   workspaceId: WorkspaceId,
   host: string,

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
@@ -23,6 +23,7 @@ vi.mock('zustand/react/shallow', () => ({
 
 vi.mock('../../../../store/slices/session-view', () => ({
   deriveSessionStage: () => ({ stage: 'running', reason: 'agent running' }),
+  isPrReviewSession: () => false,
 }));
 
 import { useWorkspaceRuns } from './index';

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -11,7 +11,7 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, agentHasUnread } from '../../../../store';
-import { deriveSessionStage } from '../../../../store/slices/session-view';
+import { deriveSessionStage, isPrReviewSession } from '../../../../store/slices/session-view';
 import { inferAgentKindFromName, type AgentKind } from '../../../session/agent-kind';
 import {
   statusToNodeStatus,
@@ -222,6 +222,7 @@ export const useWorkspaceRuns = (
           hasUnread,
           openQuestionCount,
           hasRunningAgent,
+          isPrReview: isPrReviewSession({ agents: runs ?? [] }),
         }).stage;
       }
       return out;

--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -37,6 +37,7 @@ const ALL_KINDS: ReadonlyArray<AgentKind> = [
   'debugger',
   'tester',
   'reviewer',
+  'pr-reviewer',
   'docs',
   'resolver',
   'generic',
@@ -267,11 +268,12 @@ describe('AGENT_KIND_DEFAULTS', () => {
     }
   });
 
-  it('implementer / debugger / reviewer / tester / resolver → sonnet, medium effort', () => {
+  it('implementer / debugger / reviewer / pr-reviewer / tester / resolver → sonnet, medium effort', () => {
     for (const kind of [
       'implementer',
       'debugger',
       'reviewer',
+      'pr-reviewer',
       'tester',
       'resolver',
     ] as AgentKind[]) {
@@ -292,6 +294,7 @@ describe('AGENT_KIND_DEFAULTS', () => {
       'debugger',
       'tester',
       'reviewer',
+      'pr-reviewer',
       'docs',
       'generic',
     ];
@@ -397,6 +400,8 @@ describe('inferAgentKindFromName', () => {
     ['Reproduce', 'debugger'],
     ['Review diff', 'reviewer'],
     ['Verify', 'reviewer'],
+    ['pr reviewer', 'pr-reviewer'],
+    ['PR review #42', 'pr-reviewer'],
     ['Test', 'tester'],
     ['Write docs', 'docs'],
     ['resolve: alice on foo.ts:42', 'resolver'],
@@ -415,7 +420,15 @@ describe('kindConsumesPlan', () => {
   });
 
   it('keeps read/test/doc roles as passthrough', () => {
-    for (const kind of ['scout', 'reviewer', 'tester', 'docs', 'planner', 'resolver'] as const) {
+    for (const kind of [
+      'scout',
+      'reviewer',
+      'pr-reviewer',
+      'tester',
+      'docs',
+      'planner',
+      'resolver',
+    ] as const) {
       expect(kindConsumesPlan(kind)).toBe(false);
     }
   });

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -47,6 +47,7 @@ export const AGENT_KIND_ORDER: ReadonlyArray<AgentKind> = [
   'debugger',
   'tester',
   'reviewer',
+  'pr-reviewer',
   'docs',
   'resolver',
   'generic',
@@ -99,6 +100,11 @@ export const AGENT_KIND_META: Record<AgentKind, { label: string; hint: string; p
       hint: 'Reviews diffs, suggests fixes. Read-only',
       persona: 'specs',
     },
+    'pr-reviewer': {
+      label: 'PR reviewer',
+      hint: 'Reviews an external pull request checked out locally. Read-only',
+      persona: 'monocle',
+    },
     docs: {
       label: 'Docs',
       hint: 'Writes documentation. No production logic',
@@ -141,6 +147,11 @@ export const AGENT_KIND_PALETTE: Record<AgentKind, { bg: string; fg: string; lab
     bg: 'bg-cyan-400',
     fg: 'text-cyan-400',
     label: 'review',
+  },
+  'pr-reviewer': {
+    bg: 'bg-indigo-400',
+    fg: 'text-indigo-400',
+    label: 'pr review',
   },
   docs: {
     bg: 'bg-orange-400',
@@ -189,6 +200,7 @@ export const KIND_TO_ROLE: Record<AgentKind, AgentRole> = {
   debugger: 'investigator',
   tester: 'tester',
   reviewer: 'reviewer',
+  'pr-reviewer': 'reviewer',
   docs: 'custom',
   resolver: 'custom',
   generic: 'custom',
@@ -259,6 +271,12 @@ export const AGENT_KIND_DEFAULTS: Record<
     systemPrompt:
       'you are a review agent. read the diff, identify bugs, style issues, and correctness concerns. ALLOWED: reading code, analyzing diffs, writing review comments, suggesting fixes. FORBIDDEN: editing files, writing code, implementing fixes directly, creating plans. present findings as a structured review. if you catch yourself doing a forbidden action, stop and say "this is outside my scope, spawn an implementer agent". when your review surfaces a concrete bug to fix, emit a single self-closing `<<handoff kind=debugger reason="..." >>` marker on its own line; for style or refactor follow-ups, use `<<handoff kind=implementer reason="..." >>`.',
   },
+  'pr-reviewer': {
+    model: 'claude-sonnet-4-5',
+    effort: 'medium',
+    systemPrompt:
+      "you are a pull request review agent. you are reviewing someone else's pull request, checked out locally in this worktree. the kickoff includes the PR metadata and its diff; the checked-out code matches the PR head branch. ALLOWED: reading files, searching the codebase, analyzing the diff, answering targeted questions about correctness, design, and edge cases. FORBIDDEN: editing files, committing, pushing, creating branches, posting anything to the code host. ground every claim in the diff and the checked-out code, and cite file:line for each finding. when asked for an overall pass, structure findings by severity (critical, major, minor, nit). if you catch yourself doing a forbidden action, stop and say \"this is outside my scope: this session is read-only PR review\".",
+  },
   planner: {
     model: 'claude-opus-4-5',
     effort: 'high',
@@ -298,6 +316,9 @@ export const inferAgentKindFromName = (name: string): AgentKind => {
   const lower = name.toLowerCase();
   if (/^resolve\b|: resolve|resolve(?:r|s|d)?\b/.test(lower)) {
     return 'resolver';
+  }
+  if (/pr[- ]review/.test(lower)) {
+    return 'pr-reviewer';
   }
   if (/scout|explor|survey|map/.test(lower)) {
     return 'scout';

--- a/apps/desktop/src/features/worktree/worktree.ts
+++ b/apps/desktop/src/features/worktree/worktree.ts
@@ -14,6 +14,7 @@ export type CreateWorktreeArgs = {
   readonly slug: string;
   readonly parentDir?: string;
   readonly existingBranch?: string;
+  readonly fallbackRef?: string;
   readonly baseBranch?: string;
   readonly dirName?: string;
 };

--- a/apps/desktop/src/shared/components/AgentAvatar/index.tsx
+++ b/apps/desktop/src/shared/components/AgentAvatar/index.tsx
@@ -18,6 +18,7 @@ const KIND_IMAGE: Record<AgentKind, string | null> = {
   debugger: agentDebugger,
   tester: agentTester,
   reviewer: agentReviewer,
+  'pr-reviewer': agentReviewer,
   docs: agentDocs,
   resolver: null,
 };
@@ -32,6 +33,7 @@ const KIND_COLOR: Record<AgentKind, string> = {
   debugger: 'oklch(0.81 0.14 84)',
   tester: 'oklch(0.78 0.12 188)',
   reviewer: 'oklch(0.78 0.12 213)',
+  'pr-reviewer': 'oklch(0.68 0.16 275)',
   docs: 'oklch(0.77 0.15 62)',
   resolver: 'oklch(0.82 0.18 130)',
 };

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -28,6 +28,7 @@ import { useAppStore } from './store';
 import type { AppState, SessionLoadingFlags, SummarizerSessionStatus } from './types';
 import {
   deriveSessionStage,
+  isPrReviewSession,
   sortAndGroupSessions,
   type GroupedSessions,
 } from './slices/session-view';
@@ -99,6 +100,7 @@ function stageInfoOf(state: AppState, session: Session): SessionStageInfo {
     hasUnread: sessionHasUnreadIn(state, sessionId),
     openQuestionCount: countOpenQuestions(state, sessionId),
     hasRunningAgent: sessionHasRunningAgentIn(state, sessionId),
+    isPrReview: isPrReviewSession({ agents: state.sessionPhaseRuns[sessionId] ?? [] }),
   });
 }
 

--- a/apps/desktop/src/store/slices/review-prs/buildPrReviewKickoff.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/buildPrReviewKickoff.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { ReviewablePr } from '@goodboy/types';
+import { buildPrReviewKickoff } from './buildPrReviewKickoff';
+
+const buildPr = (overrides: Partial<ReviewablePr> = {}): ReviewablePr => {
+  return {
+    id: 'github:7',
+    provider: 'github',
+    repo: 'org/repo',
+    number: 7,
+    title: 'Fix parser',
+    url: 'https://github.com/org/repo/pull/7',
+    author: 'alice',
+    authorAvatarUrl: null,
+    mine: false,
+    reviewRequested: false,
+    state: 'open',
+    baseBranch: 'main',
+    headBranch: 'alice/fix-parser',
+    isDraft: false,
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+};
+
+describe('buildPrReviewKickoff', () => {
+  it('embeds PR metadata, the review contract, and the fenced diff', () => {
+    const out = buildPrReviewKickoff({ pr: buildPr(), diff: 'diff --git a/x b/x\n+x\n' });
+    expect(out).toContain('- number: #7');
+    expect(out).toContain('- author: alice');
+    expect(out).toContain('- url: https://github.com/org/repo/pull/7');
+    expect(out).toContain('- branches: alice/fix-parser -> main');
+    expect(out).toContain('read-only review session');
+    expect(out).toContain('```diff\ndiff --git a/x b/x\n+x\n\n```');
+  });
+
+  it('instructs a structured overview first, then waiting for questions', () => {
+    const out = buildPrReviewKickoff({ pr: buildPr(), diff: '+x' });
+    expect(out).toContain('files touched, intent, risk areas');
+    expect(out).toContain('then wait for questions');
+  });
+
+  it('uses the gitlab bang identifier', () => {
+    const out = buildPrReviewKickoff({
+      pr: buildPr({ provider: 'gitlab', number: 12 }),
+      diff: '+x',
+    });
+    expect(out).toContain('- number: !12');
+  });
+
+  it('truncates an oversized diff and notes the full size', () => {
+    const out = buildPrReviewKickoff({ pr: buildPr(), diff: 'a'.repeat(60005) });
+    expect(out).toContain('[diff truncated at 60000 characters, full diff is 60005 characters]');
+    expect(out).not.toContain('a'.repeat(60001));
+  });
+
+  it('falls back to a placeholder when the diff is missing', () => {
+    const out = buildPrReviewKickoff({ pr: buildPr(), diff: null });
+    expect(out).toContain('The diff could not be fetched');
+    expect(out).not.toContain('```diff');
+  });
+});

--- a/apps/desktop/src/store/slices/review-prs/buildPrReviewKickoff.ts
+++ b/apps/desktop/src/store/slices/review-prs/buildPrReviewKickoff.ts
@@ -1,0 +1,40 @@
+import type { ReviewablePr } from '@goodboy/types';
+
+const DIFF_CHAR_LIMIT = 60000;
+
+type Params = {
+  pr: ReviewablePr;
+  diff: string | null;
+};
+
+const prIdentifier = (pr: ReviewablePr): string =>
+  pr.provider === 'gitlab' ? `!${pr.number}` : `#${pr.number}`;
+
+const diffSection = (diff: string | null): string => {
+  if (diff == null || diff === '') {
+    return 'The diff could not be fetched. Ground your review in the checked-out code instead.';
+  }
+  const truncated =
+    diff.length > DIFF_CHAR_LIMIT
+      ? `${diff.slice(0, DIFF_CHAR_LIMIT)}\n[diff truncated at ${DIFF_CHAR_LIMIT} characters, full diff is ${diff.length} characters]`
+      : diff;
+  return ['```diff', truncated, '```'].join('\n');
+};
+
+export const buildPrReviewKickoff = ({ pr, diff }: Params): string => {
+  return [
+    'PR under review:',
+    `- provider: ${pr.provider}`,
+    `- number: ${prIdentifier(pr)}`,
+    `- title: ${pr.title}`,
+    `- author: ${pr.author}`,
+    `- url: ${pr.url}`,
+    `- branches: ${pr.headBranch} -> ${pr.baseBranch}`,
+    '',
+    'This is a read-only review session: the PR head branch is checked out in this worktree, and you must never edit, commit, push, or post anything to the provider.',
+    '',
+    'First produce a concise structured overview of the change (files touched, intent, risk areas), then wait for questions.',
+    '',
+    diffSection(diff),
+  ].join('\n');
+};

--- a/apps/desktop/src/store/slices/review-prs/index.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.test.ts
@@ -146,6 +146,7 @@ describe('review-prs slice', () => {
     const mine = result.items.find((p) => p.number === 1);
     const other = result.items.find((p) => p.number === 2);
     expect(mine?.mine).toBe(true);
+    expect(mine?.repo).toBe('org/repo');
     expect(other?.mine).toBe(false);
     expect(other?.reviewRequested).toBe(true);
     expect(other?.authorAvatarUrl).toBe('https://github.com/other.png');
@@ -172,6 +173,7 @@ describe('review-prs slice', () => {
       ['closed', 'draft', 'merged', 'open'].sort(),
     );
     expect(byIid.get(2)?.mine).toBe(true);
+    expect(byIid.get(2)?.repo).toBe('acme/web');
     expect(byIid.get(2)?.authorAvatarUrl).toBe('https://gitlab.com/n.png');
     expect(byIid.get(1)?.mine).toBe(false);
     expect(byIid.get(4)?.reviewRequested).toBe(true);

--- a/apps/desktop/src/store/slices/review-prs/index.ts
+++ b/apps/desktop/src/store/slices/review-prs/index.ts
@@ -1,9 +1,11 @@
 import { refreshReviewPrs } from './refreshReviewPrs';
+import { startPrReviewSession } from './startPrReviewSession';
 import type { GetFn, SetFn } from './types';
 
 export const createReviewPrsSlice = (set: SetFn, get: GetFn) => {
   return {
     refreshReviewPrs: refreshReviewPrs(set, get),
+    startPrReviewSession: startPrReviewSession(get),
   };
 };
 

--- a/apps/desktop/src/store/slices/review-prs/mapGithubPr.ts
+++ b/apps/desktop/src/store/slices/review-prs/mapGithubPr.ts
@@ -4,13 +4,15 @@ import type { ReviewablePr } from '@goodboy/types';
 type Params = {
   pr: RepoPullRequest;
   currentUser: string | null;
+  repo: string;
 };
 
-export const mapGithubPr = ({ pr, currentUser }: Params): ReviewablePr => {
+export const mapGithubPr = ({ pr, currentUser, repo }: Params): ReviewablePr => {
   const login = currentUser != null && currentUser !== '' ? currentUser.toLowerCase() : null;
   return {
     id: `github:${pr.number}`,
     provider: 'github',
+    repo,
     number: pr.number,
     title: pr.title,
     url: pr.url,

--- a/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
+++ b/apps/desktop/src/store/slices/review-prs/mapGitlabMr.ts
@@ -4,6 +4,7 @@ import type { GitlabMergeRequest } from '../../../features/integrations/gitlab/c
 type Params = {
   mr: GitlabMergeRequest;
   currentUserName: string;
+  projectPath: string;
 };
 
 const deriveState = ({ mr }: { mr: GitlabMergeRequest }): PullRequestStateKind => {
@@ -19,11 +20,12 @@ const deriveState = ({ mr }: { mr: GitlabMergeRequest }): PullRequestStateKind =
   return 'open';
 };
 
-export const mapGitlabMr = ({ mr, currentUserName }: Params): ReviewablePr => {
+export const mapGitlabMr = ({ mr, currentUserName, projectPath }: Params): ReviewablePr => {
   const author = mr.author?.username ?? '';
   return {
     id: `gitlab:${mr.iid}`,
     provider: 'gitlab',
+    repo: projectPath,
     number: mr.iid,
     title: mr.title,
     url: mr.webUrl,

--- a/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
+++ b/apps/desktop/src/store/slices/review-prs/refreshReviewPrs.ts
@@ -39,7 +39,7 @@ export const refreshReviewPrs = (set: SetFn, get: GetFn) => {
           workspaceId,
         });
         const currentUser = get().githubStatus?.user ?? null;
-        items.push(...prs.map((pr) => mapGithubPr({ pr, currentUser })));
+        items.push(...prs.map((pr) => mapGithubPr({ pr, currentUser, repo: slug })));
       }
     } catch (err) {
       errors.push(formatError(err));
@@ -58,7 +58,9 @@ export const refreshReviewPrs = (set: SetFn, get: GetFn) => {
             projectPath,
           );
           items.push(
-            ...mrs.map((mr) => mapGitlabMr({ mr, currentUserName: integration.config.userName })),
+            ...mrs.map((mr) =>
+              mapGitlabMr({ mr, currentUserName: integration.config.userName, projectPath }),
+            ),
           );
         }
       } catch (err) {

--- a/apps/desktop/src/store/slices/review-prs/startPrReviewSession.test.ts
+++ b/apps/desktop/src/store/slices/review-prs/startPrReviewSession.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  GitlabWorkspaceIntegration,
+  IsoDateTime,
+  ReviewablePr,
+  Session,
+  SessionId,
+  Workspace,
+  WorkspaceId,
+  WorkspaceIntegrationId,
+} from '@goodboy/types';
+import type { CreatedWorktree } from '../../../features/worktree/worktree';
+import type { AppStore } from '../../store';
+import { startPrReviewSession } from './startPrReviewSession';
+
+const { ghPrDiffSpy, gitlabMrDiffSpy } = vi.hoisted(() => ({
+  ghPrDiffSpy: vi.fn(),
+  gitlabMrDiffSpy: vi.fn(),
+}));
+
+vi.mock('../../../features/github/github', () => ({ ghPrDiff: ghPrDiffSpy }));
+
+vi.mock('../../../features/integrations/gitlab/client', () => ({
+  gitlabMrDiff: gitlabMrDiffSpy,
+}));
+
+const WS_ID = 'workspace-1' as WorkspaceId;
+const NOW = '2026-07-23T00:00:00.000Z' as IsoDateTime;
+
+type CreateSessionInput = {
+  workspaceId: WorkspaceId;
+  goal: string;
+  existingBranch?: string;
+  fallbackRef?: string;
+  firstAgentKind?: string;
+  autoRun?: boolean;
+  kickoffPrompt?: string;
+  externalTask?: {
+    provider: string;
+    externalId: string;
+    identifier: string;
+    url: string;
+    title: string;
+  };
+};
+
+const buildWorkspace = (): Workspace => {
+  return {
+    id: WS_ID,
+    name: 'ws',
+    rootPath: '/tmp/repo',
+    createdAt: NOW,
+    updatedAt: NOW,
+    lastAccessedAt: NOW,
+  };
+};
+
+const buildGitlabIntegration = (): GitlabWorkspaceIntegration => {
+  return {
+    id: 'wi-1' as WorkspaceIntegrationId,
+    workspaceId: WS_ID,
+    provider: 'gitlab',
+    credentialKey: 'k',
+    config: { userName: 'nbro', userId: '1', host: 'https://gitlab.com' },
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+};
+
+const buildPr = (overrides: Partial<ReviewablePr> = {}): ReviewablePr => {
+  return {
+    id: 'github:7',
+    provider: 'github',
+    repo: 'org/repo',
+    number: 7,
+    title: 'Fix parser',
+    url: 'https://github.com/org/repo/pull/7',
+    author: 'alice',
+    authorAvatarUrl: null,
+    mine: false,
+    reviewRequested: false,
+    state: 'open',
+    baseBranch: 'main',
+    headBranch: 'alice/fix-parser',
+    isDraft: false,
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+};
+
+const buildHarness = (initial: Record<string, unknown> = {}) => {
+  const createSessionSpy = vi.fn(async (_input: CreateSessionInput) => ({
+    session: { id: 'sess-1' as SessionId } as unknown as Session,
+    worktree: {
+      worktreePath: '/tmp/wt',
+      branchName: 'alice/fix-parser',
+      slug: 'fix-parser',
+      reused: false,
+    } as CreatedWorktree,
+  }));
+  const state = {
+    workspaces: [buildWorkspace()],
+    workspaceIntegrations: {},
+    createSession: createSessionSpy,
+    ...initial,
+  } as unknown as AppStore;
+  return { action: startPrReviewSession(() => state), createSessionSpy };
+};
+
+describe('startPrReviewSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ghPrDiffSpy.mockResolvedValue('diff --git a/x b/x\n+x\n');
+    gitlabMrDiffSpy.mockResolvedValue('diff --git a/y b/y\n+y\n');
+  });
+
+  it('creates a github review session on the PR head branch with fallback ref and linked task', async () => {
+    const { action, createSessionSpy } = buildHarness();
+    const sessionId = await action(WS_ID, buildPr());
+    expect(sessionId).toBe('sess-1');
+    expect(ghPrDiffSpy).toHaveBeenCalledWith('org/repo', 7, '/tmp/repo', WS_ID);
+    const input = createSessionSpy.mock.calls[0]![0];
+    expect(input).toMatchObject({
+      workspaceId: WS_ID,
+      goal: 'Review PR #7: Fix parser',
+      existingBranch: 'alice/fix-parser',
+      fallbackRef: 'pull/7/head',
+      firstAgentKind: 'pr-reviewer',
+      autoRun: true,
+      externalTask: {
+        provider: 'github',
+        externalId: '7',
+        identifier: '#7',
+        url: 'https://github.com/org/repo/pull/7',
+        title: 'Fix parser',
+      },
+    });
+    expect(input.kickoffPrompt).toContain('diff --git a/x b/x');
+  });
+
+  it('fetches gitlab diffs through the integration host and uses MR refs', async () => {
+    const { action, createSessionSpy } = buildHarness({
+      workspaceIntegrations: { [WS_ID]: [buildGitlabIntegration()] },
+    });
+    await action(
+      WS_ID,
+      buildPr({
+        id: 'gitlab:12',
+        provider: 'gitlab',
+        repo: 'acme/web',
+        number: 12,
+        url: 'https://gitlab.com/acme/web/-/merge_requests/12',
+      }),
+    );
+    expect(gitlabMrDiffSpy).toHaveBeenCalledWith(WS_ID, 'https://gitlab.com', 'acme/web', 12);
+    const input = createSessionSpy.mock.calls[0]![0];
+    expect(input.goal).toBe('Review MR !12: Fix parser');
+    expect(input.fallbackRef).toBe('merge-requests/12/head');
+    expect(input.externalTask?.identifier).toBe('!12');
+    expect(input.kickoffPrompt).toContain('diff --git a/y b/y');
+  });
+
+  it('still creates the session with a placeholder when the diff fetch fails', async () => {
+    ghPrDiffSpy.mockRejectedValue(new Error('gh down'));
+    const { action, createSessionSpy } = buildHarness();
+    await action(WS_ID, buildPr());
+    const input = createSessionSpy.mock.calls[0]![0];
+    expect(input.kickoffPrompt).toContain('The diff could not be fetched');
+    expect(input.kickoffPrompt).not.toContain('```diff');
+  });
+
+  it('refuses to start a review session on an own PR', async () => {
+    const { action, createSessionSpy } = buildHarness();
+    await expect(action(WS_ID, buildPr({ mine: true }))).rejects.toThrow(/own pull request/);
+    expect(createSessionSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/review-prs/startPrReviewSession.ts
+++ b/apps/desktop/src/store/slices/review-prs/startPrReviewSession.ts
@@ -1,0 +1,70 @@
+import type {
+  GitlabWorkspaceIntegration,
+  ReviewablePr,
+  SessionId,
+  WorkspaceId,
+} from '@goodboy/types';
+import { ghPrDiff } from '../../../features/github/github';
+import { gitlabMrDiff } from '../../../features/integrations/gitlab/client';
+import { buildPrReviewKickoff } from './buildPrReviewKickoff';
+import type { GetFn } from './types';
+
+type FetchDiffParams = {
+  get: GetFn;
+  workspaceId: WorkspaceId;
+  pr: ReviewablePr;
+  rootPath: string;
+};
+
+const fetchDiff = async ({ get, workspaceId, pr, rootPath }: FetchDiffParams): Promise<string> => {
+  if (pr.provider === 'github') {
+    return ghPrDiff(pr.repo, pr.number, rootPath, workspaceId);
+  }
+  const integration = (get().workspaceIntegrations[workspaceId] ?? []).find(
+    (i): i is GitlabWorkspaceIntegration => i.provider === 'gitlab',
+  );
+  if (integration == null) {
+    throw new Error(`gitlab integration not connected for workspace ${workspaceId}`);
+  }
+  return gitlabMrDiff(workspaceId, integration.config.host, pr.repo, pr.number);
+};
+
+export const startPrReviewSession = (get: GetFn) => {
+  return async (workspaceId: WorkspaceId, pr: ReviewablePr): Promise<SessionId> => {
+    if (pr.mine) {
+      throw new Error(`cannot start a review session on an own pull request: ${pr.id}`);
+    }
+    const workspace = get().workspaces.find((w) => w.id === workspaceId);
+    if (workspace == null) {
+      throw new Error(`workspace not found: ${workspaceId}`);
+    }
+    let diff: string | null = null;
+    try {
+      diff = await fetchDiff({ get, workspaceId, pr, rootPath: workspace.rootPath });
+    } catch {
+      diff = null;
+    }
+    const kickoffPrompt = buildPrReviewKickoff({ pr, diff });
+    const isGitlab = pr.provider === 'gitlab';
+    const goal = isGitlab
+      ? `Review MR !${pr.number}: ${pr.title}`
+      : `Review PR #${pr.number}: ${pr.title}`;
+    const { session } = await get().createSession({
+      workspaceId,
+      goal,
+      existingBranch: pr.headBranch,
+      fallbackRef: isGitlab ? `merge-requests/${pr.number}/head` : `pull/${pr.number}/head`,
+      firstAgentKind: 'pr-reviewer',
+      autoRun: true,
+      kickoffPrompt,
+      externalTask: {
+        provider: pr.provider,
+        externalId: String(pr.number),
+        identifier: isGitlab ? `!${pr.number}` : `#${pr.number}`,
+        url: pr.url,
+        title: pr.title,
+      },
+    });
+    return session.id;
+  };
+};

--- a/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
+++ b/apps/desktop/src/store/slices/session-view/deriveSessionStage.ts
@@ -6,6 +6,7 @@ type Params = {
   hasUnread: boolean;
   openQuestionCount: number;
   hasRunningAgent?: boolean;
+  isPrReview?: boolean;
 };
 
 const isPrLive = (pr: PullRequestState | null): pr is PullRequestState =>
@@ -20,6 +21,7 @@ export const deriveSessionStage = ({
   hasUnread,
   openQuestionCount,
   hasRunningAgent = false,
+  isPrReview = false,
 }: Params): SessionStageInfo => {
   if (session.state.kind === 'error') {
     return { stage: 'attention', reason: 'agent errored' };
@@ -47,6 +49,9 @@ export const deriveSessionStage = ({
   }
   if (hasUnread) {
     return { stage: 'attention', reason: 'unread agent reply' };
+  }
+  if (isPrReview && pr === null) {
+    return { stage: 'review', reason: 'reviewing an external PR' };
   }
   if (pr === null) {
     return { stage: 'building', reason: 'no PR yet' };

--- a/apps/desktop/src/store/slices/session-view/index.ts
+++ b/apps/desktop/src/store/slices/session-view/index.ts
@@ -15,6 +15,7 @@ import type { GetFn, SessionViewSlice, SetFn } from './types';
 
 export { sortAndGroupSessions } from './sortAndGroupSessions';
 export { deriveSessionStage } from './deriveSessionStage';
+export { isPrReviewSession } from './isPrReviewSession';
 export { readPersistedLens } from './workSurfaceStorage';
 export { LENS_KINDS } from './types';
 export type { GroupedSessions, SessionViewSlice } from './types';

--- a/apps/desktop/src/store/slices/session-view/isPrReviewSession.ts
+++ b/apps/desktop/src/store/slices/session-view/isPrReviewSession.ts
@@ -1,0 +1,9 @@
+import type { Agent } from '@goodboy/types';
+import { classifyAgent } from '../../../features/session/agent-kind';
+
+type Params = {
+  agents: ReadonlyArray<Agent>;
+};
+
+export const isPrReviewSession = ({ agents }: Params): boolean =>
+  agents.some((agent) => classifyAgent(agent, null) === 'pr-reviewer');

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -54,11 +54,13 @@ type Input = {
   branchPrefix?: string;
   branchSlug?: string;
   existingBranch?: string;
+  fallbackRef?: string;
   providerPreference?: SessionProviderPreference;
   workflowId?: WorkflowId;
   autoRun?: boolean;
   firstAgentKind?: AgentKind;
   firstAgentModel?: string;
+  kickoffPrompt?: string;
   externalTask?: {
     provider: SessionExternalTaskProvider;
     externalId: string;
@@ -80,11 +82,13 @@ export const createSession = (set: SetFn, get: GetFn) => {
     branchPrefix,
     branchSlug,
     existingBranch,
+    fallbackRef,
     providerPreference,
     workflowId,
     autoRun,
     firstAgentKind,
     firstAgentModel: requestedModel,
+    kickoffPrompt,
     externalTask,
     attachmentInputs,
     mobileShared = false,
@@ -98,6 +102,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
     const slugSeed =
       branchSlug?.trim() || (goal.trim().length > 0 ? goal : `session-${Date.now()}`);
     const trimmedExisting = existingBranch?.trim();
+    const trimmedFallbackRef = fallbackRef?.trim();
     const sessionId = crypto.randomUUID() as SessionId;
     if (mobileShared) {
       markSessionMobileShared(sessionId);
@@ -121,6 +126,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
           parentDir: compositeDir,
           dirName: member.mountName,
           ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
+          ...(trimmedExisting && trimmedFallbackRef ? { fallbackRef: trimmedFallbackRef } : {}),
         });
         memberWorktrees.push({ member, worktree: wt });
       }
@@ -132,6 +138,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
         branchPrefix: prefix,
         slug: slugSeed,
         ...(trimmedExisting ? { existingBranch: trimmedExisting } : {}),
+        ...(trimmedExisting && trimmedFallbackRef ? { fallbackRef: trimmedFallbackRef } : {}),
       });
     }
 
@@ -353,8 +360,11 @@ export const createSession = (set: SetFn, get: GetFn) => {
       void get().reprocessGoalForWorkflow(session.id);
     }
 
+    const trimmedKickoffPrompt = kickoffPrompt?.trim();
     if (firstStepPromptPrefix.length > 0) {
       void get().sendTurn({ sessionId: session.id, content: firstStepPromptPrefix });
+    } else if (firstAgent != null && trimmedKickoffPrompt != null && trimmedKickoffPrompt !== '') {
+      void get().sendTurn({ sessionId: session.id, content: trimmedKickoffPrompt });
     } else if (firstAgentKind && firstAgentKind !== 'generic' && goalText.length > 0) {
       void get().sendTurn({ sessionId: session.id, content: goalText });
     }

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -50,6 +50,7 @@ import type {
   SessionSortKey,
   SessionGroupKey,
   TaskModelPreference,
+  ReviewablePr,
 } from '@goodboy/types';
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
 import { resolveSettings } from '@goodboy/core';
@@ -168,11 +169,13 @@ export type AppActions = {
     branchPrefix?: string;
     branchSlug?: string;
     existingBranch?: string;
+    fallbackRef?: string;
     providerPreference?: SessionProviderPreference;
     workflowId?: WorkflowId;
     autoRun?: boolean;
     firstAgentKind?: AgentKind;
     firstAgentModel?: string;
+    kickoffPrompt?: string;
     externalTask?: {
       provider: SessionExternalTaskProvider;
       externalId: string;
@@ -412,6 +415,7 @@ export type AppActions = {
     opts?: { force?: boolean; silent?: boolean },
   ): Promise<void>;
   refreshReviewPrs(workspaceId: WorkspaceId): Promise<void>;
+  startPrReviewSession(workspaceId: WorkspaceId, pr: ReviewablePr): Promise<SessionId>;
   createMrForSession(
     sessionId: SessionId,
     opts?: { title?: string; description?: string; targetBranch?: string; draft?: boolean },

--- a/packages/core/src/first-turn-classifier.ts
+++ b/packages/core/src/first-turn-classifier.ts
@@ -6,6 +6,7 @@ export type AgentKindLabel =
   | 'tester'
   | 'docs'
   | 'reviewer'
+  | 'pr-reviewer'
   | 'resolver'
   | 'generic';
 

--- a/packages/types/src/review-pr.ts
+++ b/packages/types/src/review-pr.ts
@@ -5,6 +5,7 @@ export type ReviewablePrProvider = 'github' | 'gitlab';
 export type ReviewablePr = {
   id: string;
   provider: ReviewablePrProvider;
+  repo: string;
   number: number;
   title: string;
   url: string;


### PR DESCRIPTION
## Obiettivo
Da una PR altrui: apri una sessione di review locale (worktree sul branch della PR) e itera con un agent read-only che ragiona sul diff, prima di scrivere qualsiasi commento.

Area 2 dello stack **PR review**. Base: `ak/feat-pr-review-data`. Da NON mergiare da sola.

## Cosa
- Agent kind `pr-reviewer` (indigo, read-only assoluto: no edit/commit/push), stesso meccanismo di enforcement di scout/reviewer.
- `startPrReviewSession`: `createSession` con `existingBranch` = head della PR, external task linkato, primo turn con il diff (github `ghPrDiff`, gitlab nuovo `gitlab_mr_diff`) + metadati.
- Fallback fork: `git fetch origin pull/N/head` (github) / `merge-requests/N/head` (gitlab) quando il branch non è su origin (`fallbackRef` in `worktree.rs`).
- `isPrReviewSession`: lo stage engine mette la sessione in `review`, niente nudge verso "Create PR".

## MUST NOT (verificati)
- Turn engine invariato. Nessuna scrittura consentita all'agent di review.

## Test
typecheck x3 + 133 desktop mirati + 49 sessions/turn/agents + 94 rust, verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)