### PR TITLE
feat(desktop): real brand marks for github, gitlab, sentry and linear

### DIFF
--- a/apps/desktop/src/features/github/components/MissingGithubRemoteEmptyState.tsx
+++ b/apps/desktop/src/features/github/components/MissingGithubRemoteEmptyState.tsx
@@ -1,5 +1,5 @@
 import { EmptyState } from '@goodboy/ui';
-import { GitBranch } from 'lucide-react';
+import { GithubIcon } from '../../../shared/components/brand-icons';
 
 type Props = {
   readonly compact?: boolean;
@@ -7,7 +7,7 @@ type Props = {
 
 export const MissingGithubRemoteEmptyState = ({ compact = false }: Props) => (
   <EmptyState
-    icon={GitBranch}
+    icon={GithubIcon}
     title="No GitHub remote"
     description="This workspace does not have a GitHub remote."
     className={compact ? 'py-5' : undefined}

--- a/apps/desktop/src/features/github/components/Panel/index.tsx
+++ b/apps/desktop/src/features/github/components/Panel/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
-import { GitFork as GithubIcon, Check, AlertCircle, RefreshCw } from 'lucide-react';
+import { Check, AlertCircle, RefreshCw } from 'lucide-react';
 import { Button, Input, cn } from '@goodboy/ui';
+import { GithubIcon } from '../../../../shared/components/brand-icons';
 import { formatError } from '../../../../shared/lib/errors';
 import type { SaveState } from '../../../../shared/types/saveState';
 import { useAppStore } from '../../../../store';

--- a/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/ExternalTaskChip/index.test.tsx
@@ -40,9 +40,9 @@ describe('ExternalTaskChip, full variant', () => {
 });
 
 describe('ExternalTaskChip, icon variant', () => {
-  it('renders the provider glyph but omits identifier and title text', () => {
+  it('renders the provider mark but omits identifier and title text', () => {
     render(<ExternalTaskChip task={makeTask()} variant="icon" />);
-    expect(screen.getByText('L')).toBeDefined();
+    expect(screen.getByRole('img', { name: 'Linear' })).toBeDefined();
     expect(screen.queryByText('GB-123')).toBeNull();
     expect(screen.queryByText('Improve preview metadata')).toBeNull();
   });
@@ -58,20 +58,20 @@ describe('ExternalTaskChip, icon variant', () => {
 describe('ExternalTaskChip, provider mapping', () => {
   const cases: ReadonlyArray<{
     provider: SessionExternalTaskProvider;
-    glyph: string;
+    mark: string;
     label: RegExp;
     event: string;
   }> = [
-    { provider: 'linear', glyph: 'L', label: /Linear/i, event: 'goodboy:open-linear-studio' },
-    { provider: 'sentry', glyph: 'S', label: /Sentry/i, event: 'goodboy:open-sentry-studio' },
-    { provider: 'gitlab', glyph: 'G', label: /GitLab/i, event: 'goodboy:open-gitlab-studio' },
-    { provider: 'github', glyph: 'GH', label: /GitHub/i, event: 'goodboy:open-github-studio' },
+    { provider: 'linear', mark: 'Linear', label: /Linear/i, event: 'goodboy:open-linear-studio' },
+    { provider: 'sentry', mark: 'Sentry', label: /Sentry/i, event: 'goodboy:open-sentry-studio' },
+    { provider: 'gitlab', mark: 'GitLab', label: /GitLab/i, event: 'goodboy:open-gitlab-studio' },
+    { provider: 'github', mark: 'GitHub', label: /GitHub/i, event: 'goodboy:open-github-studio' },
   ];
 
-  for (const { provider, glyph, label, event } of cases) {
-    it(`renders the ${provider} glyph and label`, () => {
+  for (const { provider, mark, label, event } of cases) {
+    it(`renders the ${provider} mark and label`, () => {
       render(<ExternalTaskChip task={makeTask({ provider, identifier: 'X-1' })} />);
-      expect(screen.getByText(glyph)).toBeDefined();
+      expect(screen.getByRole('img', { name: mark })).toBeDefined();
       expect(screen.getByRole('button', { name: label })).toBeDefined();
     });
 

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { IntegrationGlyph, type IntegrationGlyphProvider } from './index';
+
+afterEach(cleanup);
+
+const CASES: ReadonlyArray<{ provider: IntegrationGlyphProvider; label: string }> = [
+  { provider: 'github', label: 'GitHub' },
+  { provider: 'gitlab', label: 'GitLab' },
+  { provider: 'linear', label: 'Linear' },
+  { provider: 'sentry', label: 'Sentry' },
+];
+
+describe('IntegrationGlyph, brand marks', () => {
+  for (const { provider, label } of CASES) {
+    it(`renders the ${provider} mark under the accessible name ${label}`, () => {
+      render(<IntegrationGlyph provider={provider} />);
+      const mark = screen.getByRole('img', { name: label });
+      expect(mark.tagName.toLowerCase()).toBe('svg');
+      expect(mark.querySelector('path')).not.toBeNull();
+    });
+  }
+
+  it('maps every provider to a different mark', () => {
+    const outlines = CASES.map(({ provider, label }) => {
+      cleanup();
+      render(<IntegrationGlyph provider={provider} />);
+      return screen.getByRole('img', { name: label }).querySelector('path')?.getAttribute('d');
+    });
+    expect(new Set(outlines).size).toBe(CASES.length);
+  });
+});
+
+describe('IntegrationGlyph, sizes', () => {
+  it('renders the sm size by default', () => {
+    render(<IntegrationGlyph provider="linear" />);
+    expect(screen.getByRole('img', { name: 'Linear' }).getAttribute('width')).toBe('14');
+  });
+
+  it('shrinks the mark for the xs size', () => {
+    render(<IntegrationGlyph provider="github" size="xs" />);
+    expect(screen.getByRole('img', { name: 'GitHub' }).getAttribute('width')).toBe('12');
+  });
+});
+
+describe('IntegrationGlyph, framed variant', () => {
+  it('keeps the named mark inside a tinted frame', () => {
+    render(<IntegrationGlyph provider="sentry" framed />);
+    const mark = screen.getByRole('img', { name: 'Sentry' });
+    expect(mark.getAttribute('width')).toBe('16');
+    expect(mark.parentElement?.className).toContain('bg-provider-sentry/10');
+  });
+});

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -1,19 +1,25 @@
 import { cn } from '@goodboy/ui';
+import type { LucideIcon } from 'lucide-react';
+import {
+  GithubIcon,
+  GitlabIcon,
+  LinearIcon,
+  SentryIcon,
+} from '../../../../shared/components/brand-icons';
 
 export type IntegrationGlyphProvider = 'github' | 'gitlab' | 'linear' | 'sentry';
 
-const GLYPH: Record<IntegrationGlyphProvider, string> = {
-  github: 'GH',
-  gitlab: 'G',
-  linear: 'L',
-  sentry: 'S',
+type IntegrationBrand = {
+  readonly icon: LucideIcon;
+  readonly label: string;
+  readonly cssVar: string;
 };
 
-const BADGE_STYLE: Record<IntegrationGlyphProvider, string> = {
-  github: 'bg-provider-github',
-  gitlab: 'bg-provider-gitlab',
-  linear: 'bg-provider-linear',
-  sentry: 'bg-provider-sentry',
+const INTEGRATION_BRAND: Record<IntegrationGlyphProvider, IntegrationBrand> = {
+  github: { icon: GithubIcon, label: 'GitHub', cssVar: '--color-provider-github' },
+  gitlab: { icon: GitlabIcon, label: 'GitLab', cssVar: '--color-provider-gitlab' },
+  linear: { icon: LinearIcon, label: 'Linear', cssVar: '--color-provider-linear' },
+  sentry: { icon: SentryIcon, label: 'Sentry', cssVar: '--color-provider-sentry' },
 };
 
 const FRAME_STYLE: Record<IntegrationGlyphProvider, string> = {
@@ -23,10 +29,12 @@ const FRAME_STYLE: Record<IntegrationGlyphProvider, string> = {
   sentry: 'bg-provider-sentry/10',
 };
 
-const SIZE: Record<'xs' | 'sm', string> = {
-  xs: 'size-3 text-[7px]',
-  sm: 'size-4 text-[9px]',
+const MARK_SIZE: Record<'xs' | 'sm', number> = {
+  xs: 12,
+  sm: 14,
 };
+
+const FRAMED_MARK_SIZE = 16;
 
 type Props = {
   readonly provider: IntegrationGlyphProvider;
@@ -36,21 +44,19 @@ type Props = {
 };
 
 export const IntegrationGlyph = ({ provider, size = 'sm', framed = false, className }: Props) => {
-  const badge = (
-    <span
-      className={cn(
-        'flex shrink-0 items-center justify-center rounded-sm font-bold text-white',
-        SIZE[size],
-        BADGE_STYLE[provider],
-        !framed && className,
-      )}
-    >
-      {GLYPH[provider]}
-    </span>
-  );
+  const { icon: Icon, label, cssVar } = INTEGRATION_BRAND[provider];
+  const color = `var(${cssVar})`;
 
   if (!framed) {
-    return badge;
+    return (
+      <Icon
+        size={MARK_SIZE[size]}
+        role="img"
+        aria-label={label}
+        className={cn('shrink-0', className)}
+        style={{ color }}
+      />
+    );
   }
 
   return (
@@ -61,7 +67,7 @@ export const IntegrationGlyph = ({ provider, size = 'sm', framed = false, classN
         className,
       )}
     >
-      {badge}
+      <Icon size={FRAMED_MARK_SIZE} role="img" aria-label={label} style={{ color }} />
     </span>
   );
 };

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/CodeHostStep.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { FolderGit2, GitBranch, GitFork } from 'lucide-react';
+import { FolderGit2, GitBranch } from 'lucide-react';
 import { Button } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
+import { GithubIcon, GitlabIcon } from '../../../../shared/components/brand-icons';
 import { GithubFormBody } from '../../../integrations/github/GithubFormBody';
 import { GitlabFormBody } from '../../../integrations/gitlab/GitlabFormBody';
 import { Segmented, type SegmentedOption } from '../Segmented';
@@ -24,11 +25,17 @@ export const CodeHostStep = ({
   const [host, setHost] = useState<Host>(gitlabConnected && !githubConnected ? 'gitlab' : 'github');
 
   const options: ReadonlyArray<SegmentedOption<Host>> = [
-    { value: 'github', label: 'GitHub', icon: GitBranch, connected: githubConnected },
+    {
+      value: 'github',
+      label: 'GitHub',
+      icon: GithubIcon,
+      color: 'var(--color-provider-github)',
+      connected: githubConnected,
+    },
     {
       value: 'gitlab',
       label: 'GitLab',
-      icon: GitFork,
+      icon: GitlabIcon,
       color: 'var(--color-provider-gitlab)',
       connected: gitlabConnected,
     },

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/SentryStep.tsx
@@ -1,6 +1,7 @@
-import { Bug, FolderGit2 } from 'lucide-react';
+import { FolderGit2 } from 'lucide-react';
 import { Button } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
+import { SentryIcon } from '../../../../shared/components/brand-icons';
 import { SentryFormBody } from '../../../integrations/sentry/SentryFormBody';
 
 type Props = {
@@ -14,7 +15,7 @@ export const SentryStep = ({ workspaceId }: Props) => {
         className="flex size-14 items-center justify-center rounded-lg border border-border-soft/40 bg-subtle/40"
         style={{ color: 'var(--color-provider-sentry)' }}
       >
-        <Bug size={26} aria-hidden />
+        <SentryIcon size={26} aria-hidden />
       </span>
 
       <div className="flex flex-col gap-2">

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/TrackerStep.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { FolderGit2, Layers, ListChecks } from 'lucide-react';
 import { Button } from '@goodboy/ui';
 import type { WorkspaceId } from '@goodboy/types';
+import { LinearIcon } from '../../../../shared/components/brand-icons';
 import { LinearFormBody } from '../../../integrations/linear/LinearFormBody';
 import { Segmented, type SegmentedOption } from '../Segmented';
 
@@ -19,7 +20,7 @@ export const TrackerStep = ({ workspaceId, linearConnected }: Props) => {
     {
       value: 'linear',
       label: 'Linear',
-      icon: ListChecks,
+      icon: LinearIcon,
       color: 'var(--color-provider-linear)',
       connected: linearConnected,
     },

--- a/apps/desktop/src/features/providers/components/ProviderIcon.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderIcon.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ProviderIcon } from './ProviderIcon';
+
+afterEach(cleanup);
+
+describe('ProviderIcon, unknown provider', () => {
+  it('falls back to the raw provider name as text', () => {
+    render(<ProviderIcon provider="opencode" />);
+    expect(screen.getByText('opencode')).toBeDefined();
+  });
+
+  it('renders no brand mark alongside the fallback text', () => {
+    const { container } = render(<ProviderIcon provider="opencode" />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders nothing at all in the glyph variant', () => {
+    const { container } = render(<ProviderIcon provider="opencode" variant="glyph" />);
+    expect(container.innerHTML).toBe('');
+  });
+});
+
+describe('ProviderIcon, known provider', () => {
+  it('labels the anthropic mark claude', () => {
+    render(<ProviderIcon provider="anthropic" />);
+    expect(screen.getByLabelText('claude')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/index.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Divider, ScrollFade } from '@goodboy/ui';
 import type { ProviderId, ProviderLifecycleAction, WorkspaceId } from '@goodboy/types';
-import { ProviderStudioIcon } from '../brand-icons';
+import { ProviderStudioIcon } from '../ProviderStudioIcon';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { useAppStore } from '../../../../store';
 import { StudioShell } from '../../../../shared/components/StudioShell';

--- a/apps/desktop/src/features/providers/components/ProviderStudioIcon.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudioIcon.tsx
@@ -1,0 +1,27 @@
+import { forwardRef } from 'react';
+import type { LucideIcon, LucideProps } from 'lucide-react';
+
+export const ProviderStudioIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>(
+  ({ size = 24, color: _color, strokeWidth: _sw, absoluteStrokeWidth: _asw, ...rest }, ref) => (
+    <svg
+      ref={ref}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...rest}
+      stroke="currentColor"
+      strokeWidth={1.8}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <circle cx="5" cy="5" r="2" />
+      <circle cx="19" cy="5" r="2" />
+      <circle cx="19" cy="19" r="2" />
+      <path d="M9.7 9.9 6.3 6.5M14.3 9.9l3.4-3.4M14.3 14.1l3.4 3.4" />
+    </svg>
+  ),
+);
+ProviderStudioIcon.displayName = 'ProviderStudioIcon';

--- a/apps/desktop/src/features/providers/components/provider-brand.ts
+++ b/apps/desktop/src/features/providers/components/provider-brand.ts
@@ -1,6 +1,11 @@
 import type { LucideIcon } from 'lucide-react';
 import type { ProviderId } from '@goodboy/types';
-import { ClaudeIcon, CursorIcon, GeminiIcon, OpenAIIcon } from './brand-icons';
+import {
+  ClaudeIcon,
+  CursorIcon,
+  GeminiIcon,
+  OpenAIIcon,
+} from '../../../shared/components/brand-icons';
 
 export type ProviderBrand = {
   readonly icon: LucideIcon;

--- a/apps/desktop/src/features/session/components/NewSessionView/index.tsx
+++ b/apps/desktop/src/features/session/components/NewSessionView/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../../../features/worktree/worktree';
 import { useBranchConflict } from '../../../../features/worktree/useBranchConflict';
 import { BranchCombobox } from '../../../../features/worktree/BranchCombobox';
+import { IntegrationGlyph } from '../../../../features/integrations/components/IntegrationGlyph';
 import { IssuePicker } from '../../../../features/integrations/linear/IssuePicker';
 import { goalFromIssue } from '../../../../features/integrations/linear/goal-from-issue';
 import type { LinearIssue } from '../../../../features/integrations/linear/client';
@@ -343,11 +344,7 @@ export const NewSessionView = ({ onClose, workspaceId, onOpenSettings }: Props) 
             ) : null}
             {hasLinear ? (
               <Section
-                icon={
-                  <span className="flex h-4 w-4 items-center justify-center rounded-sm bg-provider-linear text-[9px] font-bold text-white">
-                    L
-                  </span>
-                }
+                icon={<IntegrationGlyph provider="linear" />}
                 tone="primary"
                 title="Linear issue"
                 subtitle="Pick an issue assigned to you. The goal below auto-fills from its title and description."

--- a/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/SessionActivityBar/index.test.tsx
@@ -272,7 +272,7 @@ describe('SessionActivityBar, external task chip', () => {
     };
     renderBar([], [makeSession('a-1', 'active one')]);
     expect(screen.getByLabelText(/GB-7 from Linear/i)).toBeDefined();
-    expect(screen.getByText('L')).toBeDefined();
+    expect(screen.getByRole('img', { name: 'Linear' })).toBeDefined();
     expect(screen.getByTitle(/active one · idle · GB-7/)).toBeDefined();
   });
 
@@ -291,7 +291,7 @@ describe('SessionActivityBar, external task chip', () => {
       ],
     };
     renderBar([], [makeSession('a-1', 'crashy')]);
-    expect(screen.getByText('S')).toBeDefined();
+    expect(screen.getByRole('img', { name: 'Sentry' })).toBeDefined();
     expect(screen.getByLabelText(/SENTRY-9 from Sentry/i)).toBeDefined();
   });
 });

--- a/apps/desktop/src/shared/components/brand-icons.tsx
+++ b/apps/desktop/src/shared/components/brand-icons.tsx
@@ -1,22 +1,20 @@
 import { forwardRef } from 'react';
 import type { LucideIcon, LucideProps } from 'lucide-react';
 
-function svgProps({
+const svgProps = ({
   size = 24,
   color: _color,
   strokeWidth: _sw,
   absoluteStrokeWidth: _asw,
   ...rest
-}: LucideProps) {
-  return {
-    width: size,
-    height: size,
-    viewBox: '0 0 24 24',
-    fill: 'currentColor',
-    xmlns: 'http://www.w3.org/2000/svg',
-    ...rest,
-  };
-}
+}: LucideProps) => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  fill: 'currentColor',
+  xmlns: 'http://www.w3.org/2000/svg',
+  ...rest,
+});
 
 export const ClaudeIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
   <svg ref={ref} {...svgProps(props)}>
@@ -46,22 +44,30 @@ export const CursorIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((pr
 ));
 CursorIcon.displayName = 'CursorIcon';
 
-export const ProviderStudioIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>(
-  (props, ref) => (
-    <svg
-      ref={ref}
-      {...svgProps({ ...props, fill: 'none' } as LucideProps)}
-      stroke="currentColor"
-      strokeWidth={1.8}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" />
-      <circle cx="5" cy="5" r="2" />
-      <circle cx="19" cy="5" r="2" />
-      <circle cx="19" cy="19" r="2" />
-      <path d="M9.7 9.9 6.3 6.5M14.3 9.9l3.4-3.4M14.3 14.1l3.4 3.4" />
-    </svg>
-  ),
-);
-ProviderStudioIcon.displayName = 'ProviderStudioIcon';
+export const GithubIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+  <svg ref={ref} {...svgProps(props)}>
+    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+  </svg>
+));
+GithubIcon.displayName = 'GithubIcon';
+
+export const GitlabIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+  <svg ref={ref} {...svgProps(props)}>
+    <path d="m23.6004 9.5927-.0337-.0862L20.3.9814a.851.851 0 0 0-.3362-.405.8748.8748 0 0 0-.9997.0539.8748.8748 0 0 0-.29.4399l-2.2055 6.748H7.5375l-2.2057-6.748a.8573.8573 0 0 0-.29-.4412.8748.8748 0 0 0-.9997-.0537.8585.8585 0 0 0-.3362.4049L.4332 9.5015l-.0325.0862a6.0657 6.0657 0 0 0 2.0119 7.0105l.0113.0087.03.0213 4.976 3.7264 2.462 1.8633 1.4995 1.1321a1.0085 1.0085 0 0 0 1.2197 0l1.4995-1.1321 2.4619-1.8633 5.006-3.7489.0125-.01a6.0682 6.0682 0 0 0 2.0094-7.003z" />
+  </svg>
+));
+GitlabIcon.displayName = 'GitlabIcon';
+
+export const SentryIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+  <svg ref={ref} {...svgProps(props)}>
+    <path d="M13.91 2.505c-.873-1.448-2.972-1.448-3.844 0L6.904 7.92a15.478 15.478 0 0 1 8.53 12.811h-2.221A13.301 13.301 0 0 0 5.784 9.814l-2.926 5.06a7.65 7.65 0 0 1 4.435 5.848H2.194a.365.365 0 0 1-.298-.534l1.413-2.402a5.16 5.16 0 0 0-1.614-.913L.296 19.275a2.182 2.182 0 0 0 .812 2.999 2.24 2.24 0 0 0 1.086.288h6.983a9.322 9.322 0 0 0-3.845-8.318l1.11-1.922a11.47 11.47 0 0 1 4.95 10.24h5.915a17.242 17.242 0 0 0-7.885-15.28l2.244-3.845a.37.37 0 0 1 .504-.13c.255.14 9.75 16.708 9.928 16.9a.365.365 0 0 1-.327.543h-2.287c.029.612.029 1.223 0 1.831h2.297a2.206 2.206 0 0 0 1.922-3.31z" />
+  </svg>
+));
+SentryIcon.displayName = 'SentryIcon';
+
+export const LinearIcon: LucideIcon = forwardRef<SVGSVGElement, LucideProps>((props, ref) => (
+  <svg ref={ref} {...svgProps(props)}>
+    <path d="M2.886 4.18A11.982 11.982 0 0 1 11.99 0C18.624 0 24 5.376 24 12.009c0 3.64-1.62 6.903-4.18 9.105L2.887 4.18ZM1.817 5.626l16.556 16.556c-.524.33-1.075.62-1.65.866L.951 7.277c.247-.575.537-1.126.866-1.65ZM.322 9.163l14.515 14.515c-.71.172-1.443.282-2.195.322L0 11.358a12 12 0 0 1 .322-2.195Zm-.17 4.862 9.823 9.824a12.02 12.02 0 0 1-9.824-9.824Z" />
+  </svg>
+));
+LinearIcon.displayName = 'LinearIcon';


### PR DESCRIPTION
GitHub was rendered as the two characters `GH` at 7px inside a 12px box. GitLab, Sentry and Linear were single letters in the same colored square, while the AI providers sitting right next to them had real monochrome marks. Two incoherent icon ecosystems in one app.

GitHub had actually regressed: commit `bec50279` (#969) replaced its `<GitPullRequest size={12} />` with the text badge while introducing the shared `IntegrationGlyph`. It was the only one of the four that lost a glyph.

## What changed

All four integrations now use their official marks (simple-icons, CC0 1.0, copied as inline SVG, no new dependency and no `.svg` files, matching the repo's existing convention). They follow the same rules the provider marks already followed: `viewBox="0 0 24 24"`, `fill: currentColor`, a `size` prop, color applied by the caller from the provider token.

The solid colored fill is gone from `IntegrationGlyph`. It only existed to make a white letter legible; a monochrome mark on `currentColor` does not need it, and dropping it is what makes the integrations match `ProviderIcon`. The framed variant keeps its tinted `size-8` box.

`brand-icons.tsx` moved from `features/providers/` to `shared/components/`, since six features consume it now. The one non-brand icon in that file (`ProviderStudioIcon`, a generic node graph) was split out to keep its provider-domain home.

Also swapped the lucide stand-ins for the real thing: the `GitFork` that was imported **as `GithubIcon`** and rendered next to an `<h2>GitHub</h2>`, the `GitBranch` in the missing-remote empty state, the code-host and tracker onboarding options, and the Sentry step hero. `NewSessionView` had hand-rolled its own copy of the letter badge instead of using the shared component; it uses the shared one now.

## Accessible label is now the contract

The glyph text used to be assertable, so two test files asserted `getByText('L')` and `getByText('GH')`. Those now assert `getByRole('img', { name: 'Linear' })` and friends. Same providers, same strength, but pinned to the thing that survives an icon change. Every call site still carries visible text next to the mark, so the mark is never the only carrier of meaning.

## GitHub's color token: measured, left alone

`--color-provider-github` is nearly grey, which was the worst case for white-on-fill, so it was worth checking. Contrast against all four surface tokens:

- dark: github 3.62 to 5.55, gitlab 3.38 to 5.19, linear 2.24 to 3.43, sentry 1.95 to 3.00
- light: github 6.58 to 8.11, gitlab 3.89 to 4.79, linear 4.90 to 6.04, sentry 5.62 to 6.92

GitHub reads best of the four in both modes and clears the 3:1 non-text minimum everywhere, so there was nothing to fix. The low chroma is brand-accurate for a mark that is monochrome by design.

Found while measuring, not fixed here: `ExternalTaskChip` uses `text-provider-*` for 11px chip text, where linear (2.24) and sentry (1.95) fail AA on dark. Pre-existing and unrelated to the marks.

## Not done here

- The four integration rows in `WorkspaceScopePanel` still have no mark. `FieldRow`'s `label` is typed `string` in `packages/ui`, so putting a mark there needs a UI-package API change; not worth dragging into this PR.
- The tracker onboarding hero stays a generic icon, because that step also offers Jira and branding the hero Linear would overcommit. Only the segmented option got the mark. The Sentry step hero is unambiguous, so it did get one.
- The website keeps its own copy of the provider path data. It does not diverge: the AI-provider `d` strings are still byte-identical, and desktop is now simply a superset.

## Tests

desktop 2443 -> 2455. `IntegrationGlyph` and `ProviderIcon` had no test file at all before; both have one now, including `ProviderIcon`'s unknown-provider fallback, which renders the raw provider string as text and was untested. One of the new assertions checks the four marks are distinct from each other, which is the failure a copy-paste in the mapping table would produce.
