### PR TITLE
feat(desktop): agent inspector and done state

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -192,6 +192,7 @@ pub fn run() {
       workflows::agent_set_kind,
       workflows::agent_set_verbosity,
       workflows::agent_mark_viewed,
+      workflows::agent_set_done,
       workflows::workspaces_with_unread,
       parallel_groups::parallel_group_create,
       parallel_groups::parallel_group_list,

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -169,6 +169,8 @@ pub struct SessionRow {
     pub last_finished_at: Option<String>,
     #[serde(rename = "lastViewedAt")]
     pub last_viewed_at: Option<String>,
+    #[serde(rename = "doneAt")]
+    pub done_at: Option<String>,
     pub kind: Option<String>,
     pub verbosity: Option<String>,
     #[serde(rename = "parentAgentId")]
@@ -858,7 +860,7 @@ pub fn agent_list_for_session(
     let mut stmt = conn.prepare(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, kind, verbosity,
+                provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
                 parent_agent_id, workflow_run_id, source_thread_id, source_comment_url,
                 source_kind
          FROM agents
@@ -880,13 +882,14 @@ pub fn agent_list_for_session(
             provider_session_id: row.get(10)?,
             last_finished_at: row.get(11)?,
             last_viewed_at: row.get(12)?,
-            kind: row.get(13)?,
-            verbosity: row.get(14)?,
-            parent_agent_id: row.get(15)?,
-            workflow_run_id: row.get(16)?,
-            source_thread_id: row.get(17)?,
-            source_comment_url: row.get(18)?,
-            source_kind: row.get(19)?,
+            done_at: row.get(13)?,
+            kind: row.get(14)?,
+            verbosity: row.get(15)?,
+            parent_agent_id: row.get(16)?,
+            workflow_run_id: row.get(17)?,
+            source_thread_id: row.get(18)?,
+            source_comment_url: row.get(19)?,
+            source_kind: row.get(20)?,
         })
     })?;
     rows.collect::<Result<Vec<_>, _>>().map_err(PhaseError::Db)
@@ -941,6 +944,7 @@ pub fn agent_insert(
         provider_session_id: None,
         last_finished_at: None,
         last_viewed_at: None,
+        done_at: None,
         kind: input.kind,
         verbosity: input.verbosity,
         parent_agent_id: input.parent_agent_id,
@@ -988,7 +992,7 @@ pub fn agent_update_status(
     let mut stmt = conn.prepare(
         "SELECT id, session_id, step_id, ordinal, name, status,
                 provider_run_id, output_summary, started_at, completed_at,
-                provider_session_id, last_finished_at, last_viewed_at, kind, verbosity,
+                provider_session_id, last_finished_at, last_viewed_at, done_at, kind, verbosity,
                 parent_agent_id, workflow_run_id, source_thread_id, source_comment_url,
                 source_kind
          FROM agents
@@ -1010,13 +1014,14 @@ pub fn agent_update_status(
             provider_session_id: row.get(10)?,
             last_finished_at: row.get(11)?,
             last_viewed_at: row.get(12)?,
-            kind: row.get(13)?,
-            verbosity: row.get(14)?,
-            parent_agent_id: row.get(15)?,
-            workflow_run_id: row.get(16)?,
-            source_thread_id: row.get(17)?,
-            source_comment_url: row.get(18)?,
-            source_kind: row.get(19)?,
+            done_at: row.get(13)?,
+            kind: row.get(14)?,
+            verbosity: row.get(15)?,
+            parent_agent_id: row.get(16)?,
+            workflow_run_id: row.get(17)?,
+            source_thread_id: row.get(18)?,
+            source_comment_url: row.get(19)?,
+            source_kind: row.get(20)?,
         })
     })?;
     match rows.next() {
@@ -1102,6 +1107,19 @@ pub fn agent_mark_viewed(
     Ok(())
 }
 
+#[tauri::command]
+pub fn agent_set_done(state: State<'_, Db>, id: String, done: bool) -> Result<(), PhaseError> {
+    let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
+    let affected = conn.execute(
+        "UPDATE agents SET done_at = CASE WHEN ?2 = 1 THEN CURRENT_TIMESTAMP ELSE NULL END WHERE id = ?1",
+        rusqlite::params![id, done as i32],
+    )?;
+    if affected == 0 {
+        return Err(PhaseError::RunNotFound(id));
+    }
+    Ok(())
+}
+
 // Returns the set of workspace ids that contain at least one agent whose
 // terminal turn hasn't been viewed yet. The sidebar uses this to pulse the
 // workspace dot even for workspaces the user isn't currently on (their tasks
@@ -1115,6 +1133,7 @@ pub fn workspaces_with_unread(state: State<'_, Db>) -> Result<Vec<String>, Phase
          JOIN sessions t ON a.session_id = t.id
          WHERE a.last_finished_at IS NOT NULL
            AND a.status != 'skipped'
+           AND a.done_at IS NULL
            AND (a.last_viewed_at IS NULL OR a.last_finished_at > a.last_viewed_at)
            AND t.archived_at IS NULL
            AND t.deleted_at IS NULL",

--- a/apps/desktop/src-tauri/src/workflows.rs
+++ b/apps/desktop/src-tauri/src/workflows.rs
@@ -1108,11 +1108,16 @@ pub fn agent_mark_viewed(
 }
 
 #[tauri::command]
-pub fn agent_set_done(state: State<'_, Db>, id: String, done: bool) -> Result<(), PhaseError> {
+pub fn agent_set_done(
+    state: State<'_, Db>,
+    id: String,
+    done: bool,
+    at: Option<String>,
+) -> Result<(), PhaseError> {
     let conn = state.0.lock().map_err(|_| PhaseError::Poisoned)?;
     let affected = conn.execute(
-        "UPDATE agents SET done_at = CASE WHEN ?2 = 1 THEN CURRENT_TIMESTAMP ELSE NULL END WHERE id = ?1",
-        rusqlite::params![id, done as i32],
+        "UPDATE agents SET done_at = CASE WHEN ?2 = 1 THEN ?3 ELSE NULL END WHERE id = ?1",
+        rusqlite::params![id, done as i32, at],
     )?;
     if affected == 0 {
         return Err(PhaseError::RunNotFound(id));

--- a/apps/desktop/src/features/session/components/AgentInspector/ActionsSection.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/ActionsSection.tsx
@@ -1,0 +1,71 @@
+import { CircleCheck, CircleDot, OctagonX, Trash2 } from 'lucide-react';
+import type { Agent, SessionId } from '@goodboy/types';
+import { ConfirmableButton } from '../../../../shared/components/ConfirmableButton';
+import { useAppStore } from '../../../../store';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly agent: Agent;
+  readonly sessionId: SessionId;
+  readonly onDeleted?: () => void;
+};
+
+const ACTION_CLASS =
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground';
+
+export const ActionsSection = ({ agent, sessionId, onDeleted }: Props) => {
+  const setAgentDone = useAppStore((state) => state.setAgentDone);
+  const clearAgentDone = useAppStore((state) => state.clearAgentDone);
+  const cancelCurrentTurn = useAppStore((state) => state.cancelCurrentTurn);
+  const deleteAgent = useAppStore((state) => state.deleteAgent);
+  const isTurnRunning = useAppStore((state) => state.agentTurnState[agent.id]?.kind === 'running');
+
+  const remove = async () => {
+    await deleteAgent(sessionId, agent.id);
+    onDeleted?.();
+  };
+
+  return (
+    <InspectorSection question="What you can do">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {agent.doneAt == null ? (
+          <button
+            type="button"
+            onClick={() => void setAgentDone(sessionId, agent.id)}
+            className={ACTION_CLASS}
+          >
+            <CircleCheck size={10} aria-hidden />
+            Mark done
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void clearAgentDone(sessionId, agent.id)}
+            className={ACTION_CLASS}
+          >
+            <CircleDot size={10} aria-hidden />
+            Reopen
+          </button>
+        )}
+        {isTurnRunning ? (
+          <button
+            type="button"
+            onClick={() => void cancelCurrentTurn(sessionId, agent.id)}
+            className={ACTION_CLASS}
+          >
+            <OctagonX size={10} aria-hidden />
+            Interrupt
+          </button>
+        ) : null}
+        <ConfirmableButton
+          label="Delete"
+          armedLabel="Confirm delete"
+          busyLabel="Deleting..."
+          onConfirm={remove}
+          tone="danger"
+          icon={<Trash2 size={10} aria-hidden />}
+        />
+      </div>
+    </InspectorSection>
+  );
+};

--- a/apps/desktop/src/features/session/components/AgentInspector/CostsSection.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/CostsSection.tsx
@@ -1,0 +1,43 @@
+import type { AgentAggregate } from '../AgentMetricsBlock';
+import { formatCost, formatTokens } from '../../agent-row-format';
+import {
+  ContextWindowBar,
+  type ProviderContextUsage,
+} from '../../../workspace/components/WorkspacesSidebar/parts/ContextWindowBar';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly aggregate: AgentAggregate | null;
+  readonly contextUsage: ReadonlyArray<ProviderContextUsage>;
+  readonly turns: number;
+};
+
+export const CostsSection = ({ aggregate, contextUsage, turns }: Props) => (
+  <InspectorSection question="What it costs">
+    <dl className="grid grid-cols-2 gap-2">
+      <div className="flex flex-col gap-0.5 rounded-lg bg-muted/40 p-2">
+        <dt className="text-[9px] uppercase tracking-wide text-muted-foreground/60">Cost</dt>
+        <dd className="font-mono text-xs text-foreground">
+          {formatCost(aggregate?.estimatedCostUsd ?? 0)}
+        </dd>
+      </div>
+      <div className="flex flex-col gap-0.5 rounded-lg bg-muted/40 p-2">
+        <dt className="text-[9px] uppercase tracking-wide text-muted-foreground/60">Turns</dt>
+        <dd className="font-mono text-xs text-foreground">{aggregate?.turns ?? turns}</dd>
+      </div>
+      <div className="flex flex-col gap-0.5 rounded-lg bg-muted/40 p-2">
+        <dt className="text-[9px] uppercase tracking-wide text-muted-foreground/60">Input</dt>
+        <dd className="font-mono text-xs text-foreground">
+          {formatTokens(aggregate?.inputTokens ?? 0)}
+        </dd>
+      </div>
+      <div className="flex flex-col gap-0.5 rounded-lg bg-muted/40 p-2">
+        <dt className="text-[9px] uppercase tracking-wide text-muted-foreground/60">Output</dt>
+        <dd className="font-mono text-xs text-foreground">
+          {formatTokens(aggregate?.outputTokens ?? 0)}
+        </dd>
+      </div>
+    </dl>
+    <ContextWindowBar usage={contextUsage} />
+  </InspectorSection>
+);

--- a/apps/desktop/src/features/session/components/AgentInspector/IdentitySection.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/IdentitySection.tsx
@@ -1,0 +1,37 @@
+import type { Agent } from '@goodboy/types';
+import type { AgentKind } from '../../agent-kind';
+import { AgentKindChip } from '../AgentKindChip';
+import { AgentDuration } from '../AgentMetricsBlock/AgentDuration';
+import { AgentStatusBadge } from '../../../workspace/components/WorkspacesSidebar/parts/AgentStatusBadge';
+import { InspectorSection } from './InspectorSection';
+
+type Props = {
+  readonly agent: Agent;
+  readonly kind: AgentKind;
+  readonly provider: string | null;
+  readonly model: string | null;
+  readonly effort: string | null;
+};
+
+export const IdentitySection = ({ agent, kind, provider, model, effort }: Props) => (
+  <InspectorSection question="What it is">
+    <div className="flex flex-wrap items-center gap-1.5">
+      <AgentKindChip kind={kind} />
+      <AgentStatusBadge status={agent.status} />
+    </div>
+    <dl className="grid grid-cols-[4rem_minmax(0,1fr)] gap-x-2 gap-y-1 text-2xs">
+      <dt className="text-muted-foreground/60">Provider</dt>
+      <dd className="truncate text-foreground/80">{provider ?? 'not resolved'}</dd>
+      <dt className="text-muted-foreground/60">Model</dt>
+      <dd className="truncate text-foreground/80">{model ?? 'not resolved'}</dd>
+      <dt className="text-muted-foreground/60">Effort</dt>
+      <dd className="truncate text-foreground/80">{effort ?? 'automatic'}</dd>
+      <dt className="text-muted-foreground/60">Started</dt>
+      <dd className="truncate font-mono text-foreground/80">{agent.startedAt ?? 'not started'}</dd>
+      <dt className="text-muted-foreground/60">Duration</dt>
+      <dd className="text-foreground/80">
+        <AgentDuration run={agent} />
+      </dd>
+    </dl>
+  </InspectorSection>
+);

--- a/apps/desktop/src/features/session/components/AgentInspector/InspectorSection.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/InspectorSection.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly question: string;
+  readonly children: ReactNode;
+};
+
+export const InspectorSection = ({ question, children }: Props) => (
+  <section className="flex flex-col gap-2">
+    <h3 className="text-2xs font-medium uppercase tracking-wide text-muted-foreground/70">
+      {question}
+    </h3>
+    {children}
+  </section>
+);

--- a/apps/desktop/src/features/session/components/AgentInspector/index.test.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/index.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type {
+  Agent,
+  AgentId,
+  IsoDateTime,
+  ProviderRunId,
+  SessionId,
+  TelemetryRecord,
+} from '@goodboy/types';
+
+const h = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  setAgentDone: vi.fn(async () => undefined),
+  clearAgentDone: vi.fn(async () => undefined),
+  cancelCurrentTurn: vi.fn(async () => undefined),
+  deleteAgent: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../../../store', () => ({
+  EMPTY_ARRAY: [],
+  useAppStore: <T,>(selector: (state: typeof h.state) => T) => selector(h.state),
+}));
+
+vi.mock('../../hooks/useAgentMetrics', () => ({
+  useAgentMetrics: () => ({
+    latestTelemetryByAgentId: new Map([
+      [
+        'agent-1',
+        {
+          runId: 'run-1' as ProviderRunId,
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-5',
+          inputTokens: 400,
+          outputTokens: 100,
+          estimatedCostUsd: 0.25,
+          recordedAt: '2026-07-26T12:00:00.000Z',
+          kind: 'turn',
+        } as TelemetryRecord,
+      ],
+    ]),
+    aggregatesByAgentId: new Map([
+      ['agent-1', { inputTokens: 1_200, outputTokens: 300, estimatedCostUsd: 1.5, turns: 4 }],
+    ]),
+    providerUsageByAgentId: new Map([
+      [
+        'agent-1',
+        [
+          {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5',
+            inputTokens: 1_200,
+            outputTokens: 300,
+          },
+        ],
+      ],
+    ]),
+    turnsByAgentId: new Map([['agent-1', 4]]),
+  }),
+}));
+
+import { AgentInspector } from './index';
+
+const SESSION_ID = 'session-1' as SessionId;
+const AGENT_ID = 'agent-1' as AgentId;
+const NOW = '2026-07-26T12:00:00.000Z' as IsoDateTime;
+
+const buildAgent = (overrides: Partial<Agent> = {}): Agent => ({
+  id: AGENT_ID,
+  sessionId: SESSION_ID,
+  ordinal: 0,
+  name: 'implement feature',
+  status: 'completed',
+  startedAt: NOW,
+  completedAt: '2026-07-26T12:02:00.000Z' as IsoDateTime,
+  ...overrides,
+});
+
+const reset = (agent: Agent, turnKind: 'idle' | 'running') => {
+  Object.assign(h.state, {
+    sessionPhaseRuns: { [SESSION_ID]: [agent] },
+    agentKindOverride: { [AGENT_ID]: 'implementer' },
+    agentProviderOverride: {},
+    agentModelOverride: {},
+    agentEffortOverride: { [AGENT_ID]: 'high' },
+    agentTurnState: {
+      [AGENT_ID]:
+        turnKind === 'running'
+          ? { kind: 'running', runId: 'run-1', lastActivityAt: NOW }
+          : { kind: 'idle', lastActivityAt: NOW },
+    },
+    setAgentDone: h.setAgentDone,
+    clearAgentDone: h.clearAgentDone,
+    cancelCurrentTurn: h.cancelCurrentTurn,
+    deleteAgent: h.deleteAgent,
+  });
+};
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reset(buildAgent(), 'idle');
+});
+
+describe('AgentInspector', () => {
+  it('renders identity and cumulative metrics', () => {
+    render(<AgentInspector sessionId={SESSION_ID} agentId={AGENT_ID} />);
+
+    expect(screen.getByText('implement feature')).toBeDefined();
+    expect(screen.getByText('claude-sonnet-4-5')).toBeDefined();
+    expect(screen.getByText('high')).toBeDefined();
+    expect(screen.getByText('$1.50')).toBeDefined();
+    expect(screen.getByText('4')).toBeDefined();
+  });
+
+  it('offers mark done and interrupt only when applicable', () => {
+    reset(buildAgent({ status: 'running' }), 'running');
+    render(<AgentInspector sessionId={SESSION_ID} agentId={AGENT_ID} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark done' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Interrupt' }));
+
+    expect(h.setAgentDone).toHaveBeenCalledWith(SESSION_ID, AGENT_ID);
+    expect(h.cancelCurrentTurn).toHaveBeenCalledWith(SESSION_ID, AGENT_ID);
+  });
+
+  it('reopens a done agent and hides interrupt when idle', () => {
+    reset(buildAgent({ doneAt: NOW }), 'idle');
+    render(<AgentInspector sessionId={SESSION_ID} agentId={AGENT_ID} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen' }));
+
+    expect(h.clearAgentDone).toHaveBeenCalledWith(SESSION_ID, AGENT_ID);
+    expect(screen.queryByRole('button', { name: 'Interrupt' })).toBeNull();
+  });
+});

