### PR TITLE
fix(desktop): scrollable panels, script environment, drag and drop hit testing

### DIFF
--- a/apps/desktop/src-tauri/src/path_env.rs
+++ b/apps/desktop/src-tauri/src/path_env.rs
@@ -44,6 +44,21 @@ pub fn command_with_login_env(binary: &str) -> Command {
     cmd
 }
 
+pub fn login_shell() -> String {
+    if let Ok(shell) = std::env::var("SHELL") {
+        let shell = shell.trim();
+        if !shell.is_empty() && std::path::Path::new(shell).exists() {
+            return shell.to_string();
+        }
+    }
+    for candidate in shell_candidates() {
+        if std::path::Path::new(candidate).exists() {
+            return (*candidate).to_string();
+        }
+    }
+    "/bin/sh".to_string()
+}
+
 fn compute_path() -> String {
     let inherited = std::env::var("PATH").unwrap_or_default();
     let (shell, npm_bin) = probe_login_shell();

--- a/apps/desktop/src-tauri/src/provider_lifecycle.rs
+++ b/apps/desktop/src-tauri/src/provider_lifecycle.rs
@@ -149,6 +149,9 @@ pub async fn provider_lifecycle_run(
         cmd.arg(&command);
         let cwd = std::env::var("HOME").unwrap_or_else(|_| "/".to_string());
         cmd.cwd(&cwd);
+        for (key, value) in crate::path_env::resolved_env() {
+            cmd.env(key, value);
+        }
         cmd.env("PATH", crate::path_env::resolved_path());
         cmd.env("TERM", "xterm-256color");
         if let Ok(home) = std::env::var("HOME") {

--- a/apps/desktop/src-tauri/src/scripts.rs
+++ b/apps/desktop/src-tauri/src/scripts.rs
@@ -94,6 +94,19 @@ impl From<DbError> for ScriptError {
 // Command — run a workspace script in a pty
 // ---------------------------------------------------------------------------
 
+fn build_script_command(body: &str, cwd: &str, login_env: &[(String, String)]) -> CommandBuilder {
+    let mut cmd = CommandBuilder::new("bash");
+    cmd.arg("-c");
+    cmd.arg(body);
+    cmd.cwd(cwd);
+    for (key, value) in login_env {
+        cmd.env(key, value);
+    }
+    cmd.env("PATH", crate::path_env::resolved_path());
+    cmd.env("TERM", "xterm-256color");
+    cmd
+}
+
 /// Spawns `bash -c <body>` inside a pty, registers the run under `run_id`, and
 /// returns immediately. Output is streamed as `script-output` events (base64
 /// chunks). A `script-exit` event fires when the process exits or is killed.
@@ -131,12 +144,7 @@ pub async fn workspace_script_run(
             })
             .map_err(|e| ScriptError::Io(e.to_string()))?;
 
-        let mut cmd = CommandBuilder::new("bash");
-        cmd.arg("-c");
-        cmd.arg(&body);
-        cmd.cwd(&cwd);
-        cmd.env("PATH", crate::path_env::resolved_path());
-        cmd.env("TERM", "xterm-256color");
+        let cmd = build_script_command(&body, &cwd, crate::path_env::resolved_env());
 
         let child = pair
             .slave
@@ -306,4 +314,62 @@ pub fn workspace_script_cancel(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn login_env() -> Vec<(String, String)> {
+        vec![
+            ("GITHUB_PACKAGES_TOKEN".to_string(), "tok".to_string()),
+            ("NVM_DIR".to_string(), "/home/u/.nvm".to_string()),
+        ]
+    }
+
+    #[test]
+    fn script_runs_through_bash_with_the_body_and_cwd() {
+        let cmd = build_script_command("yarn install", "/tmp/worktree", &login_env());
+        let argv: Vec<String> = cmd
+            .get_argv()
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(argv, vec!["bash", "-c", "yarn install"]);
+        assert_eq!(
+            cmd.get_cwd().map(|c| c.to_string_lossy().into_owned()),
+            Some("/tmp/worktree".to_string())
+        );
+    }
+
+    #[test]
+    fn script_inherits_the_login_shell_environment() {
+        let cmd = build_script_command("yarn install", "/tmp/worktree", &login_env());
+        assert_eq!(
+            cmd.get_env("GITHUB_PACKAGES_TOKEN")
+                .map(|v| v.to_string_lossy().into_owned()),
+            Some("tok".to_string())
+        );
+        assert_eq!(
+            cmd.get_env("NVM_DIR").map(|v| v.to_string_lossy().into_owned()),
+            Some("/home/u/.nvm".to_string())
+        );
+    }
+
+    #[test]
+    fn script_path_and_term_win_over_the_login_environment() {
+        let env = vec![
+            ("PATH".to_string(), "/stale".to_string()),
+            ("TERM".to_string(), "dumb".to_string()),
+        ];
+        let cmd = build_script_command("echo hi", "/tmp", &env);
+        assert_eq!(
+            cmd.get_env("TERM").map(|v| v.to_string_lossy().into_owned()),
+            Some("xterm-256color".to_string())
+        );
+        assert_ne!(
+            cmd.get_env("PATH").map(|v| v.to_string_lossy().into_owned()),
+            Some("/stale".to_string())
+        );
+    }
 }

--- a/apps/desktop/src-tauri/src/terminal.rs
+++ b/apps/desktop/src-tauri/src/terminal.rs
@@ -61,33 +61,7 @@ impl TerminalError {
 }
 
 fn login_shell() -> String {
-    if let Ok(shell) = std::env::var("SHELL") {
-        let shell = shell.trim();
-        if !shell.is_empty() && std::path::Path::new(shell).exists() {
-            return shell.to_string();
-        }
-    }
-    for candidate in shell_fallbacks() {
-        if std::path::Path::new(candidate).exists() {
-            return (*candidate).to_string();
-        }
-    }
-    "/bin/sh".to_string()
-}
-
-#[cfg(target_os = "macos")]
-fn shell_fallbacks() -> &'static [&'static str] {
-    &["/bin/zsh", "/bin/bash"]
-}
-
-#[cfg(target_os = "linux")]
-fn shell_fallbacks() -> &'static [&'static str] {
-    &["/bin/bash", "/bin/zsh"]
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn shell_fallbacks() -> &'static [&'static str] {
-    &["/bin/sh"]
+    crate::path_env::login_shell()
 }
 
 #[tauri::command]

--- a/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
+++ b/apps/desktop/src/__tests__/snapshots/__snapshots__/empty-error-states.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`snapshot, empty states > NewSessionView: no workflows 1`] = `
       class="relative min-h-0 max-h-[70vh] overflow-y-auto"
     >
       <div
-        class="h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-6 py-5"
+        class="h-full max-h-[inherit] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-6 py-5"
       >
         <div
           class="flex w-full flex-col gap-8"
@@ -851,7 +851,7 @@ exports[`snapshot, error states > DeleteSessionDialog: error state 1`] = `
       class="relative min-h-0 flex-1 text-sm"
     >
       <div
