### PR TITLE
feat: PR review UI (mine/others filter + review board)

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.test.tsx
@@ -37,6 +37,16 @@ vi.mock('./GithubIssueDetailPanel', () => ({
     <div>{issue?.title ?? 'No issue detail'}</div>
   ),
 }));
+vi.mock('../../../review/components/ReviewInboxList', () => ({
+  ReviewInboxList: ({ provider, scope }: { provider: string; scope: string }) => (
+    <div>
+      Review inbox {provider} {scope}
+    </div>
+  ),
+}));
+vi.mock('../../../review/components/ReviewPrDetailPanel', () => ({
+  ReviewPrDetailPanel: () => <div>Review pull request detail</div>,
+}));
 vi.mock('../../../../shared/components/StudioShell', () => ({
   StudioShell: ({
     headerAccessory,
@@ -88,8 +98,24 @@ describe('GitHubStudio', () => {
     expect(screen.getByRole('tab', { name: 'Pull requests' }).getAttribute('aria-selected')).toBe(
       'true',
     );
+    expect(screen.getByRole('radio', { name: 'Mine' }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByText('Pull request inbox')).toBeDefined();
     expect(screen.getByText('Pull request detail')).toBeDefined();
+  });
+
+  it('switches to the review inbox for the others and all scopes', () => {
+    renderStudio();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Others' }));
+    expect(screen.getByText('Review inbox github others')).toBeDefined();
+    expect(screen.getByText('Review pull request detail')).toBeDefined();
+    expect(screen.queryByText('Pull request inbox')).toBeNull();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'All' }));
+    expect(screen.getByText('Review inbox github all')).toBeDefined();
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Mine' }));
+    expect(screen.getByText('Pull request inbox')).toBeDefined();
   });
 
   it('renders grouped assigned issues in the issues tab', () => {

--- a/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cn, Divider, ScrollFade } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
-import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
+import type { GithubIssue, ReviewablePr, SessionId, WorkspaceId } from '@goodboy/types';
 import { InboxList } from './InboxList';
 import { IssueInbox } from './IssueInbox';
 import { PrDetailPanel } from './PrDetailPanel';
@@ -10,6 +10,12 @@ import { useGithubInbox } from './useGithubInbox';
 import { useGithubIssues } from './useGithubIssues';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+import {
+  SegmentedControl,
+  type SegmentedOption,
+} from '../../../../shared/components/SegmentedControl';
+import { ReviewInboxList } from '../../../review/components/ReviewInboxList';
+import { ReviewPrDetailPanel } from '../../../review/components/ReviewPrDetailPanel';
 import { IntegrationGlyph } from '../../../integrations/components/IntegrationGlyph';
 import { resolveIntegrationConnection } from '../../../integrations/connection';
 import { useRemoteHostKind } from '../../../worktree/useRemoteHostKind';
@@ -17,9 +23,17 @@ import { MissingGithubRemoteEmptyState } from '../MissingGithubRemoteEmptyState'
 
 type Tab = 'pull-requests' | 'issues';
 
+type ReviewScope = 'mine' | 'others' | 'all';
+
 const TABS: ReadonlyArray<StudioTab<Tab>> = [
   { value: 'pull-requests', label: 'Pull requests' },
   { value: 'issues', label: 'Issues' },
+];
+
+const REVIEW_SCOPES: ReadonlyArray<SegmentedOption<ReviewScope>> = [
+  { value: 'mine', label: 'Mine' },
+  { value: 'others', label: 'Others' },
+  { value: 'all', label: 'All' },
 ];
 
 type Props = {
@@ -55,6 +69,8 @@ export const GitHubStudio = ({
   const [focused, setFocused] = useState<SessionId | null>(initialSessionId);
   const [focusedIssue, setFocusedIssue] = useState<GithubIssue | null>(null);
   const [tab, setTab] = useState<Tab>(initialIssueExternalId == null ? 'pull-requests' : 'issues');
+  const [reviewScope, setReviewScope] = useState<ReviewScope>('mine');
+  const [focusedReviewPr, setFocusedReviewPr] = useState<ReviewablePr | null>(null);
 
   useEffect(() => {
     if (initialIssueExternalId == null) {
@@ -146,17 +162,45 @@ export const GitHubStudio = ({
           </div>
         ) : tab === 'pull-requests' ? (
           <>
-            <ScrollFade className="w-72 shrink-0" fadeSize={24}>
-              <InboxList groups={groups} focusedSessionId={focused} onSelect={setFocused} />
-            </ScrollFade>
+            <div className="flex w-72 shrink-0 flex-col">
+              <div className="shrink-0 px-3 pt-3">
+                <SegmentedControl
+                  ariaLabel="Review inbox filter"
+                  options={REVIEW_SCOPES}
+                  value={reviewScope}
+                  onChange={setReviewScope}
+                />
+              </div>
+              {reviewScope === 'mine' ? (
+                <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+                  <InboxList groups={groups} focusedSessionId={focused} onSelect={setFocused} />
+                </ScrollFade>
+              ) : (
+                <ReviewInboxList
+                  workspaceId={workspaceId}
+                  provider="github"
+                  scope={reviewScope}
+                  focusedPrId={focusedReviewPr?.id ?? null}
+                  onSelect={setFocusedReviewPr}
+                />
+              )}
+            </div>
             <Divider orientation="vertical" />
             <div className="min-h-0 flex-1">
-              <PrDetailPanel
-                sessionId={focused}
-                initialPrNumber={onInitialSession ? initialPrNumber : null}
-                initialThreadId={onInitialSession ? initialThreadId : null}
-                onClose={requestClose}
-              />
+              {reviewScope === 'mine' ? (
+                <PrDetailPanel
+                  sessionId={focused}
+                  initialPrNumber={onInitialSession ? initialPrNumber : null}
+                  initialThreadId={onInitialSession ? initialThreadId : null}
+                  onClose={requestClose}
+                />
+              ) : (
+                <ReviewPrDetailPanel
+                  pr={focusedReviewPr}
+                  workspaceId={workspaceId}
+                  onClose={requestClose}
+                />
+              )}
             </div>
           </>
         ) : (

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.test.tsx
@@ -34,6 +34,16 @@ vi.mock('./useGitlabMrs', () => ({
 vi.mock('./IssueInbox', () => ({ IssueInbox: () => <div>Issue inbox</div> }));
 vi.mock('./IssueDetailPanel', () => ({ IssueDetailPanel: () => <div>Issue detail</div> }));
 vi.mock('./MrDetailPanel', () => ({ MrDetailPanel: () => <div>Merge request detail</div> }));
+vi.mock('../../../review/components/ReviewInboxList', () => ({
+  ReviewInboxList: ({ provider, scope }: { provider: string; scope: string }) => (
+    <div>
+      Review inbox {provider} {scope}
+    </div>
+  ),
+}));
+vi.mock('../../../review/components/ReviewPrDetailPanel', () => ({
+  ReviewPrDetailPanel: () => <div>Review merge request detail</div>,
+}));
 vi.mock('../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(
@@ -108,9 +118,26 @@ describe('GitlabStudio', () => {
     );
     fireEvent.click(screen.getByRole('tab', { name: 'Merge requests' }));
 
+    expect(screen.getByRole('radio', { name: 'Mine' }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByText('acme/web')).toBeDefined();
     expect(screen.getByText('Add merge request dashboard')).toBeDefined();
     expect(screen.getByText('Merge request detail')).toBeDefined();
+  });
+
+  it('switches the merge requests tab to the shared review inbox for others', () => {
+    render(
+      <GitlabStudio
+        workspaceId={'workspace-1' as WorkspaceId}
+        workspaceName="Goodboy"
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('tab', { name: 'Merge requests' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Others' }));
+
+    expect(screen.getByText('Review inbox gitlab others')).toBeDefined();
+    expect(screen.getByText('Review merge request detail')).toBeDefined();
+    expect(screen.queryByText('Merge request detail')).toBeNull();
   });
 
   it('renders the disconnected state and disables both data hooks', () => {

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { cn, Divider } from '@goodboy/ui';
 import { RefreshCw } from 'lucide-react';
-import type { WorkspaceId } from '@goodboy/types';
+import type { ReviewablePr, WorkspaceId } from '@goodboy/types';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { IntegrationGlyph } from '../../components/IntegrationGlyph';
 import { EMPTY_ARRAY, useAppStore } from '../../../../store';
@@ -15,12 +15,26 @@ import { useGitlabIssues } from './useGitlabIssues';
 import { useGitlabMrs } from './useGitlabMrs';
 import type { GitlabIssue, GitlabMergeRequest } from '../client';
 import { StudioTabs, type StudioTab } from '../../../../shared/components/StudioTabs';
+import {
+  SegmentedControl,
+  type SegmentedOption,
+} from '../../../../shared/components/SegmentedControl';
+import { ReviewInboxList } from '../../../review/components/ReviewInboxList';
+import { ReviewPrDetailPanel } from '../../../review/components/ReviewPrDetailPanel';
 
 type Tab = 'issues' | 'merge-requests';
+
+type ReviewScope = 'mine' | 'others' | 'all';
 
 const TABS: ReadonlyArray<StudioTab<Tab>> = [
   { value: 'issues', label: 'Issues' },
   { value: 'merge-requests', label: 'Merge requests' },
+];
+
+const REVIEW_SCOPES: ReadonlyArray<SegmentedOption<ReviewScope>> = [
+  { value: 'mine', label: 'Mine' },
+  { value: 'others', label: 'Others' },
+  { value: 'all', label: 'All' },
 ];
 
 type Props = {
@@ -48,6 +62,8 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
   const [focused, setFocused] = useState<GitlabIssue | null>(null);
   const [focusedMr, setFocusedMr] = useState<GitlabMergeRequest | null>(null);
   const [tab, setTab] = useState<Tab>('issues');
+  const [reviewScope, setReviewScope] = useState<ReviewScope>('mine');
+  const [focusedReviewPr, setFocusedReviewPr] = useState<ReviewablePr | null>(null);
 
   useEffect(() => {
     if (focused !== null) {
@@ -148,24 +164,52 @@ export const GitlabStudio = ({ workspaceId, workspaceName, initialIssueId, onClo
           </>
         ) : (
           <>
-            <div className="w-72 shrink-0">
-              <MrInbox
-                groups={mergeRequests.groups}
-                focusedMrId={focusedMr?.id ?? null}
-                onSelect={setFocusedMr}
-                loading={mergeRequests.loading}
-                error={mergeRequests.error}
-              />
+            <div className="flex w-72 shrink-0 flex-col">
+              <div className="shrink-0 px-3 pt-3">
+                <SegmentedControl
+                  ariaLabel="Review inbox filter"
+                  options={REVIEW_SCOPES}
+                  value={reviewScope}
+                  onChange={setReviewScope}
+                />
+              </div>
+              {reviewScope === 'mine' ? (
+                <div className="min-h-0 flex-1">
+                  <MrInbox
+                    groups={mergeRequests.groups}
+                    focusedMrId={focusedMr?.id ?? null}
+                    onSelect={setFocusedMr}
+                    loading={mergeRequests.loading}
+                    error={mergeRequests.error}
+                  />
+                </div>
+              ) : (
+                <ReviewInboxList
+                  workspaceId={workspaceId}
+                  provider="gitlab"
+                  scope={reviewScope}
+                  focusedPrId={focusedReviewPr?.id ?? null}
+                  onSelect={setFocusedReviewPr}
+                />
+              )}
             </div>
             <Divider orientation="vertical" />
             <div className="min-h-0 flex-1">
-              <MrDetailPanel
-                mr={focusedMr}
-                workspaceId={workspaceId}
-                host={mergeRequests.host}
-                onRefresh={mergeRequests.refetch}
-                onClose={requestClose}
-              />
+              {reviewScope === 'mine' ? (
+                <MrDetailPanel
+                  mr={focusedMr}
+                  workspaceId={workspaceId}
+                  host={mergeRequests.host}
+                  onRefresh={mergeRequests.refetch}
+                  onClose={requestClose}
+                />
+              ) : (
+                <ReviewPrDetailPanel
+                  pr={focusedReviewPr}
+                  workspaceId={workspaceId}
+                  onClose={requestClose}
+                />
+              )}
             </div>
           </>
         )

--- a/apps/desktop/src/features/review/components/AuthorAvatar/index.tsx
+++ b/apps/desktop/src/features/review/components/AuthorAvatar/index.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+
+type Props = {
+  readonly author: string;
+  readonly avatarUrl: string | null;
+};
+
+export const AuthorAvatar = ({ author, avatarUrl }: Props) => {
+  const [failed, setFailed] = useState(false);
+  const initial = author.slice(0, 1).toUpperCase();
+
+  if (avatarUrl == null || failed) {
+    return (
+      <span
+        aria-hidden
+        className="flex size-4 shrink-0 items-center justify-center rounded-full bg-muted text-[8px] font-semibold text-muted-foreground"
+      >
+        {initial !== '' ? initial : '?'}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={avatarUrl}
+      alt=""
+      aria-hidden
+      onError={() => setFailed(true)}
+      className="size-4 shrink-0 rounded-full object-cover"
+    />
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/DraftCard.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Trash2 } from 'lucide-react';
+import { Textarea, cn } from '@goodboy/ui';
+import type { PrReviewDraft } from '@goodboy/types';
+
+type Props = {
+  readonly draft: PrReviewDraft;
+  readonly onEdit: (body: string) => void;
+  readonly onDiscard: () => void;
+};
+
+export const DraftCard = ({ draft, onEdit, onDiscard }: Props) => {
+  const [editing, setEditing] = useState(false);
+  const [body, setBody] = useState(draft.body);
+  const trimmed = body.trim();
+
+  const startEditing = () => {
+    setBody(draft.body);
+    setEditing(true);
+  };
+
+  const save = () => {
+    if (trimmed.length === 0) {
+      return;
+    }
+    onEdit(trimmed);
+    setEditing(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-md border-l-2 bg-muted/20 px-3 py-2',
+        draft.stale ? 'border-warning/70 opacity-70' : 'border-indigo-400/70',
+      )}
+    >
+      <div className="flex items-center gap-1.5">
+        <span className="min-w-0 truncate font-mono text-2xs text-muted-foreground">
+          {draft.path}:{draft.line}
+        </span>
+        <span
+          className={cn(
+            'shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+            draft.origin === 'agent'
+              ? 'bg-indigo-400/15 text-indigo-600'
+              : 'bg-muted text-muted-foreground',
+          )}
+        >
+          {draft.origin === 'agent' ? 'Agent' : 'You'}
+        </span>
+        {draft.stale ? (
+          <span
+            title="the diff changed under this comment; it will be skipped on publish"
+            className="shrink-0 rounded-full bg-warning/15 px-1.5 py-0.5 text-[10px] font-medium text-warning"
+          >
+            Stale
+          </span>
+        ) : null}
+        <span className="flex-1" />
+        <button
+          type="button"
+          onClick={onDiscard}
+          title="discard draft"
+          aria-label={`discard draft on ${draft.path}:${draft.line}`}
+          className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors hover:bg-muted hover:text-danger"
+        >
+          <Trash2 size={11} aria-hidden />
+        </button>
+      </div>
+      {editing ? (
+        <div className="flex flex-col gap-1">
+          <Textarea
+            autoFocus
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            aria-label="Edit draft comment"
+            className="text-xs"
+            autoGrow
+            maxRows={8}
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                setEditing(false);
+              }
+              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                save();
+              }
+            }}
+          />
+          <div className="flex items-center justify-end gap-1">
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              className="rounded-sm px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={save}
+              disabled={trimmed.length === 0}
+              className="rounded-sm bg-foreground px-2 py-0.5 text-[10px] font-medium text-background hover:opacity-80 disabled:opacity-30"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={startEditing}
+          title="edit draft"
+          className="whitespace-pre-wrap rounded-sm text-left text-xs leading-relaxed text-foreground/85 transition-colors hover:bg-muted/40"
+        >
+          {draft.body}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/DraftsPanel.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/DraftsPanel.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from 'react';
+import { MessageSquareDiff } from 'lucide-react';
+import { EmptyState, ScrollFade } from '@goodboy/ui';
+import type { PrReviewDraft } from '@goodboy/types';
+import { DraftCard } from './DraftCard';
+
+type Props = {
+  readonly drafts: ReadonlyArray<PrReviewDraft>;
+  readonly onEdit: (id: string, body: string) => void;
+  readonly onDiscard: (id: string) => void;
+};
+
+export const DraftsPanel = ({ drafts, onEdit, onDiscard }: Props) => {
+  const groups = useMemo(() => {
+    const byPath = new Map<string, PrReviewDraft[]>();
+    for (const draft of drafts) {
+      const list = byPath.get(draft.path);
+      if (list != null) {
+        list.push(draft);
+        continue;
+      }
+      byPath.set(draft.path, [draft]);
+    }
+    return [...byPath.entries()].map(([path, items]) => ({
+      path,
+      items: [...items].sort((a, b) => a.line - b.line),
+    }));
+  }, [drafts]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-1.5 px-3 pb-1 pt-3">
+        <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          Draft comments
+        </span>
+        <span className="text-2xs tabular-nums text-muted-foreground/50">{drafts.length}</span>
+      </div>
+      {drafts.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={MessageSquareDiff}
+            title="No draft comments yet"
+            description="Ask the agent to draft comments, or click a diff line."
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+          <div className="flex flex-col gap-3 px-3 pb-3 pt-1">
+            {groups.map((group) => (
+              <div key={group.path} className="flex flex-col gap-1.5">
+                <span className="truncate px-0.5 font-mono text-[10px] text-muted-foreground/70">
+                  {group.path}
+                </span>
+                {group.items.map((draft) => (
+                  <DraftCard
+                    key={draft.id}
+                    draft={draft}
+                    onEdit={(body) => onEdit(draft.id, body)}
+                    onDiscard={() => onDiscard(draft.id)}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { MessageSquarePlus } from 'lucide-react';
+import { Textarea } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly onSubmit: (body: string) => void;
+  readonly onCancel: () => void;
+};
+
+export const LineComposer = ({ label, onSubmit, onCancel }: Props) => {
+  const [body, setBody] = useState('');
+  const trimmed = body.trim();
+  return (
+    <div className="flex gap-2 rounded-md border border-border-soft bg-background px-2 py-1.5">
+      <MessageSquarePlus size={13} aria-hidden className="mt-0.5 shrink-0 text-indigo-500" />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-[10px] font-medium text-muted-foreground">{label}</span>
+        <Textarea
+          autoFocus
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="Draft a review comment… (⌘↵ to add)"
+          aria-label="Draft comment body"
+          className="text-xs"
+          autoGrow
+          maxRows={6}
+          onKeyDown={(event) => {
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              onCancel();
+            }
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              if (trimmed.length > 0) {
+                onSubmit(trimmed);
+              }
+            }
+          }}
+        />
+        <div className="flex items-center justify-end gap-1">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-sm px-2 py-0.5 text-[10px] text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => trimmed.length > 0 && onSubmit(trimmed)}
+            disabled={trimmed.length === 0}
+            className="inline-flex items-center gap-1 rounded-sm bg-foreground px-2 py-0.5 text-[10px] font-medium text-background hover:opacity-80 disabled:opacity-30"
+          >
+            Add draft
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/PublishBar.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/PublishBar.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { Button, Select, Textarea } from '@goodboy/ui';
+import type { ReviewablePrProvider } from '@goodboy/types';
+import type { PublishPrReviewVerdict } from '../../../../store/slices/review-drafts/types';
+
+type Props = {
+  readonly provider: ReviewablePrProvider;
+  readonly draftCount: number;
+  readonly publishing: boolean;
+  readonly onPublish: (opts: { verdict: PublishPrReviewVerdict; body: string }) => void;
+};
+
+export const PublishBar = ({ provider, draftCount, publishing, onPublish }: Props) => {
+  const [verdict, setVerdict] = useState<PublishPrReviewVerdict>('comment');
+  const [body, setBody] = useState('');
+  const canPublish = !publishing && (draftCount > 0 || body.trim() !== '');
+
+  return (
+    <div className="flex shrink-0 flex-col gap-1.5 px-4 py-3">
+      <div className="flex items-end gap-2">
+        <Textarea
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+          placeholder="Review summary (optional)"
+          aria-label="Review summary"
+          autoGrow
+          minRows={1}
+          maxRows={4}
+          disabled={publishing}
+          className="flex-1 text-xs"
+        />
+        {provider === 'github' ? (
+          <Select
+            size="md"
+            aria-label="Review verdict"
+            value={verdict}
+            onChange={(event) => setVerdict(event.target.value as PublishPrReviewVerdict)}
+            disabled={publishing}
+          >
+            <option value="comment">Comment</option>
+            <option value="approve">Approve</option>
+            <option value="request_changes">Request changes</option>
+          </Select>
+        ) : null}
+        <Button
+          onClick={() => onPublish({ verdict: provider === 'gitlab' ? 'comment' : verdict, body })}
+          disabled={!canPublish}
+        >
+          {publishing ? 'Publishing…' : `Publish review (${draftCount})`}
+        </Button>
+      </div>
+      {provider === 'gitlab' ? (
+        <p className="text-2xs text-muted-foreground">
+          Comments post as merge request discussions; the summary posts as a note.
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/ReviewFileDiff.tsx
@@ -1,0 +1,295 @@
+import { Fragment, useMemo, useState } from 'react';
+import { Bot, ChevronRight, MessageSquarePlus } from 'lucide-react';
+import { Divider, cn } from '@goodboy/ui';
+import type { DiffHunkLine, FileDiff, PrReviewDraft, ReviewDraftSide } from '@goodboy/types';
+import {
+  INITIAL_VISIBLE_LINES,
+  LINE_PREFIX,
+  STATUS_COLOR,
+  STATUS_GLYPH,
+  VISIBLE_LINES_STEP,
+} from '../../../permissions/components/DiffViewerDialog/lib';
+import { ShowMoreBar } from '../../../permissions/components/DiffViewerDialog/ShowMoreBar';
+import {
+  SYNTAX_CLASS,
+  highlightLine,
+  languageForPath,
+} from '../../../permissions/components/DiffViewerDialog/highlight';
+import { LineComposer } from './LineComposer';
+
+export type ReviewLineTarget = {
+  readonly path: string;
+  readonly line: number;
+  readonly side: ReviewDraftSide;
+  readonly text: string;
+};
+
+type Props = {
+  readonly file: FileDiff;
+  readonly drafts: ReadonlyArray<PrReviewDraft>;
+  readonly onAddDraft: (target: ReviewLineTarget, body: string) => void;
+  readonly onAskAgent: (target: ReviewLineTarget) => void;
+};
+
+type LineAnchor = {
+  readonly side: ReviewDraftSide;
+  readonly line: number;
+};
+
+const anchorOf = (line: DiffHunkLine): LineAnchor | null => {
+  if (line.newLine != null) {
+    return { side: 'new', line: line.newLine };
+  }
+  if (line.oldLine != null) {
+    return { side: 'old', line: line.oldLine };
+  }
+  return null;
+};
+
+const anchorKeyOf = (anchor: LineAnchor): string => `${anchor.side}:${anchor.line}`;
+
+export const ReviewFileDiff = ({ file, drafts, onAddDraft, onAskAgent }: Props) => {
+  const [collapsed, setCollapsed] = useState(false);
+  const [activeAnchor, setActiveAnchor] = useState<LineAnchor | null>(null);
+  const [visibleLines, setVisibleLines] = useState(INITIAL_VISIBLE_LINES);
+
+  const draftedKeys = useMemo(
+    () => new Set(drafts.map((draft) => `${draft.side}:${draft.line}`)),
+    [drafts],
+  );
+
+  const rows = useMemo(() => {
+    const out: Array<
+      | { type: 'header'; hi: number; header: string }
+      | { type: 'line'; hi: number; li: number; line: DiffHunkLine }
+    > = [];
+    file.hunks.forEach((hunk, hi) => {
+      out.push({ type: 'header', hi, header: hunk.header });
+      hunk.lines.forEach((line, li) => out.push({ type: 'line', hi, li, line }));
+    });
+    return out;
+  }, [file]);
+
+  const totalLines = useMemo(() => file.hunks.reduce((n, h) => n + h.lines.length, 0), [file]);
+
+  const visibleRows = useMemo(() => {
+    if (visibleLines >= totalLines) {
+      return rows;
+    }
+    let count = 0;
+    for (let i = 0; i < rows.length; i++) {
+      if (rows[i]?.type === 'line') {
+        count += 1;
+        if (count >= visibleLines) {
+          return rows.slice(0, i + 1);
+        }
+      }
+    }
+    return rows;
+  }, [rows, visibleLines, totalLines]);
+
+  const lang = useMemo(() => languageForPath(file.path), [file.path]);
+  const remaining = Math.max(0, totalLines - visibleLines);
+
+  return (
+    <section data-file-path={file.path}>
+      <div className="sticky top-0 z-10 bg-background">
+        <div className="flex items-center gap-2 px-3 py-1.5">
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            title={collapsed ? 'expand file' : 'collapse file'}
+            aria-label={collapsed ? 'expand file' : 'collapse file'}
+            className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ChevronRight
+              size={13}
+              aria-hidden
+              className={cn(
+                'duration-150 motion-safe:transition-transform',
+                !collapsed && 'rotate-90',
+              )}
+            />
+          </button>
+          <span
+            className={cn(
+              'w-3 shrink-0 text-center font-mono text-[11px] font-bold',
+              STATUS_COLOR[file.status],
+            )}
+            title={file.status}
+          >
+            {STATUS_GLYPH[file.status]}
+          </span>
+          <button
+            type="button"
+            onClick={() => setCollapsed((value) => !value)}
+            className="min-w-0 flex-1 truncate text-left font-mono text-xs text-foreground"
+            title={file.path}
+          >
+            {file.path}
+          </button>
+          {drafts.length > 0 ? (
+            <span className="shrink-0 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-[10px] font-medium text-indigo-600">
+              {drafts.length} {drafts.length === 1 ? 'draft' : 'drafts'}
+            </span>
+          ) : null}
+          <span className="shrink-0 text-[10px] tabular-nums">
+            {file.additions > 0 && <span className="text-success">+{file.additions}</span>}
+            {file.additions > 0 && file.deletions > 0 && <span className="opacity-40"> </span>}
+            {file.deletions > 0 && <span className="text-danger">−{file.deletions}</span>}
+          </span>
+        </div>
+        <Divider />
+      </div>
+      {collapsed ? null : (
+        <div className="p-3">
+          {file.binary ? (
+            <p className="py-4 text-center text-xs text-muted-foreground">binary file, no diff</p>
+          ) : file.hunks.length === 0 ? (
+            <p className="py-4 text-center text-xs text-muted-foreground">no changes</p>
+          ) : (
+            <>
+              <table className="w-full border-collapse font-mono text-xs leading-5">
+                <tbody>
+                  {visibleRows.map((row) => {
+                    if (row.type === 'header') {
+                      return (
+                        <tr key={`hunk-${row.hi}`}>
+                          <td
+                            colSpan={4}
+                            className="border-y border-border-soft/40 bg-muted/30 px-2.5 py-1 text-[10px] font-medium tabular-nums text-muted-foreground/70"
+                          >
+                            {row.header}
+                          </td>
+                        </tr>
+                      );
+                    }
+                    const { line, hi, li } = row;
+                    const anchor = anchorOf(line);
+                    const target: ReviewLineTarget | null =
+                      anchor == null
+                        ? null
+                        : { path: file.path, line: anchor.line, side: anchor.side, text: line.text };
+                    const isActive =
+                      anchor != null &&
+                      activeAnchor != null &&
+                      activeAnchor.side === anchor.side &&
+                      activeAnchor.line === anchor.line;
+                    const hasDraft = anchor != null && draftedKeys.has(anchorKeyOf(anchor));
+                    return (
+                      <Fragment key={`hunk-${hi}-line-${li}`}>
+                        <tr
+                          className={cn(
+                            'group',
+                            line.kind === 'add' && 'bg-success/[0.07]',
+                            line.kind === 'del' && 'bg-danger/[0.07]',
+                            hasDraft && 'bg-indigo-400/[0.08]',
+                          )}
+                        >
+                          <td
+                            className={cn(
+                              'w-11 select-none border-l-2 px-0.5 align-top',
+                              hasDraft
+                                ? 'border-indigo-400/70'
+                                : line.kind === 'add'
+                                  ? 'border-success/50'
+                                  : line.kind === 'del'
+                                    ? 'border-danger/50'
+                                    : 'border-transparent',
+                            )}
+                          >
+                            {target != null ? (
+                              <span className="flex items-center gap-0.5">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    setActiveAnchor(isActive ? null : (anchor ?? null))
+                                  }
+                                  title="draft a comment on this line"
+                                  aria-label={`draft a comment on line ${target.line}`}
+                                  className={cn(
+                                    'flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground transition-opacity hover:bg-muted hover:text-foreground',
+                                    isActive ? 'opacity-100' : 'opacity-0 group-hover:opacity-100',
+                                  )}
+                                >
+                                  <MessageSquarePlus size={9} aria-hidden />
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => onAskAgent(target)}
+                                  title="ask the agent about this line"
+                                  aria-label={`ask the agent about line ${target.line}`}
+                                  className="flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-muted hover:text-foreground group-hover:opacity-100"
+                                >
+                                  <Bot size={9} aria-hidden />
+                                </button>
+                              </span>
+                            ) : null}
+                          </td>
+                          <td className="w-9 select-none px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50">
+                            {line.oldLine ?? ''}
+                          </td>
+                          <td className="w-9 select-none border-r border-border-soft/40 px-1.5 text-right text-[10px] tabular-nums text-muted-foreground/50">
+                            {line.newLine ?? ''}
+                          </td>
+                          <td className="whitespace-pre px-2.5 text-foreground/80">
+                            <span
+                              aria-hidden
+                              className={cn(
+                                'select-none',
+                                line.kind === 'add'
+                                  ? 'text-success'
+                                  : line.kind === 'del'
+                                    ? 'text-danger'
+                                    : 'text-transparent',
+                              )}
+                            >
+                              {LINE_PREFIX[line.kind]}
+                            </span>
+                            {lang
+                              ? highlightLine(line.text, lang).map((token, ti) =>
+                                  token.kind === 'plain' ? (
+                                    <Fragment key={ti}>{token.text}</Fragment>
+                                  ) : (
+                                    <span key={ti} className={SYNTAX_CLASS[token.kind]}>
+                                      {token.text}
+                                    </span>
+                                  ),
+                                )
+                              : line.text}
+                          </td>
+                        </tr>
+                        {isActive && target != null ? (
+                          <tr>
+                            <td colSpan={4} className="bg-background px-3 py-2">
+                              <LineComposer
+                                label={`Commenting on ${file.path}:${target.line}`}
+                                onSubmit={(body) => {
+                                  onAddDraft(target, body);
+                                  setActiveAnchor(null);
+                                }}
+                                onCancel={() => setActiveAnchor(null)}
+                              />
+                            </td>
+                          </tr>
+                        ) : null}
+                      </Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+              {remaining > 0 && (
+                <ShowMoreBar
+                  step={Math.min(VISIBLE_LINES_STEP, remaining)}
+                  rendered={Math.min(visibleLines, totalLines)}
+                  total={totalLines}
+                  onShowMore={() => setVisibleLines((value) => value + VISIBLE_LINES_STEP)}
+                />
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { FileDiff, IsoDateTime, PrReviewDraft, Session } from '@goodboy/types';
+
+const h = vi.hoisted(() => {
+  const state = {
+    reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    agentDraft: {} as Record<string, string>,
+    loadReviewDrafts: vi.fn(async () => undefined),
+    addReviewDraft: vi.fn(async () => undefined),
+    updateReviewDraft: vi.fn(async () => undefined),
+    discardReviewDraft: vi.fn(async () => undefined),
+    publishPrReview: vi.fn(async () => ({ published: 1, stale: [], failed: [] })),
+    setAgentDraft: vi.fn(),
+    selectAgent: vi.fn(async () => undefined),
+  };
+  const useAppStore = Object.assign(
+    <T,>(selector: (s: typeof state) => T) => selector(state),
+    { getState: () => state },
+  );
+  return {
+    state,
+    useAppStore,
+    showToast: vi.fn(),
+    diff: {
+      files: [] as ReadonlyArray<FileDiff>,
+      loading: false,
+      error: null as string | null,
+      target: { provider: 'github', repo: 'acme/web', prNumber: 41 } as {
+        provider: 'github' | 'gitlab';
+        repo: string;
+        prNumber: number;
+      } | null,
+      refresh: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: h.useAppStore,
+}));
+
+vi.mock('./useReviewDiff', () => ({
+  useReviewDiff: () => h.diff,
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import { ReviewBoardPane } from './index';
+
+const SESSION = { id: 'session-1', workspaceId: 'workspace-1' } as unknown as Session;
+
+const FILE: FileDiff = {
+  path: 'src/auth.ts',
+  status: 'modified',
+  additions: 1,
+  deletions: 0,
+  binary: false,
+  hunks: [
+    {
+      header: '@@ -3,2 +3,3 @@',
+      oldStart: 3,
+      oldLines: 2,
+      newStart: 3,
+      newLines: 3,
+      lines: [
+        { kind: 'context', oldLine: 3, newLine: 3, text: 'const session = load();' },
+        { kind: 'add', oldLine: null, newLine: 4, text: 'retry(session);' },
+      ],
+    },
+  ],
+};
+
+const DRAFT: PrReviewDraft = {
+  id: 'draft-1',
+  sessionId: SESSION.id,
+  provider: 'github',
+  repo: 'acme/web',
+  prNumber: 41,
+  path: 'src/auth.ts',
+  line: 4,
+  startLine: null,
+  side: 'new',
+  body: 'Guard against a null session here.',
+  status: 'draft',
+  stale: false,
+  origin: 'agent',
+  createdAt: '2026-07-22T10:00:00Z' as IsoDateTime,
+};
+
+beforeEach(() => {
+  h.state.reviewDrafts = { 'session-1': [DRAFT] };
+  h.state.sessionPhaseRuns = { 'session-1': [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }] };
+  h.state.agentDraft = {};
+  h.diff.files = [FILE];
+  h.diff.loading = false;
+  h.diff.error = null;
+  h.diff.target = { provider: 'github', repo: 'acme/web', prNumber: 41 };
+  h.state.loadReviewDrafts.mockClear();
+  h.state.addReviewDraft.mockClear();
+  h.state.updateReviewDraft.mockClear();
+  h.state.discardReviewDraft.mockClear();
+  h.state.publishPrReview.mockClear();
+  h.state.publishPrReview.mockResolvedValue({ published: 1, stale: [], failed: [] });
+  h.state.setAgentDraft.mockClear();
+  h.showToast.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('ReviewBoardPane', () => {
+  it('loads drafts on mount and renders them with edit and discard', async () => {
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(h.state.loadReviewDrafts).toHaveBeenCalledWith('session-1');
+    fireEvent.click(screen.getByRole('button', { name: 'Guard against a null session here.' }));
+    const editor = screen.getByRole('textbox', { name: 'Edit draft comment' });
+    fireEvent.change(editor, { target: { value: 'Guard the session, then retry.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(h.state.updateReviewDraft).toHaveBeenCalledWith(
+      'draft-1',
+      'Guard the session, then retry.',
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'discard draft on src/auth.ts:4' }),
+    );
+    expect(h.state.discardReviewDraft).toHaveBeenCalledWith('draft-1');
+  });
+
+  it('adds a user draft from a diff line composer', async () => {
+    render(<ReviewBoardPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'draft a comment on line 3' }));
+    const composer = screen.getByRole('textbox', { name: 'Draft comment body' });
+    fireEvent.change(composer, { target: { value: 'Load lazily instead.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Add draft' }));
+
+    await waitFor(() => {
+      expect(h.state.addReviewDraft).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        path: 'src/auth.ts',
+        line: 3,
+        side: 'new',
+        body: 'Load lazily instead.',
+      });
+    });
+  });
+
+  it('prefills the reviewer chat draft from the ask agent action', () => {
+    render(<ReviewBoardPane session={SESSION} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'ask the agent about line 4' }));
+
+    expect(h.state.setAgentDraft).toHaveBeenCalledWith(
+      'agent-1',
+      'About `src/auth.ts:4`:\n> retry(session);\n',
+    );
+    expect(h.state.selectAgent).toHaveBeenCalledWith('session-1', 'agent-1');
+  });
+
+  it('publishes with the chosen verdict and disables while pending', async () => {
+    let resolvePublish: (value: { published: number; stale: never[]; failed: never[] }) => void =
+      () => undefined;
+    h.state.publishPrReview.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePublish = resolve;
+      }),
+    );
+    render(<ReviewBoardPane session={SESSION} />);
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Review verdict' }), {
+      target: { value: 'request_changes' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Publish review (1)' }));
+
+    expect(h.state.publishPrReview).toHaveBeenCalledWith('session-1', {
+      verdict: 'request_changes',
+      body: '',
+    });
+    const pending = await screen.findByRole('button', { name: 'Publishing…' });
+    expect(pending.hasAttribute('disabled')).toBe(true);
+
+    resolvePublish({ published: 1, stale: [], failed: [] });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Publish review (1)' })).toBeDefined();
+    });
+  });
+
+  it('hides the verdict select for gitlab and explains the summary note', () => {
+    h.diff.target = { provider: 'gitlab', repo: 'acme/web', prNumber: 41 };
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.queryByRole('combobox', { name: 'Review verdict' })).toBeNull();
+    expect(
+      screen.getByText('Comments post as merge request discussions; the summary posts as a note.'),
+    ).toBeDefined();
+  });
+
+  it('explains the flow when there are no drafts yet', () => {
+    h.state.reviewDrafts = { 'session-1': [] };
+    render(<ReviewBoardPane session={SESSION} />);
+
+    expect(screen.getByText('No draft comments yet')).toBeDefined();
+    expect(
+      screen.getByText('Ask the agent to draft comments, or click a diff line.'),
+    ).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/index.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, RefreshCw } from 'lucide-react';
+import { Divider, EmptyState, ScrollFade, Skeleton, cn } from '@goodboy/ui';
+import type { PrReviewDraft, Session, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import type { PublishPrReviewVerdict } from '../../../../store/slices/review-drafts/types';
+import { useToast } from '../../../../app/components/Toast';
+import { formatError } from '../../../../shared/lib/errors';
+import { classifyAgent } from '../../../session/agent-kind';
+import { DraftsPanel } from './DraftsPanel';
+import { PublishBar } from './PublishBar';
+import { ReviewFileDiff, type ReviewLineTarget } from './ReviewFileDiff';
+import { useReviewDiff } from './useReviewDiff';
+
+type Props = {
+  readonly session: Session;
+};
+
+export const ReviewBoardPane = ({ session }: Props) => {
+  const sessionId = session.id as SessionId;
+  const drafts = useAppStore(
+    (s) => s.reviewDrafts[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<PrReviewDraft>),
+  );
+  const loadReviewDrafts = useAppStore((s) => s.loadReviewDrafts);
+  const addReviewDraft = useAppStore((s) => s.addReviewDraft);
+  const updateReviewDraft = useAppStore((s) => s.updateReviewDraft);
+  const discardReviewDraft = useAppStore((s) => s.discardReviewDraft);
+  const publishPrReview = useAppStore((s) => s.publishPrReview);
+  const setAgentDraft = useAppStore((s) => s.setAgentDraft);
+  const selectAgent = useAppStore((s) => s.selectAgent);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const { files, loading, error, target, refresh } = useReviewDiff({ session });
+  const { showToast } = useToast();
+  const [publishing, setPublishing] = useState(false);
+
+  useEffect(() => {
+    void loadReviewDrafts(sessionId);
+  }, [loadReviewDrafts, sessionId]);
+
+  const openDrafts = useMemo(
+    () => drafts.filter((draft) => draft.status === 'draft'),
+    [drafts],
+  );
+  const draftsByPath = useMemo(() => {
+    const byPath = new Map<string, PrReviewDraft[]>();
+    for (const draft of openDrafts) {
+      const list = byPath.get(draft.path);
+      if (list != null) {
+        list.push(draft);
+        continue;
+      }
+      byPath.set(draft.path, [draft]);
+    }
+    return byPath;
+  }, [openDrafts]);
+
+  const addDraftFromLine = async (lineTarget: ReviewLineTarget, body: string) => {
+    try {
+      await addReviewDraft({
+        sessionId,
+        path: lineTarget.path,
+        line: lineTarget.line,
+        side: lineTarget.side,
+        body,
+      });
+    } catch (err) {
+      showToast('error', formatError(err));
+    }
+  };
+
+  const askAgent = (lineTarget: ReviewLineTarget) => {
+    const reviewer =
+      phaseRuns.find((agent) => classifyAgent(agent, null) === 'pr-reviewer') ?? phaseRuns[0];
+    if (reviewer == null) {
+      showToast('error', 'No agent in this session to ask.');
+      return;
+    }
+    const prompt = `About \`${lineTarget.path}:${lineTarget.line}\`:\n> ${lineTarget.text}\n`;
+    const existing = useAppStore.getState().agentDraft[reviewer.id] ?? '';
+    setAgentDraft(reviewer.id, existing === '' ? prompt : `${existing}\n${prompt}`);
+    void selectAgent(sessionId, reviewer.id);
+  };
+
+  const publish = async (opts: { verdict: PublishPrReviewVerdict; body: string }) => {
+    if (publishing) {
+      return;
+    }
+    setPublishing(true);
+    try {
+      const result = await publishPrReview(sessionId, opts);
+      const staleNote =
+        result.stale.length > 0 ? `, ${result.stale.length} stale skipped` : '';
+      if (result.failed.length > 0) {
+        showToast('error', `${result.failed.length} comments failed to publish${staleNote}`);
+      } else {
+        const publishedNote =
+          result.published > 0
+            ? `${result.published} ${result.published === 1 ? 'comment' : 'comments'} published`
+            : 'summary posted';
+        showToast('success', `Review published: ${publishedNote}${staleNote}`);
+      }
+      await loadReviewDrafts(sessionId);
+      refresh();
+    } catch (err) {
+      showToast('error', formatError(err));
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex shrink-0 items-center gap-2 px-3 py-1.5">
+            <span className="min-w-0 truncate text-xs font-medium text-foreground">
+              {target == null
+                ? 'Review board'
+                : `${target.repo} ${target.provider === 'gitlab' ? '!' : '#'}${target.prNumber}`}
+            </span>
+            <span className="text-2xs tabular-nums text-muted-foreground/60">
+              {loading ? '' : `${files.length} files`}
+            </span>
+            <span className="flex-1" />
+            <button
+              type="button"
+              onClick={refresh}
+              disabled={loading}
+              title="Refresh diff"
+              aria-label="Refresh diff"
+              className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+            >
+              <RefreshCw size={12} aria-hidden className={cn(loading && 'animate-spin')} />
+            </button>
+          </div>
+          <Divider className="shrink-0" />
+          {loading ? (
+            <div
+              className="flex min-h-0 flex-1 flex-col gap-4 p-4"
+              role="status"
+              aria-label="Loading diff"
+            >
+              {Array.from({ length: 2 }).map((_, cardIndex) => (
+                <div
+                  key={cardIndex}
+                  className="flex flex-col gap-1.5 rounded-md border border-border-soft p-3"
+                >
+                  <Skeleton className="h-3 w-40 rounded" />
+                  <Skeleton className="h-3 w-3/4 rounded" />
+                  <Skeleton className="h-3 w-1/2 rounded" />
+                </div>
+              ))}
+            </div>
+          ) : error != null ? (
+            <div className="flex flex-1 items-center justify-center px-6 text-center text-xs text-danger">
+              {error}
+            </div>
+          ) : files.length === 0 ? (
+            <div className="flex flex-1 items-center justify-center px-6">
+              <EmptyState
+                bordered
+                tone="success"
+                icon={CheckCircle2}
+                title="No changes in this pull request"
+                description="The diff is empty, nothing to review."
+              />
+            </div>
+          ) : (
+            <ScrollFade className="min-h-0 flex-1">
+              {files.map((file) => (
+                <ReviewFileDiff
+                  key={file.path}
+                  file={file}
+                  drafts={draftsByPath.get(file.path) ?? EMPTY_ARRAY}
+                  onAddDraft={(lineTarget, body) => void addDraftFromLine(lineTarget, body)}
+                  onAskAgent={askAgent}
+                />
+              ))}
+            </ScrollFade>
+          )}
+        </div>
+        <Divider orientation="vertical" />
+        <div className="flex w-80 shrink-0 flex-col">
+          <DraftsPanel
+            drafts={openDrafts}
+            onEdit={(id, body) => void updateReviewDraft(id, body)}
+            onDiscard={(id) => void discardReviewDraft(id)}
+          />
+        </div>
+      </div>
+      <Divider />
+      <PublishBar
+        provider={target?.provider ?? 'github'}
+        draftCount={openDrafts.length}
+        publishing={publishing}
+        onPublish={(opts) => void publish(opts)}
+      />
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/useReviewDiff.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { parseUnifiedDiff } from '@goodboy/core';
+import type { FileDiff, GitlabWorkspaceIntegration, Session, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import {
+  reviewTargetFromTasks,
+  type ReviewTarget,
+} from '../../../../store/slices/review-drafts/resolveReviewTarget';
+import { ghPrDiff } from '../../../github/github';
+import { gitlabMrDiff } from '../../../integrations/gitlab/client';
+import { formatError } from '../../../../shared/lib/errors';
+
+type Params = {
+  readonly session: Session;
+};
+
+type Result = {
+  readonly files: ReadonlyArray<FileDiff>;
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly target: ReviewTarget | null;
+  readonly refresh: () => void;
+};
+
+export const useReviewDiff = ({ session }: Params): Result => {
+  const sessionId = session.id as SessionId;
+  const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
+  const workspace = useAppStore(
+    (s) => s.workspaces.find((candidate) => candidate.id === session.workspaceId) ?? null,
+  );
+  const gitlabHost = useAppStore(
+    (s) =>
+      (s.workspaceIntegrations[session.workspaceId] ?? []).find(
+        (integration): integration is GitlabWorkspaceIntegration =>
+          integration.provider === 'gitlab',
+      )?.config.host ?? null,
+  );
+  const [files, setFiles] = useState<ReadonlyArray<FileDiff>>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tick, setTick] = useState(0);
+
+  const target = useMemo(() => reviewTargetFromTasks({ tasks: externalTasks }), [externalTasks]);
+
+  useEffect(() => {
+    if (target == null || workspace == null) {
+      setFiles([]);
+      setLoading(false);
+      setError('No linked pull request or merge request for this session.');
+      return;
+    }
+    const fetchDiff =
+      target.provider === 'github'
+        ? () => ghPrDiff(target.repo, target.prNumber, workspace.rootPath, workspace.id)
+        : gitlabHost == null
+          ? null
+          : () => gitlabMrDiff(workspace.id, gitlabHost, target.repo, target.prNumber);
+    if (fetchDiff == null) {
+      setFiles([]);
+      setLoading(false);
+      setError('GitLab is not connected for this workspace.');
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchDiff()
+      .then((raw) => {
+        if (cancelled) {
+          return;
+        }
+        setFiles(parseUnifiedDiff(raw));
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        setError(formatError(err));
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [target, workspace, gitlabHost, tick]);
+
+  const refresh = useCallback(() => setTick((value) => value + 1), []);
+
+  return { files, loading, error, target, refresh };
+};

--- a/apps/desktop/src/features/review/components/ReviewInboxList/buildReviewInboxRows.ts
+++ b/apps/desktop/src/features/review/components/ReviewInboxList/buildReviewInboxRows.ts
@@ -1,0 +1,25 @@
+import type { ReviewablePr, ReviewablePrProvider } from '@goodboy/types';
+
+export type ReviewInboxScope = 'others' | 'all';
+
+type Params = {
+  readonly items: ReadonlyArray<ReviewablePr>;
+  readonly provider: ReviewablePrProvider;
+  readonly scope: ReviewInboxScope;
+};
+
+export const buildReviewInboxRows = ({
+  items,
+  provider,
+  scope,
+}: Params): ReadonlyArray<ReviewablePr> => {
+  const scoped = items.filter(
+    (pr) => pr.provider === provider && (scope === 'all' || !pr.mine),
+  );
+  return [...scoped].sort((a, b) => {
+    if (a.reviewRequested !== b.reviewRequested) {
+      return a.reviewRequested ? -1 : 1;
+    }
+    return b.updatedAt.localeCompare(a.updatedAt);
+  });
+};

--- a/apps/desktop/src/features/review/components/ReviewInboxList/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewInboxList/index.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReviewablePr, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  refreshReviewPrs: vi.fn(async () => undefined),
+  state: {
+    reviewPrs: {} as Record<
+      string,
+      {
+        items: ReadonlyArray<unknown>;
+        loading: boolean;
+        error: string | null;
+        fetchedAt: string | null;
+      }
+    >,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(
+    selector: (state: typeof h.state & { refreshReviewPrs: typeof h.refreshReviewPrs }) => T,
+  ) => selector({ ...h.state, refreshReviewPrs: h.refreshReviewPrs }),
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import { ReviewInboxList } from './index';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const pr = (overrides: Partial<ReviewablePr>): ReviewablePr => ({
+  id: 'github:1',
+  provider: 'github',
+  repo: 'acme/web',
+  number: 1,
+  title: 'Fix login flow',
+  url: 'https://github.com/acme/web/pull/1',
+  author: 'sam',
+  authorAvatarUrl: null,
+  mine: false,
+  reviewRequested: false,
+  state: 'open',
+  baseBranch: 'main',
+  headBranch: 'sam/fix-login',
+  isDraft: false,
+  updatedAt: '2026-07-22T10:00:00Z',
+  ...overrides,
+});
+
+const setItems = (items: ReadonlyArray<ReviewablePr>, loading = false, error: string | null = null) => {
+  h.state.reviewPrs = {
+    [WORKSPACE_ID]: { items, loading, error, fetchedAt: '2026-07-22T10:00:00Z' },
+  };
+};
+
+const renderList = (scope: 'others' | 'all', onSelect = vi.fn()) => {
+  render(
+    <ReviewInboxList
+      workspaceId={WORKSPACE_ID}
+      provider="github"
+      scope={scope}
+      focusedPrId={null}
+      onSelect={onSelect}
+    />,
+  );
+  return onSelect;
+};
+
+beforeEach(() => {
+  h.state.reviewPrs = {};
+  h.refreshReviewPrs.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('ReviewInboxList', () => {
+  it('refreshes on mount and filters out own PRs in the others scope', () => {
+    setItems([
+      pr({ id: 'github:1', number: 1, title: 'Mine only', mine: true }),
+      pr({ id: 'github:2', number: 2, title: 'Teammate work' }),
+    ]);
+    renderList('others');
+
+    expect(h.refreshReviewPrs).toHaveBeenCalledWith(WORKSPACE_ID);
+    expect(screen.getByText('Teammate work')).toBeDefined();
+    expect(screen.queryByText('Mine only')).toBeNull();
+  });
+
+  it('shows own PRs with a Mine chip in the all scope and selects rows', () => {
+    setItems([
+      pr({ id: 'github:1', number: 1, title: 'Mine only', mine: true }),
+      pr({ id: 'github:2', number: 2, title: 'Teammate work' }),
+    ]);
+    const onSelect = renderList('all');
+
+    expect(screen.getByText('Mine only')).toBeDefined();
+    expect(screen.getByText('Mine')).toBeDefined();
+    fireEvent.click(screen.getByText('Teammate work'));
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'github:2' }));
+  });
+
+  it('sorts review-requested PRs first and badges them', () => {
+    setItems([
+      pr({ id: 'github:1', number: 1, title: 'Newer plain', updatedAt: '2026-07-23T10:00:00Z' }),
+      pr({
+        id: 'github:2',
+        number: 2,
+        title: 'Older requested',
+        reviewRequested: true,
+        updatedAt: '2026-07-20T10:00:00Z',
+      }),
+    ]);
+    renderList('others');
+
+    const rows = screen.getAllByRole('listitem').map((item) => item.textContent ?? '');
+    expect(rows[0]).toContain('Older requested');
+    expect(rows[0]).toContain('Review requested');
+    expect(rows[1]).toContain('Newer plain');
+  });
+
+  it('shows the teammates empty state when nothing is reviewable', () => {
+    setItems([pr({ id: 'github:1', mine: true })]);
+    renderList('others');
+
+    expect(screen.getByText('No open PRs from teammates')).toBeDefined();
+  });
+
+  it('shows loading skeletons before the first fetch resolves', () => {
+    h.state.reviewPrs = {
+      [WORKSPACE_ID]: { items: [], loading: true, error: null, fetchedAt: null },
+    };
+    renderList('others');
+
+    expect(screen.getByRole('status', { name: 'Loading pull requests' })).toBeDefined();
+  });
+
+  it('surfaces errors with a retry action', () => {
+    setItems([], false, 'gh: network unreachable');
+    renderList('others');
+
+    expect(screen.getByText('gh: network unreachable')).toBeDefined();
+    h.refreshReviewPrs.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(h.refreshReviewPrs).toHaveBeenCalledWith(WORKSPACE_ID);
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewInboxList/index.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo } from 'react';
+import { cn, EmptyState, ScrollFade, Skeleton } from '@goodboy/ui';
+import { Inbox, RefreshCw } from 'lucide-react';
+import type { ReviewablePr, ReviewablePrProvider, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import { PullRequestChip } from '../../../github/components/PullRequestChip';
+import { AuthorAvatar } from '../AuthorAvatar';
+import { buildReviewInboxRows, type ReviewInboxScope } from './buildReviewInboxRows';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly provider: ReviewablePrProvider;
+  readonly scope: ReviewInboxScope;
+  readonly focusedPrId: string | null;
+  readonly onSelect: (pr: ReviewablePr) => void;
+};
+
+export const ReviewInboxList = ({
+  workspaceId,
+  provider,
+  scope,
+  focusedPrId,
+  onSelect,
+}: Props) => {
+  const reviewPrs = useAppStore((s) => s.reviewPrs[workspaceId]);
+  const refreshReviewPrs = useAppStore((s) => s.refreshReviewPrs);
+  const items = reviewPrs?.items;
+  const isLoading = reviewPrs?.loading === true;
+  const error = reviewPrs?.error ?? null;
+
+  useEffect(() => {
+    void refreshReviewPrs(workspaceId);
+  }, [refreshReviewPrs, workspaceId]);
+
+  const rows = useMemo(
+    () => buildReviewInboxRows({ items: items ?? [], provider, scope }),
+    [items, provider, scope],
+  );
+
+  const isInitialLoading = isLoading && (items == null || items.length === 0);
+  const identifierPrefix = provider === 'gitlab' ? '!' : '#';
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex shrink-0 items-center gap-1.5 px-3 pb-1 pt-3">
+        <span className="text-2xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+          {scope === 'others' ? 'From teammates' : 'All open'}
+        </span>
+        <span className="text-2xs tabular-nums text-muted-foreground/50">{rows.length}</span>
+        <span aria-hidden className="ml-1 h-px flex-1 bg-border-soft" />
+        <button
+          type="button"
+          onClick={() => void refreshReviewPrs(workspaceId)}
+          disabled={isLoading}
+          title="Refresh pull requests"
+          aria-label="Refresh pull requests"
+          className="flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:opacity-50"
+        >
+          <RefreshCw size={12} aria-hidden className={cn(isLoading && 'animate-spin')} />
+        </button>
+      </div>
+      {isInitialLoading ? (
+        <div
+          className="flex flex-col gap-1 px-3 pb-3"
+          role="status"
+          aria-label="Loading pull requests"
+        >
+          {Array.from({ length: 6 }).map((_, index) => (
+            <div key={index} className="flex flex-col gap-1.5 px-2 py-2">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-3 w-8 shrink-0 rounded" />
+                <Skeleton className="h-3 flex-1 rounded" />
+              </div>
+              <div className="flex items-center gap-2">
+                <Skeleton className="size-4 shrink-0 rounded-full" />
+                <Skeleton className="h-2.5 w-20 rounded" />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : error != null && rows.length === 0 ? (
+        <div className="flex flex-col gap-2 px-3 pb-3">
+          <div className="rounded-lg border border-danger/30 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+          <button
+            type="button"
+            onClick={() => void refreshReviewPrs(workspaceId)}
+            className="self-start rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            Retry
+          </button>
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="flex min-h-0 flex-1 items-center justify-center px-3">
+          <EmptyState
+            icon={Inbox}
+            title={scope === 'others' ? 'No open PRs from teammates' : 'No open pull requests'}
+            description={
+              scope === 'others'
+                ? 'Pull requests by other authors will show up here.'
+                : 'Open pull requests on this repository will show up here.'
+            }
+          />
+        </div>
+      ) : (
+        <ScrollFade className="min-h-0 flex-1" fadeSize={24}>
+          <ul className="flex flex-col gap-0.5 px-3 pb-3 pt-1">
+            {rows.map((pr) => {
+              const isActive = pr.id === focusedPrId;
+              return (
+                <li key={pr.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(pr)}
+                    title={pr.title}
+                    aria-current={isActive}
+                    className={cn(
+                      'flex w-full flex-col gap-1 rounded-md px-2 py-1.5 text-left transition-colors',
+                      isActive
+                        ? 'bg-primary/10 text-foreground ring-1 ring-primary/30'
+                        : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+                    )}
+                  >
+                    <span className="flex items-center gap-1.5">
+                      <PullRequestChip
+                        state={pr.isDraft ? 'draft' : pr.state}
+                        variant="icon"
+                        iconSize={12}
+                      />
+                      <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/70">
+                        {identifierPrefix}
+                        {pr.number}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs">{pr.title}</span>
+                    </span>
+                    <span className="flex items-center gap-1.5">
+                      <AuthorAvatar author={pr.author} avatarUrl={pr.authorAvatarUrl} />
+                      <span className="min-w-0 truncate text-2xs text-muted-foreground/70">
+                        {pr.author}
+                      </span>
+                      <span className="shrink-0 text-2xs tabular-nums text-muted-foreground/50">
+                        {formatRelativeDuration(pr.updatedAt)}
+                      </span>
+                      <span className="flex-1" />
+                      {scope === 'all' && pr.mine ? (
+                        <span className="shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          Mine
+                        </span>
+                      ) : null}
+                      {pr.reviewRequested ? (
+                        <span className="shrink-0 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-600 ring-1 ring-indigo-400/30">
+                          Review requested
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </ScrollFade>
+      )}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReviewablePr, SessionId, WorkspaceId } from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  startPrReviewSession: vi.fn(async () => 'session-9' as SessionId),
+  openSession: vi.fn(),
+  state: {
+    sessions: [] as ReadonlyArray<{ id: string; workspaceId: string }>,
+    sessionExternalTasks: {} as Record<
+      string,
+      ReadonlyArray<{ provider: string; externalId: string }>
+    >,
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(
+    selector: (
+      state: typeof h.state & { startPrReviewSession: typeof h.startPrReviewSession },
+    ) => T,
+  ) => selector({ ...h.state, startPrReviewSession: h.startPrReviewSession }),
+}));
+
+vi.mock('../../../../shared/hooks/useOpenSession', () => ({
+  useOpenSession: () => h.openSession,
+}));
+
+vi.mock('../../../../shared/components/OpenSessionButton', () => ({
+  OpenSessionButton: ({ label }: { label?: string }) => (
+    <button type="button">{label ?? 'Open session'}</button>
+  ),
+}));
+
+vi.mock('@goodboy/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@goodboy/ui')>();
+  return {
+    ...actual,
+    ScrollFade: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  };
+});
+
+import { ReviewPrDetailPanel } from './index';
+
+const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+
+const PR: ReviewablePr = {
+  id: 'github:41',
+  provider: 'github',
+  repo: 'acme/web',
+  number: 41,
+  title: 'Harden webhook retries',
+  url: 'https://github.com/acme/web/pull/41',
+  author: 'sam',
+  authorAvatarUrl: null,
+  mine: false,
+  reviewRequested: true,
+  state: 'open',
+  baseBranch: 'main',
+  headBranch: 'sam/webhook-retries',
+  isDraft: false,
+  updatedAt: '2026-07-22T10:00:00Z',
+};
+
+beforeEach(() => {
+  h.state.sessions = [];
+  h.state.sessionExternalTasks = {};
+  h.startPrReviewSession.mockClear();
+  h.openSession.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('ReviewPrDetailPanel', () => {
+  it('starts a review session and navigates to it', async () => {
+    const onClose = vi.fn();
+    render(<ReviewPrDetailPanel pr={PR} workspaceId={WORKSPACE_ID} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Review locally/ }));
+
+    await waitFor(() => {
+      expect(h.startPrReviewSession).toHaveBeenCalledWith(WORKSPACE_ID, PR);
+      expect(h.openSession).toHaveBeenCalledWith('session-9', onClose);
+    });
+  });
+
+  it('offers to open an existing review session instead of spawning a duplicate', () => {
+    h.state.sessions = [{ id: 'session-5', workspaceId: WORKSPACE_ID }];
+    h.state.sessionExternalTasks = {
+      'session-5': [{ provider: 'github', externalId: '41' }],
+    };
+    render(<ReviewPrDetailPanel pr={PR} workspaceId={WORKSPACE_ID} onClose={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Open review session' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: /Review locally/ })).toBeNull();
+  });
+
+  it('never offers merge, close, or edit affordances', () => {
+    render(<ReviewPrDetailPanel pr={PR} workspaceId={WORKSPACE_ID} onClose={vi.fn()} />);
+
+    expect(screen.queryByText(/merge/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /close pull request/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
+  });
+
+  it('shows a hint instead of review actions for own PRs', () => {
+    render(
+      <ReviewPrDetailPanel pr={{ ...PR, mine: true }} workspaceId={WORKSPACE_ID} onClose={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/This is your pull request/)).toBeDefined();
+    expect(screen.queryByRole('button', { name: /Review locally/ })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
+++ b/apps/desktop/src/features/review/components/ReviewPrDetailPanel/index.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react';
+import { Button, Divider, EmptyState, ScrollFade, SectionHeader } from '@goodboy/ui';
+import {
+  ArrowRight,
+  ExternalLink,
+  GitBranch,
+  MessagesSquare,
+  MousePointerClick,
+} from 'lucide-react';
+import type { ReviewablePr, SessionId, WorkspaceId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useOpenSession } from '../../../../shared/hooks/useOpenSession';
+import { formatError } from '../../../../shared/lib/errors';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import { PullRequestChip } from '../../../github/components/PullRequestChip';
+import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
+import { AuthorAvatar } from '../AuthorAvatar';
+
+type Props = {
+  readonly pr: ReviewablePr | null;
+  readonly workspaceId: WorkspaceId;
+  readonly onClose: () => void;
+};
+
+export const ReviewPrDetailPanel = ({ pr, workspaceId, onClose }: Props) => {
+  const startPrReviewSession = useAppStore((s) => s.startPrReviewSession);
+  const existingSessionId = useAppStore((s): SessionId | null => {
+    if (pr == null) {
+      return null;
+    }
+    const match = s.sessions.find((session) => {
+      if (session.workspaceId !== workspaceId) {
+        return false;
+      }
+      const tasks = s.sessionExternalTasks[session.id] ?? [];
+      return tasks.some(
+        (task) => task.provider === pr.provider && task.externalId === String(pr.number),
+      );
+    });
+    return (match?.id as SessionId | undefined) ?? null;
+  });
+  const openSession = useOpenSession();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBusy(false);
+    setError(null);
+  }, [pr?.id]);
+
+  if (pr == null) {
+    return (
+      <div className="flex h-full items-center justify-center px-8">
+        <EmptyState
+          icon={MousePointerClick}
+          title="No pull request selected"
+          description="Pick a pull request to see its details and review it locally."
+        />
+      </div>
+    );
+  }
+
+  const isGitlab = pr.provider === 'gitlab';
+  const identifier = isGitlab ? `!${pr.number}` : `#${pr.number}`;
+  const hostLabel = isGitlab ? 'GitLab' : 'GitHub';
+
+  const reviewLocally = async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const sessionId = await startPrReviewSession(workspaceId, pr);
+      openSession(sessionId, onClose);
+    } catch (launchError) {
+      setError(formatError(launchError));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+            {identifier}
+          </span>
+          <PullRequestChip state={pr.isDraft ? 'draft' : pr.state} variant="badge" />
+          {pr.reviewRequested ? (
+            <span className="rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-600 ring-1 ring-indigo-400/30">
+              Review requested
+            </span>
+          ) : null}
+          <span className="flex-1" />
+          <a
+            href={pr.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Open in {hostLabel} <ExternalLink size={11} aria-hidden />
+          </a>
+        </div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">{pr.title}</h2>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-2xs text-muted-foreground">
+          <span className="inline-flex items-center gap-1.5">
+            <AuthorAvatar author={pr.author} avatarUrl={pr.authorAvatarUrl} />
+            <span className="font-medium text-foreground/80">{pr.author}</span>
+          </span>
+          <span className="inline-flex min-w-0 items-center gap-1">
+            <GitBranch size={11} aria-hidden className="shrink-0" />
+            <span className="truncate font-mono text-foreground/80">{pr.headBranch}</span>
+            <span aria-hidden className="text-muted-foreground/50">
+              into
+            </span>
+            <span className="truncate font-mono">{pr.baseBranch}</span>
+          </span>
+          <span>updated {formatRelativeDuration(pr.updatedAt)} ago</span>
+        </div>
+      </div>
+      <Divider />
+      <div className="flex min-h-0 flex-1 justify-center">
+        <ScrollFade
+          className="h-full w-full max-w-3xl"
+          viewportClassName="px-10 py-8"
+          fadeSize={24}
+        >
+          <section className="flex flex-col gap-3">
+            <SectionHeader label="review" />
+            {pr.mine ? (
+              <div className="rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5 text-sm text-muted-foreground">
+                This is your pull request. Manage it from the Mine inbox.
+              </div>
+            ) : existingSessionId != null ? (
+              <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+                <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-indigo-400/15">
+                  <MessagesSquare size={15} className="text-indigo-500" aria-hidden />
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="text-sm font-medium text-foreground">
+                    Review session already running
+                  </span>
+                  <span className="truncate text-2xs text-muted-foreground">
+                    A local review session is linked to this pull request.
+                  </span>
+                </div>
+                <OpenSessionButton
+                  sessionId={existingSessionId}
+                  onOpened={onClose}
+                  label="Open review session"
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  Review locally checks out the branch in an isolated worktree and starts a
+                  read-only review agent. Draft comments stay local until you publish them.
+                </p>
+                <div className="flex items-center gap-3">
+                  {error != null ? <span className="text-xs text-danger">{error}</span> : null}
+                  <span className="flex-1" />
+                  <Button variant="ghost" onClick={() => window.open(pr.url, '_blank')}>
+                    Open in browser
+                  </Button>
+                  <Button onClick={() => void reviewLocally()} disabled={busy}>
+                    {busy ? 'Starting review session…' : 'Review locally'}
+                    {!busy ? <ArrowRight size={13} aria-hidden /> : null}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </section>
+        </ScrollFade>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -39,12 +39,14 @@ import { canForceResolve } from '../ForceResolveAction/canForceResolve';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
 import { SessionOverviewSkeleton } from './parts/SessionOverviewSkeleton';
 import { ChatWorkflowContext } from './parts/ChatWorkflowContext';
+import { ReviewBoardPane } from '../../../review/components/ReviewBoardPane';
 
 const LENS_LABEL: Record<LensKind, string> = {
   questions: 'Questions',
   agents: 'Agents',
   workflows: 'Workflows',
   resolve: 'Resolve',
+  review: 'Review board',
   plans: 'Plans',
   scripts: 'Scripts',
   terminal: 'Terminal',
@@ -315,6 +317,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <SlotPane session={session} slotKey={lens} />
                 ) : null}
                 {lens === 'pr' ? <PrPane session={session} /> : null}
+                {lens === 'review' ? <ReviewBoardPane session={session} /> : null}
                 {lens === 'linear' ? (
                   <IntegrationPane
                     sessionId={sessionId}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -13,7 +13,8 @@ const { hooks, remote, store } = vi.hoisted(() => {
     remote: { kind: 'github' as 'github' | 'gitlab' | 'other' | null },
     store: {
       agentKindOverride: {},
-      sessionPhaseRuns: {},
+      sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+      reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
       scriptRuns: {},
       terminalSessions: {},
       sessionGithub: {},
@@ -76,6 +77,8 @@ beforeEach(() => {
   hooks.agentCount = 0;
   hooks.planCount = 0;
   hooks.questionCount = 0;
+  store.sessionPhaseRuns = {};
+  store.reviewDrafts = {};
   store.sessionExternalTasks = {};
   store.workspaceIntegrations = {
     'workspace-1': [{ provider: 'linear' }, { provider: 'sentry' }],
@@ -271,6 +274,40 @@ describe('LensColumn', () => {
 
     expect(screen.getByRole('button', { name: 'GitLab' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'GitLab issues 1' })).toBeDefined();
+  });
+
+  it('shows the review board lens only for PR review sessions', () => {
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /Review board/ })).toBeNull();
+
+    cleanup();
+    store.sessionPhaseRuns = {
+      'session-1': [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }],
+    };
+    store.reviewDrafts = { 'session-1': [{ id: 'draft-1', status: 'draft' }] };
+    const onSelect = vi.fn();
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={onSelect}
+        filesCount={0}
+      />,
+    );
+
+    const row = screen.getByRole('button', { name: 'Review board 1' });
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith('review');
   });
 
   it('hides disconnected integration rows without linked tasks', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -6,6 +6,7 @@ import {
   CheckCheck,
   CircleHelp,
   FileDiff,
+  MessageSquareDiff,
   FileText,
   LayoutDashboard,
   Layers,
@@ -18,6 +19,7 @@ import { KbdPill, ScrollFade, Skeleton, StatusDot, cn, tintClasses } from '@good
 import type { Tone } from '@goodboy/ui';
 import type { Agent, Session, SessionId } from '@goodboy/types';
 import { classifyAgent, isStandaloneAgent } from '../../../../session/agent-kind';
+import { isPrReviewSession } from '../../../../../store/slices/session-view';
 import {
   EMPTY_ARRAY,
   useAppStore,
@@ -66,6 +68,7 @@ const LENS_SHORTCUTS = {
   agents: '⌘⇧B',
   workflows: '⌘⇧W',
   resolve: '⌘⇧R',
+  review: null,
   plans: '⌘⇧L',
   scripts: '⌘⇧S',
   terminal: '⌘J',
@@ -154,6 +157,12 @@ export const LensColumn = ({
   const hasPendingBatch = useAppStore(
     (s) => (s.sessionPendingResolutions[sessionId]?.length ?? 0) > 0,
   );
+  const isPrReview = useMemo(() => isPrReviewSession({ agents: phaseRuns }), [phaseRuns]);
+  const reviewDraftCount = useAppStore(
+    (s) =>
+      (s.reviewDrafts[sessionId] ?? EMPTY_ARRAY).filter((draft) => draft.status === 'draft')
+        .length,
+  );
   const linearCount = externalTasks.filter((task) => task.provider === 'linear').length;
   const sentryCount = externalTasks.filter((task) => task.provider === 'sentry').length;
   const gitlabCount = externalTasks.filter((task) => task.provider === 'gitlab').length;
@@ -233,6 +242,17 @@ export const LensColumn = ({
     {
       label: 'Work',
       rows: [
+        ...(isPrReview
+          ? [
+              {
+                kind: 'review',
+                label: 'Review board',
+                icon: MessageSquareDiff,
+                tone: 'primary',
+                count: reviewDraftCount,
+              } satisfies LensRow,
+            ]
+          : []),
         {
           kind: 'workflows',
           label: 'Workflows',

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.test.tsx
@@ -20,6 +20,7 @@ type Store = {
   sessionGithub: Record<string, unknown>;
   sessionGitlabMr: Record<string, unknown>;
   sessionExternalTasks: Record<string, ReadonlyArray<SessionExternalTask>>;
+  sessionPhaseRuns: Record<string, ReadonlyArray<unknown>>;
   readonly refreshSessionPr: ReturnType<typeof vi.fn>;
   readonly createPrForSession: ReturnType<typeof vi.fn>;
   readonly spawnAgent: ReturnType<typeof vi.fn<SpawnAgent>>;
@@ -46,6 +47,7 @@ const h = vi.hoisted(() => ({
     sessionGithub: {},
     sessionGitlabMr: {},
     sessionExternalTasks: {},
+    sessionPhaseRuns: {},
     refreshSessionPr: vi.fn(),
     createPrForSession: vi.fn(async () => undefined),
     spawnAgent: vi.fn<SpawnAgent>(async () => 'agent-1'),
@@ -110,6 +112,7 @@ beforeEach(() => {
   h.store.sessionGithub = {};
   h.store.sessionGitlabMr = {};
   h.store.sessionExternalTasks = {};
+  h.store.sessionPhaseRuns = {};
   h.store.createPrForSession.mockClear();
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
@@ -120,6 +123,18 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('PrPane', () => {
+  it('never offers create-PR actions inside a PR review session', () => {
+    h.store.sessionPhaseRuns = {
+      [SESSION_ID]: [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }],
+    };
+
+    render(<PrPane session={session} />);
+
+    expect(screen.getByText('External review session')).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Draft with an agent' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Quick draft' })).toBeNull();
+  });
+
   it('renders the stored pull request as a selected list row above its detail', () => {
     h.store.sessionGithub = {
       [SESSION_ID]: {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/PrPane.tsx
@@ -24,6 +24,7 @@ import { AgentSpawnConfig } from '../../AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../AgentSpawnConfig/AgentSpawnConfigValue';
 import { taskModelAgentSpawnConfig } from '../../AgentSpawnConfig/taskModelAgentSpawnConfig';
 import { EMPTY_ARRAY, useAppStore } from '../../../../../store';
+import { isPrReviewSession } from '../../../../../store/slices/session-view';
 import { PaneShell } from './PaneShell';
 import { PrListRow } from './PrListRow';
 
@@ -38,6 +39,8 @@ export const PrPane = ({ session }: Props) => {
   const remoteKind = useRemoteHostKind(session.workspaceId);
   const pullRequest = useAppStore((state) => state.sessionGithub[sessionId]?.pr ?? null);
   const mergeRequest = useAppStore((state) => state.sessionGitlabMr[sessionId]?.mr ?? null);
+  const phaseRuns = useAppStore((state) => state.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
+  const isPrReview = useMemo(() => isPrReviewSession({ agents: phaseRuns }), [phaseRuns]);
   const [selectedProvider, setSelectedProvider] = useState<PullRequestProvider | null>(null);
   const defaultProvider: PullRequestProvider =
     remoteKind === 'gitlab' && mergeRequest != null
@@ -97,14 +100,14 @@ export const PrPane = ({ session }: Props) => {
         {activeProvider === 'gitlab' ? (
           <GitlabMrStrip sessionId={sessionId} />
         ) : (
-          <GithubPrCard session={session} />
+          <GithubPrCard session={session} isPrReview={isPrReview} />
         )}
       </div>
     </PaneShell>
   );
 };
 
-const GithubPrCard = ({ session }: { session: Session }) => {
+const GithubPrCard = ({ session, isPrReview }: { session: Session; isPrReview: boolean }) => {
   const sessionId = session.id as SessionId;
   const github = useAppStore((s) => s.sessionGithub[sessionId]);
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
@@ -189,6 +192,26 @@ const GithubPrCard = ({ session }: { session: Session }) => {
       setBusy(null);
     }
   };
+
+  if (!pr && isPrReview) {
+    return (
+      <div className="animate-fade-in flex flex-col items-center gap-3 rounded-lg border border-dashed border-border-soft bg-elevated/40 px-8 py-8 text-center">
+        <span
+          aria-hidden
+          className="flex size-12 items-center justify-center rounded-full bg-indigo-400/15"
+        >
+          <GitPullRequest size={24} className="text-indigo-500" />
+        </span>
+        <div className="flex flex-col items-center gap-1.5">
+          <h2 className="text-base font-semibold text-foreground">External review session</h2>
+          <p className="max-w-sm text-sm leading-relaxed text-muted-foreground">
+            This session reviews someone else&rsquo;s pull request, so there is no PR to open from
+            here. Draft and publish comments from the review board.
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   if (!pr) {
     return (

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -17,6 +17,9 @@ const { state, hooks } = vi.hoisted(() => ({
     sessionGitlabMr: {} as Record<string, { mr: GitlabMergeRequest | null }>,
     sessionExternalTasks: {} as Record<string, ReadonlyArray<SessionExternalTask>>,
     sessionWorktrees: {} as Record<string, ReadonlyArray<string>>,
+    sessionPhaseRuns: {} as Record<string, ReadonlyArray<unknown>>,
+    reviewDrafts: {} as Record<string, ReadonlyArray<unknown>>,
+    loadReviewDrafts: vi.fn(async () => undefined),
   },
   hooks: {
     stage: 'building' as SessionStage,
@@ -103,6 +106,9 @@ beforeEach(() => {
   state.sessionGitlabMr = {};
   state.sessionExternalTasks = {};
   state.sessionWorktrees = {};
+  state.sessionPhaseRuns = {};
+  state.reviewDrafts = {};
+  state.loadReviewDrafts.mockClear();
   hooks.reason = 'no PR yet';
   hooks.agents = [];
   hooks.cost = 0;
@@ -163,6 +169,41 @@ describe('StageBoardCard linked request', () => {
     const title = `Merge request !12 · ${expected}`;
     const icon = screen.getByLabelText(title);
     expect(icon.getAttribute('title')).toBe(title);
+  });
+});
+
+describe('StageBoardCard review drafts', () => {
+  it('shows a draft comments chip for review sessions with pending drafts', () => {
+    state.sessionPhaseRuns = {
+      [SESSION_ID]: [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }],
+    };
+    state.reviewDrafts = {
+      [SESSION_ID]: [
+        { id: 'draft-1', status: 'draft' },
+        { id: 'draft-2', status: 'draft' },
+        { id: 'draft-3', status: 'published' },
+      ],
+    };
+    render(<StageBoardCard session={session} nav={nav} />);
+
+    expect(screen.getByText('draft comments').previousElementSibling?.textContent).toBe('2');
+  });
+
+  it('loads drafts once for review sessions and hides the chip elsewhere', () => {
+    state.sessionPhaseRuns = {
+      [SESSION_ID]: [{ id: 'agent-1', name: 'pr review', kind: 'pr-reviewer' }],
+    };
+    render(<StageBoardCard session={session} nav={nav} />);
+    expect(state.loadReviewDrafts).toHaveBeenCalledWith(SESSION_ID);
+    expect(screen.queryByText(/draft comment/)).toBeNull();
+
+    cleanup();
+    state.sessionPhaseRuns = {};
+    state.reviewDrafts = { [SESSION_ID]: [{ id: 'draft-1', status: 'draft' }] };
+    state.loadReviewDrafts.mockClear();
+    render(<StageBoardCard session={session} nav={nav} />);
+    expect(state.loadReviewDrafts).not.toHaveBeenCalled();
+    expect(screen.queryByText(/draft comment/)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -1,8 +1,9 @@
-import { memo } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import {
   Archive,
   Bot,
   Code,
+  MessageSquareDiff,
   RotateCcw,
   SquareTerminal,
   Trash2,
@@ -17,6 +18,7 @@ import {
   useSessionCost,
   useSessionStageInfo,
 } from '../../../../../store';
+import { isPrReviewSession } from '../../../../../store/slices/session-view';
 import { CostBadge } from '../../../../providers/components/CostBadge';
 import { PullRequestChip } from '../../../../github/components/PullRequestChip';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
@@ -53,6 +55,21 @@ export const StageBoardCard = memo(function StageBoardCard({
   const worktreePath = useAppStore((s) => s.sessionWorktrees[id]?.[0] ?? null);
   const dynamicActions = useDynamicActions(session, nav, stage, reason);
   const sessionCost = useSessionCost(id);
+  const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[id] ?? EMPTY_ARRAY);
+  const isPrReview = useMemo(() => isPrReviewSession({ agents: phaseRuns }), [phaseRuns]);
+  const reviewDrafts = useAppStore((s) => s.reviewDrafts[id]);
+  const loadReviewDrafts = useAppStore((s) => s.loadReviewDrafts);
+
+  useEffect(() => {
+    if (!isPrReview || reviewDrafts != null) {
+      return;
+    }
+    void loadReviewDrafts(id);
+  }, [isPrReview, reviewDrafts, loadReviewDrafts, id]);
+
+  const reviewDraftCount = isPrReview
+    ? (reviewDrafts ?? []).filter((draft) => draft.status === 'draft').length
+    : 0;
 
   const linkedRequest = getLinkedRequest({ pullRequest, mergeRequest });
 
@@ -99,6 +116,13 @@ export const StageBoardCard = memo(function StageBoardCard({
                 <span className="tabular-nums">{agentCount}</span>
               </span>
             </Tooltip>
+          )}
+          {reviewDraftCount > 0 && (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-indigo-400/15 px-1.5 py-0.5 text-[10px] font-medium text-indigo-600">
+              <MessageSquareDiff size={10} aria-hidden />
+              <span className="tabular-nums">{reviewDraftCount}</span>
+              <span>draft {reviewDraftCount === 1 ? 'comment' : 'comments'}</span>
+            </span>
           )}
           {externalTasks.map((task) => (
             <ExternalTaskChip

--- a/apps/desktop/src/shared/components/SegmentedControl/index.test.tsx
+++ b/apps/desktop/src/shared/components/SegmentedControl/index.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { SegmentedControl } from './index';
+
+const OPTIONS = [
+  { value: 'mine', label: 'Mine' },
+  { value: 'others', label: 'Others' },
+  { value: 'all', label: 'All' },
+] as const;
+
+afterEach(cleanup);
+
+describe('SegmentedControl', () => {
+  it('marks the active option and switches on click', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        ariaLabel="Review inbox filter"
+        options={OPTIONS}
+        value="mine"
+        onChange={onChange}
+      />,
+    );
+
+    expect(screen.getByRole('radio', { name: 'Mine' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Others' }).getAttribute('aria-checked')).toBe(
+      'false',
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Others' }));
+    expect(onChange).toHaveBeenCalledWith('others');
+  });
+
+  it('exposes the group with its accessible label', () => {
+    render(
+      <SegmentedControl
+        ariaLabel="Review inbox filter"
+        options={OPTIONS}
+        value="all"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('radiogroup', { name: 'Review inbox filter' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/shared/components/SegmentedControl/index.tsx
+++ b/apps/desktop/src/shared/components/SegmentedControl/index.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@goodboy/ui';
+
+export type SegmentedOption<T extends string> = Readonly<{
+  label: string;
+  value: T;
+}>;
+
+type Props<T extends string> = {
+  readonly ariaLabel: string;
+  readonly options: ReadonlyArray<SegmentedOption<T>>;
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+};
+
+export const SegmentedControl = <T extends string>({
+  ariaLabel,
+  options,
+  value,
+  onChange,
+}: Props<T>) => (
+  <div
+    role="radiogroup"
+    aria-label={ariaLabel}
+    className="flex items-center gap-1 rounded-md bg-muted/50 p-1"
+  >
+    {options.map((option) => {
+      const isActive = option.value === value;
+      return (
+        <button
+          key={option.value}
+          type="button"
+          role="radio"
+          aria-checked={isActive}
+          onClick={() => onChange(option.value)}
+          className={cn(
+            'flex-1 rounded-md px-2.5 py-1 text-xs font-medium transition-colors',
+            isActive
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {option.label}
+        </button>
+      );
+    })}
+  </div>
+);

--- a/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
+++ b/apps/desktop/src/store/slices/review-drafts/resolveReviewTarget.ts
@@ -29,13 +29,11 @@ const repoFromTask = ({ task }: RepoFromTaskParams): string | null => {
   }
 };
 
-type Params = {
-  readonly get: GetFn;
-  readonly sessionId: SessionId;
+type FromTasksParams = {
+  readonly tasks: ReadonlyArray<SessionExternalTask>;
 };
 
-export const resolveReviewTarget = ({ get, sessionId }: Params): ReviewTarget | null => {
-  const tasks = get().sessionExternalTasks[sessionId] ?? [];
+export const reviewTargetFromTasks = ({ tasks }: FromTasksParams): ReviewTarget | null => {
   const task =
     tasks.find((candidate) => candidate.provider === 'github' || candidate.provider === 'gitlab') ??
     null;
@@ -52,3 +50,11 @@ export const resolveReviewTarget = ({ get, sessionId }: Params): ReviewTarget | 
   }
   return { provider: task.provider as ReviewablePrProvider, repo, prNumber };
 };
+
+type Params = {
+  readonly get: GetFn;
+  readonly sessionId: SessionId;
+};
+
+export const resolveReviewTarget = ({ get, sessionId }: Params): ReviewTarget | null =>
+  reviewTargetFromTasks({ tasks: get().sessionExternalTasks[sessionId] ?? [] });

--- a/apps/desktop/src/store/slices/session-view/types.ts
+++ b/apps/desktop/src/store/slices/session-view/types.ts
@@ -17,6 +17,7 @@ export type LensKind =
   | 'agents'
   | 'workflows'
   | 'resolve'
+  | 'review'
   | 'plans'
   | 'scripts'
   | 'terminal'
@@ -34,6 +35,7 @@ export const LENS_KINDS: ReadonlySet<LensKind> = new Set<LensKind>([
   'agents',
   'workflows',
   'resolve',
+  'review',
   'plans',
   'scripts',
   'terminal',


### PR DESCRIPTION
## Obiettivo
UX della feature: nella sezione PR filtra le mie da quelle altrui, e sulle altrui una review board diff-centrica con bozze e pubblicazione.

Area 4 dello stack **PR review**. Base: `ak/feat-pr-review-drafts`. Da NON mergiare da sola.

## Cosa
- Segmented `Mine | Others | All` negli studi GitHub e GitLab (`SegmentedControl` nuovo, role=radiogroup). Default `Mine` = comportamento attuale invariato.
- `ReviewInboxList` (provider-agnostico): righe con avatar+login autore, stato, tempo relativo, badge `Review requested` in evidenza. Nessuna affordance merge/close/edit sulle PR altrui.
- `ReviewPrDetailPanel`: `Review locally` -> `startPrReviewSession` + nav; dedup verso `Open review session` se già esiste.
- Lens `Review board` (solo nelle sessioni di review): diff navigabile, composer sulla riga -> bozza, `Ask agent` che precompila la chat, pannello bozze (edit/discard, chip origin/stale), publish bar persistente con verdict.
- Chip "N draft comments" sulla card StageBoard.

## MUST NOT (verificati)
- `PrPane`/lens e shortcut esistenti invariati. Card transcript-style left-border (no boxed).

## Test
typecheck desktop + suite completa **285 file / 2408 test** verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)