### PR TITLE
feat: dashboard layouts for integration studios

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.test.tsx
@@ -82,4 +82,18 @@ describe('GithubIssueDetailPanel', () => {
       }),
     );
   });
+
+  it('surfaces the last-updated timestamp in the metadata rail', () => {
+    render(
+      <GithubIssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Updated')).toBeDefined();
+    expect(screen.getByText(/\dd ago/)).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/GithubIssueDetailPanel/index.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useState } from 'react';
-import {
-  Button,
-  Divider,
-  EmptyState,
-  Input,
-  Markdown,
-  ScrollFade,
-  SectionHeader,
-  Textarea,
-} from '@goodboy/ui';
+import { Button, Divider, EmptyState, Input, Markdown, SectionHeader, Textarea } from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
@@ -21,6 +12,13 @@ import type { GithubIssue, SessionId, WorkspaceId } from '@goodboy/types';
 import { useToast } from '../../../../../app/components/Toast';
 import { OpenSessionButton } from '../../../../../shared/components/OpenSessionButton';
 import { BaseBranchGuide } from '../../../../../shared/components/BaseBranchGuide';
+import {
+  DetailSection,
+  HeaderBand,
+  MetaItem,
+  StudioDetailLayout,
+} from '../../../../../shared/components/StudioDetail';
+import { formatRelativeDuration } from '../../../../../shared/utils/relativeDate';
 import { formatError, isMissingBaseRefError } from '../../../../../shared/lib/errors';
 import { isValidBranchSlug } from '../../../../../shared/utils/isValidBranchSlug';
 import { sanitizeBranchPrefix } from '../../../../../shared/utils/sanitizeBranchPrefix';
@@ -124,143 +122,145 @@ export const GithubIssueDetailPanel = ({ issue, sessionId, workspaceId, onClose 
     }
   };
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-            #{issue.number}
+  const updated = formatRelativeDuration(issue.updatedAt);
+
+  const launchCard = (
+    <section className="flex flex-col gap-3">
+      <SectionHeader label="launch session" />
+      {openableSessionId != null ? (
+        <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+            <MessagesSquare size={15} className="text-success" aria-hidden />
           </span>
-          <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
-            {issue.state.toLowerCase()}
-          </span>
-          <span className="flex-1" />
-          <a
-            href={issue.url}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Open in GitHub <ExternalLink size={11} aria-hidden />
-          </a>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium text-foreground">Session already launched</span>
+            <span className="truncate text-2xs text-muted-foreground">
+              {sessionId != null
+                ? 'A session is linked to this issue.'
+                : 'A session is already on this branch.'}
+            </span>
+          </div>
+          <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
         </div>
-        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
-        {issue.labels.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-1.5">
-            {issue.labels.map((label) => (
-              <span
-                key={label}
-                className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
-              >
-                {label}
+      ) : (
+        <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader label="Goal" />
+            <Textarea
+              value={goal}
+              onChange={(event) => setGoal(event.target.value)}
+              autoGrow
+              minRows={3}
+              maxRows={10}
+              disabled={busy}
+              aria-label="Session goal"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader
+              label="Branch"
+              icon={<GitBranch size={13} aria-hidden className="text-success" />}
+            />
+            <div className="flex items-center gap-1.5">
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {prefix + '/'}
               </span>
-            ))}
+              <Input
+                value={branchSlug}
+                onChange={(event) =>
+                  setBranchSlug(sanitizeBranchSlug({ input: event.target.value, maxLength: 48 }))
+                }
+                placeholder="branch-slug"
+                className="h-8 flex-1 font-mono text-sm"
+                disabled={busy}
+                aria-label="Branch slug"
+              />
+            </div>
+            {conflictPath != null ? (
+              <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
+                <AlertTriangle size={12} aria-hidden className="shrink-0 text-warning" />
+                <span>This branch is already checked out in another worktree.</span>
+              </div>
+            ) : null}
           </div>
-        ) : null}
-      </div>
-      <Divider />
-      <div className="flex min-h-0 flex-1 justify-center">
-        <ScrollFade
-          className="h-full w-full max-w-3xl"
-          viewportClassName="px-10 py-8"
-          fadeSize={24}
-        >
-          <div className="flex flex-col gap-8">
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="description" />
-              {issue.body.trim() !== '' ? (
-                <Markdown text={issue.body} className="text-sm leading-relaxed" />
-              ) : (
-                <p className="text-sm italic text-muted-foreground/60">No description.</p>
-              )}
-            </section>
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="launch session" />
-              {openableSessionId != null ? (
-                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
-                    <MessagesSquare size={15} className="text-success" aria-hidden />
-                  </span>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="text-sm font-medium text-foreground">
-                      Session already launched
-                    </span>
-                    <span className="truncate text-2xs text-muted-foreground">
-                      {sessionId != null
-                        ? 'A session is linked to this issue.'
-                        : 'A session is already on this branch.'}
-                    </span>
-                  </div>
-                  <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
-                </div>
-              ) : (
-                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-                  <div className="flex flex-col gap-1.5">
-                    <SectionHeader label="Goal" />
-                    <Textarea
-                      value={goal}
-                      onChange={(event) => setGoal(event.target.value)}
-                      autoGrow
-                      minRows={3}
-                      maxRows={10}
-                      disabled={busy}
-                      aria-label="Session goal"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-1.5">
-                    <SectionHeader
-                      label="Branch"
-                      icon={<GitBranch size={13} aria-hidden className="text-success" />}
-                    />
-                    <div className="flex items-center gap-1.5">
-                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                        {prefix + '/'}
-                      </span>
-                      <Input
-                        value={branchSlug}
-                        onChange={(event) =>
-                          setBranchSlug(
-                            sanitizeBranchSlug({ input: event.target.value, maxLength: 48 }),
-                          )
-                        }
-                        placeholder="branch-slug"
-                        className="h-8 flex-1 font-mono text-sm"
-                        disabled={busy}
-                        aria-label="Branch slug"
-                      />
-                    </div>
-                    {conflictPath != null ? (
-                      <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
-                        <AlertTriangle size={12} aria-hidden className="shrink-0 text-warning" />
-                        <span>This branch is already checked out in another worktree.</span>
-                      </div>
-                    ) : null}
-                  </div>
-                  {isMissingBase ? <BaseBranchGuide /> : null}
-                  <div className="flex items-center gap-3">
-                    {error != null && !isMissingBase ? (
-                      <span className="text-xs text-danger">{error}</span>
-                    ) : null}
-                    <span className="flex-1" />
-                    <Button
-                      variant={isBlockedByConflict ? 'danger' : undefined}
-                      onClick={() => void launch({ eraseWorktreePath: conflictPath ?? undefined })}
-                      disabled={isBlockedByConflict ? busy || goal.trim() === '' : !canLaunch}
-                    >
-                      {busy
-                        ? 'Launching…'
-                        : isBlockedByConflict
-                          ? 'Erase worktree & launch'
-                          : 'Launch session'}
-                      {!busy ? <ArrowRight size={13} aria-hidden /> : null}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </section>
+          {isMissingBase ? <BaseBranchGuide /> : null}
+          <div className="flex items-center gap-3">
+            {error != null && !isMissingBase ? (
+              <span className="text-xs text-danger">{error}</span>
+            ) : null}
+            <span className="flex-1" />
+            <Button
+              variant={isBlockedByConflict ? 'danger' : undefined}
+              onClick={() => void launch({ eraseWorktreePath: conflictPath ?? undefined })}
+              disabled={isBlockedByConflict ? busy || goal.trim() === '' : !canLaunch}
+            >
+              {busy
+                ? 'Launching…'
+                : isBlockedByConflict
+                  ? 'Erase worktree & launch'
+                  : 'Launch session'}
+              {!busy ? <ArrowRight size={13} aria-hidden /> : null}
+            </Button>
           </div>
-        </ScrollFade>
-      </div>
-    </div>
+        </div>
+      )}
+    </section>
+  );
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <>
+              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+                #{issue.number}
+              </span>
+              <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+                {issue.state.toLowerCase()}
+              </span>
+            </>
+          }
+          title={issue.title}
+          actions={
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Open in GitHub <ExternalLink size={11} aria-hidden />
+            </a>
+          }
+        />
+      }
+      rail={
+        <>
+          {launchCard}
+          <Divider />
+          {issue.labels.length > 0 ? (
+            <MetaItem label="Labels">
+              {issue.labels.map((label) => (
+                <span
+                  key={label}
+                  className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
+                >
+                  {label}
+                </span>
+              ))}
+            </MetaItem>
+          ) : null}
+          {updated !== '' ? <MetaItem label="Updated">{updated} ago</MetaItem> : null}
+        </>
+      }
+    >
+      <DetailSection label="description">
+        {issue.body.trim() !== '' ? (
+          <Markdown text={issue.body} className="text-sm leading-relaxed" />
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No description.</p>
+        )}
+      </DetailSection>
+    </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import type { GitlabIssue } from '../client';
+
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(async () => ({
+    session: { id: 'session-9', goal: 'GitLab issue acme/web#7: Fix pipeline flake' },
+  })),
+  loadSetting: vi.fn(async () => null),
+  showToast: vi.fn(),
+  store: {
+    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (
+      state: typeof h.store & {
+        createSession: typeof h.createSession;
+        loadSetting: typeof h.loadSetting;
+      },
+    ) => T,
+  ) => selector({ ...h.store, createSession: h.createSession, loadSetting: h.loadSetting }),
+}));
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+vi.mock('../../../worktree/useBranchConflict', () => ({ useBranchConflict: () => null }));
+vi.mock('../../../worktree/worktree', () => ({ removeWorktree: vi.fn() }));
+
+import { IssueDetailPanel } from './IssueDetailPanel';
+
+const ISSUE: GitlabIssue = {
+  id: 71,
+  iid: 7,
+  projectId: 3,
+  title: 'Fix pipeline flake',
+  description: 'The nightly pipeline fails intermittently.',
+  state: 'opened',
+  webUrl: 'https://gitlab.com/acme/web/-/issues/7',
+  references: { full: 'acme/web#7' },
+  updatedAt: new Date(Date.now() - 7_200_000).toISOString(),
+  milestone: { title: 'v1.3' },
+  labels: ['bug'],
+};
+
+beforeEach(() => {
+  h.createSession.mockClear();
+  h.loadSetting.mockClear();
+  h.showToast.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('IssueDetailPanel', () => {
+  it('surfaces milestone, labels, and last update in the metadata rail', async () => {
+    render(
+      <IssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Session goal' })).toBeDefined(),
+    );
+    expect(screen.getByText('v1.3')).toBeDefined();
+    expect(screen.getByText('bug')).toBeDefined();
+    expect(screen.getByText('Updated')).toBeDefined();
+    expect(screen.getByText('2h ago')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/IssueDetailPanel.tsx
@@ -11,8 +11,14 @@ import {
   Target,
 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
-import { ScrollFade } from '@goodboy/ui';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
+import {
+  DetailSection,
+  HeaderBand,
+  MetaItem,
+  StudioDetailLayout,
+} from '../../../../shared/components/StudioDetail';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError, isMissingBaseRefError } from '../../../../shared/lib/errors';
@@ -149,194 +155,191 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     }
   };
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex shrink-0 flex-col gap-2 px-8 py-4">
-        <div className="flex items-center gap-2">
-          <span className="font-mono text-2xs tabular-nums text-muted-foreground">
-            {issueIdentifier(issue)}
+  const updated = formatRelativeDuration(issue.updatedAt);
+
+  const launch = (
+    <section className="flex flex-col gap-3">
+      <SectionHeader label="launch session" />
+      {openableSessionId ? (
+        <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+            <MessagesSquare size={15} className="text-success" aria-hidden />
           </span>
-          <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
-            {issue.state}
-          </span>
-          <span className="flex-1" />
-          <a
-            href={issue.webUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Open in GitLab <ExternalLink size={11} aria-hidden />
-          </a>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium text-foreground">Session already launched</span>
+            <span className="truncate text-2xs text-muted-foreground">
+              {sessionId
+                ? 'A session is linked to this issue.'
+                : 'A session is already on this branch.'}
+            </span>
+          </div>
+          <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
         </div>
-        <h2 className="text-lg font-semibold leading-snug text-foreground">{issue.title}</h2>
-        {issue.milestone || issue.labels.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-1.5">
-            {issue.milestone ? (
+      ) : (
+        <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+          <LaunchField
+            icon={<Target size={13} aria-hidden className="text-primary" />}
+            label="Goal"
+          >
+            <Textarea
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              autoGrow
+              minRows={3}
+              maxRows={10}
+              disabled={busy}
+              aria-label="Session goal"
+            />
+          </LaunchField>
+
+          <LaunchField
+            icon={<GitBranch size={13} aria-hidden className="text-success" />}
+            label="Branch"
+          >
+            <div className="flex items-center gap-1.5">
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {prefix + '/'}
+              </span>
+              <Input
+                value={branchSlug}
+                onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
+                placeholder="branch-slug"
+                className="h-8 flex-1 font-mono text-sm"
+                disabled={busy}
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                aria-label="Branch slug"
+              />
+            </div>
+            {conflictPath ? (
+              <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
+                <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                <span>
+                  This branch is already checked out in another worktree (
+                  <span className="break-all font-mono">{conflictPath}</span>). Launching erases
+                  that worktree and recreates it here. Pick a different slug to keep it.
+                </span>
+              </div>
+            ) : null}
+          </LaunchField>
+
+          {missingBase ? <BaseBranchGuide /> : null}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={setupWorkflow}
+                onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
+                className="accent-primary"
+                disabled={busy}
+              />
+              Set up workflow next
+            </label>
+            <span className="flex-1" />
+            {error && !missingBase ? <span className="text-xs text-danger">{error}</span> : null}
+            {blockedByConflict ? (
+              <Button
+                variant="danger"
+                onClick={() => void onLaunch(conflictPath ?? undefined)}
+                disabled={busy || goal.trim().length === 0}
+                className={busy ? 'animate-border-pulse' : undefined}
+              >
+                {busy ? (
+                  'Working…'
+                ) : (
+                  <>
+                    Erase worktree &amp; launch
+                    <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                  </>
+                )}
+              </Button>
+            ) : (
+              <Button
+                onClick={() => void onLaunch()}
+                disabled={!canLaunch}
+                className={busy ? 'animate-border-pulse' : undefined}
+              >
+                {busy ? (
+                  'Launching…'
+                ) : (
+                  <>
+                    Launch session
+                    <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <>
+              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+                {issueIdentifier(issue)}
+              </span>
+              <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+                {issue.state}
+              </span>
+            </>
+          }
+          title={issue.title}
+          actions={
+            <a
+              href={issue.webUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Open in GitLab <ExternalLink size={11} aria-hidden />
+            </a>
+          }
+        />
+      }
+      rail={
+        <>
+          {launch}
+          <Divider />
+          {issue.milestone ? (
+            <MetaItem label="Milestone">
               <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-2xs font-medium text-primary">
                 <Milestone size={10} aria-hidden />
                 {issue.milestone.title}
               </span>
-            ) : null}
-            {issue.labels.map((label) => (
-              <span
-                key={label}
-                className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
-              >
-                {label}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
-      <Divider />
-
-      <div className="min-h-0 flex-1">
-        <ScrollFade
-          className="mx-auto h-full max-w-3xl"
-          viewportClassName="px-10 py-8"
-          fadeSize={24}
-        >
-          <div className="flex flex-col gap-8">
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="description" />
-              {issue.description ? (
-                <Markdown text={issue.description} className="text-sm leading-relaxed" />
-              ) : (
-                <p className="text-sm italic text-muted-foreground/60">No description.</p>
-              )}
-            </section>
-
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="launch session" />
-              {openableSessionId ? (
-                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
-                    <MessagesSquare size={15} className="text-success" aria-hidden />
-                  </span>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="text-sm font-medium text-foreground">
-                      Session already launched
-                    </span>
-                    <span className="truncate text-2xs text-muted-foreground">
-                      {sessionId
-                        ? 'A session is linked to this issue.'
-                        : 'A session is already on this branch.'}
-                    </span>
-                  </div>
-                  <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
-                </div>
-              ) : (
-                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-                  <LaunchField
-                    icon={<Target size={13} aria-hidden className="text-primary" />}
-                    label="Goal"
-                  >
-                    <Textarea
-                      value={goal}
-                      onChange={(e) => setGoal(e.target.value)}
-                      autoGrow
-                      minRows={3}
-                      maxRows={10}
-                      disabled={busy}
-                      aria-label="Session goal"
-                    />
-                  </LaunchField>
-
-                  <LaunchField
-                    icon={<GitBranch size={13} aria-hidden className="text-success" />}
-                    label="Branch"
-                  >
-                    <div className="flex items-center gap-1.5">
-                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                        {prefix + '/'}
-                      </span>
-                      <Input
-                        value={branchSlug}
-                        onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
-                        placeholder="branch-slug"
-                        className="h-8 flex-1 font-mono text-sm"
-                        disabled={busy}
-                        autoCapitalize="off"
-                        autoCorrect="off"
-                        spellCheck={false}
-                        aria-label="Branch slug"
-                      />
-                    </div>
-                    {conflictPath ? (
-                      <div className="mt-1 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
-                        <AlertTriangle
-                          size={12}
-                          aria-hidden
-                          className="mt-0.5 shrink-0 text-warning"
-                        />
-                        <span>
-                          This branch is already checked out in another worktree (
-                          <span className="break-all font-mono">{conflictPath}</span>). Launching
-                          erases that worktree and recreates it here. Pick a different slug to keep
-                          it.
-                        </span>
-                      </div>
-                    ) : null}
-                  </LaunchField>
-
-                  {missingBase ? <BaseBranchGuide /> : null}
-
-                  <div className="flex items-center gap-3 pt-1">
-                    <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
-                      <input
-                        type="checkbox"
-                        checked={setupWorkflow}
-                        onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
-                        className="accent-primary"
-                        disabled={busy}
-                      />
-                      Set up workflow next
-                    </label>
-                    <span className="flex-1" />
-                    {error && !missingBase ? (
-                      <span className="text-xs text-danger">{error}</span>
-                    ) : null}
-                    {blockedByConflict ? (
-                      <Button
-                        variant="danger"
-                        onClick={() => void onLaunch(conflictPath ?? undefined)}
-                        disabled={busy || goal.trim().length === 0}
-                        className={busy ? 'animate-border-pulse' : undefined}
-                      >
-                        {busy ? (
-                          'Working…'
-                        ) : (
-                          <>
-                            Erase worktree &amp; launch
-                            <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                          </>
-                        )}
-                      </Button>
-                    ) : (
-                      <Button
-                        onClick={() => void onLaunch()}
-                        disabled={!canLaunch}
-                        className={busy ? 'animate-border-pulse' : undefined}
-                      >
-                        {busy ? (
-                          'Launching…'
-                        ) : (
-                          <>
-                            Launch session
-                            <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                          </>
-                        )}
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              )}
-            </section>
-          </div>
-        </ScrollFade>
-      </div>
-    </div>
+            </MetaItem>
+          ) : null}
+          {issue.labels.length > 0 ? (
+            <MetaItem label="Labels">
+              {issue.labels.map((label) => (
+                <span
+                  key={label}
+                  className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground"
+                >
+                  {label}
+                </span>
+              ))}
+            </MetaItem>
+          ) : null}
+          {updated !== '' ? <MetaItem label="Updated">{updated} ago</MetaItem> : null}
+        </>
+      }
+    >
+      <DetailSection label="description">
+        {issue.description ? (
+          <Markdown text={issue.description} className="text-sm leading-relaxed" />
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No description.</p>
+        )}
+      </DetailSection>
+    </StudioDetailLayout>
   );
 };
 

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -188,6 +188,22 @@ describe('MrDetailPanel', () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it('surfaces branches and the last update in the metadata rail', () => {
+    render(
+      <MrDetailPanel
+        mr={makeMr()}
+        workspaceId={WORKSPACE_ID}
+        host="https://gitlab.com"
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Source branch')).toBeDefined();
+    expect(screen.getByText('Target branch')).toBeDefined();
+    expect(screen.getByText('Updated')).toBeDefined();
+    expect(screen.getByText('No description.')).toBeDefined();
+  });
+
   it('disables merge when GitLab reports cannot_be_merged', () => {
     render(
       <MrDetailPanel

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, Divider, EmptyState, Input, SectionHeader, Textarea, cn } from '@goodboy/ui';
+import { Button, EmptyState, Input, Markdown, SectionHeader, Textarea, cn } from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
@@ -11,7 +11,13 @@ import {
   Sparkles,
 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
-import { ScrollFade } from '@goodboy/ui';
+import {
+  DetailSection,
+  HeaderBand,
+  MetaItem,
+  StudioDetailLayout,
+} from '../../../../shared/components/StudioDetail';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { appendOperatorNotes } from '../../../session/utils/appendOperatorNotes';
 import { AgentSpawnConfig } from '../../../session/components/AgentSpawnConfig';
 import type { AgentSpawnConfigValue } from '../../../session/components/AgentSpawnConfig/AgentSpawnConfigValue';
@@ -213,75 +219,102 @@ export const MrDetailPanel = ({
     }
   };
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="flex shrink-0 items-center gap-2 px-8 py-4">
-        <span className="inline-flex items-center gap-1.5 font-mono text-2xs text-muted-foreground">
-          <GitBranch size={11} aria-hidden />
-          {branch ?? 'no branch'}
-        </span>
-        {mr ? (
-          <span
-            className={cn(
-              'rounded px-1.5 py-0.5 text-2xs font-medium',
-              STATE_STYLE[mr.state] ?? 'bg-muted text-muted-foreground',
-            )}
-          >
-            !{mr.iid} · {mr.state}
-          </span>
-        ) : null}
-        <span className="flex-1" />
-        <button
-          type="button"
-          onClick={() => {
-            if (sessionId != null) {
-              void refreshSessionMr(sessionId, { force: true });
-              return;
-            }
-            onRefresh?.();
-          }}
-          disabled={loading}
-          title={error ? `refresh failed: ${error}` : 'refresh merge request'}
-          aria-label="refresh merge request"
-          className="flex size-7 items-center justify-center rounded-md text-muted-foreground ring-1 ring-border-soft/40 transition-colors hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
-        >
-          <RefreshCw size={12} aria-hidden />
-        </button>
-        {mr ? (
-          <a
-            href={mr.webUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
-          >
-            Open in GitLab <ExternalLink size={11} aria-hidden />
-          </a>
-        ) : null}
-      </div>
-      <Divider />
+  const updated = mr == null ? '' : formatRelativeDuration(mr.updatedAt);
+  const mergeStatus =
+    mr != null && mr.state === 'opened' ? humanizeMergeStatus(mr.mergeStatus) : null;
 
-      <div className="min-h-0 flex-1">
-        <ScrollFade
-          className="mx-auto h-full max-w-3xl"
-          viewportClassName="px-10 py-8"
-          fadeSize={24}
-        >
-          {mr ? (
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-2">
-                <h2 className="text-lg font-semibold leading-snug text-foreground">{mr.title}</h2>
-                <span className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground">
-                  <span className="font-mono">{mr.sourceBranch}</span>
-                  <ArrowRight size={11} aria-hidden />
-                  <span className="font-mono">{mr.targetBranch}</span>
-                  {mr.draft ? (
-                    <span className="rounded bg-warning/15 px-1.5 py-0.5 font-medium text-warning">
-                      draft
-                    </span>
-                  ) : null}
+  const refreshButton = (
+    <button
+      type="button"
+      onClick={() => {
+        if (sessionId != null) {
+          void refreshSessionMr(sessionId, { force: true });
+          return;
+        }
+        onRefresh?.();
+      }}
+      disabled={loading}
+      title={error ? `refresh failed: ${error}` : 'refresh merge request'}
+      aria-label="refresh merge request"
+      className="flex size-7 items-center justify-center rounded-md text-muted-foreground ring-1 ring-border-soft/40 transition-colors hover:bg-foreground/5 hover:text-foreground disabled:opacity-50"
+    >
+      <RefreshCw size={12} aria-hidden />
+    </button>
+  );
+
+  if (mr != null) {
+    return (
+      <StudioDetailLayout
+        header={
+          <HeaderBand
+            meta={
+              <>
+                <span
+                  className={cn(
+                    'rounded px-1.5 py-0.5 text-2xs font-medium',
+                    STATE_STYLE[mr.state] ?? 'bg-muted text-muted-foreground',
+                  )}
+                >
+                  !{mr.iid} · {mr.state}
                 </span>
-              </div>
-
+                {mr.draft ? (
+                  <span className="rounded bg-warning/15 px-1.5 py-0.5 text-2xs font-medium text-warning">
+                    draft
+                  </span>
+                ) : null}
+              </>
+            }
+            title={mr.title}
+            subtitle={
+              <span className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground">
+                <span className="font-mono">{mr.sourceBranch}</span>
+                <ArrowRight size={11} aria-hidden />
+                <span className="font-mono">{mr.targetBranch}</span>
+              </span>
+            }
+            actions={
+              <>
+                {refreshButton}
+                <a
+                  href={mr.webUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  Open in GitLab <ExternalLink size={11} aria-hidden />
+                </a>
+              </>
+            }
+          />
+        }
+        rail={
+          <>
+            <MetaItem label="Source branch">
+              <span className="font-mono">{mr.sourceBranch}</span>
+            </MetaItem>
+            <MetaItem label="Target branch">
+              <span className="font-mono">{mr.targetBranch}</span>
+            </MetaItem>
+            {mergeStatus != null ? (
+              <MetaItem label="Merge status">
+                <span
+                  className={cn(
+                    'rounded px-1.5 py-0.5 text-2xs font-medium',
+                    MERGE_STATUS_STYLE[mergeStatus.tone],
+                  )}
+                >
+                  {mergeStatus.label}
+                </span>
+              </MetaItem>
+            ) : null}
+            <MetaItem label="Draft">{mr.draft ? 'yes' : 'no'}</MetaItem>
+            {updated !== '' ? <MetaItem label="Updated">{updated} ago</MetaItem> : null}
+          </>
+        }
+      >
+        {mr.hasConflicts || mr.state === 'opened' ? (
+          <DetailSection label="merge status">
+            <div className="flex flex-col gap-3">
               {mr.hasConflicts ? (
                 <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5 text-2xs leading-relaxed text-foreground">
                   <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
@@ -290,22 +323,8 @@ export const MrDetailPanel = ({
                   </span>
                 </div>
               ) : null}
-
               {mr.state === 'opened' ? (
                 <div className="flex items-center gap-3">
-                  {(() => {
-                    const status = humanizeMergeStatus(mr.mergeStatus);
-                    return status ? (
-                      <span
-                        className={cn(
-                          'rounded px-1.5 py-0.5 text-2xs font-medium',
-                          MERGE_STATUS_STYLE[status.tone],
-                        )}
-                      >
-                        {status.label}
-                      </span>
-                    ) : null;
-                  })()}
                   <span className="flex-1" />
                   <Button
                     onClick={() => void onMerge()}
@@ -329,97 +348,128 @@ export const MrDetailPanel = ({
                 </div>
               ) : null}
             </div>
-          ) : session != null && sessionId != null ? (
-            <section className="flex flex-col gap-4">
-              <SectionHeader label="create merge request" />
-              <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-                <div className="flex flex-col gap-1.5">
-                  <SectionHeader label="title" />
-                  <Input
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    disabled={busy !== null}
-                    aria-label="Merge request title"
-                    className="h-8 text-sm"
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <SectionHeader label="description" />
-                  <Textarea
-                    value={description}
-                    onChange={(e) => setDescription(e.target.value)}
-                    autoGrow
-                    minRows={3}
-                    maxRows={10}
-                    disabled={busy !== null}
-                    aria-label="Merge request description"
-                  />
-                </div>
-                <div className="flex flex-col gap-1.5">
-                  <SectionHeader label="target branch" icon={<GitBranch size={13} aria-hidden />} />
-                  <Input
-                    value={targetBranch}
-                    onChange={(e) => setTargetBranch(e.target.value)}
-                    placeholder="main"
-                    className="h-8 font-mono text-sm"
-                    disabled={busy !== null}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    spellCheck={false}
-                    aria-label="Target branch"
-                  />
-                </div>
-                <AgentSpawnConfig
-                  value={agentConfig}
-                  onChange={(value) => {
-                    setAgentConfigUserTouched(true);
-                    setAgentConfig(value);
-                  }}
+          </DetailSection>
+        ) : null}
+
+        <DetailSection label="description">
+          {mr.description != null && mr.description !== '' ? (
+            <Markdown text={mr.description} className="text-sm leading-relaxed" />
+          ) : (
+            <p className="text-sm italic text-muted-foreground/60">No description.</p>
+          )}
+        </DetailSection>
+      </StudioDetailLayout>
+    );
+  }
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <span className="inline-flex items-center gap-1.5 font-mono text-2xs text-muted-foreground">
+              <GitBranch size={11} aria-hidden />
+              {branch ?? 'no branch'}
+            </span>
+          }
+          title="New merge request"
+          actions={refreshButton}
+        />
+      }
+      rail={
+        <MetaItem label="Branch">
+          <span className="font-mono">{branch ?? 'no branch'}</span>
+        </MetaItem>
+      }
+    >
+      {session != null && sessionId != null ? (
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+            <div className="flex flex-col gap-1.5">
+              <SectionHeader label="title" />
+              <Input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                disabled={busy !== null}
+                aria-label="Merge request title"
+                className="h-8 text-sm"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <SectionHeader label="description" />
+              <Textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                autoGrow
+                minRows={3}
+                maxRows={10}
+                disabled={busy !== null}
+                aria-label="Merge request description"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <SectionHeader label="target branch" icon={<GitBranch size={13} aria-hidden />} />
+              <Input
+                value={targetBranch}
+                onChange={(e) => setTargetBranch(e.target.value)}
+                placeholder="main"
+                className="h-8 font-mono text-sm"
+                disabled={busy !== null}
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                aria-label="Target branch"
+              />
+            </div>
+            <AgentSpawnConfig
+              value={agentConfig}
+              onChange={(value) => {
+                setAgentConfigUserTouched(true);
+                setAgentConfig(value);
+              }}
+              disabled={busy !== null}
+            />
+            <div className="flex items-center gap-3 pt-1">
+              <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={draft}
+                  onChange={(e) => setDraft(e.target.checked)}
+                  className="accent-primary"
                   disabled={busy !== null}
                 />
-                <div className="flex items-center gap-3 pt-1">
-                  <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
-                    <input
-                      type="checkbox"
-                      checked={draft}
-                      onChange={(e) => setDraft(e.target.checked)}
-                      className="accent-primary"
-                      disabled={busy !== null}
-                    />
-                    Mark as draft
-                  </label>
-                  <span className="flex-1" />
-                  <Button
-                    variant="secondary"
-                    onClick={() => void onCreateWithAi()}
-                    disabled={busy !== null || !branch}
-                    title="hand it to an agent: it drafts the title and description, then opens the MR"
-                    className={busy === 'ai' ? 'animate-border-pulse' : undefined}
-                  >
-                    {busy === 'ai' ? null : <Sparkles size={13} className="mr-1.5" aria-hidden />}
-                    Draft with an agent
-                  </Button>
-                  <Button
-                    onClick={() => void onCreate()}
-                    disabled={busy !== null || title.trim().length === 0 || !branch}
-                    className={busy === 'create' ? 'animate-border-pulse' : undefined}
-                  >
-                    {busy === 'create' ? (
-                      'Creating…'
-                    ) : (
-                      <>
-                        Create MR
-                        <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                      </>
-                    )}
-                  </Button>
-                </div>
-                {error ? <span className="text-xs text-danger">{error}</span> : null}
-              </div>
-            </section>
-          ) : null}
-        </ScrollFade>
-      </div>
-    </div>
+                Mark as draft
+              </label>
+              <span className="flex-1" />
+              <Button
+                variant="secondary"
+                onClick={() => void onCreateWithAi()}
+                disabled={busy !== null || !branch}
+                title="hand it to an agent: it drafts the title and description, then opens the MR"
+                className={busy === 'ai' ? 'animate-border-pulse' : undefined}
+              >
+                {busy === 'ai' ? null : <Sparkles size={13} className="mr-1.5" aria-hidden />}
+                Draft with an agent
+              </Button>
+              <Button
+                onClick={() => void onCreate()}
+                disabled={busy !== null || title.trim().length === 0 || !branch}
+                className={busy === 'create' ? 'animate-border-pulse' : undefined}
+              >
+                {busy === 'create' ? (
+                  'Creating…'
+                ) : (
+                  <>
+                    Create MR
+                    <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                  </>
+                )}
+              </Button>
+            </div>
+            {error ? <span className="text-xs text-danger">{error}</span> : null}
+          </div>
+        </section>
+      ) : null}
+    </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueComments/index.tsx
@@ -1,0 +1,62 @@
+import { EmptyState, Markdown, Skeleton } from '@goodboy/ui';
+import { MessageSquare } from 'lucide-react';
+import type { WorkspaceId } from '@goodboy/types';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import { useLinearIssueComments } from '../useLinearIssueComments';
+
+type Props = {
+  readonly workspaceId: WorkspaceId;
+  readonly issueId: string;
+};
+
+export const LinearIssueComments = ({ workspaceId, issueId }: Props) => {
+  const { comments, isLoading, error } = useLinearIssueComments({ workspaceId, issueId });
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-label="Loading comments" className="flex flex-col gap-4">
+        {[0, 1, 2].map((row) => (
+          <div key={row} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+            <Skeleton className="h-3 w-28 rounded" />
+            <Skeleton className="h-3 w-full rounded" />
+            <Skeleton className="h-3 w-2/3 rounded" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return <p className="text-sm text-danger">{error}</p>;
+  }
+
+  if (comments.length === 0) {
+    return (
+      <EmptyState
+        icon={MessageSquare}
+        title="No comments"
+        description="This issue has no comments yet."
+        className="py-5"
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {comments.map((comment) => {
+        const relativeDate = formatRelativeDuration(comment.createdAt);
+        return (
+          <div key={comment.id} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
+            <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {comment.user?.name ?? 'Unknown author'}
+              </span>
+              {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
+            </div>
+            <Markdown text={comment.body} className="text-sm leading-relaxed" />
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearIssueDetail/index.tsx
@@ -1,11 +1,10 @@
-import { EmptyState, Markdown, SectionHeader, Skeleton, cn } from '@goodboy/ui';
-import { ExternalLink, GitPullRequest, MessageSquare } from 'lucide-react';
+import { Markdown, SectionHeader, cn } from '@goodboy/ui';
+import { ExternalLink, GitPullRequest } from 'lucide-react';
 import type { WorkspaceId } from '@goodboy/types';
-import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { issuePullRequests, type LinearIssue } from '../client';
+import { LinearIssueComments } from '../LinearIssueComments';
 import { priorityTone } from '../priorityTone';
 import { prStatusTone } from '../prStatusTone';
-import { useLinearIssueComments } from '../useLinearIssueComments';
 
 type Props = {
   readonly issue: LinearIssue;
@@ -13,10 +12,6 @@ type Props = {
 };
 
 export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
-  const { comments, isLoading, error } = useLinearIssueComments({
-    workspaceId,
-    issueId: issue.id,
-  });
   const linkedPrs = issuePullRequests(issue);
   const priorityLabel = issue.priorityLabel ?? 'No priority';
 
@@ -105,43 +100,7 @@ export const LinearIssueDetail = ({ issue, workspaceId }: Props) => {
 
       <section className="flex flex-col gap-3">
         <SectionHeader label="comments" />
-        {isLoading ? (
-          <div role="status" aria-label="Loading comments" className="flex flex-col gap-4">
-            {[0, 1, 2].map((row) => (
-              <div key={row} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
-                <Skeleton className="h-3 w-28 rounded" />
-                <Skeleton className="h-3 w-full rounded" />
-                <Skeleton className="h-3 w-2/3 rounded" />
-              </div>
-            ))}
-          </div>
-        ) : error != null ? (
-          <p className="text-sm text-danger">{error}</p>
-        ) : comments.length === 0 ? (
-          <EmptyState
-            icon={MessageSquare}
-            title="No comments"
-            description="This issue has no comments yet."
-            className="py-5"
-          />
-        ) : (
-          <div className="flex flex-col gap-3">
-            {comments.map((comment) => {
-              const relativeDate = formatRelativeDuration(comment.createdAt);
-              return (
-                <div key={comment.id} className="flex flex-col gap-2 rounded-lg bg-muted/20 p-3">
-                  <div className="flex items-center gap-2 text-2xs text-muted-foreground">
-                    <span className="font-medium text-foreground">
-                      {comment.user?.name ?? 'Unknown author'}
-                    </span>
-                    {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
-                  </div>
-                  <Markdown text={comment.body} className="text-sm leading-relaxed" />
-                </div>
-              );
-            })}
-          </div>
-        )}
+        <LinearIssueComments workspaceId={workspaceId} issueId={issue.id} />
       </section>
     </article>
   );

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceId } from '@goodboy/types';
+import type { LinearIssue } from '../client';
+
+const h = vi.hoisted(() => ({
+  createSession: vi.fn(async () => ({
+    session: { id: 'session-7', goal: '[GB-42] Improve linked issue detail' },
+  })),
+  loadSetting: vi.fn(async () => null),
+  showToast: vi.fn(),
+  store: {
+    workspaces: [{ id: 'workspace-1', rootPath: '/repo' }],
+  },
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (
+      state: typeof h.store & {
+        createSession: typeof h.createSession;
+        loadSetting: typeof h.loadSetting;
+      },
+    ) => T,
+  ) => selector({ ...h.store, createSession: h.createSession, loadSetting: h.loadSetting }),
+}));
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: h.showToast }),
+}));
+vi.mock('../../../worktree/useBranchConflict', () => ({ useBranchConflict: () => null }));
+vi.mock('../../../worktree/worktree', () => ({ removeWorktree: vi.fn() }));
+vi.mock('../useLinearIssueComments', () => ({
+  useLinearIssueComments: () => ({ comments: [], isLoading: false, error: null }),
+}));
+
+import { IssueDetailPanel } from './IssueDetailPanel';
+
+const ISSUE: LinearIssue = {
+  id: 'issue-1',
+  identifier: 'GB-42',
+  title: 'Improve linked issue detail',
+  description: '**Full** description',
+  url: 'https://linear.app/goodboy/issue/GB-42',
+  state: { name: 'In Progress', type: 'started' },
+  team: { key: 'GB' },
+  priority: 1,
+  priorityLabel: 'Urgent',
+  assignee: { name: 'Grace Hopper' },
+  project: { name: 'Desktop' },
+  labels: { nodes: [{ name: 'UI', color: '#5e6ad2' }] },
+  updatedAt: new Date(Date.now() - 7_200_000).toISOString(),
+};
+
+beforeEach(() => {
+  h.createSession.mockClear();
+  h.loadSetting.mockClear();
+  h.showToast.mockClear();
+});
+
+afterEach(cleanup);
+
+describe('IssueDetailPanel', () => {
+  it('surfaces assignee, project, and last update in the metadata rail', async () => {
+    render(
+      <IssueDetailPanel
+        issue={ISSUE}
+        sessionId={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', { name: 'Session goal' })).toBeDefined(),
+    );
+    expect(screen.getByText('Grace Hopper')).toBeDefined();
+    expect(screen.getByText('Desktop')).toBeDefined();
+    expect(screen.getByText('Updated')).toBeDefined();
+    expect(screen.getByText('2h ago')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -1,8 +1,19 @@
 import { useEffect, useState } from 'react';
-import { Button, EmptyState, Input, SectionHeader, StatusDot, Textarea, cn } from '@goodboy/ui';
+import {
+  Button,
+  Divider,
+  EmptyState,
+  Input,
+  Markdown,
+  SectionHeader,
+  StatusDot,
+  Textarea,
+  cn,
+} from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
+  ExternalLink,
   GitBranch,
   GitPullRequest,
   MessagesSquare,
@@ -10,7 +21,6 @@ import {
   Target,
 } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
-import { ScrollFade } from '@goodboy/ui';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
@@ -24,9 +34,18 @@ import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/se
 import { removeWorktree } from '../../../worktree/worktree';
 import { useBranchConflict } from '../../../worktree/useBranchConflict';
 import { ghPrHeadBranch } from '../../../github/github';
+import {
+  DetailSection,
+  HeaderBand,
+  MetaItem,
+  StudioDetailLayout,
+} from '../../../../shared/components/StudioDetail';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { goalFromIssue } from '../goal-from-issue';
 import { issuePullRequests, type LinearIssue } from '../client';
-import { LinearIssueDetail } from '../LinearIssueDetail';
+import { LinearIssueComments } from '../LinearIssueComments';
+import { priorityTone } from '../priorityTone';
+import { prStatusTone } from '../prStatusTone';
 
 type BranchMode = 'pr' | 'fresh';
 
@@ -209,195 +228,276 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     }
   };
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="min-h-0 flex-1">
-        <ScrollFade
-          className="mx-auto h-full max-w-3xl"
-          viewportClassName="px-10 py-8"
-          fadeSize={24}
-        >
-          <div className="flex flex-col gap-8">
-            <LinearIssueDetail issue={issue} workspaceId={workspaceId} />
-
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="launch session" />
-              {openableSessionId ? (
-                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
-                    <MessagesSquare size={15} className="text-success" aria-hidden />
-                  </span>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="text-sm font-medium text-foreground">
-                      Session already launched
-                    </span>
-                    <span className="truncate text-2xs text-muted-foreground">
-                      {sessionId
-                        ? 'A session is linked to this issue.'
-                        : 'A session is already on this PR branch.'}
-                    </span>
-                  </div>
-                  <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
-                </div>
-              ) : (
-                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-                  <LaunchField
-                    icon={<Target size={13} aria-hidden className="text-primary" />}
-                    label="Goal"
-                  >
-                    <Textarea
-                      value={goal}
-                      onChange={(e) => setGoal(e.target.value)}
-                      autoGrow
-                      minRows={3}
-                      maxRows={10}
-                      disabled={busy}
-                      aria-label="Session goal"
-                    />
-                  </LaunchField>
-
-                  <LaunchField
-                    icon={<GitBranch size={13} aria-hidden className="text-success" />}
-                    label="Branch"
-                  >
-                    {adoptablePr ? (
-                      <div
-                        role="tablist"
-                        aria-label="branch source"
-                        className="mb-2 inline-flex rounded-md border border-border bg-background p-0.5 text-2xs"
-                      >
-                        <BranchModeButton
-                          active={mode === 'pr'}
-                          disabled={busy}
-                          onClick={() => setMode('pr')}
-                          label={`Continue on PR #${adoptablePr.number}`}
-                        />
-                        <BranchModeButton
-                          active={mode === 'fresh'}
-                          disabled={busy}
-                          onClick={() => setMode('fresh')}
-                          label="Start fresh"
-                        />
-                      </div>
-                    ) : null}
-
-                    {mode === 'pr' && adoptablePr ? (
-                      <div className="flex flex-col gap-1">
-                        <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-subtle/40 px-2.5 font-mono text-sm">
-                          <GitPullRequest
-                            size={13}
-                            aria-hidden
-                            className="shrink-0 text-muted-foreground"
-                          />
-                          {prResolving ? (
-                            <span className="inline-flex items-center gap-1.5 text-muted-foreground">
-                              <StatusDot tone="info" size="sm" pulsing /> resolving…
-                            </span>
-                          ) : prBranch ? (
-                            <span className="truncate text-foreground">{prBranch}</span>
-                          ) : (
-                            <span className="truncate text-danger">
-                              {prError ?? 'No branch found'}
-                            </span>
-                          )}
-                        </div>
-                        <span className="text-2xs leading-relaxed text-muted-foreground/70">
-                          Adopts the branch of PR #{adoptablePr.number}: the existing PR links to
-                          this session instead of starting a duplicate.
-                        </span>
-                        {conflictPath ? (
-                          <div className="mt-1 flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
-                            <AlertTriangle
-                              size={12}
-                              aria-hidden
-                              className="mt-0.5 shrink-0 text-warning"
-                            />
-                            <span>
-                              This branch is already checked out in another worktree (
-                              <span className="break-all font-mono">{conflictPath}</span>).
-                              Launching erases that worktree and recreates it here. Pick Start fresh
-                              to keep it and branch off main instead.
-                            </span>
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : (
-                      <div className="flex items-center gap-1.5">
-                        <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                          {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
-                        </span>
-                        <Input
-                          value={branchSlug}
-                          onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
-                          placeholder="branch-slug"
-                          className="h-8 flex-1 font-mono text-sm"
-                          disabled={busy}
-                          autoCapitalize="off"
-                          autoCorrect="off"
-                          spellCheck={false}
-                          aria-label="Branch slug"
-                        />
-                      </div>
-                    )}
-                  </LaunchField>
-
-                  {missingBase ? <BaseBranchGuide /> : null}
-
-                  <div className="flex items-center gap-3 pt-1">
-                    <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
-                      <input
-                        type="checkbox"
-                        checked={setupWorkflow}
-                        onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
-                        className="accent-primary"
-                        disabled={busy}
-                      />
-                      Set up workflow next
-                    </label>
-                    <span className="flex-1" />
-                    {error && !missingBase ? (
-                      <span className="text-xs text-danger">{error}</span>
-                    ) : null}
-                    {blockedByConflict ? (
-                      <Button
-                        variant="danger"
-                        onClick={() => void onLaunch(conflictPath ?? undefined)}
-                        disabled={busy || goal.trim().length === 0}
-                        className={busy ? 'animate-border-pulse' : undefined}
-                      >
-                        {busy ? (
-                          'Working…'
-                        ) : (
-                          <>
-                            Erase worktree &amp; launch
-                            <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                          </>
-                        )}
-                      </Button>
-                    ) : (
-                      <Button
-                        onClick={() => void onLaunch()}
-                        disabled={!canLaunch}
-                        className={busy ? 'animate-border-pulse' : undefined}
-                      >
-                        {busy ? (
-                          'Launching…'
-                        ) : (
-                          <>
-                            Launch session
-                            <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                          </>
-                        )}
-                      </Button>
-                    )}
-                  </div>
-                </div>
-              )}
-            </section>
+  const launch = (
+    <section className="flex flex-col gap-3">
+      <SectionHeader label="launch session" />
+      {openableSessionId ? (
+        <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+            <MessagesSquare size={15} className="text-success" aria-hidden />
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium text-foreground">Session already launched</span>
+            <span className="truncate text-2xs text-muted-foreground">
+              {sessionId
+                ? 'A session is linked to this issue.'
+                : 'A session is already on this PR branch.'}
+            </span>
           </div>
-        </ScrollFade>
-      </div>
-    </div>
+          <OpenSessionButton sessionId={openableSessionId} onOpened={onClose} />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+          <LaunchField
+            icon={<Target size={13} aria-hidden className="text-primary" />}
+            label="Goal"
+          >
+            <Textarea
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              autoGrow
+              minRows={3}
+              maxRows={10}
+              disabled={busy}
+              aria-label="Session goal"
+            />
+          </LaunchField>
+
+          <LaunchField
+            icon={<GitBranch size={13} aria-hidden className="text-success" />}
+            label="Branch"
+          >
+            {adoptablePr ? (
+              <div
+                role="tablist"
+                aria-label="branch source"
+                className="inline-flex rounded-md border border-border bg-background p-0.5 text-2xs"
+              >
+                <BranchModeButton
+                  active={mode === 'pr'}
+                  disabled={busy}
+                  onClick={() => setMode('pr')}
+                  label={`Continue on PR #${adoptablePr.number}`}
+                />
+                <BranchModeButton
+                  active={mode === 'fresh'}
+                  disabled={busy}
+                  onClick={() => setMode('fresh')}
+                  label="Start fresh"
+                />
+              </div>
+            ) : null}
+
+            {mode === 'pr' && adoptablePr ? (
+              <div className="flex flex-col gap-1">
+                <div className="flex h-9 items-center gap-2 rounded-md border border-border bg-subtle/40 px-2.5 font-mono text-sm">
+                  <GitPullRequest
+                    size={13}
+                    aria-hidden
+                    className="shrink-0 text-muted-foreground"
+                  />
+                  {prResolving ? (
+                    <span className="inline-flex items-center gap-1.5 text-muted-foreground">
+                      <StatusDot tone="info" size="sm" pulsing /> resolving…
+                    </span>
+                  ) : prBranch ? (
+                    <span className="truncate text-foreground">{prBranch}</span>
+                  ) : (
+                    <span className="truncate text-danger">{prError ?? 'No branch found'}</span>
+                  )}
+                </div>
+                <span className="text-2xs leading-relaxed text-muted-foreground/70">
+                  Adopts the branch of PR #{adoptablePr.number}: the existing PR links to this
+                  session instead of starting a duplicate.
+                </span>
+                {conflictPath ? (
+                  <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-2.5 py-2 text-2xs leading-relaxed text-foreground">
+                    <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                    <span>
+                      This branch is already checked out in another worktree (
+                      <span className="break-all font-mono">{conflictPath}</span>). Launching erases
+                      that worktree and recreates it here. Pick Start fresh to keep it and branch
+                      off main instead.
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5">
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                  {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
+                </span>
+                <Input
+                  value={branchSlug}
+                  onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
+                  placeholder="branch-slug"
+                  className="h-8 flex-1 font-mono text-sm"
+                  disabled={busy}
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  aria-label="Branch slug"
+                />
+              </div>
+            )}
+          </LaunchField>
+
+          {missingBase ? <BaseBranchGuide /> : null}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={setupWorkflow}
+                onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
+                className="accent-primary"
+                disabled={busy}
+              />
+              Set up workflow next
+            </label>
+            <span className="flex-1" />
+            {error && !missingBase ? <span className="text-xs text-danger">{error}</span> : null}
+            {blockedByConflict ? (
+              <Button
+                variant="danger"
+                onClick={() => void onLaunch(conflictPath ?? undefined)}
+                disabled={busy || goal.trim().length === 0}
+                className={busy ? 'animate-border-pulse' : undefined}
+              >
+                {busy ? (
+                  'Working…'
+                ) : (
+                  <>
+                    Erase worktree &amp; launch
+                    <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                  </>
+                )}
+              </Button>
+            ) : (
+              <Button
+                onClick={() => void onLaunch()}
+                disabled={!canLaunch}
+                className={busy ? 'animate-border-pulse' : undefined}
+              >
+                {busy ? (
+                  'Launching…'
+                ) : (
+                  <>
+                    Launch session
+                    <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                  </>
+                )}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+
+  const linkedPrs = issuePullRequests(issue);
+  const labels = issue.labels?.nodes ?? [];
+  const priorityLabel = issue.priorityLabel ?? 'No priority';
+  const updated = formatRelativeDuration(issue.updatedAt);
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <>
+              <span
+                aria-label={`Priority: ${priorityLabel}`}
+                className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground"
+              >
+                <span
+                  aria-hidden
+                  className={cn('size-2 rounded-full', priorityTone({ priority: issue.priority }))}
+                />
+                {priorityLabel}
+              </span>
+              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+                {issue.identifier}
+              </span>
+              <span className="rounded bg-muted px-1.5 py-0.5 text-2xs font-medium text-muted-foreground">
+                {issue.state.name}
+              </span>
+            </>
+          }
+          title={issue.title}
+          actions={
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Open in Linear <ExternalLink size={11} aria-hidden />
+            </a>
+          }
+        />
+      }
+      rail={
+        <>
+          {launch}
+          <Divider />
+          {issue.assignee != null ? (
+            <MetaItem label="Assignee">{issue.assignee.name}</MetaItem>
+          ) : null}
+          {issue.project != null ? <MetaItem label="Project">{issue.project.name}</MetaItem> : null}
+          {labels.length > 0 ? (
+            <MetaItem label="Labels">
+              {labels.map((label) => (
+                <span
+                  key={`${label.name}-${label.color}`}
+                  className="inline-flex items-center gap-1.5 text-2xs text-muted-foreground"
+                >
+                  <span
+                    aria-hidden
+                    className="size-2 rounded-full"
+                    style={{ backgroundColor: label.color }}
+                  />
+                  {label.name}
+                </span>
+              ))}
+            </MetaItem>
+          ) : null}
+          {linkedPrs.length > 0 ? (
+            <MetaItem label="Linked PRs">
+              {linkedPrs.map((pr) => (
+                <a
+                  key={pr.number}
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  title={pr.url}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-2xs font-medium transition-opacity hover:opacity-80',
+                    prStatusTone({ status: pr.status }),
+                  )}
+                >
+                  <GitPullRequest size={11} aria-hidden />#{pr.number}
+                  {pr.status != null ? <span className="opacity-70">· {pr.status}</span> : null}
+                </a>
+              ))}
+            </MetaItem>
+          ) : null}
+          {updated !== '' ? <MetaItem label="Updated">{updated} ago</MetaItem> : null}
+        </>
+      }
+    >
+      <DetailSection label="description">
+        {issue.description != null && issue.description !== '' ? (
+          <Markdown text={issue.description} className="text-sm leading-relaxed" />
+        ) : (
+          <p className="text-sm italic text-muted-foreground/60">No description.</p>
+        )}
+      </DetailSection>
+
+      <DetailSection label="comments">
+        <LinearIssueComments workspaceId={workspaceId} issueId={issue.id} />
+      </DetailSection>
+    </StudioDetailLayout>
   );
 };
 

--- a/apps/desktop/src/features/integrations/sentry/SentryBreadcrumbs/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryBreadcrumbs/index.tsx
@@ -1,0 +1,45 @@
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
+import type { SentryBreadcrumb } from '../client';
+
+type Props = {
+  readonly breadcrumbs: ReadonlyArray<SentryBreadcrumb>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const SentryBreadcrumbs = ({ breadcrumbs, isLoading, error }: Props) => {
+  if (isLoading || error != null || breadcrumbs.length === 0) {
+    return null;
+  }
+
+  return (
+    <details className="rounded-lg border border-border-soft bg-muted/10">
+      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-foreground">
+        Breadcrumbs ({breadcrumbs.length})
+      </summary>
+      <div className="flex flex-col gap-2 px-3 pb-3">
+        {breadcrumbs.map((breadcrumb, index) => {
+          const relativeDate =
+            breadcrumb.timestamp == null ? '' : formatRelativeDuration(breadcrumb.timestamp);
+          return (
+            <div
+              key={`${breadcrumb.timestamp ?? 'breadcrumb'}-${index}`}
+              className="flex flex-col gap-1 rounded-md bg-muted/30 p-2"
+            >
+              <div className="flex items-center gap-2 text-2xs text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  {breadcrumb.category ?? 'event'}
+                </span>
+                {breadcrumb.level != null ? <span>{breadcrumb.level}</span> : null}
+                {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
+              </div>
+              {breadcrumb.message != null ? (
+                <span className="text-xs text-muted-foreground">{breadcrumb.message}</span>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </details>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryIssueDetail/index.tsx
@@ -1,8 +1,10 @@
-import { SectionHeader, Skeleton, cn } from '@goodboy/ui';
+import { SectionHeader, cn } from '@goodboy/ui';
 import { ExternalLink, Layers } from 'lucide-react';
-import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import type { SentryIssueDetail as Detail } from '../client';
 import { levelTone } from '../levelTone';
+import { SentryBreadcrumbs } from '../SentryBreadcrumbs';
+import { SentryStackTrace } from '../SentryStackTrace';
+import { visibleSentryTags } from '../visibleSentryTags';
 
 type Props = {
   readonly identifier: string;
@@ -15,8 +17,6 @@ type Props = {
   readonly error: string | null;
 };
 
-const VISIBLE_TAGS = new Set(['release', 'environment']);
-
 export const SentryIssueDetail = ({
   identifier,
   title,
@@ -27,7 +27,7 @@ export const SentryIssueDetail = ({
   isLoading,
   error,
 }: Props) => {
-  const visibleTags = detail?.tags?.filter((tag) => VISIBLE_TAGS.has(tag.key)) ?? [];
+  const visibleTags = visibleSentryTags({ detail });
   const frames = detail?.frames ?? [];
   const breadcrumbs = detail?.breadcrumbs ?? [];
 
@@ -85,64 +85,10 @@ export const SentryIssueDetail = ({
           label="stack trace"
           icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
         />
-        {isLoading ? (
-          <div
-            role="status"
-            aria-label="Loading latest event"
-            className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/40 p-3"
-          >
-            {['w-3/4', 'w-1/2', 'w-2/3', 'w-5/6', 'w-2/5', 'w-3/5'].map((width) => (
-              <Skeleton key={width} className={cn('h-2.5 rounded', width)} />
-            ))}
-          </div>
-        ) : error != null ? (
-          <p className="text-sm text-danger">{error}</p>
-        ) : frames.length > 0 ? (
-          <pre className="overflow-x-auto rounded-lg border border-border-soft bg-subtle/40 p-3 font-mono text-2xs leading-relaxed text-muted-foreground">
-            {frames
-              .map(
-                (frame) =>
-                  `${frame.in_app ? '› ' : '  '}${frame.function ?? '?'} (${frame.filename ?? '?'}${
-                    frame.line_no != null ? `:${frame.line_no}` : ''
-                  })`,
-              )
-              .join('\n')}
-          </pre>
-        ) : (
-          <p className="text-sm italic text-muted-foreground/60">No stack trace available.</p>
-        )}
+        <SentryStackTrace frames={frames} isLoading={isLoading} error={error} />
       </section>
 
-      {!isLoading && error == null && breadcrumbs.length > 0 ? (
-        <details className="rounded-lg border border-border-soft bg-muted/10">
-          <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-foreground">
-            Breadcrumbs ({breadcrumbs.length})
-          </summary>
-          <div className="flex flex-col gap-2 px-3 pb-3">
-            {breadcrumbs.map((breadcrumb, index) => {
-              const relativeDate =
-                breadcrumb.timestamp == null ? '' : formatRelativeDuration(breadcrumb.timestamp);
-              return (
-                <div
-                  key={`${breadcrumb.timestamp ?? 'breadcrumb'}-${index}`}
-                  className="flex flex-col gap-1 rounded-md bg-muted/30 p-2"
-                >
-                  <div className="flex items-center gap-2 text-2xs text-muted-foreground">
-                    <span className="font-medium text-foreground">
-                      {breadcrumb.category ?? 'event'}
-                    </span>
-                    {breadcrumb.level != null ? <span>{breadcrumb.level}</span> : null}
-                    {relativeDate !== '' ? <span>{relativeDate} ago</span> : null}
-                  </div>
-                  {breadcrumb.message != null ? (
-                    <span className="text-xs text-muted-foreground">{breadcrumb.message}</span>
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
-        </details>
-      ) : null}
+      <SentryBreadcrumbs breadcrumbs={breadcrumbs} isLoading={isLoading} error={error} />
     </article>
   );
 };

--- a/apps/desktop/src/features/integrations/sentry/SentryStackTrace/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStackTrace/index.tsx
@@ -1,0 +1,45 @@
+import { Skeleton, cn } from '@goodboy/ui';
+import type { SentryStackFrame } from '../client';
+
+type Props = {
+  readonly frames: ReadonlyArray<SentryStackFrame>;
+  readonly isLoading: boolean;
+  readonly error: string | null;
+};
+
+export const SentryStackTrace = ({ frames, isLoading, error }: Props) => {
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading latest event"
+        className="flex flex-col gap-2 rounded-lg border border-border-soft bg-subtle/40 p-3"
+      >
+        {['w-3/4', 'w-1/2', 'w-2/3', 'w-5/6', 'w-2/5', 'w-3/5'].map((width) => (
+          <Skeleton key={width} className={cn('h-2.5 rounded', width)} />
+        ))}
+      </div>
+    );
+  }
+
+  if (error != null) {
+    return <p className="text-sm text-danger">{error}</p>;
+  }
+
+  if (frames.length === 0) {
+    return <p className="text-sm italic text-muted-foreground/60">No stack trace available.</p>;
+  }
+
+  return (
+    <pre className="overflow-x-auto rounded-lg border border-border-soft bg-subtle/40 p-3 font-mono text-2xs leading-relaxed text-muted-foreground">
+      {frames
+        .map(
+          (frame) =>
+            `${frame.in_app ? '› ' : '  '}${frame.function ?? '?'} (${frame.filename ?? '?'}${
+              frame.line_no != null ? `:${frame.line_no}` : ''
+            })`,
+        )
+        .join('\n')}
+    </pre>
+  );
+};

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.test.tsx
@@ -112,4 +112,27 @@ describe('IssueDetailPanel', () => {
     expect(goal.value).toBe('[GB-2] Second issue');
     expect(goal.value).not.toContain('firstFrame');
   });
+
+  it('surfaces event and user counts in the stats strip', async () => {
+    const issue = {
+      ...makeIssue({ id: 'issue-3', title: 'Third issue', shortId: 'GB-3' }),
+      count: '128',
+      userCount: 12,
+    };
+    fetchIssueDetail.mockResolvedValueOnce({ title: null, culprit: null, frames: [] });
+
+    render(
+      <IssueDetailPanel
+        issue={issue}
+        sessionId={null}
+        workspaceId={WORKSPACE_ID}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('Events')).toBeDefined());
+    expect(screen.getByText('128')).toBeDefined();
+    expect(screen.getByText('Users')).toBeDefined();
+    expect(screen.getByText('12')).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -1,9 +1,31 @@
 import { useEffect, useRef, useState } from 'react';
-import { Button, EmptyState, Input, SectionHeader, Textarea } from '@goodboy/ui';
-import { ArrowRight, GitBranch, MessagesSquare, MousePointerClick, Target } from 'lucide-react';
+import {
+  Button,
+  Divider,
+  EmptyState,
+  Input,
+  SectionHeader,
+  StatCard,
+  Textarea,
+  cn,
+} from '@goodboy/ui';
+import {
+  ArrowRight,
+  ExternalLink,
+  GitBranch,
+  Layers,
+  MessagesSquare,
+  MousePointerClick,
+  Target,
+} from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
-import { ScrollFade } from '@goodboy/ui';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
+import {
+  HeaderBand,
+  MetaItem,
+  StudioDetailLayout,
+} from '../../../../shared/components/StudioDetail';
+import { formatRelativeDuration } from '../../../../shared/utils/relativeDate';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
 import { formatError, isMissingBaseRefError } from '../../../../shared/lib/errors';
@@ -15,8 +37,11 @@ import { slugifyBranch } from '../../../../shared/utils/slugifyBranch';
 import { DEFAULT_BRANCH_PREFIX, settingBranchPrefix } from '../../../settings/settings';
 import { goalFromSentry } from '../goal-from-sentry';
 import type { SentryIssue } from '../client';
-import { SentryIssueDetail } from '../SentryIssueDetail';
+import { levelTone } from '../levelTone';
+import { SentryBreadcrumbs } from '../SentryBreadcrumbs';
+import { SentryStackTrace } from '../SentryStackTrace';
 import { useSentryIssueDetail } from '../useSentryIssueDetail';
+import { visibleSentryTags } from '../visibleSentryTags';
 
 type Props = {
   readonly issue: SentryIssue | null;
@@ -150,122 +175,182 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
     }
   };
 
-  return (
-    <div className="flex h-full flex-col">
-      <div className="min-h-0 flex-1">
-        <ScrollFade
-          className="mx-auto h-full max-w-3xl"
-          viewportClassName="px-10 py-8"
-          fadeSize={24}
-        >
-          <div className="flex flex-col gap-8">
-            <SentryIssueDetail
-              identifier={issue.shortId ?? issue.id}
-              title={issue.title}
-              culprit={issue.culprit}
-              level={issue.level}
-              permalink={issue.permalink}
-              detail={detail}
-              isLoading={detailLoading}
-              error={detailError}
-            />
-
-            <section className="flex flex-col gap-3">
-              <SectionHeader label="launch session" />
-              {sessionId ? (
-                <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
-                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
-                    <MessagesSquare size={15} className="text-success" aria-hidden />
-                  </span>
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="text-sm font-medium text-foreground">
-                      Session already launched
-                    </span>
-                    <span className="truncate text-2xs text-muted-foreground">
-                      A session is linked to this issue.
-                    </span>
-                  </div>
-                  <OpenSessionButton sessionId={sessionId} onOpened={onClose} />
-                </div>
-              ) : (
-                <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-                  <div className="flex flex-col gap-1.5">
-                    <SectionHeader
-                      label="Goal"
-                      icon={<Target size={13} aria-hidden className="text-primary" />}
-                    />
-                    <Textarea
-                      value={goal}
-                      onChange={(e) => setGoal(e.target.value)}
-                      autoGrow
-                      minRows={3}
-                      maxRows={12}
-                      disabled={busy}
-                      aria-label="Session goal"
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-1.5">
-                    <SectionHeader
-                      label="Branch"
-                      icon={<GitBranch size={13} aria-hidden className="text-success" />}
-                    />
-                    <div className="flex items-center gap-1.5">
-                      <span className="shrink-0 font-mono text-xs text-muted-foreground">
-                        {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
-                      </span>
-                      <Input
-                        value={branchSlug}
-                        onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
-                        placeholder="branch-slug"
-                        className="h-8 flex-1 font-mono text-sm"
-                        disabled={busy}
-                        autoCapitalize="off"
-                        autoCorrect="off"
-                        spellCheck={false}
-                        aria-label="Branch slug"
-                      />
-                    </div>
-                  </div>
-
-                  {missingBase ? <BaseBranchGuide /> : null}
-
-                  <div className="flex items-center gap-3 pt-1">
-                    <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
-                      <input
-                        type="checkbox"
-                        checked={setupWorkflow}
-                        onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
-                        className="accent-primary"
-                        disabled={busy}
-                      />
-                      Set up workflow next
-                    </label>
-                    <span className="flex-1" />
-                    {error && !missingBase ? (
-                      <span className="text-xs text-danger">{error}</span>
-                    ) : null}
-                    <Button
-                      onClick={() => void onLaunch()}
-                      disabled={!canLaunch}
-                      className={busy ? 'animate-border-pulse' : undefined}
-                    >
-                      {busy ? (
-                        'Launching…'
-                      ) : (
-                        <>
-                          Launch session
-                          <ArrowRight size={13} className="ml-1.5" aria-hidden />
-                        </>
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              )}
-            </section>
+  const launch = (
+    <section className="flex flex-col gap-3">
+      <SectionHeader label="launch session" />
+      {sessionId ? (
+        <div className="flex items-center gap-3 rounded-lg border border-border-soft bg-muted/10 px-4 py-3.5">
+          <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-success/15">
+            <MessagesSquare size={15} className="text-success" aria-hidden />
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <span className="text-sm font-medium text-foreground">Session already launched</span>
+            <span className="truncate text-2xs text-muted-foreground">
+              A session is linked to this issue.
+            </span>
           </div>
-        </ScrollFade>
-      </div>
-    </div>
+          <OpenSessionButton sessionId={sessionId} onOpened={onClose} />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader
+              label="Goal"
+              icon={<Target size={13} aria-hidden className="text-primary" />}
+            />
+            <Textarea
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              autoGrow
+              minRows={3}
+              maxRows={12}
+              disabled={busy}
+              aria-label="Session goal"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader
+              label="Branch"
+              icon={<GitBranch size={13} aria-hidden className="text-success" />}
+            />
+            <div className="flex items-center gap-1.5">
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {(sanitizePrefix(branchPrefix) || DEFAULT_BRANCH_PREFIX) + '/'}
+              </span>
+              <Input
+                value={branchSlug}
+                onChange={(e) => setBranchSlug(sanitizeSlug(e.target.value))}
+                placeholder="branch-slug"
+                className="h-8 flex-1 font-mono text-sm"
+                disabled={busy}
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                aria-label="Branch slug"
+              />
+            </div>
+          </div>
+
+          {missingBase ? <BaseBranchGuide /> : null}
+
+          <div className="flex flex-wrap items-center gap-3">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={setupWorkflow}
+                onChange={(e) => onToggleSetupWorkflow(e.target.checked)}
+                className="accent-primary"
+                disabled={busy}
+              />
+              Set up workflow next
+            </label>
+            <span className="flex-1" />
+            {error && !missingBase ? <span className="text-xs text-danger">{error}</span> : null}
+            <Button
+              onClick={() => void onLaunch()}
+              disabled={!canLaunch}
+              className={busy ? 'animate-border-pulse' : undefined}
+            >
+              {busy ? (
+                'Launching…'
+              ) : (
+                <>
+                  Launch session
+                  <ArrowRight size={13} className="ml-1.5" aria-hidden />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+
+  const identifier = issue.shortId ?? issue.id;
+  const culprit = detail?.culprit ?? issue.culprit;
+  const permalink = issue.permalink;
+  const visibleTags = visibleSentryTags({ detail });
+  const frames = detail?.frames ?? [];
+  const breadcrumbs = detail?.breadcrumbs ?? [];
+  const firstSeen = issue.firstSeen == null ? '' : formatRelativeDuration(issue.firstSeen);
+  const lastSeen = issue.lastSeen == null ? '' : formatRelativeDuration(issue.lastSeen);
+  const stats = [
+    ...(issue.count != null ? [{ label: 'Events', value: issue.count }] : []),
+    ...(issue.userCount != null ? [{ label: 'Users', value: String(issue.userCount) }] : []),
+    ...(firstSeen !== '' ? [{ label: 'First seen', value: `${firstSeen} ago` }] : []),
+    ...(lastSeen !== '' ? [{ label: 'Last seen', value: `${lastSeen} ago` }] : []),
+  ];
+
+  return (
+    <StudioDetailLayout
+      header={
+        <HeaderBand
+          meta={
+            <>
+              <span
+                className={cn(
+                  'shrink-0 rounded border px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide',
+                  levelTone({ level: issue.level }),
+                )}
+              >
+                {issue.level ?? 'error'}
+              </span>
+              <span className="font-mono text-2xs tabular-nums text-muted-foreground">
+                {identifier}
+              </span>
+            </>
+          }
+          title={detail?.title ?? issue.title}
+          subtitle={
+            culprit != null ? (
+              <span className="truncate font-mono text-2xs text-muted-foreground">{culprit}</span>
+            ) : undefined
+          }
+          actions={
+            permalink != null && permalink !== '' ? (
+              <a
+                href={permalink}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                Open in Sentry <ExternalLink size={11} aria-hidden />
+              </a>
+            ) : undefined
+          }
+        />
+      }
+      rail={
+        <>
+          {launch}
+          <Divider />
+          {visibleTags.map((tag) => (
+            <MetaItem key={tag.key} label={tag.key}>
+              {tag.value}
+            </MetaItem>
+          ))}
+          {issue.status != null ? <MetaItem label="Status">{issue.status}</MetaItem> : null}
+        </>
+      }
+    >
+      {stats.length > 0 ? (
+        <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
+          {stats.map((stat) => (
+            <StatCard key={stat.label} label={stat.label} value={stat.value} valueSize="lg" />
+          ))}
+        </div>
+      ) : null}
+
+      <section className="flex flex-col gap-3">
+        <SectionHeader
+          label="stack trace"
+          icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
+        />
+        <SentryStackTrace frames={frames} isLoading={detailLoading} error={detailError} />
+      </section>
+
+      <SentryBreadcrumbs breadcrumbs={breadcrumbs} isLoading={detailLoading} error={detailError} />
+    </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/sentry/visibleSentryTags.ts
+++ b/apps/desktop/src/features/integrations/sentry/visibleSentryTags.ts
@@ -1,0 +1,10 @@
+import type { SentryIssueDetail, SentryTag } from './client';
+
+type Params = {
+  readonly detail: SentryIssueDetail | null;
+};
+
+const VISIBLE_TAGS = new Set(['release', 'environment']);
+
+export const visibleSentryTags = ({ detail }: Params): ReadonlyArray<SentryTag> =>
+  detail?.tags?.filter((tag) => VISIBLE_TAGS.has(tag.key)) ?? [];

--- a/apps/desktop/src/shared/components/StudioDetail/DetailSection.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/DetailSection.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import { SectionHeader } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly action?: ReactNode;
+  readonly children: ReactNode;
+};
+
+export const DetailSection = ({ label, icon, action, children }: Props) => {
+  return (
+    <section className="flex flex-col gap-3">
+      <SectionHeader label={label} icon={icon} action={action} />
+      <div className="rounded-lg border border-border-soft bg-muted/10 p-4">{children}</div>
+    </section>
+  );
+};

--- a/apps/desktop/src/shared/components/StudioDetail/HeaderBand.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/HeaderBand.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly meta: ReactNode;
+  readonly title: ReactNode;
+  readonly subtitle?: ReactNode;
+  readonly actions?: ReactNode;
+};
+
+export const HeaderBand = ({ meta, title, subtitle, actions }: Props) => {
+  return (
+    <div className="flex items-start gap-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className="flex flex-wrap items-center gap-2">{meta}</div>
+        <h2 className="text-lg font-semibold leading-snug text-foreground">{title}</h2>
+        {subtitle ?? null}
+      </div>
+      {actions != null ? (
+        <div className="flex shrink-0 items-center gap-2 pt-0.5">{actions}</div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/StudioDetail/MetaItem.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/MetaItem.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly label: string;
+  readonly children: ReactNode;
+};
+
+export const MetaItem = ({ label, children }: Props) => {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-2xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex flex-wrap items-center gap-1.5 text-xs text-foreground">{children}</div>
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/StudioDetailLayout.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { Divider, ScrollFade } from '@goodboy/ui';
+
+type Props = {
+  readonly header: ReactNode;
+  readonly rail: ReactNode;
+  readonly children: ReactNode;
+};
+
+export const StudioDetailLayout = ({ header, rail, children }: Props) => {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 px-6 py-4">{header}</div>
+      <Divider />
+      <div className="flex min-h-0 flex-1">
+        <ScrollFade className="h-full min-w-0 flex-1" viewportClassName="px-6 py-6" fadeSize={24}>
+          <div className="mx-auto flex w-full max-w-3xl flex-col gap-6">{children}</div>
+        </ScrollFade>
+        <div className="hidden min-h-0 shrink-0 lg:flex">
+          <Divider orientation="vertical" />
+          <ScrollFade className="h-full w-80" viewportClassName="p-4" fadeSize={24}>
+            <div className="flex flex-col gap-4">{rail}</div>
+          </ScrollFade>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
+++ b/apps/desktop/src/shared/components/StudioDetail/index.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { DetailSection } from './DetailSection';
+import { HeaderBand } from './HeaderBand';
+import { MetaItem } from './MetaItem';
+import { StudioDetailLayout } from './StudioDetailLayout';
+
+afterEach(cleanup);
+
+describe('StudioDetailLayout', () => {
+  it('renders the header band, main content, and metadata rail', () => {
+    render(
+      <StudioDetailLayout header={<span>Header slot</span>} rail={<span>Rail slot</span>}>
+        <span>Main slot</span>
+      </StudioDetailLayout>,
+    );
+
+    expect(screen.getByText('Header slot')).toBeDefined();
+    expect(screen.getByText('Main slot')).toBeDefined();
+    expect(screen.getByText('Rail slot')).toBeDefined();
+  });
+});
+
+describe('DetailSection', () => {
+  it('renders the section label, action, and card body', () => {
+    render(
+      <DetailSection label="description" action={<button type="button">Edit</button>}>
+        <p>Body copy</p>
+      </DetailSection>,
+    );
+
+    expect(screen.getByText('description')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDefined();
+    expect(screen.getByText('Body copy')).toBeDefined();
+  });
+});
+
+describe('MetaItem', () => {
+  it('renders the label above its value', () => {
+    render(<MetaItem label="Assignee">Grace Hopper</MetaItem>);
+
+    expect(screen.getByText('Assignee')).toBeDefined();
+    expect(screen.getByText('Grace Hopper')).toBeDefined();
+  });
+});
+
+describe('HeaderBand', () => {
+  it('renders meta chips, title, subtitle, and actions', () => {
+    render(
+      <HeaderBand
+        meta={<span>GB-42</span>}
+        title="Improve detail layout"
+        subtitle={<span>api/items</span>}
+        actions={<a href="https://example.com">Open</a>}
+      />,
+    );
+
+    expect(screen.getByText('GB-42')).toBeDefined();
+    expect(screen.getByRole('heading', { name: 'Improve detail layout' })).toBeDefined();
+    expect(screen.getByText('api/items')).toBeDefined();
+    expect(screen.getByRole('link', { name: 'Open' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/shared/components/StudioDetail/index.ts
+++ b/apps/desktop/src/shared/components/StudioDetail/index.ts
@@ -1,0 +1,4 @@
+export { StudioDetailLayout } from './StudioDetailLayout';
+export { DetailSection } from './DetailSection';
+export { MetaItem } from './MetaItem';
+export { HeaderBand } from './HeaderBand';


### PR DESCRIPTION
## Obiettivo
I detail degli studi (Linear, Sentry, GitHub, GitLab) erano una colonna unica sequenziale. Ristrutturati come dashboard: header band + contenuto multi-colonna + metadata rail, su primitive condivise. Zero cambi di comportamento, solo layout + campi già fetchati ma mai mostrati.

Area 5 dello stack **PR review**. Base: `ak/feat-pr-review-ui`. Da NON mergiare da sola.

## Cosa
- Primitive `StudioDetail`: `StudioDetailLayout` (header band + main ScrollFade max-w-3xl + rail w-80 `hidden lg:flex`), `DetailSection`, `MetaItem`, `HeaderBand`. Divider come separatore (border vietati da AGENTS.md).
- **Linear**: header (priority/identifier/state/title) + Description/Comments a card + rail (assignee, project, labels, linked PR, launch card in cima).
- **Sentry**: header (level/culprit) + strip di StatCard + stack trace + breadcrumbs + rail (release/env/status).
- **GitHub/GitLab issue + GitLab MR**: stesso trattamento. Tab system del GitHub PrDetailPanel NON toccato.
- Campi finalmente in vista: Sentry events/users/firstSeen/lastSeen/status, `updatedAt` ovunque, description MR GitLab.

## MUST NOT (verificati)
- Nessun cambio di dati/azioni: merge, launch, spawn agent, open-browser tutti preservati (audit di parità dedicato). Tab GitHub PR intatti.

## Test
typecheck desktop + suite completa **288 file / 2417 test** verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)