-        class="h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden flex flex-col gap-4 px-6 py-5"
+        class="h-full max-h-[inherit] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden flex flex-col gap-4 px-6 py-5"
       >
         <div
           class="flex flex-col gap-3"
@@ -950,7 +950,7 @@ exports[`snapshot, error states > NewSessionView: form error 1`] = `
       class="relative min-h-0 max-h-[70vh] overflow-y-auto"
     >
       <div
-        class="h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-6 py-5"
+        class="h-full max-h-[inherit] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden px-6 py-5"
       >
         <div
           class="flex w-full flex-col gap-8"

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.test.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.test.ts
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+type DragHandler = (event: { payload: unknown }) => void;
+
+const { hooks } = vi.hoisted(() => ({
+  hooks: {
+    handler: null as DragHandler | null,
+    zoom: 1,
+    read: vi.fn(async (path: string) => ({
+      fileName: path.split('/').pop() ?? path,
+      mimeType: 'image/png',
+      dataBase64: 'aGk=',
+    })),
+  },
+}));
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: async (cb: DragHandler) => {
+      hooks.handler = cb;
+      return () => {
+        hooks.handler = null;
+      };
+    },
+  }),
+}));
+
+vi.mock('../../../../../shared/lib/zoom', () => ({
+  currentZoom: () => hooks.zoom,
+}));
+
+vi.mock('../../../turn', () => ({
+  readDroppedAttachment: (path: string) => hooks.read(path),
+}));
+
+import { usePendingAttachments } from './usePendingAttachments';
+
+const COMPOSER_RECT = { left: 100, right: 300, top: 400, bottom: 500 };
+
+const mountWithComposer = async (showToast: ReturnType<typeof vi.fn>, enabled = true) => {
+  const rendered = renderHook(() => usePendingAttachments({ showToast, enabled }));
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  Object.defineProperty(el, 'offsetParent', { value: document.body, configurable: true });
+  el.getBoundingClientRect = () =>
+    ({ ...COMPOSER_RECT, width: 200, height: 100, x: 100, y: 400 }) as DOMRect;
+  await act(async () => {
+    (rendered.result.current.composerRef as { current: HTMLDivElement | null }).current = el;
+  });
+  return rendered;
+};
+
+const drop = async (x: number, y: number, paths: ReadonlyArray<string>) => {
+  await act(async () => {
+    hooks.handler?.({ payload: { type: 'drop', position: { x, y }, paths } });
+  });
+};
+
+beforeEach(() => {
+  hooks.handler = null;
+  hooks.zoom = 1;
+  hooks.read = vi.fn(async (path: string) => ({
+    fileName: path.split('/').pop() ?? path,
+    mimeType: 'image/png',
+    dataBase64: 'aGk=',
+  }));
+  window.devicePixelRatio = 1;
+});
+afterEach(cleanup);
+
+describe('usePendingAttachments drop target', () => {
+  it('accepts a drop landing inside the composer', async () => {
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast);
+    await drop(200, 450, ['/tmp/a.png']);
+    expect(result.current.attachments).toHaveLength(1);
+    expect(result.current.attachments[0]?.fileName).toBe('a.png');
+  });
+
+  it('ignores a drop outside the composer', async () => {
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast);
+    await drop(10, 10, ['/tmp/a.png']);
+    expect(result.current.attachments).toHaveLength(0);
+  });
+
+  it('accounts for the webview zoom factor when hit testing', async () => {
+    hooks.zoom = 2;
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast);
+    await drop(400, 900, ['/tmp/a.png']);
+    expect(result.current.attachments).toHaveLength(1);
+  });
+
+  it('reports unsupported files instead of dropping them silently', async () => {
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast);
+    await drop(200, 450, ['/tmp/archive.zip']);
+    expect(result.current.attachments).toHaveLength(0);
+    expect(showToast).toHaveBeenCalledWith('warning', expect.stringContaining('unsupported type'));
+  });
+
+  it('explains why a drop is refused while the provider is disconnected', async () => {
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast, false);
+    await drop(200, 450, ['/tmp/a.png']);
+    expect(result.current.attachments).toHaveLength(0);
+    expect(showToast).toHaveBeenCalledWith(
+      'warning',
+      expect.stringContaining('connect the provider'),
+    );
+  });
+
+  it('highlights only while the pointer is over the composer', async () => {
+    const showToast = vi.fn();
+    const { result } = await mountWithComposer(showToast);
+    await act(async () => {
+      hooks.handler?.({ payload: { type: 'over', position: { x: 10, y: 10 } } });
+    });
+    expect(result.current.isDragging).toBe(false);
+    await act(async () => {
+      hooks.handler?.({ payload: { type: 'over', position: { x: 200, y: 450 } } });
+    });
+    expect(result.current.isDragging).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
+++ b/apps/desktop/src/features/chat/components/ChatInput/hooks/usePendingAttachments.ts
@@ -9,6 +9,7 @@ import {
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { isAllowedAttachment, resolveAttachmentMime } from '../../../attachment-kinds';
 import { readDroppedAttachment } from '../../../turn';
+import { currentZoom } from '../../../../../shared/lib/zoom';
 import type { ToastKind } from '../../../../../app/components/Toast';
 import {
   ATTACHMENT_LIMIT,
@@ -24,17 +25,13 @@ type PersistArgs = {
   readonly dataUrl: string;
 };
 
-interface UsePendingAttachmentsArgs {
+type Params = {
   readonly showToast: (kind: ToastKind, message: string) => void;
   readonly enabled?: boolean;
   readonly persistToDisk?: (att: PersistArgs) => Promise<string | null>;
-}
+};
 
-export function usePendingAttachments({
-  showToast,
-  enabled = true,
-  persistToDisk,
-}: UsePendingAttachmentsArgs) {
+export const usePendingAttachments = ({ showToast, enabled = true, persistToDisk }: Params) => {
   const [attachments, setAttachments] = useState<ReadonlyArray<PendingAttachment>>([]);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -134,23 +131,31 @@ export function usePendingAttachments({
 
     const isInsideComposer = (px: number, py: number): boolean => {
       const el = composerRef.current;
-      if (!el) {
+      if (!el || el.offsetParent === null) {
         return false;
       }
       const rect = el.getBoundingClientRect();
-      const dpr = window.devicePixelRatio || 1;
-      const candidates: ReadonlyArray<readonly [number, number]> = [
-        [px / dpr, py / dpr],
-        [px, py],
-      ];
-      return candidates.some(
-        ([x, y]) => x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom,
-      );
+      const scale = (window.devicePixelRatio || 1) * currentZoom();
+      const x = px / scale;
+      const y = py / scale;
+      return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
     };
 
+    const basename = (path: string): string => path.split('/').pop() ?? path;
+
     const ingestDroppedPaths = async (paths: ReadonlyArray<string>) => {
+      const supported = paths.filter((p) => isAllowedAttachment({ name: basename(p), type: '' }));
+      const unsupported = paths.length - supported.length;
+      if (unsupported > 0) {
+        showToastRef.current(
+          'warning',
+          `${unsupported} file${unsupported === 1 ? '' : 's'} skipped, unsupported type`,
+        );
+      }
       const dropped: PendingAttachment[] = [];
-      for (const path of paths) {
+      const rejected: string[] = [];
+      for (const path of supported) {
+        const name = basename(path);
         try {
           const r = await readDroppedAttachment(path);
           const id = crypto.randomUUID();
@@ -167,7 +172,16 @@ export function usePendingAttachments({
             dataUrl,
             relPath,
           });
-        } catch {}
+        } catch {
+          rejected.push(name);
+        }
+      }
+      if (rejected.length > 0) {
+        const label =
+          rejected.length === 1
+            ? `could not attach ${rejected[0]}, it may be over 15MB`
+            : `${rejected.length} files could not be read`;
+        showToastRef.current('error', label);
       }
       if (dropped.length === 0) {
         return;
@@ -189,14 +203,10 @@ export function usePendingAttachments({
       try {
         const off = await getCurrentWebview().onDragDropEvent((event) => {
           const p = event.payload;
-          if (!enabledRef.current) {
-            setIsDragging(false);
-            return;
-          }
           switch (p.type) {
             case 'enter':
             case 'over':
-              setIsDragging(true);
+              setIsDragging(enabledRef.current && isInsideComposer(p.position.x, p.position.y));
               break;
             case 'leave':
               setIsDragging(false);
@@ -204,6 +214,10 @@ export function usePendingAttachments({
             case 'drop': {
               setIsDragging(false);
               if (!isInsideComposer(p.position.x, p.position.y)) {
+                return;
+              }
+              if (!enabledRef.current) {
+                showToastRef.current('warning', 'connect the provider before attaching files');
                 return;
               }
               void ingestDroppedPaths(p.paths);
@@ -238,4 +252,4 @@ export function usePendingAttachments({
     onPaste,
     onFileInputChange,
   };
-}
+};

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.test.tsx
@@ -165,4 +165,26 @@ describe('NotificationCenter', () => {
     expect(state.retrySummarizer).toHaveBeenCalledWith('session-2', expected);
     expect(screen.queryByRole('button', { name: /confirm retry with selected model/i })).toBeNull();
   });
+
+  it('keeps a long notification list inside a bounded scroll viewport', async () => {
+    state.notifications = Array.from({ length: 30 }, (_, i) => ({
+      id: `n${i}`,
+      read: true,
+      severity: 'info',
+      title: `title ${i}`,
+      body: 'b',
+      ts: new Date().toISOString(),
+    })) as unknown as ReadonlyArray<Notification>;
+    render(<NotificationCenter />);
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^notifications$/i }));
+    });
+
+    const list = screen.getByText('title 0').closest('ul');
+    const viewport = list?.parentElement;
+    const fadeRoot = viewport?.parentElement;
+    expect(viewport?.className).toContain('overflow-y-auto');
+    expect(viewport?.className).toContain('max-h-[inherit]');
+    expect(fadeRoot?.className).toContain('max-h-80');
+  });
 });

--- a/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
+++ b/apps/desktop/src/features/notifications/components/NotificationCenter/index.tsx
@@ -57,6 +57,9 @@ function relativeTime(iso: string): string {
 
 const DROPDOWN_WIDTH = 320;
 const VIEWPORT_MARGIN = 8;
+const LIST_MAX_HEIGHT = 320;
+const HEADER_HEIGHT = 37;
+const DROPDOWN_MAX_HEIGHT = LIST_MAX_HEIGHT + HEADER_HEIGHT;
 
 export const NotificationCenter = () => {
   const notifications = useAppStore((s) => s.notifications);
@@ -103,7 +106,7 @@ export const NotificationCenter = () => {
       const maxLeft = window.innerWidth - DROPDOWN_WIDTH - VIEWPORT_MARGIN;
       const left = Math.min(Math.max(desiredLeft, VIEWPORT_MARGIN), maxLeft);
       const spaceBelow = window.innerHeight - rect.bottom;
-      const openAbove = spaceBelow < 300;
+      const openAbove = spaceBelow < DROPDOWN_MAX_HEIGHT + VIEWPORT_MARGIN;
       const top = openAbove ? undefined : rect.bottom + 6;
       const bottom = openAbove ? window.innerHeight - rect.top + 6 : undefined;
       setCoords({ top, bottom, left });

--- a/apps/desktop/src/shared/lib/zoom.ts
+++ b/apps/desktop/src/shared/lib/zoom.ts
@@ -31,6 +31,8 @@ async function applyZoom(factor: number): Promise<void> {
   }
 }
 
+export const currentZoom = (): number => readZoom();
+
 export const applyStoredZoom = async (): Promise<void> => {
   await applyZoom(readZoom());
 };

--- a/packages/ui/src/__tests__/ScrollFade.test.tsx
+++ b/packages/ui/src/__tests__/ScrollFade.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/react';
+import { ScrollFade } from '../components/ScrollFade';
+
+afterEach(cleanup);
+
+const viewportOf = (container: HTMLElement): HTMLElement => {
+  const root = container.firstElementChild;
+  const viewport = root?.firstElementChild;
+  if (!(viewport instanceof HTMLElement)) {
+    throw new Error('viewport not found');
+  }
+  return viewport;
+};
+
+describe('ScrollFade', () => {
+  it('bounds the scrolling viewport by the root height cap so a max-h root can scroll', () => {
+    const { container } = render(
+      <ScrollFade className="max-h-80">
+        <p>content</p>
+      </ScrollFade>,
+    );
+    const viewport = viewportOf(container);
+    expect(viewport.className).toContain('overflow-y-auto');
+    expect(viewport.className).toContain('max-h-[inherit]');
+  });
+
+  it('bounds the horizontal viewport by the root width cap', () => {
+    const { container } = render(
+      <ScrollFade className="max-w-sm" orientation="horizontal">
+        <p>content</p>
+      </ScrollFade>,
+    );
+    const viewport = viewportOf(container);
+    expect(viewport.className).toContain('overflow-x-auto');
+    expect(viewport.className).toContain('max-w-[inherit]');
+  });
+
+  it('keeps the caller viewport classes alongside the inherited cap', () => {
+    const { container } = render(
+      <ScrollFade className="h-full" viewportClassName="px-3">
+        <p>content</p>
+      </ScrollFade>,
+    );
+    expect(viewportOf(container).className).toContain('px-3');
+  });
+});

--- a/packages/ui/src/components/ScrollFade.tsx
+++ b/packages/ui/src/components/ScrollFade.tsx
@@ -72,8 +72,8 @@ export const ScrollFade = ({
         onScroll={sync}
         className={cn(
           horizontal
-            ? 'h-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
-            : 'h-full overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+            ? 'h-full max-w-[inherit] overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'
+            : 'h-full max-h-[inherit] overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
           viewportClassName,
         )}
       >


### PR DESCRIPTION
Three runtime bugs that made features silently do nothing. Part 1 of the runtime area; the permission-request chain is a separate PR because it needs a protocol change, not a fix.

## Scroll panels were unreachable past their cap

`ScrollFade` put the caller's class on its root and gave the inner viewport `h-full`. With a `max-h-*` root the root stays `height: auto`, so `h-full` resolves to auto, the viewport grows to full content height, and `overflow-y-auto` never has anything to scroll. Content past the cap spilled out of the root and was clipped by the host popover's `overflow-hidden`: invisible and unreachable, no scrollbar, no wheel scroll.

`min-h-0` was not the missing piece (nothing in the chain is a flex container, and the root already sets it). The missing piece was a bounded height on the element that scrolls. The viewport now inherits the root's cap, which fixes three panels at once:

- the notifications panel (the reported one)
- the command palette
- the diff view selector

The notifications flip threshold was also hardcoded at 300px while the panel can be 357px tall, so it could open downward with no room. It now derives from the panel's own height.

## Workspace scripts did not inherit the shell environment

Scripts ran as `bash -c <body>` with only `PATH` and `TERM` injected. That shell is neither login nor interactive, so nothing exported from `~/.zshrc` or `~/.zprofile` existed. A `yarn install` that works when typed into Goodboy's embedded terminal failed as a script with:

```
error Error: Failed to replace env in config: ${GITHUB_PACKAGES_TOKEN}
```

The embedded terminal works because it spawns `$SHELL -l -i`, which sources those files. The fix reuses the login environment the app already resolves and caches (`path_env::resolved_env`, whose own unit test happens to use this exact variable name). `PATH` and `TERM` still win over it. The same one-line defect in the provider-lifecycle pty is fixed too.

Not changed: the cwd. Scripts already get the session worktree, same as the terminal, so cwd was never part of this bug.

The shell picker that `terminal.rs` had duplicated now lives in `path_env` alongside the existing candidate list, so both paths agree on which shell is the user's.

## Dropped files missed a composer they were aimed at

The drop hit test converted the webview's physical drop position using the device pixel ratio only, and tried two candidate coordinate spaces at once. The app persists a webview zoom factor between 0.5 and 2.5, and at any zoom other than 1 neither candidate matches, so a drop aimed carefully at the composer was discarded with no feedback. The two-space union also let a composer in a hidden, kept-alive session claim a drop.

The highlight had the opposite problem: it was driven by window-wide `enter`/`over`, so the whole window said "drop to attach" while only the composer rect accepted.

Now: one conversion that accounts for zoom, composers that are not visible are skipped, and the highlight tracks the area that actually accepts. Rejections that used to disappear into a bare `catch` now say what happened, including the disconnected-provider case that used to swallow every drop.

## Verify by hand

- Open the bell with more than a screenful of notifications: the list scrolls. Same for the command palette and the diff view selector.
- Add a workspace script that echoes a variable exported from your `~/.zshrc` and run it: it resolves.
- Zoom the app in or out, then drop an image on the composer: it attaches, and the highlight only appears over the composer.
- Drop a `.zip`: it is refused with a message instead of nothing happening.

## Not done here

- The permission-request chain (allow does not reach the agent). It is broken in three independent places and needs `--input-format stream-json` plus a stdin channel, so it gets its own PR.
- `ScrollFade` still accepts a root with no height at all, which renders as an unbounded list rather than an error. The new test pins the cap-inheritance contract, not that contract.

## Tests

`packages/ui` 20 -> 23, desktop 2443 -> 2450, Rust 99 -> 102. `ScrollFade` had no test at all before; the drop path had none because every consumer test stubs the webview module. Three snapshots updated for the changed viewport class.
