### PR TITLE
refactor(desktop): settings single page

### DIFF
--- a/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/AppScopePanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
-import { DollarSign, RotateCcw } from 'lucide-react';
-import { Button, cn, FieldRow, KbdPill, ScrollFade, Select } from '@goodboy/ui';
+import { RotateCcw } from 'lucide-react';
+import { Button, cn, Divider, FieldRow, ScrollFade, SectionHeader, Select } from '@goodboy/ui';
 import { GithubPanel } from '../../../../features/github/components/Panel';
 import { ImportConfigDialog } from '../ImportConfigDialog';
 import type { ConfigBundleImportResult } from '@goodboy/types';
@@ -8,54 +8,18 @@ import {
   DEFAULT_EDITOR_BINARY,
   SETTING_EDITOR_BINARY,
 } from '../../../../features/settings/settings';
-import { SESSION_FEATURES } from '../../../../shared/lib/features';
 import { reopenWizard } from '../../../onboarding/onboarding-store';
 import { formatError } from '../../../../shared/lib/errors';
 import { useToast } from '../../../../app/components/Toast';
 import { useAppStore } from '../../../../store';
+import { ShortcutsSection } from './ShortcutsSection';
 
 type Props = {
   readonly initialSection?: string;
   readonly requestClose: () => void;
-  readonly registerScrollTo?: (fn: (id: string) => void) => void;
 };
 
-const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly label: string }> = [
-  { combo: ['⌘', 'K'], label: 'command palette' },
-  { combo: ['⌘', 'N'], label: 'new session' },
-  { combo: ['⌘', 'B'], label: 'toggle sessions sidebar' },
-  { combo: ['⌘', '1', '..', '9'], label: 'jump to workspace 1 to 9' },
-  { combo: ['⌘', '['], label: 'back (lens history)' },
-  { combo: ['⌘', ']'], label: 'forward (lens history)' },
-  { combo: ['⌘', '⇧', '['], label: 'previous session' },
-  { combo: ['⌘', '⇧', ']'], label: 'next session' },
-  { combo: ['⌘', '⇧', 'K'], label: 'open model picker' },
-  { combo: ['⌘', '⇧', 'P'], label: 'open permission picker' },
-  { combo: ['⌘', 'J'], label: 'toggle terminal' },
-  { combo: ['⌘', 'T'], label: 'new terminal tab' },
-  { combo: ['⌘', 'W'], label: 'close terminal tab' },
-  { combo: ['⌘', '⇧', 'G'], label: 'jump to goal' },
-  { combo: ['⌘', '⇧', 'W'], label: 'jump to workflows' },
-  { combo: ['⌘', '⇧', 'B'], label: 'jump to agents' },
-  { combo: ['⌘', '⇧', 'R'], label: 'jump to resolve' },
-  { combo: ['⌘', '⇧', 'D'], label: 'jump to diff' },
-  { combo: ['⌘', '⇧', 'L'], label: 'jump to plans' },
-  { combo: ['⌘', '⇧', 'S'], label: 'jump to scripts' },
-  { combo: ['⌘', '⇧', 'Q'], label: 'jump to questions' },
-  { combo: ['⌘', '⇧', 'O'], label: 'jump to overview' },
-  { combo: ['⌘', '⇧', 'H'], label: 'jump to GitHub or GitLab' },
-  { combo: ['⌘', '⇧', 'E'], label: 'jump to decisions' },
-  { combo: ['⌘', '⇧', 'U'], label: 'jump to session summary' },
-  { combo: ['⌘', '⇧', '⎋'], label: 'back to board' },
-  { combo: ['⌘', '↵'], label: 'send message (queue if running)' },
-  { combo: ['⌘', '⇧', 'A'], label: 'archive current session' },
-  { combo: ['⌘', '.'], label: 'delete current session' },
-  { combo: ['⌘', ','], label: 'open settings' },
-  { combo: ['⌘', '/'], label: 'keyboard shortcuts' },
-  { combo: ['Esc'], label: 'close dialog or cancel' },
-];
-
-export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }: Props) => {
+export const AppScopePanel = ({ initialSection, requestClose }: Props) => {
   const loadSetting = useAppStore((s) => s.loadSetting);
   const saveSetting = useAppStore((s) => s.saveSetting);
   const exportConfig = useAppStore((s) => s.exportConfig);
@@ -81,7 +45,7 @@ export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }
   );
   const [wipeError, setWipeError] = useState<string | null>(null);
 
