### PR TITLE
feat(desktop): make blocked tool permissions visible and approvable

### DIFF
--- a/apps/desktop/src/__tests__/sidebar.test.ts
+++ b/apps/desktop/src/__tests__/sidebar.test.ts
@@ -117,6 +117,7 @@ describe('status icon mapping', () => {
     'starting',
     'idle',
     'running',
+    'blocked',
     'ended',
     'error',
   ];
@@ -127,6 +128,7 @@ describe('status icon mapping', () => {
       starting: 'loader',
       idle: 'circle',
       running: 'pulse',
+      blocked: 'shield-alert',
       ended: 'check',
       error: 'x',
     };

--- a/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
+++ b/apps/desktop/src/__tests__/store/permission-scope-cta.test.ts
@@ -266,6 +266,7 @@ describe('resolvePermissionRequest', () => {
       }
       expect(decEv.decidedBy).toBe('user');
       expect(decEv.decision).toBe(scope === 'deny' ? 'deny' : 'allow');
+      expect(decEv.scope).toBe(scope);
     }
   });
 });

--- a/apps/desktop/src/__tests__/transcript-items.test.ts
+++ b/apps/desktop/src/__tests__/transcript-items.test.ts
@@ -116,6 +116,26 @@ describe('reduceTranscript, permission_decision', () => {
     }
     expect(dec.toolName).toBe('tu-orphan');
   });