--- a/apps/desktop/src/features/session/components/AgentInspector/index.tsx
+++ b/apps/desktop/src/features/session/components/AgentInspector/index.tsx
@@ -1,0 +1,66 @@
+import { Divider, ScrollFade } from '@goodboy/ui';
+import type { Agent, AgentId, SessionId } from '@goodboy/types';
+import { EMPTY_ARRAY, useAppStore } from '../../../../store';
+import { classifyAgent } from '../../agent-kind';
+import { useAgentMetrics } from '../../hooks/useAgentMetrics';
+import { InspectorHeader } from '../SessionWorkspace/parts/InspectorSplit/InspectorHeader';
+import { ActionsSection } from './ActionsSection';
+import { CostsSection } from './CostsSection';
+import { IdentitySection } from './IdentitySection';
+
+type Props = {
+  readonly sessionId: SessionId;
+  readonly agentId: AgentId;
+  readonly onClose?: () => void;
+};
+
+export const AgentInspector = ({ sessionId, agentId, onClose }: Props) => {
+  const agent = useAppStore(
+    (state) =>
+      (state.sessionPhaseRuns[sessionId] ?? (EMPTY_ARRAY as ReadonlyArray<Agent>)).find(
+        (candidate) => candidate.id === agentId,
+      ) ?? null,
+  );
+  const kindOverride = useAppStore((state) => state.agentKindOverride?.[agentId] ?? null);
+  const providerOverride = useAppStore(
+    (state) => state.agentProviderOverride?.[agentId] ?? agent?.providerOverride ?? null,
+  );
+  const modelOverride = useAppStore(
+    (state) => state.agentModelOverride?.[agentId] ?? agent?.modelOverride ?? null,
+  );
+  const effortOverride = useAppStore(
+    (state) => state.agentEffortOverride?.[agentId] ?? agent?.effort ?? null,
+  );
+  const metrics = useAgentMetrics({ sessionId });
+
+  if (agent === null) {
+    return null;
+  }
+
+  const telemetry = metrics.latestTelemetryByAgentId.get(agentId) ?? null;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <InspectorHeader title={agent.name} closeLabel="close agent inspector" onClose={onClose} />
+      <ScrollFade className="min-h-0 flex-1" viewportClassName="px-3 py-3">
+        <div className="flex flex-col gap-4">
+          <IdentitySection
+            agent={agent}
+            kind={classifyAgent(agent, kindOverride)}
+            provider={telemetry?.provider ?? providerOverride}
+            model={telemetry?.model ?? modelOverride}
+            effort={effortOverride}
+          />
+          <Divider />
+          <CostsSection
+            aggregate={metrics.aggregatesByAgentId.get(agentId) ?? null}
+            contextUsage={metrics.providerUsageByAgentId.get(agentId) ?? EMPTY_ARRAY}
+            turns={metrics.turnsByAgentId.get(agentId) ?? 0}
+          />
+          <Divider />
+          <ActionsSection agent={agent} sessionId={sessionId} onDeleted={onClose} />
+        </div>
+      </ScrollFade>
+    </div>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.test.tsx
@@ -138,6 +138,11 @@ vi.mock('../ResolverInspector', () => ({
     <div data-testid="resolver-inspector">{agentId}</div>
   ),
 }));
