### PR TITLE
refactor(desktop): flatten card-in-card surfaces

### DIFF
--- a/apps/desktop/src/features/github/components/GitHubStudio/PrSidebar.tsx
+++ b/apps/desktop/src/features/github/components/GitHubStudio/PrSidebar.tsx
@@ -235,7 +235,7 @@ function ReviewerPicker({
       </button>
       {open ? (
         <div className="absolute right-0 top-6 z-10 flex w-52 flex-col gap-1 rounded-md border border-border-soft bg-background p-1.5 shadow-lg">
-          <div className="flex items-center gap-1.5 rounded border border-border-soft px-1.5 py-1">
+          <div className="flex items-center gap-1.5 px-1.5 py-1">
             <Search size={12} aria-hidden className="shrink-0 text-muted-foreground" />
             <input
               autoFocus

--- a/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
+++ b/apps/desktop/src/features/integrations/components/LaunchSessionPanel/index.tsx
@@ -176,7 +176,6 @@ export const LaunchSessionPanel = ({
           maxRows={10}
           disabled={busy}
           aria-label="Session goal"
-          className="rounded-lg bg-subtle/80 px-3 py-2.5 ring-1 ring-border-soft focus-visible:ring-foreground/15"
         />
       </LaunchField>
 
@@ -184,7 +183,7 @@ export const LaunchSessionPanel = ({
         label="Branch"
         icon={<GitBranch size={13} aria-hidden className="text-success" />}
       >
-        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-muted/10 p-3">
+        <div className="flex flex-col gap-2">
           {adoptable != null && (
             <SegmentedTabs
               ariaLabel="branch source"

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.test.tsx
@@ -115,6 +115,7 @@ const makeMr = ({
 beforeEach(() => {
   h.gitlabMergeMr.mockClear();
   h.store.refreshSessionMr.mockClear();
+  h.store.createMrForSession.mockClear();
   h.store.spawnAgent.mockClear();
   h.store.selectAgent.mockClear();
   h.store.setCurrentSession.mockClear();
@@ -125,6 +126,29 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('MrDetailPanel', () => {
+  it('creates an MR from the form footer', async () => {
+    render(<MrDetailPanel sessionId={SESSION_ID} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByRole('textbox', { name: 'Merge request title' }), {
+      target: { value: 'Ship the GitLab release' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Merge request description' }), {
+      target: { value: 'Documents the release changes.' },
+    });
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target branch' }), {
+      target: { value: 'develop' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create MR' }));
+
+    await waitFor(() =>
+      expect(h.store.createMrForSession).toHaveBeenCalledWith(SESSION_ID, {
+        title: 'Ship the GitLab release',
+        description: 'Documents the release changes.',
+        targetBranch: 'develop',
+        draft: true,
+      }),
+    );
+  });
+
   it('spawns an MR agent with the chosen config and operator notes', async () => {
     const onClose = vi.fn();
     render(<MrDetailPanel sessionId={SESSION_ID} onClose={onClose} />);

--- a/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/gitlab/GitlabStudio/MrDetailPanel.tsx
@@ -1,5 +1,14 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button, EmptyState, Input, Markdown, SectionHeader, Textarea, cn } from '@goodboy/ui';
+import {
+  Button,
+  Divider,
+  EmptyState,
+  Input,
+  Markdown,
+  SectionHeader,
+  Textarea,
+  cn,
+} from '@goodboy/ui';
 import {
   AlertTriangle,
   ArrowRight,
@@ -313,42 +322,39 @@ export const MrDetailPanel = ({
         }
       >
         {mr.hasConflicts || mr.state === 'opened' ? (
-          <DetailSection label="merge status">
-            <div className="flex flex-col gap-3">
-              {mr.hasConflicts ? (
-                <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5 text-2xs leading-relaxed text-foreground">
-                  <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
-                  <span>
-                    This merge request has conflicts that must be resolved before merging.
-                  </span>
-                </div>
-              ) : null}
-              {mr.state === 'opened' ? (
-                <div className="flex items-center gap-3">
-                  <span className="flex-1" />
-                  <Button
-                    onClick={() => void onMerge()}
-                    disabled={
-                      busy !== null ||
-                      mr.hasConflicts ||
-                      mr.mergeStatus === 'cannot_be_merged' ||
-                      (sessionId == null && mergeProjectPath == null)
-                    }
-                    className={busy === 'merge' ? 'animate-border-pulse' : undefined}
-                  >
-                    {busy === 'merge' ? (
-                      'Merging…'
-                    ) : (
-                      <>
-                        <GitMerge size={13} className="mr-1.5" aria-hidden />
-                        Merge request
-                      </>
-                    )}
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          </DetailSection>
+          <section className="flex flex-col gap-3">
+            <SectionHeader label="merge status" />
+            {mr.hasConflicts ? (
+              <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2.5 text-2xs leading-relaxed text-foreground">
+                <AlertTriangle size={12} aria-hidden className="mt-0.5 shrink-0 text-warning" />
+                <span>This merge request has conflicts that must be resolved before merging.</span>
+              </div>
+            ) : null}
+            {mr.state === 'opened' ? (
+              <div className="flex items-center gap-3">
+                <span className="flex-1" />
+                <Button
+                  onClick={() => void onMerge()}
+                  disabled={
+                    busy !== null ||
+                    mr.hasConflicts ||
+                    mr.mergeStatus === 'cannot_be_merged' ||
+                    (sessionId == null && mergeProjectPath == null)
+                  }
+                  className={busy === 'merge' ? 'animate-border-pulse' : undefined}
+                >
+                  {busy === 'merge' ? (
+                    'Merging…'
+                  ) : (
+                    <>
+                      <GitMerge size={13} className="mr-1.5" aria-hidden />
+                      Merge request
+                    </>
+                  )}
+                </Button>
+              </div>
+            ) : null}
+          </section>
         ) : null}
 
         <DetailSection label="description">
@@ -384,52 +390,55 @@ export const MrDetailPanel = ({
     >
       {session != null && sessionId != null ? (
         <section className="flex flex-col gap-4">
-          <div className="flex flex-col gap-4 rounded-lg border border-border-soft bg-muted/10 p-4">
-            <div className="flex flex-col gap-1.5">
-              <SectionHeader label="title" />
-              <Input
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                disabled={busy !== null}
-                aria-label="Merge request title"
-                className="h-8 text-sm"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <SectionHeader label="description" />
-              <Textarea
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                autoGrow
-                minRows={3}
-                maxRows={10}
-                disabled={busy !== null}
-                aria-label="Merge request description"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <SectionHeader label="target branch" icon={<GitBranch size={13} aria-hidden />} />
-              <Input
-                value={targetBranch}
-                onChange={(e) => setTargetBranch(e.target.value)}
-                placeholder="main"
-                className="h-8 font-mono text-sm"
-                disabled={busy !== null}
-                autoCapitalize="off"
-                autoCorrect="off"
-                spellCheck={false}
-                aria-label="Target branch"
-              />
-            </div>
-            <AgentSpawnConfig
-              value={agentConfig}
-              onChange={(value) => {
-                setAgentConfigUserTouched(true);
-                setAgentConfig(value);
-              }}
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader label="title" />
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
               disabled={busy !== null}
+              aria-label="Merge request title"
+              className="h-8 text-sm"
             />
-            <div className="flex items-center gap-3 pt-1">
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader label="description" />
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              autoGrow
+              minRows={3}
+              maxRows={10}
+              disabled={busy !== null}
+              aria-label="Merge request description"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <SectionHeader label="target branch" icon={<GitBranch size={13} aria-hidden />} />
+            <Input
+              value={targetBranch}
+              onChange={(e) => setTargetBranch(e.target.value)}
+              placeholder="main"
+              className="h-8 font-mono text-sm"
+              disabled={busy !== null}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              aria-label="Target branch"
+            />
+          </div>
+          <AgentSpawnConfig
+            value={agentConfig}
+            onChange={(value) => {
+              setAgentConfigUserTouched(true);
+              setAgentConfig(value);
+            }}
+            disabled={busy !== null}
+          />
+
+          <Divider />
+
+          <footer className="flex shrink-0 items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
               <label className="flex cursor-pointer items-center gap-2 text-xs text-muted-foreground">
                 <input
                   type="checkbox"
@@ -440,7 +449,13 @@ export const MrDetailPanel = ({
                 />
                 Mark as draft
               </label>
-              <span className="flex-1" />
+              {error != null ? (
+                <span role="alert" className="text-xs text-danger">
+                  {error}
+                </span>
+              ) : null}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
               <Button
                 variant="secondary"
                 onClick={() => void onCreateWithAi()}
@@ -466,8 +481,7 @@ export const MrDetailPanel = ({
                 )}
               </Button>
             </div>
-            {error ? <span className="text-xs text-danger">{error}</span> : null}
-          </div>
+          </footer>
         </section>
       ) : null}
     </StudioDetailLayout>

--- a/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/linear/LinearStudio/IssueDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Divider, EmptyState, Markdown, cn } from '@goodboy/ui';
+import { Divider, EmptyState, Markdown, SectionHeader, cn } from '@goodboy/ui';
 import { ExternalLink, GitPullRequest, MousePointerClick } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import { useAppStore } from '../../../../store';
@@ -233,9 +233,10 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
         )}
       </DetailSection>
 
-      <DetailSection label="comments">
+      <section className="flex flex-col gap-3">
+        <SectionHeader label="comments" />
         <LinearIssueComments workspaceId={workspaceId} issueId={issue.id} />
-      </DetailSection>
+      </section>
     </StudioDetailLayout>
   );
 };

--- a/apps/desktop/src/features/integrations/sentry/SentryBreadcrumbs/index.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryBreadcrumbs/index.tsx
@@ -13,11 +13,11 @@ export const SentryBreadcrumbs = ({ breadcrumbs, isLoading, error }: Props) => {
   }
 
   return (
-    <details className="rounded-lg border border-border-soft bg-muted/10">
-      <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-foreground">
+    <details className="flex flex-col gap-2">
+      <summary className="cursor-pointer text-xs font-medium text-foreground">
         Breadcrumbs ({breadcrumbs.length})
       </summary>
-      <div className="flex flex-col gap-2 px-3 pb-3">
+      <div className="flex flex-col gap-2">
         {breadcrumbs.map((breadcrumb, index) => {
           const relativeDate =
             breadcrumb.timestamp == null ? '' : formatRelativeDuration(breadcrumb.timestamp);

--- a/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
+++ b/apps/desktop/src/features/integrations/sentry/SentryStudio/IssueDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { Divider, EmptyState, StatCard, cn } from '@goodboy/ui';
+import { Divider, EmptyState, SectionHeader, StatCard, cn } from '@goodboy/ui';
 import { ExternalLink, Layers, MousePointerClick } from 'lucide-react';
 import type { SessionId, WorkspaceId } from '@goodboy/types';
 import {
@@ -143,12 +143,13 @@ export const IssueDetailPanel = ({ issue, sessionId, workspaceId, onClose }: Pro
         </div>
       ) : null}
 
-      <DetailSection
-        label="stack trace"
-        icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
-      >
+      <section className="flex flex-col gap-3">
+        <SectionHeader
+          label="stack trace"
+          icon={<Layers size={13} aria-hidden className="text-muted-foreground" />}
+        />
         <SentryStackTrace frames={frames} isLoading={detailLoading} error={detailError} />
-      </DetailSection>
+      </section>
 
       <SentryBreadcrumbs breadcrumbs={breadcrumbs} isLoading={detailLoading} error={detailError} />
     </StudioDetailLayout>

--- a/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
+++ b/apps/desktop/src/features/providers/components/ProviderStudio/ProviderCredentialsSection.tsx
@@ -104,7 +104,7 @@ export const ProviderCredentialsSection = ({ providerId }: Props) => {
       )}
 
       {adding ? (
-        <div className="flex flex-col gap-2 rounded-lg border border-border-soft bg-muted/20 p-3">
+        <div className="flex flex-col gap-2">
           <Input
             autoFocus
             value={label}

--- a/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
+++ b/apps/desktop/src/features/review/components/ReviewBoardPane/LineComposer.tsx
@@ -12,8 +12,8 @@ export const LineComposer = ({ label, onSubmit, onCancel }: Props) => {
   const [body, setBody] = useState('');
   const trimmed = body.trim();
   return (
-    <div className="flex gap-2 rounded-md border border-border-soft bg-background px-2 py-1.5">
-      <MessageSquarePlus size={13} aria-hidden className="mt-0.5 shrink-0 text-indigo-500" />
+    <div className="flex gap-2">
+      <MessageSquarePlus size={13} aria-hidden className="shrink-0 text-indigo-500" />
       <div className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="text-[10px] font-medium text-muted-foreground">{label}</span>
         <Textarea

--- a/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
+++ b/apps/desktop/src/features/scripts/components/ScriptsPanel/index.tsx
@@ -226,7 +226,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
                 />
               </div>
               {logOpen && result ? (
-                <pre className="m-0 max-h-60 overflow-auto whitespace-pre-wrap break-all border-t border-border-soft bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/80">
+                <pre className="m-0 max-h-60 overflow-auto whitespace-pre-wrap break-all bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/80">
                   {result.stdout}
                   {result.stderr ? (
                     <span className="text-danger">
@@ -237,7 +237,7 @@ export const ScriptsPanel = ({ workspaceId, sessionId, worktreePath }: Props) =>
                   {!result.stdout && !result.stderr ? '(no output)' : null}
                 </pre>
               ) : (
-                <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all border-t border-border-soft bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/75">
+                <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all bg-subtle/40 px-3 py-2 font-mono text-2xs leading-relaxed text-foreground/75">
                   {script.body}
                 </pre>
               )}
@@ -318,7 +318,7 @@ function ScriptEditor({
   onCancel: () => void;
 }) {
   return (
-    <div className="flex flex-col gap-2 rounded-md border border-primary/40 bg-subtle/50 p-2.5">
+    <div className="flex flex-col gap-2">
       <Input
         value={draft.name}
         onChange={(e) => setDraft({ ...draft, name: e.target.value })}

--- a/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
+++ b/apps/desktop/src/features/workflows/components/LibraryStepForm/index.tsx
@@ -103,7 +103,7 @@ export const LibraryStepForm = ({
   };
 
   return (
-    <div className="flex flex-col gap-2.5 rounded-lg border border-primary/40 bg-background p-3">
+    <div className="flex flex-col gap-2.5">
       <div className="flex items-center gap-2">
         <Input
           value={name}


### PR DESCRIPTION
## Problema

Card dentro card su tutte le superfici di dettaglio: contenuti giá self-boxed (pre, tiles, Input/Textarea) annidati in wrapper con bordo e sfondo, in violazione della One creation grammar (DESIGN.md) e della regola dividers-not-borders (docs/styling.md).

## Meccanica

12 offender verificati e appiattiti, in due passate (8 dall'audit + 4 dalla sweep repo-wide):

- Sentry: stack trace e breadcrumbs come sezioni bare (il pre e il disclosure tengono la propria forma, cade il box esterno).
- Linear: comment tiles fuori dal box DetailSection.
- LaunchSessionPanel: via il box attorno al campo branch (l'Input é giá self-bordered), un solo outline sulla goal textarea.
- GitLab: warning merge-status bare; il form New merge request riallineato alla grammatica di CreatePrPanel (campi bare, Divider, un footer).
- Review LineComposer, ProviderCredentialsSection, ScriptsPanel (editor + preview), reviewer popover di PrSidebar: un layer ridondante in meno ciascuno.

Risparmiati di proposito: icon tiles, StatCard, card del transcript chat e DraftCard (decisioni giá prese).

## Verifica

typecheck e 328 file / 2663 test verdi in locale. Zero cambi comportamentali: i test dei pane (role/text based) passano invariati tranne l'aggiornamento strutturale del form MR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)