### PR TITLE
feat(desktop): persistent resolver inspector with actions

### DIFF
--- a/apps/desktop/src/features/chat/components/CommentAnalysisChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/CommentAnalysisChip/index.test.tsx
@@ -1,141 +1,72 @@
 // @vitest-environment happy-dom
 
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 const h = vi.hoisted(() => ({
-  extractMock: vi.fn<(text: string) => unknown>(() => null),
-  sendMock: vi.fn(async () => undefined),
-  resolveMock: vi.fn(async () => true),
-  resolvedComments: [] as Array<{ threadId: string; resolved: boolean }>,
+  extract: vi.fn<(text: string) => unknown>(() => null),
 }));
 
 vi.mock('@goodboy/core', () => ({
-  extractCommentAnalysis: h.extractMock,
+  extractCommentAnalysis: h.extract,
   isReviewThreadId: (id: string) => /^PRRT_/.test(id),
 }));
 
-vi.mock('../../../../store', () => ({
-  useAppStore: <T,>(
-    selector: (state: {
-      sendTurn: typeof h.sendMock;
-      resolveGithubThread: typeof h.resolveMock;
-      sessionGithub: Record<
-        string,
-        { detail: { comments: Array<{ threadId: string; resolved: boolean }> } }
-      >;
-    }) => T,
-  ) =>
-    selector({
-      sendTurn: h.sendMock,
-      resolveGithubThread: h.resolveMock,
-      sessionGithub: { s: { detail: { comments: h.resolvedComments } } },
-    }),
-}));
-
-import { CommentAnalysisChip } from './index';
-
-beforeEach(() => {
-  h.extractMock.mockReset();
-  h.sendMock.mockReset().mockResolvedValue(undefined);
-  h.resolveMock.mockReset().mockResolvedValue(true);
-  h.resolvedComments = [];
-  localStorage.clear();
-});
-
-afterEach(cleanup);
+import { CommentAnalysisChip } from '.';
 
 describe('CommentAnalysisChip', () => {
-  it('renders nothing without a valid review analysis marker', () => {
-    h.extractMock.mockReturnValue(null);
-    const { container, rerender } = render(
-      <CommentAnalysisChip assistantText="" sessionId={'s' as never} agentId={'a' as never} />,
-    );
-    expect(container.firstChild).toBeNull();
+  beforeEach(() => {
+    h.extract.mockReset();
+    localStorage.clear();
+  });
+  afterEach(cleanup);
 
-    h.extractMock.mockReturnValue({ threadId: 'local-1', verdict: 'fix', summary: 'Use a helper' });
-    rerender(
-      <CommentAnalysisChip assistantText="x" sessionId={'s' as never} agentId={'a' as never} />,
-    );
+  it('renders nothing without a review marker', () => {
+    h.extract.mockReturnValue(null);
+    const { container } = render(<CommentAnalysisChip assistantText="" sessionId={'s' as never} />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders a fix verdict and routes proceed to the resolver', async () => {
-    h.extractMock.mockReturnValue({
+  it('keeps the analysis status without resolution actions', () => {
+    h.extract.mockReturnValue({
       threadId: 'PRRT_1',
       verdict: 'fix',
       summary: '**Use the shared helper**',
     });
     render(
-      <CommentAnalysisChip assistantText="x" sessionId={'s' as never} agentId={'a' as never} />,
+      <CommentAnalysisChip
+        assistantText="x"
+        sessionId={'s' as never}
+        agentId={'agent-1' as never}
+      />,
     );
 
     expect(screen.getByText('fix recommended')).toBeDefined();
     expect(screen.getByText('Use the shared helper')).toBeDefined();
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-analysis-proceed'));
-    });
-    expect(h.sendMock).toHaveBeenCalledWith({
-      sessionId: 's',
-      agentId: 'a',
-      content:
-        'Proceed with the fix you proposed in your analysis. When done, commit and emit the <<comment-resolved>> marker as instructed.',
-    });
+    expect(screen.queryByText('Proceed with fix')).toBeNull();
+    expect(screen.getByText('Manage in panel')).toBeDefined();
   });
 
-  it('posts an edited explanation and marks the thread solved', async () => {
-    h.extractMock.mockReturnValue({
-      threadId: 'PRRT_2',
-      verdict: 'fix',
-      summary: 'Original summary',
-    });
-    render(
-      <CommentAnalysisChip assistantText="x" sessionId={'s' as never} agentId={'a' as never} />,
-    );
-
-    fireEvent.click(screen.getByTestId('comment-analysis-close'));
-    fireEvent.change(screen.getByRole('textbox', { name: 'explanation' }), {
-      target: { value: 'Edited explanation' },
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-analysis-confirm'));
-    });
-
-    expect(h.resolveMock).toHaveBeenCalledWith('s', 'PRRT_2', {
-      reason: 'Edited explanation',
-    });
-    expect(screen.getByText(/marked solved with explanation/i)).toBeDefined();
-  });
-
-  it('makes close primary for wontfix while allowing an override', async () => {
-    h.extractMock.mockReturnValue({
-      threadId: 'PRRT_3',
+  it('opens the resolver inspector from the manage link', () => {
+    h.extract.mockReturnValue({
+      threadId: 'PRRT_1',
       verdict: 'wontfix',
-      summary: 'Already covered',
+      summary: 'No change',
     });
+    const onOpen = vi.fn();
+    window.addEventListener('goodboy:open-resolver-inspector', onOpen);
     render(
-      <CommentAnalysisChip assistantText="x" sessionId={'s' as never} agentId={'a' as never} />,
+      <CommentAnalysisChip
+        assistantText="x"
+        sessionId={'s' as never}
+        agentId={'agent-1' as never}
+      />,
     );
 
-    const buttons = screen.getAllByRole('button');
-    expect(buttons[0]?.textContent).toContain('Close with explanation');
-    expect(screen.getByText('Proceed with fix anyway')).toBeDefined();
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-analysis-proceed'));
-    });
-    expect(h.sendMock).toHaveBeenCalledOnce();
-  });
+    fireEvent.click(screen.getByTestId('comment-analysis-manage'));
 
-  it('shows success when the thread is already resolved on github', () => {
-    h.extractMock.mockReturnValue({
-      threadId: 'PRRT_4',
-      verdict: 'wontfix',
-      summary: 'No change needed',
-    });
-    h.resolvedComments = [{ threadId: 'PRRT_4', resolved: true }];
-    render(
-      <CommentAnalysisChip assistantText="x" sessionId={'s' as never} agentId={'a' as never} />,
-    );
-    expect(screen.getByText(/marked solved with explanation/i)).toBeDefined();
+    const event = onOpen.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).toEqual({ sessionId: 's', agentId: 'agent-1' });
+    window.removeEventListener('goodboy:open-resolver-inspector', onOpen);
   });
 });

--- a/apps/desktop/src/features/chat/components/CommentAnalysisChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/CommentAnalysisChip/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
-import { Ban, CheckCheck, Play, Search, X } from 'lucide-react';
-import { Markdown, Textarea, cn } from '@goodboy/ui';
+import { CheckCheck, Search, X } from 'lucide-react';
+import { Markdown } from '@goodboy/ui';
 import { extractCommentAnalysis, isReviewThreadId } from '@goodboy/core';
 import type { AgentId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -8,27 +8,17 @@ import { commentChipDismissal } from '../../../../shared/utils/commentChipDismis
 import { MARKER_ACCENT } from '../marker-accents';
 import { TranscriptShell } from '../TranscriptShell';
 
-const PROCEED_PROMPT =
-  'Proceed with the fix you proposed in your analysis. When done, commit and emit the <<comment-resolved>> marker as instructed.';
-
 type Props = {
   readonly assistantText: string;
   readonly sessionId: SessionId;
   readonly agentId?: AgentId | null;
 };
 
-type ChipState =
-  | { kind: 'idle' }
-  | { kind: 'continuing' }
-  | { kind: 'resolving' }
-  | { kind: 'resolved' }
-  | { kind: 'dismissed' };
+type ChipState = { kind: 'idle' } | { kind: 'dismissed' };
 
 export const CommentAnalysisChip = ({ assistantText, sessionId, agentId = null }: Props) => {
   const marker = useMemo(() => extractCommentAnalysis(assistantText), [assistantText]);
   const threadId = marker?.threadId;
-  const sendTurn = useAppStore((state) => state.sendTurn);
-  const resolveGithubThread = useAppStore((state) => state.resolveGithubThread);
   const resolvedOnGithub = useAppStore((state) =>
     threadId != null
       ? (state.sessionGithub[sessionId]?.detail?.comments?.some(
@@ -41,14 +31,16 @@ export const CommentAnalysisChip = ({ assistantText, sessionId, agentId = null }
       ? { kind: 'dismissed' }
       : { kind: 'idle' },
   );
-  const [isExplaining, setIsExplaining] = useState(false);
-  const [reason, setReason] = useState(marker?.summary ?? '');
 
   if (marker === null || !isReviewThreadId(marker.threadId)) {
     return null;
   }
 
-  if (state.kind === 'resolved' || resolvedOnGithub) {
+  if (state.kind === 'dismissed') {
+    return null;
+  }
+
+  if (resolvedOnGithub) {
     return (
       <TranscriptShell
         tone="success"
@@ -61,79 +53,9 @@ export const CommentAnalysisChip = ({ assistantText, sessionId, agentId = null }
     );
   }
 
-  if (state.kind === 'dismissed') {
-    return null;
-  }
-
-  const busy = state.kind === 'continuing' || state.kind === 'resolving';
   const isFix = marker.verdict === 'fix';
   const tone = isFix ? 'info' : 'warning';
   const accent = isFix ? MARKER_ACCENT.info : MARKER_ACCENT.warning;
-
-  const proceed = async () => {
-    if (busy || agentId === null) {
-      return;
-    }
-    setState({ kind: 'continuing' });
-    try {
-      await sendTurn({ sessionId, agentId, content: PROCEED_PROMPT });
-    } finally {
-      setState({ kind: 'idle' });
-    }
-  };
-
-  const resolve = async () => {
-    if (busy || reason.trim().length === 0) {
-      return;
-    }
-    setState({ kind: 'resolving' });
-    const ok = await resolveGithubThread(sessionId, marker.threadId, { reason });
-    setState(ok ? { kind: 'resolved' } : { kind: 'idle' });
-  };
-
-  const proceedButton = (
-    <button
-      type="button"
-      onClick={() => void proceed()}
-      disabled={busy || agentId === null}
-      data-testid="comment-analysis-proceed"
-      className={cn(
-        'relative inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-semibold transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
-        isFix
-          ? 'bg-info text-info-foreground'
-          : `border ${MARKER_ACCENT.warning.border} ${MARKER_ACCENT.warning.text}`,
-        state.kind === 'continuing' && 'animate-border-pulse',
-      )}
-    >
-      <Play size={9} aria-hidden />
-      {state.kind === 'continuing'
-        ? 'Proceeding…'
-        : isFix
-          ? 'Proceed with fix'
-          : 'Proceed with fix anyway'}
-    </button>
-  );
-
-  const closeButton = (
-    <button
-      type="button"
-      onClick={() => {
-        setReason(marker.summary);
-        setIsExplaining(true);
-      }}
-      disabled={busy}
-      data-testid="comment-analysis-close"
-      className={cn(
-        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-semibold transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
-        isFix
-          ? `border ${MARKER_ACCENT.info.border} ${MARKER_ACCENT.info.text}`
-          : 'bg-warning text-warning-foreground',
-      )}
-    >
-      <Ban size={9} aria-hidden />
-      Close with explanation
-    </button>
-  );
 
   return (
     <TranscriptShell
@@ -150,68 +72,38 @@ export const CommentAnalysisChip = ({ assistantText, sessionId, agentId = null }
       <div className="text-muted-foreground">
         <Markdown text={marker.summary} />
       </div>
-      {isExplaining ? (
-        <div className="flex flex-col gap-2">
-          <Textarea
-            value={reason}
-            onChange={(event) => setReason(event.target.value)}
-            disabled={busy}
-            aria-label="explanation"
-            autoGrow
-            maxRows={6}
-            className="min-h-16 resize-none bg-background/60 px-2 py-1.5 text-xs leading-relaxed"
-          />
-          <div className="flex items-center justify-end gap-1">
-            <button
-              type="button"
-              onClick={() => setIsExplaining(false)}
-              disabled={busy}
-              className="rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => void resolve()}
-              disabled={busy || reason.trim().length === 0}
-              data-testid="comment-analysis-confirm"
-              className={cn(
-                'relative rounded-full bg-warning px-2 py-0.5 text-2xs font-semibold text-warning-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
-                state.kind === 'resolving' && 'animate-border-pulse',
-              )}
-            >
-              {state.kind === 'resolving' ? 'Marking…' : 'Post explanation & close'}
-            </button>
-          </div>
-        </div>
-      ) : (
-        <div className="flex flex-wrap items-center justify-end gap-1">
-          {isFix ? (
-            <>
-              {proceedButton}
-              {closeButton}
-            </>
-          ) : (
-            <>
-              {closeButton}
-              {proceedButton}
-            </>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              commentChipDismissal.persist({ threadId: marker.threadId });
-              setState({ kind: 'dismissed' });
-            }}
-            disabled={busy}
-            title="dismiss this recommendation"
-            aria-label="dismiss this recommendation"
-            className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <X size={10} aria-hidden />
-          </button>
-        </div>
-      )}
+      <div className="flex flex-wrap items-center justify-end gap-1">
+        <button
+          type="button"
+          disabled={agentId === null}
+          onClick={() => {
+            if (agentId === null) {
+              return;
+            }
+            window.dispatchEvent(
+              new CustomEvent('goodboy:open-resolver-inspector', {
+                detail: { sessionId, agentId },
+              }),
+            );
+          }}
+          data-testid="comment-analysis-manage"
+          className="rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
+        >
+          Manage in panel
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            commentChipDismissal.persist({ threadId: marker.threadId });
+            setState({ kind: 'dismissed' });
+          }}
+          title="dismiss this recommendation"
+          aria-label="dismiss this recommendation"
+          className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <X size={10} aria-hidden />
+        </button>
+      </div>
     </TranscriptShell>
   );
 };

--- a/apps/desktop/src/features/chat/components/CommentResolvedChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/CommentResolvedChip/index.test.tsx
@@ -1,115 +1,57 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 const h = vi.hoisted(() => ({
-  extractMock: vi.fn<(text: string) => unknown>(() => null),
-  resolveMock: vi.fn(async () => true),
-  queueMock: vi.fn(async () => {}),
-  dequeueMock: vi.fn(async () => {}),
-  loadMock: vi.fn(async () => {}),
-  selectMock: vi.fn(async () => {}),
-  pr: { number: 123 } as { number: number } | null,
+  extract: vi.fn<(text: string) => unknown>(() => null),
   pending: [] as Array<{ threadId: string }>,
 }));
 
 vi.mock('@goodboy/core', () => ({
-  extractCommentResolved: h.extractMock,
+  extractCommentResolved: h.extract,
   isReviewThreadId: (id: string) => /^PRRT_/.test(id),
 }));
+
 vi.mock('../../../../store', () => ({
   useAppStore: <T,>(
-    selector: (s: {
-      queueResolution: typeof h.queueMock;
-      dequeueResolution: typeof h.dequeueMock;
-      resolveGithubThread: typeof h.resolveMock;
-      loadPendingResolutions: typeof h.loadMock;
-      selectAgent: typeof h.selectMock;
-      sessionGithub: Record<string, { pr: { number: number } | null; detail: null }>;
+    selector: (state: {
+      sessionGithub: Record<string, { detail: null }>;
       sessionPendingResolutions: Record<string, Array<{ threadId: string }>>;
     }) => T,
   ) =>
     selector({
-      queueResolution: h.queueMock,
-      dequeueResolution: h.dequeueMock,
-      resolveGithubThread: h.resolveMock,
-      loadPendingResolutions: h.loadMock,
-      selectAgent: h.selectMock,
-      sessionGithub: { s: { pr: h.pr, detail: null } },
+      sessionGithub: { s: { detail: null } },
       sessionPendingResolutions: { s: h.pending },
     }),
 }));
 
-import { CommentResolvedChip } from './index';
-
-beforeEach(() => {
-  h.extractMock.mockReset();
-  h.resolveMock.mockReset().mockResolvedValue(true);
-  h.queueMock.mockReset().mockResolvedValue(undefined);
-  h.dequeueMock.mockReset().mockResolvedValue(undefined);
-  h.loadMock.mockReset().mockResolvedValue(undefined);
-  h.selectMock.mockReset().mockResolvedValue(undefined);
-  localStorage.clear();
-  h.pr = { number: 123 };
-  h.pending = [];
-});
-afterEach(cleanup);
+import { CommentResolvedChip } from '.';
 
 describe('CommentResolvedChip', () => {
-  it('renders nothing when no marker is found', () => {
-    h.extractMock.mockReturnValue(null);
-    const { container } = render(<CommentResolvedChip assistantText="" sessionId={'s' as never} />);
-    expect(container.firstChild).toBeNull();
+  beforeEach(() => {
+    h.extract.mockReset();
+    h.pending = [];
+    localStorage.clear();
   });
 
-  it('renders nothing when the marker references a local diff comment id', () => {
-    h.extractMock.mockReturnValue({
-      threadId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
-      commitSha: 'abcdef1234567890',
-    });
-    const { container } = render(
-      <CommentResolvedChip assistantText="x" sessionId={'s' as never} />,
+  afterEach(cleanup);
+
+  it('renders nothing without a review marker', () => {
+    h.extract.mockReturnValue(null);
+    const { container, rerender } = render(
+      <CommentResolvedChip assistantText="" sessionId={'s' as never} />,
     );
     expect(container.firstChild).toBeNull();
+
+    h.extract.mockReturnValue({ threadId: 'local-1', commitSha: 'abcdef1234567890' });
+    rerender(<CommentResolvedChip assistantText="x" sessionId={'s' as never} />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it('queues the resolution when the primary button is clicked', async () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_kwDOABC123', commitSha: 'abcdef1234567890' });
-    render(<CommentResolvedChip assistantText="x" sessionId={'s' as never} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-resolved-queue'));
-    });
-    expect(h.queueMock).toHaveBeenCalledWith('s', {
-      threadId: 'PRRT_kwDOABC123',
-      commitSha: 'abcdef1234567890',
-      prNumber: 123,
-    });
-  });
-
-  it('pushes and resolves the thread when the secondary button is clicked', async () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_kwDOABC123', commitSha: 'abcdef1234567890' });
-    render(<CommentResolvedChip assistantText="x" sessionId={'s' as never} />);
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-resolved-confirm'));
-    });
-    expect(h.resolveMock).toHaveBeenCalledWith('s', 'PRRT_kwDOABC123', {
-      commitSha: 'abcdef1234567890',
-    });
-    expect(screen.getByText(/conversation resolved/i)).toBeDefined();
-  });
-
-  it('shows the pending-push state when the thread is queued', () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_kwDOABC123', commitSha: 'abcdef1234567890' });
-    h.pending = [{ threadId: 'PRRT_kwDOABC123' }];
-    render(<CommentResolvedChip assistantText="x" sessionId={'s' as never} />);
-    expect(screen.getByText(/pending push/i)).toBeDefined();
-  });
-
-  it('selects the resolver and focuses the composer when continuing work', async () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_kwDOABC123', commitSha: 'abcdef1234567890' });
-    const focus = vi.fn();
-    window.addEventListener('goodboy:focus-composer', focus);
+  it('shows queued status without action buttons', () => {
+    h.extract.mockReturnValue({ threadId: 'PRRT_1', commitSha: 'abcdef1234567890' });
+    h.pending = [{ threadId: 'PRRT_1' }];
     render(
       <CommentResolvedChip
         assistantText="x"
@@ -118,12 +60,28 @@ describe('CommentResolvedChip', () => {
       />,
     );
 
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-resolved-continue'));
-    });
+    expect(screen.getByText(/pending push/i)).toBeDefined();
+    expect(screen.queryByText('Push now')).toBeNull();
+    expect(screen.getByText('Manage in panel')).toBeDefined();
+  });
 
-    expect(h.selectMock).toHaveBeenCalledWith('s', 'agent-1');
-    expect(focus).toHaveBeenCalledOnce();
-    window.removeEventListener('goodboy:focus-composer', focus);
+  it('opens the resolver inspector from the manage link', () => {
+    h.extract.mockReturnValue({ threadId: 'PRRT_1', commitSha: 'abcdef1234567890' });
+    const onOpen = vi.fn();
+    window.addEventListener('goodboy:open-resolver-inspector', onOpen);
+    render(
+      <CommentResolvedChip
+        assistantText="x"
+        sessionId={'s' as never}
+        agentId={'agent-1' as never}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-resolved-manage'));
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    const event = onOpen.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).toEqual({ sessionId: 's', agentId: 'agent-1' });
+    window.removeEventListener('goodboy:open-resolver-inspector', onOpen);
   });
 });

--- a/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/CommentResolvedChip/index.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { ArrowUpRight, CheckCheck, Clock, GitCommit, Upload, X } from 'lucide-react';
-import { cn } from '@goodboy/ui';
+import { useMemo, useState } from 'react';
+import { CheckCheck, Clock, GitCommit, X } from 'lucide-react';
 import { extractCommentResolved, isReviewThreadId } from '@goodboy/core';
 import type { AgentId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -17,54 +16,33 @@ type Props = {
   readonly agentId?: AgentId | null;
 };
 
-type ChipState =
-  | { kind: 'idle' }
-  | { kind: 'resolving' }
-  | { kind: 'resolved' }
-  | { kind: 'dismissed' };
-
 export const CommentResolvedChip = ({ assistantText, sessionId, agentId = null }: Props) => {
   const marker = useMemo(() => extractCommentResolved(assistantText), [assistantText]);
   const threadId = marker?.threadId;
-
-  const queueResolution = useAppStore((s) => s.queueResolution);
-  const dequeueResolution = useAppStore((s) => s.dequeueResolution);
-  const resolveGithubThread = useAppStore((s) => s.resolveGithubThread);
-  const loadPendingResolutions = useAppStore((s) => s.loadPendingResolutions);
-  const setActiveLens = useAppStore((s) => s.setActiveLens);
-  const selectAgent = useAppStore((s) => s.selectAgent);
-
-  const prNumber = useAppStore((s) => s.sessionGithub[sessionId]?.pr?.number ?? null);
-  const resolvedOnGithub = useAppStore((s) =>
-    threadId
-      ? (s.sessionGithub[sessionId]?.detail?.comments?.some(
-          (c) => c.threadId === threadId && c.resolved === true,
+  const resolvedOnGithub = useAppStore((state) =>
+    threadId != null
+      ? (state.sessionGithub[sessionId]?.detail?.comments?.some(
+          (comment) => comment.threadId === threadId && comment.resolved === true,
         ) ?? false)
       : false,
   );
-  const queued = useAppStore((s) =>
-    threadId
-      ? (s.sessionPendingResolutions[sessionId]?.some((r) => r.threadId === threadId) ?? false)
+  const queued = useAppStore((state) =>
+    threadId != null
+      ? (state.sessionPendingResolutions[sessionId]?.some(
+          (resolution) => resolution.threadId === threadId,
+        ) ?? false)
       : false,
   );
-
-  const [state, setState] = useState<ChipState>(() =>
-    threadId != null && commentChipDismissal.read({ threadId })
-      ? { kind: 'dismissed' }
-      : { kind: 'idle' },
+  const [isDismissed, setIsDismissed] = useState(
+    threadId != null && commentChipDismissal.read({ threadId }),
   );
 
-  useEffect(() => {
-    void loadPendingResolutions(sessionId);
-  }, [sessionId, loadPendingResolutions]);
-
-  if (!marker || !isReviewThreadId(marker.threadId)) {
+  if (marker === null || !isReviewThreadId(marker.threadId) || isDismissed) {
     return null;
   }
 
   const shaShort = marker.commitSha.slice(0, 7);
-
-  if (state.kind === 'resolved' || resolvedOnGithub) {
+  if (resolvedOnGithub) {
     return (
       <TranscriptShell
         tone="success"
@@ -73,103 +51,41 @@ export const CommentResolvedChip = ({ assistantText, sessionId, agentId = null }
       >
         <CheckCheck size={11} aria-hidden />
         <span>conversation resolved</span>
-        <span className="text-muted-foreground/70">·</span>
         <GitCommit size={10} aria-hidden className="text-muted-foreground/80" />
         <span className="font-mono text-muted-foreground/80">{shaShort}</span>
       </TranscriptShell>
     );
   }
 
-  if (state.kind === 'dismissed' && !queued) {
-    return null;
-  }
-
-  const pushNow = async () => {
-    if (state.kind === 'resolving') {
+  const dismiss = () => {
+    commentChipDismissal.persist({ threadId: marker.threadId });
+    setIsDismissed(true);
+  };
+  const manage = () => {
+    if (agentId === null) {
       return;
     }
-    setState({ kind: 'resolving' });
-    const ok = await resolveGithubThread(sessionId, marker.threadId, {
-      commitSha: marker.commitSha,
-    });
-    if (ok && queued) {
-      await dequeueResolution(sessionId, marker.threadId);
-    }
-    setState(ok ? { kind: 'resolved' } : { kind: 'idle' });
-  };
-
-  const queue = () => {
-    if (prNumber === null) {
-      return;
-    }
-    void queueResolution(sessionId, {
-      threadId: marker.threadId,
-      commitSha: marker.commitSha,
-      prNumber,
-    });
-  };
-
-  const busy = state.kind === 'resolving';
-
-  if (queued) {
-    return (
-      <TranscriptShell
-        tone="info"
-        variant="boxed"
-        className="mt-2 flex flex-wrap items-center gap-1.5 text-xs"
-      >
-        <Clock size={12} aria-hidden className={infoAccent.icon} />
-        <span className="font-medium text-foreground">solved locally · pending push</span>
-        <span className="inline-flex items-center gap-1 rounded bg-background/60 px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
-          <GitCommit size={9} aria-hidden />
-          {shaShort}
-        </span>
-        <span className="text-muted-foreground/80">publish from the Resolve lens</span>
-        <div className="ml-auto flex items-center gap-1">
-          <button
-            type="button"
-            onClick={() => setActiveLens(sessionId, 'resolve')}
-            title="open the Resolve lens to publish queued comments"
-            className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground"
-          >
-            Go to Resolve
-            <ArrowUpRight size={10} aria-hidden />
-          </button>
-          <button
-            type="button"
-            onClick={() => void pushNow()}
-            disabled={busy}
-            title="push and resolve this one now"
-            className={cn(
-              'relative inline-flex items-center gap-1 rounded-full bg-info px-2 py-0.5 text-2xs font-semibold text-info-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
-              busy && 'animate-border-pulse',
-            )}
-          >
-            {busy ? 'Pushing…' : 'Push now'}
-          </button>
-          <button
-            type="button"
-            onClick={() => void dequeueResolution(sessionId, marker.threadId)}
-            disabled={busy}
-            title="remove from the batch (keeps the local commit)"
-            aria-label="remove from the batch"
-            className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <X size={10} aria-hidden />
-          </button>
-        </div>
-      </TranscriptShell>
+    window.dispatchEvent(
+      new CustomEvent('goodboy:open-resolver-inspector', {
+        detail: { sessionId, agentId },
+      }),
     );
-  }
+  };
 
   return (
     <TranscriptShell
-      tone="success"
+      tone={queued ? 'info' : 'success'}
       variant="boxed"
       className="mt-2 flex flex-wrap items-center gap-1.5 text-xs"
     >
-      <CheckCheck size={12} aria-hidden className={successAccent.icon} />
-      <span className="font-medium text-foreground">fix committed locally</span>
+      {queued ? (
+        <Clock size={12} aria-hidden className={infoAccent.icon} />
+      ) : (
+        <CheckCheck size={12} aria-hidden className={successAccent.icon} />
+      )}
+      <span className="font-medium text-foreground">
+        {queued ? 'solved locally · pending push' : 'fix committed locally'}
+      </span>
       <span className="inline-flex items-center gap-1 rounded bg-background/60 px-1.5 py-0.5 font-mono text-2xs text-muted-foreground">
         <GitCommit size={9} aria-hidden />
         {shaShort}
@@ -177,59 +93,19 @@ export const CommentResolvedChip = ({ assistantText, sessionId, agentId = null }
       <div className="ml-auto flex items-center gap-1">
         <button
           type="button"
-          onClick={queue}
-          disabled={busy || prNumber === null}
-          data-testid="comment-resolved-queue"
-          aria-label="mark solved, push later"
-          title="mark solved and batch it for a single push later"
-          className="inline-flex items-center gap-1 rounded-full bg-success px-2 py-0.5 text-2xs font-semibold text-success-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          onClick={manage}
+          disabled={agentId === null}
+          data-testid="comment-resolved-manage"
+          className="rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
         >
-          <Clock size={9} aria-hidden />
-          Mark solved (push later)
+          Manage in panel
         </button>
         <button
           type="button"
-          onClick={() => void pushNow()}
-          disabled={busy}
-          data-testid="comment-resolved-confirm"
-          aria-label="push and mark as solved now"
-          title="push and resolve this thread immediately"
-          className={cn(
-            'relative inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-2xs font-semibold transition-opacity hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-60',
-            infoAccent.border,
-            infoAccent.text,
-            busy && 'animate-border-pulse',
-          )}
-        >
-          <Upload size={9} aria-hidden />
-          {busy ? 'Pushing…' : 'Push & mark now'}
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            if (agentId === null) {
-              return;
-            }
-            void selectAgent(sessionId, agentId).then(() => {
-              window.dispatchEvent(new CustomEvent('goodboy:focus-composer'));
-            });
-          }}
-          disabled={busy || agentId === null}
-          data-testid="comment-resolved-continue"
-          className="inline-flex items-center rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Continue working
-        </button>
-        <button
-          type="button"
-          onClick={() => {
-            commentChipDismissal.persist({ threadId: marker.threadId });
-            setState({ kind: 'dismissed' });
-          }}
-          disabled={busy}
-          title="keep the conversation open on GitHub"
-          aria-label="keep the conversation open on GitHub"
-          className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={dismiss}
+          title="dismiss resolver status"
+          aria-label="dismiss resolver status"
+          className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
         >
           <X size={10} aria-hidden />
         </button>

--- a/apps/desktop/src/features/chat/components/CommentWontfixChip/index.test.tsx
+++ b/apps/desktop/src/features/chat/components/CommentWontfixChip/index.test.tsx
@@ -1,75 +1,66 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 
 const h = vi.hoisted(() => ({
-  extractMock: vi.fn<(text: string) => unknown>(() => null),
-  resolveMock: vi.fn(async () => true),
-  resolvedComments: [] as Array<{ threadId: string; resolved: boolean }>,
+  extract: vi.fn<(text: string) => unknown>(() => null),
 }));
 
 vi.mock('@goodboy/core', () => ({
-  extractCommentWontfix: h.extractMock,
+  extractCommentWontfix: h.extract,
   isReviewThreadId: (id: string) => /^PRRT_/.test(id),
 }));
-vi.mock('../../../../store', () => ({
-  useAppStore: <T,>(
-    selector: (s: {
-      resolveGithubThread: typeof h.resolveMock;
-      sessionGithub: Record<
-        string,
-        { detail: { comments: Array<{ threadId: string; resolved: boolean }> } }
-      >;
-    }) => T,
-  ) =>
-    selector({
-      resolveGithubThread: h.resolveMock,
-      sessionGithub: { s: { detail: { comments: h.resolvedComments } } },
-    }),
-}));
 
-import { CommentWontfixChip } from './index';
-
-beforeEach(() => {
-  h.extractMock.mockReset();
-  h.resolveMock.mockReset().mockResolvedValue(true);
-  h.resolvedComments = [];
-});
-afterEach(cleanup);
+import { CommentWontfixChip } from '.';
 
 describe('CommentWontfixChip', () => {
-  it('renders nothing when no marker is found', () => {
-    h.extractMock.mockReturnValue(null);
-    const { container } = render(<CommentWontfixChip assistantText="" sessionId={'s' as never} />);
+  beforeEach(() => h.extract.mockReset());
+  afterEach(cleanup);
+
+  it('renders nothing without a review marker', () => {
+    h.extract.mockReturnValue(null);
+    const { container, rerender } = render(
+      <CommentWontfixChip assistantText="" sessionId={'s' as never} />,
+    );
+    expect(container.firstChild).toBeNull();
+
+    h.extract.mockReturnValue({ threadId: 'local-1', reason: 'no change' });
+    rerender(<CommentWontfixChip assistantText="x" sessionId={'s' as never} />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders nothing for a non-review thread id', () => {
-    h.extractMock.mockReturnValue({ threadId: 'th-1', reason: 'nope' });
-    const { container } = render(<CommentWontfixChip assistantText="x" sessionId={'s' as never} />);
-    expect(container.firstChild).toBeNull();
+  it('keeps the status reason and replaces actions with a manage link', () => {
+    h.extract.mockReturnValue({ threadId: 'PRRT_1', reason: 'already covered upstream' });
+    render(
+      <CommentWontfixChip
+        assistantText="x"
+        sessionId={'s' as never}
+        agentId={'agent-1' as never}
+      />,
+    );
+
+    expect(screen.getByText('already covered upstream')).toBeDefined();
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByText('Manage in panel')).toBeDefined();
   });
 
-  it('posts the reason and resolves the thread when clicked', async () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_9', reason: 'already covered upstream' });
-    render(<CommentWontfixChip assistantText="x" sessionId={'s' as never} />);
-    const explanation = screen.getByRole('textbox', { name: 'explanation' });
-    expect((explanation as HTMLTextAreaElement).value).toBe('already covered upstream');
-    fireEvent.change(explanation, { target: { value: 'covered by the new helper' } });
-    await act(async () => {
-      fireEvent.click(screen.getByTestId('comment-wontfix-explain'));
-    });
-    expect(h.resolveMock).toHaveBeenCalledWith('s', 'PRRT_9', {
-      reason: 'covered by the new helper',
-    });
-    expect(screen.getByText(/marked solved with explanation/i)).toBeDefined();
-  });
+  it('opens the resolver inspector from the manage link', () => {
+    h.extract.mockReturnValue({ threadId: 'PRRT_1', reason: 'no change' });
+    const onOpen = vi.fn();
+    window.addEventListener('goodboy:open-resolver-inspector', onOpen);
+    render(
+      <CommentWontfixChip
+        assistantText="x"
+        sessionId={'s' as never}
+        agentId={'agent-1' as never}
+      />,
+    );
 
-  it('shows the resolved state when the thread is already resolved on github', () => {
-    h.extractMock.mockReturnValue({ threadId: 'PRRT_9', reason: 'already covered upstream' });
-    h.resolvedComments = [{ threadId: 'PRRT_9', resolved: true }];
-    render(<CommentWontfixChip assistantText="x" sessionId={'s' as never} />);
-    expect(screen.getByText(/marked solved with explanation/i)).toBeDefined();
+    fireEvent.click(screen.getByTestId('comment-wontfix-manage'));
+
+    const event = onOpen.mock.calls[0]?.[0] as CustomEvent;
+    expect(event.detail).toEqual({ sessionId: 's', agentId: 'agent-1' });
+    window.removeEventListener('goodboy:open-resolver-inspector', onOpen);
   });
 });

--- a/apps/desktop/src/features/chat/components/CommentWontfixChip/index.tsx
+++ b/apps/desktop/src/features/chat/components/CommentWontfixChip/index.tsx
@@ -1,73 +1,46 @@
 import { useMemo, useState } from 'react';
-import { Ban, CheckCheck, MessageSquareReply, X } from 'lucide-react';
-import { Textarea, cn } from '@goodboy/ui';
+import { Ban, CheckCheck, X } from 'lucide-react';
 import { extractCommentWontfix, isReviewThreadId } from '@goodboy/core';
-import type { SessionId } from '@goodboy/types';
+import type { AgentId, SessionId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
 import { MARKER_ACCENT } from '../marker-accents';
 import { TranscriptShell } from '../TranscriptShell';
 
-const successAccent = MARKER_ACCENT.success;
 const warningAccent = MARKER_ACCENT.warning;
 
 type Props = {
   readonly assistantText: string;
   readonly sessionId: SessionId;
+  readonly agentId?: AgentId | null;
 };
 
-type ChipState =
-  | { kind: 'idle' }
-  | { kind: 'resolving' }
-  | { kind: 'resolved' }
-  | { kind: 'dismissed' };
-
-export const CommentWontfixChip = ({ assistantText, sessionId }: Props) => {
+export const CommentWontfixChip = ({ assistantText, sessionId, agentId = null }: Props) => {
   const marker = useMemo(() => extractCommentWontfix(assistantText), [assistantText]);
-  const threadId = marker?.threadId;
-
-  const resolveGithubThread = useAppStore((s) => s.resolveGithubThread);
-  const resolvedOnGithub = useAppStore((s) =>
-    threadId
-      ? (s.sessionGithub[sessionId]?.detail?.comments?.some(
-          (c) => c.threadId === threadId && c.resolved === true,
+  const resolvedOnGithub = useAppStore((state) =>
+    marker?.threadId != null
+      ? (state.sessionGithub[sessionId]?.detail?.comments?.some(
+          (comment) => comment.threadId === marker.threadId && comment.resolved === true,
         ) ?? false)
       : false,
   );
+  const [isDismissed, setIsDismissed] = useState(false);
 
-  const [state, setState] = useState<ChipState>({ kind: 'idle' });
-  const [reason, setReason] = useState(marker?.reason ?? '');
-
-  if (!marker || !isReviewThreadId(marker.threadId)) {
+  if (marker === null || !isReviewThreadId(marker.threadId) || isDismissed) {
     return null;
   }
 
-  if (state.kind === 'resolved' || resolvedOnGithub) {
+  if (resolvedOnGithub) {
     return (
       <TranscriptShell
         tone="success"
         variant="pill"
-        className={`mt-2 inline-flex items-center gap-1.5 text-xs font-medium ${successAccent.text}`}
+        className={`mt-2 inline-flex items-center gap-1.5 text-xs font-medium ${MARKER_ACCENT.success.text}`}
       >
         <CheckCheck size={11} aria-hidden />
         <span>marked solved with explanation</span>
       </TranscriptShell>
     );
   }
-
-  if (state.kind === 'dismissed') {
-    return null;
-  }
-
-  const busy = state.kind === 'resolving';
-
-  const markSolved = async () => {
-    if (busy) {
-      return;
-    }
-    setState({ kind: 'resolving' });
-    const ok = await resolveGithubThread(sessionId, marker.threadId, { reason });
-    setState(ok ? { kind: 'resolved' } : { kind: 'idle' });
-  };
 
   return (
     <TranscriptShell
@@ -77,38 +50,32 @@ export const CommentWontfixChip = ({ assistantText, sessionId }: Props) => {
     >
       <Ban size={12} aria-hidden className={warningAccent.icon} />
       <span className="font-medium text-foreground">not worth a change</span>
-      <Textarea
-        value={reason}
-        onChange={(event) => setReason(event.target.value)}
-        disabled={busy}
-        aria-label="explanation"
-        autoGrow
-        maxRows={5}
-        className="min-h-8 min-w-64 flex-1 resize-none bg-background/60 px-2 py-1 text-xs leading-relaxed"
-      />
+      <span className="min-w-0 flex-1 text-muted-foreground">{marker.reason}</span>
       <div className="ml-auto flex items-center gap-1">
         <button
           type="button"
-          onClick={() => void markSolved()}
-          disabled={busy || reason.trim().length === 0}
-          data-testid="comment-wontfix-explain"
-          aria-label="post the explanation and mark the thread solved"
-          title="post the reason as a reply and resolve the thread on GitHub"
-          className={cn(
-            'relative inline-flex items-center gap-1 rounded-full bg-warning px-2 py-0.5 text-2xs font-semibold text-warning-foreground transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60',
-            busy && 'animate-border-pulse',
-          )}
+          disabled={agentId === null}
+          onClick={() => {
+            if (agentId === null) {
+              return;
+            }
+            window.dispatchEvent(
+              new CustomEvent('goodboy:open-resolver-inspector', {
+                detail: { sessionId, agentId },
+              }),
+            );
+          }}
+          data-testid="comment-wontfix-manage"
+          className="rounded-full px-2 py-0.5 text-2xs font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:opacity-50"
         >
-          <MessageSquareReply size={9} aria-hidden />
-          {busy ? 'Marking…' : 'Mark as solved & explain'}
+          Manage in panel
         </button>
         <button
           type="button"
-          onClick={() => setState({ kind: 'dismissed' })}
-          disabled={busy}
-          title="keep the conversation open on GitHub"
-          aria-label="keep the conversation open on GitHub"
-          className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={() => setIsDismissed(true)}
+          title="dismiss resolver status"
+          aria-label="dismiss resolver status"
+          className="rounded p-1 text-muted-foreground/70 transition-colors hover:bg-muted hover:text-foreground"
         >
           <X size={10} aria-hidden />
         </button>

--- a/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
+++ b/apps/desktop/src/features/chat/components/TranscriptCards/AssistantText.tsx
@@ -35,7 +35,7 @@ export const AssistantText = ({ text, sessionId, agentId = null }: Props) => {
           <HandoffChip assistantText={text} sessionId={sessionId} />
           <CommentAnalysisChip assistantText={text} sessionId={sessionId} agentId={agentId} />
           <CommentResolvedChip assistantText={text} sessionId={sessionId} agentId={agentId} />
-          <CommentWontfixChip assistantText={text} sessionId={sessionId} />
+          <CommentWontfixChip assistantText={text} sessionId={sessionId} agentId={agentId} />
         </div>
       ) : null}
     </TranscriptShell>

--- a/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
+++ b/apps/desktop/src/features/plans/components/PlanStudio/index.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
-  AlertTriangle,
   ArchiveRestore,
   CheckCircle2,
   ClipboardList,
@@ -25,6 +24,7 @@ import {
 import type { Agent, PlanId, PlanWithCount, SessionId } from '@goodboy/types';
 import { EMPTY_ARRAY, useAppStore, useSessionPlans } from '../../../../store';
 import { useToast } from '../../../../app/components/Toast';
+import { ConfirmableButton } from '../../../../shared/components/ConfirmableButton';
 import { fmtTimestamp } from './fmtTimestamp';
 import { planStatusBadge } from './planStatusBadge';
 import { PlanListPanel } from './PlanListPanel';
@@ -54,22 +54,6 @@ export const PlanStudio = ({ sessionId, initialPlanId }: Props) => {
   const [mode, setMode] = useState<'preview' | 'edit'>('preview');
   const [draft, setDraft] = useState('');
   const [spawning, setSpawning] = useState(false);
-  const [retriggerArmed, setRetriggerArmed] = useState(false);
-  const retriggerTimerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    setRetriggerArmed(false);
-    if (retriggerTimerRef.current !== null) {
-      window.clearTimeout(retriggerTimerRef.current);
-      retriggerTimerRef.current = null;
-    }
-  }, [selectedId]);
-
-  useEffect(() => {
-    return () => {
-      if (retriggerTimerRef.current !== null) window.clearTimeout(retriggerTimerRef.current);
-    };
-  }, []);
 
   useEffect(() => {
     if (selectedId === null && plans.length > 0) {
@@ -122,21 +106,9 @@ export const PlanStudio = ({ sessionId, initialPlanId }: Props) => {
   };
 
   const handleTrigger = async () => {
-    if (!selected || spawning) return;
-    if (selected.status === 'consumed' && !retriggerArmed) {
-      setRetriggerArmed(true);
-      if (retriggerTimerRef.current !== null) window.clearTimeout(retriggerTimerRef.current);
-      retriggerTimerRef.current = window.setTimeout(() => {
-        setRetriggerArmed(false);
-        retriggerTimerRef.current = null;
-      }, 4000);
+    if (!selected || spawning) {
       return;
     }
-    if (retriggerTimerRef.current !== null) {
-      window.clearTimeout(retriggerTimerRef.current);
-      retriggerTimerRef.current = null;
-    }
-    setRetriggerArmed(false);
     setSpawning(true);
     try {
       await runPlan(sessionId, selected.id);
@@ -334,38 +306,43 @@ export const PlanStudio = ({ sessionId, initialPlanId }: Props) => {
                           size="sm"
                         />
                         {selected.status !== 'discarded' ? (
-                          <button
-                            type="button"
-                            onClick={() => void handleTrigger()}
-                            disabled={spawning}
-                            className={cn(
-                              'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent px-2.5 py-1 text-xs font-medium shadow-sm transition-colors',
-                              retriggerArmed
-                                ? 'w-36 bg-warning/15 text-warning hover:bg-warning/20'
-                                : 'bg-primary text-primary-foreground hover:bg-primary/90',
-                              spawning && 'cursor-not-allowed opacity-60 animate-border-pulse',
-                            )}
-                            title={
-                              retriggerArmed
-                                ? 'Already consumed, click again to confirm and spawn a fresh agent'
-                                : selected.status === 'consumed' || selected.status === 'superseded'
-                                  ? 'Plan already ran, click to replay (asks for confirmation)'
-                                  : 'Spawn new agent to execute this plan'
-                            }
-                          >
-                            {retriggerArmed ? (
-                              <AlertTriangle size={12} aria-hidden />
-                            ) : selected.status === 'active' ? (
-                              <Play size={12} aria-hidden className="fill-current" />
-                            ) : (
-                              <RotateCw size={12} aria-hidden />
-                            )}
-                            {retriggerArmed
-                              ? 'Confirm replay'
-                              : selected.status === 'active'
-                                ? 'Start'
-                                : 'Replay'}
-                          </button>
+                          selected.status === 'consumed' ? (
+                            <ConfirmableButton
+                              key={selected.id}
+                              label="Replay"
+                              armedLabel="Confirm replay"
+                              busyLabel="Replaying..."
+                              onConfirm={handleTrigger}
+                              disabled={spawning}
+                              tone="warning"
+                              autoDisarmMs={4000}
+                              title="Plan already ran, click to replay and confirm"
+                              icon={<RotateCw size={12} aria-hidden />}
+                              className="rounded-md px-2.5 py-1 text-xs"
+                            />
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => void handleTrigger()}
+                              disabled={spawning}
+                              className={cn(
+                                'inline-flex items-center justify-center gap-1.5 rounded-md border border-transparent bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90',
+                                spawning && 'cursor-not-allowed opacity-60 animate-border-pulse',
+                              )}
+                              title={
+                                selected.status === 'active'
+                                  ? 'Spawn new agent to execute this plan'
+                                  : 'Replay this plan'
+                              }
+                            >
+                              {selected.status === 'active' ? (
+                                <Play size={12} aria-hidden className="fill-current" />
+                              ) : (
+                                <RotateCw size={12} aria-hidden />
+                              )}
+                              {selected.status === 'active' ? 'Start' : 'Replay'}
+                            </button>
+                          )
                         ) : null}
                         {selected.status === 'consumed' ? (
                           <Tooltip content="Consumed plans cannot be deleted">

--- a/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.tsx
+++ b/apps/desktop/src/features/session/components/ForceCloseResolverAction/index.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from 'react';
 import { CircleStop } from 'lucide-react';
 import type { Agent, SessionId } from '@goodboy/types';
-import { cn } from '@goodboy/ui';
 import { useAppStore } from '../../../../store';
+import { ConfirmableButton } from '../../../../shared/components/ConfirmableButton';
 import type { ResolverStatus } from '../../resolver-linkage';
 import { canForceCloseResolver } from './canForceCloseResolver';
 
@@ -14,51 +13,25 @@ type Props = {
 
 export const ForceCloseResolverAction = ({ agent, sessionId, status }: Props) => {
   const forceCloseResolver = useAppStore((state) => state.forceCloseResolver);
-  const [isArmed, setIsArmed] = useState(false);
-  const [isBusy, setIsBusy] = useState(false);
-
-  useEffect(() => {
-    setIsArmed(false);
-  }, [agent.id]);
 
   if (!canForceCloseResolver({ agent, status })) {
     return null;
   }
 
   const onConfirm = async () => {
-    if (isBusy) {
-      return;
-    }
-    setIsBusy(true);
-    setIsArmed(false);
-    try {
-      await forceCloseResolver(sessionId, agent.id);
-    } finally {
-      setIsBusy(false);
-    }
+    await forceCloseResolver(sessionId, agent.id);
   };
 
   return (
-    <button
-      type="button"
-      disabled={isBusy}
+    <ConfirmableButton
+      key={agent.id}
+      label="Force close"
+      armedLabel="Confirm stop"
+      busyLabel="Stopping..."
+      onConfirm={onConfirm}
+      tone="danger"
       title="stop this resolver now and let the next queued one run"
-      onClick={(event) => {
-        event.stopPropagation();
-        if (isArmed) {
-          void onConfirm();
-          return;
-        }
-        setIsArmed(true);
-      }}
-      onBlur={() => setIsArmed(false)}
-      className={cn(
-        'inline-flex shrink-0 items-center gap-1 rounded-full border border-danger/40 px-2 py-0.5 text-[10px] font-semibold text-danger transition-colors hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-60',
-        isBusy && 'animate-border-pulse',
-      )}
-    >
-      <CircleStop size={9} aria-hidden />
-      {isBusy ? 'Stopping...' : isArmed ? 'Confirm stop' : 'Force close'}
-    </button>
+      icon={<CircleStop size={9} aria-hidden />}
+    />
   );
 };

--- a/apps/desktop/src/features/session/components/ForceResolveAction/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ForceResolveAction/index.test.tsx
@@ -149,7 +149,9 @@ describe('ForceResolveAction', () => {
       <ForceResolveAction agent={OTHER_AGENT} sessionId={SESSION_ID} status="awaiting" />,
     );
 
-    expect(screen.queryByRole('textbox', { name: 'Resolution note' })).toBeNull();
+    expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Resolution note' }).value).toBe(
+      '',
+    );
     expect(screen.getByRole('button', { name: 'Mark resolved' })).toBeDefined();
   });
 

--- a/apps/desktop/src/features/session/components/ForceResolveAction/index.tsx
+++ b/apps/desktop/src/features/session/components/ForceResolveAction/index.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { CheckCheck } from 'lucide-react';
 import type { Agent, SessionId } from '@goodboy/types';
-import { cn } from '@goodboy/ui';
 import { useAppStore } from '../../../../store';
+import { ConfirmableButton } from '../../../../shared/components/ConfirmableButton';
 import type { ResolverStatus } from '../../resolver-linkage';
 import { canForceResolve } from './canForceResolve';
 
@@ -15,12 +15,9 @@ type Props = {
 export const ForceResolveAction = ({ agent, sessionId, status }: Props) => {
   const turnState = useAppStore((state) => state.agentTurnState[agent.id]);
   const resolveGithubThread = useAppStore((state) => state.resolveGithubThread);
-  const [isArmed, setIsArmed] = useState(false);
-  const [isBusy, setIsBusy] = useState(false);
   const [note, setNote] = useState('');
 
   useEffect(() => {
-    setIsArmed(false);
     setNote('');
   }, [agent.id]);
 
@@ -29,23 +26,17 @@ export const ForceResolveAction = ({ agent, sessionId, status }: Props) => {
   }
 
   const onConfirm = async () => {
-    if (isBusy || agent.sourceThreadId == null) {
+    if (agent.sourceThreadId == null) {
       return;
     }
-    setIsBusy(true);
-    setIsArmed(false);
     const reason = note.trim();
-    try {
-      const didResolve = await resolveGithubThread(
-        sessionId,
-        agent.sourceThreadId,
-        reason !== '' ? { reason } : {},
-      );
-      if (didResolve) {
-        setNote('');
-      }
-    } finally {
-      setIsBusy(false);
+    const didResolve = await resolveGithubThread(
+      sessionId,
+      agent.sourceThreadId,
+      reason !== '' ? { reason } : {},
+    );
+    if (didResolve) {
+      setNote('');
     }
   };
 
@@ -54,41 +45,23 @@ export const ForceResolveAction = ({ agent, sessionId, status }: Props) => {
       className="flex min-w-0 items-center justify-end gap-1.5"
       onClick={(event) => event.stopPropagation()}
       onKeyDown={(event) => event.stopPropagation()}
-      onBlur={(event) => {
-        if (!event.currentTarget.contains(event.relatedTarget)) {
-          setIsArmed(false);
-        }
-      }}
     >
-      {isArmed ? (
-        <input
-          autoFocus
-          type="text"
-          value={note}
-          onChange={(event) => setNote(event.target.value)}
-          placeholder="Optional note"
-          aria-label="Resolution note"
-          className="h-6 min-w-0 max-w-48 flex-1 rounded border border-border bg-background px-2 text-[10px] font-medium text-foreground outline-none placeholder:text-muted-foreground/60 focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
-        />
-      ) : null}
-      <button
-        type="button"
-        disabled={isBusy}
-        onClick={() => {
-          if (isArmed) {
-            void onConfirm();
-            return;
-          }
-          setIsArmed(true);
-        }}
-        className={cn(
-          'inline-flex shrink-0 items-center gap-1 rounded-full border border-warning/40 px-2 py-0.5 text-[10px] font-semibold text-warning transition-colors hover:bg-warning/10 disabled:cursor-not-allowed disabled:opacity-60',
-          isBusy && 'animate-border-pulse',
-        )}
-      >
-        <CheckCheck size={9} aria-hidden />
-        {isBusy ? 'Resolving...' : isArmed ? 'Confirm resolved' : 'Mark resolved'}
-      </button>
+      <input
+        type="text"
+        value={note}
+        onChange={(event) => setNote(event.target.value)}
+        placeholder="Optional note"
+        aria-label="Resolution note"
+        className="h-6 min-w-0 max-w-48 flex-1 rounded border border-border bg-background px-2 text-[10px] font-medium text-foreground outline-none placeholder:text-muted-foreground/60 focus-visible:ring-2 focus-visible:ring-[var(--color-focus-ring)]"
+      />
+      <ConfirmableButton
+        key={agent.id}
+        label="Mark resolved"
+        armedLabel="Confirm resolved"
+        busyLabel="Resolving..."
+        onConfirm={onConfirm}
+        icon={<CheckCheck size={9} aria-hidden />}
+      />
     </div>
   );
 };

--- a/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.test.tsx
@@ -105,4 +105,10 @@ describe('ActionsSection', () => {
 
     expect(screen.getByRole('button', { name: 'Run now' })).toBeDefined();
   });
+
+  it('points at force close for a running resolver', () => {
+    renderSection({ status: 'running' });
+
+    expect(screen.getByText(/force close above/i)).toBeDefined();
+  });
 });

--- a/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import type { ResolverStatus } from '../../resolver-linkage';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT = {
+  id: 'agent-1' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'resolver',
+  status: 'completed',
+  sourceThreadId: 'PRRT_1',
+} satisfies Agent;
+
+const h = vi.hoisted(() => ({
+  pending: [] as Array<{ threadId: string; commitSha: string }>,
+  resolveGithubThread: vi.fn(async () => true),
+  queueResolution: vi.fn(async () => undefined),
+  dequeueResolution: vi.fn(async () => undefined),
+  activateNextResolver: vi.fn(async () => undefined),
+  sendTurn: vi.fn(async () => undefined),
+  selectAgent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(
+    selector: (state: {
+      resolveGithubThread: typeof h.resolveGithubThread;
+      queueResolution: typeof h.queueResolution;
+      dequeueResolution: typeof h.dequeueResolution;
+      activateNextResolver: typeof h.activateNextResolver;
+      sendTurn: typeof h.sendTurn;
+      selectAgent: typeof h.selectAgent;
+      sessionGithub: Record<string, { pr: { number: number } }>;
+      sessionPendingResolutions: Record<string, Array<{ threadId: string; commitSha: string }>>;
+    }) => T,
+  ) =>
+    selector({
+      resolveGithubThread: h.resolveGithubThread,
+      queueResolution: h.queueResolution,
+      dequeueResolution: h.dequeueResolution,
+      activateNextResolver: h.activateNextResolver,
+      sendTurn: h.sendTurn,
+      selectAgent: h.selectAgent,
+      sessionGithub: { [SESSION_ID]: { pr: { number: 7 } } },
+      sessionPendingResolutions: { [SESSION_ID]: h.pending },
+    }),
+}));
+
+import { ActionsSection } from './ActionsSection';
+
+type RenderParams = {
+  readonly status: ResolverStatus;
+};
+
+const renderSection = ({ status }: RenderParams) =>
+  render(
+    <ActionsSection agent={AGENT} sessionId={SESSION_ID} status={status} commitSha="abc1234" />,
+  );
+
+describe('ActionsSection', () => {
+  afterEach(() => {
+    cleanup();
+    h.pending = [];
+  });
+
+  it('offers push and queue for a committed resolver', () => {
+    renderSection({ status: 'committed' });
+
+    expect(screen.getByRole('button', { name: 'Push & resolve' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Queue for batch push' })).toBeDefined();
+  });
+
+  it('offers remove and push for a queued resolver', () => {
+    h.pending = [{ threadId: 'PRRT_1', commitSha: 'abc1234' }];
+    renderSection({ status: 'committed' });
+
+    expect(screen.getByRole('button', { name: 'Remove from batch' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Push now' })).toBeDefined();
+  });
+
+  it('offers an editable explanation for wontfix', () => {
+    renderSection({ status: 'wontfix' });
+
+    expect(screen.getByRole('textbox', { name: 'resolution explanation' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Post explanation & close' })).toBeDefined();
+  });
+
+  it('offers proceed and close for analyzed', () => {
+    renderSection({ status: 'analyzed' });
+
+    expect(screen.getByRole('button', { name: 'Proceed with fix' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Post explanation & close' })).toBeDefined();
+  });
+
+  it('offers continue for awaiting', () => {
+    renderSection({ status: 'awaiting' });
+
+    expect(screen.getByRole('button', { name: 'Continue working' })).toBeDefined();
+  });
+
+  it('offers run now for pending', () => {
+    renderSection({ status: 'pending' });
+
+    expect(screen.getByRole('button', { name: 'Run now' })).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.tsx
@@ -188,6 +188,16 @@ export const ActionsSection = ({ agent, sessionId, status, commitSha }: Props) =
     );
   }
 
+  if (status === 'running') {
+    return (
+      <InspectorSection question="What you can do">
+        <p className="text-2xs italic text-muted-foreground/70">
+          working on it, force close above if it is stuck
+        </p>
+      </InspectorSection>
+    );
+  }
+
   if (status === 'resolved' || status === 'done' || status === 'stopped') {
     return (
       <InspectorSection question="What you can do">

--- a/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/ActionsSection.tsx
@@ -1,0 +1,204 @@
+import { useEffect, useState } from 'react';
+import { Clock, MessageSquareReply, Play, Upload, X } from 'lucide-react';
+import { Textarea } from '@goodboy/ui';
+import type { Agent, SessionId } from '@goodboy/types';
+import { useAppStore } from '../../../../store';
+import { ConfirmableButton } from '../../../../shared/components/ConfirmableButton';
+import { PROCEED_RESOLVER_PROMPT } from '../../../../shared/utils/proceedResolverPrompt';
+import type { ResolverStatus } from '../../resolver-linkage';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly agent: Agent;
+  readonly sessionId: SessionId;
+  readonly status: ResolverStatus;
+  readonly commitSha: string | null;
+};
+
+const SINGLE_ACTION_CLASS =
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50';
+
+export const ActionsSection = ({ agent, sessionId, status, commitSha }: Props) => {
+  const resolveGithubThread = useAppStore((state) => state.resolveGithubThread);
+  const queueResolution = useAppStore((state) => state.queueResolution);
+  const dequeueResolution = useAppStore((state) => state.dequeueResolution);
+  const activateNextResolver = useAppStore((state) => state.activateNextResolver);
+  const sendTurn = useAppStore((state) => state.sendTurn);
+  const selectAgent = useAppStore((state) => state.selectAgent);
+  const prNumber = useAppStore((state) => state.sessionGithub[sessionId]?.pr?.number ?? null);
+  const pendingResolution = useAppStore(
+    (state) =>
+      state.sessionPendingResolutions[sessionId]?.find(
+        (resolution) => resolution.threadId === agent.sourceThreadId,
+      ) ?? null,
+  );
+  const [reason, setReason] = useState('');
+
+  useEffect(() => setReason(''), [agent.id]);
+
+  const threadId = agent.sourceThreadId ?? null;
+  const effectiveCommitSha = pendingResolution?.commitSha ?? commitSha;
+  const push = async () => {
+    if (threadId === null || effectiveCommitSha === null) {
+      return;
+    }
+    const didResolve = await resolveGithubThread(sessionId, threadId, {
+      commitSha: effectiveCommitSha,
+    });
+    if (didResolve && pendingResolution !== null) {
+      await dequeueResolution(sessionId, threadId);
+    }
+  };
+  const queue = async () => {
+    if (threadId === null || effectiveCommitSha === null || prNumber === null) {
+      return;
+    }
+    await queueResolution(sessionId, { threadId, commitSha: effectiveCommitSha, prNumber });
+  };
+  const explain = async () => {
+    if (threadId === null || reason.trim() === '') {
+      return;
+    }
+    await resolveGithubThread(sessionId, threadId, { reason: reason.trim() });
+  };
+
+  if (status === 'committed') {
+    return (
+      <InspectorSection question="What you can do">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {pendingResolution === null ? (
+            <>
+              <ConfirmableButton
+                label="Push & resolve"
+                armedLabel="Confirm push & resolve"
+                busyLabel="Pushing..."
+                onConfirm={push}
+                disabled={threadId === null || effectiveCommitSha === null}
+                tone="accent"
+                icon={<Upload size={9} aria-hidden />}
+              />
+              <button
+                type="button"
+                onClick={() => void queue()}
+                disabled={threadId === null || effectiveCommitSha === null || prNumber === null}
+                className={SINGLE_ACTION_CLASS}
+              >
+                <Clock size={9} aria-hidden />
+                Queue for batch push
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={() => void dequeueResolution(sessionId, pendingResolution.threadId)}
+                className={SINGLE_ACTION_CLASS}
+              >
+                <X size={9} aria-hidden />
+                Remove from batch
+              </button>
+              <ConfirmableButton
+                label="Push now"
+                armedLabel="Confirm push now"
+                busyLabel="Pushing..."
+                onConfirm={push}
+                tone="accent"
+                icon={<Upload size={9} aria-hidden />}
+              />
+            </>
+          )}
+        </div>
+      </InspectorSection>
+    );
+  }
+
+  if (status === 'wontfix' || status === 'analyzed') {
+    return (
+      <InspectorSection question="What you can do">
+        <Textarea
+          value={reason}
+          onChange={(event) => setReason(event.target.value)}
+          aria-label="resolution explanation"
+          placeholder="Explain why this can be closed"
+          autoGrow
+          maxRows={6}
+          className="min-h-16 resize-none bg-background/60 px-2 py-1.5 text-xs leading-relaxed"
+        />
+        <div className="flex flex-wrap items-center gap-1.5">
+          {status === 'analyzed' ? (
+            <button
+              type="button"
+              onClick={() =>
+                void sendTurn({
+                  sessionId,
+                  agentId: agent.id,
+                  content: PROCEED_RESOLVER_PROMPT,
+                })
+              }
+              className={SINGLE_ACTION_CLASS}
+            >
+              <Play size={9} aria-hidden />
+              Proceed with fix
+            </button>
+          ) : null}
+          <ConfirmableButton
+            label="Post explanation & close"
+            armedLabel="Confirm explanation & close"
+            busyLabel="Posting..."
+            onConfirm={explain}
+            disabled={threadId === null || reason.trim() === ''}
+            tone="warning"
+            icon={<MessageSquareReply size={9} aria-hidden />}
+          />
+        </div>
+      </InspectorSection>
+    );
+  }
+
+  if (status === 'awaiting') {
+    return (
+      <InspectorSection question="What you can do">
+        <button
+          type="button"
+          onClick={() => {
+            void selectAgent(sessionId, agent.id).then(() => {
+              window.dispatchEvent(new CustomEvent('goodboy:focus-composer'));
+            });
+          }}
+          className={SINGLE_ACTION_CLASS}
+        >
+          Continue working
+        </button>
+      </InspectorSection>
+    );
+  }
+
+  if (status === 'pending') {
+    return (
+      <InspectorSection question="What you can do">
+        <button
+          type="button"
+          onClick={() => void activateNextResolver(sessionId)}
+          className={SINGLE_ACTION_CLASS}
+        >
+          <Play size={9} aria-hidden />
+          Run now
+        </button>
+      </InspectorSection>
+    );
+  }
+
+  if (status === 'resolved' || status === 'done' || status === 'stopped') {
+    return (
+      <InspectorSection question="What you can do">
+        <p className="text-2xs italic text-muted-foreground/70">nothing left to do here</p>
+      </InspectorSection>
+    );
+  }
+
+  return (
+    <InspectorSection question="What you can do">
+      <p className="text-2xs italic text-muted-foreground/70">no additional actions right now</p>
+    </InspectorSection>
+  );
+};

--- a/apps/desktop/src/features/session/components/ResolverInspector/index.test.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.test.tsx
@@ -123,12 +123,13 @@ describe('ResolverInspector', () => {
 
   afterEach(cleanup);
 
-  it('groups the answers into the three governance questions', () => {
+  it('groups the answers into the four governance questions', () => {
     render(
       <ResolverInspector sessionId={SESSION_ID} agentId={RUNNING_ID} onClose={() => undefined} />,
     );
 
     expect(screen.getByText('Where it came from')).toBeDefined();
+    expect(screen.getByText('What you can do')).toBeDefined();
     expect(screen.getByText('What it changed')).toBeDefined();
     expect(screen.getByText('What state it is in')).toBeDefined();
   });

--- a/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/ResolverInspector/index.tsx
@@ -8,13 +8,14 @@ import { useResolverIndex } from '../../hooks/useResolverIndex';
 import { useResolverChanges } from '../../hooks/useResolverChanges';
 import { resolverOrigin } from '../../resolver-origin';
 import { ChangesSection } from './ChangesSection';
+import { ActionsSection } from './ActionsSection';
 import { OriginSection } from './OriginSection';
 import { StateSection } from './StateSection';
 
 type Props = {
   readonly sessionId: SessionId;
   readonly agentId: AgentId;
-  readonly onClose: () => void;
+  readonly onClose?: () => void;
 };
 
 const OPEN_LABEL: Record<AgentSourceKind | 'unknown', string | null> = {
@@ -106,6 +107,13 @@ export const ResolverInspector = ({ sessionId, agentId, onClose }: Props) => {
             diffComment={diffComment}
             openLabel={canOpen ? OPEN_LABEL[origin.kind] : null}
             onOpen={onOpen}
+          />
+          <Divider />
+          <ActionsSection
+            agent={agent}
+            sessionId={sessionId}
+            status={link.status}
+            commitSha={changes.reported[0]?.sha ?? changes.reportedMissingShas[0] ?? null}
           />
           <Divider />
           <ChangesSection

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -133,6 +133,11 @@ vi.mock('../ForceResolveAction', () => ({
     <div data-testid="force-resolve-action">{agent.name}</div>
   ),
 }));
+vi.mock('../ResolverInspector', () => ({
+  ResolverInspector: ({ agentId }: { agentId: string }) => (
+    <div data-testid="resolver-inspector">{agentId}</div>
+  ),
+}));
 
 import { SessionWorkspace } from './index';
 
@@ -257,7 +262,7 @@ describe('SessionWorkspace agent overlay', () => {
     expect(screen.queryByRole('button', { name: 'Release flow' })).toBeNull();
   });
 
-  it('shows the force resolve action in a markerless resolver header', () => {
+  it('shows the selected resolver in the overlay inspector without a header action', () => {
     const standaloneResolver = {
       ...selectedAgent,
       id: 'resolver-1',
@@ -275,7 +280,8 @@ describe('SessionWorkspace agent overlay', () => {
 
     render(<SessionWorkspace session={session} isActive />);
 
-    expect(screen.getByTestId('force-resolve-action').textContent).toBe('Markerless resolver');
+    expect(screen.getByTestId('resolver-inspector').textContent).toBe('resolver-1');
+    expect(screen.queryByTestId('force-resolve-action')).toBeNull();
   });
 
   it('keeps the agents-home overlay panel unchanged', () => {
@@ -291,11 +297,65 @@ describe('SessionWorkspace agent overlay', () => {
     expect(container.querySelector('.w-72')).not.toBeNull();
     expect(screen.getByTestId('agents-section').getAttribute('data-home')).toBe('agents');
     expect(screen.getAllByRole('button', { name: 'Agents' })).toHaveLength(2);
+    expect(screen.queryByTestId('resolver-inspector')).toBeNull();
     expect(
       screen
         .getAllByTestId('divider')
         .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
     ).toHaveLength(2);
+  });
+
+  it('keeps the selected inspector open across the resolve chat overlay', () => {
+    const waiting = {
+      ...selectedAgent,
+      id: 'resolver-waiting',
+      name: 'Waiting resolver',
+      kind: 'resolver',
+      status: 'completed',
+      stepId: undefined,
+      workflowRunId: undefined,
+    } as Agent;
+    store.activeLens = { [SESSION_ID]: 'resolve' };
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [waiting] };
+    store.resolverState = { [waiting.id]: 'awaiting' };
+    hooks.agentHome = 'resolve';
+    const view = render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('resolver-inspector').textContent).toBe(waiting.id);
+
+    store.selectedAgentId = { [SESSION_ID]: waiting.id };
+    view.rerender(<SessionWorkspace session={session} isActive />);
+    expect(screen.getByTestId('resolver-inspector').textContent).toBe(waiting.id);
+
+    store.selectedAgentId = {};
+    view.rerender(<SessionWorkspace session={session} isActive />);
+    expect(screen.getByTestId('resolver-inspector').textContent).toBe(waiting.id);
+  });
+
+  it('opens the running resolver by default before an awaiting resolver', () => {
+    const awaiting = {
+      ...selectedAgent,
+      id: 'resolver-awaiting',
+      kind: 'resolver',
+      status: 'completed',
+      stepId: undefined,
+      workflowRunId: undefined,
+    } as Agent;
+    const running = {
+      ...awaiting,
+      id: 'resolver-running',
+      ordinal: 1,
+      status: 'running',
+    } as Agent;
+    store.activeLens = { [SESSION_ID]: 'resolve' };
+    store.selectedAgentId = {};
+    store.sessionPhaseRuns = { [SESSION_ID]: [awaiting, running] };
+    store.resolverState = { [awaiting.id]: 'awaiting' };
+
+    render(<SessionWorkspace session={session} isActive />);
+
+    expect(screen.getByTestId('resolver-inspector').textContent).toBe(running.id);
   });
 });
 

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
 import { Divider, cn } from '@goodboy/ui';
 import { TerminalDock } from '../../../terminal/components/TerminalDock';
@@ -35,7 +35,6 @@ import { WorkflowsPane } from './parts/WorkflowsPane';
 import { IntegrationPane } from './parts/IntegrationPane';
 import { useAttachedWorkflowRuns } from '../../../workflows/useAttachedWorkflowRuns';
 import { isStandaloneAgent, resolveRootAgent } from '../../agent-kind';
-import { canForceResolve } from '../ForceResolveAction/canForceResolve';
 import { useResolverIndex } from '../../hooks/useResolverIndex';
 import { SessionOverviewSkeleton } from './parts/SessionOverviewSkeleton';
 import { ReviewBoardPane } from '../../../review/components/ReviewBoardPane';
@@ -66,6 +65,8 @@ type SessionWorkspaceProps = {
 
 export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) => {
   const sessionId = session.id as SessionId;
+  const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
+  const hasInitializedResolverInspector = useRef(false);
   const activeLens = useAppStore((s) => s.activeLens[sessionId]);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
   const focusedPlanId = useAppStore((s) => s.focusedPlanId[sessionId] ?? null);
@@ -122,10 +123,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const showAgentOverlay = selectedAgentId != null && !showStudio;
   const showLens = selectedAgentId == null && !showStudio;
   const overlayHome = resolveOverlayHome({ lens, agentHome });
-  const selectedAgent = useMemo(
-    () => phaseRuns.find((agent) => agent.id === selectedAgentId) ?? null,
-    [phaseRuns, selectedAgentId],
-  );
   const selectedRootAgent = useMemo(() => {
     if (selectedAgentId == null) {
       return null;
@@ -135,7 +132,6 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
   const selectedWorkflowRunId = selectedRootAgent?.workflowRunId ?? null;
   const showWorkflowStrip =
     showAgentOverlay && overlayHome === 'workflows' && selectedWorkflowRunId != null;
-  const selectedThreadId = selectedAgent?.sourceThreadId ?? null;
   const resolverIndex = useResolverIndex(sessionId);
   const resolverAgentIds = useMemo(
     () => new Set(resolverIndex.links.map(({ agent }) => agent.id)),
@@ -172,23 +168,42 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
     resolverCounts.queued === 0 && resolverCounts.resolved === 0
       ? undefined
       : `${resolverCounts.queued} queued, ${resolverCounts.resolved} resolved`;
-  const selectedResolverLink =
-    selectedThreadId == null ? undefined : resolverIndex.byThreadId.get(selectedThreadId);
-  const selectedResolverStatus =
-    selectedResolverLink?.agent.id === selectedAgentId ? selectedResolverLink.status : null;
-  const selectedTurnState = useAppStore((state) =>
-    selectedAgentId == null ? undefined : state.agentTurnState[selectedAgentId],
-  );
-  const showForceResolveHeader =
-    showAgentOverlay &&
-    overlayHome === 'resolve' &&
-    selectedAgent != null &&
-    selectedResolverStatus != null &&
-    canForceResolve({
-      agent: selectedAgent,
-      status: selectedResolverStatus,
-      turnState: selectedTurnState,
-    });
+  useEffect(() => {
+    if (hasInitializedResolverInspector.current || resolverIndex.links.length === 0) {
+      return;
+    }
+    const running = resolverIndex.links.find(({ status }) => status === 'running');
+    const awaiting = resolverIndex.links.find(({ status }) => status === 'awaiting');
+    const unresolved = resolverIndex.links.find(
+      ({ status }) => !['resolved', 'wontfix', 'stopped', 'done'].includes(status),
+    );
+    hasInitializedResolverInspector.current = true;
+    setInspectedResolverId((running ?? awaiting ?? unresolved)?.agent.id ?? null);
+  }, [resolverIndex]);
+
+  useEffect(() => {
+    if (showAgentOverlay && overlayHome === 'resolve' && selectedAgentId !== null) {
+      hasInitializedResolverInspector.current = true;
+      setInspectedResolverId(selectedAgentId);
+    }
+  }, [overlayHome, selectedAgentId, showAgentOverlay]);
+
+  useEffect(() => {
+    const onOpenResolverInspector = (event: Event) => {
+      if (!(event instanceof CustomEvent)) {
+        return;
+      }
+      const detail = event.detail as { sessionId?: unknown; agentId?: unknown };
+      if (detail.sessionId !== sessionId || typeof detail.agentId !== 'string') {
+        return;
+      }
+      hasInitializedResolverInspector.current = true;
+      setInspectedResolverId(detail.agentId as AgentId);
+    };
+    window.addEventListener('goodboy:open-resolver-inspector', onOpenResolverInspector);
+    return () =>
+      window.removeEventListener('goodboy:open-resolver-inspector', onOpenResolverInspector);
+  }, [sessionId]);
   const focusedWorkflowName = useMemo(() => {
     const focusedRun = attachedWorkflowRuns.find(({ run }) => run.id === focusedWorkflowRunId);
     const visibleRun = focusedRun ?? (lens === 'workflows' ? attachedWorkflowRuns[0] : null);
@@ -281,7 +296,14 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   <PlanStudio sessionId={sessionId} initialPlanId={focusedPlanId ?? undefined} />
                 ) : null}
                 {lens === 'workflows' ? <WorkflowsPane session={session} /> : null}
-                {lens === 'resolve' ? <ResolvePane session={session} meta={resolveMeta} /> : null}
+                {lens === 'resolve' ? (
+                  <ResolvePane
+                    session={session}
+                    meta={resolveMeta}
+                    inspectedResolverId={inspectedResolverId}
+                    onInspectResolver={setInspectedResolverId}
+                  />
+                ) : null}
                 {lens === 'scripts' ? (
                   <PaneShell title="Scripts" width="3xl">
                     <ScriptsPanel
@@ -343,12 +365,12 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                 sessionId={sessionId}
                 isChatActive={isActive && selectedAgentId != null}
                 selectedAgentId={selectedAgentId}
-                selectedAgent={selectedAgent}
+                inspectedResolverId={
+                  overlayHome === 'resolve' ? selectedAgentId : inspectedResolverId
+                }
                 overlayHome={overlayHome}
                 overlayHomeLabel={LENS_LABEL[overlayHome]}
                 showWorkflowStrip={showWorkflowStrip}
-                showForceResolve={showForceResolveHeader}
-                resolverStatus={selectedResolverStatus}
                 onBack={() => setActiveLens(sessionId, overlayHome)}
                 onOpenWorkflow={() => {
                   if (selectedWorkflowRunId == null) {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
@@ -1,10 +1,10 @@
 import { ArrowLeft } from 'lucide-react';
 import { Divider, ScrollFade } from '@goodboy/ui';
-import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
+import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { ChatView } from '../../../../chat/components/ChatView';
 import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
 import type { AgentHomeLens } from '../../../agent-kind';
-import type { ResolverStatus } from '../../../resolver-linkage';
+import { ResolverInspector } from '../../ResolverInspector';
 import { agentOverlayHeader } from './agentOverlayHeader';
 
 type Props = {
@@ -12,12 +12,10 @@ type Props = {
   readonly sessionId: SessionId;
   readonly isChatActive: boolean;
   readonly selectedAgentId: AgentId | null;
-  readonly selectedAgent: Agent | null;
+  readonly inspectedResolverId: AgentId | null;
   readonly overlayHome: AgentHomeLens;
   readonly overlayHomeLabel: string;
   readonly showWorkflowStrip: boolean;
-  readonly showForceResolve: boolean;
-  readonly resolverStatus: ResolverStatus | null;
   readonly onBack: () => void;
   readonly onOpenWorkflow: () => void;
 };
@@ -27,12 +25,10 @@ export const AgentOverlay = ({
   sessionId,
   isChatActive,
   selectedAgentId,
-  selectedAgent,
+  inspectedResolverId,
   overlayHome,
   overlayHomeLabel,
   showWorkflowStrip,
-  showForceResolve,
-  resolverStatus,
   onBack,
   onOpenWorkflow,
 }: Props) => {
@@ -40,12 +36,9 @@ export const AgentOverlay = ({
     session,
     sessionId,
     selectedAgentId,
-    selectedAgent,
     overlayHome,
     overlayHomeLabel,
     showWorkflowStrip,
-    showForceResolve,
-    resolverStatus,
     onBack,
     onOpenWorkflow,
   });
@@ -76,6 +69,14 @@ export const AgentOverlay = ({
       <div className="min-h-0 min-w-0 flex-1">
         <ChatView session={session} isActive={isChatActive} header={header} />
       </div>
+      {overlayHome === 'resolve' && inspectedResolverId !== null ? (
+        <>
+          <Divider orientation="vertical" />
+          <div className="flex w-80 shrink-0 flex-col bg-background">
+            <ResolverInspector sessionId={sessionId} agentId={inspectedResolverId} />
+          </div>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/InspectorSplit/InspectorHeader.tsx
@@ -3,8 +3,8 @@ import { X } from 'lucide-react';
 
 type Props = {
   readonly title: string;
-  readonly closeLabel: string;
-  readonly onClose: () => void;
+  readonly closeLabel?: string;
+  readonly onClose?: () => void;
 };
 
 export const InspectorHeader = ({ title, closeLabel, onClose }: Props) => (
@@ -13,14 +13,16 @@ export const InspectorHeader = ({ title, closeLabel, onClose }: Props) => (
       <span className="truncate text-xs font-medium text-foreground" title={title}>
         {title}
       </span>
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label={closeLabel}
-        className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
-      >
-        <X size={14} aria-hidden />
-      </button>
+      {onClose === undefined ? null : (
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={closeLabel}
+          className="rounded-md p-1 text-muted-foreground/60 transition-colors hover:bg-foreground/5 hover:text-foreground"
+        >
+          <X size={14} aria-hidden />
+        </button>
+      )}
     </div>
     <Divider />
   </>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/ResolvePane.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
 import { ResolverInspector } from '../../ResolverInspector';
@@ -8,21 +7,22 @@ import { PaneShell } from './PaneShell';
 type Props = {
   readonly session: Session;
   readonly meta: string | undefined;
+  readonly inspectedResolverId: AgentId | null;
+  readonly onInspectResolver: (agentId: AgentId | null) => void;
 };
 
-export const ResolvePane = ({ session, meta }: Props) => {
+export const ResolvePane = ({ session, meta, inspectedResolverId, onInspectResolver }: Props) => {
   const sessionId = session.id as SessionId;
-  const [inspectedId, setInspectedId] = useState<AgentId | null>(null);
 
   return (
     <InspectorSplit
-      open={inspectedId !== null}
+      open={inspectedResolverId !== null}
       panel={
-        inspectedId !== null ? (
+        inspectedResolverId !== null ? (
           <ResolverInspector
             sessionId={sessionId}
-            agentId={inspectedId}
-            onClose={() => setInspectedId(null)}
+            agentId={inspectedResolverId}
+            onClose={() => onInspectResolver(null)}
           />
         ) : null
       }
@@ -36,10 +36,8 @@ export const ResolvePane = ({ session, meta }: Props) => {
         <AgentsSection
           task={session}
           only="resolve"
-          inspectedResolverId={inspectedId}
-          onInspectResolver={(agentId) =>
-            setInspectedId((prev) => (prev === agentId ? null : agentId))
-          }
+          inspectedResolverId={inspectedResolverId}
+          onInspectResolver={(agentId) => onInspectResolver(agentId)}
         />
       </PaneShell>
     </InspectorSplit>

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayHeader.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/agentOverlayHeader.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode } from 'react';
 import { Divider } from '@goodboy/ui';
-import type { Agent, AgentId, Session, SessionId } from '@goodboy/types';
+import type { AgentId, Session, SessionId } from '@goodboy/types';
 import type { AgentHomeLens } from '../../../agent-kind';
-import type { ResolverStatus } from '../../../resolver-linkage';
-import { ForceResolveAction } from '../../ForceResolveAction';
 import { ChatHeaderBack } from './ChatHeaderBack';
 import { ChatWorkflowHeader } from './ChatWorkflowHeader';
 
@@ -11,12 +9,9 @@ type Params = {
   readonly session: Session;
   readonly sessionId: SessionId;
   readonly selectedAgentId: AgentId | null;
-  readonly selectedAgent: Agent | null;
   readonly overlayHome: AgentHomeLens;
   readonly overlayHomeLabel: string;
   readonly showWorkflowStrip: boolean;
-  readonly showForceResolve: boolean;
-  readonly resolverStatus: ResolverStatus | null;
   readonly onBack: () => void;
   readonly onOpenWorkflow: () => void;
 };
@@ -25,12 +20,8 @@ export const agentOverlayHeader = ({
   session,
   sessionId,
   selectedAgentId,
-  selectedAgent,
-  overlayHome,
   overlayHomeLabel,
   showWorkflowStrip,
-  showForceResolve,
-  resolverStatus,
   onBack,
   onOpenWorkflow,
 }: Params): ReactNode | undefined => {
@@ -46,11 +37,8 @@ export const agentOverlayHeader = ({
   }
   return (
     <>
-      <div className="flex h-[var(--chat-header-h)] shrink-0 items-center justify-between gap-2 px-3">
+      <div className="flex h-[var(--chat-header-h)] shrink-0 items-center gap-2 px-3">
         <ChatHeaderBack label={overlayHomeLabel} onClick={onBack} />
-        {showForceResolve && selectedAgent != null && resolverStatus != null ? (
-          <ForceResolveAction agent={selectedAgent} sessionId={sessionId} status={resolverStatus} />
-        ) : null}
       </div>
       <Divider className="shrink-0" />
     </>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+
+vi.mock('./ResolverRows', () => ({
+  ResolverRows: ({ entries }: { entries: ReadonlyArray<{ agent: Agent; status: string }> }) => (
+    <>
+      {entries.map(({ agent, status }) => (
+        <span key={agent.id}>
+          {agent.name}:{status}
+        </span>
+      ))}
+    </>
+  ),
+}));
+
+vi.mock('../../../../../shared/lib/editor', () => ({ openUrl: vi.fn() }));
+
+import { ResolveCluster } from './ResolveCluster';
+
+const SESSION_ID = 'session-1' as SessionId;
+const active = {
+  id: 'active' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'Active resolver',
+  status: 'running',
+} satisfies Agent;
+const completed = {
+  id: 'completed' as AgentId,
+  sessionId: SESSION_ID,
+  ordinal: 1,
+  name: 'Completed resolver',
+  status: 'completed',
+  sourceThreadId: 'PRRT_1',
+} satisfies Agent;
+
+describe('ResolveCluster', () => {
+  afterEach(cleanup);
+
+  it('keeps active resolvers visible and completed resolvers collapsed', () => {
+    render(
+      <ResolveCluster
+        agents={[active, completed]}
+        sessionId={SESSION_ID}
+        isTaskActive
+        prNumber={null}
+        resolvedThreadIds={new Set(['PRRT_1'])}
+        pendingThreadIds={new Set()}
+        resolverState={{}}
+        commentByThreadId={new Map()}
+        diffCommentByAgentId={new Map()}
+        metrics={{
+          latestTelemetryByAgentId: new Map(),
+          aggregatesByAgentId: new Map(),
+          providerUsageByAgentId: new Map(),
+          turnsByAgentId: new Map(),
+        }}
+        isTranscriptLoading={false}
+        selectedAgentId={null}
+        expanded
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        onForceNext={vi.fn()}
+        onResolveThread={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Active resolver:running')).toBeDefined();
+    expect(screen.queryByText('Completed resolver:resolved')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Completed (1)' }));
+
+    expect(screen.getByText('Completed resolver:resolved')).toBeDefined();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolveCluster.tsx
@@ -1,10 +1,10 @@
+import { useState } from 'react';
 import { ArrowUpRight, ChevronDown, ChevronRight, MessageSquareReply, Play } from 'lucide-react';
 import type { Agent, AgentId, DiffComment, PrComment, SessionId } from '@goodboy/types';
 import { openUrl } from '../../../../../shared/lib/editor';
-import { EMPTY_ARRAY } from '../../../../../store';
 import type { AgentMetrics } from '../../../../session/hooks/useAgentMetrics';
 import { resolverStatus, type ResolverState, type ResolverStatus } from '../lib';
-import { ResolveClusterRow } from './ResolveClusterRow';
+import { ResolverRows } from './ResolverRows';
 
 type ResolveClusterProps = {
   readonly agents: ReadonlyArray<Agent>;
@@ -49,9 +49,17 @@ export const ResolveCluster = ({
   onForceNext,
   onResolveThread,
 }: ResolveClusterProps) => {
+  const [isCompletedExpanded, setIsCompletedExpanded] = useState(false);
   const statusOf = (a: Agent): ResolverStatus =>
     resolverStatus(a, resolvedThreadIds, pendingThreadIds, resolverState[a.id]);
-  const resolvedCount = agents.filter((a) => statusOf(a) === 'resolved').length;
+  const entries = agents.map((agent, index) => ({ agent, index, status: statusOf(agent) }));
+  const completedEntries = entries.filter(({ status }) =>
+    ['resolved', 'wontfix', 'stopped', 'done'].includes(status),
+  );
+  const activeEntries = entries.filter(
+    ({ status }) => !['resolved', 'wontfix', 'stopped', 'done'].includes(status),
+  );
+  const resolvedCount = entries.filter(({ status }) => status === 'resolved').length;
   const anyRunning = agents.some((a) => a.status === 'running');
   const queuedCount = agents.filter((a) => a.status === 'pending').length;
   const stalled = !anyRunning && queuedCount > 0;
@@ -122,40 +130,53 @@ export const ResolveCluster = ({
       </div>
       {expanded ? (
         <>
-          {agents.map((agent, i) => {
-            const diffComment =
-              agent.sourceThreadId == null && agent.sourceCommentUrl == null
-                ? (diffCommentByAgentId.get(agent.id) ?? null)
-                : null;
-            const threadComment =
-              agent.sourceThreadId != null
-                ? (commentByThreadId.get(agent.sourceThreadId) ?? null)
-                : null;
-            return (
-              <ResolveClusterRow
-                key={agent.id}
-                agent={agent}
-                index={i}
-                total={agents.length}
-                status={statusOf(agent)}
-                threadComment={threadComment}
-                diffComment={diffComment}
-                telemetry={metrics.latestTelemetryByAgentId.get(agent.id) ?? null}
-                aggregate={metrics.aggregatesByAgentId.get(agent.id) ?? null}
-                contextUsage={metrics.providerUsageByAgentId.get(agent.id) ?? EMPTY_ARRAY}
-                turns={metrics.turnsByAgentId.get(agent.id) ?? 0}
-                turnsLoading={agent.id === selectedAgentId && isTranscriptLoading}
-                isSelected={agent.id === selectedAgentId}
-                isTaskActive={isTaskActive}
-                canJump={agent.sourceThreadId != null || agent.sourceCommentUrl != null}
-                isInspected={agent.id === inspectedAgentId}
-                onSelect={() => onSelect(agent.id)}
-                onJump={() => jump(agent)}
-                onInspect={onInspect === undefined ? undefined : () => onInspect(agent.id)}
-                onResolveThread={onResolveThread}
-              />
-            );
-          })}
+          <ResolverRows
+            entries={activeEntries}
+            total={agents.length}
+            isTaskActive={isTaskActive}
+            isTranscriptLoading={isTranscriptLoading}
+            selectedAgentId={selectedAgentId}
+            inspectedAgentId={inspectedAgentId}
+            commentByThreadId={commentByThreadId}
+            diffCommentByAgentId={diffCommentByAgentId}
+            metrics={metrics}
+            onSelect={onSelect}
+            onInspect={onInspect}
+            onJump={jump}
+            onResolveThread={onResolveThread}
+          />
+          {completedEntries.length > 0 ? (
+            <button
+              type="button"
+              onClick={() => setIsCompletedExpanded((current) => !current)}
+              aria-expanded={isCompletedExpanded}
+              className="flex items-center gap-1 self-start rounded px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {isCompletedExpanded ? (
+                <ChevronDown size={11} aria-hidden className="shrink-0" />
+              ) : (
+                <ChevronRight size={11} aria-hidden className="shrink-0" />
+              )}
+              Completed ({completedEntries.length})
+            </button>
+          ) : null}
+          {isCompletedExpanded ? (
+            <ResolverRows
+              entries={completedEntries}
+              total={agents.length}
+              isTaskActive={isTaskActive}
+              isTranscriptLoading={isTranscriptLoading}
+              selectedAgentId={selectedAgentId}
+              inspectedAgentId={inspectedAgentId}
+              commentByThreadId={commentByThreadId}
+              diffCommentByAgentId={diffCommentByAgentId}
+              metrics={metrics}
+              onSelect={onSelect}
+              onInspect={onInspect}
+              onJump={jump}
+              onResolveThread={onResolveThread}
+            />
+          ) : null}
           <button
             type="button"
             onClick={openResolveBoard}

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolverRows.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/ResolverRows.tsx
@@ -1,0 +1,78 @@
+import type { Agent, AgentId, DiffComment, PrComment } from '@goodboy/types';
+import { EMPTY_ARRAY } from '../../../../../store';
+import type { AgentMetrics } from '../../../../session/hooks/useAgentMetrics';
+import type { ResolverStatus } from '../lib';
+import { ResolveClusterRow } from './ResolveClusterRow';
+
+type Entry = {
+  readonly agent: Agent;
+  readonly status: ResolverStatus;
+  readonly index: number;
+};
+
+type Props = {
+  readonly entries: ReadonlyArray<Entry>;
+  readonly total: number;
+  readonly isTaskActive: boolean;
+  readonly isTranscriptLoading: boolean;
+  readonly selectedAgentId: AgentId | null;
+  readonly inspectedAgentId: AgentId | null;
+  readonly commentByThreadId: ReadonlyMap<string, PrComment>;
+  readonly diffCommentByAgentId: ReadonlyMap<AgentId, DiffComment>;
+  readonly metrics: AgentMetrics;
+  readonly onSelect: (id: AgentId) => void;
+  readonly onInspect?: (id: AgentId) => void;
+  readonly onJump: (agent: Agent) => void;
+  readonly onResolveThread: (threadId: string) => Promise<void> | void;
+};
+
+export const ResolverRows = ({
+  entries,
+  total,
+  isTaskActive,
+  isTranscriptLoading,
+  selectedAgentId,
+  inspectedAgentId,
+  commentByThreadId,
+  diffCommentByAgentId,
+  metrics,
+  onSelect,
+  onInspect,
+  onJump,
+  onResolveThread,
+}: Props) => (
+  <>
+    {entries.map(({ agent, status, index }) => {
+      const diffComment =
+        agent.sourceThreadId == null && agent.sourceCommentUrl == null
+          ? (diffCommentByAgentId.get(agent.id) ?? null)
+          : null;
+      const threadComment =
+        agent.sourceThreadId != null ? (commentByThreadId.get(agent.sourceThreadId) ?? null) : null;
+      return (
+        <ResolveClusterRow
+          key={agent.id}
+          agent={agent}
+          index={index}
+          total={total}
+          status={status}
+          threadComment={threadComment}
+          diffComment={diffComment}
+          telemetry={metrics.latestTelemetryByAgentId.get(agent.id) ?? null}
+          aggregate={metrics.aggregatesByAgentId.get(agent.id) ?? null}
+          contextUsage={metrics.providerUsageByAgentId.get(agent.id) ?? EMPTY_ARRAY}
+          turns={metrics.turnsByAgentId.get(agent.id) ?? 0}
+          turnsLoading={agent.id === selectedAgentId && isTranscriptLoading}
+          isSelected={agent.id === selectedAgentId}
+          isTaskActive={isTaskActive}
+          canJump={agent.sourceThreadId != null || agent.sourceCommentUrl != null}
+          isInspected={agent.id === inspectedAgentId}
+          onSelect={() => onSelect(agent.id)}
+          onJump={() => onJump(agent)}
+          onInspect={onInspect === undefined ? undefined : () => onInspect(agent.id)}
+          onResolveThread={onResolveThread}
+        />
+      );
+    })}
+  </>
+);

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowKillButton.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowKillButton.test.tsx
@@ -1,0 +1,20 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { WorkflowKillButton } from './WorkflowKillButton';
+
+describe('WorkflowKillButton', () => {
+  afterEach(cleanup);
+
+  it('confirms before discarding the workflow', () => {
+    const onConfirm = vi.fn();
+    render(<WorkflowKillButton onConfirm={onConfirm} />);
+
+    const button = screen.getByRole('button', { name: 'discard workflow' });
+    fireEvent.click(button);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(button.textContent).toContain('Confirm discard');
+
+    fireEvent.click(button);
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowKillButton.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/WorkflowKillButton.tsx
@@ -1,45 +1,20 @@
-import { useState } from 'react';
-import { Ban, Check, X } from 'lucide-react';
+import { Ban } from 'lucide-react';
+import { ConfirmableButton } from '../../../../../shared/components/ConfirmableButton';
 
-export function WorkflowKillButton({ onConfirm }: { onConfirm: () => void }) {
-  const [confirming, setConfirming] = useState(false);
-  if (confirming) {
-    return (
-      <span className="flex shrink-0 items-center gap-0.5 rounded-md border border-border bg-background/95 px-1 py-0.5 shadow-sm">
-        <span className="px-0.5 text-2xs text-muted-foreground">Discard?</span>
-        <button
-          type="button"
-          onClick={() => {
-            setConfirming(false);
-            onConfirm();
-          }}
-          title="confirm discard"
-          aria-label="confirm discard workflow"
-          className="rounded p-0.5 text-danger transition-colors hover:bg-danger/10"
-        >
-          <Check size={12} aria-hidden />
-        </button>
-        <button
-          type="button"
-          onClick={() => setConfirming(false)}
-          title="cancel"
-          aria-label="cancel discard workflow"
-          className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-        >
-          <X size={12} aria-hidden />
-        </button>
-      </span>
-    );
-  }
+type Props = {
+  readonly onConfirm: () => void;
+};
+
+export const WorkflowKillButton = ({ onConfirm }: Props) => {
   return (
-    <button
-      type="button"
-      onClick={() => setConfirming(true)}
+    <ConfirmableButton
+      label="Discard"
+      armedLabel="Confirm discard"
+      onConfirm={onConfirm}
+      tone="danger"
       title="discard workflow"
-      aria-label="discard workflow"
-      className="shrink-0 rounded p-0.5 text-muted-foreground/60 transition-colors hover:bg-danger/10 hover:text-danger"
-    >
-      <Ban size={11} aria-hidden />
-    </button>
+      ariaLabel="discard workflow"
+      icon={<Ban size={9} aria-hidden />}
+    />
   );
-}
+};

--- a/apps/desktop/src/shared/components/ConfirmableButton/index.test.tsx
+++ b/apps/desktop/src/shared/components/ConfirmableButton/index.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConfirmableButton } from '.';
+
+describe('ConfirmableButton', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('arms before confirming', () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmableButton label="Delete" armedLabel="Confirm delete" onConfirm={onConfirm} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('disarms on blur', () => {
+    render(<ConfirmableButton label="Delete" armedLabel="Confirm delete" onConfirm={vi.fn()} />);
+
+    const button = screen.getByRole('button', { name: 'Delete' });
+    fireEvent.click(button);
+    fireEvent.blur(button);
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined();
+  });
+
+  it('disarms after the configured delay', () => {
+    vi.useFakeTimers();
+    render(
+      <ConfirmableButton
+        label="Delete"
+        armedLabel="Confirm delete"
+        autoDisarmMs={4000}
+        onConfirm={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    act(() => vi.advanceTimersByTime(4000));
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined();
+  });
+
+  it('shows a disabled busy state while confirmation is pending', async () => {
+    let finish: () => void = () => undefined;
+    const pending = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    render(
+      <ConfirmableButton
+        label="Delete"
+        armedLabel="Confirm delete"
+        busyLabel="Deleting..."
+        onConfirm={() => pending}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm delete' }));
+
+    expect(screen.getByRole('button', { name: 'Deleting...' })).toHaveProperty('disabled', true);
+    finish();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Delete' })).toBeDefined());
+  });
+});

--- a/apps/desktop/src/shared/components/ConfirmableButton/index.tsx
+++ b/apps/desktop/src/shared/components/ConfirmableButton/index.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+import { cn } from '@goodboy/ui';
+
+type Tone = 'warning' | 'danger' | 'accent';
+
+type Props = {
+  readonly label: string;
+  readonly armedLabel: string;
+  readonly busyLabel?: string;
+  readonly onConfirm: () => void | Promise<void>;
+  readonly disabled?: boolean;
+  readonly tone?: Tone;
+  readonly icon?: ReactNode;
+  readonly autoDisarmMs?: number;
+  readonly className?: string;
+  readonly title?: string;
+  readonly ariaLabel?: string;
+};
+
+const TONE_CLASS: Record<Tone, string> = {
+  warning: 'border-warning/40 text-warning hover:bg-warning/10 data-[armed=true]:ring-warning/30',
+  danger: 'border-danger/40 text-danger hover:bg-danger/10 data-[armed=true]:ring-danger/30',
+  accent: 'border-primary/40 text-primary hover:bg-primary/10 data-[armed=true]:ring-primary/30',
+};
+
+export const ConfirmableButton = ({
+  label,
+  armedLabel,
+  busyLabel,
+  onConfirm,
+  disabled = false,
+  tone = 'warning',
+  icon,
+  autoDisarmMs,
+  className,
+  title,
+  ariaLabel,
+}: Props) => {
+  const [isArmed, setIsArmed] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+
+  useEffect(() => {
+    if (!isArmed || autoDisarmMs === undefined) {
+      return;
+    }
+    const timer = window.setTimeout(() => setIsArmed(false), autoDisarmMs);
+    return () => window.clearTimeout(timer);
+  }, [autoDisarmMs, isArmed]);
+
+  const confirm = async () => {
+    setIsArmed(false);
+    setIsBusy(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={disabled || isBusy}
+      data-armed={isArmed}
+      title={title}
+      aria-label={ariaLabel}
+      onClick={() => {
+        if (!isArmed) {
+          setIsArmed(true);
+          return;
+        }
+        void confirm();
+      }}
+      onBlur={() => setIsArmed(false)}
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold transition-colors data-[armed=true]:ring-2 disabled:cursor-not-allowed disabled:opacity-60',
+        TONE_CLASS[tone],
+        isBusy && 'animate-border-pulse',
+        className,
+      )}
+    >
+      {icon}
+      {isBusy ? (busyLabel ?? armedLabel) : isArmed ? armedLabel : label}
+    </button>
+  );
+};

--- a/apps/desktop/src/shared/utils/proceedResolverPrompt.ts
+++ b/apps/desktop/src/shared/utils/proceedResolverPrompt.ts
@@ -1,0 +1,2 @@
+export const PROCEED_RESOLVER_PROMPT =
+  'Proceed with the fix you proposed in your analysis. When done, commit and emit the <<comment-resolved>> marker as instructed.';


### PR DESCRIPTION
## Problema

L'inspector dei resolver era completo ma effimero: lo stato viveva in ResolvePane e moriva aprendo la chat, proprio nel momento in cui serviva governare. Le CTA di risoluzione erano sepolte in tre chip dentro il transcript, la lista mischiava risolti e attivi, e il pattern armed-confirm era copiato a mano in cinque punti.

## Meccanica

- **Inspector persistente**: lo stato `inspectedResolverId` sale a SessionWorkspace (montato stabile tra lens e overlay). Nella lens Resolve si apre di default sul resolver piú rilevante (running > awaiting > primo non risolto); nell'overlay chat resolve compare una terza colonna `w-80` con l'inspector del resolver selezionato: `[lista w-72][chat][inspector w-80]`.
- **ActionsSection**: le CTA derivano da `resolverStatus`/`resolverState` dello store, mai dal parse della chat. committed → push & resolve / queue batch (o remove + push now se giá in coda); wontfix/analyzed → spiegazione editabile + post & close, analyzed anche proceed-with-fix; awaiting → continue working; pending → run now. Ogni scrittura verso GitHub passa da double-confirm.
- **`ConfirmableButton`** (shared): primitiva armed-confirm con disarmo su blur e auto-disarm opzionale; sostituisce ForceResolveAction, ForceCloseResolverAction, WorkflowKillButton e il replay di PlanStudio (4s). SessionScopePanel mantiene la sua conferma form-level: lí lo stato é del form, non del bottone.
- **Chip informativi**: i tre chip in chat perdono i bottoni d'azione e guadagnano un link "Manage in panel" (evento `goodboy:open-resolver-inspector`). Il force-resolve duplicato nell'header dell'overlay sparisce.
- **Partizione lista**: attivi in alto, "Completed (N)" collassato in coda (stessa grammatica del disclosure Runs dei workflow).

## Verifica

- typecheck 5/5 e suite completa verdi in locale (exit 0), 327 file di test desktop.
- Test nuovi: ConfirmableButton (arm/confirm/blur/auto-disarm), persistenza inspector lens↔overlay, colonna overlay, matrice CTA per status, partizione Completed, chip demolizione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)