### PR TITLE
feat(desktop): discoverable resolver inspector and stateful agent rows

### DIFF
--- a/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { X } from 'lucide-react';
 import { Divider, ScrollFade } from '@goodboy/ui';
+import { InspectorHeader } from '../SessionWorkspace/parts/InspectorSplit/InspectorHeader';
 import type { AgentId, AgentSourceKind, PrComment, SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useDiffComments } from '../../../../store';
 import { openUrl } from '../../../../shared/lib/editor';
@@ -97,20 +97,7 @@ export const ResolverInspector = ({ sessionId, agentId, onClose }: Props) => {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
-        <span className="truncate text-xs font-medium text-foreground" title={agent.name}>
-          {agent.name}
-        </span>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="close resolver inspector"
-          className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-        >
-          <X size={14} aria-hidden />
-        </button>
-      </div>
-      <Divider />
+      <InspectorHeader title={agent.name} closeLabel="close resolver inspector" onClose={onClose} />
       <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
         <div className="flex flex-col gap-4">
           <OriginSection

--- a/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
@@ -96,7 +96,7 @@ export const ResolverInspector = ({ sessionId, agentId, onClose }: Props) => {
         : null;
 
   return (
-    <div className="flex w-80 shrink-0 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
         <span className="truncate text-xs font-medium text-foreground" title={agent.name}>
           {agent.name}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
@@ -1,0 +1,27 @@
+import { Divider } from '@goodboy/ui';
+import { X } from 'lucide-react';
+
+type Props = {
+  readonly title: string;
+  readonly closeLabel: string;
+  readonly onClose: () => void;
+};
+
+export const InspectorHeader = ({ title, closeLabel, onClose }: Props) => (
+  <>
+    <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
+      <span className="truncate text-xs font-medium text-foreground" title={title}>
+        {title}
+      </span>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label={closeLabel}
+        className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+      >
+        <X size={14} aria-hidden />
+      </button>
+    </div>
+    <Divider />
+  </>
+);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/index.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { InspectorSplit } from './index';
+
+afterEach(cleanup);
+
+describe('InspectorSplit', () => {
+  it('keeps the main content visible while the panel is closed', () => {
+    render(
+      <InspectorSplit open={false} panel={<div>Inspector content</div>}>
+        <div>Main content</div>
+      </InspectorSplit>,
+    );
+
+    expect(screen.getByText('Main content')).toBeDefined();
+    expect(screen.queryByText('Inspector content')).toBeNull();
+  });
+
+  it('shows the panel at the standard width when open', () => {
+    const { container } = render(
+      <InspectorSplit open panel={<div>Inspector content</div>}>
+        <div>Main content</div>
+      </InspectorSplit>,
+    );
+
+    expect(screen.getByText('Inspector content')).toBeDefined();
+    expect(container.querySelector('.w-80')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/index.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import { Divider } from '@goodboy/ui';
+
+type Props = {
+  readonly open: boolean;
+  readonly panel: ReactNode;
+  readonly children: ReactNode;
+};
+
+export const InspectorSplit = ({ open, panel, children }: Props) => (
+  <div className="flex h-full min-h-0">
+    <div className="min-h-0 min-w-0 flex-1">{children}</div>
+    {open ? (
+      <>
+        <Divider orientation="vertical" />
+        <div className="flex min-h-0 w-80 shrink-0 flex-col">{panel}</div>
+      </>
+    ) : null}
+  </div>
+);

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
-import { Divider } from '@goodboy/ui';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
 import { ResolverInspector } from '../../ResolverInspector';
+import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from './PaneShell';
 
 type Props = {
@@ -15,34 +15,33 @@ export const ResolvePane = ({ session, meta }: Props) => {
   const [inspectedId, setInspectedId] = useState<AgentId | null>(null);
 
   return (
-    <div className="flex h-full min-h-0">
-      <div className="min-h-0 flex-1">
-        <PaneShell
-          title="Resolve"
-          description="Resolver agents spawned from pull request comments and diff selections."
-          meta={meta}
-          width="3xl"
-        >
-          <AgentsSection
-            task={session}
-            only="resolve"
-            inspectedResolverId={inspectedId}
-            onInspectResolver={(agentId) =>
-              setInspectedId((prev) => (prev === agentId ? null : agentId))
-            }
-          />
-        </PaneShell>
-      </div>
-      {inspectedId !== null ? (
-        <>
-          <Divider orientation="vertical" />
+    <InspectorSplit
+      open={inspectedId !== null}
+      panel={
+        inspectedId !== null ? (
           <ResolverInspector
             sessionId={sessionId}
             agentId={inspectedId}
             onClose={() => setInspectedId(null)}
           />
-        </>
-      ) : null}
-    </div>
+        ) : null
+      }
+    >
+      <PaneShell
+        title="Resolve"
+        description="Resolver agents spawned from pull request comments and diff selections."
+        meta={meta}
+        width="3xl"
+      >
+        <AgentsSection
+          task={session}
+          only="resolve"
+          inspectedResolverId={inspectedId}
+          onInspectResolver={(agentId) =>
+            setInspectedId((prev) => (prev === agentId ? null : agentId))
+          }
+        />
+      </PaneShell>
+    </InspectorSplit>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import { Check, Copy, RotateCcw, X } from 'lucide-react';
-import { Divider, Markdown, ScrollFade, cn } from '@goodboy/ui';
+import { Check, Copy, RotateCcw } from 'lucide-react';
+import { Markdown, ScrollFade, cn } from '@goodboy/ui';
 import type { ContextSlotHistoryEntry } from '@goodboy/types';
+import { InspectorHeader } from './InspectorSplit/InspectorHeader';
 
 type HistoryEntryProps = {
   readonly entry: ContextSlotHistoryEntry;
@@ -126,18 +127,11 @@ export const SlotHistoryPanel = ({
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
-        <span className="text-xs font-medium text-foreground">history: {label}</span>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="close history panel"
-          className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-        >
-          <X size={14} aria-hidden />
-        </button>
-      </div>
-      <Divider />
+      <InspectorHeader
+        title={`history: ${label}`}
+        closeLabel="close history panel"
+        onClose={onClose}
+      />
       <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
         {entries.length === 0 ? (
           <p className="text-xs italic text-muted-foreground">no history yet</p>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotHistoryPanel.tsx
@@ -125,7 +125,7 @@ export const SlotHistoryPanel = ({
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   return (
-    <div className="flex w-80 shrink-0 flex-col">
+    <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 px-3 py-2.5">
         <span className="text-xs font-medium text-foreground">history: {label}</span>
         <button

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/SlotPane.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, CheckSquare, Copy, FileText, History, Target } from 'lucide-react';
-import { Button, Divider, EmptyState, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
+import { Button, EmptyState, Markdown, Textarea, cn, type Tone } from '@goodboy/ui';
 import type { LucideIcon } from 'lucide-react';
 import type { Session, SessionId } from '@goodboy/types';
 import {
@@ -12,6 +12,7 @@ import {
   useSummarizerStatus,
 } from '../../../../../store';
 import { GoalAttachmentsStrip } from '../../../../context/components/ContextPanel/strips/GoalAttachmentsStrip';
+import { InspectorSplit } from './InspectorSplit';
 import { PaneShell } from './PaneShell';
 import { SlotHistoryPanel } from './SlotHistoryPanel';
 
@@ -172,150 +173,146 @@ export const SlotPane = ({ session, slotKey }: Props) => {
   };
 
   return (
-    <div className="flex h-full min-h-0">
-      <div className="min-h-0 flex-1">
-        <PaneShell
-          title={SLOT_TITLE[slotKey]}
-          description={SLOT_DESCRIPTION[slotKey]}
-          actions={
-            <>
-              {hasValue ? (
-                <button
-                  type="button"
-                  onClick={() => void copyValue()}
-                  title={
-                    valueCopied
-                      ? 'copied'
-                      : slotKey === 'last_output_summary'
-                        ? 'copy shareable summary'
-                        : 'copy'
-                  }
-                  aria-label={
-                    valueCopied
-                      ? 'copied'
-                      : slotKey === 'last_output_summary'
-                        ? 'copy shareable summary'
-                        : 'copy'
-                  }
-                  className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-                >
-                  {valueCopied ? <Check size={15} aria-hidden /> : <Copy size={15} aria-hidden />}
-                </button>
-              ) : null}
-              {history.length > 0 ? (
-                <button
-                  type="button"
-                  onClick={toggleHistory}
-                  title="view history"
-                  aria-label={`view history for ${SLOT_TITLE[slotKey]}`}
-                  className={cn(
-                    'rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
-                    historyOpen && 'bg-foreground/5 text-foreground',
-                  )}
-                >
-                  <History size={15} aria-hidden />
-                </button>
-              ) : null}
-            </>
-          }
-        >
+    <InspectorSplit
+      open={historyOpen}
+      panel={
+        <SlotHistoryPanel
+          label={SLOT_TITLE[slotKey]}
+          renderAsMarkdown={renderAsMarkdown}
+          entries={history}
+          onRestore={(entry) => {
+            void upsertSessionSlot(sessionId, slotKey, entry.value);
+            setHistoryOpen(false);
+          }}
+          onClose={() => setHistoryOpen(false)}
+        />
+      }
+    >
+      <PaneShell
+        title={SLOT_TITLE[slotKey]}
+        description={SLOT_DESCRIPTION[slotKey]}
+        actions={
           <>
-            {slot === undefined && loading.slots ? (
-              <div className="flex flex-col gap-2">
-                <div className="h-4 w-full rounded bg-muted/50" />
-                <div className="h-4 w-3/4 rounded bg-muted/50" />
-              </div>
-            ) : editing ? (
-              <Textarea
-                autoFocus
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onBlur={commit}
-                onKeyDown={(e) => {
-                  if (e.key === 'Escape') {
-                    e.preventDefault();
-                    setDraft(value);
-                    setEditing(false);
-                  }
-                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                    e.preventDefault();
-                    commit();
-                  }
-                }}
-                className="font-mono text-sm"
-                autoGrow
-                maxRows={24}
-              />
-            ) : !hasValue ? (
-              <EmptyState
-                bordered
-                tone={SLOT_TONE[slotKey]}
-                icon={SLOT_ICON[slotKey]}
-                title={SLOT_EMPTY_CTA[slotKey]}
-                description={SLOT_EMPTY_DESCRIPTION[slotKey]}
-                action={
-                  <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
-                    Add
-                  </Button>
-                }
-              />
-            ) : renderAsMarkdown ? (
-              <div
-                role={isSummarizing ? undefined : 'button'}
-                tabIndex={isSummarizing ? -1 : 0}
-                onClick={startEditing}
-                onKeyDown={(e) => {
-                  if (isSummarizing) {
-                    return;
-                  }
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    setEditing(true);
-                  }
-                }}
-                className={cn(
-                  'rounded-lg leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_code]:break-all [&_pre]:whitespace-pre-wrap [&_pre]:break-all',
-                  isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
-                )}
-              >
-                <Markdown text={value} className="text-sm text-foreground" />
-              </div>
-            ) : (
+            {hasValue ? (
               <button
                 type="button"
-                onClick={startEditing}
-                disabled={isSummarizing}
+                onClick={() => void copyValue()}
+                title={
+                  valueCopied
+                    ? 'copied'
+                    : slotKey === 'last_output_summary'
+                      ? 'copy shareable summary'
+                      : 'copy'
+                }
+                aria-label={
+                  valueCopied
+                    ? 'copied'
+                    : slotKey === 'last_output_summary'
+                      ? 'copy shareable summary'
+                      : 'copy'
+                }
+                className="rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+              >
+                {valueCopied ? <Check size={15} aria-hidden /> : <Copy size={15} aria-hidden />}
+              </button>
+            ) : null}
+            {history.length > 0 ? (
+              <button
+                type="button"
+                onClick={toggleHistory}
+                title="view history"
+                aria-label={`view history for ${SLOT_TITLE[slotKey]}`}
                 className={cn(
-                  'whitespace-pre-wrap break-words rounded-lg text-left text-base font-medium leading-relaxed text-foreground transition-colors',
-                  isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
+                  'rounded-md p-1.5 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground',
+                  historyOpen && 'bg-foreground/5 text-foreground',
                 )}
               >
-                {value}
+                <History size={15} aria-hidden />
               </button>
-            )}
-
-            {slotKey === 'goal' ? (
-              <GoalAttachmentsStrip owner={{ type: 'session', id: sessionId }} />
             ) : null}
           </>
-        </PaneShell>
-      </div>
-
-      {historyOpen ? (
+        }
+      >
         <>
-          <Divider orientation="vertical" />
-          <SlotHistoryPanel
-            label={SLOT_TITLE[slotKey]}
-            renderAsMarkdown={renderAsMarkdown}
-            entries={history}
-            onRestore={(entry) => {
-              void upsertSessionSlot(sessionId, slotKey, entry.value);
-              setHistoryOpen(false);
-            }}
-            onClose={() => setHistoryOpen(false)}
-          />
+          {slot === undefined && loading.slots ? (
+            <div className="flex flex-col gap-2">
+              <div className="h-4 w-full rounded bg-muted/50" />
+              <div className="h-4 w-3/4 rounded bg-muted/50" />
+            </div>
+          ) : editing ? (
+            <Textarea
+              autoFocus
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commit}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setDraft(value);
+                  setEditing(false);
+                }
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+                  e.preventDefault();
+                  commit();
+                }
+              }}
+              className="font-mono text-sm"
+              autoGrow
+              maxRows={24}
+            />
+          ) : !hasValue ? (
+            <EmptyState
+              bordered
+              tone={SLOT_TONE[slotKey]}
+              icon={SLOT_ICON[slotKey]}
+              title={SLOT_EMPTY_CTA[slotKey]}
+              description={SLOT_EMPTY_DESCRIPTION[slotKey]}
+              action={
+                <Button size="sm" variant="ghost" onClick={startEditing} disabled={isSummarizing}>
+                  Add
+                </Button>
+              }
+            />
+          ) : renderAsMarkdown ? (
+            <div
+              role={isSummarizing ? undefined : 'button'}
+              tabIndex={isSummarizing ? -1 : 0}
+              onClick={startEditing}
+              onKeyDown={(e) => {
+                if (isSummarizing) {
+                  return;
+                }
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setEditing(true);
+                }
+              }}
+              className={cn(
+                'rounded-lg leading-relaxed transition-colors [overflow-wrap:anywhere] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/15 [&_code]:break-all [&_pre]:whitespace-pre-wrap [&_pre]:break-all',
+                isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
+              )}
+            >
+              <Markdown text={value} className="text-sm text-foreground" />
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={startEditing}
+              disabled={isSummarizing}
+              className={cn(
+                'whitespace-pre-wrap break-words rounded-lg text-left text-base font-medium leading-relaxed text-foreground transition-colors',
+                isSummarizing ? 'cursor-default' : 'cursor-text hover:bg-foreground/[0.02]',
+              )}
+            >
+              {value}
+            </button>
+          )}
+
+          {slotKey === 'goal' ? (
+            <GoalAttachmentsStrip owner={{ type: 'session', id: sessionId }} />
+          ) : null}
         </>
-      ) : null}
-    </div>
+      </PaneShell>
+    </InspectorSplit>
   );
 };

--- a/apps/desktop/src/features/settings/components/GuideStudio/parts/SectionHeader.tsx
+++ b/apps/desktop/src/features/settings/components/GuideStudio/parts/SectionHeader.tsx
@@ -1,34 +1,18 @@
 import type { ReactNode } from 'react';
-import { cn } from '@goodboy/ui';
-
-type Tone = 'primary' | 'success' | 'warning' | 'danger' | 'info' | 'muted';
+import { IconTile, type Tone } from '@goodboy/ui';
 
 type Props = {
   readonly icon: ReactNode;
   readonly title: string;
   readonly description: string;
-  readonly tone: Tone;
-};
-
-const TONE_BG: Record<Tone, string> = {
-  primary: 'bg-primary/10',
-  success: 'bg-success/10',
-  warning: 'bg-warning/10',
-  danger: 'bg-danger/10',
-  info: 'bg-info/10',
-  muted: 'bg-muted',
+  readonly tone: Tone | 'muted';
 };
 
 export const SectionHeader = ({ icon, title, description, tone }: Props) => (
   <div className="flex items-start gap-3">
-    <span
-      className={cn(
-        'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg',
-        TONE_BG[tone],
-      )}
-    >
+    <IconTile size="sm" tone={tone === 'muted' ? 'neutral' : tone} ring={false} className="mt-0.5">
       {icon}
-    </span>
+    </IconTile>
     <div className="flex flex-col gap-1">
       <h2 className="text-base font-semibold text-foreground">{title}</h2>
       <p className="text-sm leading-relaxed text-muted-foreground">{description}</p>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
@@ -102,4 +102,9 @@ describe('AgentRow', () => {
     expect(screen.getAllByTestId('agent-metrics-inline')).toHaveLength(1);
     expect(screen.getAllByTestId('agent-metrics-block')).toHaveLength(1);
   });
+
+  it('shows the agent status next to its name', () => {
+    renderRow(false);
+    expect(screen.getByText('scout one').nextElementSibling?.textContent).toBe('completed');
+  });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../../../features/session/components/AgentMetricsBlock';
 import { AgentMetricsInline } from '../../../../../features/session/components/AgentMetricsInline';
 import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar';
+import { AgentStatusBadge } from './AgentStatusBadge';
 
 type Props = {
   readonly run: Agent;
@@ -147,6 +148,7 @@ export const AgentRow = ({
             {run.name}
           </span>
         )}
+        <AgentStatusBadge status={run.status} />
         {!isEditing &&
           (confirmingDelete ? (
             <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentStatusBadge/index.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentStatusBadge/index.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { AgentStatus } from '@goodboy/types';
+import { AgentStatusBadge } from './index';
+
+const STATUSES: ReadonlyArray<AgentStatus> = [
+  'pending',
+  'running',
+  'completed',
+  'failed',
+  'skipped',
+];
+
+afterEach(cleanup);
+
+describe('AgentStatusBadge', () => {
+  it('names every agent state', () => {
+    render(
+      <>
+        {STATUSES.map((status) => (
+          <AgentStatusBadge key={status} status={status} />
+        ))}
+      </>,
+    );
+
+    STATUSES.forEach((status) => expect(screen.getByText(status)).toBeDefined());
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentStatusBadge/index.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentStatusBadge/index.tsx
@@ -1,0 +1,21 @@
+import type { AgentStatus } from '@goodboy/types';
+
+const CLASS_NAME: Record<AgentStatus, string> = {
+  pending: 'bg-muted text-muted-foreground',
+  running: 'bg-info/10 text-info',
+  completed: 'bg-success/10 text-success',
+  failed: 'bg-danger/10 text-danger',
+  skipped: 'bg-muted text-muted-foreground/70',
+};
+
+type Props = {
+  readonly status: AgentStatus;
+};
+
+export const AgentStatusBadge = ({ status }: Props) => (
+  <span
+    className={`inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${CLASS_NAME[status]}`}
+  >
+    {status}
+  </span>
+);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Agent, AgentId, SessionId, TelemetryRecord } from '@goodboy/types';
 
 vi.mock('../../../../../store', () => ({
@@ -26,6 +26,7 @@ const agent = {
   ordinal: 0,
   name: 'resolve comment 12',
   status: 'completed',
+  sourceKind: 'review_comment',
   startedAt: '2026-05-28T00:00:00Z',
   completedAt: '2026-05-28T00:01:00Z',
 } as Agent;
@@ -41,7 +42,12 @@ const telemetry = {
   recordedAt: '2026-01-01T00:00:00.000Z',
 } as TelemetryRecord;
 
-const renderRow = () =>
+type Params = {
+  readonly onSelect?: () => void;
+  readonly onInspect?: () => void;
+};
+
+const renderRow = ({ onSelect = () => undefined, onInspect }: Params = {}) =>
   render(
     <ResolveClusterRow
       agent={agent}
@@ -60,8 +66,9 @@ const renderRow = () =>
       isSelected={false}
       isTaskActive
       canJump={false}
-      onSelect={() => undefined}
+      onSelect={onSelect}
       onJump={() => undefined}
+      onInspect={onInspect}
       onResolveThread={() => undefined}
     />,
   );
@@ -98,5 +105,26 @@ describe('ResolveClusterRow', () => {
     renderRow();
     expect(screen.getByText('resolve comment 12')).toBeTruthy();
     expect(screen.getByText('1/2')).toBeTruthy();
+    expect(screen.getByText('Review comment')).toBeTruthy();
+  });
+
+  it('opens details from the row and keeps chat behind an explicit button', () => {
+    const onInspect = vi.fn();
+    const onSelect = vi.fn();
+    renderRow({ onInspect, onSelect });
+
+    fireEvent.click(screen.getByRole('button', { name: 'resolve comment 12 details' }));
+    expect(onInspect).toHaveBeenCalledOnce();
+    expect(onSelect).not.toHaveBeenCalled();
+
+    expect(screen.getByRole('button', { name: 'Toggle resolver details' }).textContent).toContain(
+      'Details',
+    );
+    const openChat = screen.getByRole('button', { name: 'Open resolver chat' });
+    fireEvent.keyDown(openChat, { key: 'Enter' });
+    expect(onInspect).toHaveBeenCalledOnce();
+    fireEvent.click(openChat);
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onInspect).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveClusterRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { StatusDot, cn } from '@goodboy/ui';
-import { MessageSquareReply, PanelRight, Upload } from 'lucide-react';
+import { MessageSquare, MessageSquareReply, PanelRight, Upload } from 'lucide-react';
 import type { Agent, DiffComment, PrComment, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread } from '../../../../../store';
 import {
@@ -18,6 +18,7 @@ import { ContextWindowBar, type ProviderContextUsage } from './ContextWindowBar'
 import { ForceCloseResolverAction } from '../../../../session/components/ForceCloseResolverAction';
 import { diffCommentLocation } from '../../../../session/diff-comment-location';
 import { prCommentLocation } from '../../../../session/pr-comment-location';
+import { resolverOrigin } from '../../../../session/resolver-origin';
 import type { ResolverStatus } from '../lib';
 
 type Props = {
@@ -66,6 +67,7 @@ export const ResolveClusterRow = ({
   const hasUnread = agentHasUnread(agent, isSelected && isTaskActive);
   const [pushing, setPushing] = useState(false);
   const canPush = agent.sourceThreadId != null && (status === 'committed' || status === 'wontfix');
+  const origin = resolverOrigin({ agent, hasDiffComment: diffComment !== null });
   const onPush = async () => {
     if (pushing || agent.sourceThreadId == null) {
       return;
@@ -93,17 +95,21 @@ export const ResolveClusterRow = ({
     <div
       role="button"
       tabIndex={0}
-      onClick={onSelect}
+      onClick={onInspect ?? onSelect}
       onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) {
+          return;
+        }
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          onSelect();
+          (onInspect ?? onSelect)();
         }
       }}
-      aria-label={agent.name}
+      aria-label={onInspect === undefined ? agent.name : `${agent.name} details`}
+      aria-pressed={onInspect === undefined ? isSelected : isInspected}
       className={cn(
         'relative flex w-full cursor-pointer flex-col gap-1 rounded border px-2 py-1.5 text-2xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]',
-        isSelected
+        isSelected || isInspected
           ? 'bg-elevated text-foreground border-border'
           : 'text-foreground/70 hover:bg-muted/60',
         status === 'running'
@@ -121,6 +127,9 @@ export const ResolveClusterRow = ({
           {agent.name}
         </span>
         <ResolverStateBadge state={resolverBadgeState(status)} />
+        <span className="inline-flex shrink-0 items-center rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+          {origin.label}
+        </span>
         {onInspect !== undefined ? (
           <button
             type="button"
@@ -128,15 +137,31 @@ export const ResolveClusterRow = ({
               e.stopPropagation();
               onInspect();
             }}
-            title="Inspect resolver"
-            aria-label="Inspect resolver"
+            title="Toggle resolver details"
+            aria-label="Toggle resolver details"
             aria-pressed={isInspected}
             className={cn(
-              'shrink-0 rounded-md p-0.5 text-muted-foreground/60 transition-colors hover:bg-foreground/10 hover:text-foreground',
+              'inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground',
               isInspected && 'bg-foreground/10 text-foreground',
             )}
           >
-            <PanelRight size={11} aria-hidden />
+            <PanelRight size={12} aria-hidden />
+            Details
+          </button>
+        ) : null}
+        {onInspect !== undefined ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSelect();
+            }}
+            title="Open resolver chat"
+            aria-label="Open resolver chat"
+            className="inline-flex shrink-0 items-center gap-1 rounded-md bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium text-foreground/80 transition-colors hover:bg-foreground/10 hover:text-foreground"
+          >
+            <MessageSquare size={12} aria-hidden />
+            Open chat
           </button>
         ) : null}
         {canJump ? (

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowRow.tsx
@@ -358,7 +358,7 @@ export const WorkflowRow = ({
                       ) : (
                         <WorkflowStepRuns
                           run={run}
-                          children={clusterChildren}
+                          agents={clusterChildren}
                           isExpanded={clustersExpanded}
                           unreadCount={clusterUnread}
                           aggregatesByAgentId={aggregatesByAgentId}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRuns.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowStepRuns.tsx
@@ -5,7 +5,7 @@ import { ClusterChildRow } from './ClusterChildRow';
 
 type Props = {
   readonly run: Agent;
-  readonly children: ReadonlyArray<Agent>;
+  readonly agents: ReadonlyArray<Agent>;
   readonly isExpanded: boolean;
   readonly unreadCount: number;
   readonly aggregatesByAgentId: ReadonlyMap<string, AgentAggregate>;
@@ -17,7 +17,7 @@ type Props = {
 
 export const WorkflowStepRuns = ({
   run,
-  children,
+  agents,
   isExpanded,
   unreadCount,
   aggregatesByAgentId,
@@ -26,7 +26,7 @@ export const WorkflowStepRuns = ({
   onToggle,
   onSelect,
 }: Props) => {
-  const doneCount = children.filter(
+  const doneCount = agents.filter(
     (child) => child.status === 'completed' || child.status === 'skipped',
   ).length;
 
@@ -45,7 +45,7 @@ export const WorkflowStepRuns = ({
           <ChevronRight size={11} aria-hidden className="shrink-0" />
         )}
         <span className="min-w-0 truncate">
-          Runs ({doneCount}/{children.length})
+          Runs ({doneCount}/{agents.length})
         </span>
         {!isExpanded && unreadCount > 0 ? (
           <span
@@ -58,12 +58,12 @@ export const WorkflowStepRuns = ({
         ) : null}
       </button>
       {isExpanded
-        ? children.map((child, index) => (
+        ? agents.map((child, index) => (
             <ClusterChildRow
               key={child.id}
               child={child}
               index={index}
-              total={children.length}
+              total={agents.length}
               costUsd={aggregatesByAgentId.get(child.id)?.estimatedCostUsd ?? 0}
               isSelected={child.id === selectedAgentId}
               isTaskActive={isTaskActive}

--- a/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
+++ b/apps/desktop/src/shared/components/RoutingPicker/index.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { PROVIDER_CAPABILITIES } from '@goodboy/core';
 import type { ProviderId } from '@goodboy/types';
 import { RoutingPicker } from './index';
 
@@ -59,10 +60,18 @@ describe('RoutingPicker', () => {
   it('bounds only the model list as the scroll region', () => {
     render(<RoutingPicker {...baseProps} />);
     fireEvent.click(screen.getByRole('button', { name: /routing/i }));
-    const viewports = screen.getByRole('dialog').querySelectorAll('[class*="overflow-y-auto"]');
+    const dialog = screen.getByRole('dialog');
+    const viewports = dialog.querySelectorAll('[class*="overflow-y-auto"]');
     const viewport = viewports.item(0);
     expect(viewports).toHaveLength(1);
     expect(viewport?.parentElement?.className).toContain('max-h-[15rem]');
+    expect(viewport?.className).toContain('max-h-[inherit]');
+    expect(dialog.className).not.toMatch(/max-h-/);
+    const modelIds = PROVIDER_CAPABILITIES.anthropic.models.map((entry) => entry.id);
+    expect(modelIds.length).toBeGreaterThan(3);
+    for (const id of modelIds) {
+      expect(viewport?.querySelector(`[title="${id}"]`)).not.toBeNull();
+    }
   });
 
   it('offers verbosity only when the caller wires it', () => {


### PR DESCRIPTION
Stacked on #1002. Closes the five-area UI overhaul.

## Problem

The resolver inspector (origin, files touched, commits, queue position, force actions) was reachable only through an 11px muted icon, in one lens. `ResolvePane` and `SlotPane` each hand-rolled the same right-panel split. Agent rows signalled status only through a border color, and a resolver's origin was invisible until the inspector opened.

## Solution

- In the resolve lens the row itself toggles the inspector (list -> detail, the Linear pattern); opening the chat is an explicit `Open chat` button and the naked icon becomes a readable `Details` toggle. Sidebar behavior unchanged.
- New shared `InspectorSplit` wrapper; `ResolvePane` and `SlotPane` (slot history) migrate onto it.
- `AgentStatusBadge` on agent rows: pending/running/completed/failed/skipped as text next to the name; running keeps the colored border.
- Origin badge (Review comment / Conversation comment / Inline diff note) on every resolver row via the existing `resolverOrigin`.
- Store logic untouched (`forceCloseResolver`, `activateNextResolver`, metrics hooks).

## Verification

typecheck green, full desktop suite 323 files / 2640 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)