### PR TITLE
feat(desktop): make resolve governable, and show what a resolver changed

### DIFF
--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -171,6 +171,8 @@ pub struct SessionRow {
     pub source_thread_id: Option<String>,
     #[serde(rename = "sourceCommentUrl")]
     pub source_comment_url: Option<String>,
+    #[serde(rename = "sourceKind")]
+    pub source_kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -201,6 +203,8 @@ pub struct PhaseRunInsertInput {
     pub source_thread_id: Option<String>,
     #[serde(rename = "sourceCommentUrl")]
     pub source_comment_url: Option<String>,
+    #[serde(rename = "sourceKind")]
+    pub source_kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -828,7 +832,8 @@ pub fn agent_list_for_session(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
                 provider_session_id, last_finished_at, last_viewed_at, kind, verbosity,
-                parent_agent_id, workflow_run_id, source_thread_id, source_comment_url
+                parent_agent_id, workflow_run_id, source_thread_id, source_comment_url,
+                source_kind
          FROM agents
          WHERE session_id = ?1
          ORDER BY ordinal ASC",
@@ -854,6 +859,7 @@ pub fn agent_list_for_session(
             workflow_run_id: row.get(16)?,
             source_thread_id: row.get(17)?,
             source_comment_url: row.get(18)?,
+            source_kind: row.get(19)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -871,8 +877,8 @@ pub fn agent_insert(
         "INSERT INTO agents
            (id, session_id, step_id, ordinal, name, status,
             provider_run_id, output_summary, started_at, completed_at, kind, verbosity,
-            parent_agent_id, workflow_run_id, source_thread_id, source_comment_url)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
+            parent_agent_id, workflow_run_id, source_thread_id, source_comment_url, source_kind)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)",
         rusqlite::params![
             id,
             input.session_id,
@@ -890,6 +896,7 @@ pub fn agent_insert(
             input.workflow_run_id,
             input.source_thread_id,
             input.source_comment_url,
+            input.source_kind,
         ],
     )?;
 
@@ -913,6 +920,7 @@ pub fn agent_insert(
         workflow_run_id: input.workflow_run_id,
         source_thread_id: input.source_thread_id,
         source_comment_url: input.source_comment_url,
+        source_kind: input.source_kind,
     })
 }
 
@@ -954,7 +962,8 @@ pub fn agent_update_status(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
                 provider_session_id, last_finished_at, last_viewed_at, kind, verbosity,
-                parent_agent_id, workflow_run_id, source_thread_id, source_comment_url
+                parent_agent_id, workflow_run_id, source_thread_id, source_comment_url,
+                source_kind
          FROM agents
          WHERE id = ?1
          LIMIT 1",
@@ -980,6 +989,7 @@ pub fn agent_update_status(
             workflow_run_id: row.get(16)?,
             source_thread_id: row.get(17)?,
             source_comment_url: row.get(18)?,
+            source_kind: row.get(19)?,
         })
     })?;
     match rows.next() {

--- a/apps/desktop/src/features/chat/spawn-from-comment.ts
+++ b/apps/desktop/src/features/chat/spawn-from-comment.ts
@@ -1,4 +1,4 @@
-import type { PrComment, ProviderId, PullRequestState } from '@goodboy/types';
+import type { AgentSourceKind, PrComment, ProviderId, PullRequestState } from '@goodboy/types';
 import type { AgentKind } from '../session/agent-kind';
 import { kindRouting } from '../session/agent-kind';
 import type { EffortLevel } from './utils/chat-constants';
@@ -94,6 +94,7 @@ export type CommentAgentArgs = {
   readonly initialPrompt: string;
   readonly sourceThreadId?: string;
   readonly sourceCommentUrl: string;
+  readonly sourceKind: AgentSourceKind;
   readonly mode?: ResolveMode;
 };
 
@@ -122,6 +123,7 @@ export const buildCommentAgentArgs = (
     initialPrompt: buildCommentAgentPrompt({ comment: c, pr, replies, mode, hint: choice.hint }),
     ...(c.source === 'review' && c.threadId ? { sourceThreadId: c.threadId } : {}),
     sourceCommentUrl: c.url,
+    sourceKind: c.source === 'review' ? 'review_comment' : 'issue_comment',
     ...(mode !== 'fix' && { mode }),
   };
 };

--- a/apps/desktop/src/features/companion/commandExecutor.ts
+++ b/apps/desktop/src/features/companion/commandExecutor.ts
@@ -9,6 +9,7 @@ import {
 } from '@goodboy/core';
 import type {
   AgentId,
+  AgentSourceKind,
   AttachmentInput,
   ProviderId,
   SessionId,
@@ -626,12 +627,18 @@ async function dispatchMobile(cmd: BridgeCommand): Promise<unknown> {
       markSessionMobileShared(sessionId);
       const sourceCommentUrl = asString(data.commentUrl);
       const sourceThreadId = asString(data.threadId);
+      const sourceKind: AgentSourceKind | null = sourceThreadId
+        ? 'review_comment'
+        : sourceCommentUrl
+          ? 'issue_comment'
+          : null;
       await store.spawnAgent(sessionId, {
         kindOverride: 'resolver',
         deferKickoff: true,
         initialPrompt: prompt,
         ...(sourceCommentUrl ? { sourceCommentUrl } : {}),
         ...(sourceThreadId ? { sourceThreadId } : {}),
+        ...(sourceKind !== null && { sourceKind }),
       });
       await store.activateNextResolver(sessionId);
       return undefined;

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -228,6 +228,7 @@ export const PrDetailPanel = ({
       kindOverride: args.kind,
       ...(args.sourceThreadId !== undefined && { sourceThreadId: args.sourceThreadId }),
       sourceCommentUrl: args.sourceCommentUrl,
+      sourceKind: args.sourceKind,
       ...(deferKickoff && { deferKickoff: true }),
     });
     await setAgentConfig(sessionId, agentId, {

--- a/apps/desktop/src/features/orchestration/components/SpawnTree/lib.ts
+++ b/apps/desktop/src/features/orchestration/components/SpawnTree/lib.ts
@@ -12,7 +12,6 @@ export type SpawnNode = {
   readonly costUsd: number;
   readonly outputSummary: string | null;
   readonly children: ReadonlyArray<SpawnNode>;
-  readonly resolver?: { readonly state: string; readonly commentUrl: string | null };
   readonly isSelected: boolean;
 };
 
@@ -59,28 +58,6 @@ export const outcomeTone = (status: SpawnNodeStatus): Tone => {
     return 'danger';
   }
   return 'neutral';
-};
-
-export const resolverOutcome = (state: string): { tone: Tone; label: string } => {
-  if (state === 'resolved') {
-    return { tone: 'success', label: 'resolved' };
-  }
-  if (state === 'committed') {
-    return { tone: 'success', label: 'committed' };
-  }
-  if (state === 'wontfix') {
-    return { tone: 'neutral', label: "won't fix" };
-  }
-  if (state === 'awaiting') {
-    return { tone: 'warning', label: 'awaiting you' };
-  }
-  if (state === 'failed') {
-    return { tone: 'danger', label: 'stalled' };
-  }
-  if (state === 'running') {
-    return { tone: 'info', label: 'running' };
-  }
-  return { tone: 'neutral', label: 'queued' };
 };
 
 const KIND_EYEBROW_LABEL: Partial<Record<AgentKind, string>> = {

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.test.ts
@@ -209,7 +209,6 @@ describe('useWorkspaceRuns', () => {
     const { result } = renderHook(() => useWorkspaceRuns(WS, [session]));
     expect(result.current.freeAgents.map((n) => n.id)).toEqual(['free-1']);
     expect(result.current.resolveQueue.map((n) => n.id)).toEqual(['resolve-1']);
-    expect(result.current.resolveQueue[0]!.resolver?.commentUrl).toBe('https://x/y');
     expect(result.current.aggregate.runningCount).toBe(2);
     expect(result.current.aggregate.agentCount).toBe(2);
   });

--- a/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
+++ b/apps/desktop/src/features/orchestration/hooks/useWorkspaceRuns/index.ts
@@ -137,10 +137,6 @@ const agentToNode = (
   const children = [...kids]
     .sort((a, b) => a.ordinal - b.ordinal)
     .map((c) => agentToNode(c, childrenByParentId, costByAgentId, selectedAgentId, depth + 1));
-  const resolver =
-    agent.sourceThreadId != null
-      ? { state: statusToNodeStatus(agent.status), commentUrl: agent.sourceCommentUrl ?? null }
-      : undefined;
   return {
     id: agent.id,
     name: agent.name,
@@ -149,7 +145,6 @@ const agentToNode = (
     costUsd: costByAgentId.get(agent.id) ?? 0,
     outputSummary: agent.outputSummary ?? null,
     children,
-    ...(resolver != null && { resolver }),
     isSelected: agent.id === selectedAgentId,
   };
 };

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -588,6 +588,7 @@ export const DiffViewerContent = ({
         model: resolverRouting.model,
         effort: resolverRouting.effort,
         kindOverride: 'resolver',
+        sourceKind: 'diff_comment',
       });
       try {
         await consumeDiffComments(sessionId, idsToConsume, agentId);

--- a/apps/desktop/src/features/session/components/ForceCloseResolverAction/canForceCloseResolver.ts
+++ b/apps/desktop/src/features/session/components/ForceCloseResolverAction/canForceCloseResolver.ts
@@ -1,0 +1,14 @@
+import type { Agent } from '@goodboy/types';
+import type { ResolverStatus } from '../../resolver-linkage';
+
+type Params = {
+  readonly agent: Agent;
+  readonly status: ResolverStatus;
+};
+
+export const canForceCloseResolver = ({ agent, status }: Params): boolean => {
+  if (status === 'running') {
+    return true;
+  }
+  return agent.status === 'running';
+};

--- a/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import type { ResolverStatus } from '../../resolver-linkage';
+
+const h = vi.hoisted(() => ({ forceCloseResolver: vi.fn(async () => undefined) }));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: { forceCloseResolver: typeof h.forceCloseResolver }) => T) =>
+    selector({ forceCloseResolver: h.forceCloseResolver }),
+}));
+
+import { ForceCloseResolverAction } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUNNING = {
+  id: 'agent-1' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'resolve: reviewer on a.ts:1',
+  status: 'running',
+  sourceThreadId: 'PRRT_1',
+} satisfies Agent;
+
+describe('ForceCloseResolverAction', () => {
+  beforeEach(() => h.forceCloseResolver.mockReset());
+  afterEach(cleanup);
+
+  it('arms on the first click and force closes on confirmation', async () => {
+    render(<ForceCloseResolverAction agent={RUNNING} sessionId={SESSION_ID} status="running" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Force close' }));
+    expect(h.forceCloseResolver).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm stop' }));
+    await waitFor(() => expect(h.forceCloseResolver).toHaveBeenCalledWith(SESSION_ID, RUNNING.id));
+  });
+
+  it('stays available for a row stuck at running without a live status', () => {
+    render(<ForceCloseResolverAction agent={RUNNING} sessionId={SESSION_ID} status="done" />);
+
+    expect(screen.getByRole('button', { name: 'Force close' })).toBeDefined();
+  });
+
+  it.each(['resolved', 'committed', 'awaiting'] satisfies ReadonlyArray<ResolverStatus>)(
+    'is absent for a %s resolver that is not running',
+    (status) => {
+      render(
+        <ForceCloseResolverAction
+          agent={{ ...RUNNING, status: 'completed' }}
+          sessionId={SESSION_ID}
+          status={status}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: 'Force close' })).toBeNull();
+    },
+  );
+});

