### PR TITLE
feat: UI polish pass (board card + dashboard consistency)

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -471,7 +471,7 @@ function SectionBody({
   children: ReactNode;
 }) {
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-8 py-6">
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-3 px-6 py-6">
       {detailError ? (
         <div className="flex items-center gap-1.5 text-xs text-danger">
           <AlertCircle size={13} aria-hidden />

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrOverview.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrOverview.tsx
@@ -79,7 +79,7 @@ export const PrOverview = ({ pr, sessionId, onMutated }: Props) => {
   };
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 py-6">
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-6 py-6">
       <div className="flex flex-col gap-1">
         {editing === 'title' ? (
           <div className="flex items-center gap-2">

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -21,6 +21,7 @@ import {
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { OpenSessionButton } from '../../../../shared/components/OpenSessionButton';
 import {
+  DetailSection,
   HeaderBand,
   MetaItem,
   StudioDetailLayout,
@@ -342,13 +343,12 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
         </div>
       ) : null}
 
-      <section className="flex flex-col gap-3">
-        <SectionHeader
-          label="stack trace"
-          icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
-        />
+      <DetailSection
+        label="stack trace"
+        icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
+      >
         <SentryStackTrace frames={frames} isLoading={detailLoading} error={detailError} />
-      </section>
+      </DetailSection>
 
       <SentryBreadcrumbs breadcrumbs={breadcrumbs} isLoading={detailLoading} error={detailError} />
     </StudioDetailLayout>

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.test.tsx
@@ -139,12 +139,11 @@ describe('StageBoardCard layout', () => {
 });
 
 describe('StageBoardCard linked request', () => {
-  it('always renders a no pull request icon in the title row when no PR exists', () => {
+  it('renders no pull request indicator when no PR exists', () => {
     render(<StageBoardCard session={session} nav={nav} />);
-    const icon = screen.getByLabelText('No pull request');
-    const titleRow = screen.getByText(session.goal).closest('[data-tooltip]')?.parentElement;
-    expect(icon.getAttribute('title')).toBe('No pull request');
-    expect(titleRow?.contains(icon)).toBe(true);
+    expect(screen.queryByLabelText('No pull request')).toBeNull();
+    expect(screen.queryByLabelText(/open in GitHub/)).toBeNull();
+    expect(screen.getByText(session.goal)).toBeTruthy();
   });
 
   it('renders a clickable GitHub PR button that calls nav.openGithub', () => {

--- a/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
+++ b/apps/desktop/src/features/workspace/components/StageBoard/StageBoardCard/index.tsx
@@ -21,7 +21,6 @@ import {
 import { isPrReviewSession } from '../../../../../store/slices/session-view';
 import { CostBadge } from '../../../../providers/components/CostBadge';
 import { PullRequestChip, pullRequestMeta } from '../../../../github/components/PullRequestChip';
-import { IntegrationGlyph } from '../../../../integrations/components/IntegrationGlyph';
 import { ExternalTaskChip } from '../../../../integrations/components/ExternalTaskChip';
 import type { BoardNavigation } from '../useBoardNavigation';
 import { getLinkedRequest } from './getLinkedRequest';
@@ -111,41 +110,30 @@ export const StageBoardCard = memo(function StageBoardCard({
       )}
     >
       <span className="flex min-w-0 flex-1 flex-col gap-2">
-        <span className="flex min-h-10 items-start gap-2">
+        <span className="flex min-h-10 items-start gap-1.5">
+          {hasLinkedRequest && (
+            <Tooltip content={prTooltip} side="top">
+              <button
+                type="button"
+                aria-label={prTooltip}
+                onClick={handlePrClick}
+                className="-ml-0.5 mt-px inline-flex size-5 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-muted"
+              >
+                <PullRequestChip
+                  state={linkedRequest.state}
+                  variant="icon"
+                  number={linkedRequest.number}
+                  iconSize={14}
+                  title={linkedRequest.title}
+                />
+              </button>
+            </Tooltip>
+          )}
           <Tooltip content={`${session.goal}${reason ? ` · ${reason}` : ''}`} side="top">
             <span className="line-clamp-2 min-h-10 min-w-0 flex-1 text-sm font-medium leading-snug">
               {session.goal}
             </span>
           </Tooltip>
-          <span className="inline-flex h-5 shrink-0 items-center">
-            {hasLinkedRequest ? (
-              <Tooltip content={prTooltip} side="top">
-                <button
-                  type="button"
-                  aria-label={prTooltip}
-                  onClick={handlePrClick}
-                  className="inline-flex shrink-0 items-center gap-0.5 rounded-sm transition-colors hover:bg-muted"
-                >
-                  <IntegrationGlyph provider={isGitlab ? 'gitlab' : 'github'} size="xs" />
-                  <PullRequestChip
-                    state={linkedRequest.state}
-                    variant="icon"
-                    number={linkedRequest.number}
-                    iconSize={12}
-                    title={linkedRequest.title}
-                  />
-                </button>
-              </Tooltip>
-            ) : (
-              <PullRequestChip
-                state={linkedRequest.state}
-                variant="icon"
-                number={linkedRequest.number}
-                iconSize={12}
-                title={linkedRequest.title}
-              />
-            )}
-          </span>
         </span>
 
         <span className="mt-auto flex min-h-5 flex-nowrap items-center gap-1.5 overflow-hidden">


### PR DESCRIPTION
## Obiettivo
Passata di rifinitura UI/UX post feature PR-review: card della board de-clutterata + coerenza visiva delle studio dashboard. Nessun cambio di comportamento, solo presentazione.

## Cosa
- **Board card**: rimosso il glyph testuale "GH"/"GL" (rumore); lo stato PR ora è un indicatore colorato per stato (draft/open/approved/queued/merged/closed) **prima del titolo**, cliccabile, con provider e numero nel tooltip. Hit target più grande (20px).
- **Sentry studio**: stack trace ora dentro la `DetailSection` condivisa come Linear/GitHub/GitLab (prima `<section>` grezzo). Breadcrumbs lasciati intatti (sono già una card `<details>` autonoma, wrapparli = card-in-card).
- **GitHub PR**: padding overview + section body allineato a `px-6` (studio standard, era `px-8`).

## Audit
2 audit read-only paralleli (StageBoard/card/breadcrumb + studio/session dashboards): app risultata ben strutturata, zero dead-code o bottoni morti. Breadcrumb tooltip e ordering rail erano già conformi (nessuna modifica necessaria). Nessun redesign speculativo: cambiato solo ciò che era realmente incoerente.

## Non toccato (di proposito)
Tab system del GitHub PrDetailPanel; Budget/Provider/Plan/Guide studio (superfici coerenti a sé); turn engine.

## Test
typecheck desktop pulito + suite completa **289 file / 2441 test** verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)