### PR TITLE
feat(core): add opus 5 to the anthropic model registry

### DIFF
--- a/apps/desktop/src/__tests__/chat-constants.test.ts
+++ b/apps/desktop/src/__tests__/chat-constants.test.ts
@@ -12,6 +12,7 @@ const ANTHROPIC = [
   'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-fable-5',
 ];
 
@@ -22,6 +23,14 @@ const GEMINI = ['gemini-3.5-flash', 'gemini-3.1-pro'];
 describe('suggestLighterModel', () => {
   it('Opus 4.8 → Sonnet 4.6, strong, about 1.7x cheaper', () => {
     expect(suggestLighterModel('claude-opus-4-8', ANTHROPIC)).toEqual({
+      id: 'claude-sonnet-4-6',
+      kind: 'strong',
+      costMultiplier: 1.7,
+    });
+  });
+
+  it('Opus 5 → Sonnet 4.6, strong, about 1.7x cheaper', () => {
+    expect(suggestLighterModel('claude-opus-5', ANTHROPIC)).toEqual({
       id: 'claude-sonnet-4-6',
       kind: 'strong',
       costMultiplier: 1.7,
@@ -130,6 +139,14 @@ describe('suggestHeavierModel', () => {
 });
 
 describe('parseModelId', () => {
+  it('single-segment opus version keeps the opus subfamily', () => {
+    expect(parseModelId('claude-opus-5')).toEqual({
+      family: 'claude',
+      subfamily: 'opus',
+      variantLabel: '5',
+    });
+  });
+
   it('canonical anthropic ids: family/subfamily/variant', () => {
     expect(parseModelId('claude-haiku-4-5')).toEqual({
       family: 'claude',

--- a/apps/desktop/src/features/chat/utils/chat-constants.ts
+++ b/apps/desktop/src/features/chat/utils/chat-constants.ts
@@ -94,6 +94,7 @@ const MODEL_COST: Record<string, { weight: number; tier: CostTier }> = {
   'claude-opus-4-6': { weight: 60, tier: 'expensive' },
   'claude-opus-4-7': { weight: 75, tier: 'expensive' },
   'claude-opus-4-8': { weight: 80, tier: 'expensive' },
+  'claude-opus-5': { weight: 85, tier: 'expensive' },
   'claude-fable-5': { weight: 90, tier: 'expensive' },
 };
 

--- a/apps/desktop/src/features/session/agent-row-format.test.ts
+++ b/apps/desktop/src/features/session/agent-row-format.test.ts
@@ -60,6 +60,7 @@ describe('shortModel', () => {
     expect(shortModel('claude-sonnet-4-6')).toBe('sonnet');
     expect(shortModel('claude-opus-4-7')).toBe('opus');
     expect(shortModel('claude-fable-5')).toBe('fable');
+    expect(shortModel('claude-opus-5')).toBe('opus');
   });
 
   it('passes non-claude models through', () => {

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -11,7 +11,7 @@ describe('autoModelForRole', () => {
     it('keeps the curated default for a high-tier role', () => {
       expect(autoModelForRole('planner', ['anthropic'])).toEqual({
         provider: 'anthropic',
-        model: 'claude-opus-4-8',
+        model: 'claude-opus-5',
       });
     });
 
@@ -25,7 +25,7 @@ describe('autoModelForRole', () => {
     it('prefers the default provider even when other providers are enabled', () => {
       expect(autoModelForRole('planner', ['gemini', 'anthropic'])).toEqual({
         provider: 'anthropic',
-        model: 'claude-opus-4-8',
+        model: 'claude-opus-5',
       });
     });
   });

--- a/packages/core/src/providers/capabilities.ts
+++ b/packages/core/src/providers/capabilities.ts
@@ -10,6 +10,18 @@ export const PROVIDER_CAPABILITIES: Readonly<Record<ProviderId, ProviderRegistry
   anthropic: {
     models: [
       {
+        id: 'claude-opus-5',
+        tier: 'turn',
+        contextWindow: 1_000_000,
+        family: 'claude',
+        subfamily: 'opus',
+        label: 'Opus 5',
+        variantLabel: '5',
+        costTier: 'expensive',
+        weight: 85,
+        effort: OPUS_EFFORT,
+      },
+      {
         id: 'claude-opus-4-8',
         tier: 'turn',
         contextWindow: 1_000_000,

--- a/packages/core/src/providers/claude/adapter.ts
+++ b/packages/core/src/providers/claude/adapter.ts
@@ -17,8 +17,9 @@ const CAPABILITIES: ProviderCapabilities = {
   toolUse: true,
   fileEdits: true,
   contextWindow: 1_000_000,
-  defaultModel: 'claude-opus-4-8',
+  defaultModel: 'claude-opus-5',
   availableModels: [
+    'claude-opus-5',
     'claude-opus-4-8',
     'claude-fable-5',
     'claude-opus-4-7',

--- a/packages/core/src/providers/claude/cost.test.ts
+++ b/packages/core/src/providers/claude/cost.test.ts
@@ -18,6 +18,10 @@ describe('computeCostUsd', () => {
     expect(computeCostUsd(usage, 'claude-opus-4-7')).toBeCloseTo(5 + 25);
   });
 
+  it('opus-5 is priced as opus', () => {
+    expect(computeCostUsd(usage, 'claude-opus-5')).toBeCloseTo(5 + 25);
+  });
+
   it('opus-4-8 is priced as opus', () => {
     expect(computeCostUsd(usage, 'claude-opus-4-8')).toBeCloseTo(5 + 25);
   });

--- a/packages/core/src/providers/claude/cost.ts
+++ b/packages/core/src/providers/claude/cost.ts
@@ -24,6 +24,7 @@ const SONNET_PRICE: ModelPrice = {
 
 export const CLAUDE_PRICES: Record<string, ModelPrice> = {
   'claude-fable-5': FABLE_PRICE,
+  'claude-opus-5': OPUS_PRICE,
   'claude-opus-4-8': OPUS_PRICE,
   'claude-opus-4-7': OPUS_PRICE,
   'claude-opus-4-6': OPUS_PRICE,

--- a/packages/core/src/providers/model-map.test.ts
+++ b/packages/core/src/providers/model-map.test.ts
@@ -47,12 +47,12 @@ describe('resolveModelForProvider', () => {
     );
     expect(
       resolveModelForProvider({ provider: 'anthropic', modelId: 'totally-unknown-model' }),
-    ).toBe('claude-opus-4-8');
+    ).toBe('claude-opus-5');
   });
 
   it('falls back to the default turn model when the family has no counterpart', () => {
     expect(resolveModelForProvider({ provider: 'anthropic', modelId: 'auto' })).toBe(
-      'claude-opus-4-8',
+      'claude-opus-5',
     );
   });
 });

--- a/packages/core/src/providers/model-price.test.ts
+++ b/packages/core/src/providers/model-price.test.ts
@@ -3,6 +3,7 @@ import { getModelPrice } from './model-price';
 
 describe('getModelPrice', () => {
   it('returns claude opus pricing for a known opus id', () => {
+    expect(getModelPrice('claude-opus-5')).toEqual({ inputPerMtok: 5, outputPerMtok: 25 });
     expect(getModelPrice('claude-opus-4-8')).toEqual({ inputPerMtok: 5, outputPerMtok: 25 });
   });
 

--- a/packages/core/src/providers/registry.test.ts
+++ b/packages/core/src/providers/registry.test.ts
@@ -97,6 +97,10 @@ describe('getCapabilities', () => {
     expect(getDefaultTurnModel('gemini')).toBe('gemini-3.5-flash');
   });
 
+  it('getDefaultTurnModel for anthropic returns the newest opus', () => {
+    expect(getDefaultTurnModel('anthropic')).toBe('claude-opus-5');
+  });
+
   it('getDefaultTurnModel for cursor returns the composer turn model', () => {
     expect(getDefaultTurnModel('cursor')).toBe('composer-2');
   });

--- a/packages/core/src/roles.ts
+++ b/packages/core/src/roles.ts
@@ -24,13 +24,13 @@ export const ROLE_DEFAULTS = {
   },
   planner: {
     provider: 'anthropic',
-    model: 'claude-opus-4-8',
+    model: 'claude-opus-5',
     effort: 'high',
     description: 'design the change; produce an ordered plan',
   },
   architect: {
     provider: 'anthropic',
-    model: 'claude-opus-4-8',
+    model: 'claude-opus-5',
     effort: 'high',
     description: 'propose technical approach, modules, data flow, migrations',
   },


### PR DESCRIPTION
## What

Adds Opus 5 to the Claude provider and promotes it to the flagship turn model.

- `capabilities.ts`: new `claude-opus-5` entry, first in the anthropic list (1M context, `expensive` tier, full opus effort range, weight 85, between Opus 4.8 at 80 and Fable 5 at 90)
- `claude/adapter.ts`: `defaultModel` and `availableModels`
- `claude/cost.ts`: priced as opus (5 / 25 per Mtok)
- `chat-constants.ts`: fallback weight/tier table entry
- `roles.ts`: planner and architect defaults move from Opus 4.8 to Opus 5

Being first in the list makes `getDefaultTurnModel('anthropic')` return `claude-opus-5`, so new sessions, the "recommended" tag, and cross-provider model resolution for unknown ids now land on Opus 5. Opus 4.8, 4.7 and 4.6 stay selectable.

## Why the id is verified, not assumed

`claude-opus-5` is a single-segment version, a shape the id-parsing fallbacks do not match (same as `claude-fable-5`), so the registry entry is what makes it render correctly. Checked against the CLI before writing any code: `claude -p --model claude-opus-5` answers, `claude -p --model claude-opus-99` is rejected with an unknown-model error, so the id resolves rather than silently falling back.

## Assumptions

Pricing and context window are taken from Opus 4.8 (5 / 25 per Mtok, 1M). Weight keeps Fable 5 as the top-of-tier model, so the lighter/heavier suggestions are unchanged.

## Tests

- core 833, desktop 2443, typecheck clean
- new: `getDefaultTurnModel('anthropic')`, opus-5 pricing in `cost.test.ts` and `model-price.test.ts`, `parseModelId('claude-opus-5')`, `shortModel`, a lighter-model suggestion, and the planner/architect role defaults
- `claude-opus-4-7-thinking-high` still maps back to Opus 4.8 (nearest weight), asserted unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)