-  const anchorsRef = useRef<Record<string, HTMLDivElement | null>>({});
+  const anchorsRef = useRef<Record<string, HTMLElement | null>>({});
 
   useEffect(() => {
     void loadSetting(SETTING_EDITOR_BINARY).then((v) =>
@@ -90,17 +54,11 @@ export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }
   }, [loadSetting]);
 
   useEffect(() => {
-    if (!initialSection) {
+    if (initialSection == null || initialSection === '') {
       return;
     }
     anchorsRef.current[initialSection]?.scrollIntoView({ block: 'start' });
   }, [initialSection]);
-
-  useEffect(() => {
-    registerScrollTo?.((id) =>
-      anchorsRef.current[id]?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-    );
-  }, [registerScrollTo]);
 
   const onExport = async () => {
     setExportState('busy');
@@ -155,89 +113,71 @@ export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }
     ? detectedEditors
     : [...detectedEditors, { binary: editorBinary, label: editorBinary }];
 
-  const anchor = (id: string) => (el: HTMLDivElement | null) => {
+  const anchor = (id: string) => (el: HTMLElement | null) => {
     anchorsRef.current[id] = el;
   };
 
   return (
     <ScrollFade className="h-full w-full" viewportClassName="px-5 py-5">
       <div className="mx-auto flex w-full max-w-2xl flex-col">
-        <div className="flex flex-col divide-y divide-border-soft/50">
-          <div ref={anchor('editor')} className="py-4 first:pt-0 last:pb-0">
-            <FieldRow label="Default editor" help="Opens session worktrees.">
-              <Select
-                size="sm"
-                value={editorBinary}
-                onChange={(e) => void onChangeEditor(e.target.value)}
-                aria-label="default editor"
-              >
-                {editorOptions.map((ed) => (
-                  <option key={ed.binary} value={ed.binary}>
-                    {ed.label}
-                  </option>
-                ))}
-              </Select>
-            </FieldRow>
+        <div className="flex flex-col gap-6">
+          <section id="editor" ref={anchor('editor')} className="flex flex-col gap-4">
+            <SectionHeader label="Editor" hint="Default tools and first-run preferences." />
+            <div className="flex flex-col">
+              <FieldRow label="Default editor" help="Opens session worktrees.">
+                <Select
+                  size="sm"
+                  value={editorBinary}
+                  onChange={(e) => void onChangeEditor(e.target.value)}
+                  aria-label="default editor"
+                >
+                  {editorOptions.map((editor) => (
+                    <option key={editor.binary} value={editor.binary}>
+                      {editor.label}
+                    </option>
+                  ))}
+                </Select>
+              </FieldRow>
 
-            <FieldRow label="Setup guide" help="Replay the first-run walkthrough.">
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={() => {
-                  requestClose();
-                  reopenWizard();
-                }}
-              >
-                <RotateCcw size={14} aria-hidden /> Run setup again
-              </Button>
-            </FieldRow>
-          </div>
-
-          {SESSION_FEATURES.budget ? (
-            <div ref={anchor('budget')} className="py-4 first:pt-0 last:pb-0">
-              <FieldRow label="Budget" help="Spend, caps, and alerts live in Budget Studio.">
+              <FieldRow label="Setup guide" help="Replay the first-run walkthrough.">
                 <Button
                   variant="secondary"
                   size="sm"
                   onClick={() => {
                     requestClose();
-                    window.dispatchEvent(new CustomEvent('goodboy:open-budget-studio'));
+                    reopenWizard();
                   }}
                 >
-                  <DollarSign size={14} aria-hidden /> Open Budget Studio
+                  <RotateCcw size={14} aria-hidden /> Run setup again
                 </Button>
               </FieldRow>
             </div>
-          ) : null}
+          </section>
 
-          <div ref={anchor('shortcuts')} className="py-4 first:pt-0 last:pb-0">
-            <FieldRow label="Keyboard shortcuts" layout="stacked">
-              <ul className="grid grid-cols-2 gap-x-10">
-                {SHORTCUTS.map((s) => (
-                  <li key={s.label} className="flex items-center justify-between py-1.5 text-xs">
-                    <span className="text-muted-foreground">{s.label}</span>
-                    <span className="flex items-center gap-0.5">
-                      {s.combo.map((k) => (
-                        <KbdPill key={k}>{k}</KbdPill>
-                      ))}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </FieldRow>
-          </div>
+          <Divider />
 
-          <div ref={anchor('integrations')} className="py-4 first:pt-0 last:pb-0">
-            <FieldRow label="GitHub" layout="stacked">
-              <GithubPanel hideSectionHeader />
-            </FieldRow>
-          </div>
+          <section id="shortcuts" ref={anchor('shortcuts')}>
+            <ShortcutsSection initiallyExpanded={initialSection === 'shortcuts'} />
+          </section>
 
-          <div ref={anchor('advanced')} className="py-4 first:pt-0 last:pb-0">
-            <FieldRow
+          <Divider />
+
+          <section id="integrations" ref={anchor('integrations')} className="flex flex-col gap-4">
+            <SectionHeader label="GitHub" hint="Global fallback token used by every workspace." />
+            <GithubPanel hideSectionHeader />
+            <p className="text-2xs text-muted-foreground">
+              Per-workspace overrides live in Workspace settings, Integrations.
+            </p>
+          </section>
+
+          <Divider />
+
+          <section id="advanced" ref={anchor('advanced')} className="flex flex-col gap-4">
+            <SectionHeader
               label="Config backup"
-              help="Export or import workspaces, skills, workflows, rules, and settings as JSON. API keys are never included."
-            >
+              hint="Export or import workspaces, skills, workflows, rules, and settings as JSON."
+            />
+            <FieldRow label="Backup file" help="API keys are never included.">
               <span className="flex items-center gap-2">
                 <Button
                   variant="secondary"
@@ -257,9 +197,16 @@ export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }
                 </Button>
               </span>
             </FieldRow>
-          </div>
+          </section>
 
-          <div ref={anchor('initialization')} className="py-4 first:pt-0 last:pb-0">
+          <Divider />
+
+          <section
+            id="initialization"
+            ref={anchor('initialization')}
+            className="flex flex-col gap-4"
+          >
+            <SectionHeader label="Danger zone" hint="Destructive local data controls." />
             <FieldRow
               label="Wipe local database"
               help="Every workspace, session, transcript, and rule. Keychain keys are untouched. Fresh schema on next boot."
@@ -301,8 +248,8 @@ export const AppScopePanel = ({ initialSection, requestClose, registerScrollTo }
                 </Button>
               )}
             </FieldRow>
-            {wipeError ? <p className="pt-2 text-xs text-danger">{wipeError}</p> : null}
-          </div>
+            {wipeError ? <p className="text-xs text-danger">{wipeError}</p> : null}
+          </section>
         </div>
       </div>
 

--- a/apps/desktop/src/features/settings/components/SettingsStudio/ShortcutsSection.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/ShortcutsSection.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { KbdPill, SectionHeader } from '@goodboy/ui';
+
+type Props = {
+  readonly initiallyExpanded: boolean;
+};
+
+const SHORTCUTS: ReadonlyArray<{ readonly combo: readonly string[]; readonly label: string }> = [
+  { combo: ['⌘', 'K'], label: 'command palette' },
+  { combo: ['⌘', 'O'], label: 'open workspace switcher' },
+  { combo: ['⌘', 'N'], label: 'new session' },
+  { combo: ['⌘', 'B'], label: 'toggle sessions sidebar' },
+  { combo: ['⌘', '1', '..', '9'], label: 'jump to workspace 1 to 9' },
+  { combo: ['⌘', '['], label: 'back (lens history)' },
+  { combo: ['⌘', ']'], label: 'forward (lens history)' },
+  { combo: ['⌘', '⇧', '['], label: 'previous session' },
+  { combo: ['⌘', '⇧', ']'], label: 'next session' },
+  { combo: ['⌘', '⇧', 'K'], label: 'open model picker' },
+  { combo: ['⌘', '⇧', 'P'], label: 'open permission picker' },
+  { combo: ['⌘', 'J'], label: 'toggle terminal' },
+  { combo: ['⌘', 'T'], label: 'new terminal tab' },
+  { combo: ['⌘', 'W'], label: 'close terminal tab' },
+  { combo: ['⌘', '⇧', 'G'], label: 'jump to goal' },
+  { combo: ['⌘', '⇧', 'W'], label: 'jump to workflows' },
+  { combo: ['⌘', '⇧', 'B'], label: 'jump to agents' },
+  { combo: ['⌘', '⇧', 'R'], label: 'jump to resolve' },
+  { combo: ['⌘', '⇧', 'D'], label: 'jump to diff' },
+  { combo: ['⌘', '⇧', 'L'], label: 'jump to plans' },
+  { combo: ['⌘', '⇧', 'S'], label: 'jump to scripts' },
+  { combo: ['⌘', '⇧', 'Q'], label: 'jump to questions' },
+  { combo: ['⌘', '⇧', 'O'], label: 'jump to overview' },
+  { combo: ['⌘', '⇧', 'H'], label: 'jump to GitHub or GitLab' },
+  { combo: ['⌘', '⇧', 'E'], label: 'jump to decisions' },
+  { combo: ['⌘', '⇧', 'U'], label: 'jump to session summary' },
+  { combo: ['⌘', '⇧', '⎋'], label: 'back to board' },
+  { combo: ['⌘', '↵'], label: 'send message (queue if running)' },
+  { combo: ['⌘', '⇧', 'A'], label: 'archive current session' },
+  { combo: ['⌘', '.'], label: 'delete current session' },
+  { combo: ['⌘', ','], label: 'open settings' },
+  { combo: ['⌘', '/'], label: 'keyboard shortcuts' },
+  { combo: ['Esc'], label: 'close dialog or cancel' },
+];
+
+export const ShortcutsSection = ({ initiallyExpanded }: Props) => {
+  const [isExpanded, setIsExpanded] = useState(initiallyExpanded);
+
+  useEffect(() => {
+    if (initiallyExpanded) {
+      setIsExpanded(true);
+    }
+  }, [initiallyExpanded]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SectionHeader
+        label="Shortcuts"
+        action={
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            aria-expanded={isExpanded}
+            aria-controls="keyboard-shortcuts-list"
+            aria-label={isExpanded ? 'Collapse keyboard shortcuts' : 'Expand keyboard shortcuts'}
+            className="inline-flex items-center gap-2 rounded-md px-2 py-1 text-2xs font-medium text-muted-foreground motion-safe:transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <span className="rounded-full bg-muted px-2 py-0.5">{SHORTCUTS.length} shortcuts</span>
+            {isExpanded ? (
+              <ChevronDown size={13} aria-hidden />
+            ) : (
+              <ChevronRight size={13} aria-hidden />
+            )}
+          </button>
+        }
+      />
+      {isExpanded ? (
+        <ul id="keyboard-shortcuts-list" className="grid grid-cols-2 gap-x-10 gap-y-3">
+          {SHORTCUTS.map((shortcut) => (
+            <li key={shortcut.label} className="flex items-center justify-between gap-4 text-xs">
+              <span className="text-muted-foreground">{shortcut.label}</span>
+              <span className="flex items-center gap-0.5">
+                {shortcut.combo.map((key) => (
+                  <KbdPill key={key}>{key}</KbdPill>
+                ))}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/desktop/src/features/settings/components/SettingsStudio/index.test.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/index.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+
+const { scrollIntoViewMock, state, toastMock } = vi.hoisted(() => ({
+  scrollIntoViewMock: vi.fn(),
+  state: {
+    loadSetting: vi.fn(async () => null),
+    saveSetting: vi.fn(async () => undefined),
+    exportConfig: vi.fn(async () => null),
+    importConfig: vi.fn(async () => null),
+    wipeLocalDatabase: vi.fn(async () => undefined),
+    loadDetectedEditors: vi.fn(async () => undefined),
+    detectedEditors: [] as ReadonlyArray<{ binary: string; label: string }>,
+  },
+  toastMock: vi.fn(),
+}));
+
+vi.mock('../../../../store', () => ({
+  useAppStore: <T,>(selector: (store: typeof state) => T) => selector(state),
+}));
+
+vi.mock('../../../../app/components/Toast', () => ({
+  useToast: () => ({ showToast: toastMock }),
+}));
+
+vi.mock('../../../../features/github/components/Panel', () => ({
+  GithubPanel: () => <div>GitHub token controls</div>,
+}));
+
+vi.mock('../ImportConfigDialog', () => ({
+  ImportConfigDialog: () => null,
+}));
+
+vi.mock('../../../onboarding/onboarding-store', () => ({
+  reopenWizard: vi.fn(),
+}));
+
+import { SettingsStudio } from './index';
+
+beforeEach(() => {
+  Object.defineProperty(Element.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: scrollIntoViewMock,
+  });
+  scrollIntoViewMock.mockReset();
+  state.loadSetting.mockClear();
+  state.loadDetectedEditors.mockClear();
+  toastMock.mockReset();
+});
+
+afterEach(cleanup);
+
+describe('SettingsStudio', () => {
+  it('renders all settings sections without a navigation rail', () => {
+    render(<SettingsStudio onClose={vi.fn()} />);
+
+    expect(
+      ['Editor', 'Shortcuts', 'GitHub', 'Config backup', 'Danger zone'].map(
+        (label) => screen.getByText(label).textContent,
+      ),
+    ).toEqual(['Editor', 'Shortcuts', 'GitHub', 'Config backup', 'Danger zone']);
+    expect(screen.queryByRole('navigation', { name: /settings sections/i })).toBeNull();
+  });
+
+  it('collapses shortcuts by default', () => {
+    render(<SettingsStudio onClose={vi.fn()} />);
+
+    const toggle = screen.getByRole('button', { name: /expand keyboard shortcuts/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.getByText('33 shortcuts')).toBeDefined();
+    expect(screen.queryByText('command palette')).toBeNull();
+    fireEvent.click(toggle);
+    expect(screen.getByText('command palette')).toBeDefined();
+  });
+
+  it('expands and scrolls to shortcuts when focused', () => {
+    render(<SettingsStudio initialFocus="shortcuts" onClose={vi.fn()} />);
+
+    expect(
+      screen
+        .getByRole('button', { name: /collapse keyboard shortcuts/i })
+        .getAttribute('aria-expanded'),
+    ).toBe('true');
+    expect(screen.getByText('command palette')).toBeDefined();
+    expect(scrollIntoViewMock.mock.contexts.at(-1)).toBe(document.getElementById('shortcuts'));
+  });
+
+  it('explains the scope of the GitHub token', () => {
+    render(<SettingsStudio onClose={vi.fn()} />);
+
+    expect(screen.getByText('Global fallback token used by every workspace.')).toBeDefined();
+    expect(
+      screen.getByText('Per-workspace overrides live in Workspace settings, Integrations.'),
+    ).toBeDefined();
+  });
+
+  it.each(['editor', 'integrations', 'advanced', 'initialization'])(
+    'resolves the %s deep link',
+    (section) => {
+      render(<SettingsStudio initialFocus={section} onClose={vi.fn()} />);
+
+      expect(scrollIntoViewMock.mock.contexts.at(-1)).toBe(document.getElementById(section));
+    },
+  );
+});

--- a/apps/desktop/src/features/settings/components/SettingsStudio/index.tsx
+++ b/apps/desktop/src/features/settings/components/SettingsStudio/index.tsx
@@ -1,6 +1,4 @@
-import { useRef, useState, type ReactNode } from 'react';
-import { AlertTriangle, Archive, Keyboard, Plug, Settings, SlidersHorizontal } from 'lucide-react';
-import { cn, Divider } from '@goodboy/ui';
+import { Settings } from 'lucide-react';
 import { StudioShell } from '../../../../shared/components/StudioShell';
 import { AppScopePanel } from './AppScopePanel';
 
@@ -9,31 +7,7 @@ type Props = {
   readonly onClose: () => void;
 };
 
-type NavItem = {
-  readonly id: string;
-  readonly label: string;
-  readonly icon: ReactNode;
-};
-
-const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { id: 'editor', label: 'Editor', icon: <SlidersHorizontal size={13} aria-hidden /> },
-  { id: 'shortcuts', label: 'Shortcuts', icon: <Keyboard size={13} aria-hidden /> },
-  { id: 'integrations', label: 'Integrations', icon: <Plug size={13} aria-hidden /> },
-  { id: 'advanced', label: 'Config backup', icon: <Archive size={13} aria-hidden /> },
-  { id: 'initialization', label: 'Danger zone', icon: <AlertTriangle size={13} aria-hidden /> },
-];
-
 export const SettingsStudio = ({ initialFocus, onClose }: Props) => {
-  const scrollToRef = useRef<(id: string) => void>(() => {});
-  const [active, setActive] = useState(() =>
-    NAV_ITEMS.some((i) => i.id === initialFocus) ? (initialFocus as string) : NAV_ITEMS[0]!.id,
-  );
-
-  const jump = (id: string) => {
-    setActive(id);
-    scrollToRef.current(id);
-  };
-
   return (
     <StudioShell
       icon={Settings}
@@ -43,39 +17,8 @@ export const SettingsStudio = ({ initialFocus, onClose }: Props) => {
       onClose={onClose}
     >
       {(requestClose) => (
-        <div className="flex min-h-0 flex-1">
-          <nav
-            aria-label="settings sections"
-            className="flex w-52 shrink-0 flex-col gap-1 bg-subtle/40 p-3"
-          >
-            {NAV_ITEMS.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                onClick={() => jump(item.id)}
-                aria-current={active === item.id ? 'true' : undefined}
-                className={cn(
-                  'relative flex items-center gap-2 rounded-md py-2 pl-3 pr-2 text-left text-sm motion-safe:transition-colors',
-                  active === item.id
-                    ? 'bg-background font-medium text-foreground shadow-sm before:absolute before:left-1 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full before:bg-primary'
-                    : 'text-muted-foreground hover:bg-background/60 hover:text-foreground',
-                )}
-              >
-                {item.icon}
-                <span>{item.label}</span>
-              </button>
-            ))}
-          </nav>
-          <Divider orientation="vertical" />
-          <div className="min-h-0 flex-1">
-            <AppScopePanel
-              initialSection={initialFocus}
-              requestClose={requestClose}
-              registerScrollTo={(fn) => {
-                scrollToRef.current = fn;
-              }}
-            />
-          </div>
+        <div className="min-h-0 flex-1">
+          <AppScopePanel initialSection={initialFocus} requestClose={requestClose} />
         </div>
       )}
     </StudioShell>


### PR DESCRIPTION
## Problema

Cinque voci di nav per una pagina in cui quattro sezioni su cinque sono 1-2 righe; l'unica sezione lunga (33 shortcut) costringeva tutta la pagina a scrollare. La voce Integrations non diceva la cosa importante: quel token github é GLOBALE, il fallback di tutti i workspace, mentre l'override per-workspace vive altrove.

## Meccanica

- Nav rimossa: colonna singola con sezioni separate da Divider (Editor, Shortcuts, GitHub, Config backup, Danger zone).
- Shortcuts collassata di default (badge `33 shortcuts`); i deep-link (`detail.section`, `initialFocus`, shortcut-help) la espandono e continuano a funzionare tutti, `integrations` mappa sull'ancora GitHub.
- Sezione GitHub con copy di scope esplicito: token globale di fallback, cross-link all'override in workspace settings. Storage keychain e `read_token` intoccati.
- Ancora `budget` morta (flag spento, nessuna voce nav) rimossa.
- Bonus verificato: la binding `⌘O` (workspace switcher, App.tsx:696) mancava dalla lista, aggiunta.

## Verifica

typecheck e suite completa verdi in locale; test nuovi su layout single-page, disclosure shortcuts, copy GitHub e tutti i deep-link; GithubPanel invariato e verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)