### PR TITLE
test(desktop): stop the store contract suite flaking on a cold ci runner

### DIFF
--- a/apps/desktop/src/store/slices/sessions/index.test.ts
+++ b/apps/desktop/src/store/slices/sessions/index.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   Agent,
   AgentId,
@@ -419,7 +419,13 @@ async function getStore() {
 
 let resetState: Record<string, unknown> | null = null;
 
+const STORE_IMPORT_TIMEOUT_MS = 60_000;
+
 describe('store contract', () => {
+  beforeAll(async () => {
+    await getStore();
+  }, STORE_IMPORT_TIMEOUT_MS);
+
   beforeEach(async () => {
     vi.clearAllMocks();
     invokeBudgetRuleListSpy.mockResolvedValue([]);


### PR DESCRIPTION
`store contract > sessions > refreshSessions overwrites sessions from DB` failed on two separate PRs today, both times with `Hook timed out in 10000ms` and 2634 of 2635 tests passing. Not the test's logic.

## Cause

The suite's `beforeEach` did:

```ts
const store = await getStore();
```

and `getStore()` is a dynamic `import('../../store')`, i.e. the entire store module graph. The import is cached, so only the **first** call pays for it, which means the cost always lands on whichever test runs first in that file, inside a hook with a 10 second budget. On a loaded CI runner that is not enough, and the failure looks like it belongs to an arbitrary test.

## Fix

Warm the import once in `beforeAll`, with a budget that fits it. The per-test hook now only ever hits the module cache. Nothing about what the tests assert changes, and there is no `resetModules` in play, so the semantics are identical.

Locally: 28 tests, 1.35s.