### PR TITLE
feat(desktop): override agent roles from the providers page, and persist the overrides at all

### DIFF
--- a/apps/desktop/src-tauri/src/settings_overrides.rs
+++ b/apps/desktop/src-tauri/src/settings_overrides.rs
@@ -17,18 +17,22 @@ pub struct SettingsOverrides {
     pub default_verbosity: Option<String>,
     #[serde(rename = "providerBindings")]
     pub provider_bindings: Option<serde_json::Value>,
+    #[serde(rename = "taskModels")]
+    pub task_models: Option<serde_json::Value>,
+    #[serde(rename = "roleModels")]
+    pub role_models: Option<serde_json::Value>,
     #[serde(rename = "scoutFanout")]
     pub scout_fanout: Option<bool>,
 }
 
-fn bindings_to_text(value: &Option<serde_json::Value>) -> Option<String> {
+fn json_to_text(value: &Option<serde_json::Value>) -> Option<String> {
     match value {
         Some(serde_json::Value::Null) | None => None,
         Some(v) => Some(v.to_string()),
     }
 }
 
-fn bindings_from_text(raw: Option<String>) -> Option<serde_json::Value> {
+fn json_from_text(raw: Option<String>) -> Option<serde_json::Value> {
     raw.and_then(|s| serde_json::from_str(&s).ok())
 }
 
@@ -39,19 +43,21 @@ pub fn get_workspace_overrides(
 ) -> Result<Option<SettingsOverrides>, DbError> {
     let conn = state.0.lock().map_err(|_| DbError::Poisoned)?;
     let mut stmt = conn.prepare(
-        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, scout_fanout
+        "SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, task_models, role_models, scout_fanout
          FROM workspaces WHERE id = ?1",
     )?;
     let mut rows = stmt.query_map(rusqlite::params![workspace_id], |row| {
         let parallel_raw: Option<i64> = row.get(3)?;
-        let scout_raw: Option<i64> = row.get(6)?;
+        let scout_raw: Option<i64> = row.get(8)?;
         Ok(SettingsOverrides {
             default_provider_id: row.get(0)?,
             default_workflow_id: row.get(1)?,
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
             default_verbosity: row.get(4)?,
-            provider_bindings: bindings_from_text(row.get(5)?),
+            provider_bindings: json_from_text(row.get(5)?),
+            task_models: json_from_text(row.get(6)?),
+            role_models: json_from_text(row.get(7)?),
             scout_fanout: scout_raw.map(|v| v != 0),
         })
     })?;
@@ -79,16 +85,20 @@ pub fn set_workspace_overrides(
              parallel_enabled = ?4,
              default_verbosity = ?5,
              provider_bindings = ?6,
-             scout_fanout = ?7,
-             updated_at = ?8
-         WHERE id = ?9",
+             task_models = ?7,
+             role_models = ?8,
+             scout_fanout = ?9,
+             updated_at = ?10
+         WHERE id = ?11",
         rusqlite::params![
             overrides.default_provider_id,
             overrides.default_workflow_id,
             overrides.default_branch_prefix,
             parallel_val,
             overrides.default_verbosity,
-            bindings_to_text(&overrides.provider_bindings),
+            json_to_text(&overrides.provider_bindings),
+            json_to_text(&overrides.task_models),
+            json_to_text(&overrides.role_models),
             scout_val,
             now,
             workspace_id,
@@ -115,7 +125,9 @@ pub fn get_session_overrides(
             default_branch_prefix: row.get(2)?,
             parallel_enabled: parallel_raw.map(|v| v != 0),
             default_verbosity: None,
-            provider_bindings: bindings_from_text(row.get(4)?),
+            provider_bindings: json_from_text(row.get(4)?),
+            task_models: None,
+            role_models: None,
             scout_fanout: None,
         })
     })?;
@@ -148,7 +160,7 @@ pub fn set_session_overrides(
             overrides.default_workflow_id,
             overrides.default_branch_prefix,
             parallel_val,
-            bindings_to_text(&overrides.provider_bindings),
+            json_to_text(&overrides.provider_bindings),
             now,
             session_id,
         ],

--- a/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrDetailPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../chat/spawn-from-comment';
 import { useResolverIndex } from '../../../session/hooks/useResolverIndex';
 import { resolverForComment, type ResolverLink } from '../../../session/resolver-linkage';
+import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import { openUrl } from '../../../../shared/lib/editor';
 import { formatError } from '../../../../shared/lib/errors';
 import { useAppStore, useSessions } from '../../../../store';
@@ -45,6 +46,7 @@ export const PrDetailPanel = ({
     return ws?.rootPath ?? null;
   });
   const workspaceId = session?.workspaceId;
+  const roleModels = useSessionRoleModels({ sessionId });
   const refreshSessionPrDetail = useAppStore((s) => s.refreshSessionPrDetail);
   const refreshSessionPr = useAppStore((s) => s.refreshSessionPr);
   const markPrReady = useAppStore((s) => s.markPrReady);
@@ -429,6 +431,7 @@ export const PrDetailPanel = ({
                     onSpawnOne={onSpawnOne}
                     onSpawnBatch={onSpawnBatch}
                     onOpenResolver={openResolver}
+                    roleModels={roleModels}
                     onOpenThread={(threadId) => {
                       setJumpThreadId(threadId);
                       setSection('comments');

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.test.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_CONFIG, aggregateConfig, clampEffort, configFor, sameConfig } from './config';
+import { aggregateConfig, clampEffort, configFor, defaultConfig, sameConfig } from './config';
+
+const DEFAULT_CONFIG = defaultConfig({ roleModels: null });
 
 describe('ResolveBoard config', () => {
   it('clampEffort keeps supported levels and falls back to the top for unsupported ones', () => {
@@ -12,11 +14,11 @@ describe('ResolveBoard config', () => {
   });
 
   it('configFor seeds the resolver default model for anthropic', () => {
-    expect(configFor('anthropic')).toEqual(DEFAULT_CONFIG);
+    expect(configFor({ provider: 'anthropic', base: DEFAULT_CONFIG })).toEqual(DEFAULT_CONFIG);
   });
 
   it('configFor uses the provider default model for non-anthropic', () => {
-    const cfg = configFor('codex');
+    const cfg = configFor({ provider: 'codex', base: DEFAULT_CONFIG });
     expect(cfg.provider).toBe('codex');
     expect(cfg.model).not.toBe(DEFAULT_CONFIG.model);
   });
@@ -27,10 +29,18 @@ describe('ResolveBoard config', () => {
   });
 
   it('aggregateConfig returns the shared config when uniform, else mixed', () => {
-    expect(aggregateConfig([DEFAULT_CONFIG, { ...DEFAULT_CONFIG }])).toEqual(DEFAULT_CONFIG);
-    expect(aggregateConfig([DEFAULT_CONFIG, { ...DEFAULT_CONFIG, model: 'claude-opus-4-5' }])).toBe(
-      'mixed',
-    );
-    expect(aggregateConfig([])).toEqual(DEFAULT_CONFIG);
+    expect(
+      aggregateConfig({
+        configs: [DEFAULT_CONFIG, { ...DEFAULT_CONFIG }],
+        fallback: DEFAULT_CONFIG,
+      }),
+    ).toEqual(DEFAULT_CONFIG);
+    expect(
+      aggregateConfig({
+        configs: [DEFAULT_CONFIG, { ...DEFAULT_CONFIG, model: 'claude-opus-4-5' }],
+        fallback: DEFAULT_CONFIG,
+      }),
+    ).toBe('mixed');
+    expect(aggregateConfig({ configs: [], fallback: DEFAULT_CONFIG })).toEqual(DEFAULT_CONFIG);
   });
 });

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.ts
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/config.ts
@@ -1,4 +1,4 @@
-import type { ProviderId } from '@goodboy/types';
+import type { ProviderId, RoleModelPreferences } from '@goodboy/types';
 import { getDefaultTurnModel } from '@goodboy/core';
 import { clampEffort, type EffortLevel } from '../../../../chat/utils/chat-constants';
 import { kindRouting } from '../../../../session/agent-kind';
@@ -11,27 +11,38 @@ export type CardConfig = {
   readonly effort: EffortLevel;
 };
 
-const RESOLVER_ROUTING = kindRouting({ kind: 'resolver' });
-
-export const DEFAULT_CONFIG: CardConfig = {
-  provider: RESOLVER_ROUTING.provider,
-  model: RESOLVER_ROUTING.model,
-  effort: RESOLVER_ROUTING.effort,
+type DefaultParams = {
+  readonly roleModels: RoleModelPreferences | null;
 };
 
-export const configFor = (provider: ProviderId): CardConfig => {
-  const model = provider === 'anthropic' ? DEFAULT_CONFIG.model : getDefaultTurnModel(provider);
-  return { provider, model, effort: clampEffort(model, DEFAULT_CONFIG.effort) };
+export const defaultConfig = ({ roleModels }: DefaultParams): CardConfig => {
+  const routing = kindRouting({ kind: 'resolver', roleModels });
+  return { provider: routing.provider, model: routing.model, effort: routing.effort };
+};
+
+type ConfigForParams = {
+  readonly provider: ProviderId;
+  readonly base: CardConfig;
+};
+
+export const configFor = ({ provider, base }: ConfigForParams): CardConfig => {
+  const model = provider === base.provider ? base.model : getDefaultTurnModel(provider);
+  return { provider, model, effort: clampEffort(model, base.effort) };
 };
 
 export const sameConfig = (a: CardConfig, b: CardConfig): boolean => {
   return a.provider === b.provider && a.model === b.model && a.effort === b.effort;
 };
 
-export const aggregateConfig = (configs: ReadonlyArray<CardConfig>): CardConfig | 'mixed' => {
+type AggregateParams = {
+  readonly configs: ReadonlyArray<CardConfig>;
+  readonly fallback: CardConfig;
+};
+
+export const aggregateConfig = ({ configs, fallback }: AggregateParams): CardConfig | 'mixed' => {
   const first = configs[0];
-  if (!first) {
-    return DEFAULT_CONFIG;
+  if (first == null) {
+    return fallback;
   }
   return configs.every((c) => sameConfig(c, first)) ? first : 'mixed';
 };

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.test.tsx
@@ -54,6 +54,7 @@ describe('ResolveBoard', () => {
     const onSpawnBatch = vi.fn();
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
         onSpawnOne={vi.fn()}
         onSpawnBatch={onSpawnBatch}
@@ -80,6 +81,7 @@ describe('ResolveBoard', () => {
     const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[thread({ id: 'c1' })]}
         onSpawnOne={onSpawnOne}
         onSpawnBatch={vi.fn()}
@@ -100,6 +102,7 @@ describe('ResolveBoard', () => {
     const onSpawnOne = vi.fn<(thread: CommentThread, choice: ResolveModelChoice) => void>();
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[thread({ id: 'c1' })]}
         onSpawnOne={onSpawnOne}
         onSpawnBatch={vi.fn()}
@@ -133,6 +136,7 @@ describe('ResolveBoard', () => {
       >();
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[thread({ id: 'c1' }), thread({ id: 'c2', threadId: 'PRRT_2' })]}
         onSpawnOne={vi.fn()}
         onSpawnBatch={onSpawnBatch}
@@ -163,6 +167,7 @@ describe('ResolveBoard', () => {
   it('renders the head comment plus its replies as context', () => {
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[
           thread({ id: 'c1', body: 'main request' }, [
             comment({ id: 'r1', author: 'bob', body: 'agree, ship it' }),
@@ -181,6 +186,7 @@ describe('ResolveBoard', () => {
   it('renders an empty state when there are no open comments', () => {
     render(
       <ResolveBoard
+        roleModels={null}
         threads={[]}
         onSpawnOne={vi.fn()}
         onSpawnBatch={vi.fn()}

--- a/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/ResolveBoard/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, type ReactNode } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { AgentId, ProviderId } from '@goodboy/types';
+import type { AgentId, ProviderId, RoleModelPreferences } from '@goodboy/types';
 import { cn, EmptyState } from '@goodboy/ui';
 import {
   ArrowUpRight,
@@ -30,7 +30,7 @@ import {
 } from '../../../../session/components/ResolverStateBadge';
 import type { ResolverLink } from '../../../../session/resolver-linkage';
 import { useAppStore } from '../../../../../store';
-import { DEFAULT_CONFIG, aggregateConfig, clampEffort, configFor, type CardConfig } from './config';
+import { aggregateConfig, clampEffort, configFor, defaultConfig, type CardConfig } from './config';
 
 type Props = {
   readonly threads: ReadonlyArray<CommentThread>;
@@ -42,6 +42,7 @@ type Props = {
   ) => void;
   readonly onOpenResolver?: (agentId: AgentId) => void;
   readonly onOpenThread: (threadId: string) => void;
+  readonly roleModels: RoleModelPreferences | null;
 };
 
 const isClaimed = (link: ResolverLink | undefined): boolean =>
@@ -59,6 +60,7 @@ export const ResolveBoard = ({
   onSpawnBatch,
   onOpenResolver,
   onOpenThread,
+  roleModels,
 }: Props) => {
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
@@ -69,7 +71,8 @@ export const ResolveBoard = ({
   const [mode, setMode] = useState<ResolveMode>('fix');
   const [hint, setHint] = useState('');
 
-  const getConfig = (id: string): CardConfig => configById[id] ?? DEFAULT_CONFIG;
+  const base = useMemo(() => defaultConfig({ roleModels }), [roleModels]);
+  const getConfig = (id: string): CardConfig => configById[id] ?? base;
   const patchConfig = (id: string, next: CardConfig) =>
     setConfigById((prev) => ({ ...prev, [id]: next }));
   const applyToAll = (next: CardConfig) =>
@@ -84,7 +87,10 @@ export const ResolveBoard = ({
     [selectable, deselected],
   );
   const allSelected = selectable.length > 0 && selected.length === selectable.length;
-  const aggregate = aggregateConfig(threads.map((t) => getConfig(t.head.id)));
+  const aggregate = aggregateConfig({
+    configs: threads.map((t) => getConfig(t.head.id)),
+    fallback: base,
+  });
 
   if (threads.length === 0) {
     return (
@@ -151,7 +157,8 @@ export const ResolveBoard = ({
             <ConfigPanel
               className="absolute right-0 top-8 z-20 w-64"
               title="Apply to all comments"
-              config={aggregate === 'mixed' ? DEFAULT_CONFIG : aggregate}
+              config={aggregate === 'mixed' ? base : aggregate}
+              base={base}
               mode={mode}
               hint={hint}
               connectedProviders={connectedProviders}
@@ -188,6 +195,7 @@ export const ResolveBoard = ({
             <ResolveCard
               thread={t}
               config={getConfig(t.head.id)}
+              base={base}
               checked={!deselected.has(t.head.id)}
               link={resolverFor?.(t)}
               connectedProviders={connectedProviders}
@@ -213,6 +221,7 @@ export const ResolveBoard = ({
 function ResolveCard({
   thread,
   config,
+  base,
   checked,
   link,
   connectedProviders,
@@ -228,6 +237,7 @@ function ResolveCard({
 }: {
   thread: CommentThread;
   config: CardConfig;
+  base: CardConfig;
   checked: boolean;
   link?: ResolverLink;
   connectedProviders: ReadonlyArray<ProviderId>;
@@ -334,6 +344,7 @@ function ResolveCard({
                       className="absolute left-0 top-8 z-20 w-60"
                       title="Resolve with"
                       config={config}
+                      base={base}
                       mode={mode}
                       hint={hint}
                       connectedProviders={connectedProviders}
@@ -387,6 +398,7 @@ function ConfigPanel({
   className,
   title,
   config,
+  base,
   mode,
   hint,
   connectedProviders,
@@ -398,6 +410,7 @@ function ConfigPanel({
   className?: string;
   title: string;
   config: CardConfig;
+  base: CardConfig;
   mode: ResolveMode;
   hint: string;
   connectedProviders: ReadonlyArray<ProviderId>;
@@ -410,7 +423,7 @@ function ConfigPanel({
     if (next === '') {
       return;
     }
-    onChange(configFor(next));
+    onChange(configFor({ provider: next, base }));
   };
   const onModel = (model: string) =>
     onChange({ ...config, model, effort: clampEffort(model, config.effort) });

--- a/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
+++ b/apps/desktop/src/features/onboarding/OnboardingWizard/steps/PreferencesStep.tsx
@@ -105,6 +105,7 @@ const PreferencesForm = ({ workspaceId }: { workspaceId: WorkspaceId }) => {
         defaultVerbosity: verbosity,
         providerBindings: wsOverrides?.providerBindings ?? null,
         taskModels: wsOverrides?.taskModels ?? null,
+        roleModels: wsOverrides?.roleModels ?? null,
         scoutFanout,
         ...partial,
       });

--- a/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
+++ b/apps/desktop/src/features/permissions/components/DiffViewerDialog/DiffViewerContent.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../../../features/settings/settings';
 import { useAppStore, useDiffComments, useSummarizerStatus } from '../../../../store';
 import { kindRouting, type AgentKindRouting } from '../../../../features/session/agent-kind';
+import { useSessionRoleModels } from '../../../../shared/hooks/useSessionRoleModels';
 import { clampEffort } from '../../../../features/chat/utils/chat-constants';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { STORAGE_KEYS, STORAGE_PREFIXES } from '../../../../shared/lib/storage-keys';
@@ -311,8 +312,9 @@ export const DiffViewerContent = ({
   const sendTurn = useAppStore((s) => s.sendTurn);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const [spawning, setSpawning] = useState(false);
+  const resolverRoleModels = useSessionRoleModels({ sessionId: sessionId ?? null });
   const [resolverRouting, setResolverRouting] = useState<AgentKindRouting>(() =>
-    kindRouting({ kind: 'resolver' }),
+    kindRouting({ kind: 'resolver', roleModels: resolverRoleModels }),
   );
 
   useEffect(() => {

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/RoleModelRow.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from 'react';
+import {
+  PROVIDER_CAPABILITIES,
+  defaultsForRole,
+  recommendedModelForRole,
+  resolveRoleRouting,
+} from '@goodboy/core';
+import type {
+  AgentRole,
+  ProviderId,
+  RoleModelPreference,
+  RoleModelPreferences,
+} from '@goodboy/types';
+import { FieldRow } from '@goodboy/ui';
+import {
+  EFFORT_LABEL,
+  PROVIDER_LABEL,
+  modelEffortLevels,
+  modelLabel,
+} from '../../../../chat/utils/chat-constants';
+import { RoutingPicker } from '../../../../../shared/components/RoutingPicker';
+
+type Props = {
+  readonly role: AgentRole;
+  readonly label: string;
+  readonly help: string;
+  readonly preference: RoleModelPreference | null;
+  readonly connectedProviderIds: ReadonlyArray<ProviderId>;
+  readonly disabled: boolean;
+  readonly onChange: (preference: RoleModelPreference | null) => void;
+};
+
+type CommitParams = {
+  readonly providerId: ProviderId;
+  readonly model: string;
+  readonly effort: RoleModelPreference['effort'];
+};
+
+export const RoleModelRow = ({
+  role,
+  label,
+  help,
+  preference,
+  connectedProviderIds,
+  disabled,
+  onChange,
+}: Props) => {
+  const compiled = defaultsForRole(role);
+  const prefs: RoleModelPreferences | null = preference == null ? null : { [role]: preference };
+  const resolved = resolveRoleRouting({ role, prefs });
+  const [providerId, setProviderId] = useState(resolved.provider);
+  const availableProviderIds = connectedProviderIds.filter(
+    (candidate) => PROVIDER_CAPABILITIES[candidate].models.length > 0,
+  );
+  const recommendedModel = recommendedModelForRole({ role, provider: providerId });
+  const compiledRouting = `${PROVIDER_LABEL[compiled.provider]} · ${modelLabel(compiled.model)}`;
+  const defaultSummary =
+    modelEffortLevels(compiled.model) == null
+      ? compiledRouting
+      : `${compiledRouting} · ${EFFORT_LABEL[compiled.effort]} effort`;
+
+  useEffect(() => {
+    setProviderId(resolved.provider);
+  }, [resolved.provider]);
+
+  const commit = ({ providerId: nextProvider, model, effort }: CommitParams) => {
+    const candidate: RoleModelPreference = { providerId: nextProvider, model, effort };
+    const next = resolveRoleRouting({ role, prefs: { [role]: candidate } });
+    if (!next.isOverride) {
+      onChange(null);
+      return;
+    }
+    onChange({ providerId: next.provider, model: next.model, effort: next.effort });
+  };
+
+  return (
+    <FieldRow label={label} help={help}>
+      <div className="w-80">
+        <RoutingPicker
+          ariaLabel={`${label} routing`}
+          providers={availableProviderIds}
+          provider={providerId}
+          model={resolved.isOverride ? resolved.model : ''}
+          effort={resolved.effort}
+          recommendedProvider={compiled.provider}
+          recommendedModel={recommendedModel}
+          defaultSummary={defaultSummary}
+          overridden={resolved.isOverride}
+          disabled={disabled}
+          onReset={() => onChange(null)}
+          onProvider={(next) => {
+            if (next === '') {
+              onChange(null);
+              return;
+            }
+            setProviderId(next);
+            if (!resolved.isOverride) {
+              return;
+            }
+            commit({
+              providerId: next,
+              model: recommendedModelForRole({ role, provider: next }),
+              effort: resolved.effort,
+            });
+          }}
+          onModel={(nextModel) => {
+            if (nextModel === '') {
+              onChange(null);
+              return;
+            }
+            commit({ providerId, model: nextModel, effort: resolved.effort });
+          }}
+          onEffort={(effort) =>
+            commit({
+              providerId,
+              model: resolved.isOverride ? resolved.model : recommendedModel,
+              effort,
+            })
+          }
+        />
+      </div>
+    </FieldRow>
+  );
+};

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -67,6 +67,13 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
       >
         {model === '' ? `${recommendedModel} recommended` : model}
       </button>
+      <button
+        type="button"
+        aria-label={`${ariaLabel} cheap model`}
+        onClick={() => onModel('claude-haiku-4-5')}
+      >
+        pick haiku
+      </button>
     </>
   ),
 }));
@@ -79,6 +86,7 @@ const EMPTY_OVERRIDES: OverrideSettings = {
   defaultVerbosity: null,
   providerBindings: null,
   taskModels: null,
+  roleModels: null,
   scoutFanout: null,
 };
 
@@ -88,6 +96,8 @@ beforeEach(() => {
 });
 
 afterEach(cleanup);
+
+const TASK_LABELS = ['Summaries', 'Branch names', 'Planning', 'Agent titles', 'PR and MR drafts'];
 
 describe('DefaultsPanel', () => {
   it('renders every task model row', () => {
@@ -100,10 +110,14 @@ describe('DefaultsPanel', () => {
     expect(screen.getByText('PR and MR drafts')).toBeDefined();
   });
 
-  it('shows the resolved model for automatic preferences', () => {
+  it('shows the resolved model for automatic task preferences', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
-    expect(screen.getAllByText('claude-haiku-4-5 recommended')).toHaveLength(5);
+    for (const label of TASK_LABELS) {
+      expect(screen.getByRole('button', { name: `${label} routing model` }).textContent).toBe(
+        'claude-haiku-4-5 recommended',
+      );
+    }
   });
 
   it('persists a selected task model immediately', () => {
@@ -117,6 +131,70 @@ describe('DefaultsPanel', () => {
           summarizer: { providerId: 'anthropic', model: 'claude-sonnet-4-6' },
         },
       }),
+    );
+  });
+
+  it('renders a row per agent role', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByText('Scout')).toBeDefined();
+    expect(screen.getByText('Debugger')).toBeDefined();
+    expect(screen.getByText('Planner')).toBeDefined();
+    expect(screen.getByText('Reviewer')).toBeDefined();
+    expect(screen.getByText('Custom')).toBeDefined();
+  });
+
+  it('reads a role with no override as its compiled default', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByRole('button', { name: 'Planner routing model' }).textContent).toBe(
+      'claude-opus-5 recommended',
+    );
+  });
+
+  it('persists a role model with an effort the model supports', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Scout routing model' }));
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        roleModels: {
+          scout: { providerId: 'anthropic', model: 'claude-sonnet-4-6', effort: 'low' },
+        },
+      }),
+    );
+  });
+
+  it('pins a role to a cheap model with no effort ladder instead of clearing it', () => {
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Debugger routing cheap model' }));
+
+    expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({
+        roleModels: {
+          investigator: { providerId: 'anthropic', model: 'claude-haiku-4-5', effort: 'medium' },
+        },
+      }),
+    );
+  });
+
+  it('shows a stored role override instead of the compiled default', () => {
+    state.workspaceOverrides = {
+      'ws-1': {
+        ...EMPTY_OVERRIDES,
+        roleModels: {
+          reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+        },
+      },
+    };
+    render(<DefaultsPanel workspaceId={'ws-1' as never} />);
+
+    expect(screen.getByRole('button', { name: 'Reviewer routing model' }).textContent).toBe(
+      'claude-opus-5',
     );
   });
 

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.tsx
@@ -1,11 +1,13 @@
 import { DEFAULT_SESSION_PROVIDER_PREFERENCE } from '@goodboy/types';
-import type { AuxTaskId, OverrideSettings, WorkspaceId } from '@goodboy/types';
+import type { AgentRole, AuxTaskId, OverrideSettings, WorkspaceId } from '@goodboy/types';
+import { ROLE_DEFAULTS, isAgentRole } from '@goodboy/core';
 import { Divider, FieldRow, ScrollFade, SectionHeader } from '@goodboy/ui';
 import { useShallow } from 'zustand/react/shallow';
 import { ProviderChip } from '../../ProviderChip';
-import { PROVIDER_LABEL } from '../../../../chat/utils/chat-constants';
+import { ROLE_LABEL } from '../../../../session/agent-kind';
 import { useAppStore } from '../../../../../store';
 import { PROVIDER_ORDER } from '../providerOrder';
+import { RoleModelRow } from './RoleModelRow';
 import { TaskModelRow } from './TaskModelRow';
 import { useDefaultsPersistence } from './useDefaultsPersistence';
 
@@ -45,6 +47,8 @@ const TASKS: ReadonlyArray<{
   },
 ];
 
+const ROLES: ReadonlyArray<AgentRole> = Object.keys(ROLE_DEFAULTS).filter(isAgentRole);
+
 const EMPTY_OVERRIDES: OverrideSettings = {
   defaultProviderId: null,
   defaultWorkflowId: null,
@@ -53,6 +57,7 @@ const EMPTY_OVERRIDES: OverrideSettings = {
   defaultVerbosity: null,
   providerBindings: null,
   taskModels: null,
+  roleModels: null,
   scoutFanout: null,
 };
 
@@ -71,17 +76,18 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
   const defaultProviderId =
     overrides.defaultProviderId ?? DEFAULT_SESSION_PROVIDER_PREFERENCE.defaultProvider;
 
-  const { busy, error, persistOverrides, persistTaskModel } = useDefaultsPersistence({
-    workspaceId,
-    overrides,
-  });
+  const { busy, error, persistOverrides, persistTaskModel, persistRoleModel } =
+    useDefaultsPersistence({
+      workspaceId,
+      overrides,
+    });
 
   return (
     <div className="flex h-full flex-col">
       <div className="flex flex-col gap-0.5 px-8 py-4">
         <h2 className="text-base font-semibold text-foreground">Defaults</h2>
         <p className="text-2xs text-muted-foreground">
-          Choose provider defaults for this workspace and its auxiliary tasks.
+          Choose provider defaults for this workspace, its agent roles, and its auxiliary tasks.
         </p>
       </div>
       <Divider />
@@ -127,6 +133,29 @@ export const DefaultsPanel = ({ workspaceId }: Props) => {
                     connectedProviderIds={connectedProviderIds}
                     disabled={busy}
                     onChange={(preference) => persistTaskModel({ task: task.id, preference })}
+                  />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <SectionHeader
+              label="Agent roles"
+              hint="Applies to every agent spawned in this role unless pinned per agent or per step"
+            />
+            <div className="flex flex-col">
+              {ROLES.map((role, index) => (
+                <div key={role} className="flex flex-col">
+                  {index > 0 ? <Divider /> : null}
+                  <RoleModelRow
+                    role={role}
+                    label={ROLE_LABEL[role]}
+                    help={ROLE_DEFAULTS[role].description}
+                    preference={overrides.roleModels?.[role] ?? null}
+                    connectedProviderIds={connectedProviderIds}
+                    disabled={busy}
+                    onChange={(preference) => persistRoleModel({ role, preference })}
                   />
                 </div>
               ))}

--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/useDefaultsPersistence.ts
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/useDefaultsPersistence.ts
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import type { AuxTaskId, OverrideSettings, TaskModelPreference, WorkspaceId } from '@goodboy/types';
+import type {
+  AgentRole,
+  AuxTaskId,
+  OverrideSettings,
+  RoleModelPreference,
+  TaskModelPreference,
+  WorkspaceId,
+} from '@goodboy/types';
 import { formatError } from '../../../../../shared/lib/errors';
 import { useAppStore } from '../../../../../store';
 
@@ -15,6 +22,11 @@ type PersistParams = {
 type PersistTaskModelParams = {
   readonly task: AuxTaskId;
   readonly preference: TaskModelPreference | null;
+};
+
+type PersistRoleModelParams = {
+  readonly role: AgentRole;
+  readonly preference: RoleModelPreference | null;
 };
 
 export const useDefaultsPersistence = ({ workspaceId, overrides }: Params) => {
@@ -49,5 +61,20 @@ export const useDefaultsPersistence = ({ workspaceId, overrides }: Params) => {
     });
   };
 
-  return { busy, error, persistOverrides, persistTaskModel };
+  const persistRoleModel = ({ role, preference }: PersistRoleModelParams) => {
+    const roleModels = { ...(overrides.roleModels ?? {}) };
+    if (preference == null) {
+      delete roleModels[role];
+    }
+    if (preference != null) {
+      roleModels[role] = preference;
+    }
+    void persistOverrides({
+      partial: {
+        roleModels: Object.keys(roleModels).length > 0 ? roleModels : null,
+      },
+    });
+  };
+
+  return { busy, error, persistOverrides, persistTaskModel, persistRoleModel };
 };

--- a/apps/desktop/src/features/session/agent-kind.test.ts
+++ b/apps/desktop/src/features/session/agent-kind.test.ts
@@ -338,6 +338,79 @@ describe('AGENT_KIND_DEFAULTS', () => {
   });
 });
 
+describe('kindRouting role overrides', () => {
+  it('lets a stored role preference win over the compiled default', () => {
+    const routing = kindRouting({
+      kind: 'debugger',
+      roleModels: {
+        investigator: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+      },
+    });
+
+    expect(routing).toEqual({ provider: 'anthropic', model: 'claude-opus-5', effort: 'max' });
+  });
+
+  it('lets an override beat the cheap-tier downgrade', () => {
+    const routing = kindRouting({
+      kind: 'scout',
+      roleModels: {
+        scout: { providerId: 'anthropic', model: 'claude-sonnet-4-6', effort: 'high' },
+      },
+    });
+
+    expect(routing.model).toBe('claude-sonnet-4-6');
+    expect(routing.effort).toBe('high');
+  });
+
+  it('keeps the cheap-tier downgrade when no override is stored for the role', () => {
+    const routing = kindRouting({
+      kind: 'scout',
+      roleModels: {
+        planner: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'low' },
+      },
+    });
+
+    expect(routing.model).toMatch(/haiku/i);
+    expect(routing.effort).toBe('low');
+  });
+
+  it('keeps a pinned model and defaults the effort the model cannot honor', () => {
+    const routing = kindRouting({
+      kind: 'reviewer',
+      roleModels: {
+        reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'minimal' },
+      },
+    });
+
+    expect(routing.model).toBe('claude-opus-5');
+    expect(routing.effort).toBe(ROLE_DEFAULTS.reviewer.effort);
+  });
+
+  it('pins a role to a cheap model that has no effort ladder', () => {
+    const routing = kindRouting({
+      kind: 'debugger',
+      roleModels: {
+        investigator: { providerId: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+      },
+    });
+
+    expect(routing.provider).toBe('anthropic');
+    expect(routing.model).toBe('claude-haiku-4-5');
+  });
+
+  it('drops an override whose model the registry no longer ships', () => {
+    const routing = kindRouting({
+      kind: 'reviewer',
+      roleModels: {
+        reviewer: { providerId: 'anthropic', model: 'claude-opus-99', effort: 'high' },
+      },
+    });
+
+    expect(routing.model).toBe(ROLE_DEFAULTS.reviewer.model);
+    expect(routing.effort).toBe(ROLE_DEFAULTS.reviewer.effort);
+  });
+});
+
 describe('inferAgentKindFromStep', () => {
   it.each([
     ['scout', 'scout'],

--- a/apps/desktop/src/features/session/agent-kind.ts
+++ b/apps/desktop/src/features/session/agent-kind.ts
@@ -1,11 +1,18 @@
 import {
   classifyFirstTurn,
-  defaultsForRole,
   getCheapModel,
+  resolveRoleRouting,
   type AgentKindLabel,
   type WorkflowLibraryStep,
 } from '@goodboy/core';
-import type { Agent, AgentEffort, AgentId, AgentRole, ProviderId } from '@goodboy/types';
+import type {
+  Agent,
+  AgentEffort,
+  AgentId,
+  AgentRole,
+  ProviderId,
+  RoleModelPreferences,
+} from '@goodboy/types';
 
 export type AgentKind = AgentKindLabel;
 
@@ -235,11 +242,12 @@ const CHEAP_TIER_KINDS: ReadonlySet<AgentKind> = new Set<AgentKind>(['scout', 'd
 
 type KindRoutingParams = {
   readonly kind: AgentKind;
+  readonly roleModels?: RoleModelPreferences | null;
 };
 
-export const kindRouting = ({ kind }: KindRoutingParams): AgentKindRouting => {
-  const role = defaultsForRole(KIND_TO_ROLE[kind]);
-  if (!CHEAP_TIER_KINDS.has(kind)) {
+export const kindRouting = ({ kind, roleModels }: KindRoutingParams): AgentKindRouting => {
+  const role = resolveRoleRouting({ role: KIND_TO_ROLE[kind], prefs: roleModels });
+  if (role.isOverride || !CHEAP_TIER_KINDS.has(kind)) {
     return { provider: role.provider, model: role.model, effort: role.effort };
   }
   return { provider: role.provider, model: getCheapModel(role.provider), effort: 'low' };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ChatWorkflowAdvance.tsx
@@ -5,6 +5,7 @@ import { EMPTY_ARRAY, useAppStore, useSessionOpenQuestions } from '../../../../.
 import { workflowRunHasOpenQuestions } from '../../../../context/openQuestionsGate';
 import { resolveWorkflowAdvance } from '../../../../workflows/advanceGate';
 import { WorkflowNextStepCta } from '../../../../workflows/components/WorkflowNextStepCta';
+import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRoleModels';
 
 type Props = {
   readonly sessionId: SessionId;
@@ -21,6 +22,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
     (state) => state.summarizerStatus?.[sessionId]?.status === 'running',
   );
   const openQuestions = useSessionOpenQuestions(sessionId);
+  const roleModels = useSessionRoleModels({ sessionId });
   const activateWorkflowAgent = useAppStore((state) => state.activateWorkflowAgent);
   const skipStuckStepAndAdvance = useAppStore((state) => state.skipStuckStepAndAdvance);
 
@@ -62,6 +64,7 @@ export const ChatWorkflowAdvance = ({ sessionId, workflowRunId, workflow }: Prop
       <WorkflowNextStepCta
         workflow={workflow}
         runs={stepAgents}
+        roleModels={roleModels}
         blockReason={state.kind === 'blocked' ? state.reason : null}
         onAdvance={(step) => void onAdvance(step)}
         onForceAdvance={() => void skipStuckStepAndAdvance(sessionId, workflowRunId)}

--- a/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowBuilderView/index.tsx
@@ -29,6 +29,7 @@ import {
   polishStepInstruction,
   polishWorkflowGoal,
   recommendedModelForRole,
+  resolveRoleRouting,
   resolveTaskModel,
   runsForWorkflowRun,
 } from '@goodboy/core';
@@ -36,6 +37,7 @@ import type {
   AgentEffort,
   AgentRole,
   ProviderId,
+  RoleModelPreferences,
   Session,
   Step,
   StepId,
@@ -99,7 +101,12 @@ const stepsFromTemplate = (template: Workflow): ReadonlyArray<EditableStep> =>
     ...(s.effort && { effort: s.effort as EffortLevel }),
   }));
 
-const stepsFromPlan = (plan: PlannerOutput): ReadonlyArray<EditableStep> =>
+type StepsFromPlanParams = {
+  readonly plan: PlannerOutput;
+  readonly roleModels: RoleModelPreferences | null;
+};
+
+const stepsFromPlan = ({ plan, roleModels }: StepsFromPlanParams): ReadonlyArray<EditableStep> =>
   plan.steps.map((s) => {
     const role = s.role as AgentRole;
     return {
@@ -108,7 +115,7 @@ const stepsFromPlan = (plan: PlannerOutput): ReadonlyArray<EditableStep> =>
       name: s.name,
       promptPrefix: s.promptPrefix ?? '',
       expectedOutput: s.expectedOutput ?? '',
-      effort: defaultsForRole(role).effort as EffortLevel,
+      effort: resolveRoleRouting({ role, prefs: roleModels }).effort as EffortLevel,
     };
   });
 
@@ -175,6 +182,9 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const workspaceOverrides = useAppStore(
     (s) => s.workspaceOverrides?.[session.workspaceId] ?? null,
   );
+  const roleModels = workspaceOverrides?.roleModels ?? null;
+  const roleEffort = (role: AgentRole): EffortLevel =>
+    resolveRoleRouting({ role, prefs: roleModels }).effort as EffortLevel;
   const setWorkflowDraft = useAppStore((s) => s.setWorkflowDraft);
   const clearWorkflowDraft = useAppStore((s) => s.clearWorkflowDraft);
   const sessionSlots = useSessionSlots(session.id);
@@ -394,7 +404,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
         name: '',
         promptPrefix: '',
         expectedOutput: '',
-        effort: defaultsForRole('custom').effort as EffortLevel,
+        effort: roleEffort('custom'),
       },
     ]);
   };
@@ -411,7 +421,11 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
   const resolvedProvider = (step: EditableStep): ProviderId =>
     step.providerOverride ?? recommendedProvider(step);
   const recommendedModel = (step: EditableStep): string =>
-    recommendedModelForRole({ role: step.role ?? 'custom', provider: resolvedProvider(step) });
+    recommendedModelForRole({
+      role: step.role ?? 'custom',
+      provider: resolvedProvider(step),
+      prefs: roleModels,
+    });
   const resolvedModel = (step: EditableStep): string =>
     step.modelOverride !== undefined && step.modelOverride !== ''
       ? step.modelOverride
@@ -540,7 +554,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
       });
       const result = await client.plan({ process });
       setPlan(result.output);
-      setSteps(stepsFromPlan(result.output));
+      setSteps(stepsFromPlan({ plan: result.output, roleModels }));
       setStage(2);
     } catch (err) {
       setError(formatError(err));
@@ -558,7 +572,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
 
   const buildSteps = (workflowId: WorkflowId): ReadonlyArray<Step> =>
     steps.map((st, ordinal) => {
-      const effort = (st.effort ?? defaultsForRole(st.role).effort) as EffortLevel;
+      const effort = (st.effort ?? roleEffort(st.role)) as EffortLevel;
       const base: Step = {
         id: `step_builder_${crypto.randomUUID()}` as StepId,
         workflowId,
@@ -1063,9 +1077,7 @@ export const WorkflowBuilderView = ({ session, onClose }: Props) => {
                                 model={st.modelOverride ?? ''}
                                 resolvedModel={resolvedModel(st)}
                                 recommendedModel={recommendedModel(st)}
-                                effort={
-                                  (st.effort ?? defaultsForRole(st.role).effort) as EffortLevel
-                                }
+                                effort={(st.effort ?? roleEffort(st.role)) as EffortLevel}
                                 expanded={expandedKey === st.key}
                                 dragging={draggingKey === st.key}
                                 disabled={busy}

--- a/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/WorkspaceScopePanel.tsx
@@ -85,6 +85,7 @@ export const WorkspaceScopePanel = ({ workspaceId, initialSection, requestClose 
         defaultVerbosity: verbosity,
         providerBindings: wsOverrides?.providerBindings ?? null,
         taskModels: wsOverrides?.taskModels ?? null,
+        roleModels: wsOverrides?.roleModels ?? null,
         scoutFanout,
         ...partial,
       });

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -16,6 +16,7 @@ import { RoleSelect } from '../../../session/components/RoleSelect';
 import { InlineField } from '../../../session/components/InlineField';
 import { VerbositySelect } from '../../../session/components/VerbositySelect';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
+import { useAppStore } from '../../../../store';
 
 type Props = {
   readonly def: StepDef | null;
@@ -37,6 +38,7 @@ export const LibraryStepForm = ({
   onCommit,
   onClose,
 }: Props) => {
+  const roleModels = useAppStore((s) => s.workspaceOverrides?.[workspaceId]?.roleModels ?? null);
   const isGlobal = def?.workspaceId === null;
   const [name, setName] = useState(def?.name ?? '');
   const [role, setRole] = useState<AgentRole>(def?.role ?? 'custom');
@@ -54,7 +56,11 @@ export const LibraryStepForm = ({
 
   const recommendedProv: ProviderId = connectedProviders[0] ?? 'anthropic';
   const effProvider: ProviderId = providerOverride !== '' ? providerOverride : recommendedProv;
-  const recommendedMod: string = recommendedModelForRole({ role, provider: effProvider });
+  const recommendedMod: string = recommendedModelForRole({
+    role,
+    provider: effProvider,
+    prefs: roleModels,
+  });
 
   type FormState = {
     name: string;

--- a/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowNextStepCta/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import { AlertTriangle, ArrowRight, ClipboardList } from 'lucide-react';
 import { cn } from '@goodboy/ui';
 import { classifyWorkflowChain } from '@goodboy/core';
-import type { Agent, Step, Workflow } from '@goodboy/types';
+import type { Agent, RoleModelPreferences, Step, Workflow } from '@goodboy/types';
 import type { VerbosityLevel } from '../../../../features/settings/verbosity';
 import {
   kindRouting,
@@ -25,6 +25,7 @@ export type Props = {
   readonly blockReason?: WorkflowBlockReason | null;
   readonly consumesActivePlan?: boolean;
   readonly className?: string;
+  readonly roleModels?: RoleModelPreferences | null;
 };
 
 export type PickNextWorkflowStepGate = {
@@ -66,6 +67,7 @@ export const WorkflowNextStepCta = ({
   blockReason = null,
   consumesActivePlan = false,
   className,
+  roleModels = null,
 }: Props) => {
   const [busy, setBusy] = useState(false);
   const [pendingConfirm, setPendingConfirm] = useState(false);
@@ -73,7 +75,7 @@ export const WorkflowNextStepCta = ({
   const chain = useMemo(() => classifyWorkflowChain(workflow, runs), [workflow, runs]);
   const next = chain.kind === 'step' ? chain.step : null;
   const kind = useMemo(() => (next ? inferAgentKindFromName(next.name) : 'generic'), [next]);
-  const defaults = kindRouting({ kind });
+  const defaults = kindRouting({ kind, roleModels });
   const palette = AGENT_KIND_PALETTE[kind];
   const doForce = async () => {
     if (busy) {

--- a/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
+++ b/apps/desktop/src/features/workflows/components/WorkflowStudio/WorkflowComposer/index.tsx
@@ -10,6 +10,7 @@ import { WorkflowStepCard } from '../../../../session/components/WorkflowStepCar
 import { StepFlowConnector } from '../StepFlowConnector';
 import { StepLibraryPalette } from '../StepLibraryPalette';
 import { EmptyGuide } from '../EmptyGuide';
+import { useAppStore } from '../../../../../store';
 
 type Props = {
   readonly open: boolean;
@@ -78,6 +79,7 @@ export const WorkflowComposer = ({
   onDeleteDef,
   onClose,
 }: Props) => {
+  const roleModels = useAppStore((s) => s.workspaceOverrides?.[workspaceId]?.roleModels ?? null);
   if (!open) {
     return (
       <section className="flex min-w-0 flex-1 flex-col">
@@ -104,7 +106,7 @@ export const WorkflowComposer = ({
       : recommendedProvider(def);
 
   const recommendedModel = (def: DefinitionForm): string =>
-    recommendedModelForRole({ role: def.role, provider: resolvedProvider(def) });
+    recommendedModelForRole({ role: def.role, provider: resolvedProvider(def), prefs: roleModels });
 
   const resolvedModel = (def: DefinitionForm): string =>
     def.modelOverride !== undefined && def.modelOverride !== ''

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../../../../features/session/agent-kind';
 import { clampEffort } from '../../../../../../features/chat/utils/chat-constants';
 import { RoutingPicker } from '../../../../../../shared/components/RoutingPicker';
+import { useSessionRoleModels } from '../../../../../../shared/hooks/useSessionRoleModels';
 
 type SpawnAgentMenuProps = {
   readonly sessionId: SessionId;
@@ -48,7 +49,8 @@ export function SpawnAgentMenu({ sessionId, trigger, onSpawned }: SpawnAgentMenu
   const connectedProviders = useAppStore(
     useShallow((s) => s.providers.filter((p) => p.connection === 'connected').map((p) => p.id)),
   );
-  const baseline = kindRouting({ kind: 'generic' });
+  const roleModels = useSessionRoleModels({ sessionId });
+  const baseline = kindRouting({ kind: 'generic', roleModels });
   const onProvider = (next: ProviderId | '') => {
     if (next === '') {
       setRouting(null);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.test.tsx
@@ -16,7 +16,10 @@ import type {
   WorkspaceId,
 } from '@goodboy/types';
 
-vi.mock('../../../../../store', () => ({ EMPTY_ARRAY: Object.freeze([]) }));
+vi.mock('../../../../../store', () => ({
+  EMPTY_ARRAY: Object.freeze([]),
+  useAppStore: <T,>(selector: (state: unknown) => T) => selector({}),
+}));
 
 vi.mock(
   '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip',

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -25,6 +25,7 @@ import {
   inferAgentKindFromName,
   type AgentKind,
 } from '../../../../../features/session/agent-kind';
+import { useSessionRoleModels } from '../../../../../shared/hooks/useSessionRoleModels';
 import type { AgentAggregate } from '../../../../../features/session/components/AgentMetricsBlock';
 import { WorkflowNextStepCta } from '../../../../../features/workflows/components/WorkflowNextStepCta';
 import { GoalAttachmentsStrip } from '../../../../../features/context/components/ContextPanel/strips/GoalAttachmentsStrip';
@@ -120,6 +121,7 @@ export const WorkflowRow = ({
   toggleClusterExpand,
   forceAdvanceWorkflowStep,
 }: Props) => {
+  const roleModels = useSessionRoleModels({ sessionId: task.id });
   const workflowRun = run;
   const isDiscarded = run.discardedAt != null;
   const wfAgents = agentsByRunId.get(run.id) ?? EMPTY_ARRAY;
@@ -326,7 +328,7 @@ export const WorkflowRow = ({
                 stepModel ??
                 agentModelOverride[run.id] ??
                 run.modelOverride ??
-                kindRouting({ kind }).model;
+                kindRouting({ kind, roleModels }).model;
               const clusterChildren = childrenByParentId.get(run.id) ?? EMPTY_ARRAY;
               const clustersExpanded = clusterExpand.get(run.id) ?? false;
               const clusterUnread = countUnread(clusterChildren);
@@ -427,6 +429,7 @@ export const WorkflowRow = ({
           <WorkflowNextStepCta
             workflow={workflow}
             runs={wfAgents}
+            roleModels={roleModels}
             blockReason={wfBlockReason}
             onAdvance={(step) => {
               const pending = wfAgents.find(

--- a/apps/desktop/src/shared/hooks/useSessionRoleModels/index.ts
+++ b/apps/desktop/src/shared/hooks/useSessionRoleModels/index.ts
@@ -1,0 +1,10 @@
+import type { RoleModelPreferences, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../store';
+import { roleModelsForSession } from '../../../store/slices/overrides/roleModelsForSession';
+
+type Params = {
+  readonly sessionId: SessionId | null;
+};
+
+export const useSessionRoleModels = ({ sessionId }: Params): RoleModelPreferences | null =>
+  useAppStore((state) => roleModelsForSession({ state, sessionId }));

--- a/apps/desktop/src/store/slices/agents/index.ts
+++ b/apps/desktop/src/store/slices/agents/index.ts
@@ -18,7 +18,7 @@ import type { GetFn, SetFn } from './types';
 
 export const createAgentsSlice = (set: SetFn, get: GetFn) => {
   return {
-    setAgentKind: setAgentKind(set),
+    setAgentKind: setAgentKind(set, get),
     setAgentEffortOverride: setAgentEffortOverride(set),
     setAgentDraft: setAgentDraft(set),
     clearAgentDraft: clearAgentDraft(set),

--- a/apps/desktop/src/store/slices/agents/setAgentKind.ts
+++ b/apps/desktop/src/store/slices/agents/setAgentKind.ts
@@ -1,15 +1,21 @@
 import type { AgentId } from '@goodboy/types';
 import { kindRouting, type AgentKind } from '../../../features/session/agent-kind';
 import { invokeAgentSetKind } from '../../../features/workflows/workflows';
-import type { SetFn } from './types';
+import { roleModelsForSession } from '../overrides/roleModelsForSession';
+import type { GetFn, SetFn } from './types';
 
-export const setAgentKind = (set: SetFn) => {
+export const setAgentKind = (set: SetFn, get: GetFn) => {
   return (agentId: AgentId, kind: AgentKind) => {
+    const state = get();
+    const owner = Object.values(state.sessionPhaseRuns ?? {})
+      .flat()
+      .find((agent) => agent.id === agentId);
+    const roleModels = roleModelsForSession({ state, sessionId: owner?.sessionId ?? null });
     set((s) => {
       const nextModelOverride = { ...s.agentModelOverride };
       const nextProviderOverride = { ...s.agentProviderOverride };
       const nextEffortOverride = { ...s.agentEffortOverride };
-      const defaults = kindRouting({ kind });
+      const defaults = kindRouting({ kind, roleModels });
       if (defaults?.model) {
         nextModelOverride[agentId] = defaults.model;
         delete nextProviderOverride[agentId];

--- a/apps/desktop/src/store/slices/overrides/roleModelsForSession.ts
+++ b/apps/desktop/src/store/slices/overrides/roleModelsForSession.ts
@@ -1,0 +1,18 @@
+import type { RoleModelPreferences, SessionId } from '@goodboy/types';
+import type { AppStore } from '../../store';
+
+type Params = {
+  readonly state: AppStore;
+  readonly sessionId: SessionId | null;
+};
+
+export const roleModelsForSession = ({ state, sessionId }: Params): RoleModelPreferences | null => {
+  if (sessionId == null) {
+    return null;
+  }
+  const session = state.sessions?.find((entry) => entry.id === sessionId);
+  if (session == null) {
+    return null;
+  }
+  return state.workspaceOverrides?.[session.workspaceId]?.roleModels ?? null;
+};

--- a/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
+++ b/apps/desktop/src/store/slices/overrides/setWorkspaceProviderBinding.ts
@@ -10,6 +10,7 @@ const EMPTY_OVERRIDE: OverrideSettings = {
   defaultVerbosity: null,
   providerBindings: null,
   taskModels: null,
+  roleModels: null,
   scoutFanout: null,
 };
 

--- a/apps/desktop/src/store/slices/sessions/createSession.ts
+++ b/apps/desktop/src/store/slices/sessions/createSession.ts
@@ -245,6 +245,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
 
     const workspaceVerbositySeed =
       get().workspaceOverrides[workspaceId]?.defaultVerbosity ?? undefined;
+    const roleModels = get().workspaceOverrides[workspaceId]?.roleModels ?? null;
 
     if (workflowId) {
       const templates = get().phaseTemplates[workspaceId] ?? [];
@@ -265,7 +266,8 @@ export const createSession = (set: SetFn, get: GetFn) => {
             kind,
             ...(workspaceVerbositySeed && { verbosity: workspaceVerbositySeed }),
           });
-          agentModelOverrides[agent.id] = step.modelOverride ?? kindRouting({ kind }).model;
+          agentModelOverrides[agent.id] =
+            step.modelOverride ?? kindRouting({ kind, roleModels }).model;
           agentKindOverrides[agent.id] = kind;
           allAgents.push(agent);
         }
@@ -284,7 +286,7 @@ export const createSession = (set: SetFn, get: GetFn) => {
       }
     } else if (firstAgentKind !== undefined) {
       const agentName = AGENT_KIND_META[firstAgentKind].label.toLowerCase();
-      const model = requestedModel ?? kindRouting({ kind: firstAgentKind }).model;
+      const model = requestedModel ?? kindRouting({ kind: firstAgentKind, roleModels }).model;
       const singleAgent = await invokeAgentInsert({
         sessionId: session.id,
         ordinal: 0,

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -353,7 +353,11 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     const turnOverrideActive = turnOverride !== undefined && effectiveOverride === turnOverride;
     const autoStepModel =
       phaseDefinition != null && !phaseDefinition.modelOverride
-        ? (autoModelForRole(phaseDefinition.role ?? 'custom', [provider])?.model ?? null)
+        ? (autoModelForRole({
+            role: phaseDefinition.role ?? 'custom',
+            providers: [provider],
+            prefs: get().workspaceOverrides[session.workspaceId]?.roleModels ?? null,
+          })?.model ?? null)
         : null;
     const model = resolveModelForProvider({
       provider,

--- a/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
+++ b/apps/desktop/src/store/slices/workflows/attachWorkflowToSession.ts
@@ -19,6 +19,7 @@ import {
 import { tauriDatabase } from '../../../shared/lib/db';
 import { invokeAgentInsert } from '../../../features/workflows/workflows';
 import { ROLE_TO_KIND, inferAgentKindFromName } from '../../../features/session/agent-kind';
+import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import type { GetFn, SetFn } from './types';
 
 type Options = {
@@ -81,6 +82,7 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
     const sortedSteps = [...template.steps].sort((a, b) => a.ordinal - b.ordinal);
     const sessionDefaultProvider = (session.providerOverride ??
       session.providerPreference.defaultProvider) as ProviderId;
+    const roleModels = roleModelsForSession({ state: get(), sessionId });
     const newAgents: Agent[] = [];
     const agentModelOverrides: Record<string, string> = {};
     const agentKindOverrides: Record<string, string> = {};
@@ -104,7 +106,11 @@ export const attachWorkflowToSession = (set: SetFn, get: GetFn) => {
         provider: resolvedProvider,
         modelId:
           step.modelOverride ??
-          recommendedModelForRole({ role: step.role ?? 'custom', provider: resolvedProvider }),
+          recommendedModelForRole({
+            role: step.role ?? 'custom',
+            provider: resolvedProvider,
+            prefs: roleModels,
+          }),
       });
       agentKindOverrides[agent.id] = kind;
       if (step.effort) {

--- a/apps/desktop/src/store/slices/workflows/scoutTree.ts
+++ b/apps/desktop/src/store/slices/workflows/scoutTree.ts
@@ -14,6 +14,7 @@ import {
   inferAgentKindFromName,
   type AgentKind,
 } from '../../../features/session/agent-kind';
+import { roleModelsForSession } from '../overrides/roleModelsForSession';
 import type { GetFn, SetFn } from './types';
 
 export const SCOUT_DEPTH_CAP = 2;
@@ -28,7 +29,8 @@ function resolveContainerModel(get: GetFn, container: Agent): string {
     return container.modelOverride;
   }
   const kind = (container.kind as AgentKind | undefined) ?? inferAgentKindFromName(container.name);
-  return kindRouting({ kind }).model;
+  const roleModels = roleModelsForSession({ state: get(), sessionId: container.sessionId });
+  return kindRouting({ kind, roleModels }).model;
 }
 
 const synthesisStarted = new Set<string>();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,8 @@ export { resolveModelForProvider } from './providers/model-map';
 
 export { resolveTaskModel } from './providers/task-models';
 
+export { resolveRoleRouting, type ResolvedRoleRouting } from './providers/role-models';
+
 export { getCheapModel, getDefaultBinary } from './providers/cli-defaults';
 export { extractAuxOutput, type AuxOutput, type AuxUsage } from './providers/aux-output';
 

--- a/packages/core/src/providers/auto-model.test.ts
+++ b/packages/core/src/providers/auto-model.test.ts
@@ -4,26 +4,26 @@ import { CURSOR_MODELS } from './cursor/models';
 
 describe('autoModelForRole', () => {
   it('returns null when no providers are available', () => {
-    expect(autoModelForRole('planner', [])).toBeNull();
+    expect(autoModelForRole({ role: 'planner', providers: [] })).toBeNull();
   });
 
   describe('with the role default provider available', () => {
     it('keeps the curated default for a high-tier role', () => {
-      expect(autoModelForRole('planner', ['anthropic'])).toEqual({
+      expect(autoModelForRole({ role: 'planner', providers: ['anthropic'] })).toEqual({
         provider: 'anthropic',
         model: 'claude-opus-5',
       });
     });
 
     it('keeps the curated cheap default for a scout role', () => {
-      expect(autoModelForRole('scout', ['anthropic'])).toEqual({
+      expect(autoModelForRole({ role: 'scout', providers: ['anthropic'] })).toEqual({
         provider: 'anthropic',
         model: 'claude-haiku-4-5',
       });
     });
 
     it('prefers the default provider even when other providers are enabled', () => {
-      expect(autoModelForRole('planner', ['gemini', 'anthropic'])).toEqual({
+      expect(autoModelForRole({ role: 'planner', providers: ['gemini', 'anthropic'] })).toEqual({
         provider: 'anthropic',
         model: 'claude-opus-5',
       });
@@ -32,55 +32,55 @@ describe('autoModelForRole', () => {
 
   describe('when the default provider is not available', () => {
     it('picks the matching expensive-tier model for a high-tier role', () => {
-      expect(autoModelForRole('planner', ['gemini'])).toEqual({
+      expect(autoModelForRole({ role: 'planner', providers: ['gemini'] })).toEqual({
         provider: 'gemini',
         model: 'gemini-3.1-pro',
       });
     });
 
     it('picks the highest-weight cheap model for a low-tier role', () => {
-      expect(autoModelForRole('scout', ['gemini'])).toEqual({
+      expect(autoModelForRole({ role: 'scout', providers: ['gemini'] })).toEqual({
         provider: 'gemini',
         model: 'gemini-3.5-flash',
       });
     });
 
     it('treats an unknown role as the custom default tier', () => {
-      expect(autoModelForRole('totally-made-up', ['gemini'])).toEqual({
+      expect(autoModelForRole({ role: 'totally-made-up', providers: ['gemini'] })).toEqual({
         provider: 'gemini',
         model: 'gemini-3.1-pro',
       });
     });
 
     it('picks the expensive codex model for a high-tier role', () => {
-      expect(autoModelForRole('planner', ['codex'])).toEqual({
+      expect(autoModelForRole({ role: 'planner', providers: ['codex'] })).toEqual({
         provider: 'codex',
         model: 'gpt-5.6',
       });
     });
 
     it('picks the cheap codex model for a scout role', () => {
-      const result = autoModelForRole('scout', ['codex']);
+      const result = autoModelForRole({ role: 'scout', providers: ['codex'] });
       expect(result?.provider).toBe('codex');
       const model = result?.model ?? '';
       expect(['gpt-5.4-mini', 'gpt-4.1-mini', 'gpt-4.1-nano'].some((m) => model === m)).toBe(true);
     });
 
     it('weight tie-break: picks highest-weight model when two providers share cost tier', () => {
-      const result = autoModelForRole('planner', ['gemini', 'codex']);
+      const result = autoModelForRole({ role: 'planner', providers: ['gemini', 'codex'] });
       expect(result).not.toBeNull();
       expect(['gemini', 'codex']).toContain(result?.provider);
     });
 
     it('cursor provider: picks a real cursor slug for a mid-tier role, not auto', () => {
-      const result = autoModelForRole('product', ['cursor']);
+      const result = autoModelForRole({ role: 'product', providers: ['cursor'] });
       expect(result?.provider).toBe('cursor');
       expect(result?.model).not.toBe('auto');
       expect(CURSOR_MODELS.some((m) => m.id === result?.model)).toBe(true);
     });
 
     it('cursor provider: picks a real expensive slug for a high-tier role', () => {
-      const result = autoModelForRole('planner', ['cursor']);
+      const result = autoModelForRole({ role: 'planner', providers: ['cursor'] });
       expect(result).toEqual({ provider: 'cursor', model: 'claude-opus-4-7-thinking-high' });
     });
   });

--- a/packages/core/src/providers/auto-model.ts
+++ b/packages/core/src/providers/auto-model.ts
@@ -1,15 +1,22 @@
-import type { ModelCostTier, ProviderId } from '@goodboy/types';
+import type { ModelCostTier, ProviderId, RoleModelPreferences } from '@goodboy/types';
 import { PROVIDER_CAPABILITIES, getDefaultTurnModel } from './capabilities';
-import { defaultsForRole } from '../roles';
+import { resolveRoleRouting } from './role-models';
 
 export type AutoModelChoice = {
   readonly provider: ProviderId;
   readonly model: string;
 };
 
+type AutoParams = {
+  readonly role: string;
+  readonly providers: ReadonlyArray<ProviderId>;
+  readonly prefs?: RoleModelPreferences | null;
+};
+
 type Params = {
   readonly role: string;
   readonly provider: ProviderId;
+  readonly prefs?: RoleModelPreferences | null;
 };
 
 const COST_RANK: Readonly<Record<ModelCostTier, number>> = {
@@ -18,26 +25,22 @@ const COST_RANK: Readonly<Record<ModelCostTier, number>> = {
   expensive: 3,
 };
 
-const targetCostRankForRole = (role: string): number => {
-  const { provider, model } = defaultsForRole(role);
-  const tier = PROVIDER_CAPABILITIES[provider].models.find((m) => m.id === model)?.costTier;
-  return COST_RANK[tier ?? 'mid'];
-};
-
-export const autoModelForRole = (
-  role: string,
-  providers: ReadonlyArray<ProviderId>,
-): AutoModelChoice | null => {
+export const autoModelForRole = ({
+  role,
+  providers,
+  prefs,
+}: AutoParams): AutoModelChoice | null => {
   if (providers.length === 0) {
     return null;
   }
 
-  const def = defaultsForRole(role);
+  const def = resolveRoleRouting({ role, prefs });
   if (providers.includes(def.provider)) {
     return { provider: def.provider, model: def.model };
   }
 
-  const target = targetCostRankForRole(role);
+  const tier = PROVIDER_CAPABILITIES[def.provider].models.find((m) => m.id === def.model)?.costTier;
+  const target = COST_RANK[tier ?? 'mid'];
   let best: { provider: ProviderId; model: string; score: number } | null = null;
   for (const provider of providers) {
     for (const m of PROVIDER_CAPABILITIES[provider].models) {
@@ -53,6 +56,8 @@ export const autoModelForRole = (
   return { provider: best.provider, model: best.model };
 };
 
-export const recommendedModelForRole = ({ role, provider }: Params): string => {
-  return autoModelForRole(role, [provider])?.model ?? getDefaultTurnModel(provider);
+export const recommendedModelForRole = ({ role, provider, prefs }: Params): string => {
+  return (
+    autoModelForRole({ role, providers: [provider], prefs })?.model ?? getDefaultTurnModel(provider)
+  );
 };

--- a/packages/core/src/providers/role-models.test.ts
+++ b/packages/core/src/providers/role-models.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { ProviderId, RoleModelPreferences } from '@goodboy/types';
+import { ROLE_DEFAULTS } from '../roles';
+import { resolveRoleRouting } from './role-models';
+
+describe('resolveRoleRouting', () => {
+  it('resolves a role with no stored preference to its compiled default', () => {
+    expect(resolveRoleRouting({ role: 'investigator', prefs: null })).toEqual({
+      provider: ROLE_DEFAULTS.investigator.provider,
+      model: ROLE_DEFAULTS.investigator.model,
+      effort: ROLE_DEFAULTS.investigator.effort,
+      isOverride: false,
+    });
+  });
+
+  it('prefers a valid stored preference over the compiled default', () => {
+    const prefs: RoleModelPreferences = {
+      investigator: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+    };
+
+    expect(resolveRoleRouting({ role: 'investigator', prefs })).toEqual({
+      provider: 'anthropic',
+      model: 'claude-opus-5',
+      effort: 'max',
+      isOverride: true,
+    });
+  });
+
+  it('falls back when the stored model is unknown to the provider', () => {
+    const prefs: RoleModelPreferences = {
+      reviewer: { providerId: 'anthropic', model: 'claude-opus-99', effort: 'high' },
+    };
+    const resolved = resolveRoleRouting({ role: 'reviewer', prefs });
+
+    expect(resolved.model).toBe(ROLE_DEFAULTS.reviewer.model);
+    expect(resolved.isOverride).toBe(false);
+  });
+
+  it('falls back when the stored provider is unknown to the registry', () => {
+    const prefs: RoleModelPreferences = {
+      reviewer: { providerId: 'ollama' as ProviderId, model: 'llama-4', effort: 'high' },
+    };
+    const resolved = resolveRoleRouting({ role: 'reviewer', prefs });
+
+    expect(resolved.provider).toBe(ROLE_DEFAULTS.reviewer.provider);
+    expect(resolved.model).toBe(ROLE_DEFAULTS.reviewer.model);
+    expect(resolved.isOverride).toBe(false);
+  });
+
+  it('keeps the pinned model and defaults the effort when the ladder omits it', () => {
+    const prefs: RoleModelPreferences = {
+      reviewer: { providerId: 'anthropic', model: 'claude-sonnet-4-6', effort: 'max' },
+    };
+    const resolved = resolveRoleRouting({ role: 'reviewer', prefs });
+
+    expect(resolved.model).toBe('claude-sonnet-4-6');
+    expect(resolved.effort).toBe(ROLE_DEFAULTS.reviewer.effort);
+    expect(resolved.isOverride).toBe(true);
+  });
+
+  it('keeps a pin on a model that has no effort ladder at all', () => {
+    const prefs: RoleModelPreferences = {
+      investigator: { providerId: 'anthropic', model: 'claude-haiku-4-5', effort: 'low' },
+    };
+    const resolved = resolveRoleRouting({ role: 'investigator', prefs });
+
+    expect(resolved.provider).toBe('anthropic');
+    expect(resolved.model).toBe('claude-haiku-4-5');
+    expect(resolved.isOverride).toBe(true);
+  });
+
+  it('takes the top of the ladder when neither the stored nor the role effort fits', () => {
+    const prefs: RoleModelPreferences = {
+      planner: { providerId: 'codex', model: 'gpt-5.4-mini', effort: 'max' },
+    };
+    const resolved = resolveRoleRouting({ role: 'planner', prefs });
+
+    expect(resolved.model).toBe('gpt-5.4-mini');
+    expect(resolved.effort).toBe('medium');
+    expect(resolved.isOverride).toBe(true);
+  });
+
+  it('ignores a preference stored for a different role', () => {
+    const prefs: RoleModelPreferences = {
+      planner: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'low' },
+    };
+    const resolved = resolveRoleRouting({ role: 'tester', prefs });
+
+    expect(resolved.model).toBe(ROLE_DEFAULTS.tester.model);
+    expect(resolved.isOverride).toBe(false);
+  });
+
+  it('routes an unknown role through the custom preference, like the compiled default does', () => {
+    const prefs: RoleModelPreferences = {
+      custom: { providerId: 'codex', model: 'gpt-5.6', effort: 'high' },
+    };
+
+    expect(resolveRoleRouting({ role: 'emperor', prefs })).toEqual({
+      provider: 'codex',
+      model: 'gpt-5.6',
+      effort: 'high',
+      isOverride: true,
+    });
+  });
+});

--- a/packages/core/src/providers/role-models.ts
+++ b/packages/core/src/providers/role-models.ts
@@ -1,0 +1,64 @@
+import type { AgentEffort, ProviderId, RoleModelPreferences } from '@goodboy/types';
+import { PROVIDER_CAPABILITIES } from './capabilities';
+import { defaultsForRole, isAgentRole } from '../roles';
+
+export type ResolvedRoleRouting = Readonly<{
+  provider: ProviderId;
+  model: string;
+  effort: AgentEffort;
+  isOverride: boolean;
+}>;
+
+type Params = {
+  readonly role: string;
+  readonly prefs: RoleModelPreferences | null | undefined;
+};
+
+type LadderParams = {
+  readonly ladder: ReadonlyArray<AgentEffort> | null;
+  readonly requested: AgentEffort;
+  readonly roleDefault: AgentEffort;
+};
+
+const effortOnLadder = ({ ladder, requested, roleDefault }: LadderParams): AgentEffort => {
+  if (ladder == null) {
+    return roleDefault;
+  }
+  if (ladder.includes(requested)) {
+    return requested;
+  }
+  if (ladder.includes(roleDefault)) {
+    return roleDefault;
+  }
+  return ladder[ladder.length - 1] ?? roleDefault;
+};
+
+export const resolveRoleRouting = ({ role, prefs }: Params): ResolvedRoleRouting => {
+  const fallback = defaultsForRole(role);
+  const compiled: ResolvedRoleRouting = {
+    provider: fallback.provider,
+    model: fallback.model,
+    effort: fallback.effort,
+    isOverride: false,
+  };
+  const preference = prefs?.[isAgentRole(role) ? role : 'custom'];
+  if (preference == null) {
+    return compiled;
+  }
+  const descriptor = PROVIDER_CAPABILITIES[preference.providerId]?.models.find(
+    (model) => model.id === preference.model,
+  );
+  if (descriptor == null) {
+    return compiled;
+  }
+  return {
+    provider: preference.providerId,
+    model: preference.model,
+    effort: effortOnLadder({
+      ladder: descriptor.effort,
+      requested: preference.effort,
+      roleDefault: fallback.effort,
+    }),
+    isOverride: true,
+  };
+};

--- a/packages/core/src/settings/__tests__/resolver.test.ts
+++ b/packages/core/src/settings/__tests__/resolver.test.ts
@@ -20,6 +20,7 @@ const NULL_OVERRIDE: OverrideSettings = {
   defaultVerbosity: null,
   providerBindings: null,
   taskModels: null,
+  roleModels: null,
   scoutFanout: null,
 };
 
@@ -41,6 +42,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: 'verbose',
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({ global: GLOBAL, workspaceOverride: wsOverride });
@@ -60,6 +62,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: null,
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({ global: GLOBAL, sessionOverride: sessOverride });
@@ -79,6 +82,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: 'verbose',
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const sessOverride: OverrideSettings = {
@@ -89,6 +93,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: null,
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({
@@ -112,6 +117,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: 'verbose',
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const sessOverride: OverrideSettings = {
@@ -122,6 +128,7 @@ describe('resolveSettings', () => {
       defaultVerbosity: null,
       providerBindings: null,
       taskModels: null,
+      roleModels: null,
       scoutFanout: null,
     };
     const result = resolveSettings({

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -76,6 +76,7 @@ import { m075PrReviewDrafts } from './m075-pr-review-drafts';
 import { m076AgentSourceKind } from './m076-agent-source-kind';
 import { m077StepExpectedOutput } from './m077-step-expected-output';
 import { m078WorkflowProcessText } from './m078-workflow-process-text';
+import { m079RoleModels } from './m079-role-models';
 
 export type Migration = {
   readonly version: number;
@@ -161,4 +162,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 76, sql: m076AgentSourceKind },
   { version: 77, sql: m077StepExpectedOutput },
   { version: 78, sql: m078WorkflowProcessText },
+  { version: 79, sql: m079RoleModels },
 ];

--- a/packages/db/src/migrations/m079-role-models.ts
+++ b/packages/db/src/migrations/m079-role-models.ts
@@ -1,0 +1,3 @@
+export const m079RoleModels = `
+ALTER TABLE workspaces ADD COLUMN role_models TEXT;
+`;

--- a/packages/db/src/queries/settings-overrides.test.ts
+++ b/packages/db/src/queries/settings-overrides.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { IsoDateTime, OverrideSettings, WorkspaceId } from '@goodboy/types';
+import { makeTestDatabase } from '../test-helpers/test-db';
+import { migrate } from '../migrations/runner';
+import { insertWorkspace } from './workspace';
+import { getWorkspaceOverrides, setWorkspaceOverrides } from './settings-overrides';
+
+const WS_ID = 'w1' as WorkspaceId;
+
+const EMPTY: OverrideSettings = {
+  defaultProviderId: null,
+  defaultWorkflowId: null,
+  defaultBranchPrefix: null,
+  parallelEnabled: null,
+  defaultVerbosity: null,
+  providerBindings: null,
+  taskModels: null,
+  roleModels: null,
+  scoutFanout: null,
+};
+
+async function makeDb() {
+  const db = makeTestDatabase();
+  await migrate(db);
+  const now = new Date().toISOString() as IsoDateTime;
+  await insertWorkspace(db, {
+    id: WS_ID,
+    name: 'my-repo',
+    rootPath: '/tmp/my-repo',
+    createdAt: now,
+    updatedAt: now,
+  });
+  return db;
+}
+
+describe('workspace role model overrides', () => {
+  it('round-trips role preferences through the overrides row', async () => {
+    const db = await makeDb();
+    await setWorkspaceOverrides(db, WS_ID, {
+      ...EMPTY,
+      roleModels: {
+        reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+      },
+    });
+
+    const stored = await getWorkspaceOverrides(db, WS_ID);
+
+    expect(stored?.roleModels).toEqual({
+      reviewer: { providerId: 'anthropic', model: 'claude-opus-5', effort: 'max' },
+    });
+  });
+
+  it('stores no row value for an empty preference map', async () => {
+    const db = await makeDb();
+    await setWorkspaceOverrides(db, WS_ID, { ...EMPTY, roleModels: {} });
+
+    expect((await getWorkspaceOverrides(db, WS_ID))?.roleModels).toBeNull();
+  });
+});

--- a/packages/db/src/queries/settings-overrides.ts
+++ b/packages/db/src/queries/settings-overrides.ts
@@ -2,6 +2,7 @@ import type {
   OverrideSettings,
   ProviderBindings,
   ProviderId,
+  RoleModelPreferences,
   SessionId,
   TaskModelPreferences,
   VerbosityLevel,
@@ -18,6 +19,7 @@ type WorkspaceOverrideRow = {
   default_verbosity: string | null;
   provider_bindings: string | null;
   task_models: string | null;
+  role_models: string | null;
   scout_fanout: number | null;
 };
 
@@ -59,6 +61,21 @@ function serializeTaskModels(taskModels: TaskModelPreferences | null): string | 
   return taskModels && Object.keys(taskModels).length > 0 ? JSON.stringify(taskModels) : null;
 }
 
+function parseRoleModels(raw: string | null): RoleModelPreferences | null {
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as RoleModelPreferences;
+  } catch {
+    return null;
+  }
+}
+
+function serializeRoleModels(roleModels: RoleModelPreferences | null): string | null {
+  return roleModels && Object.keys(roleModels).length > 0 ? JSON.stringify(roleModels) : null;
+}
+
 function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
   return {
     defaultProviderId: row.default_provider_id as ProviderId | null,
@@ -68,6 +85,7 @@ function workspaceRowToOverride(row: WorkspaceOverrideRow): OverrideSettings {
     defaultVerbosity: row.default_verbosity as VerbosityLevel | null,
     providerBindings: parseBindings(row.provider_bindings),
     taskModels: parseTaskModels(row.task_models),
+    roleModels: parseRoleModels(row.role_models),
     scoutFanout: row.scout_fanout === null ? null : row.scout_fanout !== 0,
   };
 }
@@ -81,6 +99,7 @@ function sessionRowToOverride(row: SessionOverrideRow): OverrideSettings {
     defaultVerbosity: null,
     providerBindings: parseBindings(row.provider_bindings),
     taskModels: null,
+    roleModels: null,
     scoutFanout: null,
   };
 }
@@ -90,7 +109,7 @@ export const getWorkspaceOverrides = async (
   workspaceId: WorkspaceId,
 ): Promise<OverrideSettings | null> => {
   const rows = await db.select<WorkspaceOverrideRow>(
-    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, task_models, scout_fanout
+    `SELECT default_provider_id, default_workflow_id, default_branch_prefix, parallel_enabled, default_verbosity, provider_bindings, task_models, role_models, scout_fanout
      FROM workspaces WHERE id = ?`,
     [workspaceId],
   );
@@ -112,6 +131,7 @@ export const setWorkspaceOverrides = async (
          default_verbosity = ?,
          provider_bindings = ?,
          task_models = ?,
+         role_models = ?,
          scout_fanout = ?,
          updated_at = ?
      WHERE id = ?`,
@@ -123,6 +143,7 @@ export const setWorkspaceOverrides = async (
       overrides.defaultVerbosity,
       serializeBindings(overrides.providerBindings),
       serializeTaskModels(overrides.taskModels),
+      serializeRoleModels(overrides.roleModels),
       overrides.scoutFanout === null ? null : overrides.scoutFanout ? 1 : 0,
       Date.now(),
       workspaceId,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -118,6 +118,8 @@ export type {
   OverrideSettings,
   ProviderBindings,
   ResolvedSettings,
+  RoleModelPreference,
+  RoleModelPreferences,
   SettingsScope,
   TaskModelPreference,
   TaskModelPreferences,

--- a/packages/types/src/settings.ts
+++ b/packages/types/src/settings.ts
@@ -1,5 +1,6 @@
 import type { SessionId, WorkflowId, WorkspaceId } from './ids';
-import type { ProviderId } from './provider-registry';
+import type { ModelEffort, ProviderId } from './provider-registry';
+import type { AgentRole } from './workflow';
 
 export type VerbosityLevel = 'brief' | 'normal' | 'verbose';
 
@@ -19,6 +20,14 @@ export type TaskModelPreference = Readonly<{
 
 export type TaskModelPreferences = Readonly<Partial<Record<AuxTaskId, TaskModelPreference>>>;
 
+export type RoleModelPreference = Readonly<{
+  providerId: ProviderId;
+  model: string;
+  effort: ModelEffort;
+}>;
+
+export type RoleModelPreferences = Readonly<Partial<Record<AgentRole, RoleModelPreference>>>;
+
 export type OverrideSettings = Readonly<{
   defaultProviderId: ProviderId | null;
   defaultWorkflowId: WorkflowId | null;
@@ -27,6 +36,7 @@ export type OverrideSettings = Readonly<{
   defaultVerbosity: VerbosityLevel | null;
   providerBindings: ProviderBindings | null;
   taskModels: TaskModelPreferences | null;
+  roleModels: RoleModelPreferences | null;
   scoutFanout: boolean | null;
 }>;
 


### PR DESCRIPTION
You asked whether `investigator` could be overridden from the Providers page like the other entries. It could not, and while wiring it I found that the entries that *are* on that page were never persisting either.

## The gap you spotted

That page covers exactly five things, and they are all **background tasks**: summaries, branch names, planning, agent titles, PR drafts. Agent **roles** are a different concept and were compiled in. Wanting the investigator on something cheaper meant pinning a model by hand at every single spawn.

Roles now get the same affordance, as a second group on the same page, with **effort included** (roles honour effort; the background tasks never plumb it, so adding it there would be a dead field). A row with no override reads as its default and says which model that is.

## The bug found on the way: those overrides never reached disk

The store persists workspace overrides through the Tauri commands, not the TS query layer. The Rust struct and **both** SQL statements had no `task_models` column at all. So every task-model override you have ever set lived in memory and came back null after a reload.

That is why this is a `fix(db)` and not just a feature. Both fields are wired now.

## How a stored pin is validated

Only the **identity** of a pin can invalidate it. The effort is normalised, never fatal:

- Unknown provider, or a model that provider does not ship: rejected, falls back to the compiled default. This is the stale-registry case and the only rejection left.
- Model exists but has no effort ladder: provider and model honoured, the stored effort dropped.
- Model exists with a ladder and the stored effort is not in it: model kept, effort falls back to the role's compiled effort, or the top of the ladder if that misses too.

That second rule is the point. Strict validation would have made "pin investigator to haiku" unrepresentable, because haiku has no ladder, which is precisely the case that motivated the request. The user picked the model deliberately; the effort is the incidental part.

The panel also runs a candidate through the resolver before storing it, so what is written is exactly what will run: it can never show a pin that silently does nothing.

## Compiled defaults unchanged

`ROLE_DEFAULTS` stays the fallback, `investigator` included. This adds a way to override it, it does not redecide it.

## Worth knowing

`autoModelForRole` derives its cost-tier target from the resolved routing, so pinning a role to haiku and then losing the anthropic connection picks the *cheap* model on the surviving provider rather than a mid one. The cheapness intent propagates across providers, which I think is right, but it is a behavior worth naming.

## Not threaded, deliberately

- The PR-draft spawn config: its model already comes from the `pr_draft` **task** preference, so a role override should not reach it.
- The builder's planner effort: decorates the `plan_generation` task picker, also a background task.
- `buildCommentAgentArgs`' internal fallback: unreachable from the UI, since both production callers pass a config that is now override-aware.

## Tests

core 851 -> 860, db 95 -> 97, desktop 2624 -> 2635, Rust unchanged, typecheck clean. Migration 79. Covers: a valid pin winning, an unknown provider and an unknown model both falling back, a pin on a ladder-less model surviving, an unsupported effort being normalised rather than discarding the pin, the top-of-ladder case when neither the stored nor the role effort fits, the override beating the cheap-tier downgrade, a round-trip through the overrides row, and the panel persisting a pick per role.
