### PR TITLE
refactor(ui): one icon tile for every boxed icon

### DIFF
--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.test.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.test.tsx
@@ -50,6 +50,6 @@ describe('IntegrationGlyph, framed variant', () => {
     render(<IntegrationGlyph provider="sentry" framed />);
     const mark = screen.getByRole('img', { name: 'Sentry' });
     expect(mark.getAttribute('width')).toBe('16');
-    expect(mark.parentElement?.className).toContain('bg-provider-sentry/10');
+    expect(mark.parentElement?.className).toContain('size-7 rounded-md');
   });
 });

--- a/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
+++ b/apps/desktop/src/features/integrations/components/IntegrationGlyph/index.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@goodboy/ui';
+import { cn, IconTile } from '@goodboy/ui';
 import type { LucideIcon } from 'lucide-react';
 import {
   GithubIcon,
@@ -20,13 +20,6 @@ const INTEGRATION_BRAND: Record<IntegrationGlyphProvider, IntegrationBrand> = {
   gitlab: { icon: GitlabIcon, label: 'GitLab', cssVar: '--color-provider-gitlab' },
   linear: { icon: LinearIcon, label: 'Linear', cssVar: '--color-provider-linear' },
   sentry: { icon: SentryIcon, label: 'Sentry', cssVar: '--color-provider-sentry' },
-};
-
-const FRAME_STYLE: Record<IntegrationGlyphProvider, string> = {
-  github: 'bg-provider-github/10',
-  gitlab: 'bg-provider-gitlab/10',
-  linear: 'bg-provider-linear/10',
-  sentry: 'bg-provider-sentry/10',
 };
 
 const MARK_SIZE: Record<'xs' | 'sm', number> = {
@@ -60,14 +53,8 @@ export const IntegrationGlyph = ({ provider, size = 'sm', framed = false, classN
   }
 
   return (
-    <span
-      className={cn(
-        'flex size-8 shrink-0 items-center justify-center rounded-lg',
-        FRAME_STYLE[provider],
-        className,
-      )}
-    >
+    <IconTile size="sm" color={color} className={className}>
       <Icon size={FRAMED_MARK_SIZE} role="img" aria-label={label} style={{ color }} />
-    </span>
+    </IconTile>
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderConnectModal/index.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderConnectModal/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Dialog, Button } from '@goodboy/ui';
+import { Button, Dialog, IconTile } from '@goodboy/ui';
 import { CheckCircle2 } from 'lucide-react';
 import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
@@ -71,16 +71,9 @@ function ModalBody({ providerId, initialAction, open, onClose }: BodyProps) {
       panelClassName="bg-subtle/30 px-5 py-5 overflow-y-auto"
       title={
         <span className="inline-flex items-center gap-2">
-          <span
-            aria-hidden
-            className="flex h-7 w-7 items-center justify-center rounded-full"
-            style={{
-              backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
-              color,
-            }}
-          >
-            <Icon size={14} strokeWidth={2} />
-          </span>
+          <IconTile size="sm" color={color}>
+            <Icon size={14} strokeWidth={2} aria-hidden />
+          </IconTile>
           <span className="lowercase">{provider?.label ?? providerId}</span>
           <StatusPill phase={lifecycle.phase} connection={provider?.connection ?? 'missing'} />
         </span>

--- a/apps/desktop/src/features/providers/components/ProviderIcon.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderIcon.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@goodboy/ui';
+import { cn, IconTile } from '@goodboy/ui';
 import type { ProviderId } from '@goodboy/types';
 import { PROVIDER_BRAND, brandColor } from './provider-brand';
 
@@ -47,17 +47,20 @@ export const ProviderIcon = ({
     return <Icon size={size} aria-label={label} style={{ color }} />;
   }
 
+  let tileSize: 'xs' | 'sm' | 'md' | 'lg' = 'md';
+  if (size <= 16) {
+    tileSize = 'xs';
+  }
+  if (size > 16 && size <= 22) {
+    tileSize = 'sm';
+  }
+  if (size > 30) {
+    tileSize = 'lg';
+  }
+
   return (
-    <span
-      className="flex items-center justify-center rounded"
-      style={{
-        width: size + 8,
-        height: size + 8,
-        backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`,
-        color,
-      }}
-    >
+    <IconTile size={tileSize} color={color}>
       <Icon size={size} aria-label={label} />
-    </span>
+    </IconTile>
   );
 };

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderConnectPane.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderConnectPane.tsx
@@ -1,4 +1,4 @@
-import { Button, Divider, ScrollFade } from '@goodboy/ui';
+import { Button, Divider, IconTile, ScrollFade } from '@goodboy/ui';
 import { ArrowLeft } from 'lucide-react';
 import type { ProviderId, ProviderLifecycleAction } from '@goodboy/types';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
@@ -41,13 +41,9 @@ export const ProviderConnectPane = ({ providerId, action, onBack }: Props) => {
         >
           <ArrowLeft size={16} aria-hidden />
         </button>
-        <span
-          aria-hidden
-          className="flex size-9 items-center justify-center rounded-lg"
-          style={{ backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`, color }}
-        >
-          <Icon size={18} strokeWidth={2} />
-        </span>
+        <IconTile size="md" color={color}>
+          <Icon size={18} strokeWidth={2} aria-hidden />
+        </IconTile>
         <span className="text-base font-semibold lowercase text-foreground">
           {provider?.label ?? providerId}
         </span>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { cn, Divider, ScrollFade, SectionHeader } from '@goodboy/ui';
+import { cn, Divider, IconTile, ScrollFade, SectionHeader } from '@goodboy/ui';
 import {
   ArrowRight,
   Download,
@@ -66,12 +66,9 @@ function Detail({
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-3 px-8 py-4">
-        <span
-          className="flex size-11 items-center justify-center rounded-lg"
-          style={{ backgroundColor: `color-mix(in oklch, ${color} 18%, transparent)`, color }}
-        >
+        <IconTile size="lg" color={color}>
           <Icon size={22} aria-hidden />
-        </span>
+        </IconTile>
         <div className="flex min-w-0 flex-col">
           <span className="text-base font-semibold lowercase text-foreground">{info.label}</span>
           <span className="truncate text-2xs text-muted-foreground">

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProvidersRail.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@goodboy/ui';
+import { cn, IconTile } from '@goodboy/ui';
 import type { ProviderConnectionState, ProviderId } from '@goodboy/types';
 import type { ProviderInfo } from '../../../../features/providers/providers';
 import { brandColor, PROVIDER_BRAND } from '../provider-brand';
@@ -43,9 +43,9 @@ export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults
               : 'text-muted-foreground hover:bg-muted/50',
           )}
         >
-          <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+          <IconTile size="sm" tone="primary" ring={false}>
             <SlidersHorizontal size={15} aria-hidden />
-          </span>
+          </IconTile>
           <span className="text-sm font-medium text-foreground">Defaults</span>
         </button>
       </section>
@@ -75,15 +75,9 @@ export const ProvidersRail = ({ providers, focusedId, onSelect, onSelectDefaults
                     : 'text-muted-foreground hover:bg-muted/50',
                 )}
               >
-                <span
-                  className="flex size-7 shrink-0 items-center justify-center rounded-md"
-                  style={{
-                    backgroundColor: `color-mix(in oklch, ${brandColor(id)} 18%, transparent)`,
-                    color: brandColor(id),
-                  }}
-                >
+                <IconTile size="sm" color={brandColor(id)}>
                   <Icon size={15} aria-hidden />
-                </span>
+                </IconTile>
                 <span className="flex min-w-0 flex-1 flex-col">
                   <span className="truncate text-sm font-medium lowercase text-foreground">
                     {p.label}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -15,7 +15,7 @@ import {
   Target,
   Terminal,
 } from 'lucide-react';
-import { KbdPill, ScrollFade, Skeleton, StatusDot, cn, tintClasses } from '@goodboy/ui';
+import { IconTile, KbdPill, ScrollFade, Skeleton, StatusDot, cn } from '@goodboy/ui';
 import type { Tone } from '@goodboy/ui';
 import type { Agent, Session, SessionId } from '@goodboy/types';
 import { classifyAgent, isStandaloneAgent } from '../../../../session/agent-kind';
@@ -373,16 +373,9 @@ export const LensColumn = ({
               : 'text-muted-foreground hover:bg-foreground/[0.03] hover:text-foreground',
           )}
         >
-          <span
-            aria-hidden
-            className={cn(
-              'flex size-5 shrink-0 items-center justify-center rounded-md ring-1 transition-colors',
-              tintClasses('neutral').bg,
-              tintClasses('neutral').ring,
-            )}
-          >
-            <LayoutDashboard size={12} aria-hidden className={tintClasses('neutral').icon} />
-          </span>
+          <IconTile size="xs" tone="neutral" className="transition-colors">
+            <LayoutDashboard size={12} aria-hidden />
+          </IconTile>
           <span
             className={cn(
               'min-w-0 flex-1 truncate pr-12 text-[13px]',
@@ -426,20 +419,20 @@ export const LensColumn = ({
                   )}
                 >
                   {row.glyph ? (
-                    <span aria-hidden className="flex size-5 shrink-0 items-center justify-center">
-                      <IntegrationGlyph provider={row.glyph} />
-                    </span>
-                  ) : row.icon ? (
-                    <span
-                      aria-hidden
-                      className={cn(
-                        'flex size-5 shrink-0 items-center justify-center rounded-md ring-1 transition-colors',
-                        tintClasses(row.tone).bg,
-                        tintClasses(row.tone).ring,
-                      )}
+                    <IconTile
+                      size="xs"
+                      color={`var(--color-provider-${row.glyph})`}
+                      ring
+                      className="transition-colors"
                     >
-                      <row.icon size={12} aria-hidden className={tintClasses(row.tone).icon} />
-                    </span>
+                      <span aria-hidden>
+                        <IntegrationGlyph provider={row.glyph} />
+                      </span>
+                    </IconTile>
+                  ) : row.icon ? (
+                    <IconTile size="xs" tone={row.tone} className="transition-colors">
+                      <row.icon size={12} aria-hidden />
+                    </IconTile>
                   ) : null}
                   <span
                     className={cn(

--- a/packages/ui/src/__tests__/IconTile.test.tsx
+++ b/packages/ui/src/__tests__/IconTile.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { IconTile } from '../components/IconTile';
+
+afterEach(cleanup);
+
+describe('IconTile', () => {
+  it.each([
+    ['xs', 'size-5 rounded-md'],
+    ['sm', 'size-7 rounded-md'],
+    ['md', 'size-9 rounded-lg'],
+    ['lg', 'size-11 rounded-lg'],
+  ] as const)('renders the %s size', (size, classes) => {
+    render(
+      <IconTile size={size}>
+        <span role="img" aria-label="mark" />
+      </IconTile>,
+    );
+
+    expect(screen.getByRole('img', { name: 'mark' }).parentElement?.className).toContain(classes);
+  });
+
+  it('renders the tone background, ring, and icon color', () => {
+    render(
+      <IconTile tone="success">
+        <span role="img" aria-label="mark" />
+      </IconTile>,
+    );
+
+    const className = screen.getByRole('img', { name: 'mark' }).parentElement?.className ?? '';
+    expect(['bg-success/10', 'ring-1', 'ring-success/20', 'text-success']).toSatisfy(
+      (classes: ReadonlyArray<string>) => classes.every((value) => className.includes(value)),
+    );
+  });
+
+  it('renders a custom color without a ring by default', () => {
+    const markup = renderToStaticMarkup(
+      <IconTile color="#ff00aa">
+        <span role="img" aria-label="mark" />
+      </IconTile>,
+    );
+
+    expect(markup).toContain(
+      'style="background-color:color-mix(in oklab, #ff00aa 15%, transparent);color:#ff00aa"',
+    );
+    expect(markup).not.toContain('ring-1');
+  });
+});

--- a/packages/ui/src/components/IconTile.tsx
+++ b/packages/ui/src/components/IconTile.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react';
+import { cn } from '../cn';
+import { tintClasses, type Tone } from '../tint';
+
+export type Props = {
+  readonly children: ReactNode;
+  readonly size?: 'xs' | 'sm' | 'md' | 'lg';
+  readonly tone?: Tone;
+  readonly color?: string;
+  readonly ring?: boolean;
+  readonly className?: string;
+};
+
+const SIZE_CLASSES = {
+  xs: 'size-5 rounded-md',
+  sm: 'size-7 rounded-md',
+  md: 'size-9 rounded-lg',
+  lg: 'size-11 rounded-lg',
+} satisfies Record<NonNullable<Props['size']>, string>;
+
+export const IconTile = ({ children, size = 'sm', tone, color, ring, className }: Props) => {
+  const tint = tone != null && color == null ? tintClasses(tone) : null;
+  const isRingVisible = ring ?? tint != null;
+
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center',
+        SIZE_CLASSES[size],
+        tint?.bg,
+        tint?.icon,
+        isRingVisible && 'ring-1',
+        isRingVisible && tint?.ring,
+        className,
+      )}
+      style={
+        color != null
+          ? {
+              backgroundColor: `color-mix(in oklab, ${color} 15%, transparent)`,
+              color,
+            }
+          : undefined
+      }
+    >
+      {children}
+    </span>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,8 @@ export { FieldRow } from './components/FieldRow';
 export type { FieldRowProps } from './components/FieldRow';
 export { Input } from './components/Input';
 export type { InputProps } from './components/Input';
+export { IconTile } from './components/IconTile';
+export type { Props as IconTileProps } from './components/IconTile';
 export { KbdPill } from './components/KbdPill';
 export type { KbdPillProps } from './components/KbdPill';
 export { Markdown } from './components/Markdown';


### PR DESCRIPTION
Stacked on #1000.

## Problem

At least six independent square-icon wrappers with divergent sizes, radii and background formulas: `ProviderIcon withChip` (color-mix 18%), `IntegrationGlyph framed` (`bg-provider-*/10`), the lens-rail ring boxes (tintClasses), and three different provider-studio tiles. In the lens rail, lens rows got a tinted ring box while integration rows in the same list rendered bare: one list, two treatments.

## Solution

- New `IconTile` primitive in `@goodboy/ui`: sizes xs/sm/md/lg (size-5/7/9/11), `tone` (tintClasses) or `color` (css color via color-mix) tinting, consistent radii.
- `ProviderIcon withChip` and `IntegrationGlyph framed` delegate to it internally (public APIs unchanged); provider studio tiles and the lens rail migrate to it.
- Integration rows in the lens rail now get the same tile as lens rows.

Real brand marks for GitHub/GitLab/Linear/Sentry already landed in #987; this PR only unifies the boxes around icons.

## Verification

typecheck green, ui suite 33 tests, full desktop suite 2638 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)