+
+  it('carries the approval scope, and leaves it unset for events persisted without one', () => {
+    const scoped: TurnEvent = {
+      kind: 'permission_decision',
+      runId: RUN,
+      toolUseId: 'tu-scoped',
+      decision: 'allow',
+      scope: 'session',
+      ruleId: null,
+      decidedBy: 'user',
+      at: AT,
+    };
+    const items = reduceTranscript([scoped, permDecEvent('tu-legacy')]);
+    const [withScope, withoutScope] = items;
+    if (withScope?.kind !== 'permission_decision' || withoutScope?.kind !== 'permission_decision') {
+      throw new Error('expected two permission_decision items');
+    }
+    expect(withScope.scope).toBe('session');
+    expect(withoutScope.scope).toBeUndefined();
+  });
 });
 
 describe('reduceTranscript, request + decision pair', () => {

--- a/apps/desktop/src/app/components/StatusBar/index.tsx
+++ b/apps/desktop/src/app/components/StatusBar/index.tsx
@@ -15,6 +15,7 @@ const STATE_LABEL: Record<TurnState['kind'], string | null> = {
   starting: 'starting',
   idle: null,
   running: 'running',
+  blocked: 'waiting on approval',
   error: 'failed',
   ended: 'ended',
 };

--- a/apps/desktop/src/features/chat/utils/transcript-items.ts
+++ b/apps/desktop/src/features/chat/utils/transcript-items.ts
@@ -2,6 +2,7 @@ import type {
   IsoDateTime,
   MessageAttachment,
   PermissionRuleId,
+  PermissionScope,
   ProviderId,
   ProviderRunId,
   ProviderUsage,
@@ -75,6 +76,7 @@ export type TranscriptItem =
       toolName: string;
       runId: ProviderRunId;
       decision: 'allow' | 'deny';
+      scope?: PermissionScope;
       ruleId: PermissionRuleId | null;
       decidedBy: 'engine' | 'user' | 'default';
       at: IsoDateTime;
@@ -257,6 +259,7 @@ export const reduceTranscript = (
           toolName: permToolNames.get(event.toolUseId) ?? event.toolUseId,
           runId: event.runId,
           decision: event.decision,
+          ...(event.scope !== undefined && { scope: event.scope }),
           ruleId: event.ruleId,
           decidedBy: event.decidedBy,
           at: event.at,

--- a/apps/desktop/src/features/permissions/components/PermissionDecisionCard/RetryButton.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionDecisionCard/RetryButton.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { RotateCcw } from 'lucide-react';
+import { cn } from '@goodboy/ui';
+import type { AgentId, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { useToast } from '../../../../app/components/Toast';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly toolName: string;
+};
+
+export const RetryButton = ({ sessionId, agentId, toolName }: Props) => {
+  const retryBlockedTool = useAppStore((s) => s.retryBlockedTool);
+  const isRunning = useAppStore((s) => s.agentTurnState[agentId]?.kind === 'running');
+  const { showToast } = useToast();
+  const [busy, setBusy] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handle = async () => {
+    if (busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await retryBlockedTool({ sessionId, agentId, toolName });
+      setSent(true);
+    } catch (err) {
+      showToast('error', err instanceof Error ? err.message : 'retry failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (sent) {
+    return <span className="text-2xs text-muted-foreground">retry sent</span>;
+  }
+
+  const disabled = busy || isRunning;
+
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => void handle()}
+      title="re-run the turn so the agent retries the tool with the new rule in place"
+      className={cn(
+        'flex items-center gap-1 rounded border border-primary/40 px-2 py-0.5 text-2xs font-medium text-primary transition-colors hover:bg-primary/10',
+        disabled && 'cursor-not-allowed opacity-50',
+      )}
+    >
+      <RotateCcw size={10} aria-hidden />
+      retry {toolName}
+    </button>
+  );
+};

--- a/apps/desktop/src/features/permissions/components/PermissionDecisionCard/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionDecisionCard/index.test.tsx
@@ -1,8 +1,17 @@
 // @vitest-environment happy-dom
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import type { TranscriptItem } from '../../../chat/utils/transcript-items';
+
+vi.mock('./RetryButton', () => ({
+  RetryButton: ({ toolName }: { toolName: string }) => (
+    <button type="button" data-testid="retry-mock">
+      retry {toolName}
+    </button>
+  ),
+}));
+
 import { PermissionDecisionCard } from './index';
 
 afterEach(cleanup);
@@ -12,16 +21,18 @@ function makeItem(over: Partial<Extract<TranscriptItem, { kind: 'permission_deci
     kind: 'permission_decision',
     at: '2026-05-28T03:00:00Z',
     toolUseId: 'tool-7',
+    toolName: 'Bash',
     decision: 'allow',
+    scope: 'session',
     ruleId: null,
     ...over,
   } as Extract<TranscriptItem, { kind: 'permission_decision' }>;
 }
 
 describe('PermissionDecisionCard', () => {
-  it('renders the tool use id and the allow decision', () => {
+  it('renders the tool name and the allow decision', () => {
     render(<PermissionDecisionCard item={makeItem()} sessionId={null} agentId={null} />);
-    expect(screen.getByText('tool-7')).toBeDefined();
+    expect(screen.getByText('Bash')).toBeDefined();
     expect(screen.getByText('allow')).toBeDefined();
   });
 
@@ -35,5 +46,51 @@ describe('PermissionDecisionCard', () => {
     );
     expect(screen.getByText('rule-42')).toBeDefined();
     expect(screen.getByText('deny')).toBeDefined();
+  });
+
+  it('offers a retry affordance for a session-scoped allow with a session and agent', () => {
+    render(
+      <PermissionDecisionCard
+        item={makeItem()}
+        sessionId={'sess' as never}
+        agentId={'agent' as never}
+      />,
+    );
+    expect(screen.getByTestId('retry-mock')).toBeDefined();
+  });
+
+  it('offers no retry affordance for a deny decision', () => {
+    render(
+      <PermissionDecisionCard
+        item={makeItem({ decision: 'deny', scope: 'deny' })}
+        sessionId={'sess' as never}
+        agentId={'agent' as never}
+      />,
+    );
+    expect(screen.queryByTestId('retry-mock')).toBeNull();
+  });
+
+  it('explains instead of offering a retry when the allow was scoped once', () => {
+    render(
+      <PermissionDecisionCard
+        item={makeItem({ scope: 'once' })}
+        sessionId={'sess' as never}
+        agentId={'agent' as never}
+      />,
+    );
+    expect(screen.queryByTestId('retry-mock')).toBeNull();
+    expect(screen.getByText(/cannot carry into a new run/)).toBeDefined();
+  });
+
+  it('offers no retry affordance for a persisted decision without a scope', () => {
+    render(
+      <PermissionDecisionCard
+        item={makeItem({ scope: undefined })}
+        sessionId={'sess' as never}
+        agentId={'agent' as never}
+      />,
+    );
+    expect(screen.queryByTestId('retry-mock')).toBeNull();
+    expect(screen.getByText('Bash')).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/permissions/components/PermissionDecisionCard/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionDecisionCard/index.tsx
@@ -4,6 +4,7 @@ import type { TranscriptItem } from '../../../chat/utils/transcript-items';
 import { formatCardTime } from '../../../chat/utils/format-card-time';
 import { TranscriptShell } from '../../../chat/components/TranscriptShell';
 import { MARKER_ACCENT } from '../../../chat/components/marker-accents';
+import { RetryButton } from './RetryButton';
 
 type Props = {
   readonly item: Extract<TranscriptItem, { kind: 'permission_decision' }>;
@@ -16,20 +17,20 @@ const DECISION_TONE: Record<'allow' | 'deny', string> = {
   deny: MARKER_ACCENT.danger.text,
 };
 
-export const PermissionDecisionCard = ({
-  item,
-  sessionId: _sessionId,
-  agentId: _agentId,
-}: Props) => {
+export const PermissionDecisionCard = ({ item, sessionId, agentId }: Props) => {
   const timestamp = formatCardTime(item.at);
+  const isRetryableScope = item.scope !== undefined && item.scope !== 'once';
+  const canRetry =
+    item.decision === 'allow' && isRetryableScope && sessionId !== null && agentId !== null;
+  const isOnceAllow = item.decision === 'allow' && item.scope === 'once';
 
   return (
-    <TranscriptShell tone="neutral" variant="boxed" className="text-xs">
+    <TranscriptShell tone="neutral" variant="boxed" className="flex flex-col gap-1.5 text-xs">
       <div className="flex flex-wrap items-center gap-2">
         <span className="rounded bg-background px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
           perm decision
         </span>
-        <code className="font-mono text-foreground">{item.toolUseId}</code>
+        <code className="font-mono text-foreground">{item.toolName}</code>
         <span className={cn('font-semibold', DECISION_TONE[item.decision])}>{item.decision}</span>
         {item.ruleId !== null && (
           <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-2xs text-secondary-foreground">
@@ -38,6 +39,20 @@ export const PermissionDecisionCard = ({
         )}
         <span className="ml-auto text-2xs text-muted-foreground">{timestamp}</span>
       </div>
+      {canRetry && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground">
+            the agent stopped when it was blocked, so it needs a new turn to use this rule.
+          </span>
+          <RetryButton sessionId={sessionId} agentId={agentId} toolName={item.toolName} />
+        </div>
+      )}
+      {isOnceAllow && (
+        <span className="text-muted-foreground">
+          an approval for one use cannot carry into a new run: approve for the session or wider to
+          let the agent retry.
+        </span>
+      )}
     </TranscriptShell>
   );
 };

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/formatRequestInput.ts
@@ -1,0 +1,16 @@
+const MAX_CHARS = 400;
+
+type Params = {
+  readonly input: unknown;
+};
+
+export const formatRequestInput = ({ input }: Params): string | null => {
+  if (input == null) {
+    return null;
+  }
+  const json = JSON.stringify(input, null, 2);
+  if (json === undefined || json === '{}') {
+    return null;
+  }
+  return json.length > MAX_CHARS ? `${json.slice(0, MAX_CHARS)}...` : json;
+};

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.test.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.test.tsx
@@ -16,13 +16,16 @@ import { PermissionRequestCard } from './index';
 
 afterEach(cleanup);
 
-function makeItem(): Extract<TranscriptItem, { kind: 'permission_request' }> {
+function makeItem(
+  over: Partial<Extract<TranscriptItem, { kind: 'permission_request' }>> = {},
+): Extract<TranscriptItem, { kind: 'permission_request' }> {
   return {
     kind: 'permission_request',
     at: '2026-05-28T03:00:00Z',
     toolUseId: 'tu-1',
     toolName: 'bash',
     runId: 'run-1',
+    ...over,
   } as Extract<TranscriptItem, { kind: 'permission_request' }>;
 }
 
@@ -42,5 +45,16 @@ describe('PermissionRequestCard', () => {
   it('does not render a scope picker when sessionId is missing', () => {
     render(<PermissionRequestCard item={makeItem()} sessionId={null} agentId={null} />);
     expect(screen.queryByTestId('scope-picker-mock')).toBeNull();
+  });
+
+  it('previews the requested tool input when present', () => {
+    render(
+      <PermissionRequestCard
+        item={makeItem({ input: { command: 'rm -rf build' } })}
+        sessionId={null}
+        agentId={null}
+      />,
+    );
+    expect(screen.getByText(/rm -rf build/)).toBeDefined();
   });
 });

--- a/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionRequestCard/index.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
+import { ShieldAlert } from 'lucide-react';
 import type { AgentId, SessionId } from '@goodboy/types';
 import type { TranscriptItem } from '../../../chat/utils/transcript-items';
 import { PermissionScopePicker } from '../PermissionScopePicker';
 import { formatCardTime } from '../../../chat/utils/format-card-time';
 import { TranscriptShell } from '../../../chat/components/TranscriptShell';
 import { MARKER_ACCENT } from '../../../chat/components/marker-accents';
+import { formatRequestInput } from './formatRequestInput';
 
+const warningAccent = MARKER_ACCENT.warning;
 const resolvedAccent = MARKER_ACCENT.success;
 
 type Props = {
@@ -18,14 +21,16 @@ export const PermissionRequestCard = ({ item, sessionId, agentId }: Props) => {
   const [resolved, setResolved] = useState(false);
 
   const timestamp = formatCardTime(item.at);
+  const inputPreview = formatRequestInput({ input: item.input });
 
   const showPicker = !resolved && sessionId !== null && agentId !== null;
 
   return (
-    <TranscriptShell tone="neutral" variant="boxed" className="text-xs">
+    <TranscriptShell tone="warning" variant="boxed" className="flex flex-col gap-1.5 text-xs">
       <div className="flex flex-wrap items-center gap-2">
+        <ShieldAlert size={11} aria-hidden className={warningAccent.icon} />
         <span className="rounded bg-background px-1.5 py-0.5 text-2xs font-medium uppercase tracking-wide text-muted-foreground">
-          perm request
+          approval needed
         </span>
         <code className="font-mono text-foreground">{item.toolName}</code>
         {resolved ? (
@@ -34,6 +39,15 @@ export const PermissionRequestCard = ({ item, sessionId, agentId }: Props) => {
           <span className="ml-auto text-2xs text-muted-foreground">{timestamp}</span>
         )}
       </div>
+      <span className="text-muted-foreground">
+        the agent was blocked on this tool and stopped without running it. pick a scope to allow it,
+        or deny.
+      </span>
+      {inputPreview !== null && (
+        <pre className="min-w-0 whitespace-pre-wrap break-words rounded bg-background/60 px-2 py-1 font-mono text-2xs text-muted-foreground">
+          {inputPreview}
+        </pre>
+      )}
       {showPicker ? (
         <PermissionScopePicker
           sessionId={sessionId}

--- a/apps/desktop/src/features/permissions/components/PermissionScopePicker/index.tsx
+++ b/apps/desktop/src/features/permissions/components/PermissionScopePicker/index.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react';
 import { cn } from '@goodboy/ui';
-import type { AgentId, ProviderRunId, SessionId } from '@goodboy/types';
+import type { AgentId, PermissionScope, ProviderRunId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
-
-export type PermissionScope = 'global' | 'workspace' | 'session' | 'once' | 'deny';
 
 const SCOPE_LABELS: Record<PermissionScope, string> = {
   global: 'approve global',
@@ -80,7 +78,7 @@ export const PermissionScopePicker = ({
   };
 
   return (
-    <div className="mt-1.5 flex flex-wrap gap-1">
+    <div className="flex flex-wrap gap-1">
       {scopes.map((scope) => (
         <button
           key={scope}

--- a/apps/desktop/src/store/slices/permissions/index.ts
+++ b/apps/desktop/src/store/slices/permissions/index.ts
@@ -1,8 +1,10 @@
 import { resolvePermissionRequest } from './resolvePermissionRequest';
+import { retryBlockedTool } from './retryBlockedTool';
 import type { GetFn, SetFn } from './types';
 
 export const createPermissionsSlice = (set: SetFn, get: GetFn) => {
   return {
     resolvePermissionRequest: resolvePermissionRequest(set, get),
+    retryBlockedTool: retryBlockedTool(get),
   };
 };

--- a/apps/desktop/src/store/slices/permissions/resolvePermissionRequest.ts
+++ b/apps/desktop/src/store/slices/permissions/resolvePermissionRequest.ts
@@ -2,6 +2,7 @@ import type {
   AgentId,
   IsoDateTime,
   PermissionDecisionKind,
+  PermissionScope,
   ProviderRunId,
   SessionId,
 } from '@goodboy/types';
@@ -14,7 +15,7 @@ type Params = {
   toolUseId: string;
   toolName: string;
   runId: ProviderRunId;
-  scope: 'global' | 'workspace' | 'session' | 'once' | 'deny';
+  scope: PermissionScope;
 };
 
 export const resolvePermissionRequest = (set: SetFn, get: GetFn) => {
@@ -47,6 +48,7 @@ export const resolvePermissionRequest = (set: SetFn, get: GetFn) => {
       runId,
       toolUseId,
       decision: scope === 'deny' ? 'deny' : 'allow',
+      scope,
       ruleId: null,
       decidedBy: 'user',
       at: now,

--- a/apps/desktop/src/store/slices/permissions/retryBlockedTool.ts
+++ b/apps/desktop/src/store/slices/permissions/retryBlockedTool.ts
@@ -1,0 +1,27 @@
+import type { AgentId, SessionId } from '@goodboy/types';
+import type { GetFn } from './types';
+
+type Params = {
+  sessionId: SessionId;
+  agentId: AgentId;
+  toolName: string;
+};
+
+const composeRetryPrompt = ({ toolName }: Pick<Params, 'toolName'>): string =>
+  [
+    `Permission for ${toolName} is now granted.`,
+    'Retry the tool call that was blocked, then continue where you stopped.',
+  ].join('\n');
+
+export const retryBlockedTool = (get: GetFn) => {
+  return async ({ sessionId, agentId, toolName }: Params): Promise<void> => {
+    const session = get().sessions.find((s) => s.id === sessionId);
+    if (session == null) {
+      return;
+    }
+    if (get().agentTurnState[agentId]?.kind === 'running') {
+      return;
+    }
+    await get().sendTurn({ sessionId, agentId, content: composeRetryPrompt({ toolName }) });
+  };
+};

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -484,7 +484,7 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
       if (nextAgentState.kind === 'draft') {
         nextAgentState = turnReducer(nextAgentState, { kind: 'start', at: now() });
       }
-      if (nextAgentState.kind === 'error') {
+      if (nextAgentState.kind === 'error' || nextAgentState.kind === 'blocked') {
         nextAgentState = turnReducer(nextAgentState, { kind: 'retry', at: now() });
       }
       nextAgentState = turnReducer(nextAgentState, { kind: 'send', runId, at: now() });

--- a/apps/desktop/src/store/store.permissions.test.ts
+++ b/apps/desktop/src/store/store.permissions.test.ts
@@ -148,6 +148,7 @@ vi.mock('../shared/lib/repo', () => ({
 
 const SESSION_ID = 'session-1' as SessionId;
 const WORKSPACE_ID = 'workspace-1' as WorkspaceId;
+const AGENT_ID = 'agent-1' as AgentId;
 
 function buildSession(): Session {
   const now = '2026-05-07T00:00:00.000Z' as IsoDateTime;
@@ -215,7 +216,7 @@ describe('sendTurn, permission proxy integration', () => {
 
   function setupSession(useAppStore: Awaited<ReturnType<typeof importStore>>) {
     const defaultAgent: Agent = {
-      id: 'agent-1' as AgentId,
+      id: AGENT_ID,
       sessionId: SESSION_ID,
       ordinal: 0,
       name: 'agent 1',
@@ -325,5 +326,67 @@ describe('sendTurn, permission proxy integration', () => {
     expect(args.disallowedTools).toBeUndefined();
     expect(args.permissionMode).toBeUndefined();
     expect(permissionRuleListSpy).not.toHaveBeenCalled();
+  });
+
+  it('marks the agent turn blocked when the stream reports a permission request', async () => {
+    const runId = 'run-blocked' as ProviderRunId;
+    runTurnSpy.mockImplementation(async function* (): AsyncIterable<TurnEvent> {
+      yield {
+        kind: 'permission_request',
+        runId,
+        toolUseId: 'toolu_1',
+        toolName: 'Write',
+        input: { file_path: '/tmp/wt/out.txt' },
+        at: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+      };
+    });
+
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    await useAppStore.getState().sendTurn({ sessionId: SESSION_ID, content: 'hi' });
+
+    expect(useAppStore.getState().agentTurnState[AGENT_ID]?.kind).toBe('blocked');
+  });
+
+  it('retryBlockedTool re-sends the turn with a prompt naming the approved tool', async () => {
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    useAppStore.setState({
+      agentTurnState: {
+        [AGENT_ID]: {
+          kind: 'blocked',
+          runId: 'run-blocked' as ProviderRunId,
+          blockedAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+        },
+      },
+    });
+
+    await useAppStore
+      .getState()
+      .retryBlockedTool({ sessionId: SESSION_ID, agentId: AGENT_ID, toolName: 'Bash' });
+
+    expect(runTurnSpy).toHaveBeenCalledTimes(1);
+    const args = runTurnSpy.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(String(args.prompt)).toContain('Permission for Bash is now granted.');
+  });
+
+  it('retryBlockedTool does nothing while that agent is still running', async () => {
+    const useAppStore = await importStore();
+    setupSession(useAppStore);
+    useAppStore.setState({
+      agentTurnState: {
+        [AGENT_ID]: {
+          kind: 'running',
+          runId: 'run-live' as ProviderRunId,
+          startedAt: '2026-05-07T00:00:00.000Z' as IsoDateTime,
+        },
+      },
+    });
+
+    await useAppStore
+      .getState()
+      .retryBlockedTool({ sessionId: SESSION_ID, agentId: AGENT_ID, toolName: 'Bash' });
+
+    expect(runTurnSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -18,6 +18,7 @@ import type {
   OverrideSettings,
   OpenQuestion,
   OpenQuestionId,
+  PermissionScope,
   PlanId,
   PlanStatus,
   StepId,
@@ -460,7 +461,12 @@ export type AppActions = {
     toolUseId: string;
     toolName: string;
     runId: ProviderRunId;
-    scope: 'global' | 'workspace' | 'session' | 'once' | 'deny';
+    scope: PermissionScope;
+  }): Promise<void>;
+  retryBlockedTool(input: {
+    sessionId: SessionId;
+    agentId: AgentId;
+    toolName: string;
   }): Promise<void>;
   setSessionPermissionMode(sessionId: SessionId, mode: ClaudePermissionMode): Promise<void>;
   loadDiffComments(sessionId: SessionId): Promise<void>;

--- a/packages/core/src/permissions/events.test.ts
+++ b/packages/core/src/permissions/events.test.ts
@@ -76,4 +76,26 @@ describe('createPermissionDecisionEvent', () => {
     });
     expect(event.decidedBy).toBe('user');
   });
+
+  it('carries the chosen scope, and omits it when none was chosen', () => {
+    const scoped = createPermissionDecisionEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-4',
+      decision: 'allow',
+      scope: 'workspace',
+      ruleId: null,
+      decidedBy: 'user',
+      at: AT,
+    });
+    const unscoped = createPermissionDecisionEvent({
+      runId: RUN_ID,
+      toolUseId: 'tu-5',
+      decision: 'allow',
+      ruleId: null,
+      decidedBy: 'engine',
+      at: AT,
+    });
+    expect(scoped.scope).toBe('workspace');
+    expect('scope' in unscoped).toBe(false);
+  });
 });

--- a/packages/core/src/permissions/events.ts
+++ b/packages/core/src/permissions/events.ts
@@ -1,4 +1,10 @@
-import type { IsoDateTime, PermissionRuleId, ProviderRunId, TurnEvent } from '@goodboy/types';
+import type {
+  IsoDateTime,
+  PermissionRuleId,
+  PermissionScope,
+  ProviderRunId,
+  TurnEvent,
+} from '@goodboy/types';
 
 export const createPermissionRequestEvent = (params: {
   readonly runId: ProviderRunId;
@@ -21,6 +27,7 @@ export const createPermissionDecisionEvent = (params: {
   readonly runId: ProviderRunId;
   readonly toolUseId: string;
   readonly decision: 'allow' | 'deny';
+  readonly scope?: PermissionScope;
   readonly ruleId: PermissionRuleId | null;
   readonly decidedBy: 'engine' | 'user' | 'default';
   readonly at: IsoDateTime;
@@ -30,6 +37,7 @@ export const createPermissionDecisionEvent = (params: {
     runId: params.runId,
     toolUseId: params.toolUseId,
     decision: params.decision,
+    ...(params.scope !== undefined && { scope: params.scope }),
     ruleId: params.ruleId,
     decidedBy: params.decidedBy,
     at: params.at,

--- a/packages/core/src/providers/claude/parser.test.ts
+++ b/packages/core/src/providers/claude/parser.test.ts
@@ -157,6 +157,57 @@ describe('parseStreamJsonLine', () => {
     expect(events[1]).toMatchObject({ kind: 'done' });
   });
 
+  it('emits a permission_request per permission_denials entry, before done', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        permission_denials: [
+          {
+            tool_name: 'Write',
+            tool_use_id: 'toolu_1',
+            tool_input: { file_path: '/tmp/x/out.txt', content: 'hi' },
+          },
+        ],
+      }),
+    );
+    expect(events).toEqual([
+      {
+        kind: 'permission_request',
+        runId: ctx.runId,
+        toolUseId: 'toolu_1',
+        toolName: 'Write',
+        input: { file_path: '/tmp/x/out.txt', content: 'hi' },
+        at,
+      },
+      { kind: 'done', runId: ctx.runId, at },
+    ]);
+  });
+
+  it('emits no permission_request when the result carries no denials', () => {
+    const events = parse(JSON.stringify({ type: 'result', subtype: 'success' }));
+    expect(events.some((e) => e.kind === 'permission_request')).toBe(false);
+  });
+
+  it('skips malformed permission_denials entries', () => {
+    const events = parse(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        permission_denials: [
+          { tool_use_id: 'toolu_2' },
+          { tool_name: 'Bash' },
+          'nope',
+          null,
+          { tool_name: 'Bash', tool_use_id: 'toolu_3' },
+        ],
+      }),
+    );
+    const requests = events.filter((e) => e.kind === 'permission_request');
+    expect(requests).toHaveLength(1);
+    expect(requests[0]).toMatchObject({ toolUseId: 'toolu_3', toolName: 'Bash', input: null });
+  });
+
   it('emits error from result with error message', () => {
     const events = parse(JSON.stringify({ type: 'result', subtype: 'error', error: 'rate limit' }));
     const error = events.find((e) => e.kind === 'error');

--- a/packages/core/src/providers/shared/anthropic-envelope-parser.ts
+++ b/packages/core/src/providers/shared/anthropic-envelope-parser.ts
@@ -1,5 +1,6 @@
 import type { IsoDateTime, ProviderRunId, TurnEvent } from '@goodboy/types';
 import { devWarn } from '../../dev-log';
+import { createPermissionRequestEvent } from '../../permissions/events';
 
 export type ParseContext = {
   readonly runId: ProviderRunId;
@@ -72,6 +73,51 @@ function fileEditFromInput(
   return { path, editType };
 }
 
+type PermissionDenial = {
+  readonly tool_name: string;
+  readonly tool_use_id: string;
+  readonly tool_input?: unknown;
+};
+
+const isPermissionDenial = (value: unknown): value is PermissionDenial => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.tool_name === 'string' &&
+    record.tool_name !== '' &&
+    typeof record.tool_use_id === 'string' &&
+    record.tool_use_id !== ''
+  );
+};
+
+type Params = {
+  readonly denials: unknown;
+  readonly runId: ProviderRunId;
+  readonly at: IsoDateTime;
+};
+
+const permissionRequestsFromDenials = ({
+  denials,
+  runId,
+  at,
+}: Params): ReadonlyArray<TurnEvent> => {
+  if (!Array.isArray(denials)) {
+    return [];
+  }
+  const entries: ReadonlyArray<unknown> = denials;
+  return entries.filter(isPermissionDenial).map((denial) =>
+    createPermissionRequestEvent({
+      runId,
+      toolUseId: denial.tool_use_id,
+      toolName: denial.tool_name,
+      input: denial.tool_input ?? null,
+      at,
+    }),
+  );
+};
+
 function isToolResultBlock(block: unknown): block is ToolResultBlock {
   return (
     typeof block === 'object' &&
@@ -126,6 +172,13 @@ export const parseAnthropicEnvelopeLine = (
           at,
         });
       }
+      events.push(
+        ...permissionRequestsFromDenials({
+          denials: payload.permission_denials,
+          runId: ctx.runId,
+          at,
+        }),
+      );
       const subtype = payload.subtype as string | undefined;
       if (subtype === 'success') {
         events.push({ kind: 'done', runId: ctx.runId, at });

--- a/packages/core/src/turn/reducer.test.ts
+++ b/packages/core/src/turn/reducer.test.ts
@@ -10,6 +10,7 @@ const draft: TurnState = { kind: 'draft' };
 const starting: TurnState = { kind: 'starting', startedAt: at };
 const idle: TurnState = { kind: 'idle', lastActivityAt: at };
 const running: TurnState = { kind: 'running', runId, startedAt: at };
+const blocked: TurnState = { kind: 'blocked', runId, blockedAt: at };
 const errored: TurnState = { kind: 'error', message: 'boom', failedAt: at };
 const ended: TurnState = { kind: 'ended', endedAt: at };
 
@@ -73,6 +74,22 @@ describe('turnReducer, receive_event', () => {
     });
   });
 
+  it('permission_request → blocked', () => {
+    const event: TurnEvent = {
+      kind: 'permission_request',
+      runId,
+      toolUseId: 'toolu_1',
+      toolName: 'Write',
+      input: { file_path: '/tmp/x' },
+      at: later,
+    };
+    expect(turnReducer(running, { kind: 'receive_event', event })).toEqual({
+      kind: 'blocked',
+      runId,
+      blockedAt: later,
+    });
+  });
+
   it.each<TurnEvent>([
     { kind: 'assistant_text', runId, delta: 'hi', at: later },
     {
@@ -127,6 +144,13 @@ describe('turnReducer, error', () => {
 describe('turnReducer, retry', () => {
   it('error → idle', () => {
     expect(turnReducer(errored, { kind: 'retry', at: later })).toEqual({
+      kind: 'idle',
+      lastActivityAt: later,
+    });
+  });
+
+  it('blocked → idle, so an approved tool can be retried', () => {
+    expect(turnReducer(blocked, { kind: 'retry', at: later })).toEqual({
       kind: 'idle',
       lastActivityAt: later,
     });

--- a/packages/core/src/turn/reducer.ts
+++ b/packages/core/src/turn/reducer.ts
@@ -52,7 +52,7 @@ export const turnReducer = (state: TurnState, event: TurnLifecycleEvent): TurnSt
       return { kind: 'error', message: event.message, failedAt: event.at };
 
     case 'retry':
-      if (state.kind !== 'error') {
+      if (state.kind !== 'error' && state.kind !== 'blocked') {
         throw new IllegalTurnTransitionError(state, event);
       }
       return { kind: 'idle', lastActivityAt: event.at };
@@ -70,6 +70,8 @@ function applyTurnEvent(state: TurnState, turn: TurnEvent): TurnState {
       return { kind: 'idle', lastActivityAt: turn.at };
     case 'error':
       return { kind: 'error', message: turn.message, failedAt: turn.at };
+    case 'permission_request':
+      return { kind: 'blocked', runId: turn.runId, blockedAt: turn.at };
     case 'user_text':
     case 'assistant_text':
     case 'tool_call_start':
@@ -78,7 +80,6 @@ function applyTurnEvent(state: TurnState, turn: TurnEvent): TurnState {
     case 'usage':
     case 'skill_invocation':
     case 'step_transition':
-    case 'permission_request':
     case 'permission_decision':
     case 'unknown_payload':
     case 'provider_session_init':

--- a/packages/types/src/adapter.ts
+++ b/packages/types/src/adapter.ts
@@ -1,6 +1,6 @@
 import type { IsoDateTime, PermissionRuleId, ProviderRunId, SessionId } from './ids';
 import type { MessageAttachment } from './message';
-import type { ClaudePermissionMode } from './permission';
+import type { ClaudePermissionMode, PermissionScope } from './permission';
 import type { ProviderName } from './provider';
 import type { ProviderId } from './provider-registry';
 
@@ -115,6 +115,7 @@ export type TurnEvent =
       runId: ProviderRunId;
       toolUseId: string;
       decision: 'allow' | 'deny';
+      scope?: PermissionScope;
       ruleId: PermissionRuleId | null;
       decidedBy: 'engine' | 'user' | 'default';
       at: IsoDateTime;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -147,6 +147,7 @@ export type {
   PermissionRule,
   PermissionRulePattern,
   PermissionRuleScope,
+  PermissionScope,
 } from './permission';
 export { CLAUDE_PERMISSION_MODES } from './permission';
 export type {

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -24,6 +24,8 @@ export const CLAUDE_PERMISSION_MODES = [
 
 export type PermissionRuleScope = 'workspace' | 'session' | 'global';
 
+export type PermissionScope = PermissionRuleScope | 'once' | 'deny';
+
 export type PermissionDecisionKind = 'allow' | 'deny' | 'ask';
 
 export type PermissionRulePattern = {

--- a/packages/types/src/workspace.ts
+++ b/packages/types/src/workspace.ts
@@ -53,6 +53,7 @@ export type TurnState =
   | { kind: 'starting'; startedAt: IsoDateTime }
   | { kind: 'idle'; lastActivityAt: IsoDateTime }
   | { kind: 'running'; runId: ProviderRunId; startedAt: IsoDateTime }
+  | { kind: 'blocked'; runId: ProviderRunId; blockedAt: IsoDateTime }
   | { kind: 'error'; message: string; failedAt: IsoDateTime }
   | { kind: 'ended'; endedAt: IsoDateTime };
 


### PR DESCRIPTION
Outside `bypassPermissions`, an agent that hit a permission wall looked like an agent that silently did nothing. This makes the wall visible and gives the user a way through it.

## What was actually broken

Three independent breaks, all verified in the code:

1. `createPermissionRequestEvent` (packages/core/src/permissions/events.ts) had **zero production callers**, only its own test. So nothing ever appended a `permission_request` event, `transcript-items.ts:240` never fired, and `PermissionRequestCard` **never mounted in a real session**.
2. The stream-json parser handled only `system|assistant|user|result`. Anything else became `unknown_payload`.
3. `resolvePermissionRequest` wrote a permission rule that is only read at the **next** spawn, so approving did nothing for the run that was blocked. `permission_request` and `permission_decision` were also no-ops in the turn reducer, so there was no "waiting on approval" state.

That is why bypass was the only mode that worked: it is the only mode where the CLI never needs to ask.

## What the CLI actually does (verified against the real binary, not the docs)

I ran `claude -p --input-format stream-json --output-format stream-json --verbose --permission-mode default` against a `Write` call. In headless print mode the CLI does **not** ask and does **not** wait. There is no `control_request`, no `can_use_tool`, and **no `--permission-prompt-tool` flag in this CLI version** (`--help` lists only `--permission-mode`). Adding `--input-format stream-json` changes nothing about approvals.

What it does instead is report the denial, twice:

```json
{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_01BHYz…","type":"tool_result","content":"Claude requested permissions to write to /private/tmp/x/out.txt, but you haven't granted it yet.","is_error":true}]}}
{"type":"result","subtype":"success","permission_denials":[{"tool_name":"Write","tool_use_id":"toolu_01BHYz…","tool_input":{"file_path":"…","content":"hi"}}]}
```

So there is no channel to answer a request mid-run, but the denial is on the stream in a structured form. That is what this PR hooks into.

## The design that follows from that

- The parser reads `permission_denials` from the `result` envelope and emits one `permission_request` per entry, defensively (an entry without a string `tool_name` and `tool_use_id` is skipped).
- The reducer parks the turn in a new `blocked` state, so a blocked agent no longer reads as a completed one.
- The card explains what the agent wanted and offers the existing scope picker.
- An allow at session scope or wider offers an **explicit** retry that re-sends the turn, so the freshly written rule is picked up at spawn. Nothing auto-approves and nothing auto-retries.

The approval reaches the agent by re-running with the rule in place, not by writing to the live process, because no such channel exists.

## Approve-once is told the truth

`volatilePermissionAllows` is audit-only: it never feeds the CLI flags, and a re-run gets a fresh `tool_use_id` anyway. So a single-use approval genuinely cannot be honored by a retry. Rather than offering a retry that would be blocked again, that case says a session-or-wider scope is needed. The chosen scope now rides on the decision event to make this decidable; a decision row written before this change has no scope and gets no retry CTA rather than a wrong guess.

## Verify by hand

Set a session to permission mode `default`, then ask the agent to write a file outside anything you have allowed. You should see: the tool fails, a card appears saying approval is needed and showing what it wanted, the turn reads as blocked. Approve for the session, hit retry, and the write goes through. Approve once instead and you are told why retry is not offered.

## Not done here

- No session-level blocked state. `sessions.state_kind` has a SQL `CHECK` constraint (m001, recreated in m014) that does not include it, so surfacing it there needs a table rebuild. Consequence: the stage board has no "waiting on approval" stage, and a window reload downgrades a blocked agent to idle. The transcript card, approve and retry all still work.
- `once` still cannot reach the CLI. Making it work needs a per-turn allow threaded into flag building, which touches `claude-flags`; out of scope here.
- The permission mode picker still offers a subset of the CLI's modes (`auto` and `dontAsk` are absent, and `dontAsk` is in our type but unreachable). Left alone deliberately: changing the mode surface and fixing the chain in one PR would make a regression impossible to attribute.
- The default mode stays `bypassPermissions`, for the same reason.

## Tests

core 833 -> 839, desktop 2443 -> 2452. New coverage on the parser (denials to events, no denials, malformed entries), the reducer state, the retry action (re-sends with the tool name, no-ops while running), and the card matrix (retry for session scope, none for deny, none for once plus the explanation, none for a legacy scope-less row). One pre-existing card assertion changed on purpose: it asserted the opaque `toolUseId` was rendered, and now asserts the tool name, because a `toolu_…` id is not something a user can act on.