--- a/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.tsx
+++ b/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { CircleStop } from 'lucide-react';
+import type { Agent, SessionId } from '@goodboy/types';
+import { cn } from '@goodboy/ui';
+import { useAppStore } from '../../../../store';
+import type { ResolverStatus } from '../../resolver-linkage';
+import { canForceCloseResolver } from './canForceCloseResolver';
+
+type Props = {
+  readonly agent: Agent;
+  readonly sessionId: SessionId;
+  readonly status: ResolverStatus;
+};
+
+export const ForceCloseResolverAction = ({ agent, sessionId, status }: Props) => {
+  const forceCloseResolver = useAppStore((state) => state.forceCloseResolver);
+  const [isArmed, setIsArmed] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+
+  useEffect(() => {
+    setIsArmed(false);
+  }, [agent.id]);
+
+  if (!canForceCloseResolver({ agent, status })) {
+    return null;
+  }
+
+  const onConfirm = async () => {
+    if (isBusy) {
+      return;
+    }
+    setIsBusy(true);
+    setIsArmed(false);
+    try {
+      await forceCloseResolver(sessionId, agent.id);
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={isBusy}
+      title="stop this resolver now and let the next queued one run"
+      onClick={(event) => {
+        event.stopPropagation();
+        if (isArmed) {
+          void onConfirm();
+          return;
+        }
+        setIsArmed(true);
+      }}
+      onBlur={() => setIsArmed(false)}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-full border border-danger/40 px-2 py-0.5 text-[10px] font-semibold text-danger transition-colors hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60',
+        isBusy && 'animate-border-pulse',
+      )}
+    >
+      <CircleStop size={9} aria-hidden />
+      {isBusy ? 'Stopping...' : isArmed ? 'Confirm stop' : 'Force close'}
+    </button>
+  );
+};

--- a/apps/desktop/src/features/session/components/ForceResolveAction/canForceResolve.ts
+++ b/apps/desktop/src/features/session/components/ForceResolveAction/canForceResolve.ts
@@ -14,5 +14,5 @@ export const canForceResolve = ({ agent, status, turnState }: Params): boolean =
   if (turnState?.kind === 'running' || turnState?.kind === 'starting') {
     return false;
   }
-  return status === 'awaiting' || status === 'failed' || status === 'done';
+  return status === 'awaiting' || status === 'failed' || status === 'done' || status === 'stopped';
 };

--- a/apps/desktop/src/features/session/components/ForceResolveAction/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ForceResolveAction/index.test.tsx
@@ -130,6 +130,12 @@ describe('ForceResolveAction', () => {
     },
   );
 
+  it('stays available for a resolver the user force closed', () => {
+    render(<ForceResolveAction agent={AGENT} sessionId={SESSION_ID} status="stopped" />);
+
+    expect(screen.getByRole('button', { name: 'Mark resolved' })).toBeDefined();
+  });
+
   it('resets the armed note when the selected resolver changes', () => {
     const view = render(
       <ForceResolveAction agent={AGENT} sessionId={SESSION_ID} status="awaiting" />,

--- a/apps/desktop/src/features/session/components/ResolverInspector/ChangesSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/ChangesSection.tsx
@@ -1,0 +1,73 @@
+import { FileText } from 'lucide-react';
+import type { BranchCommit } from '@goodboy/types';
+import { CommitRow } from './CommitRow';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly files: ReadonlyArray<string>;
+  readonly reported: ReadonlyArray<BranchCommit>;
+  readonly reportedMissingShas: ReadonlyArray<string>;
+  readonly withinRunWindow: ReadonlyArray<BranchCommit>;
+  readonly isLoading: boolean;
+};
+
+export const ChangesSection = ({
+  files,
+  reported,
+  reportedMissingShas,
+  withinRunWindow,
+  isLoading,
+}: Props) => (
+  <InspectorSection question="What it changed">
+    {files.length > 0 ? (
+      <ul className="flex flex-col gap-1">
+        {files.map((path) => (
+          <li key={path} className="flex min-w-0 items-baseline gap-2">
+            <FileText size={11} aria-hidden className="shrink-0 text-muted-foreground/60" />
+            <span className="truncate font-mono text-2xs text-foreground/80" title={path}>
+              {path}
+            </span>
+          </li>
+        ))}
+      </ul>
+    ) : (
+      <p className="text-2xs italic text-muted-foreground/70">
+        {isLoading ? 'reading its turn history...' : 'no file edits recorded'}
+      </p>
+    )}
+    {reported.length > 0 ? (
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-muted-foreground/60">commits it reported</span>
+        <ul className="flex flex-col gap-1">
+          {reported.map((commit) => (
+            <CommitRow key={commit.sha} commit={commit} />
+          ))}
+        </ul>
+      </div>
+    ) : null}
+    {reportedMissingShas.length > 0 ? (
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-muted-foreground/60">reported, absent from the branch</span>
+        <ul className="flex flex-col gap-1">
+          {reportedMissingShas.map((sha) => (
+            <li key={sha} className="font-mono text-2xs text-warning">
+              {sha.slice(0, 7)}
+            </li>
+          ))}
+        </ul>
+      </div>
+    ) : null}
+    {withinRunWindow.length > 0 ? (
+      <div className="flex flex-col gap-1">
+        <span className="text-2xs text-muted-foreground/60">
+          landed while it ran, author not verified
+        </span>
+        <ul className="flex flex-col gap-1">
+          {withinRunWindow.map((commit) => (
+            <CommitRow key={commit.sha} commit={commit} />
+          ))}
+        </ul>
+      </div>
+    ) : null}
+  </InspectorSection>
+);

--- a/apps/desktop/src/features/session/components/ResolverInspector/CommitRow.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/CommitRow.tsx
@@ -1,0 +1,18 @@
+import { GitCommit } from 'lucide-react';
+import type { BranchCommit } from '@goodboy/types';
+
+type Props = {
+  readonly commit: BranchCommit;
+};
+
+export const CommitRow = ({ commit }: Props) => (
+  <li className="flex min-w-0 items-baseline gap-2">
+    <GitCommit size={11} aria-hidden className="shrink-0 text-muted-foreground/60" />
+    <span className="shrink-0 font-mono text-2xs tabular-nums text-muted-foreground/80">
+      {commit.shortSha}
+    </span>
+    <span className="truncate text-2xs text-foreground/80" title={commit.subject}>
+      {commit.subject}
+    </span>
+  </li>
+);

--- a/apps/desktop/src/features/session/components/ResolverInspector/InspectorSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/InspectorSection.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly question: string;
+  readonly children: ReactNode;
+};
+
+export const InspectorSection = ({ question, children }: Props) => (
+  <section className="flex flex-col gap-2">
+    <h3 className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+      {question}
+    </h3>
+    {children}
+  </section>
+);

--- a/apps/desktop/src/features/session/components/ResolverInspector/OriginSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/OriginSection.tsx
@@ -1,0 +1,57 @@
+import { ArrowUpRight } from 'lucide-react';
+import type { DiffComment, PrComment } from '@goodboy/types';
+import { CommentSnippet } from '../CommentSnippet';
+import type { ResolverOrigin } from '../../resolver-origin';
+import { diffCommentLocation } from '../../diff-comment-location';
+import { prCommentLocation } from '../../pr-comment-location';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly origin: ResolverOrigin;
+  readonly threadComment: PrComment | null;
+  readonly diffComment: DiffComment | null;
+  readonly openLabel: string | null;
+  readonly onOpen: () => void;
+};
+
+export const OriginSection = ({ origin, threadComment, diffComment, openLabel, onOpen }: Props) => (
+  <InspectorSection question="Where it came from">
+    <div className="flex items-center gap-2">
+      <span className="rounded-full bg-muted px-2 py-0.5 text-2xs font-medium text-foreground/80">
+        {origin.label}
+      </span>
+      {origin.isRecorded ? null : (
+        <span
+          title="reconstructed from the resolver's links, not recorded at spawn time"
+          className="text-2xs text-muted-foreground/60"
+        >
+          inferred
+        </span>
+      )}
+    </div>
+    {threadComment !== null ? (
+      <CommentSnippet
+        author={threadComment.author}
+        location={prCommentLocation({ comment: threadComment })}
+        body={threadComment.body}
+      />
+    ) : diffComment !== null ? (
+      <CommentSnippet
+        location={diffCommentLocation({ comment: diffComment })}
+        body={diffComment.body}
+      />
+    ) : (
+      <p className="text-2xs italic text-muted-foreground/70">comment text is no longer cached</p>
+    )}
+    {openLabel !== null ? (
+      <button
+        type="button"
+        onClick={onOpen}
+        className="inline-flex items-center gap-1 self-start rounded-md px-1.5 py-0.5 text-2xs font-medium text-muted-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground"
+      >
+        {openLabel}
+        <ArrowUpRight size={11} aria-hidden className="opacity-70" />
+      </button>
+    ) : null}
+  </InspectorSection>
+);

--- a/apps/desktop/src/features/session/components/ResolverInspector/StateSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/StateSection.tsx
@@ -1,0 +1,42 @@
+import type { Agent, SessionId } from '@goodboy/types';
+import { ResolverStateBadge, resolverBadgeState } from '../ResolverStateBadge';
+import { ForceCloseResolverAction } from '../ForceCloseResolverAction';
+import { ForceResolveAction } from '../ForceResolveAction';
+import type { ResolverStatus } from '../../resolver-linkage';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly agent: Agent;
+  readonly sessionId: SessionId;
+  readonly status: ResolverStatus;
+  readonly queuePosition: number;
+  readonly queueTotal: number;
+  readonly blockedBy: string | null;
+};
+
+export const StateSection = ({
+  agent,
+  sessionId,
+  status,
+  queuePosition,
+  queueTotal,
+  blockedBy,
+}: Props) => (
+  <InspectorSection question="What state it is in">
+    <div className="flex items-center gap-2">
+      <ResolverStateBadge state={resolverBadgeState(status)} />
+      <span className="text-2xs tabular-nums text-muted-foreground/70">
+        {queuePosition} of {queueTotal} in the queue
+      </span>
+    </div>
+    {blockedBy !== null ? (
+      <p className="text-2xs text-warning">blocked: {blockedBy}</p>
+    ) : (
+      <p className="text-2xs text-muted-foreground/60">not blocked</p>
+    )}
+    <div className="flex flex-wrap items-center gap-1.5">
+      <ForceCloseResolverAction agent={agent} sessionId={sessionId} status={status} />
+      <ForceResolveAction agent={agent} sessionId={sessionId} status={status} />
+    </div>
+  </InspectorSection>
+);

