### PR TITLE
fix(desktop): compact routing picker with a bounded scroll region

### DIFF
--- a/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/DefaultsPanel/index.test.tsx
@@ -65,7 +65,7 @@ vi.mock('../../../../../shared/components/RoutingPicker', () => ({
         aria-label={`${ariaLabel} model`}
         onClick={() => onModel('claude-sonnet-4-6')}
       >
-        {model === '' ? `${recommendedModel} recommended` : model}
+        {model === '' ? `${recommendedModel} auto` : model}
       </button>
       <button
         type="button"
@@ -115,14 +115,14 @@ describe('DefaultsPanel', () => {
 
     for (const label of TASK_LABELS) {
       expect(screen.getByRole('button', { name: `${label} routing model` }).textContent).toBe(
-        'claude-haiku-4-5 recommended',
+        'claude-haiku-4-5 auto',
       );
     }
   });
 
   it('persists a selected task model immediately', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
-    fireEvent.click(screen.getAllByText('claude-haiku-4-5 recommended')[0]!);
+    fireEvent.click(screen.getAllByText('claude-haiku-4-5 auto')[0]!);
 
     expect(state.setWorkspaceOverrides).toHaveBeenCalledWith(
       'ws-1',
@@ -148,7 +148,7 @@ describe('DefaultsPanel', () => {
     render(<DefaultsPanel workspaceId={'ws-1' as never} />);
 
     expect(screen.getByRole('button', { name: 'Planner routing model' }).textContent).toBe(
-      'claude-opus-5 recommended',
+      'claude-opus-5 auto',
     );
   });
 

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.test.tsx
@@ -14,14 +14,6 @@ vi.mock('../RoleSelect', () => ({
   ),
 }));
 
-vi.mock('../VerbositySelect', () => ({
-  VerbositySelect: ({ onChange }: { onChange: (v: string) => void }) => (
-    <button type="button" onClick={() => onChange('verbose')}>
-      verbosity-select
-    </button>
-  ),
-}));
-
 vi.mock('../../../../shared/components/AgentAvatar', () => ({
   AgentAvatar: ({ kind }: { kind: string }) => <span data-testid="agent-avatar">{kind}</span>,
 }));
@@ -46,6 +38,7 @@ const baseProps = {
   resolvedModel: 'claude-haiku-4-5',
   recommendedModel: 'claude-haiku-4-5',
   effort: 'medium' as EffortLevel,
+  verbosity: 'normal' as const,
   expanded: false,
   dragging: false,
   disabled: false,
@@ -58,6 +51,7 @@ const baseProps = {
   onModel: vi.fn(),
   onProvider: vi.fn(),
   onEffort: vi.fn(),
+  onVerbosity: vi.fn(),
   onRemove: vi.fn(),
   onMoveUp: vi.fn(),
   onMoveDown: vi.fn(),
@@ -107,5 +101,13 @@ describe('WorkflowStepCard (expanded)', () => {
 
     render(<WorkflowStepCard {...baseProps} expanded={true} />);
     expect(screen.queryByRole('button', { name: /polish step instruction/i })).toBeNull();
+  });
+
+  it('changes verbosity through the routing picker', () => {
+    const onVerbosity = vi.fn();
+    render(<WorkflowStepCard {...baseProps} expanded={true} onVerbosity={onVerbosity} />);
+    fireEvent.click(screen.getByRole('button', { name: 'routing for step 1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Verbose' }));
+    expect(onVerbosity).toHaveBeenCalledWith('verbose');
   });
 });

--- a/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
+++ b/apps/desktop/src/features/session/components/WorkflowStepCard/index.tsx
@@ -16,7 +16,6 @@ import { PROVIDER_BRAND, brandColor } from '../../../providers/components/provid
 import { MODEL_COST_DOT, modelCostTier } from '../dropdown-utils';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { RoleSelect } from '../RoleSelect';
-import { VerbositySelect } from '../VerbositySelect';
 import { useClickOutside } from '../../../../shared/hooks/useClickOutside';
 
 type Props = {
@@ -313,12 +312,6 @@ export const WorkflowStepCard = ({
                   <RoleSelect value={role} onChange={onRole} disabled={disabled} />
                 </div>
               )}
-              {verbosity != null && onVerbosity != null && (
-                <div className="flex flex-col gap-1">
-                  <FieldLabel>Verbosity</FieldLabel>
-                  <VerbositySelect value={verbosity} onChange={onVerbosity} disabled={disabled} />
-                </div>
-              )}
               <div className="col-span-2 flex flex-col gap-1">
                 <FieldLabel>Provider, model, effort</FieldLabel>
                 <RoutingPicker
@@ -329,10 +322,12 @@ export const WorkflowStepCard = ({
                   effort={effort}
                   recommendedProvider={recommendedProvider}
                   recommendedModel={recommendedModel}
+                  verbosity={verbosity}
                   disabled={disabled}
                   onProvider={onProvider}
                   onModel={onModel}
                   onEffort={onEffort}
+                  onVerbosity={onVerbosity}
                 />
               </div>
             </div>

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ProviderId, WorkspaceId } from '@goodboy/types';
+
+type Store = {
+  readonly workspaceOverrides: null;
+};
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (state: Store) => T) =>
+    selector({
+      workspaceOverrides: null,
+    }),
+}));
+
+import { LibraryStepForm } from './index';
+
+afterEach(cleanup);
+
+describe('LibraryStepForm', () => {
+  it('persists verbosity through the routing picker', () => {
+    const onCommit = vi.fn();
+    render(
+      <LibraryStepForm
+        def={null}
+        workspaceId={'workspace-1' as WorkspaceId}
+        connectedProviders={['anthropic' as ProviderId]}
+        onCommit={onCommit}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('step name'), {
+      target: { value: 'Summarize changes' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'step routing' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Verbose' }));
+    expect(onCommit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Summarize changes',
+        verbosityDefault: 'verbose',
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -14,7 +14,6 @@ import type { StepDefUpsertArgs } from '../../workflows';
 import { modelEffortLevels, type EffortLevel } from '../../../chat/utils/chat-constants';
 import { RoleSelect } from '../../../session/components/RoleSelect';
 import { InlineField } from '../../../session/components/InlineField';
-import { VerbositySelect } from '../../../session/components/VerbositySelect';
 import { RoutingPicker } from '../../../../shared/components/RoutingPicker';
 import { useAppStore } from '../../../../store';
 
@@ -22,9 +21,7 @@ type Props = {
   readonly def: StepDef | null;
   readonly workspaceId: WorkspaceId;
   readonly connectedProviders: ReadonlyArray<ProviderId>;
-  // Commit the current values without closing the editor (blur-driven autosave).
   readonly onCommit: (args: StepDefUpsertArgs) => void;
-  // Close the editor; for an unsaved new step this discards it.
   readonly onClose: () => void;
 };
 
@@ -72,8 +69,6 @@ export const LibraryStepForm = ({
     verbosity: VerbosityLevel;
   };
 
-  // Build args from a partial override so a freshly-changed select commits its new
-  // value immediately rather than the stale state captured in this render.
   const commit = (over: Partial<FormState> = {}) => {
     const next: FormState = {
       name,
@@ -168,6 +163,7 @@ export const LibraryStepForm = ({
               effort={effort}
               recommendedProvider={recommendedProv}
               recommendedModel={recommendedMod}
+              verbosity={verbosity}
               disabled={false}
               onProvider={(p) => {
                 setProviderOverride(p);
@@ -187,19 +183,13 @@ export const LibraryStepForm = ({
                 setEffort(eff);
                 commit({ effort: eff });
               }}
+              onVerbosity={(next) => {
+                setVerbosity(next);
+                commit({ verbosity: next });
+              }}
             />
           </InlineField>
         </div>
-        <InlineField label="Verbosity">
-          <VerbositySelect
-            value={verbosity}
-            onChange={(v) => {
-              setVerbosity(v);
-              commit({ verbosity: v });
-            }}
-            disabled={false}
-          />
-        </InlineField>
       </div>
     </div>
   );

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/SpawnAgentMenu/index.test.tsx
@@ -48,7 +48,7 @@ describe('SpawnAgentMenu', () => {
     openMenu();
     const picker = screen.getByRole('button', { name: 'new agent routing' });
     expect(picker.textContent).toContain('Claude');
-    expect(picker.textContent).toContain('recommended');
+    expect(picker.textContent).not.toContain('recommended');
   });
 
   it('spawns with the role default until the routing is pinned', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/ModelOptions.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/ModelOptions.tsx
@@ -37,7 +37,7 @@ export const ModelOptions = ({ ids, value, recommendedModel, isRecommended, onSe
         active={isRecommended}
         onSelect={() => onSelect('')}
         glyph={<Sparkles size={11} className="shrink-0 text-primary" aria-hidden />}
-        tag="recommended"
+        tag="auto"
       />
     )}
     {groupModels({ ids }).map((group) => (

--- a/apps/desktop/src/shared/components/RoutingPicker/PickerChip.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/PickerChip.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react';
+import { cn } from '@goodboy/ui';
+
+type Props = {
+  readonly label: string;
+  readonly active: boolean;
+  readonly onSelect: () => void;
+  readonly glyph?: ReactNode;
+  readonly note?: string;
+  readonly title?: string;
+};
+
+export const PickerChip = ({ label, active, onSelect, glyph, note, title }: Props) => (
+  <button
+    type="button"
+    onClick={onSelect}
+    title={title}
+    aria-pressed={active}
+    className={cn(
+      'inline-flex min-w-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors',
+      active
+        ? 'bg-background font-medium text-foreground shadow-sm'
+        : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
+    )}
+  >
+    {glyph}
+    <span className="truncate">{label}</span>
+    {note != null && <span className="text-2xs text-muted-foreground/60">{note}</span>}
+  </button>
+);

--- a/apps/desktop/src/shared/components/RoutingPicker/TriggerLabel.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/TriggerLabel.tsx
@@ -20,18 +20,10 @@ type Props = {
   readonly model: string;
   readonly effort: EffortLevel;
   readonly showEffort: boolean;
-  readonly isModelRecommended: boolean;
   readonly verbosity?: VerbosityLevel;
 };
 
-export const TriggerLabel = ({
-  provider,
-  model,
-  effort,
-  showEffort,
-  isModelRecommended,
-  verbosity,
-}: Props) => {
+export const TriggerLabel = ({ provider, model, effort, showEffort, verbosity }: Props) => {
   const ProviderGlyph = PROVIDER_BRAND[provider].icon;
   return (
     <>
@@ -61,11 +53,6 @@ export const TriggerLabel = ({
             {VERBOSITY_LABEL[verbosity]}
           </span>
         </>
-      )}
-      {isModelRecommended && (
-        <span className="shrink-0 rounded bg-muted px-1 text-[9px] font-medium uppercase leading-tight tracking-wide text-muted-foreground/70">
-          recommended
-        </span>
       )}
     </>
   );

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -41,7 +41,10 @@ describe('RoutingPicker', () => {
     render(<RoutingPicker {...baseProps} model="" recommendedModel="claude-sonnet-4-6" />);
     const trigger = screen.getByRole('button', { name: /routing/i });
     expect(trigger.textContent).toContain('Sonnet 4.6');
-    expect(trigger.textContent).toContain('recommended');
+    expect(trigger.textContent).not.toContain('recommended');
+    fireEvent.click(trigger);
+    expect(screen.getByRole('dialog').textContent).toContain('auto');
+    expect(screen.getByRole('dialog').textContent).not.toContain('recommended');
   });
 
   it('reports the picked model and closes the popover', () => {
@@ -51,6 +54,15 @@ describe('RoutingPicker', () => {
     fireEvent.click(screen.getByTitle('claude-sonnet-4-6'));
     expect(onModel).toHaveBeenCalledWith('claude-sonnet-4-6');
     expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('bounds only the model list as the scroll region', () => {
+    render(<RoutingPicker {...baseProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /routing/i }));
+    const viewports = screen.getByRole('dialog').querySelectorAll('[class*="overflow-y-auto"]');
+    const viewport = viewports.item(0);
+    expect(viewports).toHaveLength(1);
+    expect(viewport?.parentElement?.className).toContain('max-h-[15rem]');
   });
 
   it('offers verbosity only when the caller wires it', () => {

--- a/apps/desktop/src/shared/components/RoutingPicker/index.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.tsx
@@ -16,11 +16,13 @@ import {
 } from '../../../features/settings/verbosity';
 import { useDropdown } from '../../hooks/useDropdown';
 import { ModelOptions } from './ModelOptions';
-import { OptionRow } from './OptionRow';
+import { PickerChip } from './PickerChip';
 import { PickerSection } from './PickerSection';
 import { ProviderGlyph } from './ProviderGlyph';
 import { TriggerLabel } from './TriggerLabel';
 import { resolveRouting } from './resolveRouting';
+
+const CHIP_GROUP_CLASS_NAME = 'flex flex-wrap gap-1 bg-subtle px-2.5';
 
 export type Props = {
   readonly providers: ReadonlyArray<ProviderId>;
@@ -74,7 +76,7 @@ export const RoutingPicker = ({
     align,
     openEvent,
     expectedHeight: 320,
-    width: variant === 'pill' ? 'w-80' : 'w-full min-w-[15rem]',
+    width: 'w-80 max-w-[calc(100vw-2rem)]',
   });
   const routing = resolveRouting({
     providers,
@@ -143,7 +145,6 @@ export const RoutingPicker = ({
             model={routing.model}
             effort={routing.effort}
             showEffort={showEffort}
-            isModelRecommended={isModelRecommended}
             verbosity={verbosity}
           />
         </span>
@@ -160,7 +161,7 @@ export const RoutingPicker = ({
         <Popover
           role="dialog"
           ariaLabel={ariaLabel ?? 'model routing'}
-          className={cn(popupClassName, 'flex max-h-[24rem] flex-col bg-subtle')}
+          className={cn(popupClassName, 'flex flex-col bg-subtle')}
         >
           {defaultSummary != null && (
             <div className="flex items-start gap-1.5 px-2.5 py-2 text-2xs leading-relaxed">
@@ -189,13 +190,11 @@ export const RoutingPicker = ({
               )}
             </div>
           )}
-          <ScrollFade fadeFrom="subtle" className="min-h-0 flex-1">
-            <PickerSection label="Provider" hint="Which CLI agent runs the turn">
+          <PickerSection label="Provider" hint="Which CLI agent runs the turn">
+            <div className={CHIP_GROUP_CLASS_NAME}>
               {(recommendedProvider != null || provider === '') && (
-                <OptionRow
-                  label={
-                    recommendedProvider != null ? PROVIDER_LABEL[recommendedProvider] : 'Default'
-                  }
+                <PickerChip
+                  label="auto"
                   active={routing.isProviderRecommended}
                   onSelect={() => onPickProvider('')}
                   glyph={
@@ -208,7 +207,9 @@ export const RoutingPicker = ({
                       />
                     )
                   }
-                  tag={recommendedProvider != null ? 'recommended' : undefined}
+                  note={
+                    recommendedProvider != null ? PROVIDER_LABEL[recommendedProvider] : undefined
+                  }
                 />
               )}
               {providers
@@ -217,7 +218,7 @@ export const RoutingPicker = ({
                   const unavailable =
                     connectedProviders != null && !connectedProviders.includes(id);
                   return (
-                    <OptionRow
+                    <PickerChip
                       key={id}
                       label={PROVIDER_LABEL[id]}
                       active={!routing.isProviderRecommended && routing.provider === id}
@@ -228,9 +229,11 @@ export const RoutingPicker = ({
                     />
                   );
                 })}
-            </PickerSection>
-            <Divider />
-            <PickerSection label="Model" hint="Cost tier shown next to each variant">
+            </div>
+          </PickerSection>
+          <Divider />
+          <PickerSection label="Model" hint="Cost tier shown next to each variant">
+            <ScrollFade fadeFrom="subtle" className="min-h-0 max-h-[15rem]">
               <ModelOptions
                 ids={routing.models}
                 value={routing.model}
@@ -241,23 +244,25 @@ export const RoutingPicker = ({
                   close();
                 }}
               />
-            </PickerSection>
-            <Divider />
-            <PickerSection label="Effort" hint="How hard the model thinks before answering">
-              {onEffort == null && (
-                <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
-                  This task always runs at the model default effort.
-                </p>
-              )}
-              {onEffort != null && routing.effortLevels == null && (
-                <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
-                  {modelLabel(routing.model)} answers in a single pass, so it has no thinking levels
-                  to set.
-                </p>
-              )}
-              {onEffort != null &&
-                routing.effortLevels?.map((level) => (
-                  <OptionRow
+            </ScrollFade>
+          </PickerSection>
+          <Divider />
+          <PickerSection label="Effort" hint="How hard the model thinks before answering">
+            {onEffort == null && (
+              <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
+                This task always runs at the model default effort.
+              </p>
+            )}
+            {onEffort != null && routing.effortLevels == null && (
+              <p className="px-2.5 text-2xs leading-relaxed text-muted-foreground/60">
+                {modelLabel(routing.model)} answers in a single pass, so it has no thinking levels
+                to set.
+              </p>
+            )}
+            {onEffort != null && routing.effortLevels != null && (
+              <div className={CHIP_GROUP_CLASS_NAME}>
+                {routing.effortLevels.map((level) => (
+                  <PickerChip
                     key={level}
                     label={EFFORT_LABEL[level]}
                     active={routing.effort === level}
@@ -273,13 +278,16 @@ export const RoutingPicker = ({
                     }
                   />
                 ))}
-            </PickerSection>
-            {verbosity != null && onVerbosity != null && (
-              <>
-                <Divider />
-                <PickerSection label="Replies" hint="How detailed the answers should be">
+              </div>
+            )}
+          </PickerSection>
+          {verbosity != null && onVerbosity != null && (
+            <>
+              <Divider />
+              <PickerSection label="Replies" hint="How detailed the answers should be">
+                <div className={CHIP_GROUP_CLASS_NAME}>
                   {VERBOSITY_LEVELS.map((level) => (
-                    <OptionRow
+                    <PickerChip
                       key={level}
                       label={VERBOSITY_LABEL[level]}
                       active={verbosity === level}
@@ -295,10 +303,10 @@ export const RoutingPicker = ({
                       }
                     />
                   ))}
-                </PickerSection>
-              </>
-            )}
-          </ScrollFade>
+                </div>
+              </PickerSection>
+            </>
+          )}
         </Popover>
       )}
     </div>


### PR DESCRIPTION
## Problem

The #990 picker rework put `max-h-[24rem]` on the popover itself, an auto-height flex column. `flex-1` on the ScrollFade inside never received a bounded height, its viewport never scrolled, and the popover's `overflow-hidden` hard-clipped every row past 384px: on providers with long model lists the effort section was unreachable. The vertical option-row layout was also much taller than the pre-rework chip grid, which is why it needed the scroll the old picker never did.

## Solution

- The grouped model list is now the only scroll region, bounded with `max-h` on the ScrollFade root (the pattern docs/styling.md mandates), with a regression test.
- Provider, effort and replies go back to compact chip rows (`PickerChip`, active state `bg-background shadow-sm`), restoring the pre-#990 density while keeping the single unified `RoutingPicker` and its prop contract.
- The visible "recommended" copy (trigger pill, provider row tag, model row tag) becomes `auto`; `resolveRouting` semantics untouched.
- LibraryStepForm and WorkflowStepCard stop rendering a separate `VerbositySelect` and feed verbosity through the picker's Replies section, like the composer already did.

## Verification

- typecheck green, full desktop suite 321 files / 2638 tests green.
- New tests: scroll-region bounding regression, verbosity persistence through the picker on both workflow forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)