+vi.mock('../AgentInspector', () => ({
+  AgentInspector: ({ agentId }: { agentId: string }) => (
+    <div data-testid="agent-inspector">{agentId}</div>
+  ),
+}));
 
 import { SessionWorkspace } from './index';
 
@@ -284,7 +289,7 @@ describe('SessionWorkspace agent overlay', () => {
     expect(screen.queryByTestId('force-resolve-action')).toBeNull();
   });
 
-  it('keeps the agents-home overlay panel unchanged', () => {
+  it('adds the selected agent inspector to the agents-home overlay', () => {
     const standaloneAgent = {
       ...selectedAgent,
       stepId: undefined,
@@ -298,11 +303,12 @@ describe('SessionWorkspace agent overlay', () => {
     expect(screen.getByTestId('agents-section').getAttribute('data-home')).toBe('agents');
     expect(screen.getAllByRole('button', { name: 'Agents' })).toHaveLength(2);
     expect(screen.queryByTestId('resolver-inspector')).toBeNull();
+    expect(screen.getByTestId('agent-inspector').textContent).toBe(standaloneAgent.id);
     expect(
       screen
         .getAllByTestId('divider')
         .filter((divider) => divider.getAttribute('data-orientation') === 'vertical'),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
   });
 
   it('keeps the selected inspector open across the resolve chat overlay', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/index.tsx
@@ -13,11 +13,11 @@ import {
 } from '../../../../store';
 import type { LensKind } from '../../../../store';
 import { worktreeStatus } from '../../../worktree/worktree';
-import { AgentsSection } from '../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
 import { workflowKindName } from '../../../workspace/components/WorkspacesSidebar/lib';
 import { AppBreadcrumb } from '../../../../app/components/AppBreadcrumb';
 import { SessionOverviewPane } from '../SessionOverviewPane';
 import { AgentOverlay } from './parts/AgentOverlay';
+import { AgentsPane } from './parts/AgentsPane';
 import { Pane } from './parts/Pane';
 import { SessionStudioLayer } from './parts/SessionStudioLayer';
 import { SessionTopBar } from './parts/SessionTopBar';
@@ -66,6 +66,7 @@ type SessionWorkspaceProps = {
 export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) => {
   const sessionId = session.id as SessionId;
   const [inspectedResolverId, setInspectedResolverId] = useState<AgentId | null>(null);
+  const [inspectedAgentId, setInspectedAgentId] = useState<AgentId | null>(null);
   const hasInitializedResolverInspector = useRef(false);
   const activeLens = useAppStore((s) => s.activeLens[sessionId]);
   const setActiveLens = useAppStore((s) => s.setActiveLens);
@@ -347,14 +348,12 @@ export const SessionWorkspace = ({ session, isActive }: SessionWorkspaceProps) =
                   />
                 ) : null}
                 <Pane visible={lens === 'agents'}>
-                  <PaneShell
-                    title="Agents"
-                    description="Agents you spawn by hand to work this session."
+                  <AgentsPane
+                    session={session}
                     meta={agentsMeta}
-                    width="3xl"
-                  >
-                    <AgentsSection task={session} only="agents" />
-                  </PaneShell>
+                    inspectedAgentId={inspectedAgentId}
+                    onInspectAgent={setInspectedAgentId}
+                  />
                 </Pane>
               </div>
             ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentOverlay.tsx
@@ -4,6 +4,7 @@ import type { AgentId, Session, SessionId } from '@goodboy/types';
 import { ChatView } from '../../../../chat/components/ChatView';
 import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
 import type { AgentHomeLens } from '../../../agent-kind';
+import { AgentInspector } from '../../AgentInspector';
 import { ResolverInspector } from '../../ResolverInspector';
 import { agentOverlayHeader } from './agentOverlayHeader';
 
@@ -74,6 +75,14 @@ export const AgentOverlay = ({
           <Divider orientation="vertical" />
           <div className="flex w-80 shrink-0 flex-col bg-background">
             <ResolverInspector sessionId={sessionId} agentId={inspectedResolverId} />
+          </div>
+        </>
+      ) : null}
+      {overlayHome === 'agents' && selectedAgentId !== null ? (
+        <>
+          <Divider orientation="vertical" />
+          <div className="flex w-80 shrink-0 flex-col bg-background">
+            <AgentInspector sessionId={sessionId} agentId={selectedAgentId} />
           </div>
         </>
       ) : null}

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/AgentsPane.tsx
@@ -1,0 +1,45 @@
+import type { AgentId, Session, SessionId } from '@goodboy/types';
+import { AgentsSection } from '../../../../workspace/components/WorkspacesSidebar/parts/AgentsSection';
+import { AgentInspector } from '../../AgentInspector';
+import { InspectorSplit } from './InspectorSplit';
+import { PaneShell } from './PaneShell';
+
+type Props = {
+  readonly session: Session;
+  readonly meta: string | undefined;
+  readonly inspectedAgentId: AgentId | null;
+  readonly onInspectAgent: (agentId: AgentId | null) => void;
+};
+
+export const AgentsPane = ({ session, meta, inspectedAgentId, onInspectAgent }: Props) => {
+  const sessionId = session.id as SessionId;
+
+  return (
+    <InspectorSplit
+      open={inspectedAgentId !== null}
+      panel={
+        inspectedAgentId !== null ? (
+          <AgentInspector
+            sessionId={sessionId}
+            agentId={inspectedAgentId}
+            onClose={() => onInspectAgent(null)}
+          />
+        ) : null
+      }
+    >
+      <PaneShell
+        title="Agents"
+        description="Agents you spawn by hand to work this session."
+        meta={meta}
+        width="3xl"
+      >
+        <AgentsSection
+          task={session}
+          only="agents"
+          inspectedAgentId={inspectedAgentId}
+          onInspectAgent={(agentId) => onInspectAgent(agentId)}
+        />
+      </PaneShell>
+    </InspectorSplit>
+  );
+};

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.test.tsx
@@ -11,6 +11,7 @@ const { hooks, remote, store } = vi.hoisted(() => {
   return {
     hooks: {
       agentCount: 0,
+      doneAgentCount: 0,
       planCount: 0,
       questionCount: 0,
       liveTerminals: 0,
@@ -39,11 +40,17 @@ const { hooks, remote, store } = vi.hoisted(() => {
 vi.mock('../../../../../store', () => ({
   EMPTY_ARRAY: Object.freeze([]),
   useAppStore: <T,>(selector: (state: typeof store) => T) => selector(store),
-  useNonResolverStandaloneAgents: () =>
-    Array.from({ length: hooks.agentCount }, (_, index) => ({
+  useNonResolverStandaloneAgents: () => [
+    ...Array.from({ length: hooks.agentCount }, (_, index) => ({
       id: `agent-${index}`,
       status: 'running',
     })),
+    ...Array.from({ length: hooks.doneAgentCount }, (_, index) => ({
+      id: `done-agent-${index}`,
+      status: 'completed',
+      doneAt: '2026-07-26T12:00:00.000Z',
+    })),
+  ],
   useSessionOpenQuestions: () =>
     Array.from({ length: hooks.questionCount }, (_, index) => ({
       id: `question-${index}`,
@@ -83,6 +90,7 @@ const SESSION = {
 beforeEach(() => {
   remote.kind = 'github';
   hooks.agentCount = 0;
+  hooks.doneAgentCount = 0;
   hooks.planCount = 0;
   hooks.questionCount = 0;
   hooks.liveTerminals = 0;
@@ -224,6 +232,23 @@ describe('LensColumn', () => {
     expect(screen.getByRole('button', { name: 'Questions 1' })).toBeDefined();
     expect(screen.queryByTestId('lens-count-loading-agents')).toBeNull();
     expect(screen.queryByTestId('lens-count-loading-plans')).toBeNull();
+  });
+
+  it('excludes user-completed agents from the agents count', () => {
+    hooks.agentCount = 2;
+    hooks.doneAgentCount = 1;
+
+    render(
+      <LensColumn
+        session={SESSION}
+        activeLens={null}
+        onSelectOverview={vi.fn()}
+        onSelect={vi.fn()}
+        filesCount={0}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Agents 2' })).toBeDefined();
   });
 
   it('keeps the question badge loading until questions resolve', () => {

--- a/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
+++ b/apps/desktop/src/features/session/components/SessionWorkspace/parts/LensColumn.tsx
@@ -100,6 +100,10 @@ export const LensColumn = ({
   const agentKindOverride = useAppStore((s) => s.agentKindOverride);
   const phaseRuns = useAppStore((s) => s.sessionPhaseRuns[sessionId] ?? EMPTY_ARRAY);
   const nonResolverStandalone = useNonResolverStandaloneAgents(sessionId);
+  const activeNonResolverStandalone = useMemo(
+    () => nonResolverStandalone.filter((agent) => agent.doneAt == null),
+    [nonResolverStandalone],
+  );
   const unreadLens = useSessionUnreadLens(sessionId);
   const remoteKind = useRemoteHostKind(session.workspaceId);
   const externalTasks = useAppStore((s) => s.sessionExternalTasks[sessionId] ?? EMPTY_ARRAY);
@@ -113,14 +117,14 @@ export const LensColumn = ({
     [agentKindOverride],
   );
 
-  const hasNonResolverStandalone = nonResolverStandalone.length > 0;
+  const hasNonResolverStandalone = activeNonResolverStandalone.length > 0;
   const hasResolverAgent = useMemo(
     () => phaseRuns.some((a) => isStandaloneAgent(a) && isResolver(a)),
     [phaseRuns, isResolver],
   );
   const hasRunningAgent = useMemo(
-    () => nonResolverStandalone.some((agent) => agent.status === 'running'),
-    [nonResolverStandalone],
+    () => activeNonResolverStandalone.some((agent) => agent.status === 'running'),
+    [activeNonResolverStandalone],
   );
 
   const activeWorkflows = session.workflowRuns.filter((r) => r.discardedAt == null).length;
@@ -275,7 +279,7 @@ export const LensColumn = ({
           label: 'Agents',
           icon: Bot,
           tone: 'primary',
-          count: nonResolverStandalone.length,
+          count: activeNonResolverStandalone.length,
           isCountLoading: areAgentsLoading,
           dot:
             attentionLens === 'agents' || unreadLens === 'agents'

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -384,8 +384,12 @@ export const invokeAgentMarkViewed = async (id: AgentId, at: IsoDateTime): Promi
   await invoke<void>('agent_mark_viewed', { id, at });
 };
 
-export const invokeAgentSetDone = async (id: AgentId, done: boolean): Promise<void> => {
-  await invoke<void>('agent_set_done', { id, done });
+export const invokeAgentSetDone = async (
+  id: AgentId,
+  done: boolean,
+  at: IsoDateTime | null,
+): Promise<void> => {
+  await invoke<void>('agent_set_done', { id, done, at });
 };
 
 export const invokeWorkspacesWithUnread = async (): Promise<ReadonlyArray<WorkspaceId>> => {

--- a/apps/desktop/src/features/workflows/workflows.ts
+++ b/apps/desktop/src/features/workflows/workflows.ts
@@ -85,6 +85,7 @@ type RawAgentRow = {
   readonly providerSessionId: string | null;
   readonly lastFinishedAt: string | null;
   readonly lastViewedAt: string | null;
+  readonly doneAt: string | null;
   readonly kind: string | null;
   readonly verbosity: string | null;
   readonly sourceThreadId: string | null;
@@ -165,6 +166,7 @@ function rowToAgent(row: RawAgentRow): Agent {
     ...(row.providerSessionId != null && { providerSessionId: row.providerSessionId }),
     ...(row.lastFinishedAt != null && { lastFinishedAt: row.lastFinishedAt as IsoDateTime }),
     ...(row.lastViewedAt != null && { lastViewedAt: row.lastViewedAt as IsoDateTime }),
+    ...(row.doneAt != null && { doneAt: row.doneAt as IsoDateTime }),
     ...(row.kind != null && { kind: row.kind }),
     ...(row.verbosity != null && { verbosity: row.verbosity as VerbosityLevel }),
     ...(row.sourceThreadId != null && { sourceThreadId: row.sourceThreadId }),
@@ -380,6 +382,10 @@ export const invokeAgentSetProviderSessionId = async (
 
 export const invokeAgentMarkViewed = async (id: AgentId, at: IsoDateTime): Promise<void> => {
   await invoke<void>('agent_mark_viewed', { id, at });
+};
+
+export const invokeAgentSetDone = async (id: AgentId, done: boolean): Promise<void> => {
+  await invoke<void>('agent_set_done', { id, done });
 };
 
 export const invokeWorkspacesWithUnread = async (): Promise<ReadonlyArray<WorkspaceId>> => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AdHocRow.tsx
@@ -27,6 +27,10 @@ type Props = {
   readonly onPickAgent: (id: AgentId) => void;
   readonly onRenameCommit: (id: AgentId, name: string) => Promise<void>;
   readonly onDeleteAgent: (id: AgentId) => Promise<void>;
+  readonly isInspected?: boolean;
+  readonly onInspectAgent?: (id: AgentId) => void;
+  readonly onMarkDone: (id: AgentId) => void;
+  readonly isMuted?: boolean;
 };
 
 export const AdHocRow = ({
@@ -49,6 +53,10 @@ export const AdHocRow = ({
   onPickAgent,
   onRenameCommit,
   onDeleteAgent,
+  isInspected = false,
+  onInspectAgent,
+  onMarkDone,
+  isMuted = false,
 }: Props) => {
   const kind = resolveAgentKind(
     run.name,
@@ -75,6 +83,10 @@ export const AdHocRow = ({
         onRenameCommit={(name) => void onRenameCommit(run.id, name)}
         onRenameCancel={() => setEditingId(null)}
         onDelete={() => void onDeleteAgent(run.id)}
+        isInspected={isInspected}
+        onInspect={onInspectAgent === undefined ? undefined : () => onInspectAgent(run.id)}
+        onMarkDone={() => onMarkDone(run.id)}
+        isMuted={isMuted}
       />
       {scoutChildren.length > 0 && (
         <li>

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { Agent, AgentId, SessionId, TelemetryRecord } from '@goodboy/types';
 
 vi.mock('../../../../../store', () => ({
@@ -33,11 +33,13 @@ const telemetry = {
   recordedAt: '2026-01-01T00:00:00.000Z',
 } as TelemetryRecord;
 
-const renderRow = (isSelected: boolean) =>
+const markDone = vi.fn();
+
+const renderRow = (isSelected: boolean, runOverride: Partial<Agent> = {}) =>
   render(
     <ul>
       <AgentRow
-        run={run}
+        run={{ ...run, ...runOverride }}
         kind="scout"
         index={0}
         telemetry={telemetry}
@@ -60,11 +62,15 @@ const renderRow = (isSelected: boolean) =>
         onRenameCommit={() => undefined}
         onRenameCancel={() => undefined}
         onDelete={() => undefined}
+        onMarkDone={markDone}
       />
     </ul>,
   );
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
 
 describe('AgentRow', () => {
   it('shows model, cost, context share and turns without being selected', () => {
@@ -106,5 +112,16 @@ describe('AgentRow', () => {
   it('shows the agent status next to its name', () => {
     renderRow(false);
     expect(screen.getByText('scout one').nextElementSibling?.textContent).toBe('completed');
+  });
+
+  it('offers mark done for a stopped standalone agent', () => {
+    renderRow(false);
+    fireEvent.click(screen.getByRole('button', { name: 'mark agent done' }));
+    expect(markDone).toHaveBeenCalledOnce();
+  });
+
+  it('hides mark done while the agent is running', () => {
+    renderRow(false, { status: 'running' });
+    expect(screen.queryByRole('button', { name: 'mark agent done' })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { cn } from '@goodboy/ui';
-import { Trash2 } from 'lucide-react';
+import { CircleCheck, PanelRight, Trash2 } from 'lucide-react';
 import type { Agent, TelemetryRecord } from '@goodboy/types';
 import { agentHasUnread } from '../../../../../store';
 import { formatCost } from '../../../../../features/session/agent-row-format';
@@ -31,6 +31,10 @@ type Props = {
   readonly onRenameCommit: (name: string) => void;
   readonly onRenameCancel: () => void;
   readonly onDelete: () => void;
+  readonly isInspected?: boolean;
+  readonly isMuted?: boolean;
+  readonly onInspect?: () => void;
+  readonly onMarkDone?: () => void;
 };
 
 export const AgentRow = ({
@@ -50,6 +54,10 @@ export const AgentRow = ({
   onRenameCommit,
   onRenameCancel,
   onDelete,
+  isInspected = false,
+  isMuted = false,
+  onInspect,
+  onMarkDone,
 }: Props) => {
   const total = telemetry ? telemetry.inputTokens + telemetry.outputTokens : null;
   const titleParts = [
@@ -94,6 +102,7 @@ export const AgentRow = ({
       }}
       className={cn(
         'group rounded border transition-colors',
+        isMuted && 'opacity-60',
         isEditing ? '' : 'cursor-pointer',
         isSelected ? 'bg-elevated' : 'bg-muted/40 hover:bg-muted/60',
         run.status === 'running'
@@ -149,6 +158,25 @@ export const AgentRow = ({
           </span>
         )}
         <AgentStatusBadge status={run.status} />
+        {!isEditing && onInspect !== undefined ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onInspect();
+            }}
+            title="Toggle agent details"
+            aria-label="Toggle agent details"
+            aria-pressed={isInspected}
+            className={cn(
+              'inline-flex shrink-0 items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-foreground/10 hover:text-foreground',
+              isInspected && 'bg-foreground/10 text-foreground',
+            )}
+          >
+            <PanelRight size={12} aria-hidden />
+            Details
+          </button>
+        ) : null}
         {!isEditing &&
           (confirmingDelete ? (
             <div className="flex shrink-0 items-center gap-1" onClick={(e) => e.stopPropagation()}>
@@ -174,6 +202,20 @@ export const AgentRow = ({
             </div>
           ) : (
             <div className="flex shrink-0 items-center gap-1.5">
+              {onMarkDone !== undefined && run.status !== 'running' && run.doneAt == null ? (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onMarkDone();
+                  }}
+                  className="hidden rounded p-0.5 text-muted-foreground/60 transition-colors group-hover:inline-flex hover:text-success"
+                  title="mark agent done"
+                  aria-label="mark agent done"
+                >
+                  <CircleCheck size={11} aria-hidden />
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={(e) => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.test.tsx
@@ -73,8 +73,16 @@ vi.mock('./CollapsedSummary', () => ({
   CollapsedSummary: ({ text }: { text: string }) => <div data-testid="collapsed">{text}</div>,
 }));
 vi.mock('./AgentRow', () => ({
-  AgentRow: ({ run, onClick }: { run: Agent; onClick?: () => void }) => (
-    <li data-testid="agent-row">
+  AgentRow: ({
+    run,
+    onClick,
+    isMuted,
+  }: {
+    run: Agent;
+    onClick?: () => void;
+    isMuted?: boolean;
+  }) => (
+    <li data-testid="agent-row" data-muted={isMuted}>
       <button onClick={onClick}>{run.name}</button>
     </li>
   ),
@@ -181,6 +189,7 @@ function reset() {
     activateWorkflowAgent: vi.fn(),
     renameAgent: vi.fn(),
     deleteAgent: vi.fn(),
+    setAgentDone: vi.fn(),
     phaseTemplates: {},
     sessionWorkflows: {},
     discardWorkflow: vi.fn(),
@@ -248,6 +257,24 @@ describe('AgentsSection collapse defaults', () => {
 
     expect(screen.getByTestId('toggle-agents').textContent).toBe('collapsed');
     expect(screen.getByTestId('collapsed').textContent).toBe('1 agent');
+  });
+
+  it('partitions user-completed agents into a collapsed done group', () => {
+    h.state.sessionPhaseRuns = {
+      [SESSION_ID]: [
+        buildAgent({ id: 'active' as AgentId, name: 'active agent' }),
+        buildAgent({ id: 'done' as AgentId, name: 'done agent', doneAt: NOW }),
+      ],
+    };
+
+    render(<AgentsSection task={buildSession()} only="agents" />);
+
+    expect(screen.getByText('active agent')).toBeDefined();
+    expect(screen.queryByText('done agent')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: 'Done (1)' }));
+    expect(screen.getByText('done agent').closest('[data-muted]')?.getAttribute('data-muted')).toBe(
+      'true',
+    );
   });
 
   it('workflow unread badge counts step agents and their cluster children', () => {

--- a/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
+++ b/apps/desktop/src/features/workspace/components/WorkspacesSidebar/parts/AgentsSection.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { EmptyState, SectionHeader, cn } from '@goodboy/ui';
-import { ArrowUpRight, CheckCheck, Layers } from 'lucide-react';
+import { ArrowUpRight, CheckCheck, ChevronDown, ChevronRight, Layers } from 'lucide-react';
 import { ScriptsSection } from '../../../../scripts/components/ScriptsSection';
 import { DogMascot } from '../../../../../shared/components/DogMascot';
 import type {
@@ -50,6 +50,8 @@ type Props = {
   showWorkflowAttach?: boolean;
   inspectedResolverId?: AgentId | null;
   onInspectResolver?: (agentId: AgentId) => void;
+  inspectedAgentId?: AgentId | null;
+  onInspectAgent?: (agentId: AgentId) => void;
 };
 
 export const AgentsSection = ({
@@ -60,6 +62,8 @@ export const AgentsSection = ({
   showWorkflowAttach = true,
   inspectedResolverId = null,
   onInspectResolver,
+  inspectedAgentId = null,
+  onInspectAgent,
 }: Props) => {
   const showWorkflows = only == null || only === 'workflows';
   const showAgents = only == null || only === 'agents';
@@ -151,6 +155,7 @@ export const AgentsSection = ({
   const forceAdvanceWorkflowStep = useAppStore((s) => s.forceAdvanceWorkflowStep);
   const renameAgent = useAppStore((s) => s.renameAgent);
   const deleteAgent = useAppStore((s) => s.deleteAgent);
+  const setAgentDone = useAppStore((s) => s.setAgentDone);
   const attachedRuns = useAttachedWorkflowRuns({ session: task });
   const discardWorkflow = useAppStore((s) => s.discardWorkflow);
   const reorderSessionWorkflows = useAppStore((s) => s.reorderSessionWorkflows);
@@ -172,6 +177,7 @@ export const AgentsSection = ({
   const focusedWorkflowRunId = useAppStore((s) => s.focusedWorkflowRunId?.[task.id] ?? null);
   const toggleWorkflowExpand = useAppStore((s) => s.toggleWorkflowExpand);
   const [resolveExpanded, setResolveExpanded] = useState(true);
+  const [doneExpanded, setDoneExpanded] = useState(false);
   const setPanelSectionExpanded = useAppStore((s) => s.setPanelSectionExpanded);
   const workflowExpanded = useAppStore((s) => s.sessionPanelExpanded[task.id]?.workflow ?? true);
   const [clusterExpand, setClusterExpand] = useState<ReadonlyMap<string, boolean>>(new Map());
@@ -349,6 +355,22 @@ export const AgentsSection = ({
     [sorted, agentKindOverride],
   );
   const resolverIds = useMemo(() => new Set(resolverAgents.map((r) => r.id)), [resolverAgents]);
+  const standaloneAgents = useMemo(
+    () => adHocAgents.filter((agent) => !resolverIds.has(agent.id)),
+    [adHocAgents, resolverIds],
+  );
+  const activeStandaloneAgents = useMemo(
+    () =>
+      only === 'agents'
+        ? standaloneAgents.filter((agent) => agent.doneAt == null)
+        : standaloneAgents,
+    [only, standaloneAgents],
+  );
+  const doneStandaloneAgents = useMemo(
+    () =>
+      only === 'agents' ? standaloneAgents.filter((agent) => agent.doneAt != null) : EMPTY_ARRAY,
+    [only, standaloneAgents],
+  );
   const commentByThreadId = useMemo(() => {
     const map = new Map<string, PrComment>();
     for (const c of prComments) {
@@ -380,8 +402,8 @@ export const AgentsSection = ({
     [resolveGithubThread, dequeueResolution, task.id],
   );
   const standaloneAgentCount = useMemo(
-    () => adHocAgents.filter((r) => !resolverIds.has(r.id)).length,
-    [adHocAgents, resolverIds],
+    () => activeStandaloneAgents.length,
+    [activeStandaloneAgents],
   );
   const agentsExpanded = useAppStore(
     (s) => s.sessionPanelExpanded[task.id]?.agents ?? standaloneAgentCount > 0,
@@ -558,37 +580,38 @@ export const AgentsSection = ({
           {agExpanded ? (
             <>
               {hasAnyWorkflow ? (
-                adHocAgents.some((r) => !resolverIds.has(r.id)) ? (
+                activeStandaloneAgents.length > 0 ? (
                   <ul className="flex flex-col gap-1 pl-2">
-                    {adHocAgents
-                      .filter((r) => !resolverIds.has(r.id))
-                      .map((run, index) => (
-                        <AdHocRow
-                          key={run.id}
-                          run={run}
-                          index={index}
-                          firstUserTextByAgentId={firstUserTextByAgentId}
-                          agentKindOverride={agentKindOverride}
-                          childrenByParentId={childrenByParentId}
-                          latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
-                          aggregatesByAgentId={metrics.aggregatesByAgentId}
-                          providerUsageByAgentId={metrics.providerUsageByAgentId}
-                          turnsByAgentId={metrics.turnsByAgentId}
-                          selectedAgentId={selectedAgentId}
-                          isTranscriptLoading={loading.transcript}
-                          isTaskActive={isTaskActive}
-                          editingId={editingId}
-                          setEditingId={setEditingId}
-                          clusterExpand={clusterExpand}
-                          toggleClusterExpand={toggleClusterExpand}
-                          onPickAgent={onPickAgent}
-                          onRenameCommit={onRenameCommit}
-                          onDeleteAgent={onDeleteAgent}
-                        />
-                      ))}
+                    {activeStandaloneAgents.map((run, index) => (
+                      <AdHocRow
+                        key={run.id}
+                        run={run}
+                        index={index}
+                        firstUserTextByAgentId={firstUserTextByAgentId}
+                        agentKindOverride={agentKindOverride}
+                        childrenByParentId={childrenByParentId}
+                        latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
+                        aggregatesByAgentId={metrics.aggregatesByAgentId}
+                        providerUsageByAgentId={metrics.providerUsageByAgentId}
+                        turnsByAgentId={metrics.turnsByAgentId}
+                        selectedAgentId={selectedAgentId}
+                        isTranscriptLoading={loading.transcript}
+                        isTaskActive={isTaskActive}
+                        editingId={editingId}
+                        setEditingId={setEditingId}
+                        clusterExpand={clusterExpand}
+                        toggleClusterExpand={toggleClusterExpand}
+                        onPickAgent={onPickAgent}
+                        onRenameCommit={onRenameCommit}
+                        onDeleteAgent={onDeleteAgent}
+                        isInspected={run.id === inspectedAgentId}
+                        onInspectAgent={onInspectAgent}
+                        onMarkDone={(id) => void setAgentDone(task.id, id)}
+                      />
+                    ))}
                   </ul>
                 ) : null
-              ) : sorted.length === 0 ? (
+              ) : standaloneAgents.length === 0 ? (
                 loading.agents ? (
                   <ul
                     role="status"
@@ -627,34 +650,82 @@ export const AgentsSection = ({
                 ) : null
               ) : (
                 <ul className="flex flex-col gap-1 pl-2">
-                  {sorted
-                    .filter((r) => !resolverIds.has(r.id))
-                    .map((run, index) => (
-                      <AdHocRow
-                        key={run.id}
-                        run={run}
-                        index={index}
-                        firstUserTextByAgentId={firstUserTextByAgentId}
-                        agentKindOverride={agentKindOverride}
-                        childrenByParentId={childrenByParentId}
-                        latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
-                        aggregatesByAgentId={metrics.aggregatesByAgentId}
-                        providerUsageByAgentId={metrics.providerUsageByAgentId}
-                        turnsByAgentId={metrics.turnsByAgentId}
-                        selectedAgentId={selectedAgentId}
-                        isTranscriptLoading={loading.transcript}
-                        isTaskActive={isTaskActive}
-                        editingId={editingId}
-                        setEditingId={setEditingId}
-                        clusterExpand={clusterExpand}
-                        toggleClusterExpand={toggleClusterExpand}
-                        onPickAgent={onPickAgent}
-                        onRenameCommit={onRenameCommit}
-                        onDeleteAgent={onDeleteAgent}
-                      />
-                    ))}
+                  {activeStandaloneAgents.map((run, index) => (
+                    <AdHocRow
+                      key={run.id}
+                      run={run}
+                      index={index}
+                      firstUserTextByAgentId={firstUserTextByAgentId}
+                      agentKindOverride={agentKindOverride}
+                      childrenByParentId={childrenByParentId}
+                      latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
+                      aggregatesByAgentId={metrics.aggregatesByAgentId}
+                      providerUsageByAgentId={metrics.providerUsageByAgentId}
+                      turnsByAgentId={metrics.turnsByAgentId}
+                      selectedAgentId={selectedAgentId}
+                      isTranscriptLoading={loading.transcript}
+                      isTaskActive={isTaskActive}
+                      editingId={editingId}
+                      setEditingId={setEditingId}
+                      clusterExpand={clusterExpand}
+                      toggleClusterExpand={toggleClusterExpand}
+                      onPickAgent={onPickAgent}
+                      onRenameCommit={onRenameCommit}
+                      onDeleteAgent={onDeleteAgent}
+                      isInspected={run.id === inspectedAgentId}
+                      onInspectAgent={onInspectAgent}
+                      onMarkDone={(id) => void setAgentDone(task.id, id)}
+                    />
+                  ))}
                 </ul>
               )}
+              {doneStandaloneAgents.length > 0 ? (
+                <button
+                  type="button"
+                  onClick={() => setDoneExpanded((current) => !current)}
+                  aria-expanded={doneExpanded}
+                  className="flex items-center gap-1 self-start rounded px-2 py-0.5 text-2xs text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {doneExpanded ? (
+                    <ChevronDown size={11} aria-hidden className="shrink-0" />
+                  ) : (
+                    <ChevronRight size={11} aria-hidden className="shrink-0" />
+                  )}
+                  Done ({doneStandaloneAgents.length})
+                </button>
+              ) : null}
+              {doneExpanded ? (
+                <ul className="flex flex-col gap-1 pl-2">
+                  {doneStandaloneAgents.map((run, index) => (
+                    <AdHocRow
+                      key={run.id}
+                      run={run}
+                      index={activeStandaloneAgents.length + index}
+                      firstUserTextByAgentId={firstUserTextByAgentId}
+                      agentKindOverride={agentKindOverride}
+                      childrenByParentId={childrenByParentId}
+                      latestTelemetryByAgentId={metrics.latestTelemetryByAgentId}
+                      aggregatesByAgentId={metrics.aggregatesByAgentId}
+                      providerUsageByAgentId={metrics.providerUsageByAgentId}
+                      turnsByAgentId={metrics.turnsByAgentId}
+                      selectedAgentId={selectedAgentId}
+                      isTranscriptLoading={loading.transcript}
+                      isTaskActive={isTaskActive}
+                      editingId={editingId}
+                      setEditingId={setEditingId}
+                      clusterExpand={clusterExpand}
+                      toggleClusterExpand={toggleClusterExpand}
+                      onPickAgent={onPickAgent}
+                      onRenameCommit={onRenameCommit}
+                      onDeleteAgent={onDeleteAgent}
+                      isInspected={run.id === inspectedAgentId}
+                      onInspectAgent={onInspectAgent}
+                      onMarkDone={(id) => void setAgentDone(task.id, id)}
+                      isMuted
+                    />
+                  ))}
+                </ul>
+              ) : null}
               <SpawnAgentControl sessionId={task.id} />
               {spawnError ? <p className="mt-1 px-2 text-2xs text-danger">{spawnError}</p> : null}
             </>

--- a/apps/desktop/src/store/selectors.ts
+++ b/apps/desktop/src/store/selectors.ts
@@ -426,6 +426,9 @@ export const useFilesTouched = (
 };
 
 export const agentHasUnread = (agent: Agent, isCurrentlyViewed: boolean): boolean => {
+  if (agent.doneAt != null) {
+    return false;
+  }
   if (isCurrentlyViewed) {
     return false;
   }

--- a/apps/desktop/src/store/slices/agents/clearAgentDone.ts
+++ b/apps/desktop/src/store/slices/agents/clearAgentDone.ts
@@ -1,0 +1,21 @@
+import type { AgentId, SessionId } from '@goodboy/types';
+import { invokeAgentSetDone } from '../../../features/workflows/workflows';
+import type { SetFn } from './types';
+
+export const clearAgentDone = (set: SetFn) => {
+  return async (sessionId: SessionId, agentId: AgentId) => {
+    set((state) => ({
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((agent) => {
+          if (agent.id !== agentId || agent.doneAt == null) {
+            return agent;
+          }
+          const { doneAt: _, ...reopenedAgent } = agent;
+          return reopenedAgent;
+        }),
+      },
+    }));
+    await invokeAgentSetDone(agentId, false);
+  };
+};

--- a/apps/desktop/src/store/slices/agents/clearAgentDone.ts
+++ b/apps/desktop/src/store/slices/agents/clearAgentDone.ts
@@ -16,6 +16,6 @@ export const clearAgentDone = (set: SetFn) => {
         }),
       },
     }));
-    await invokeAgentSetDone(agentId, false);
+    await invokeAgentSetDone(agentId, false, null);
   };
 };

--- a/apps/desktop/src/store/slices/agents/index.test.ts
+++ b/apps/desktop/src/store/slices/agents/index.test.ts
@@ -233,6 +233,7 @@ const invokeAgentUpdateStatusSpy = vi.fn();
 const invokeAgentSetKindSpy = vi.fn(async () => undefined);
 const invokeAgentSetVerbositySpy = vi.fn(async () => undefined);
 const invokeAgentMarkViewedSpy = vi.fn(async () => undefined);
+const invokeAgentSetDoneSpy = vi.fn(async () => undefined);
 const invokeAgentSetProviderSessionIdSpy = vi.fn(async () => undefined);
 const invokeWorkspacesWithUnreadSpy = vi.fn(async () => [] as ReadonlyArray<WorkspaceId>);
 
@@ -246,6 +247,7 @@ vi.mock('../../../features/workflows/workflows', () => ({
   invokeAgentSetKind: invokeAgentSetKindSpy,
   invokeAgentSetVerbosity: invokeAgentSetVerbositySpy,
   invokeAgentMarkViewed: invokeAgentMarkViewedSpy,
+  invokeAgentSetDone: invokeAgentSetDoneSpy,
   invokeAgentSetProviderSessionId: invokeAgentSetProviderSessionIdSpy,
   invokeWorkspacesWithUnread: invokeWorkspacesWithUnreadSpy,
 }));
@@ -570,6 +572,22 @@ describe('store contract', () => {
       store.setState({ sessionPhaseRuns: { [SESSION_ID]: [agent] } });
       await store.getState().markAgentViewed(SESSION_ID, AGENT_ID);
       expect(invokeAgentMarkViewedSpy).not.toHaveBeenCalled();
+    });
+
+    it('sets and clears the user-controlled done timestamp', async () => {
+      const store = await getStore();
+      const agent = buildAgent({ id: AGENT_ID });
+      store.setState({ sessionPhaseRuns: { [SESSION_ID]: [agent] } });
+
+      await store.getState().setAgentDone(SESSION_ID, AGENT_ID);
+
+      expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeDefined();
+      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, true);
+
+      await store.getState().clearAgentDone(SESSION_ID, AGENT_ID);
+
+      expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeUndefined();
+      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, false);
     });
 
     it('markAgentViewed stamps lastViewedAt and invokes persist when finished is newer than viewed', async () => {

--- a/apps/desktop/src/store/slices/agents/index.test.ts
+++ b/apps/desktop/src/store/slices/agents/index.test.ts
@@ -582,12 +582,12 @@ describe('store contract', () => {
       await store.getState().setAgentDone(SESSION_ID, AGENT_ID);
 
       expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeDefined();
-      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, true);
+      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, true, expect.any(String));
 
       await store.getState().clearAgentDone(SESSION_ID, AGENT_ID);
 
       expect(store.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeUndefined();
-      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, false);
+      expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_ID, false, null);
     });
 
     it('markAgentViewed stamps lastViewedAt and invokes persist when finished is newer than viewed', async () => {

--- a/apps/desktop/src/store/slices/agents/index.ts
+++ b/apps/desktop/src/store/slices/agents/index.ts
@@ -1,5 +1,6 @@
 import { activateNextResolver } from './activateNextResolver';
 import { clearAgentAttachments } from './clearAgentAttachments';
+import { clearAgentDone } from './clearAgentDone';
 import { clearAgentDraft } from './clearAgentDraft';
 import { clearAgentQueue } from './clearAgentQueue';
 import { deleteAgent } from './deleteAgent';
@@ -10,6 +11,7 @@ import { renameAgent } from './renameAgent';
 import { selectAgent } from './selectAgent';
 import { setAgentAttachments } from './setAgentAttachments';
 import { setAgentDraft } from './setAgentDraft';
+import { setAgentDone } from './setAgentDone';
 import { setAgentEffortOverride } from './setAgentEffortOverride';
 import { setAgentKind } from './setAgentKind';
 import { setAgentQueue } from './setAgentQueue';
@@ -29,6 +31,8 @@ export const createAgentsSlice = (set: SetFn, get: GetFn) => {
     selectAgent: selectAgent(set, get),
     deselectAgent: deselectAgent(set),
     markAgentViewed: markAgentViewed(set, get),
+    setAgentDone: setAgentDone(set),
+    clearAgentDone: clearAgentDone(set),
     renameAgent: renameAgent(set),
     spawnAgent: spawnAgent(set, get),
     deleteAgent: deleteAgent(set, get),

--- a/apps/desktop/src/store/slices/agents/setAgentDone.ts
+++ b/apps/desktop/src/store/slices/agents/setAgentDone.ts
@@ -1,0 +1,18 @@
+import type { AgentId, IsoDateTime, SessionId } from '@goodboy/types';
+import { invokeAgentSetDone } from '../../../features/workflows/workflows';
+import type { SetFn } from './types';
+
+export const setAgentDone = (set: SetFn) => {
+  return async (sessionId: SessionId, agentId: AgentId) => {
+    const doneAt = new Date().toISOString() as IsoDateTime;
+    set((state) => ({
+      sessionPhaseRuns: {
+        ...state.sessionPhaseRuns,
+        [sessionId]: (state.sessionPhaseRuns[sessionId] ?? []).map((agent) =>
+          agent.id === agentId ? { ...agent, doneAt } : agent,
+        ),
+      },
+    }));
+    await invokeAgentSetDone(agentId, true);
+  };
+};

--- a/apps/desktop/src/store/slices/agents/setAgentDone.ts
+++ b/apps/desktop/src/store/slices/agents/setAgentDone.ts
@@ -13,6 +13,6 @@ export const setAgentDone = (set: SetFn) => {
         ),
       },
     }));
-    await invokeAgentSetDone(agentId, true);
+    await invokeAgentSetDone(agentId, true, doneAt);
   };
 };

--- a/apps/desktop/src/store/slices/turn/cancelCurrentTurn.ts
+++ b/apps/desktop/src/store/slices/turn/cancelCurrentTurn.ts
@@ -1,4 +1,4 @@
-import type { IsoDateTime, SessionId, TurnState } from '@goodboy/types';
+import type { AgentId, IsoDateTime, SessionId, TurnState } from '@goodboy/types';
 import { updateSessionState } from '@goodboy/db';
 import { tauriDatabase } from '../../../shared/lib/db';
 import { cancelTurn } from '../../../features/chat/turn';
@@ -6,12 +6,12 @@ import { applyAgentTurnState, cancelledRunIds } from '../../session-mutators';
 import type { GetFn, SetFn } from './types';
 
 export const cancelCurrentTurn = (set: SetFn, get: GetFn) => {
-  return async (sessionId: SessionId) => {
-    const selectedAgentId = get().selectedAgentId[sessionId] ?? null;
-    if (!selectedAgentId) {
+  return async (sessionId: SessionId, agentId?: AgentId) => {
+    const activeAgentId = agentId ?? get().selectedAgentId[sessionId] ?? null;
+    if (activeAgentId == null) {
       return;
     }
-    const agentState = get().agentTurnState[selectedAgentId];
+    const agentState = get().agentTurnState[activeAgentId];
     if (agentState?.kind !== 'running') {
       return;
     }
@@ -19,7 +19,7 @@ export const cancelCurrentTurn = (set: SetFn, get: GetFn) => {
     await cancelTurn(agentState.runId).catch(() => undefined);
     const now = new Date().toISOString() as IsoDateTime;
     const idleState: TurnState = { kind: 'idle', lastActivityAt: now };
-    const derived = applyAgentTurnState(set, sessionId, selectedAgentId, idleState, now);
+    const derived = applyAgentTurnState(set, sessionId, activeAgentId, idleState, now);
     await updateSessionState(tauriDatabase, sessionId, derived, now).catch(() => undefined);
   };
 };

--- a/apps/desktop/src/store/slices/turn/sendTurn.ts
+++ b/apps/desktop/src/store/slices/turn/sendTurn.ts
@@ -132,6 +132,12 @@ export const sendTurn = (set: SetFn, get: GetFn) => {
     if (!activeAgentId) {
       throw new Error('no agent selected. spawn one before sending a turn');
     }
+    const activeAgent = (before.sessionPhaseRuns[sessionId] ?? []).find(
+      (candidate) => candidate.id === activeAgentId,
+    );
+    if (activeAgent?.doneAt != null) {
+      await get().clearAgentDone(sessionId, activeAgentId);
+    }
 
     const userTurnText = content;
 

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -801,7 +801,7 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
       .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'continue' });
 
     expect(useAppStore.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeUndefined();
-    expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_A, false);
+    expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_A, false, null);
   });
 
   it('omits effort from runTurn when no override is set (model default preserved)', async () => {

--- a/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
+++ b/apps/desktop/src/store/store.sendturn-agent-routing.test.ts
@@ -20,6 +20,7 @@ const runTurnSpy = vi.fn();
 const cancelTurnSpy = vi.fn();
 const invokeSpy = vi.fn();
 const invokeAgentUpdateStatusSpy = vi.fn();
+const invokeAgentSetDoneSpy = vi.fn(async () => undefined);
 
 vi.mock('../features/chat/turn', () => ({
   runTurn: (args: unknown) => runTurnSpy(args),
@@ -136,6 +137,7 @@ vi.mock('../features/workflows/workflows', () => ({
   invokeAgentInsert: vi.fn(),
   invokeAgentUpdateStatus: invokeAgentUpdateStatusSpy,
   invokeAgentMarkViewed: vi.fn(async () => undefined),
+  invokeAgentSetDone: invokeAgentSetDoneSpy,
 }));
 
 vi.mock('../features/worktree/worktree', () => ({
@@ -778,6 +780,28 @@ describe('sendTurn, resolver config (provider pin + effort)', () => {
 
     expect(runTurnSpy).toHaveBeenCalledOnce();
     expect(runTurnSpy.mock.calls[0]?.[0]?.effort).toBe('xhigh');
+  });
+
+  it('reopens a done agent before sending its next turn', async () => {
+    const useAppStore = await importStore();
+    setup(useAppStore);
+    useAppStore.setState({
+      sessionPhaseRuns: {
+        [SESSION_ID]: [
+          {
+            ...buildAgent(AGENT_A, 0),
+            doneAt: '2026-07-26T12:00:00.000Z' as IsoDateTime,
+          },
+        ],
+      },
+    });
+
+    await useAppStore
+      .getState()
+      .sendTurn({ sessionId: SESSION_ID, agentId: AGENT_A, content: 'continue' });
+
+    expect(useAppStore.getState().sessionPhaseRuns[SESSION_ID]?.[0]?.doneAt).toBeUndefined();
+    expect(invokeAgentSetDoneSpy).toHaveBeenCalledWith(AGENT_A, false);
   });
 
   it('omits effort from runTurn when no override is set (model default preserved)', async () => {

--- a/apps/desktop/src/store/store.ts
+++ b/apps/desktop/src/store/store.ts
@@ -268,7 +268,7 @@ export type AppActions = {
     override?: TurnProviderOverride;
     onNewAlerts?: (alerts: ReadonlyArray<BudgetAlert>) => void;
   }): Promise<void>;
-  cancelCurrentTurn(sessionId: SessionId): Promise<void>;
+  cancelCurrentTurn(sessionId: SessionId, agentId?: AgentId): Promise<void>;
   retrySummarizer(sessionId: SessionId, taskModelOverride?: TaskModelPreference): void;
   refreshWorkspaceSummary(workspaceId: WorkspaceId): Promise<void>;
   loadSessionTelemetry(sessionId: SessionId): Promise<void>;
@@ -315,6 +315,8 @@ export type AppActions = {
   selectAgent(sessionId: SessionId, agentId: AgentId): Promise<void>;
   deselectAgent(sessionId: SessionId): void;
   markAgentViewed(sessionId: SessionId, agentId: AgentId): Promise<void>;
+  setAgentDone(sessionId: SessionId, agentId: AgentId): Promise<void>;
+  clearAgentDone(sessionId: SessionId, agentId: AgentId): Promise<void>;
   spawnAgent(
     sessionId: SessionId,
     args: {

--- a/apps/desktop/src/store/store.viewed-stamping.test.ts
+++ b/apps/desktop/src/store/store.viewed-stamping.test.ts
@@ -252,6 +252,11 @@ describe('agentHasUnread skipped guard', () => {
     const agent = buildAgent({ status: 'skipped', lastFinishedAt: T2 });
     expect(agentHasUnread(agent, false)).toBe(false);
   });
+
+  it('returns false for a user-completed agent', () => {
+    const agent = buildAgent({ status: 'completed', lastFinishedAt: T2, doneAt: T2 });
+    expect(agentHasUnread(agent, false)).toBe(false);
+  });
 });
 
 describe('selectAgent cascades lastViewedAt to descendants', () => {

--- a/packages/db/src/migrations/index.ts
+++ b/packages/db/src/migrations/index.ts
@@ -77,6 +77,7 @@ import { m076AgentSourceKind } from './m076-agent-source-kind';
 import { m077StepExpectedOutput } from './m077-step-expected-output';
 import { m078WorkflowProcessText } from './m078-workflow-process-text';
 import { m079RoleModels } from './m079-role-models';
+import { m080AgentDone } from './m080-agent-done';
 
 export type Migration = {
   readonly version: number;
@@ -163,4 +164,5 @@ export const migrations: ReadonlyArray<Migration> = [
   { version: 77, sql: m077StepExpectedOutput },
   { version: 78, sql: m078WorkflowProcessText },
   { version: 79, sql: m079RoleModels },
+  { version: 80, sql: m080AgentDone },
 ];

--- a/packages/db/src/migrations/m080-agent-done.ts
+++ b/packages/db/src/migrations/m080-agent-done.ts
@@ -1,0 +1,3 @@
+export const m080AgentDone = `
+ALTER TABLE agents ADD COLUMN done_at TEXT;
+`;

--- a/packages/db/src/queries/agent.ts
+++ b/packages/db/src/queries/agent.ts
@@ -29,6 +29,7 @@ type AgentRow = {
   provider_session_id: string | null;
   last_finished_at: string | null;
   last_viewed_at: string | null;
+  done_at: string | null;
   deleted_at: number | null;
   verbosity: string | null;
   effort: string | null;
@@ -54,6 +55,7 @@ function toAgent(row: AgentRow): Agent {
     ...(row.provider_session_id && { providerSessionId: row.provider_session_id }),
     ...(row.last_finished_at && { lastFinishedAt: row.last_finished_at as IsoDateTime }),
     ...(row.last_viewed_at && { lastViewedAt: row.last_viewed_at as IsoDateTime }),
+    ...(row.done_at && { doneAt: row.done_at as IsoDateTime }),
     ...(row.deleted_at != null && {
       deletedAt: new Date(row.deleted_at).toISOString() as IsoDateTime,
     }),

--- a/packages/types/src/workflow.ts
+++ b/packages/types/src/workflow.ts
@@ -97,6 +97,7 @@ export type Agent = Readonly<{
   providerSessionId?: string;
   lastFinishedAt?: IsoDateTime;
   lastViewedAt?: IsoDateTime;
+  doneAt?: IsoDateTime;
   deletedAt?: IsoDateTime;
   verbosity?: VerbosityLevel;
   effort?: ModelEffort;


### PR DESCRIPTION
## Problema

Il dettaglio di un agent non esisteva come superficie: metriche schiacciate in due righe di lista, CTA sparse tra riga, header e chat, e nessun modo di dire "per me questo agent ha finito" senza cancellarlo.

## Meccanica

- **AgentInspector** (stessa grammatica del ResolverInspector): identitá (kind, status, provider/modello/effort risolti), metriche da `useAgentMetrics` (costo, tokens ↓↑, context bar, turni, durata), azioni canoniche (mark done / reopen, interrupt, delete con `ConfirmableButton`).
- **Layout**: overlay agents = `[lista w-72][chat][inspector w-80]`, identico a resolve. Nella lens, il bottone Details apre l'inspector via `InspectorSplit`; il click sulla riga continua ad aprire la chat.
- **Done state**: colonna `agents.done_at` (m080), comando `agent_set_done`, azioni store `setAgentDone`/`clearAgentDone`. Done = de-enfatizzato e raggruppato in "Done (N)" collassato, escluso da count della lens e dot unread. `sendTurn` verso un agent done lo riapre automaticamente; guardarlo no. Nessuna eviction: non é né delete né archive.
- `cancelCurrentTurn` accetta un agentId opzionale cosí l'inspector interrompe senza cambiare la selezione chat (retrocompatibile).

## Verifica

- typecheck, 328 file / 2662 test JS e `cargo test --locked` verdi in locale.
- Test nuovi: registry migration a 80 con convergenza, set/clear + auto-clear su sendTurn, matrice render/azioni dell'inspector, partizione Done, esclusione count/unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)