--- a/apps/desktop/src/features/session/components/ResolverInspector/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  BranchCommit,
+  IsoDateTime,
+  ProviderRunId,
+  SessionId,
+  TurnEvent,
+} from '@goodboy/types';
+
+const SESSION_ID = 'session-1' as SessionId;
+const RUNNING_ID = 'resolver-1' as AgentId;
+const QUEUED_ID = 'resolver-2' as AgentId;
+
+const h = vi.hoisted(() => {
+  const runtime: { events: ReadonlyArray<unknown> } = { events: [] };
+  return {
+    runtime,
+    listTurnEventsForAgent: vi.fn(async () => [] as ReadonlyArray<unknown>),
+    listBranchCommits: vi.fn(async () => [] as ReadonlyArray<unknown>),
+    forceCloseResolver: vi.fn(async () => undefined),
+    resolveGithubThread: vi.fn(async () => true),
+  };
+});
+
+const agent = (over: Partial<Agent> & { id: AgentId }): Agent => ({
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'resolve: reviewer on a.ts',
+  status: 'pending',
+  kind: 'resolver',
+  ...over,
+});
+
+const state = {
+  sessionPhaseRuns: {
+    [SESSION_ID]: [
+      agent({
+        id: RUNNING_ID,
+        ordinal: 0,
+        status: 'running',
+        name: 'resolve: reviewer on a.ts',
+        sourceThreadId: 'PRRT_1',
+        sourceCommentUrl: 'https://github.com/x/y/pull/7#discussion_r1',
+        sourceKind: 'review_comment',
+        startedAt: '2026-07-25T09:00:00.000Z' as IsoDateTime,
+      }),
+      agent({ id: QUEUED_ID, ordinal: 1, name: 'resolve: reviewer on b.ts' }),
+    ],
+  },
+  agentKindOverride: {},
+  resolverState: {},
+  sessionPendingResolutions: {},
+  diffComments: { [SESSION_ID]: [] },
+  sessionWorktrees: { [SESSION_ID]: ['/tmp/wt'] },
+  pendingResolverKickoff: {},
+  agentTurnState: {},
+  sessionGithub: {
+    [SESSION_ID]: {
+      pr: { number: 7 },
+      detail: {
+        comments: [
+          {
+            id: 'c1',
+            author: 'reviewer',
+            body: 'this needs a guard clause',
+            url: 'https://github.com/x/y/pull/7#discussion_r1',
+            source: 'review',
+            threadId: 'PRRT_1',
+            path: 'a.ts',
+            line: 12,
+          },
+        ],
+      },
+    },
+  },
+  forceCloseResolver: h.forceCloseResolver,
+  resolveGithubThread: h.resolveGithubThread,
+};
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: <T,>(selector: (s: typeof state) => T) => selector(state),
+  useDiffComments: () => [],
+}));
+
+vi.mock('../../../../store/transcript', () => ({
+  useTranscript: () => h.runtime.events,
+}));
+
+vi.mock('@goodboy/db', () => ({ listTurnEventsForAgent: h.listTurnEventsForAgent }));
+vi.mock('../../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+vi.mock('../../../worktree/worktree', () => ({ listBranchCommits: h.listBranchCommits }));
+
+import { ResolverInspector } from './index';
+
+const fileEdit: TurnEvent = {
+  kind: 'file_edit',
+  runId: 'run-1' as ProviderRunId,
+  path: 'src/auth/guard.ts',
+  editType: 'modify',
+  at: '2026-07-25T09:01:00.000Z' as IsoDateTime,
+};
+
+const COMMIT: BranchCommit = {
+  sha: 'abc1234def',
+  shortSha: 'abc1234',
+  subject: 'fix(auth): guard the nullable session',
+  author: 'agent',
+  timestamp: 1,
+  pushed: false,
+  parentSha: null,
+};
+
+describe('ResolverInspector', () => {
+  beforeEach(() => {
+    h.runtime.events = [];
+    h.listTurnEventsForAgent.mockResolvedValue([]);
+    h.listBranchCommits.mockResolvedValue([COMMIT]);
+  });
+
+  afterEach(cleanup);
+
+  it('groups the answers into the three governance questions', () => {
+    render(
+      <ResolverInspector sessionId={SESSION_ID} agentId={RUNNING_ID} onClose={() => undefined} />,
+    );
+
+    expect(screen.getByText('Where it came from')).toBeDefined();
+    expect(screen.getByText('What it changed')).toBeDefined();
+    expect(screen.getByText('What state it is in')).toBeDefined();
+  });
+
+  it('names the recorded origin and surfaces the comment behind it', () => {
+    render(
+      <ResolverInspector sessionId={SESSION_ID} agentId={RUNNING_ID} onClose={() => undefined} />,
+    );
+
+    expect(screen.getByText('Review comment')).toBeDefined();
+    expect(screen.queryByText('inferred')).toBeNull();
+    expect(screen.getByText('this needs a guard clause')).toBeDefined();
+  });
+
+  it('lists the files the resolver edited', () => {
+    h.runtime.events = [fileEdit];
+
+    render(
+      <ResolverInspector sessionId={SESSION_ID} agentId={RUNNING_ID} onClose={() => undefined} />,
+    );
+
+    expect(screen.getByText('src/auth/guard.ts')).toBeDefined();
+  });
+
+  it('offers force close for the running resolver', () => {
+    render(
+      <ResolverInspector sessionId={SESSION_ID} agentId={RUNNING_ID} onClose={() => undefined} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Force close' })).toBeDefined();
+  });
+
+  it('explains why a queued resolver is blocked and where it sits', () => {
+    render(
+      <ResolverInspector sessionId={SESSION_ID} agentId={QUEUED_ID} onClose={() => undefined} />,
+    );
+
+    expect(screen.getByText('2 of 2 in the queue')).toBeDefined();
+    expect(screen.getByText(/resolve: reviewer on a.ts is still running/)).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from 'react';
+import { X } from 'lucide-react';
+import { Divider, ScrollFade } from '@goodboy/ui';
+import type { AgentId, AgentSourceKind, PrComment, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore, useDiffComments } from '../../../../store';
+import { openUrl } from '../../../../shared/lib/editor';
+import { useResolverIndex } from '../../hooks/useResolverIndex';
+import { useResolverChanges } from '../../hooks/useResolverChanges';
+import { resolverOrigin } from '../../resolver-origin';
+import { ChangesSection } from './ChangesSection';
+import { OriginSection } from './OriginSection';
+import { StateSection } from './StateSection';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly onClose: () => void;
+};
+
+const OPEN_LABEL: Record<AgentSourceKind | 'unknown', string | null> = {
+  review_comment: 'Open the review thread',
+  issue_comment: 'Open the comment on GitHub',
+  diff_comment: 'Open the diff',
+  unknown: null,
+};
+
+export const ResolverInspector = ({ sessionId, agentId, onClose }: Props) => {
+  const resolverIndex = useResolverIndex(sessionId);
+  const diffComments = useDiffComments(sessionId);
+  const prComments = useAppStore(
+    (s) =>
+      s.sessionGithub[sessionId]?.detail?.comments ?? (EMPTY_ARRAY as ReadonlyArray<PrComment>),
+  );
+  const prNumber = useAppStore((s) => s.sessionGithub[sessionId]?.pr?.number ?? null);
+  const worktreePath = useAppStore((s) => (s.sessionWorktrees[sessionId] ?? [])[0] ?? null);
+  const hasKickoff = useAppStore((s) => s.pendingResolverKickoff[agentId] !== undefined);
+
+  const position = resolverIndex.links.findIndex((link) => link.agent.id === agentId);
+  const link = resolverIndex.links[position] ?? null;
+  const agent = link?.agent ?? null;
+  const changes = useResolverChanges({ agent, worktreePath });
+  const diffComment = useMemo(
+    () => diffComments.find((comment) => comment.consumedByAgentId === agentId) ?? null,
+    [diffComments, agentId],
+  );
+  const threadComment = useMemo(() => {
+    const threadId = agent?.sourceThreadId ?? null;
+    if (threadId === null) {
+      return null;
+    }
+    return (
+      prComments.find((comment) => comment.threadId === threadId && comment.inReplyToId == null) ??
+      null
+    );
+  }, [prComments, agent?.sourceThreadId]);
+  const runningResolverName = useMemo(
+    () => resolverIndex.links.find(({ status }) => status === 'running')?.agent.name ?? null,
+    [resolverIndex],
+  );
+
+  if (link === null || agent === null) {
+    return null;
+  }
+
+  const origin = resolverOrigin({ agent, hasDiffComment: diffComment !== null });
+  const canOpen =
+    (origin.kind === 'review_comment' && agent.sourceThreadId != null && prNumber != null) ||
+    (origin.kind === 'issue_comment' && agent.sourceCommentUrl != null) ||
+    (origin.kind === 'diff_comment' && worktreePath != null);
+  const onOpen = () => {
+    if (origin.kind === 'diff_comment') {
+      window.dispatchEvent(
+        new CustomEvent('goodboy:open-diff-viewer', {
+          detail: { sessionId, workingDir: worktreePath },
+        }),
+      );
+      return;
+    }
+    if (agent.sourceThreadId != null && prNumber != null) {
+      window.dispatchEvent(
+        new CustomEvent('goodboy:open-github-session', {
+          detail: { sessionId, prNumber, threadId: agent.sourceThreadId },
+        }),
+      );
+      return;
+    }
+    if (agent.sourceCommentUrl != null) {
+      void openUrl(agent.sourceCommentUrl);
+    }
+  };
+  const blockedBy =
+    link.status === 'pending' && runningResolverName !== null
+      ? `${runningResolverName} is still running`
+      : link.status === 'pending' && !hasKickoff
+        ? 'no queued kickoff, it will not start on its own'
+        : null;
+
+  return (
+    <div className="flex w-80 shrink-0 flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
+        <span className="truncate text-xs font-medium text-foreground" title={agent.name}>
+          {agent.name}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="close resolver inspector"
+          className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      </div>
+      <Divider />
+      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
+        <div className="flex flex-col gap-4">
+          <OriginSection
+            origin={origin}
+            threadComment={threadComment}
+            diffComment={diffComment}
+            openLabel={canOpen ? OPEN_LABEL[origin.kind] : null}
+            onOpen={onOpen}
+          />
+          <Divider />
+          <ChangesSection
+            files={changes.files}
+            reported={changes.reported}
+            reportedMissingShas={changes.reportedMissingShas}
+            withinRunWindow={changes.withinRunWindow}
+            isLoading={changes.isLoading}
+          />
+          <Divider />
+          <StateSection
+            agent={agent}
+            sessionId={sessionId}
+            status={link.status}
+            queuePosition={position + 1}
+            queueTotal={resolverIndex.links.length}
+            blockedBy={blockedBy}
+          />
+        </div>
+      </ScrollFade>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/ResolverStateBadge/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverStateBadge/index.tsx
@@ -1,5 +1,5 @@
 import { StatusDot, cn } from '@goodboy/ui';
-import { AlertTriangle, Ban, Check, CheckCheck, Clock, GitCommit } from 'lucide-react';
+import { AlertTriangle, Ban, Check, CheckCheck, CircleStop, Clock, GitCommit } from 'lucide-react';
 import type { ResolverStatus } from '../../resolver-linkage';
 
 export type ResolverBadgeState =
@@ -11,6 +11,7 @@ export type ResolverBadgeState =
   | 'resolved'
   | 'wontfix'
   | 'awaiting'
+  | 'stopped'
   | 'failed';
 
 export const resolverBadgeState = (status: ResolverStatus): ResolverBadgeState => {
@@ -29,6 +30,8 @@ export const resolverBadgeState = (status: ResolverStatus): ResolverBadgeState =
       return 'wontfix';
     case 'awaiting':
       return 'awaiting';
+    case 'stopped':
+      return 'stopped';
     case 'failed':
       return 'failed';
     default:
@@ -50,6 +53,7 @@ const COPY: Record<ResolverBadgeState, string> = {
   resolved: 'resolved',
   wontfix: 'explained',
   awaiting: 'needs you',
+  stopped: 'stopped',
   failed: 'failed',
 };
 
@@ -59,6 +63,8 @@ export const ResolverStateBadge = ({ state, className }: ResolverStateBadgeProps
       <StatusDot tone="info" size="sm" pulsing />
     ) : state === 'failed' ? (
       <span className="size-1.5 rounded-full bg-danger" aria-hidden />
+    ) : state === 'stopped' ? (
+      <CircleStop size={10} className="text-danger" aria-hidden />
     ) : state === 'queued' ? (
       <Clock size={10} className="text-muted-foreground/60" aria-hidden />
     ) : state === 'resolved' ? (
@@ -80,7 +86,7 @@ export const ResolverStateBadge = ({ state, className }: ResolverStateBadgeProps
           ? 'bg-success/10 text-success'
           : state === 'committed' || state === 'awaiting' || state === 'analyzed'
             ? 'bg-warning/10 text-warning'
-            : state === 'failed'
+            : state === 'failed' || state === 'stopped'
               ? 'bg-danger/10 text-danger'
               : state === 'running'
                 ? 'bg-info/10 text-info'

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -24,6 +24,7 @@ import { SessionTopBar } from './parts/SessionTopBar';
 import { LensColumn } from './parts/LensColumn';
 import { QuestionsPane } from './parts/QuestionsPane';
 import { SlotPane } from './parts/SlotPane';
+import { ResolvePane } from './parts/ResolvePane';
 import { PrPane } from './parts/PrPane';
 import { FilesPane } from './parts/FilesPane';
 import { PaneShell } from './parts/PaneShell';
@@ -292,16 +293,7 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <PlanStudio sessionId={sessionId} initialPlanId={focusedPlanId ?? undefined} />
                 ) : null}
                 {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
-                {lens === 'resolve' ? (
-                  <PaneShell
-                    title="Resolve"
-                    description="Resolver agents spawned from pull request comments and diff selections."
-                    meta={resolveMeta}
-                    width="3xl"
-                  >
-                    <AgentsSection task={session} only="resolve" />
-                  </PaneShell>
-                ) : null}
+                {lens === 'resolve' ? <ResolvePane session={session} meta={resolveMeta} /> : null}
                 {lens === 'scripts' ? (
                   <PaneShell title="Scripts" width="3xl">
                     <ScriptsPanel

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { Divider } from '@goodboy/ui';
+import type { AgentId, Session, SessionId } from '@goodboy/types';
+import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
+import { ResolverInspector } from '../../ResolverInspector';
+import { PaneShell } from './PaneShell';
+
+type Props = {
+  readonly session: Session;
+  readonly meta: string | undefined;
+};
+
+export const ResolvePane = ({ session, meta }: Props) => {
+  const sessionId = session.id as SessionId;
+  const [inspectedId, setInspectedId] = useState<AgentId | null>(null);
+
+  return (
+    <div className="flex h-full min-h-0">
+      <div className="min-h-0 flex-1">
+        <PaneShell
+          title="Resolve"
+          description="Resolver agents spawned from pull request comments and diff selections."
+          meta={meta}
+          width="3xl"
+        >
+          <AgentsSection
+            task={session}
+            only="resolve"
+            inspectedResolverId={inspectedId}
+            onInspectResolver={(agentId) =>
+              setInspectedId((prev) => (prev === agentId ? null : agentId))
+            }
+          />
+        </PaneShell>
+      </div>
+      {inspectedId !== null ? (
+        <>
+          <Divider orientation="vertical" />
+          <ResolverInspector
+            sessionId={sessionId}
+            agentId={inspectedId}
+            onClose={() => setInspectedId(null)}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/diff-comment-location.ts
+++ b/apps/desktop/src/features/session/diff-comment-location.ts
@@ -1,0 +1,12 @@
+import type { DiffComment } from '@goodboy/types';
+
+type Params = {
+  readonly comment: DiffComment;
+};
+
+export const diffCommentLocation = ({ comment }: Params): string => {
+  if (comment.anchor == null) {
+    return comment.filePath;
+  }
+  return `${comment.filePath}:${comment.anchor.lineNumber}`;
+};

--- a/apps/desktop/src/features/session/hooks/useResolverChanges/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverChanges/index.ts
@@ -1,0 +1,86 @@
+import { useEffect, useMemo, useState } from 'react';
+import { extractFilesTouched } from '@goodboy/core';
+import { listTurnEventsForAgent } from '@goodboy/db';
+import type { Agent, BranchCommit, TurnEvent } from '@goodboy/types';
+import { tauriDatabase } from '../../../../shared/lib/db';
+import { useTranscript } from '../../../../store/transcript';
+import { listBranchCommits } from '../../../worktree/worktree';
+import { attributeResolverCommits, type AttributedCommits } from '../../resolver-commits';
+import { resolverReportedShas } from '../../resolver-reported-shas';
+
+export type ResolverChanges = AttributedCommits & {
+  readonly files: ReadonlyArray<string>;
+  readonly isLoading: boolean;
+};
+
+const EMPTY_EVENTS: ReadonlyArray<TurnEvent> = [];
+const EMPTY_COMMITS: ReadonlyArray<BranchCommit> = [];
+
+type Params = {
+  readonly agent: Agent | null;
+  readonly worktreePath: string | null;
+};
+
+export const useResolverChanges = ({ agent, worktreePath }: Params): ResolverChanges => {
+  const liveEvents = useTranscript(agent?.id ?? null);
+  const [storedEvents, setStoredEvents] = useState<ReadonlyArray<TurnEvent>>(EMPTY_EVENTS);
+  const [commits, setCommits] = useState<ReadonlyArray<BranchCommit>>(EMPTY_COMMITS);
+  const [isLoading, setIsLoading] = useState(false);
+  const agentId = agent?.id ?? null;
+  const hasLiveEvents = liveEvents.length > 0;
+
+  useEffect(() => {
+    setStoredEvents(EMPTY_EVENTS);
+    if (agentId == null || hasLiveEvents) {
+      return;
+    }
+    let cancelled = false;
+    setIsLoading(true);
+    listTurnEventsForAgent(tauriDatabase, agentId)
+      .then((events) => {
+        if (!cancelled) {
+          setStoredEvents(events);
+        }
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, hasLiveEvents]);
+
+  useEffect(() => {
+    setCommits(EMPTY_COMMITS);
+    if (worktreePath == null || agentId == null) {
+      return;
+    }
+    let cancelled = false;
+    listBranchCommits(worktreePath)
+      .then((list) => {
+        if (!cancelled) {
+          setCommits(list);
+        }
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [worktreePath, agentId]);
+
+  const events = hasLiveEvents ? liveEvents : storedEvents;
+
+  return useMemo(() => {
+    const attributed = attributeResolverCommits({
+      commits,
+      reportedShas: resolverReportedShas({ events }),
+      startedAt: agent?.startedAt,
+      completedAt: agent?.completedAt,
+      now: Date.now(),
+    });
+    return { ...attributed, files: extractFilesTouched(events), isLoading };
+  }, [events, commits, agent?.startedAt, agent?.completedAt, isLoading]);
+};

--- a/apps/desktop/src/features/session/hooks/useResolverIndex/index.ts
+++ b/apps/desktop/src/features/session/hooks/useResolverIndex/index.ts
@@ -7,6 +7,7 @@ import {
   buildResolverIndex,
   resolverStatus,
   type ResolverIndex,
+  type ResolverState,
   type ResolverStatus,
 } from '../../resolver-linkage';
 
@@ -47,7 +48,7 @@ export const useResolverIndex = (sessionId: SessionId): ResolverIndex => {
   );
   const resolverState = useAppStore(
     useShallow((s) => {
-      const out: Record<string, 'awaiting' | 'committed' | 'wontfix' | 'analyzed'> = {};
+      const out: Record<string, ResolverState> = {};
       const runs = s.sessionPhaseRuns[sessionId];
       if (!runs) {
         return out;

--- a/apps/desktop/src/features/session/pr-comment-location.ts
+++ b/apps/desktop/src/features/session/pr-comment-location.ts
@@ -1,0 +1,15 @@
+import type { PrComment } from '@goodboy/types';
+
+type Params = {
+  readonly comment: PrComment;
+};
+
+export const prCommentLocation = ({ comment }: Params): string | null => {
+  if (comment.source === 'issue') {
+    return 'conversation';
+  }
+  if (comment.path == null) {
+    return null;
+  }
+  return comment.line != null ? `${comment.path}:${comment.line}` : comment.path;
+};

--- a/apps/desktop/src/features/session/resolver-commits.test.ts
+++ b/apps/desktop/src/features/session/resolver-commits.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import type { BranchCommit } from '@goodboy/types';
+import { attributeResolverCommits } from './resolver-commits';
+
+const commit = ({
+  sha,
+  timestamp,
+}: {
+  readonly sha: string;
+  readonly timestamp: number;
+}): BranchCommit => ({
+  sha,
+  shortSha: sha.slice(0, 7),
+  subject: `work on ${sha.slice(0, 4)}`,
+  author: 'agent',
+  timestamp,
+  pushed: false,
+  parentSha: null,
+});
+
+const COMMITS: ReadonlyArray<BranchCommit> = [
+  commit({ sha: 'aaaaaaa1111', timestamp: 1_000 }),
+  commit({ sha: 'bbbbbbb2222', timestamp: 2_000 }),
+  commit({ sha: 'ccccccc3333', timestamp: 3_000 }),
+];
+
+const NOW = 4_000_000;
+
+describe('attributeResolverCommits', () => {
+  it('matches a reported short sha against the full branch log sha', () => {
+    const result = attributeResolverCommits({
+      commits: COMMITS,
+      reportedShas: ['bbbbbbb'],
+      startedAt: undefined,
+      completedAt: undefined,
+      now: NOW,
+    });
+
+    expect(result.reported.map((c) => c.sha)).toEqual(['bbbbbbb2222']);
+    expect(result.reportedMissingShas).toEqual([]);
+  });
+
+  it('keeps a reported sha that is absent from the branch log separate', () => {
+    const result = attributeResolverCommits({
+      commits: COMMITS,
+      reportedShas: ['deadbeef'],
+      startedAt: undefined,
+      completedAt: undefined,
+      now: NOW,
+    });
+
+    expect(result.reported).toEqual([]);
+    expect(result.reportedMissingShas).toEqual(['deadbeef']);
+  });
+
+  it('collects run-window commits without repeating the reported ones', () => {
+    const result = attributeResolverCommits({
+      commits: COMMITS,
+      reportedShas: ['ccccccc3333'],
+      startedAt: new Date(1_500 * 1000).toISOString(),
+      completedAt: new Date(3_500 * 1000).toISOString(),
+      now: NOW,
+    });
+
+    expect(result.reported.map((c) => c.sha)).toEqual(['ccccccc3333']);
+    expect(result.withinRunWindow.map((c) => c.sha)).toEqual(['bbbbbbb2222']);
+  });
+
+  it('returns no window commits when the resolver never started', () => {
+    const result = attributeResolverCommits({
+      commits: COMMITS,
+      reportedShas: [],
+      startedAt: undefined,
+      completedAt: undefined,
+      now: NOW,
+    });
+
+    expect(result.withinRunWindow).toEqual([]);
+  });
+
+  it('treats a still running resolver as open ended up to now', () => {
+    const result = attributeResolverCommits({
+      commits: COMMITS,
+      reportedShas: [],
+      startedAt: new Date(2_500 * 1000).toISOString(),
+      completedAt: undefined,
+      now: NOW,
+    });
+
+    expect(result.withinRunWindow.map((c) => c.sha)).toEqual(['ccccccc3333']);
+  });
+});

--- a/apps/desktop/src/features/session/resolver-commits.ts
+++ b/apps/desktop/src/features/session/resolver-commits.ts
@@ -1,0 +1,60 @@
+import type { BranchCommit } from '@goodboy/types';
+
+export type AttributedCommits = {
+  readonly reported: ReadonlyArray<BranchCommit>;
+  readonly reportedMissingShas: ReadonlyArray<string>;
+  readonly withinRunWindow: ReadonlyArray<BranchCommit>;
+};
+
+const shaMatches = ({ sha, candidate }: { readonly sha: string; readonly candidate: string }) => {
+  const a = sha.toLowerCase();
+  const b = candidate.toLowerCase();
+  return a.startsWith(b) || b.startsWith(a);
+};
+
+const toEpoch = ({ iso }: { readonly iso: string | undefined }): number | null => {
+  if (iso === undefined) {
+    return null;
+  }
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+};
+
+type Params = {
+  readonly commits: ReadonlyArray<BranchCommit>;
+  readonly reportedShas: ReadonlyArray<string>;
+  readonly startedAt: string | undefined;
+  readonly completedAt: string | undefined;
+  readonly now: number;
+};
+
+export const attributeResolverCommits = ({
+  commits,
+  reportedShas,
+  startedAt,
+  completedAt,
+  now,
+}: Params): AttributedCommits => {
+  const reported: BranchCommit[] = [];
+  const reportedMissingShas: string[] = [];
+  const matchedShas = new Set<string>();
+  for (const sha of reportedShas) {
+    const found = commits.find((commit) => shaMatches({ sha: commit.sha, candidate: sha }));
+    if (found === undefined) {
+      reportedMissingShas.push(sha);
+      continue;
+    }
+    matchedShas.add(found.sha);
+    reported.push(found);
+  }
+  const from = toEpoch({ iso: startedAt });
+  if (from === null) {
+    return { reported, reportedMissingShas, withinRunWindow: [] };
+  }
+  const until = toEpoch({ iso: completedAt }) ?? Math.floor(now / 1000);
+  const withinRunWindow = commits.filter(
+    (commit) =>
+      !matchedShas.has(commit.sha) && commit.timestamp >= from && commit.timestamp <= until,
+  );
+  return { reported, reportedMissingShas, withinRunWindow };
+};

--- a/apps/desktop/src/features/session/resolver-linkage.ts
+++ b/apps/desktop/src/features/session/resolver-linkage.ts
@@ -1,8 +1,12 @@
 import type { Agent, AgentId } from '@goodboy/types';
-import { resolverStatus, type ResolverStatus } from '../workspace/components/WorkspacesSidebar/lib';
+import {
+  resolverStatus,
+  type ResolverState,
+  type ResolverStatus,
+} from '../workspace/components/WorkspacesSidebar/lib';
 
 export { resolverStatus };
-export type { ResolverStatus };
+export type { ResolverState, ResolverStatus };
 
 export type ResolverLink = {
   readonly agent: Agent;

--- a/apps/desktop/src/features/session/resolver-origin.test.ts
+++ b/apps/desktop/src/features/session/resolver-origin.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import { resolverOrigin } from './resolver-origin';
+
+const base = {
+  id: 'agent-1' as AgentId,
+  sessionId: 'session-1' as SessionId,
+  ordinal: 0,
+  name: 'resolve: reviewer on a.ts:1',
+  status: 'completed',
+} satisfies Agent;
+
+describe('resolverOrigin', () => {
+  it('trusts the recorded source kind over any inference', () => {
+    const origin = resolverOrigin({
+      agent: { ...base, sourceKind: 'diff_comment' },
+      hasDiffComment: false,
+    });
+
+    expect(origin.kind).toBe('diff_comment');
+    expect(origin.isRecorded).toBe(true);
+  });
+
+  it('infers a review comment from the source thread when the kind is missing', () => {
+    const origin = resolverOrigin({
+      agent: { ...base, sourceThreadId: 'PRRT_1', sourceCommentUrl: 'https://x/1' },
+      hasDiffComment: false,
+    });
+
+    expect(origin.kind).toBe('review_comment');
+    expect(origin.isRecorded).toBe(false);
+  });
+
+  it('infers a conversation comment from a url without a thread', () => {
+    const origin = resolverOrigin({
+      agent: { ...base, sourceCommentUrl: 'https://x/1' },
+      hasDiffComment: false,
+    });
+
+    expect(origin.kind).toBe('issue_comment');
+  });
+
+  it('infers an inline diff note from a consumed diff comment', () => {
+    const origin = resolverOrigin({ agent: base, hasDiffComment: true });
+
+    expect(origin.kind).toBe('diff_comment');
+    expect(origin.isRecorded).toBe(false);
+  });
+
+  it('reports an unknown origin when nothing links the resolver', () => {
+    const origin = resolverOrigin({ agent: base, hasDiffComment: false });
+
+    expect(origin.kind).toBe('unknown');
+    expect(origin.label).toBe('Unknown origin');
+  });
+});

--- a/apps/desktop/src/features/session/resolver-origin.ts
+++ b/apps/desktop/src/features/session/resolver-origin.ts
@@ -1,0 +1,37 @@
+import type { Agent, AgentSourceKind } from '@goodboy/types';
+
+export type ResolverOrigin = {
+  readonly kind: AgentSourceKind | 'unknown';
+  readonly label: string;
+  readonly isRecorded: boolean;
+};
+
+type Params = {
+  readonly agent: Agent;
+  readonly hasDiffComment: boolean;
+};
+
+const LABEL: Record<AgentSourceKind | 'unknown', string> = {
+  review_comment: 'Review comment',
+  issue_comment: 'Conversation comment',
+  diff_comment: 'Inline diff note',
+  unknown: 'Unknown origin',
+};
+
+const inferKind = ({ agent }: { readonly agent: Agent }): AgentSourceKind | 'unknown' => {
+  if (agent.sourceThreadId != null) {
+    return 'review_comment';
+  }
+  if (agent.sourceCommentUrl != null) {
+    return 'issue_comment';
+  }
+  return 'unknown';
+};
+
+export const resolverOrigin = ({ agent, hasDiffComment }: Params): ResolverOrigin => {
+  if (agent.sourceKind !== undefined) {
+    return { kind: agent.sourceKind, label: LABEL[agent.sourceKind], isRecorded: true };
+  }
+  const inferred = hasDiffComment ? 'diff_comment' : inferKind({ agent });
+  return { kind: inferred, label: LABEL[inferred], isRecorded: false };
+};

--- a/apps/desktop/src/features/session/resolver-reported-shas.test.ts
+++ b/apps/desktop/src/features/session/resolver-reported-shas.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, ProviderRunId, TurnEvent } from '@goodboy/types';
+import { resolverReportedShas } from './resolver-reported-shas';
+
+const at = '2026-07-25T10:00:00.000Z' as IsoDateTime;
+
+const delta = ({ run, text }: { readonly run: string; readonly text: string }): TurnEvent => ({
+  kind: 'assistant_text',
+  runId: run as ProviderRunId,
+  delta: text,
+  at,
+});
+
+describe('resolverReportedShas', () => {
+  it('reassembles a marker split across streaming deltas', () => {
+    const shas = resolverReportedShas({
+      events: [
+        delta({ run: 'run-1', text: '<<comment-resolved threadId="PRRT_1" ' }),
+        delta({ run: 'run-1', text: 'commit="abc1234">>' }),
+      ],
+    });
+
+    expect(shas).toEqual(['abc1234']);
+  });
+
+  it('reports one sha per turn instead of only the last turn', () => {
+    const shas = resolverReportedShas({
+      events: [
+        delta({ run: 'run-1', text: '<<comment-resolved threadId="PRRT_1" commit="aaa1111">>' }),
+        delta({ run: 'run-2', text: '<<comment-resolved threadId="PRRT_1" commit="bbb2222">>' }),
+      ],
+    });
+
+    expect(shas).toEqual(['aaa1111', 'bbb2222']);
+  });
+
+  it('ignores turns without a resolution marker', () => {
+    const shas = resolverReportedShas({
+      events: [delta({ run: 'run-1', text: 'looked into it, nothing to change' })],
+    });
+
+    expect(shas).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/session/resolver-reported-shas.ts
+++ b/apps/desktop/src/features/session/resolver-reported-shas.ts
@@ -1,0 +1,27 @@
+import { extractCommentResolved } from '@goodboy/core';
+import type { ProviderRunId, TurnEvent } from '@goodboy/types';
+
+type Params = {
+  readonly events: ReadonlyArray<TurnEvent>;
+};
+
+export const resolverReportedShas = ({ events }: Params): ReadonlyArray<string> => {
+  const textByRun = new Map<ProviderRunId, string>();
+  for (const event of events) {
+    if (event.kind !== 'assistant_text') {
+      continue;
+    }
+    textByRun.set(event.runId, `${textByRun.get(event.runId) ?? ''}${event.delta}`);
+  }
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const text of textByRun.values()) {
+    const marker = extractCommentResolved(text);
+    if (marker === null || seen.has(marker.commitSha)) {
+      continue;
+    }
+    seen.add(marker.commitSha);
+    out.push(marker.commitSha);
+  }
+  return out;
+};

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -2,6 +2,7 @@ import { invoke } from '@tauri-apps/api/core';
 import type {
   AgentEffort,
   AgentRole,
+  AgentSourceKind,
   IsoDateTime,
   ParallelMergeStrategy,
   ParallelGroup,
@@ -86,6 +87,7 @@ type RawAgentRow = {
   readonly verbosity: string | null;
   readonly sourceThreadId: string | null;
   readonly sourceCommentUrl: string | null;
+  readonly sourceKind: string | null;
 };
 
 function rowToStep(row: RawWorkflowStepRow): Step {
@@ -162,6 +164,7 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(row.verbosity != null && { verbosity: row.verbosity as VerbosityLevel }),
     ...(row.sourceThreadId != null && { sourceThreadId: row.sourceThreadId }),
     ...(row.sourceCommentUrl != null && { sourceCommentUrl: row.sourceCommentUrl }),
+    ...(row.sourceKind != null && { sourceKind: row.sourceKind as AgentSourceKind }),
   };
 }
 
@@ -292,6 +295,7 @@ export type AgentInsertArgs = {
   readonly verbosity?: VerbosityLevel;
   readonly sourceThreadId?: string;
   readonly sourceCommentUrl?: string;
+  readonly sourceKind?: AgentSourceKind;
 };
 
 export const invokeAgentInsert = async (run: AgentInsertArgs): Promise<Agent> => {
@@ -313,6 +317,7 @@ export const invokeAgentInsert = async (run: AgentInsertArgs): Promise<Agent> =>
       verbosity: run.verbosity ?? null,
       sourceThreadId: run.sourceThreadId ?? null,
       sourceCommentUrl: run.sourceCommentUrl ?? null,
+      sourceKind: run.sourceKind ?? null,
     },
   });
   return rowToAgent(row);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/lib.ts
@@ -15,7 +15,7 @@ export const pluralize = (count: number, singular: string) =>
 
 export type WorkflowBlockReason = 'questions' | 'summarizer' | 'failed-step';
 
-export type ResolverState = 'awaiting' | 'committed' | 'wontfix' | 'analyzed';
+export type ResolverState = 'awaiting' | 'committed' | 'wontfix' | 'analyzed' | 'stopped';
 export type ResolverStatus =
   | 'running'
   | 'failed'
@@ -25,6 +25,7 @@ export type ResolverStatus =
   | 'analyzed'
   | 'wontfix'
   | 'awaiting'
+  | 'stopped'
   | 'done';
 
 export function resolverStatus(
@@ -48,6 +49,9 @@ export function resolverStatus(
   }
   if (state === 'committed' || (tid != null && pendingThreadIds.has(tid))) {
     return 'committed';
+  }
+  if (state === 'stopped') {
+    return 'stopped';
   }
   if (state === 'analyzed') {
     return 'analyzed';

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -36,7 +36,7 @@ import { WorkflowStartButton } from './WorkflowStartButton';
 import { CollapsedSummary } from './CollapsedSummary';
 import { AdHocRow } from './AdHocRow';
 import { WorkflowRow } from './WorkflowRow';
-import { pluralize, workflowKindName, type WorkflowBlockReason } from '../lib';
+import { pluralize, workflowKindName, type ResolverState, type WorkflowBlockReason } from '../lib';
 
 type Props = {
   task: Session;
@@ -44,6 +44,8 @@ type Props = {
   workflowRunId?: WorkflowRunId;
   workflowVariant?: 'sidebar' | 'detail';
   showWorkflowAttach?: boolean;
+  inspectedResolverId?: AgentId | null;
+  onInspectResolver?: (agentId: AgentId) => void;
 };
 
 export const AgentsSection = ({
@@ -52,6 +54,8 @@ export const AgentsSection = ({
   workflowRunId,
   workflowVariant = 'sidebar',
   showWorkflowAttach = true,
+  inspectedResolverId = null,
+  onInspectResolver,
 }: Props) => {
   const showWorkflows = only == null || only === 'workflows';
   const showAgents = only == null || only === 'agents';
@@ -113,7 +117,7 @@ export const AgentsSection = ({
   );
   const resolverState = useAppStore(
     useShallow((s) => {
-      const out: Record<string, 'awaiting' | 'committed' | 'wontfix' | 'analyzed'> = {};
+      const out: Record<string, ResolverState> = {};
       const runs = s.sessionPhaseRuns[task.id];
       if (!runs) {
         return out;
@@ -700,9 +704,11 @@ export const AgentsSection = ({
               metrics={metrics}
               isTranscriptLoading={loading.transcript}
               selectedAgentId={selectedAgentId}
+              inspectedAgentId={inspectedResolverId}
               expanded={forceExpanded || resolveExpanded}
               onToggle={() => setResolveExpanded((v) => !v)}
               onSelect={onPickAgent}
+              onInspect={onInspectResolver}
               onForceNext={() => void activateNextResolver(task.id)}
               onResolveThread={onResolveThread}
             />

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
@@ -19,9 +19,11 @@ type ResolveClusterProps = {
   readonly metrics: AgentMetrics;
   readonly isTranscriptLoading: boolean;
   readonly selectedAgentId: AgentId | null;
+  readonly inspectedAgentId?: AgentId | null;
   readonly expanded: boolean;
   readonly onToggle: () => void;
   readonly onSelect: (id: AgentId) => void;
+  readonly onInspect?: (id: AgentId) => void;
   readonly onForceNext: () => void;
   readonly onResolveThread: (threadId: string) => Promise<void> | void;
 };
@@ -39,9 +41,11 @@ export const ResolveCluster = ({
   metrics,
   isTranscriptLoading,
   selectedAgentId,
+  inspectedAgentId = null,
   expanded,
   onToggle,
   onSelect,
+  onInspect,
   onForceNext,
   onResolveThread,
 }: ResolveClusterProps) => {
@@ -144,8 +148,10 @@ export const ResolveCluster = ({
                 isSelected={agent.id === selectedAgentId}
                 isTaskActive={isTaskActive}
                 canJump={agent.sourceThreadId != null || agent.sourceCommentUrl != null}
+                isInspected={agent.id === inspectedAgentId}
                 onSelect={() => onSelect(agent.id)}
                 onJump={() => jump(agent)}
+                onInspect={onInspect === undefined ? undefined : () => onInspect(agent.id)}
                 onResolveThread={onResolveThread}
               />
             );

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
@@ -12,6 +12,10 @@ vi.mock('../../../../session/components/ForceResolveAction', () => ({
   ForceResolveAction: () => null,
 }));
 
+vi.mock('../../../../session/components/ForceCloseResolverAction', () => ({
+  ForceCloseResolverAction: () => null,
+}));
+
 import { ResolveClusterRow } from './ResolveClusterRow';
 
 const SID = 'sess-1' as SessionId;

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { StatusDot, cn } from '@goodboy/ui';
-import { MessageSquareReply, Upload } from 'lucide-react';
+import { MessageSquareReply, PanelRight, Upload } from 'lucide-react';
 import type { Agent, DiffComment, PrComment, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread } from '../../../../../store';
 import {
@@ -15,6 +15,9 @@ import {
 } from '../../../../session/components/AgentMetricsBlock';
 import { AgentMetricsInline } from '../../../../session/components/AgentMetricsInline';
 import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
+import { ForceCloseResolverAction } from '../../../../session/components/ForceCloseResolverAction';
+import { diffCommentLocation } from '../../../../session/diff-comment-location';
+import { prCommentLocation } from '../../../../session/pr-comment-location';
 import type { ResolverStatus } from '../lib';
 
 type Props = {
@@ -32,26 +35,11 @@ type Props = {
   readonly isSelected: boolean;
   readonly isTaskActive: boolean;
   readonly canJump: boolean;
+  readonly isInspected?: boolean;
   readonly onSelect: () => void;
   readonly onJump: () => void;
+  readonly onInspect?: () => void;
   readonly onResolveThread: (threadId: string) => Promise<void> | void;
-};
-
-const diffLocation = (comment: DiffComment): string => {
-  if (comment.anchor == null) {
-    return comment.filePath;
-  }
-  return `${comment.filePath}:${comment.anchor.lineNumber}`;
-};
-
-const commentLocation = (comment: PrComment): string | null => {
-  if (comment.source === 'issue') {
-    return 'conversation';
-  }
-  if (comment.path == null) {
-    return null;
-  }
-  return comment.line != null ? `${comment.path}:${comment.line}` : comment.path;
 };
 
 export const ResolveClusterRow = ({
@@ -69,8 +57,10 @@ export const ResolveClusterRow = ({
   isSelected,
   isTaskActive,
   canJump,
+  isInspected = false,
   onSelect,
   onJump,
+  onInspect,
   onResolveThread,
 }: Props) => {
   const hasUnread = agentHasUnread(agent, isSelected && isTaskActive);
@@ -90,11 +80,14 @@ export const ResolveClusterRow = ({
   const snippet = threadComment ? (
     <CommentSnippet
       author={threadComment.author}
-      location={commentLocation(threadComment)}
+      location={prCommentLocation({ comment: threadComment })}
       body={threadComment.body}
     />
   ) : diffComment ? (
-    <CommentSnippet location={diffLocation(diffComment)} body={diffComment.body} />
+    <CommentSnippet
+      location={diffCommentLocation({ comment: diffComment })}
+      body={diffComment.body}
+    />
   ) : null;
   return (
     <div
@@ -128,6 +121,24 @@ export const ResolveClusterRow = ({
           {agent.name}
         </span>
         <ResolverStateBadge state={resolverBadgeState(status)} />
+        {onInspect !== undefined ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onInspect();
+            }}
+            title="Inspect resolver"
+            aria-label="Inspect resolver"
+            aria-pressed={isInspected}
+            className={cn(
+              'shrink-0 rounded-md p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground',
+              isInspected && 'bg-foreground/10 text-foreground',
+            )}
+          >
+            <PanelRight size={11} aria-hidden />
+          </button>
+        ) : null}
         {canJump ? (
           <button
             type="button"
@@ -137,7 +148,7 @@ export const ResolveClusterRow = ({
             }}
             title="Go to comment"
             aria-label="Go to comment"
-            className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
+            className="shrink-0 rounded-md p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground"
           >
             <MessageSquareReply size={11} aria-hidden />
           </button>
@@ -179,7 +190,8 @@ export const ResolveClusterRow = ({
           </button>
         </div>
       ) : null}
-      <div className="pl-7">
+      <div className="flex items-center justify-end gap-1.5 pl-7">
+        <ForceCloseResolverAction agent={agent} sessionId={agent.sessionId} status={status} />
         <ForceResolveAction agent={agent} sessionId={agent.sessionId} status={status} />
       </div>
     </div>

--- a/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
+++ b/apps/desktop/src/store/slices/agents/activateNextResolver.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+import { activateNextResolver } from './activateNextResolver';
+
+const SID = 'sess-1' as SessionId;
+const FIRST = 'resolver-1' as AgentId;
+const SECOND = 'resolver-2' as AgentId;
+
+const resolver = (over: Partial<Agent> & { id: AgentId }): Agent => ({
+  sessionId: SID,
+  ordinal: 0,
+  name: 'resolve: reviewer on a.ts:1',
+  status: 'pending',
+  kind: 'resolver',
+  ...over,
+});
+
+const makeStore = ({
+  agents,
+  pendingResolverKickoff,
+}: {
+  readonly agents: ReadonlyArray<Agent>;
+  readonly pendingResolverKickoff: Record<string, string>;
+}) => {
+  const sendTurn = vi.fn(async () => undefined);
+  const selectAgent = vi.fn(async () => undefined);
+  const state: Record<string, unknown> = {
+    sessionPhaseRuns: { [SID]: agents },
+    agentKindOverride: {},
+    pendingResolverKickoff,
+    sendTurn,
+    selectAgent,
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((u: unknown) => {
+    const patch =
+      typeof u === 'function'
+        ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (u as Record<string, unknown>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  return { state, get, set, sendTurn, selectAgent };
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('activateNextResolver', () => {
+  it('starts the lowest ordinal queued resolver and consumes its kickoff', async () => {
+    const { state, get, set, sendTurn, selectAgent } = makeStore({
+      agents: [resolver({ id: SECOND, ordinal: 2 }), resolver({ id: FIRST, ordinal: 1 })],
+      pendingResolverKickoff: { [FIRST]: 'fix comment one', [SECOND]: 'fix comment two' },
+    });
+
+    await activateNextResolver(set, get)(SID);
+
+    expect(selectAgent).toHaveBeenCalledWith(SID, FIRST);
+    expect(sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: FIRST, content: 'fix comment one' }),
+    );
+    expect((state.pendingResolverKickoff as Record<string, string>)[FIRST]).toBeUndefined();
+  });
+
+  it('keeps one resolver at a time while another is running', async () => {
+    const { get, set, sendTurn } = makeStore({
+      agents: [
+        resolver({ id: FIRST, ordinal: 1, status: 'running' }),
+        resolver({ id: SECOND, ordinal: 2 }),
+      ],
+      pendingResolverKickoff: { [SECOND]: 'fix comment two' },
+    });
+
+    await activateNextResolver(set, get)(SID);
+
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('skips a queued resolver that has no kickoff waiting', async () => {
+    const { get, set, sendTurn } = makeStore({
+      agents: [resolver({ id: FIRST, ordinal: 1 })],
+      pendingResolverKickoff: {},
+    });
+
+    await activateNextResolver(set, get)(SID);
+
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+
+  it('ignores a force closed resolver when picking the next one', async () => {
+    const { get, set, sendTurn } = makeStore({
+      agents: [
+        resolver({ id: FIRST, ordinal: 1, status: 'skipped' }),
+        resolver({ id: SECOND, ordinal: 2 }),
+      ],
+      pendingResolverKickoff: { [SECOND]: 'fix comment two' },
+    });
+
+    await activateNextResolver(set, get)(SID);
+
+    expect(sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: SECOND, content: 'fix comment two' }),
+    );
+  });
+});

--- a/apps/desktop/src/store/slices/agents/forceCloseResolver.test.ts
+++ b/apps/desktop/src/store/slices/agents/forceCloseResolver.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Agent, AgentId, ProviderRunId, SessionId } from '@goodboy/types';
+import type { GetFn, SetFn } from './types';
+
+const hoisted = vi.hoisted(() => ({
+  cancelTurn: vi.fn(async () => undefined),
+  invokeAgentUpdateStatus: vi.fn(async () => undefined),
+  invokeAgentList: vi.fn(async () => [] as ReadonlyArray<Agent>),
+  updateSessionState: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../features/chat/turn', () => ({ cancelTurn: hoisted.cancelTurn }));
+vi.mock('../../../features/workflows/workflows', () => ({
+  invokeAgentUpdateStatus: hoisted.invokeAgentUpdateStatus,
+  invokeAgentList: hoisted.invokeAgentList,
+}));
+vi.mock('@goodboy/db', () => ({ updateSessionState: hoisted.updateSessionState }));
+vi.mock('../../../shared/lib/db', () => ({ tauriDatabase: {} }));
+
+import { activateNextResolver } from './activateNextResolver';
+import { forceCloseResolver } from './forceCloseResolver';
+
+const SID = 'sess-1' as SessionId;
+const STUCK = 'resolver-1' as AgentId;
+const NEXT = 'resolver-2' as AgentId;
+const RUN = 'run-1' as ProviderRunId;
+
+const resolver = (over: Partial<Agent> & { id: AgentId }): Agent => ({
+  sessionId: SID,
+  ordinal: 0,
+  name: 'resolve: reviewer on a.ts:1',
+  status: 'pending',
+  kind: 'resolver',
+  ...over,
+});
+
+const makeStore = () => {
+  const sendTurn = vi.fn(async () => undefined);
+  const selectAgent = vi.fn(async () => undefined);
+  const state: Record<string, unknown> = {
+    sessionPhaseRuns: {
+      [SID]: [
+        resolver({ id: STUCK, status: 'running', ordinal: 0 }),
+        resolver({ id: NEXT, status: 'pending', ordinal: 1 }),
+      ],
+    },
+    agentTurnState: {
+      [STUCK]: { kind: 'running', runId: RUN, startedAt: '2026-07-25T09:00:00.000Z' },
+    },
+    agentKindOverride: {},
+    resolverState: {},
+    pendingResolverKickoff: { [NEXT]: 'resolve the next comment' },
+    sessions: [{ id: SID, state: { kind: 'idle', lastActivityAt: '2026-07-25T09:00:00.000Z' } }],
+    sendTurn,
+    selectAgent,
+  };
+  const get = (() => state) as unknown as GetFn;
+  const set = ((u: unknown) => {
+    const patch =
+      typeof u === 'function'
+        ? (u as (s: Record<string, unknown>) => Record<string, unknown>)(state)
+        : (u as Record<string, unknown>);
+    Object.assign(state, patch);
+  }) as unknown as SetFn;
+  state.activateNextResolver = activateNextResolver(set, get);
+  return { state, get, set, sendTurn, selectAgent };
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('forceCloseResolver', () => {
+  it('cancels the live run of the stuck resolver', async () => {
+    const { get, set } = makeStore();
+    hoisted.invokeAgentList.mockResolvedValue([
+      resolver({ id: STUCK, status: 'skipped', ordinal: 0 }),
+      resolver({ id: NEXT, status: 'pending', ordinal: 1 }),
+    ]);
+
+    await forceCloseResolver(set, get)(SID, STUCK);
+
+    expect(hoisted.cancelTurn).toHaveBeenCalledWith(RUN);
+    expect(hoisted.invokeAgentUpdateStatus).toHaveBeenCalledWith(
+      STUCK,
+      expect.objectContaining({ status: 'skipped' }),
+    );
+  });
+
+  it('marks the resolver stopped and leaves its turn idle', async () => {
+    const { state, get, set } = makeStore();
+    hoisted.invokeAgentList.mockResolvedValue([
+      resolver({ id: STUCK, status: 'skipped', ordinal: 0 }),
+    ]);
+
+    await forceCloseResolver(set, get)(SID, STUCK);
+
+    expect((state.resolverState as Record<string, string>)[STUCK]).toBe('stopped');
+    expect((state.agentTurnState as Record<string, { kind: string }>)[STUCK]?.kind).toBe('idle');
+  });
+
+  it('frees the serial queue so the next queued resolver starts', async () => {
+    const { get, set, sendTurn } = makeStore();
+    hoisted.invokeAgentList.mockResolvedValue([
+      resolver({ id: STUCK, status: 'skipped', ordinal: 0 }),
+      resolver({ id: NEXT, status: 'pending', ordinal: 1 }),
+    ]);
+
+    await forceCloseResolver(set, get)(SID, STUCK);
+
+    expect(sendTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: NEXT, content: 'resolve the next comment' }),
+    );
+  });
+
+  it('leaves the queue untouched while the stuck resolver is still running', async () => {
+    const { get, set, sendTurn } = makeStore();
+
+    await activateNextResolver(set, get)(SID);
+
+    expect(sendTurn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/store/slices/agents/forceCloseResolver.ts
+++ b/apps/desktop/src/store/slices/agents/forceCloseResolver.ts
@@ -1,0 +1,32 @@
+import type { AgentId, IsoDateTime, SessionId, TurnState } from '@goodboy/types';
+import { updateSessionState } from '@goodboy/db';
+import { tauriDatabase } from '../../../shared/lib/db';
+import { cancelTurn } from '../../../features/chat/turn';
+import { invokeAgentList, invokeAgentUpdateStatus } from '../../../features/workflows/workflows';
+import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
+import type { GetFn, SetFn } from './types';
+
+export const forceCloseResolver = (set: SetFn, get: GetFn) => {
+  return async (sessionId: SessionId, agentId: AgentId): Promise<void> => {
+    const turnState = get().agentTurnState[agentId];
+    if (turnState?.kind === 'running') {
+      cancelledRunIds.add(turnState.runId);
+      await cancelTurn(turnState.runId).catch(() => undefined);
+    }
+    const now = new Date().toISOString() as IsoDateTime;
+    await invokeAgentUpdateStatus(agentId, { status: 'skipped', completedAt: now }).catch(
+      () => undefined,
+    );
+    const refreshed = await invokeAgentList(sessionId).catch(() => null);
+    set((state) => ({
+      resolverState: { ...state.resolverState, [agentId]: 'stopped' },
+      ...(refreshed !== null && {
+        sessionPhaseRuns: { ...state.sessionPhaseRuns, [sessionId]: refreshed },
+      }),
+    }));
+    const idleState: TurnState = { kind: 'idle', lastActivityAt: now };
+    const derived = applyAgentTurnState(set, sessionId, agentId, idleState, now);
+    await updateSessionState(tauriDatabase, sessionId, derived, now).catch(() => undefined);
+    await get().activateNextResolver(sessionId);
+  };
+};

--- a/apps/desktop/src/store/slices/agents/index.ts
+++ b/apps/desktop/src/store/slices/agents/index.ts
@@ -4,6 +4,7 @@ import { clearAgentDraft } from './clearAgentDraft';
 import { clearAgentQueue } from './clearAgentQueue';
 import { deleteAgent } from './deleteAgent';
 import { deselectAgent } from './deselectAgent';
+import { forceCloseResolver } from './forceCloseResolver';
 import { markAgentViewed } from './markAgentViewed';
 import { renameAgent } from './renameAgent';
 import { selectAgent } from './selectAgent';
@@ -32,5 +33,6 @@ export const createAgentsSlice = (set: SetFn, get: GetFn) => {
     spawnAgent: spawnAgent(set, get),
     deleteAgent: deleteAgent(set, get),
     activateNextResolver: activateNextResolver(set, get),
+    forceCloseResolver: forceCloseResolver(set, get),
   };
 };

--- a/apps/desktop/src/store/slices/agents/spawnAgent.ts
+++ b/apps/desktop/src/store/slices/agents/spawnAgent.ts
@@ -1,5 +1,6 @@
 import type {
   AgentId,
+  AgentSourceKind,
   IsoDateTime,
   PlanId,
   PlanWithCount,
@@ -36,6 +37,7 @@ type SpawnArgs = {
   kindOverride?: AgentKind;
   sourceThreadId?: string;
   sourceCommentUrl?: string;
+  sourceKind?: AgentSourceKind;
   deferKickoff?: boolean;
 };
 
@@ -97,6 +99,7 @@ export const spawnAgent = (set: SetFn, get: GetFn) => {
       ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
       ...(args.sourceThreadId !== undefined && { sourceThreadId: args.sourceThreadId }),
       ...(args.sourceCommentUrl !== undefined && { sourceCommentUrl: args.sourceCommentUrl }),
+      ...(args.sourceKind !== undefined && { sourceKind: args.sourceKind }),
     });
     const refreshed = await invokeAgentList(sessionId);
     set((s) => ({

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -9,6 +9,7 @@ import {
 } from '@goodboy/db';
 import type {
   AgentId,
+  AgentSourceKind,
   BudgetAlert,
   BudgetRule,
   ClaudePermissionMode,
@@ -328,10 +329,12 @@ export type AppActions = {
       kindOverride?: AgentKind;
       sourceThreadId?: string;
       sourceCommentUrl?: string;
+      sourceKind?: AgentSourceKind;
       deferKickoff?: boolean;
     },
   ): Promise<AgentId>;
   activateNextResolver(sessionId: SessionId): Promise<void>;
+  forceCloseResolver(sessionId: SessionId, agentId: AgentId): Promise<void>;
   renameAgent(sessionId: SessionId, agentId: AgentId, name: string): Promise<void>;
   setAgentKind(agentId: AgentId, kind: AgentKind): void;
   setAgentEffortOverride(agentId: AgentId, effort: string): void;

--- a/apps/desktop/src/store/types.ts
+++ b/apps/desktop/src/store/types.ts
@@ -45,6 +45,7 @@ import type {
   WorkspaceScriptId,
 } from '@goodboy/types';
 import type { AgentKind } from '../features/session/agent-kind';
+import type { ResolverState } from '../features/workspace/components/WorkspacesSidebar/lib';
 import type { GitlabMergeRequest } from '../features/integrations/gitlab/client';
 import type {
   ProviderAuthResults,
@@ -227,9 +228,7 @@ export type AppState = UpdaterState & {
   readonly agentEffortOverride: Readonly<Record<AgentId, string>>;
   readonly agentKindOverride: Readonly<Record<AgentId, AgentKind>>;
   readonly pendingResolverKickoff: Readonly<Record<AgentId, string>>;
-  readonly resolverState: Readonly<
-    Record<AgentId, 'awaiting' | 'committed' | 'wontfix' | 'analyzed'>
-  >;
+  readonly resolverState: Readonly<Record<AgentId, ResolverState>>;
   readonly agentDraft: Readonly<Record<AgentId, string>>;
   readonly workflowDrafts: Readonly<Record<SessionId, WorkflowBuilderDraft | undefined>>;
   readonly agentAttachments: Readonly<Record<AgentId, ReadonlyArray<DraftAttachment>>>;

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -73,6 +73,7 @@ import { m072TaskModels } from './m072-task-models';
 import { m073SessionExternalTaskGithubProvider } from './m073-session-external-task-github-provider';
 import { m074NotificationAction } from './m074-notification-action';
 import { m075PrReviewDrafts } from './m075-pr-review-drafts';
+import { m076AgentSourceKind } from './m076-agent-source-kind';
 
 export type Migration = {
   readonly version: number;
@@ -155,4 +156,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 73, sql: m073SessionExternalTaskGithubProvider },
   { version: 74, sql: m074NotificationAction },
   { version: 75, sql: m075PrReviewDrafts },
+  { version: 76, sql: m076AgentSourceKind },
 ];

--- a/packages/db/src/migrations/m076-agent-source-kind.ts
+++ b/packages/db/src/migrations/m076-agent-source-kind.ts
@@ -1,0 +1,11 @@
+export const m076AgentSourceKind = /* sql */ `
+ALTER TABLE agents ADD COLUMN source_kind TEXT;
+
+UPDATE agents
+SET source_kind = CASE
+  WHEN source_thread_id IS NOT NULL THEN 'review_comment'
+  WHEN source_comment_url IS NOT NULL THEN 'issue_comment'
+  ELSE source_kind
+END
+WHERE source_thread_id IS NOT NULL OR source_comment_url IS NOT NULL;
+`;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -103,6 +103,7 @@ export type {
   Agent,
   AgentEffort,
   AgentRole,
+  AgentSourceKind,
   AgentStatus,
   ParallelAgent,
   ParallelMergeStrategy,

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -30,6 +30,8 @@ export type AgentRole =
 
 export type AgentStatus = 'pending' | 'running' | 'completed' | 'failed' | 'skipped';
 
+export type AgentSourceKind = 'review_comment' | 'issue_comment' | 'diff_comment';
+
 export type ParallelMergeStrategy = 'last_write_wins' | 'manual' | 'synthesizer_driven';
 
 export type StepDef = Readonly<{
@@ -101,6 +103,7 @@ export type Agent = Readonly<{
   kind?: string;
   sourceThreadId?: string;
   sourceCommentUrl?: string;
+  sourceKind?: AgentSourceKind;
 }>;
 
 export type ParallelGroup = {


### PR DESCRIPTION
Resolve had the highest potential in the app and the least exploited. You could not close a stuck resolver, you could not see what one had changed, and the origin of each was known to the code but nearly invisible.

## A stuck resolver could not be closed, and the reason is worse than it looked

Grepping `stop|abort|kill|cancel|terminate` across the entire resolve feature returned **zero matches**. Three things conspired:

- `ForceResolveAction` is the button you reach for and the wrong one: it marks the GitHub **thread** resolved and is disabled while the turn runs. It never touches the agent or the process.
- `deleteAgent` is unreachable for resolvers: both lists that receive it filter resolvers out.
- "Run next" cannot help, because `activateNextResolver` returns early if any resolver is running, by design.

And the actual root cause, which my own brief had wrong: cancelling a turn **never writes a terminal agent status**. The cancelled branch only refreshes the list, so the row stays `running` in the DB forever. That is why force close has to stamp the status rather than just cancel the run.

Force close now cancels the run, stamps the row, marks the resolver stopped and frees the serial queue. It sits next to `ForceResolveAction` and is visibly distinct, because these are two different intents and only the wrong one existed. The serial queue itself is untouched: one resolver at a time is settled, since they all commit to the same worktree.

## What a resolver changed is now visible

A right panel in the Resolve lens, three sections, one question each, using the same shape as the session-summary history panel:

- **Where it came from.** The origin, the comment itself, and a link back to it.
- **What it changed.** Files touched, then commits.
- **What state it is in.** State, queue position (`N of M`), and an explicit reason when it is blocked ("X is still running", "no queued kickoff").

### Commits are labeled, not guessed

Two sources, deliberately never merged into one confident list:

1. **Reported**: the resolver's own `<<comment-resolved commit="...">>` marker, reassembled from the assistant deltas and then **verified to exist in the branch log**. A sha it claimed that is not in the log gets its own bucket rather than being shown as landed.
2. **Landed while it ran**: branch commits inside the agent's run window, shown under "author not verified".

I did not use `pending_resolutions.commit_sha`, which the brief suggested: `pushAllResolutions` deletes that row on push, so it disappears exactly when the work lands. And I did not add a commit-to-agent link table. Labeling the uncertainty is honest; a column would imply an attribution git does not give us.

## Origin is recorded instead of inferred

Migration **m076** adds `agents.source_kind`, backfilled from the columns that already existed (thread present means review comment, url only means conversation comment). Every spawn path now sets it, including the inline diff comment path that recorded nothing at all and the mobile path the brief did not list. When a resolver predates this, the panel tags the origin as inferred rather than pretending.

## Dead infrastructure removed

`resolverOutcome()` and `SpawnNode.resolver` are gone: they made the feature look like it existed. `SpawnNode.resolver` did have one consumer, an assertion in a test, contrary to my brief's "zero callers". `SpawnTree/lib.ts` stays, because the rest of it is genuinely used.

## Not done here, and one thing I want to be straight about

- **A GitLab MR resolver still does not exist, and it is not cheap.** The MR panel only spawns an MR-creation agent. A resolver would need a notes list UI, a prompt builder, a new source kind and GitLab discussion-resolve plumbing. Out of scope, and I did not fake a start on it.
- `resolverState` is in-memory, like `awaiting` and `analyzed` already are, so after an app restart a force-closed resolver reads as done (the skipped row persists). Persisting it needs another column.
- Force close is offered while a resolver is running; dropping a still-queued one from the queue is not offered.
- The changes hook could not be a plain store selector: `transcripts[agentId]` is only populated by `selectAgent`, so a resolver you never opened has nothing in the store, and the existing loader also overwrites the session's messages. It reads the store when present and queries the agent's events otherwise.

## Tests

desktop 2443 -> 2475, core unchanged, db 90 unchanged with the migration runner green, Rust 99 unchanged, typecheck clean. New coverage on origin resolution, commit attribution, reported-sha reassembly, `activateNextResolver`, force close, and the panel. `activateNextResolver`, `ResolveCluster`, `ResolveClusterRow` and `canForceResolve` had no test file at all before.
